### PR TITLE
[v11.x backport] deps: V8: cherry-pick 56f6a76

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -30,7 +30,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.13',
+    'v8_embedder_string': '-node.14',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/compiler/effect-control-linearizer.cc
+++ b/deps/v8/src/compiler/effect-control-linearizer.cc
@@ -773,6 +773,9 @@ bool EffectControlLinearizer::TryWireInStateEffect(Node* node,
     case IrOpcode::kObjectIsMinusZero:
       result = LowerObjectIsMinusZero(node);
       break;
+    case IrOpcode::kNumberIsMinusZero:
+      result = LowerNumberIsMinusZero(node);
+      break;
     case IrOpcode::kObjectIsNaN:
       result = LowerObjectIsNaN(node);
       break;
@@ -2312,6 +2315,14 @@ Node* EffectControlLinearizer::LowerObjectIsSafeInteger(Node* node) {
   return done.PhiAt(0);
 }
 
+namespace {
+
+const int64_t kMinusZeroBits = bit_cast<int64_t>(-0.0);
+const int32_t kMinusZeroLoBits = static_cast<int32_t>(kMinusZeroBits);
+const int32_t kMinusZeroHiBits = static_cast<int32_t>(kMinusZeroBits >> 32);
+
+}  // namespace
+
 Node* EffectControlLinearizer::LowerObjectIsMinusZero(Node* node) {
   Node* value = node->InputAt(0);
   Node* zero = __ Int32Constant(0);
@@ -2328,13 +2339,41 @@ Node* EffectControlLinearizer::LowerObjectIsMinusZero(Node* node) {
 
   // Check if {value} contains -0.
   Node* value_value = __ LoadField(AccessBuilder::ForHeapNumberValue(), value);
-  __ Goto(&done,
-          __ Float64Equal(
-              __ Float64Div(__ Float64Constant(1.0), value_value),
-              __ Float64Constant(-std::numeric_limits<double>::infinity())));
+  if (machine()->Is64()) {
+    Node* value64 = __ BitcastFloat64ToInt64(value_value);
+    __ Goto(&done, __ Word64Equal(value64, __ Int64Constant(kMinusZeroBits)));
+  } else {
+    Node* value_lo = __ Float64ExtractLowWord32(value_value);
+    __ GotoIfNot(__ Word32Equal(value_lo, __ Int32Constant(kMinusZeroLoBits)),
+                 &done, zero);
+    Node* value_hi = __ Float64ExtractHighWord32(value_value);
+    __ Goto(&done,
+            __ Word32Equal(value_hi, __ Int32Constant(kMinusZeroHiBits)));
+  }
 
   __ Bind(&done);
   return done.PhiAt(0);
+}
+
+Node* EffectControlLinearizer::LowerNumberIsMinusZero(Node* node) {
+  Node* value = node->InputAt(0);
+
+  if (machine()->Is64()) {
+    Node* value64 = __ BitcastFloat64ToInt64(value);
+    return __ Word64Equal(value64, __ Int64Constant(kMinusZeroBits));
+  } else {
+    auto done = __ MakeLabel(MachineRepresentation::kBit);
+
+    Node* value_lo = __ Float64ExtractLowWord32(value);
+    __ GotoIfNot(__ Word32Equal(value_lo, __ Int32Constant(kMinusZeroLoBits)),
+                 &done, __ Int32Constant(0));
+    Node* value_hi = __ Float64ExtractHighWord32(value);
+    __ Goto(&done,
+            __ Word32Equal(value_hi, __ Int32Constant(kMinusZeroHiBits)));
+
+    __ Bind(&done);
+    return done.PhiAt(0);
+  }
 }
 
 Node* EffectControlLinearizer::LowerObjectIsNaN(Node* node) {

--- a/deps/v8/src/compiler/effect-control-linearizer.h
+++ b/deps/v8/src/compiler/effect-control-linearizer.h
@@ -98,6 +98,7 @@ class V8_EXPORT_PRIVATE EffectControlLinearizer {
   Node* LowerObjectIsConstructor(Node* node);
   Node* LowerObjectIsDetectableCallable(Node* node);
   Node* LowerObjectIsMinusZero(Node* node);
+  Node* LowerNumberIsMinusZero(Node* node);
   Node* LowerObjectIsNaN(Node* node);
   Node* LowerNumberIsNaN(Node* node);
   Node* LowerObjectIsNonCallable(Node* node);

--- a/deps/v8/src/compiler/opcodes.h
+++ b/deps/v8/src/compiler/opcodes.h
@@ -405,6 +405,7 @@
   V(ObjectIsConstructor)                \
   V(ObjectIsDetectableCallable)         \
   V(ObjectIsMinusZero)                  \
+  V(NumberIsMinusZero)                  \
   V(ObjectIsNaN)                        \
   V(NumberIsNaN)                        \
   V(ObjectIsNonCallable)                \

--- a/deps/v8/src/compiler/simplified-lowering.cc
+++ b/deps/v8/src/compiler/simplified-lowering.cc
@@ -2870,17 +2870,7 @@ class RepresentationSelector {
           VisitUnop(node, UseInfo::TruncatingFloat64(),
                     MachineRepresentation::kBit);
           if (lower()) {
-            // ObjectIsMinusZero(x:kRepFloat64)
-            //   => Float64Equal(Float64Div(1.0,x),-Infinity)
-            Node* const input = node->InputAt(0);
-            node->ReplaceInput(
-                0, jsgraph_->graph()->NewNode(
-                       lowering->machine()->Float64Div(),
-                       lowering->jsgraph()->Float64Constant(1.0), input));
-            node->AppendInput(jsgraph_->zone(),
-                              jsgraph_->Float64Constant(
-                                  -std::numeric_limits<double>::infinity()));
-            NodeProperties::ChangeOp(node, lowering->machine()->Float64Equal());
+            NodeProperties::ChangeOp(node, simplified()->NumberIsMinusZero());
           }
         } else {
           VisitUnop(node, UseInfo::AnyTagged(), MachineRepresentation::kBit);

--- a/deps/v8/src/compiler/simplified-operator.cc
+++ b/deps/v8/src/compiler/simplified-operator.cc
@@ -740,6 +740,7 @@ bool operator==(CheckMinusZeroParameters const& lhs,
   V(ObjectIsConstructor, Operator::kNoProperties, 1, 0)          \
   V(ObjectIsDetectableCallable, Operator::kNoProperties, 1, 0)   \
   V(ObjectIsMinusZero, Operator::kNoProperties, 1, 0)            \
+  V(NumberIsMinusZero, Operator::kNoProperties, 1, 0)            \
   V(ObjectIsNaN, Operator::kNoProperties, 1, 0)                  \
   V(NumberIsNaN, Operator::kNoProperties, 1, 0)                  \
   V(ObjectIsNonCallable, Operator::kNoProperties, 1, 0)          \

--- a/deps/v8/src/compiler/simplified-operator.h
+++ b/deps/v8/src/compiler/simplified-operator.h
@@ -710,6 +710,7 @@ class V8_EXPORT_PRIVATE SimplifiedOperatorBuilder final
   const Operator* ObjectIsConstructor();
   const Operator* ObjectIsDetectableCallable();
   const Operator* ObjectIsMinusZero();
+  const Operator* NumberIsMinusZero();
   const Operator* ObjectIsNaN();
   const Operator* NumberIsNaN();
   const Operator* ObjectIsNonCallable();

--- a/deps/v8/src/compiler/typer.cc
+++ b/deps/v8/src/compiler/typer.cc
@@ -290,6 +290,7 @@ class Typer::Visitor : public Reducer {
   static Type ObjectIsConstructor(Type, Typer*);
   static Type ObjectIsDetectableCallable(Type, Typer*);
   static Type ObjectIsMinusZero(Type, Typer*);
+  static Type NumberIsMinusZero(Type, Typer*);
   static Type ObjectIsNaN(Type, Typer*);
   static Type NumberIsNaN(Type, Typer*);
   static Type ObjectIsNonCallable(Type, Typer*);
@@ -592,6 +593,12 @@ Type Typer::Visitor::ObjectIsDetectableCallable(Type type, Typer* t) {
 }
 
 Type Typer::Visitor::ObjectIsMinusZero(Type type, Typer* t) {
+  if (type.Is(Type::MinusZero())) return t->singleton_true_;
+  if (!type.Maybe(Type::MinusZero())) return t->singleton_false_;
+  return Type::Boolean();
+}
+
+Type Typer::Visitor::NumberIsMinusZero(Type type, Typer* t) {
   if (type.Is(Type::MinusZero())) return t->singleton_true_;
   if (!type.Maybe(Type::MinusZero())) return t->singleton_false_;
   return Type::Boolean();
@@ -2111,6 +2118,10 @@ Type Typer::Visitor::TypeObjectIsDetectableCallable(Node* node) {
 
 Type Typer::Visitor::TypeObjectIsMinusZero(Node* node) {
   return TypeUnaryOp(node, ObjectIsMinusZero);
+}
+
+Type Typer::Visitor::TypeNumberIsMinusZero(Node* node) {
+  return TypeUnaryOp(node, NumberIsMinusZero);
 }
 
 Type Typer::Visitor::TypeNumberIsFloat64Hole(Node* node) {

--- a/deps/v8/src/compiler/verifier.cc
+++ b/deps/v8/src/compiler/verifier.cc
@@ -1185,6 +1185,7 @@ void Verifier::Visitor::Check(Node* node, const AllNodes& all) {
       CheckValueInputIs(node, 0, Type::Number());
       CheckTypeIs(node, Type::Boolean());
       break;
+    case IrOpcode::kNumberIsMinusZero:
     case IrOpcode::kNumberIsNaN:
       CheckValueInputIs(node, 0, Type::Number());
       CheckTypeIs(node, Type::Boolean());

--- a/deps/v8/test/mjsunit/regress/regress-crbug-903043.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-903043.js
@@ -1,0 +1,39 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+(function() {
+  function foo() {
+    const x = 1e-1;
+    return Object.is(-0, x * (-1e-308));
+  }
+
+  assertFalse(foo());
+  assertFalse(foo());
+  %OptimizeFunctionOnNextCall(foo);
+  assertFalse(foo());
+})();
+
+(function() {
+  function foo(x) {
+    return Object.is(-0, x * (-1e-308));
+  }
+
+  assertFalse(foo(1e-1));
+  assertFalse(foo(1e-1));
+  %OptimizeFunctionOnNextCall(foo);
+  assertFalse(foo(1e-1));
+})();
+
+(function() {
+  function foo(x) {
+    return Object.is(-0, x);
+  }
+
+  assertFalse(foo(1e-1 * (-1e-308)));
+  assertFalse(foo(1e-1 * (-1e-308)));
+  %OptimizeFunctionOnNextCall(foo);
+  assertFalse(foo(1e-1 * (-1e-308)));
+})();


### PR DESCRIPTION
Original commit message:

    [turbofan] Fix -0 check for subnormals.

    Previously we'd check `x` for -0 by testing `(1.0 / x) == -Infinity`,
    but this will yield the wrong results when `x` is a subnormal, i.e.
    really close to 0.

    In CSA we already perform bit checks to test for -0, so teach TurboFan
    to do the same for comparisons to -0 (via `Object.is`). We introduce a
    new NumberIsMinusZero simplified operator to handle the case where
    SimplifiedLowering already knows that the input is a number.

    Bug: chromium:903043, v8:6882
    Change-Id: I0cb7c568029b461a92fc183104d5f359b4bfe7f4
    Reviewed-on: https://chromium-review.googlesource.com/c/1328802
    Commit-Queue: Benedikt Meurer <bmeurer@chromium.org>
    Reviewed-by: Sigurd Schneider <sigurds@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#57382}

Refs: https://github.com/v8/v8/commit/56f6a763c27d77afbee997a50baa34996e97ba40

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Refs: #25268

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
