### PR TITLE
win, url: make fileURLToPath return backslashes

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1328,6 +1328,7 @@ function getPathFromURLPosix(url) {
   return decodeURIComponent(pathname);
 }
 
+const forwardslashRegEx = /\//g;
 function fileURLToPath(path) {
   if (typeof path === 'string')
     path = new URL(path);
@@ -1336,7 +1337,9 @@ function fileURLToPath(path) {
     throw new ERR_INVALID_ARG_TYPE('path', ['string', 'URL'], path);
   if (path.protocol !== 'file:')
     throw new ERR_INVALID_URL_SCHEME('file');
-  return isWindows ? getPathFromURLWin32(path) : getPathFromURLPosix(path);
+  return isWindows ?
+    getPathFromURLWin32(path).replace(forwardslashRegEx, '\\') :
+    getPathFromURLPosix(path);
 }
 
 // The following characters are percent-encoded when converting from file path

--- a/test/parallel/test-fs-whatwg-url.js
+++ b/test/parallel/test-fs-whatwg-url.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const URL = require('url').URL;
+const { fileURLToPath, URL } = require('url');
 
 function pathToFileURL(p) {
   if (!path.isAbsolute(p))
@@ -29,6 +29,17 @@ fs.readFile(url, common.mustCall((err, data) => {
 
 // Check that using a non file:// URL reports an error
 const httpUrl = new URL('http://example.org');
+
+// Check that the fileURLToPath uses platform separator
+['file:///c:/tmp', 'file://tmp/tmp'].forEach((i) => {
+  assert(fileURLToPath(i).includes(path.sep));
+});
+
+// Check fileURLToPath examples from documentation
+if (common.isWindows) {
+  assert.strictEqual(fileURLToPath('file:///C:/path/'), 'C:\\path\\');
+  assert.strictEqual(fileURLToPath('file://nas/foo.txt'), '\\\\nas\\foo.txt');
+}
 
 common.expectsError(
   () => {
@@ -63,7 +74,7 @@ if (common.isWindows) {
       code: 'ERR_INVALID_ARG_VALUE',
       type: TypeError,
       message: 'The argument \'path\' must be a string or Uint8Array without ' +
-               'null bytes. Received \'c:/tmp/\\u0000test\''
+               'null bytes. Received \'c:\\\\tmp\\\\\\u0000test\''
     }
   );
 } else {


### PR DESCRIPTION
Makes `fileURLToPath` use backslashes as path separator on Windows

Fixes: https://github.com/nodejs/node/issues/25265

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
