### PR TITLE
src: move per-process global variables into node::per_process

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -79,7 +79,8 @@ IsolateData::IsolateData(Isolate* isolate,
   if (platform_ != nullptr)
     platform_->RegisterIsolate(isolate_, event_loop);
 
-  options_.reset(new PerIsolateOptions(*per_process_opts->per_isolate));
+  options_.reset(
+      new PerIsolateOptions(*(per_process::cli_options->per_isolate)));
 
   // Create string and private symbol properties as internalized one byte
   // strings after the platform is properly initialized.

--- a/src/node.cc
+++ b/src/node.cc
@@ -141,9 +141,12 @@ using v8::Value;
 
 namespace per_process {
 // Tells whether --prof is passed.
-// TODO(joyeecheung): replace this with env->options()->prof_process
+// TODO(joyeecheung): move env->options()->prof_process to
+// per_process::cli_options.prof_process and use that instead.
 static bool v8_is_profiling = false;
 
+// TODO(joyeecheung): these are no longer necessary. Remove them.
+// See: https://github.com/nodejs/node/pull/25302#discussion_r244924196
 // Isolate on the main thread
 static Mutex main_isolate_mutex;
 static Isolate* main_isolate;

--- a/src/node.cc
+++ b/src/node.cc
@@ -139,21 +139,28 @@ using v8::Undefined;
 using v8::V8;
 using v8::Value;
 
+namespace per_process {
+// Tells whether --prof is passed.
+// TODO(joyeecheung): replace this with env->options()->prof_process
 static bool v8_is_profiling = false;
 
-// Bit flag used to track security reverts (see node_revert.h)
-unsigned int reverted = 0;
+// Isolate on the main thread
+static Mutex main_isolate_mutex;
+static Isolate* main_isolate;
 
+// node_revert.h
+// Bit flag used to track security reverts.
+unsigned int reverted_cve = 0;
+
+// util.h
+// Tells whether the per-process V8::Initialize() is called and
+// if it is safe to call v8::Isolate::GetCurrent().
 bool v8_initialized = false;
 
+// node_internals.h
 // process-relative uptime base, initialized at start-up
 double prog_start_time;
-
-Mutex per_process_opts_mutex;
-std::shared_ptr<PerProcessOptions> per_process_opts {
-    new PerProcessOptions() };
-static Mutex node_isolate_mutex;
-static Isolate* node_isolate;
+}  // namespace per_process
 
 // Ensures that __metadata trace events are only emitted
 // when tracing is enabled.
@@ -265,14 +272,15 @@ static struct {
 #endif  // HAVE_INSPECTOR
 
   void StartTracingAgent() {
-    if (per_process_opts->trace_event_categories.empty()) {
+    if (per_process::cli_options->trace_event_categories.empty()) {
       tracing_file_writer_ = tracing_agent_->DefaultHandle();
     } else {
       tracing_file_writer_ = tracing_agent_->AddClient(
-          ParseCommaSeparatedSet(per_process_opts->trace_event_categories),
+          ParseCommaSeparatedSet(
+              per_process::cli_options->trace_event_categories),
           std::unique_ptr<tracing::AsyncTraceWriter>(
               new tracing::NodeTraceWriter(
-                  per_process_opts->trace_event_file_pattern)),
+                  per_process::cli_options->trace_event_file_pattern)),
           tracing::Agent::kUseDefaultCategories);
     }
   }
@@ -496,7 +504,7 @@ const char* signo_string(int signo) {
 }
 
 void* ArrayBufferAllocator::Allocate(size_t size) {
-  if (zero_fill_field_ || per_process_opts->zero_fill_all_buffers)
+  if (zero_fill_field_ || per_process::cli_options->zero_fill_all_buffers)
     return UncheckedCalloc(size);
   else
     return UncheckedMalloc(size);
@@ -1271,12 +1279,12 @@ void ProcessArgv(std::vector<std::string>* args,
   {
     // TODO(addaleax): The mutex here should ideally be held during the
     // entire function, but that doesn't play well with the exit() calls below.
-    Mutex::ScopedLock lock(per_process_opts_mutex);
+    Mutex::ScopedLock lock(per_process::cli_options_mutex);
     options_parser::PerProcessOptionsParser::instance.Parse(
         args,
         exec_args,
         &v8_args,
-        per_process_opts.get(),
+        per_process::cli_options.get(),
         is_env ? kAllowedInEnvironment : kDisallowedInEnvironment,
         &errors);
   }
@@ -1288,20 +1296,20 @@ void ProcessArgv(std::vector<std::string>* args,
     exit(9);
   }
 
-  if (per_process_opts->print_version) {
+  if (per_process::cli_options->print_version) {
     printf("%s\n", NODE_VERSION);
     exit(0);
   }
 
-  if (per_process_opts->print_v8_help) {
+  if (per_process::cli_options->print_v8_help) {
     V8::SetFlagsFromString("--help", 6);
     exit(0);
   }
 
-  for (const std::string& cve : per_process_opts->security_reverts)
+  for (const std::string& cve : per_process::cli_options->security_reverts)
     Revert(cve.c_str());
 
-  auto env_opts = per_process_opts->per_isolate->per_env;
+  auto env_opts = per_process::cli_options->per_isolate->per_env;
   if (std::find(v8_args.begin(), v8_args.end(),
                 "--abort-on-uncaught-exception") != v8_args.end() ||
       std::find(v8_args.begin(), v8_args.end(),
@@ -1314,14 +1322,14 @@ void ProcessArgv(std::vector<std::string>* args,
   // behavior but it could also interfere with the user's intentions in ways
   // we fail to anticipate.  Dillema.
   if (std::find(v8_args.begin(), v8_args.end(), "--prof") != v8_args.end()) {
-    v8_is_profiling = true;
+    per_process::v8_is_profiling = true;
   }
 
 #ifdef __POSIX__
   // Block SIGPROF signals when sleeping in epoll_wait/kevent/etc.  Avoids the
   // performance penalty of frequent EINTR wakeups when the profiler is running.
   // Only do this for v8.log profiling, as it breaks v8::CpuProfiler users.
-  if (v8_is_profiling) {
+  if (per_process::v8_is_profiling) {
     uv_loop_configure(uv_default_loop(), UV_LOOP_BLOCK_SIGNAL, SIGPROF);
   }
 #endif
@@ -1350,7 +1358,7 @@ void ProcessArgv(std::vector<std::string>* args,
 void Init(std::vector<std::string>* argv,
           std::vector<std::string>* exec_argv) {
   // Initialize prog_start_time to get relative uptime.
-  prog_start_time = static_cast<double>(uv_now(uv_default_loop()));
+  per_process::prog_start_time = static_cast<double>(uv_now(uv_default_loop()));
 
   // Register built-in modules
   binding::RegisterBuiltinModules();
@@ -1366,7 +1374,7 @@ void Init(std::vector<std::string>* argv,
 #endif
 
   std::shared_ptr<EnvironmentOptions> default_env_options =
-      per_process_opts->per_isolate->per_env;
+      per_process::cli_options->per_isolate->per_env;
   {
     std::string text;
     default_env_options->pending_deprecation =
@@ -1395,7 +1403,7 @@ void Init(std::vector<std::string>* argv,
   }
 
 #if HAVE_OPENSSL
-  std::string* openssl_config = &per_process_opts->openssl_config;
+  std::string* openssl_config = &per_process::cli_options->openssl_config;
   if (openssl_config->empty()) {
     credentials::SafeGetenv("OPENSSL_CONF", openssl_config);
   }
@@ -1429,16 +1437,17 @@ void Init(std::vector<std::string>* argv,
   ProcessArgv(argv, exec_argv, false);
 
   // Set the process.title immediately after processing argv if --title is set.
-  if (!per_process_opts->title.empty())
-    uv_set_process_title(per_process_opts->title.c_str());
+  if (!per_process::cli_options->title.empty())
+    uv_set_process_title(per_process::cli_options->title.c_str());
 
 #if defined(NODE_HAVE_I18N_SUPPORT)
   // If the parameter isn't given, use the env variable.
-  if (per_process_opts->icu_data_dir.empty())
-    credentials::SafeGetenv("NODE_ICU_DATA", &per_process_opts->icu_data_dir);
+  if (per_process::cli_options->icu_data_dir.empty())
+    credentials::SafeGetenv("NODE_ICU_DATA",
+                            &per_process::cli_options->icu_data_dir);
   // Initialize ICU.
   // If icu_data_dir is empty here, it will load the 'minimal' data.
-  if (!i18n::InitializeICUDirectory(per_process_opts->icu_data_dir)) {
+  if (!i18n::InitializeICUDirectory(per_process::cli_options->icu_data_dir)) {
     fprintf(stderr,
             "%s: could not initialize ICU "
             "(check NODE_ICU_DATA or --icu-data-dir parameters)\n",
@@ -1599,7 +1608,7 @@ Environment* CreateEnvironment(IsolateData* isolate_data,
   std::vector<std::string> args(argv, argv + argc);
   std::vector<std::string> exec_args(exec_argv, exec_argv + exec_argc);
   Environment* env = new Environment(isolate_data, context);
-  env->Start(args, exec_args, v8_is_profiling);
+  env->Start(args, exec_args, per_process::v8_is_profiling);
   return env;
 }
 
@@ -1673,7 +1682,7 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   Local<Context> context = NewContext(isolate);
   Context::Scope context_scope(context);
   Environment env(isolate_data, context);
-  env.Start(args, exec_args, v8_is_profiling);
+  env.Start(args, exec_args, per_process::v8_is_profiling);
 
   const char* path = args.size() > 1 ? args[1].c_str() : nullptr;
   StartInspector(&env, path);
@@ -1780,9 +1789,9 @@ inline int Start(uv_loop_t* event_loop,
     return 12;  // Signal internal error.
 
   {
-    Mutex::ScopedLock scoped_lock(node_isolate_mutex);
-    CHECK_NULL(node_isolate);
-    node_isolate = isolate;
+    Mutex::ScopedLock scoped_lock(per_process::main_isolate_mutex);
+    CHECK_NULL(per_process::main_isolate);
+    per_process::main_isolate = isolate;
   }
 
   int exit_code;
@@ -1807,9 +1816,9 @@ inline int Start(uv_loop_t* event_loop,
   }
 
   {
-    Mutex::ScopedLock scoped_lock(node_isolate_mutex);
-    CHECK_EQ(node_isolate, isolate);
-    node_isolate = nullptr;
+    Mutex::ScopedLock scoped_lock(per_process::main_isolate_mutex);
+    CHECK_EQ(per_process::main_isolate, isolate);
+    per_process::main_isolate = nullptr;
   }
 
   isolate->Dispose();
@@ -1857,14 +1866,14 @@ int Start(int argc, char** argv) {
   V8::SetEntropySource(crypto::EntropySource);
 #endif  // HAVE_OPENSSL
 
-  InitializeV8Platform(per_process_opts->v8_thread_pool_size);
+  InitializeV8Platform(per_process::cli_options->v8_thread_pool_size);
   V8::Initialize();
   performance::performance_v8_start = PERFORMANCE_NOW();
-  v8_initialized = true;
+  per_process::v8_initialized = true;
   const int exit_code =
       Start(uv_default_loop(), args, exec_args);
   v8_platform.StopTracingAgent();
-  v8_initialized = false;
+  per_process::v8_initialized = false;
   V8::Dispose();
 
   // uv_run cannot be called from the time before the beforeExit callback

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -59,9 +59,9 @@ namespace node {
 namespace {
 
 inline void* BufferMalloc(size_t length) {
-  return per_process_opts->zero_fill_all_buffers ?
-      node::UncheckedCalloc(length) :
-      node::UncheckedMalloc(length);
+  return per_process::cli_options->zero_fill_all_buffers
+             ? node::UncheckedCalloc(length)
+             : node::UncheckedMalloc(length);
 }
 
 }  // namespace

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -41,7 +41,7 @@ static void Initialize(Local<Object> target,
 #ifdef NODE_FIPS_MODE
   READONLY_TRUE_PROPERTY(target, "fipsMode");
   // TODO(addaleax): Use options parser variable instead.
-  if (per_process_opts->force_fips_crypto)
+  if (per_process::cli_options->force_fips_crypto)
     READONLY_TRUE_PROPERTY(target, "fipsForced");
 #endif
 

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1234,9 +1234,10 @@ void DefineCryptoConstants(Local<Object> target) {
   NODE_DEFINE_STRING_CONSTANT(target,
                               "defaultCoreCipherList",
                               DEFAULT_CIPHER_LIST_CORE);
-  NODE_DEFINE_STRING_CONSTANT(target,
-                              "defaultCipherList",
-                              per_process_opts->tls_cipher_list.c_str());
+  NODE_DEFINE_STRING_CONSTANT(
+      target,
+      "defaultCipherList",
+      per_process::cli_options->tls_cipher_list.c_str());
 
   NODE_DEFINE_CONSTANT(target, TLS1_VERSION);
   NODE_DEFINE_CONSTANT(target, TLS1_1_VERSION);

--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -38,7 +38,7 @@ bool SafeGetenv(const char* key, std::string* text) {
 #endif
 
   {
-    Mutex::ScopedLock lock(environ_mutex);
+    Mutex::ScopedLock lock(per_process::env_var_mutex);
     if (const char* value = getenv(key)) {
       *text = value;
       return true;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -787,7 +787,7 @@ static X509_STORE* NewRootCertStore() {
   if (*system_cert_path != '\0') {
     X509_STORE_load_locations(store, system_cert_path, nullptr);
   }
-  if (per_process_opts->ssl_openssl_cert_store) {
+  if (per_process::cli_options->ssl_openssl_cert_store) {
     X509_STORE_set_default_paths(store);
   } else {
     for (X509* cert : root_certs_vector) {
@@ -6207,16 +6207,15 @@ void InitCryptoOnce() {
   OPENSSL_no_config();
 
   // --openssl-config=...
-  if (!per_process_opts->openssl_config.empty()) {
+  if (!per_process::cli_options->openssl_config.empty()) {
     OPENSSL_load_builtin_modules();
 #ifndef OPENSSL_NO_ENGINE
     ENGINE_load_builtin_engines();
 #endif
     ERR_clear_error();
-    CONF_modules_load_file(
-        per_process_opts->openssl_config.c_str(),
-        nullptr,
-        CONF_MFLAGS_DEFAULT_SECTION);
+    CONF_modules_load_file(per_process::cli_options->openssl_config.c_str(),
+                           nullptr,
+                           CONF_MFLAGS_DEFAULT_SECTION);
     int err = ERR_get_error();
     if (0 != err) {
       fprintf(stderr,
@@ -6232,8 +6231,8 @@ void InitCryptoOnce() {
 #ifdef NODE_FIPS_MODE
   /* Override FIPS settings in cnf file, if needed. */
   unsigned long err = 0;  // NOLINT(runtime/int)
-  if (per_process_opts->enable_fips_crypto ||
-      per_process_opts->force_fips_crypto) {
+  if (per_process::cli_options->enable_fips_crypto ||
+      per_process::cli_options->force_fips_crypto) {
     if (0 == FIPS_mode() && !FIPS_mode_set(1)) {
       err = ERR_get_error();
     }
@@ -6296,7 +6295,7 @@ void GetFipsCrypto(const FunctionCallbackInfo<Value>& args) {
 }
 
 void SetFipsCrypto(const FunctionCallbackInfo<Value>& args) {
-  CHECK(!per_process_opts->force_fips_crypto);
+  CHECK(!per_process::cli_options->force_fips_crypto);
   Environment* env = Environment::GetCurrent(args);
   const bool enabled = FIPS_mode();
   bool enable = args[0]->BooleanValue(env->isolate());

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -35,6 +35,10 @@ bool IsExceptionDecorated(Environment* env, Local<Value> er) {
   return false;
 }
 
+namespace per_process {
+static Mutex tty_mutex;
+}  // namespace per_process
+
 void AppendExceptionLine(Environment* env,
                          Local<Value> er,
                          Local<Message> message,
@@ -137,7 +141,7 @@ void AppendExceptionLine(Environment* env,
   // by the caller.
   if (!can_set_arrow || (mode == FATAL_ERROR && !err_obj->IsNativeError())) {
     if (env->printed_error()) return;
-    Mutex::ScopedLock lock(process_mutex);
+    Mutex::ScopedLock lock(per_process::tty_mutex);
     env->set_printed_error(true);
 
     uv_tty_reset_mode();

--- a/src/node_http_parser_impl.h
+++ b/src/node_http_parser_impl.h
@@ -830,7 +830,7 @@ class Parser : public AsyncWrap, public StreamListener {
   int TrackHeader(size_t len) {
 #ifdef NODE_EXPERIMENTAL_HTTP
     header_nread_ += len;
-    if (header_nread_ >= per_process_opts->max_http_header_size) {
+    if (header_nread_ >= per_process::cli_options->max_http_header_size) {
       llhttp_set_error_reason(&parser_, "HPE_HEADER_OVERFLOW:Header overflow");
       return HPE_USER;
     }
@@ -915,7 +915,8 @@ const parser_settings_t Parser::settings = {
 
 #ifndef NODE_EXPERIMENTAL_HTTP
 void InitMaxHttpHeaderSizeOnce() {
-  const uint32_t max_http_header_size = per_process_opts->max_http_header_size;
+  const uint32_t max_http_header_size =
+      per_process::cli_options->max_http_header_size;
   http_parser_set_max_header_size(max_http_header_size);
 }
 #endif  /* NODE_EXPERIMENTAL_HTTP */

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -83,14 +83,10 @@ namespace native_module {
 class NativeModuleLoader;
 }
 
-extern Mutex process_mutex;
-extern Mutex environ_mutex;
-
-// Tells whether it is safe to call v8::Isolate::GetCurrent().
-extern bool v8_initialized;
-
-extern Mutex per_process_opts_mutex;
-extern std::shared_ptr<PerProcessOptions> per_process_opts;
+namespace per_process {
+extern Mutex env_var_mutex;
+extern double prog_start_time;
+}  // namespace per_process
 
 // Forward declaration
 class Environment;
@@ -694,8 +690,6 @@ static inline const char* errno_string(int errorno) {
     TRACING_CATEGORY_NODE "." #one "." #two
 
 // Functions defined in node.cc that are exposed via the bootstrapper object
-
-extern double prog_start_time;
 
 void RawDebug(const v8::FunctionCallbackInfo<v8::Value>& args);
 

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <vector>
 #include "node_constants.h"
+#include "node_mutex.h"
 #include "util.h"
 
 namespace node {
@@ -422,6 +423,13 @@ class PerProcessOptionsParser : public OptionsParser<PerProcessOptions> {
 };
 
 }  // namespace options_parser
+
+namespace per_process {
+
+extern Mutex cli_options_mutex;
+extern std::shared_ptr<PerProcessOptions> cli_options;
+
+}  // namespace per_process
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -50,9 +50,6 @@ using v8::Uint32;
 using v8::Uint32Array;
 using v8::Value;
 
-Mutex process_mutex;
-Mutex environ_mutex;
-
 // Microseconds in a second, as a float, used in CPUUsage() below
 #define MICROS_PER_SEC 1e6
 // used in Hrtime() below
@@ -244,7 +241,7 @@ static void Uptime(const FunctionCallbackInfo<Value>& args) {
   double uptime;
 
   uv_update_time(env->event_loop());
-  uptime = uv_now(env->event_loop()) - prog_start_time;
+  uptime = uv_now(env->event_loop()) - per_process::prog_start_time;
 
   args.GetReturnValue().Set(uptime / 1000);
 }

--- a/src/node_revert.h
+++ b/src/node_revert.h
@@ -24,7 +24,9 @@ enum reversion {
 #undef V
 };
 
-extern unsigned int reverted;
+namespace per_process {
+extern unsigned int reverted_cve;
+}
 
 inline const char* RevertMessage(const reversion cve) {
 #define V(code, label, msg) case SECURITY_REVERT_##code: return label ": " msg;
@@ -37,7 +39,7 @@ inline const char* RevertMessage(const reversion cve) {
 }
 
 inline void Revert(const reversion cve) {
-  reverted |= 1 << cve;
+  per_process::reverted_cve |= 1 << cve;
   printf("SECURITY WARNING: Reverting %s\n", RevertMessage(cve));
 }
 
@@ -51,7 +53,7 @@ inline void Revert(const char* cve) {
 }
 
 inline bool IsReverted(const reversion cve) {
-  return reverted & (1 << cve);
+  return per_process::reverted_cve & (1 << cve);
 }
 
 inline bool IsReverted(const char* cve) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -101,7 +101,7 @@ BufferValue::BufferValue(Isolate* isolate, Local<Value> value) {
 }
 
 void LowMemoryNotification() {
-  if (v8_initialized) {
+  if (per_process::v8_initialized) {
     auto isolate = Isolate::GetCurrent();
     if (isolate != nullptr) {
       isolate->LowMemoryNotification();

--- a/src/util.h
+++ b/src/util.h
@@ -74,6 +74,12 @@ inline char* UncheckedCalloc(size_t n);
 template <typename T>
 inline T MultiplyWithOverflowCheck(T a, T b);
 
+namespace per_process {
+// Tells whether the per-process V8::Initialize() is called and
+// if it is safe to call v8::Isolate::GetCurrent().
+extern bool v8_initialized;
+}  // namespace per_process
+
 // Used by the allocation functions when allocation fails.
 // Thin wrapper around v8::Isolate::LowMemoryNotification() that checks
 // whether V8 is initialized.


### PR DESCRIPTION
So that it's easier to tell whether we are manipulating per-process
global states that may need to be treated with care to avoid races.

Also added comments about these variables and moved some of them
to a more suitable compilation unit:

- Move `v8_initialized` to `util.h` since it's only used in
  `util.cc` and `node.cc`
- Rename `process_mutex` to `tty_mutex` and move it into
  `node_errors.cc` since that's the only place it's used
  to guard the tty.
- Move `per_process_opts_mutex` and `per_process_opts`
  into `node_options.h` and rename them to
  `per_process::cli_options[_mutex]`
- Rename `node_isolate[_mutex]` to `per_process::main_isolate[_mutex]`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
