### PR TITLE
test: remove unused --expose-native-as V8 flag

### DIFF
--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -155,7 +155,7 @@ if (common.isWindows) {
 // https://github.com/nodejs/node/issues/1691
 process.chdir(fixtures.fixturesDir);
 childProcess.exec(
-  `"${nodeBinary}" --expose_natives_as=v8natives --require ` +
+  `"${nodeBinary}" --require ` +
      `"${fixtures.path('cluster-preload.js')}" cluster-preload-test.js`,
   function(err, stdout, stderr) {
     assert.ifError(err);


### PR DESCRIPTION
test-preload.js was using a V8 flag (`--expose-native-as`) that made
an V8 internally used object available. As this test does not use this
object, this commit removes the usage of this flag.

In some distant past, this internally used object may have had some
external use, but currently is essentially an empty object.

In the near future, the V8 internal infrastructure (JS Natives)
producing the object exposed by `--expose-native-as` will be phased out.
For more details, visit:
https://bugs.chromium.org/p/v8/issues/detail?id=7624

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
