### PR TITLE
benchmark: fix net-wrap-js-stream-passthrough

### DIFF
--- a/benchmark/net/net-wrap-js-stream-passthrough.js
+++ b/benchmark/net/net-wrap-js-stream-passthrough.js
@@ -17,7 +17,7 @@ var encoding;
 
 function main({ dur, len, type }) {
   // Can only require internals inside main().
-  const JSStreamWrap = require('internal/wrap_js_stream');
+  const JSStreamWrap = require('internal/js_stream_socket');
 
   switch (type) {
     case 'buf':


### PR DESCRIPTION
The net-wrap-js-stream-passthrough benchmark was inadvertently broken by
00944c7cc25f391c3fbeba1e054a56a62cf0de12. This fixes it.

👍 here to fast-track. This fixes node-daily-master Jenkins job. (The benchmark tests are only run there.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
