### PR TITLE
src: remove redundant if block

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1166,11 +1166,7 @@ void LoadEnvironment(Environment* env) {
       loader_exports.ToLocalChecked(),
       Boolean::New(isolate, env->is_main_thread())};
 
-  if (ExecuteBootstrapper(
-          env, "internal/bootstrap/node", &node_params, &node_args)
-          .IsEmpty()) {
-    return;
-  }
+  ExecuteBootstrapper(env, "internal/bootstrap/node", &node_params, &node_args);
 }
 
 static void StartInspector(Environment* env, const char* path) {


### PR DESCRIPTION
`void LoadEnvironment(Environment* env)` had a redundant if block at
the end of the function.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
