### PR TITLE
test: replace internals with public API

### DIFF
--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-at-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-at-max.js
@@ -1,8 +1,6 @@
 'use strict';
-// Flags: --expose-internals
 
 const common = require('../../common');
-const { internalBinding } = require('internal/test/binding');
 const skipMessage = 'intensive toString tests due to memory confinements';
 if (!common.enoughTestMem)
   common.skip(skipMessage);
@@ -12,7 +10,7 @@ const assert = require('assert');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
-const kStringMaxLength = internalBinding('buffer').kStringMaxLength;
+const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
 
 let buf;
 try {

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii.js
@@ -1,8 +1,6 @@
 'use strict';
-// Flags: --expose-internals
 
 const common = require('../../common');
-const { internalBinding } = require('internal/test/binding');
 const skipMessage = 'intensive toString tests due to memory confinements';
 if (!common.enoughTestMem)
   common.skip(skipMessage);
@@ -11,7 +9,7 @@ const binding = require(`./build/${common.buildType}/binding`);
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
-const kStringMaxLength = internalBinding('buffer').kStringMaxLength;
+const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
 
 let buf;
 try {

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
@@ -1,8 +1,6 @@
 'use strict';
-// Flags: --expose-internals
 
 const common = require('../../common');
-const { internalBinding } = require('internal/test/binding');
 const skipMessage = 'intensive toString tests due to memory confinements';
 if (!common.enoughTestMem)
   common.skip(skipMessage);
@@ -11,7 +9,7 @@ const binding = require(`./build/${common.buildType}/binding`);
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
-const kStringMaxLength = internalBinding('buffer').kStringMaxLength;
+const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
 
 let buf;
 try {

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
@@ -1,8 +1,7 @@
-// Flags: --expose-gc --expose-internals
+// Flags: --expose-gc
 'use strict';
 
 const common = require('../../common');
-const { internalBinding } = require('internal/test/binding');
 const skipMessage = 'intensive toString tests due to memory confinements';
 if (!common.enoughTestMem)
   common.skip(skipMessage);
@@ -12,7 +11,7 @@ const assert = require('assert');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
-const kStringMaxLength = internalBinding('buffer').kStringMaxLength;
+const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
 
 let buf;
 try {

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
@@ -1,8 +1,6 @@
 'use strict';
-// Flags: --expose-internals
 
 const common = require('../../common');
-const { internalBinding } = require('internal/test/binding');
 const skipMessage = 'intensive toString tests due to memory confinements';
 if (!common.enoughTestMem)
   common.skip(skipMessage);
@@ -11,7 +9,7 @@ const binding = require(`./build/${common.buildType}/binding`);
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
-const kStringMaxLength = internalBinding('buffer').kStringMaxLength;
+const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
 
 let buf;
 try {

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
@@ -1,8 +1,6 @@
 'use strict';
-// Flags: --expose-internals
 
 const common = require('../../common');
-const { internalBinding } = require('internal/test/binding');
 const skipMessage = 'intensive toString tests due to memory confinements';
 if (!common.enoughTestMem)
   common.skip(skipMessage);
@@ -12,7 +10,7 @@ const assert = require('assert');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
-const kStringMaxLength = internalBinding('buffer').kStringMaxLength;
+const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
 
 let buf;
 try {

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2.js
@@ -1,8 +1,6 @@
 'use strict';
-// Flags: --expose-internals
 
 const common = require('../../common');
-const { internalBinding } = require('internal/test/binding');
 const skipMessage = 'intensive toString tests due to memory confinements';
 if (!common.enoughTestMem)
   common.skip(skipMessage);
@@ -12,7 +10,7 @@ const assert = require('assert');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
-const kStringMaxLength = internalBinding('buffer').kStringMaxLength;
+const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
 
 let buf;
 try {

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
@@ -1,8 +1,6 @@
 'use strict';
-// Flags: --expose-internals
 
 const common = require('../../common');
-const { internalBinding } = require('internal/test/binding');
 const skipMessage = 'intensive toString tests due to memory confinements';
 if (!common.enoughTestMem)
   common.skip(skipMessage);
@@ -11,7 +9,7 @@ const binding = require(`./build/${common.buildType}/binding`);
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
-const kStringMaxLength = internalBinding('buffer').kStringMaxLength;
+const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
 
 let buf;
 try {

--- a/test/sequential/test-fs-readfile-tostring-fail.js
+++ b/test/sequential/test-fs-readfile-tostring-fail.js
@@ -1,8 +1,6 @@
 'use strict';
-// Flags: --expose-internals
 
 const common = require('../common');
-const { internalBinding } = require('internal/test/binding');
 
 if (!common.enoughTestMem)
   common.skip('intensive toString tests due to memory confinements');
@@ -11,7 +9,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
-const kStringMaxLength = internalBinding('buffer').kStringMaxLength;
+const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
 if (common.isAIX && (Number(cp.execSync('ulimit -f')) * 512) < kStringMaxLength)
   common.skip('intensive toString tests due to file size confinements');
 


### PR DESCRIPTION
Remove instances where `--expose-internals` is used to gain access to
buffer.kStringMaxLength. The property is availalble without a flag. It
is undocumented but the same as the documented
`buffer.constants.MAX_STRING_LENGTH` so use that. (We even have a test
that confirms that they are the same value.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
