### PR TITLE
util: update comment in util.promisify

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -282,7 +282,7 @@ function promisify(original) {
   }
 
   // Names to create an object from in case the callback receives multiple
-  // arguments, e.g. ['stdout', 'stderr'] for child_process.exec.
+  // arguments, e.g. ['bytesRead', 'buffer'] for fs.read.
   const argumentNames = original[kCustomPromisifyArgsSymbol];
 
   function fn(...args) {


### PR DESCRIPTION
child_process.exec has Symbol('util.promisify.custom') in its keys
and no longer has Symbol('customPromisifyArgs') in its keys, but it was
still used as an example of funtions with
Symbol('customPromisifyArgs').

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
