### PR TITLE
src: improve JS Array creation from C++

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -932,28 +932,15 @@ void SetupProcessObject(Environment* env,
 #endif
 
   // process.argv
-  Local<Array> arguments = Array::New(env->isolate(), args.size());
-  for (size_t i = 0; i < args.size(); ++i) {
-    arguments->Set(env->context(), i,
-        String::NewFromUtf8(env->isolate(), args[i].c_str(),
-                            NewStringType::kNormal).ToLocalChecked())
-        .FromJust();
-  }
   process->Set(env->context(),
                FIXED_ONE_BYTE_STRING(env->isolate(), "argv"),
-               arguments).FromJust();
+               ToV8Value(env->context(), args).ToLocalChecked()).FromJust();
 
   // process.execArgv
-  Local<Array> exec_arguments = Array::New(env->isolate(), exec_args.size());
-  for (size_t i = 0; i < exec_args.size(); ++i) {
-    exec_arguments->Set(env->context(), i,
-        String::NewFromUtf8(env->isolate(), exec_args[i].c_str(),
-                            NewStringType::kNormal).ToLocalChecked())
-        .FromJust();
-  }
   process->Set(env->context(),
                FIXED_ONE_BYTE_STRING(env->isolate(), "execArgv"),
-               exec_arguments).FromJust();
+               ToV8Value(env->context(), exec_args)
+                   .ToLocalChecked()).FromJust();
 
   // create process.env
   process
@@ -1004,17 +991,10 @@ void SetupProcessObject(Environment* env,
   const std::vector<std::string>& preload_modules =
       env->options()->preload_modules;
   if (!preload_modules.empty()) {
-    Local<Array> array = Array::New(env->isolate());
-    for (unsigned int i = 0; i < preload_modules.size(); ++i) {
-      Local<String> module = String::NewFromUtf8(env->isolate(),
-                                                 preload_modules[i].c_str(),
-                                                 NewStringType::kNormal)
-                                 .ToLocalChecked();
-      array->Set(env->context(), i, module).FromJust();
-    }
     READONLY_PROPERTY(process,
                       "_preload_modules",
-                      array);
+                      ToV8Value(env->context(), preload_modules)
+                          .ToLocalChecked());
   }
 
   // --no-deprecation

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -250,22 +250,12 @@ struct CryptoErrorVector : public std::vector<std::string> {
     CHECK(!exception_v.IsEmpty());
 
     if (!empty()) {
-      Local<Array> array = Array::New(env->isolate(), size());
-      CHECK(!array.IsEmpty());
-
-      for (const std::string& string : *this) {
-        const size_t index = &string - &front();
-        Local<String> value =
-            String::NewFromUtf8(env->isolate(), string.data(),
-                                NewStringType::kNormal, string.size())
-            .ToLocalChecked();
-        array->Set(env->context(), index, value).FromJust();
-      }
-
       CHECK(exception_v->IsObject());
       Local<Object> exception = exception_v.As<Object>();
       exception->Set(env->context(),
-                     env->openssl_error_stack(), array).FromJust();
+                     env->openssl_error_stack(),
+                     ToV8Value(env->context(), *this).ToLocalChecked())
+          .FromJust();
     }
 
     return exception_v;

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1190,15 +1190,6 @@ inline std::vector<std::string> FromJSStringArray(Environment* env,
   return vec;
 }
 
-inline Local<Array> ToJSStringArray(Environment* env,
-                                    const std::vector<std::string>& vec) {
-  Isolate* isolate = env->isolate();
-  Local<Array> array = Array::New(isolate, vec.size());
-  for (size_t n = 0; n < vec.size(); n++)
-    array->Set(env->context(), n, Utf8String(isolate, vec[n])).FromJust();
-  return array;
-}
-
 inline url_data HarvestBase(Environment* env, Local<Object> base_obj) {
   url_data base;
   Local<Context> context = env->context();
@@ -2119,7 +2110,7 @@ static inline void SetArgs(Environment* env,
   if (url.port > -1)
     argv[ARG_PORT] = Integer::New(isolate, url.port);
   if (url.flags & URL_FLAGS_HAS_PATH)
-    argv[ARG_PATH] = ToJSStringArray(env, url.path);
+    argv[ARG_PATH] = ToV8Value(env->context(), url.path).ToLocalChecked();
 }
 
 static void Parse(Environment* env,

--- a/src/util.h
+++ b/src/util.h
@@ -35,6 +35,7 @@
 #include <string.h>
 
 #include <functional>  // std::function
+#include <limits>
 #include <set>
 #include <string>
 #include <array>
@@ -519,13 +520,21 @@ using DeleteFnPtr = typename FunctionDeleter<T, function>::Pointer;
 std::set<std::string> ParseCommaSeparatedSet(const std::string& in);
 
 inline v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
-                                           const std::string& str);
+                                           const std::string& str,
+                                           v8::Isolate* isolate = nullptr);
+template <typename T, typename test_for_number =
+    typename std::enable_if<std::numeric_limits<T>::is_specialized, bool>::type>
+inline v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
+                                           const T& number,
+                                           v8::Isolate* isolate = nullptr);
 template <typename T>
 inline v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
-                                           const std::vector<T>& vec);
+                                           const std::vector<T>& vec,
+                                           v8::Isolate* isolate = nullptr);
 template <typename T, typename U>
 inline v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
-                                           const std::unordered_map<T, U>& map);
+                                           const std::unordered_map<T, U>& map,
+                                           v8::Isolate* isolate = nullptr);
 
 // These macros expects a `Isolate* isolate` and a `Local<Context> context`
 // to be in the scope.


### PR DESCRIPTION
**src: improve ToV8Value() functions**

- Cache the `isolate` value between calls
- Introduce an overload for dealing with integers/numbers
- Use the vectored `v8::Array::New` constructor + `MaybeStackBuffer`
  for faster array creation

**src: simplify JS Array creation**

Use `ToV8Value()` where appropriate to reduce duplication
and avoid extra `Array::Set()` calls.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
