### PR TITLE
coverage: fix broken coverage setup

### DIFF
--- a/lib/internal/process/coverage.js
+++ b/lib/internal/process/coverage.js
@@ -76,9 +76,10 @@ function setup() {
   }));
 
   try {
+    const { cwd } = internalBinding('process_methods');
     const { resolve } = require('path');
     coverageDirectory = process.env.NODE_V8_COVERAGE =
-      resolve(process.env.NODE_V8_COVERAGE);
+      resolve(cwd(), process.env.NODE_V8_COVERAGE);
   } catch (err) {
     process._rawDebug(err.toString());
   }

--- a/lib/internal/process/coverage.js
+++ b/lib/internal/process/coverage.js
@@ -53,7 +53,7 @@ exports.writeCoverage = writeCoverage;
 function setup() {
   const { Connection } = internalBinding('inspector');
   if (!Connection) {
-    console.warn('inspector not enabled');
+    process._rawDebug('inspector not enabled');
     return;
   }
 
@@ -80,7 +80,7 @@ function setup() {
     coverageDirectory = process.env.NODE_V8_COVERAGE =
       resolve(process.env.NODE_V8_COVERAGE);
   } catch (err) {
-    console.error(err);
+    process._rawDebug(err.toString());
   }
 }
 

--- a/test/parallel/test-v8-coverage.js
+++ b/test/parallel/test-v8-coverage.js
@@ -23,6 +23,7 @@ function nextdir() {
     require.resolve('../fixtures/v8-coverage/basic')
   ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
   assert.strictEqual(output.status, 0);
+  assert.strictEqual(output.stderr.toString(), '');
   const fixtureCoverage = getFixtureCoverage('basic.js', coverageDirectory);
   assert.ok(fixtureCoverage);
   // first branch executed.
@@ -38,6 +39,7 @@ function nextdir() {
     require.resolve('../fixtures/v8-coverage/exit-1')
   ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
   assert.strictEqual(output.status, 1);
+  assert.strictEqual(output.stderr.toString(), '');
   const fixtureCoverage = getFixtureCoverage('exit-1.js', coverageDirectory);
   assert.ok(fixtureCoverage, 'coverage not found for file');
   // first branch executed.
@@ -55,6 +57,7 @@ function nextdir() {
   if (!common.isWindows) {
     assert.strictEqual(output.signal, 'SIGINT');
   }
+  assert.strictEqual(output.stderr.toString(), '');
   const fixtureCoverage = getFixtureCoverage('sigint.js', coverageDirectory);
   assert.ok(fixtureCoverage);
   // first branch executed.
@@ -70,6 +73,7 @@ function nextdir() {
     require.resolve('../fixtures/v8-coverage/spawn-subprocess')
   ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
   assert.strictEqual(output.status, 0);
+  assert.strictEqual(output.stderr.toString(), '');
   const fixtureCoverage = getFixtureCoverage('subprocess.js',
                                              coverageDirectory);
   assert.ok(fixtureCoverage);
@@ -87,6 +91,7 @@ function nextdir() {
     require.resolve('../fixtures/v8-coverage/worker')
   ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
   assert.strictEqual(output.status, 0);
+  assert.strictEqual(output.stderr.toString(), '');
   const fixtureCoverage = getFixtureCoverage('subprocess.js',
                                              coverageDirectory);
   assert.ok(fixtureCoverage);
@@ -103,6 +108,7 @@ function nextdir() {
     require.resolve('../fixtures/v8-coverage/spawn-subprocess-no-cov')
   ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
   assert.strictEqual(output.status, 0);
+  assert.strictEqual(output.stderr.toString(), '');
   const fixtureCoverage = getFixtureCoverage('subprocess.js',
                                              coverageDirectory);
   assert.strictEqual(fixtureCoverage, undefined);
@@ -115,11 +121,33 @@ function nextdir() {
     require.resolve('../fixtures/v8-coverage/async-hooks')
   ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
   assert.strictEqual(output.status, 0);
+  assert.strictEqual(output.stderr.toString(), '');
   const fixtureCoverage = getFixtureCoverage('async-hooks.js',
                                              coverageDirectory);
   assert.ok(fixtureCoverage);
   // first branch executed.
   assert.strictEqual(fixtureCoverage.functions[1].ranges[0].count, 1);
+}
+
+// Outputs coverage when the coverage directory is not absolute.
+{
+  const coverageDirectory = nextdir();
+  const absoluteCoverageDirectory = path.join(tmpdir.path, coverageDirectory);
+  const output = spawnSync(process.execPath, [
+    require.resolve('../fixtures/v8-coverage/basic')
+  ], {
+    cwd: tmpdir.path,
+    env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory }
+  });
+  assert.strictEqual(output.status, 0);
+  assert.strictEqual(output.stderr.toString(), '');
+  const fixtureCoverage = getFixtureCoverage('basic.js',
+                                             absoluteCoverageDirectory);
+  assert.ok(fixtureCoverage);
+  // first branch executed.
+  assert.strictEqual(fixtureCoverage.functions[1].ranges[0].count, 1);
+  // second branch did not execute.
+  assert.strictEqual(fixtureCoverage.functions[1].ranges[1].count, 0);
 }
 
 // Extracts the coverage object for a given fixture name.


### PR DESCRIPTION
This PR replaces `console.warn()` and `console.error()` in coverage setup with `process._rawDebug()`, as `console` hasn't been properly bootstrapped at this point. This PR also prevents a problematic call to `process.cwd()`, which also hasn't been bootstrapped yet.

Fixes: https://github.com/nodejs/node/issues/25287

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
