### PR TITLE
test: remove unnecessary test flags

### DIFF
--- a/test/parallel/test-buffer-of-no-deprecation.js
+++ b/test/parallel/test-buffer-of-no-deprecation.js
@@ -1,4 +1,3 @@
-// Flags: --pending-deprecation --no-warnings
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -19,8 +19,6 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-v8-deserialize-buffer.js
+++ b/test/parallel/test-v8-deserialize-buffer.js
@@ -1,4 +1,3 @@
-// Flags: --pending-deprecation --no-warnings
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -1,4 +1,4 @@
-// Flags: --expose-gc --expose-internals
+// Flags: --expose-internals
 
 'use strict';
 


### PR DESCRIPTION
This commit removes unnecessary flags used when starting tests via the `"// Flags:"` directive.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
