### PR TITLE
test: remove flag for test-addon-uv-handle-leak

### DIFF
--- a/test/abort/test-addon-uv-handle-leak.js
+++ b/test/abort/test-addon-uv-handle-leak.js
@@ -1,11 +1,9 @@
-// Flags: --experimental-worker
 'use strict';
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
-const { Worker } = require('worker_threads');
 const { spawnSync } = require('child_process');
 
 // This is a sibling test to test/addons/uv-handle-leak.
@@ -18,6 +16,8 @@ if (!fs.existsSync(bindingPath))
   common.skip('binding not built yet');
 
 if (process.argv[2] === 'child') {
+
+  const { Worker } = require('worker_threads');
 
   // The worker thread loads and then unloads `bindingPath`. Because of this the
   // symbols in `bindingPath` are lost when the worker thread quits, but the


### PR DESCRIPTION
test-addon-uv-handle-leak only requires worker_threads for the
subprocess which it explicitly calls with --experimental-worker. The
main test itself does not need it. Remove Flags: comment and move
loading of worker_threads into subprocess-only logic.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
