### PR TITLE
crypto: fix key object wrapping in sync keygen

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1954,8 +1954,9 @@ If a `publicKeyEncoding` or `privateKeyEncoding` was specified, this function
 behaves as if [`keyObject.export()`][] had been called on its result. Otherwise,
 the respective part of the key is returned as a [`KeyObject`].
 
-It is recommended to encode public keys as `'spki'` and private keys as
-`'pkcs8'` with encryption for long-term storage:
+When encoding public keys, it is recommended to use `'spki'`. When encoding
+private keys, it is recommended to use `'pks8'` with a strong passphrase, and to
+keep the passphrase confidential.
 
 ```js
 const { generateKeyPairSync } = require('crypto');

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1941,18 +1941,8 @@ changes:
   - `publicExponent`: {number} Public exponent (RSA). **Default:** `0x10001`.
   - `divisorLength`: {number} Size of `q` in bits (DSA).
   - `namedCurve`: {string} Name of the curve to use (EC).
-  - `publicKeyEncoding`: {Object}
-    - `type`: {string} Must be one of `'pkcs1'` (RSA only) or `'spki'`.
-    - `format`: {string} Must be `'pem'` or `'der'`.
-  - `privateKeyEncoding`: {Object}
-    - `type`: {string} Must be one of `'pkcs1'` (RSA only), `'pkcs8'` or
-      `'sec1'` (EC only).
-    - `format`: {string} Must be `'pem'` or `'der'`.
-    - `cipher`: {string} If specified, the private key will be encrypted with
-      the given `cipher` and `passphrase` using PKCS#5 v2.0 password based
-      encryption.
-    - `passphrase`: {string | Buffer} The passphrase to use for encryption, see
-      `cipher`.
+  - `publicKeyEncoding`: {Object} See [`keyObject.export()`][].
+  - `privateKeyEncoding`: {Object} See [`keyObject.export()`][].
 * Returns: {Object}
   - `publicKey`: {string | Buffer | KeyObject}
   - `privateKey`: {string | Buffer | KeyObject}
@@ -1960,8 +1950,12 @@ changes:
 Generates a new asymmetric key pair of the given `type`. Only RSA, DSA and EC
 are currently supported.
 
+If a `publicKeyEncoding` or `privateKeyEncoding` was specified, this function
+behaves as if [`keyObject.export()`][] had been called on its result. Otherwise,
+the respective part of the key is returned as a [`KeyObject`].
+
 It is recommended to encode public keys as `'spki'` and private keys as
-`'pkcs8'` with encryption:
+`'pkcs8'` with encryption for long-term storage:
 
 ```js
 const { generateKeyPairSync } = require('crypto');

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -74,7 +74,11 @@ function handleError(impl, wrap) {
   if (err !== undefined)
     throw err;
 
-  return { publicKey, privateKey };
+  // If no encoding was chosen, return key objects instead.
+  return {
+    publicKey: wrapKey(publicKey, PublicKeyObject),
+    privateKey: wrapKey(privateKey, PrivateKeyObject)
+  };
 }
 
 function parseKeyEncoding(keyType, options) {

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -96,6 +96,21 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 }
 
 {
+  // Test sync key generation with key objects.
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 512
+  });
+
+  assert.strictEqual(typeof publicKey, 'object');
+  assert.strictEqual(publicKey.type, 'public');
+  assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
+
+  assert.strictEqual(typeof privateKey, 'object');
+  assert.strictEqual(privateKey.type, 'private');
+  assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
+}
+
+{
   const publicKeyEncoding = {
     type: 'pkcs1',
     format: 'der'


### PR DESCRIPTION
`generateKeyPairSync` incorrectly returns the native key object handle instead of the higher-level JS key object. This change fixes that and aligns the documentation with `generateKeyPair`.

Fixes: https://github.com/nodejs/node/issues/25322

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
