### PR TITLE
v8: enable inline WASM in serialization API

### DIFF
--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -282,6 +282,7 @@ DeserializerContext::DeserializerContext(Environment* env,
     length_(Buffer::Length(buffer)),
     deserializer_(env->isolate(), data_, length_, this) {
   object()->Set(env->context(), env->buffer_string(), buffer).FromJust();
+  deserializer_.SetExpectInlineWasm(true);
 
   MakeWeak();
 }


### PR DESCRIPTION
Since the API we expose through the `v8` module is Buffer-based,
we cannot transfer WASM modules directly. Instead, we enable
the V8-provided inline WASM (de)serialization for WASM modules.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
