### PR TITLE
repl: treat tab as spaces while pasting

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -989,6 +989,7 @@ Interface.prototype._ttyWrite = function(s, key) {
           s = s.toString('utf-8');
 
         if (s) {
+          s = s.replace(/\t/g, ' ');
           var lines = s.split(/\r\n|\n|\r/);
           for (var i = 0, len = lines.length; i < len; i++) {
             if (i > 0) {

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -311,8 +311,8 @@ function isWarned(emitter) {
     }), delay);
   }
 
-  // \t when there is no completer function should behave like an ordinary
-  // character
+  // \t when there is no completer function should be
+  // treated as space
   {
     const fi = new FakeInput();
     const rli = new readline.Interface(
@@ -320,11 +320,12 @@ function isWarned(emitter) {
     );
     let called = false;
     rli.on('line', function(line) {
-      assert.strictEqual(line, '\t');
+      assert.strictEqual(line, ' var   a = 5;');
       assert.strictEqual(called, false);
       called = true;
     });
     fi.emit('data', '\t');
+    fi.emit('data', 'var \t\ta\t=\t5;');
     fi.emit('data', '\n');
     assert.ok(called);
     rli.close();


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/25272

##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
