### PR TITLE
src: split `LoadEnvironment()` at `startExecution()`

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -302,7 +302,7 @@ function startup() {
   } = perf.constants;
   perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
 
-  startExecution();
+  return startExecution;
 }
 
 // There are various modes that Node can run in. The most common two
@@ -728,4 +728,4 @@ function checkScriptSyntax(source, filename) {
   new vm.Script(source, { displayErrors: true, filename });
 }
 
-startup();
+return startup();

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -637,6 +637,14 @@ inline void Environment::set_can_call_into_js(bool can_call_into_js) {
   can_call_into_js_ = can_call_into_js;
 }
 
+inline bool Environment::has_run_bootstrapping_code() const {
+  return has_run_bootstrapping_code_;
+}
+
+inline void Environment::set_has_run_bootstrapping_code(bool value) {
+  has_run_bootstrapping_code_ = value;
+}
+
 inline bool Environment::is_main_thread() const {
   return thread_id_ == 0;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -371,6 +371,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(script_data_constructor_function, v8::Function)                            \
   V(secure_context_constructor_template, v8::FunctionTemplate)                 \
   V(shutdown_wrap_template, v8::ObjectTemplate)                                \
+  V(start_execution_function, v8::Function)                                    \
   V(tcp_constructor_template, v8::FunctionTemplate)                            \
   V(tick_callback_function, v8::Function)                                      \
   V(timers_callback_function, v8::Function)                                    \
@@ -755,6 +756,9 @@ class Environment {
   inline bool can_call_into_js() const;
   inline void set_can_call_into_js(bool can_call_into_js);
 
+  inline bool has_run_bootstrapping_code() const;
+  inline void set_has_run_bootstrapping_code(bool has_run_bootstrapping_code);
+
   inline bool is_main_thread() const;
   inline uint64_t thread_id() const;
   inline void set_thread_id(uint64_t id);
@@ -980,6 +984,7 @@ class Environment {
   std::unique_ptr<performance::performance_state> performance_state_;
   std::unordered_map<std::string, uint64_t> performance_marks_;
 
+  bool has_run_bootstrapping_code_ = false;
   bool can_call_into_js_ = true;
   uint64_t thread_id_ = 0;
   std::unordered_set<worker::Worker*> sub_worker_contexts_;

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -724,6 +724,9 @@ bool SafeGetenv(const char* key, std::string* text);
 
 void DefineZlibConstants(v8::Local<v8::Object> target);
 
+void RunBootstrapping(Environment* env);
+void StartExecution(Environment* env);
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -18,4 +18,3 @@ AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
     at *
     at *
     at *
-    at *

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -16,4 +16,3 @@ AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
-    at startup (internal/bootstrap/node.js:*:*)

--- a/test/message/eval_messages.out
+++ b/test/message/eval_messages.out
@@ -11,8 +11,6 @@ SyntaxError: Strict mode code may not include a with statement
     at evalScript (internal/process/execution.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
-    at startup (internal/bootstrap/node.js:*:*)
-    at internal/bootstrap/node.js:*:*
 42
 42
 [eval]:1
@@ -28,8 +26,6 @@ Error: hello
     at evalScript (internal/process/execution.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
-    at startup (internal/bootstrap/node.js:*:*)
-    at internal/bootstrap/node.js:*:*
 
 [eval]:1
 throw new Error("hello")
@@ -44,8 +40,6 @@ Error: hello
     at evalScript (internal/process/execution.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
-    at startup (internal/bootstrap/node.js:*:*)
-    at internal/bootstrap/node.js:*:*
 100
 [eval]:1
 var x = 100; y = x;
@@ -60,8 +54,6 @@ ReferenceError: y is not defined
     at evalScript (internal/process/execution.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
-    at startup (internal/bootstrap/node.js:*:*)
-    at internal/bootstrap/node.js:*:*
 
 [eval]:1
 var ______________________________________________; throw 10

--- a/test/message/events_unhandled_error_nexttick.out
+++ b/test/message/events_unhandled_error_nexttick.out
@@ -12,7 +12,6 @@ Error
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
-    at startup (internal/bootstrap/node.js:*:*)
 Emitted 'error' event at:
     at process.nextTick (*events_unhandled_error_nexttick.js:*:*)
     at internalTickCallback (internal/process/next_tick.js:*:*)
@@ -20,5 +19,3 @@ Emitted 'error' event at:
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
-    at startup (internal/bootstrap/node.js:*:*)
-    at internal/bootstrap/node.js:*:*

--- a/test/message/events_unhandled_error_sameline.out
+++ b/test/message/events_unhandled_error_sameline.out
@@ -12,9 +12,8 @@ Error
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
-    at startup (internal/bootstrap/node.js:*:*)
 Emitted 'error' event at:
     at Object.<anonymous> (*events_unhandled_error_sameline.js:*:*)
     at Module._compile (internal/modules/cjs/loader.js:*:*)
     [... lines matching original stack trace ...]
-    at startup (internal/bootstrap/node.js:*:*)
+    at startExecution (internal/bootstrap/node.js:*:*)

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -9,5 +9,3 @@ ReferenceError: undefined_reference_error_maker is not defined
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
-    at startup (internal/bootstrap/node.js:*:*)
-    at internal/bootstrap/node.js:*:*

--- a/test/message/unhandled_promise_trace_warnings.out
+++ b/test/message/unhandled_promise_trace_warnings.out
@@ -15,9 +15,6 @@
     at *
     at *
     at *
-    at *
-    at *
-    at *
 (node:*) Error: This was rejected
     at * (*test*message*unhandled_promise_trace_warnings.js:*)
     at *
@@ -28,10 +25,7 @@
     at *
     at *
     at *
-    at *
 (node:*) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
-    at *
-    at *
     at *
     at *
     at *

--- a/test/message/util_inspect_error.out
+++ b/test/message/util_inspect_error.out
@@ -10,7 +10,6 @@
        at *
        at *
        at *
-       at *
   nested:
    { err:
       Error: foo
@@ -23,13 +22,11 @@
           at *
           at *
           at *
-          at *
           at * } }
 {
   err: Error: foo
   bar
       at *util_inspect_error*
-      at *
       at *
       at *
       at *
@@ -50,13 +47,11 @@
         at *
         at *
         at *
-        at *
   }
 }
 { Error: foo
 bar
     at *util_inspect_error*
-    at *
     at *
     at *
     at *


### PR DESCRIPTION
This makes it easier to cater to embedders which wish to skip
the `startExecution()` part.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
