### PR TITLE
doc/api: extended the object mode section in the stream.md

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -61,7 +61,7 @@ Stream instances are switched into object mode using the `objectMode` option
 when the stream is created. Attempting to switch an existing stream into
 object mode is not safe.
 
-The object mode indicates that the stream either accepts and / or emits objects.
+The object mode indicates that the stream accepts and/or emits objects.
 Be aware that streams which operate in the object mode can only pipe to streams
 which are also in the object mode. Otherwise an error will be thrown. To pipe a
 stream to an non object mode stream, create an appropriate implementation to

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -64,10 +64,10 @@ object mode is not safe.
 The object mode indicates that the stream accepts and/or emits objects.
 Be aware that streams which operate in the object mode can only pipe to streams
 which are also in the object mode. Otherwise an error will be thrown. To pipe a
-stream to an non object mode stream, create an appropriate implementation to
-transform the objects into buffers, then you use this stream to pipe to a non 
-object mode stream (the stream which transforms the object has to be in the
-object mode as well to be able to accept objects!).
+stream which is not in object mode, create an appropriate implementation to
+transform the objects into buffers. You can use this stream to pipe to a non 
+object mode stream. The stream which transforms the object has to be in the
+object mode as well to be able to accept objects.
 
 ### Buffering
 
@@ -1473,12 +1473,12 @@ class MyWritable extends Writable {
 The new stream class must then implement one or more specific methods, depending
 on the type of stream being created, as detailed in the chart below:
 
-| Use-case | Class | Method(s) to implement |
-| -------- | ----- | ---------------------- |
-| Reading only | [`Readable`] | <code>[_read][stream-_read]</code> |
-| Writing only | [`Writable`] | <code>[_write][stream-_write]</code>, <code>[_writev][stream-_writev]</code>, <code>[_final][stream-_final]</code> |
-| Reading and writing | [`Duplex`] | <code>[_read][stream-_read]</code>, <code>[_write][stream-_write]</code>, <code>[_writev][stream-_writev]</code>, <code>[_final][stream-_final]</code> |
-| Operate on written data, then read the result | [`Transform`] | <code>[_transform][stream-_transform]</code>, <code>[_flush][stream-_flush]</code>, <code>[_final][stream-_final]</code> |
+| Use-case                                      | Class         | Method(s) to implement                                                                                                                                 |
+|-----------------------------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Reading only                                  | [`Readable`]  | <code>[_read][stream-_read]</code>                                                                                                                     |
+| Writing only                                  | [`Writable`]  | <code>[_write][stream-_write]</code>, <code>[_writev][stream-_writev]</code>, <code>[_final][stream-_final]</code>                                     |
+| Reading and writing                           | [`Duplex`]    | <code>[_read][stream-_read]</code>, <code>[_write][stream-_write]</code>, <code>[_writev][stream-_writev]</code>, <code>[_final][stream-_final]</code> |
+| Operate on written data, then read the result | [`Transform`] | <code>[_transform][stream-_transform]</code>, <code>[_flush][stream-_flush]</code>, <code>[_final][stream-_final]</code>                               |
 
 The implementation code for a stream should *never* call the "public" methods
 of a stream that are intended for use by consumers (as described in the

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -61,13 +61,14 @@ Stream instances are switched into object mode using the `objectMode` option
 when the stream is created. Attempting to switch an existing stream into
 object mode is not safe.
 
-The object mode indicates that the stream accepts and/or emits objects.
-Be aware that streams which operate in the object mode can only pipe to streams
-which are also in the object mode. Otherwise an error will be thrown. To pipe a
-stream which is not in object mode, create an appropriate implementation to
-transform the objects into buffers. You can use this stream to pipe to a non 
-object mode stream. The stream which transforms the object has to be in the
-object mode as well to be able to accept objects.
+The object mode indicates that the stream accepts and/or emits values which are
+not limited to `Buffer` or strings. Be aware that streams which are in object
+mode can be connected to streams not in the object mode but an exception will
+be raised if you attempt to write something except a `Buffer` or a string. To
+prevent this create an appropriate implementation to
+[transform][stream-_transform] the values into buffers or strings. The stream
+which transforms the values has to be in the object mode as well to be able to
+accept objects.
 
 ### Buffering
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -63,7 +63,7 @@ object mode is not safe.
 
 The object mode indicates that the stream accepts and/or emits values which are
 not limited to `Buffer` or strings. Be aware that streams which are in object
-mode can be connected to streams not in the object mode but an exception will
+mode can be piped to streams not in the object mode but an exception will
 be raised if you attempt to write something except a `Buffer` or a string. To
 prevent this create an appropriate implementation to
 [transform][stream-_transform] the values into buffers or strings. The stream

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -61,6 +61,14 @@ Stream instances are switched into object mode using the `objectMode` option
 when the stream is created. Attempting to switch an existing stream into
 object mode is not safe.
 
+The object mode indicates that the stream either accepts and / or emits objects.
+Be aware that streams which operate in the object mode can only pipe to streams
+which are also in the object mode. Otherwise an error will be thrown. To pipe a
+stream to an non object mode stream, create an appropriate implementation to
+transform the objects into buffers, then you use this stream to pipe to a non 
+object mode stream (the stream which transforms the object has to be in the
+object mode as well to be able to accept objects!).
+
 ### Buffering
 
 <!--type=misc-->


### PR DESCRIPTION
doc/api: extended the object mode section in the stream.md

Added a section to describe the object mode a little bit more,
especially the internal handling when piping from object mode into
other streams.

##### Checklist

- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
