### PR TITLE
worker: improve JS-side debugging

### DIFF
--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -62,7 +62,8 @@ MessagePort.prototype.unref = MessagePortPrototype.unref;
 // .onmessage events, and a function used for sending data to a MessagePort
 // in some other thread.
 MessagePort.prototype[kOnMessageListener] = function onmessage(payload) {
-  debug(`[${threadId}] received message`, payload);
+  if (payload.type !== messageTypes.STDIO_WANTS_MORE_DATA)
+    debug(`[${threadId}] received message`, payload);
   // Emit the deserialized object to userland.
   this.emit('message', payload);
 };


### PR DESCRIPTION
Do not print debug messages that indicate that a stdio stream
has drained; because `util.debuglog()` uses `console.log`, which
in turn uses stdio streams, this would otherwise have lead to an
endless loop.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
