### PR TITLE
src: add NAPI_VERSION_EXPERIMENTAL

### DIFF
--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -5,10 +5,10 @@
 #include <stdbool.h>
 #include "js_native_api_types.h"
 
+// Use INT_MAX, this should only be consumed by the pre-processor anyway.
 #define NAPI_VERSION_EXPERIMENTAL 2147483647
 #ifndef NAPI_VERSION
 #ifdef NAPI_EXPERIMENTAL
-// Use INT_MAX, this should only be consumed by the pre-processor anyway.
 #define NAPI_VERSION NAPI_VERSION_EXPERIMENTAL
 #else
 // The baseline version for N-API

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -5,10 +5,11 @@
 #include <stdbool.h>
 #include "js_native_api_types.h"
 
+#define NAPI_VERSION_EXPERIMENTAL 2147483647
 #ifndef NAPI_VERSION
 #ifdef NAPI_EXPERIMENTAL
 // Use INT_MAX, this should only be consumed by the pre-processor anyway.
-#define NAPI_VERSION 2147483647
+#define NAPI_VERSION NAPI_VERSION_EXPERIMENTAL
 #else
 // The baseline version for N-API
 #define NAPI_VERSION 3


### PR DESCRIPTION
Refs: https://github.com/nodejs/node-addon-api/issues/421

Define NAPI_VERSION_EXPERIMENTAL so that it can be
used to guard code in addons that need to check
if a function they want to use is available.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
