### PR TITLE
test: remove redundant fchmod test

### DIFF
--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -147,17 +147,6 @@ if (fs.lchmod) {
   }));
 }
 
-['', false, null, undefined, {}, []].forEach((input) => {
-  const errObj = {
-    code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-    message: 'The "fd" argument must be of type number. ' +
-             `Received type ${typeof input}`
-  };
-  assert.throws(() => fs.fchmod(input, 0o000), errObj);
-  assert.throws(() => fs.fchmodSync(input, 0o000), errObj);
-});
-
 [false, 1, {}, [], null, undefined].forEach((input) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

We test `fs.fchmod` function in [test-fs-fchmod.js](https://github.com/nodejs/node/blob/master/test/parallel/test-fs-fchmod.js), so the test snippet in `test-fs-chmod.js` is redundant and remove it now.
https://github.com/nodejs/node/blob/903630e72ece60c764b9cac9d0941400377b7ac6/test/parallel/test-fs-fchmod.js#L10-L20

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
