### PR TITLE
lib: move DEP0023 to end of life

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -513,6 +513,9 @@ The `os.tmpDir()` API is deprecated. Please use [`os.tmpdir()`][] instead.
 ### DEP0023: os.getNetworkInterfaces()
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/25280
+    description: End-of-Life.
   - version:
     - v4.8.6
     - v6.12.0
@@ -523,10 +526,10 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
 The `os.getNetworkInterfaces()` method is deprecated. Please use the
-[`os.networkInterfaces`][] property instead.
+[`os.networkInterfaces()`][] method instead.
 
 <a id="DEP0024"></a>
 ### DEP0024: REPLServer.prototype.convertToContext()
@@ -2366,7 +2369,7 @@ Setting the TLS ServerName to an IP address is not permitted by
 [`http.request()`]: http.html#http_http_request_options_callback
 [`https.get()`]: https.html#https_https_get_options_callback
 [`https.request()`]: https.html#https_https_request_options_callback
-[`os.networkInterfaces`]: os.html#os_os_networkinterfaces
+[`os.networkInterfaces()`]: os.html#os_os_networkinterfaces
 [`os.tmpdir()`]: os.html#os_os_tmpdir
 [`process.env`]: process.html#process_process_env
 [`punycode`]: punycode.html

--- a/lib/os.js
+++ b/lib/os.js
@@ -78,9 +78,6 @@ const kEndianness = isBigEndian ? 'BE' : 'LE';
 const tmpDirDeprecationMsg =
   'os.tmpDir() is deprecated. Use os.tmpdir() instead.';
 
-const getNetworkInterfacesDepMsg =
-  'os.getNetworkInterfaces is deprecated. Use os.networkInterfaces instead.';
-
 const avgValues = new Float64Array(3);
 
 function loadavg() {
@@ -269,9 +266,6 @@ module.exports = {
   uptime: getUptime,
 
   // Deprecated APIs
-  getNetworkInterfaces: deprecate(getInterfaceAddresses,
-                                  getNetworkInterfacesDepMsg,
-                                  'DEP0023'),
   tmpDir: deprecate(tmpdir, tmpDirDeprecationMsg, 'DEP0022')
 };
 


### PR DESCRIPTION
This commit moves `DEP0023` to end of life status. The `os.getNetworkInterfaces()` method was introduced in the unstable 0.5.0 release, and runtime deprecated in 0.6.0, the first stable release of its existence.

This commit also fixes an inaccuracy in the deprecation, as the replacement (`os.networkInterfaces()`) is a method.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
