### PR TITLE
src: move arch, platform and release into node_metadata.cc

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -168,8 +168,10 @@ class NodeTraceStateObserver :
       TRACE_EVENT_METADATA1("__metadata", "process_name",
                             "name", TRACE_STR_COPY(name_buffer));
     }
-    TRACE_EVENT_METADATA1("__metadata", "version",
-                          "node", NODE_VERSION_STRING);
+    TRACE_EVENT_METADATA1("__metadata",
+                          "version",
+                          "node",
+                          per_process::metadata.versions.node.c_str());
     TRACE_EVENT_METADATA1("__metadata", "thread_name",
                           "name", "JavaScriptMainThread");
 
@@ -184,13 +186,15 @@ class NodeTraceStateObserver :
 
     trace_process->EndDictionary();
 
-    trace_process->SetString("arch", NODE_ARCH);
-    trace_process->SetString("platform", NODE_PLATFORM);
+    trace_process->SetString("arch", per_process::metadata.arch.c_str());
+    trace_process->SetString("platform",
+                             per_process::metadata.platform.c_str());
 
     trace_process->BeginDictionary("release");
-    trace_process->SetString("name", NODE_RELEASE);
+    trace_process->SetString("name",
+                             per_process::metadata.release.name.c_str());
 #if NODE_VERSION_IS_LTS
-    trace_process->SetString("lts", NODE_VERSION_LTS_CODENAME);
+    trace_process->SetString("lts", per_process::metadata.release.lts.c_str());
 #endif
     trace_process->EndDictionary();
     TRACE_EVENT_METADATA1("__metadata", "node",
@@ -839,54 +843,29 @@ void SetupProcessObject(Environment* env,
 #undef V
 
   // process.arch
-  READONLY_PROPERTY(process, "arch", OneByteString(env->isolate(), NODE_ARCH));
+  READONLY_STRING_PROPERTY(process, "arch", per_process::metadata.arch);
 
   // process.platform
-  READONLY_PROPERTY(process,
-                    "platform",
-                    OneByteString(env->isolate(), NODE_PLATFORM));
+  READONLY_STRING_PROPERTY(process, "platform", per_process::metadata.platform);
 
   // process.release
   Local<Object> release = Object::New(env->isolate());
   READONLY_PROPERTY(process, "release", release);
-  READONLY_PROPERTY(release, "name",
-                    OneByteString(env->isolate(), NODE_RELEASE));
-
+  READONLY_STRING_PROPERTY(release, "name", per_process::metadata.release.name);
 #if NODE_VERSION_IS_LTS
-  READONLY_PROPERTY(release, "lts",
-                    OneByteString(env->isolate(), NODE_VERSION_LTS_CODENAME));
-#endif
+  READONLY_STRING_PROPERTY(release, "lts", per_process::metadata.release.lts);
+#endif  // NODE_VERSION_IS_LTS
 
-// if this is a release build and no explicit base has been set
-// substitute the standard release download URL
-#ifndef NODE_RELEASE_URLBASE
-# if NODE_VERSION_IS_RELEASE
-#  define NODE_RELEASE_URLBASE "https://nodejs.org/download/release/"
-# endif
-#endif
-
-#if defined(NODE_RELEASE_URLBASE)
-#  define NODE_RELEASE_URLPFX NODE_RELEASE_URLBASE "v" NODE_VERSION_STRING "/"
-#  define NODE_RELEASE_URLFPFX NODE_RELEASE_URLPFX "node-v" NODE_VERSION_STRING
-
-  READONLY_PROPERTY(release,
-                    "sourceUrl",
-                    OneByteString(env->isolate(),
-                    NODE_RELEASE_URLFPFX ".tar.gz"));
-  READONLY_PROPERTY(release,
-                    "headersUrl",
-                    OneByteString(env->isolate(),
-                    NODE_RELEASE_URLFPFX "-headers.tar.gz"));
-#  ifdef _WIN32
-  READONLY_PROPERTY(release,
-                    "libUrl",
-                    OneByteString(env->isolate(),
-                    strcmp(NODE_ARCH, "ia32") ? NODE_RELEASE_URLPFX "win-"
-                                                NODE_ARCH "/node.lib"
-                                              : NODE_RELEASE_URLPFX
-                                                "win-x86/node.lib"));
-#  endif
-#endif
+#ifdef NODE_HAS_RELEASE_URLS
+  READONLY_STRING_PROPERTY(
+      release, "sourceUrl", per_process::metadata.release.sourceUrl);
+  READONLY_STRING_PROPERTY(
+      release, "headersUrl", per_process::metadata.release.headersUrl);
+#ifdef _WIN32
+  READONLY_STRING_PROPERTY(
+      release, "libUrl", per_process::metadata.release.libUrl);
+#endif  // _WIN32
+#endif  // NODE_HAS_RELEASE_URLS
 
   // process.argv
   Local<Array> arguments = Array::New(env->isolate(), args.size());

--- a/src/node.cc
+++ b/src/node.cc
@@ -858,12 +858,12 @@ void SetupProcessObject(Environment* env,
 
 #ifdef NODE_HAS_RELEASE_URLS
   READONLY_STRING_PROPERTY(
-      release, "sourceUrl", per_process::metadata.release.sourceUrl);
+      release, "sourceUrl", per_process::metadata.release.source_url);
   READONLY_STRING_PROPERTY(
-      release, "headersUrl", per_process::metadata.release.headersUrl);
+      release, "headersUrl", per_process::metadata.release.headers_url);
 #ifdef _WIN32
   READONLY_STRING_PROPERTY(
-      release, "libUrl", per_process::metadata.release.libUrl);
+      release, "libUrl", per_process::metadata.release.lib_url);
 #endif  // _WIN32
 #endif  // NODE_HAS_RELEASE_URLS
 

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -82,4 +82,26 @@ Metadata::Versions::Versions() {
 #endif  // NODE_HAVE_I18N_SUPPORT
 }
 
+Metadata::Release::Release() : name(NODE_RELEASE) {
+#if NODE_VERSION_IS_LTS
+  lts = NODE_VERSION_LTS_CODENAME;
+#endif  // NODE_VERSION_IS_LTS
+
+#ifdef NODE_HAS_RELEASE_URLS
+#define NODE_RELEASE_URLPFX NODE_RELEASE_URLBASE "v" NODE_VERSION_STRING "/"
+#define NODE_RELEASE_URLFPFX NODE_RELEASE_URLPFX "node-v" NODE_VERSION_STRING
+
+  sourceUrl = NODE_RELEASE_URLFPFX ".tar.gz";
+  headersUrl = NODE_RELEASE_URLFPFX "-headers.tar.gz";
+#ifdef _WIN32
+  libUrl = strcmp(NODE_ARCH, "ia32") ? NODE_RELEASE_URLPFX "win-" NODE_ARCH
+                                                           "/node.lib"
+                                     : NODE_RELEASE_URLPFX "win-x86/node.lib";
+#endif  // _WIN32
+
+#endif  // NODE_HAS_RELEASE_URLS
+}
+
+Metadata::Metadata() : arch(NODE_ARCH), platform(NODE_PLATFORM) {}
+
 }  // namespace node

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -91,10 +91,10 @@ Metadata::Release::Release() : name(NODE_RELEASE) {
 #define NODE_RELEASE_URLPFX NODE_RELEASE_URLBASE "v" NODE_VERSION_STRING "/"
 #define NODE_RELEASE_URLFPFX NODE_RELEASE_URLPFX "node-v" NODE_VERSION_STRING
 
-  sourceUrl = NODE_RELEASE_URLFPFX ".tar.gz";
-  headersUrl = NODE_RELEASE_URLFPFX "-headers.tar.gz";
+  source_url = NODE_RELEASE_URLFPFX ".tar.gz";
+  headers_url = NODE_RELEASE_URLFPFX "-headers.tar.gz";
 #ifdef _WIN32
-  libUrl = strcmp(NODE_ARCH, "ia32") ? NODE_RELEASE_URLPFX "win-" NODE_ARCH
+  lib_url = strcmp(NODE_ARCH, "ia32") ? NODE_RELEASE_URLPFX "win-" NODE_ARCH
                                                            "/node.lib"
                                      : NODE_RELEASE_URLPFX "win-x86/node.lib";
 #endif  // _WIN32

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -84,19 +84,18 @@ class Metadata {
 #endif  // NODE_VERSION_IS_LTS
 
 #ifdef NODE_HAS_RELEASE_URLS
-    std::string sourceUrl;
-    std::string headersUrl;
+    std::string source_url;
+    std::string headers_url;
 #ifdef _WIN32
-    std::string libUrl;
+    std::string lib_url;
 #endif  // _WIN32
 #endif  // NODE_HAS_RELEASE_URLS
   };
 
   Versions versions;
-  Release release;
-
-  std::string arch;
-  std::string platform;
+  const Release release;
+  const std::string arch;
+  const std::string platform;
 };
 
 // Per-process global

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -4,8 +4,21 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include <string>
+#include "node_version.h"
 
 namespace node {
+
+// if this is a release build and no explicit base has been set
+// substitute the standard release download URL
+#ifndef NODE_RELEASE_URLBASE
+#if NODE_VERSION_IS_RELEASE
+#define NODE_RELEASE_URLBASE "https://nodejs.org/download/release/"
+#endif  // NODE_VERSION_IS_RELEASE
+#endif  // NODE_RELEASE_URLBASE
+
+#if defined(NODE_RELEASE_URLBASE)
+#define NODE_HAS_RELEASE_URLS
+#endif
 
 #define NODE_VERSIONS_KEYS_BASE(V)                                             \
   V(node)                                                                      \
@@ -42,7 +55,7 @@ namespace node {
 
 class Metadata {
  public:
-  Metadata() = default;
+  Metadata();
   Metadata(Metadata&) = delete;
   Metadata(Metadata&&) = delete;
   Metadata operator=(Metadata&) = delete;
@@ -62,7 +75,28 @@ class Metadata {
 #undef V
   };
 
+  struct Release {
+    Release();
+
+    std::string name;
+#if NODE_VERSION_IS_LTS
+    std::string lts;
+#endif  // NODE_VERSION_IS_LTS
+
+#ifdef NODE_HAS_RELEASE_URLS
+    std::string sourceUrl;
+    std::string headersUrl;
+#ifdef _WIN32
+    std::string libUrl;
+#endif  // _WIN32
+#endif  // NODE_HAS_RELEASE_URLS
+  };
+
   Versions versions;
+  Release release;
+
+  std::string arch;
+  std::string platform;
 };
 
 // Per-process global


### PR DESCRIPTION
Move definitions of more metadata into node_metadata{.h, .cc}
so the data can be reused and easily inspected in C++.

In a peudo-release build:

```
(lldb) p node::per_process::metadata
(node::Metadata) $0 = {
  versions = {
    node = "12.0.0-nightly2018-12-31819a868a49a2b7dbb7b3adab2b79cc8b783f7279"
    v8 = "7.1.302.33-node.8"
    uv = "1.24.1"
    zlib = "1.2.11"
    ares = "1.15.0"
    modules = "68"
    nghttp2 = "1.34.0"
    napi = "3"
    llhttp = "1.0.1"
    http_parser = "2.8.0"
    openssl = "1.1.0j"
    cldr = "34.0"
    icu = "63.1"
    tz = "2018e"
    unicode = "11.0"
  }
  release = (name = "node", sourceUrl = "https://nodejs.org/download/release/v12.0.0-nightly2018-12-31819a868a49a2b7dbb7b3adab2b79cc8b783f7279/node-v12.0.0-nightly2018-12-31819a868a49a2b7dbb7b3adab2b79cc8b783f7279.tar.gz", headersUrl = "https://nodejs.org/download/release/v12.0.0-nightly2018-12-31819a868a49a2b7dbb7b3adab2b79cc8b783f7279/node-v12.0.0-nightly2018-12-31819a868a49a2b7dbb7b3adab2b79cc8b783f7279-headers.tar.gz")
  arch = "x64"
  platform = "darwin"
}
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
