### PR TITLE
worker: enable transferring WASM modules

### DIFF
--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -47,6 +47,9 @@ class Message : public MemoryRetainer {
   // Internal method of Message that is called once serialization finishes
   // and that transfers ownership of `data` to this message.
   void AddMessagePort(std::unique_ptr<MessagePortData>&& data);
+  // Internal method of Message that is called when a new WebAssembly.Module
+  // object is encountered in the incoming value's structure.
+  uint32_t AddWASMModule(v8::WasmCompiledModule::TransferrableModule&& mod);
 
   // The MessagePorts that will be transferred, as recorded by Serialize().
   // Used for warning user about posting the target MessagePort to itself,
@@ -65,6 +68,7 @@ class Message : public MemoryRetainer {
   std::vector<MallocedBuffer<char>> array_buffer_contents_;
   std::vector<SharedArrayBufferMetadataReference> shared_array_buffers_;
   std::vector<std::unique_ptr<MessagePortData>> message_ports_;
+  std::vector<v8::WasmCompiledModule::TransferrableModule> wasm_modules_;
 
   friend class MessagePort;
 };

--- a/test/parallel/test-worker-message-port-wasm-module.js
+++ b/test/parallel/test-worker-message-port-wasm-module.js
@@ -1,0 +1,19 @@
+// Flags: --experimental-worker
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+
+const { Worker } = require('worker_threads');
+const wasmModule = new WebAssembly.Module(fixtures.readSync('test.wasm'));
+
+const worker = new Worker(`
+const { parentPort } = require('worker_threads');
+parentPort.once('message', ({ wasmModule }) => {
+  const instance = new WebAssembly.Instance(wasmModule);
+  parentPort.postMessage(instance.exports.addTwo(10, 20));
+});
+`, { eval: true });
+
+worker.once('message', common.mustCall((num) => assert.strictEqual(num, 30)));
+worker.postMessage({ wasmModule });


### PR DESCRIPTION
Enable in-memory transfer of WASM modules without recompilation.

Previously, the serialization step worked, but deserialization failed
because we did not explicitly enable decoding inline WASM modules,
and so the message was not successfully received.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
