### PR TITLE
[v10.x] deps: cherry-pick d9fbfeb from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -33,7 +33,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -10001,6 +10001,47 @@ debug::TypeProfile::ScriptData debug::TypeProfile::GetScriptData(
   return ScriptData(i, type_profile_);
 }
 
+v8::MaybeLocal<v8::Value> debug::WeakMap::Get(v8::Local<v8::Context> context,
+                                              v8::Local<v8::Value> key) {
+  PREPARE_FOR_EXECUTION(context, WeakMap, Get, Value);
+  auto self = Utils::OpenHandle(this);
+  Local<Value> result;
+  i::Handle<i::Object> argv[] = {Utils::OpenHandle(*key)};
+  has_pending_exception =
+      !ToLocal<Value>(i::Execution::Call(isolate, isolate->weakmap_get(), self,
+                                         arraysize(argv), argv),
+                      &result);
+  RETURN_ON_FAILED_EXECUTION(Value);
+  RETURN_ESCAPED(result);
+}
+
+v8::MaybeLocal<debug::WeakMap> debug::WeakMap::Set(
+    v8::Local<v8::Context> context, v8::Local<v8::Value> key,
+    v8::Local<v8::Value> value) {
+  PREPARE_FOR_EXECUTION(context, WeakMap, Set, WeakMap);
+  auto self = Utils::OpenHandle(this);
+  i::Handle<i::Object> result;
+  i::Handle<i::Object> argv[] = {Utils::OpenHandle(*key),
+                                 Utils::OpenHandle(*value)};
+  has_pending_exception = !i::Execution::Call(isolate, isolate->weakmap_set(),
+                                              self, arraysize(argv), argv)
+                               .ToHandle(&result);
+  RETURN_ON_FAILED_EXECUTION(WeakMap);
+  RETURN_ESCAPED(Local<WeakMap>::Cast(Utils::ToLocal(result)));
+}
+
+Local<debug::WeakMap> debug::WeakMap::New(v8::Isolate* isolate) {
+  i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);
+  LOG_API(i_isolate, WeakMap, New);
+  ENTER_V8_NO_SCRIPT_NO_EXCEPTION(i_isolate);
+  i::Handle<i::JSWeakMap> obj = i_isolate->factory()->NewJSWeakMap();
+  return ToApiHandle<debug::WeakMap>(obj);
+}
+
+debug::WeakMap* debug::WeakMap::Cast(v8::Value* value) {
+  return static_cast<debug::WeakMap*>(value);
+}
+
 const char* CpuProfileNode::GetFunctionNameStr() const {
   const i::ProfileNode* node = reinterpret_cast<const i::ProfileNode*>(this);
   return node->entry()->name();

--- a/deps/v8/src/api.h
+++ b/deps/v8/src/api.h
@@ -124,6 +124,7 @@ class RegisteredExtension {
   V(Proxy, JSProxy)                            \
   V(debug::GeneratorObject, JSGeneratorObject) \
   V(debug::Script, Script)                     \
+  V(debug::WeakMap, JSWeakMap)                 \
   V(Promise, JSPromise)                        \
   V(Primitive, Object)                         \
   V(PrimitiveArray, FixedArray)                \

--- a/deps/v8/src/bootstrapper.cc
+++ b/deps/v8/src/bootstrapper.cc
@@ -3250,7 +3250,9 @@ void Genesis::InitializeGlobal(Handle<JSGlobalObject> global_object,
 
     SimpleInstallFunction(prototype, "delete",
                           Builtins::kWeakMapPrototypeDelete, 1, true);
-    SimpleInstallFunction(prototype, "get", Builtins::kWeakMapGet, 1, true);
+    Handle<JSFunction> weakmap_get = SimpleInstallFunction(prototype, "get",
+        Builtins::kWeakMapGet, 1, true);
+    native_context()->set_weakmap_get(*weakmap_get);
     SimpleInstallFunction(prototype, "has", Builtins::kWeakMapHas, 1, true);
     Handle<JSFunction> weakmap_set = SimpleInstallFunction(
         prototype, "set", Builtins::kWeakMapPrototypeSet, 2, true);

--- a/deps/v8/src/contexts.h
+++ b/deps/v8/src/contexts.h
@@ -108,6 +108,7 @@ enum ContextLookupFlags {
   V(WASM_RUNTIME_ERROR_FUNCTION_INDEX, JSFunction,                        \
     wasm_runtime_error_function)                                          \
   V(WEAKMAP_SET_INDEX, JSFunction, weakmap_set)                           \
+  V(WEAKMAP_GET_INDEX, JSFunction, weakmap_get)                           \
   V(WEAKSET_ADD_INDEX, JSFunction, weakset_add)
 
 #define NATIVE_CONTEXT_FIELDS(V)                                               \

--- a/deps/v8/src/counters.h
+++ b/deps/v8/src/counters.h
@@ -730,6 +730,9 @@ class RuntimeCallTimer final {
   V(Map_Has)                                               \
   V(Map_New)                                               \
   V(Map_Set)                                               \
+  V(WeakMap_Get)                                           \
+  V(WeakMap_Set)                                           \
+  V(WeakMap_New)                                           \
   V(Message_GetEndColumn)                                  \
   V(Message_GetLineNumber)                                 \
   V(Message_GetSourceLine)                                 \

--- a/deps/v8/src/debug/debug-interface.h
+++ b/deps/v8/src/debug/debug-interface.h
@@ -515,6 +515,20 @@ bool SetFunctionBreakpoint(v8::Local<v8::Function> function,
 
 v8::Platform* GetCurrentPlatform();
 
+class WeakMap : public v8::Object {
+ public:
+  V8_WARN_UNUSED_RESULT v8::MaybeLocal<v8::Value> Get(
+      v8::Local<v8::Context> context, v8::Local<v8::Value> key);
+  V8_WARN_UNUSED_RESULT v8::MaybeLocal<WeakMap> Set(
+      v8::Local<v8::Context> context, v8::Local<v8::Value> key,
+      v8::Local<v8::Value> value);
+
+  static Local<WeakMap> New(v8::Isolate* isolate);
+  V8_INLINE static WeakMap* Cast(Value* obj);
+
+ private:
+  WeakMap();
+};
 }  // namespace debug
 }  // namespace v8
 

--- a/deps/v8/src/inspector/v8-debugger.cc
+++ b/deps/v8/src/inspector/v8-debugger.cc
@@ -703,11 +703,37 @@ v8::MaybeLocal<v8::Value> V8Debugger::generatorScopes(
   return getTargetScopes(context, generator, GENERATOR);
 }
 
+v8::MaybeLocal<v8::Uint32> V8Debugger::stableObjectId(
+    v8::Local<v8::Context> context, v8::Local<v8::Value> value) {
+  DCHECK(value->IsObject());
+  if (m_stableObjectId.IsEmpty()) {
+    m_stableObjectId.Reset(m_isolate, v8::debug::WeakMap::New(m_isolate));
+  }
+  v8::Local<v8::debug::WeakMap> stableObjectId =
+      m_stableObjectId.Get(m_isolate);
+  v8::Local<v8::Value> idValue;
+  if (!stableObjectId->Get(context, value).ToLocal(&idValue) ||
+      !idValue->IsUint32()) {
+    idValue = v8::Integer::NewFromUnsigned(m_isolate, ++m_lastStableObjectId);
+    stableObjectId->Set(context, value, idValue).ToLocalChecked();
+  }
+  return idValue.As<v8::Uint32>();
+}
+
 v8::MaybeLocal<v8::Array> V8Debugger::internalProperties(
     v8::Local<v8::Context> context, v8::Local<v8::Value> value) {
   v8::Local<v8::Array> properties;
   if (!v8::debug::GetInternalProperties(m_isolate, value).ToLocal(&properties))
     return v8::MaybeLocal<v8::Array>();
+  if (value->IsObject()) {
+    v8::Local<v8::Uint32> id;
+    if (stableObjectId(context, value).ToLocal(&id)) {
+      createDataProperty(
+          context, properties, properties->Length(),
+          toV8StringInternalized(m_isolate, "[[StableObjectId]]"));
+      createDataProperty(context, properties, properties->Length(), id);
+    }
+  }
   if (value->IsFunction()) {
     v8::Local<v8::Function> function = value.As<v8::Function>();
     v8::Local<v8::Object> location;

--- a/deps/v8/src/inspector/v8-debugger.h
+++ b/deps/v8/src/inspector/v8-debugger.h
@@ -185,6 +185,9 @@ class V8Debugger : public v8::debug::DebugDelegate {
 
   int currentContextGroupId();
 
+  v8::MaybeLocal<v8::Uint32> stableObjectId(v8::Local<v8::Context>,
+                                            v8::Local<v8::Value>);
+
   v8::Isolate* m_isolate;
   V8InspectorImpl* m_inspector;
   int m_enableCount;
@@ -240,6 +243,9 @@ class V8Debugger : public v8::debug::DebugDelegate {
       m_serializedDebuggerIdToDebuggerId;
 
   std::unique_ptr<TerminateExecutionCallback> m_terminateExecutionCallback;
+
+  uint32_t m_lastStableObjectId = 0;
+  v8::Global<v8::debug::WeakMap> m_stableObjectId;
 
   WasmTranslation m_wasmTranslation;
 

--- a/deps/v8/test/inspector/debugger/eval-scopes-expected.txt
+++ b/deps/v8/test/inspector/debugger/eval-scopes-expected.txt
@@ -2,6 +2,12 @@ Tests that variables introduced in eval scopes are accessible
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true

--- a/deps/v8/test/inspector/debugger/scope-skip-variables-with-empty-name-expected.txt
+++ b/deps/v8/test/inspector/debugger/scope-skip-variables-with-empty-name-expected.txt
@@ -2,6 +2,12 @@ Tests that scopes do not report variables with empty names
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true

--- a/deps/v8/test/inspector/protocol-test.js
+++ b/deps/v8/test/inspector/protocol-test.js
@@ -45,6 +45,8 @@ InspectorTest.logMessage = function(originalMessage) {
   var objects = [ message ];
   while (objects.length) {
     var object = objects.shift();
+    if (object && object.name === '[[StableObjectId]]')
+      object.value = '<StablectObjectId>';
     for (var key in object) {
       if (nonStableFields.has(key))
         object[key] = `<${key}>`;

--- a/deps/v8/test/inspector/runtime/es6-module-expected.txt
+++ b/deps/v8/test/inspector/runtime/es6-module-expected.txt
@@ -128,6 +128,12 @@ console.log(239)
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true

--- a/deps/v8/test/inspector/runtime/get-properties-expected.txt
+++ b/deps/v8/test/inspector/runtime/get-properties-expected.txt
@@ -5,6 +5,7 @@ Running test: testObject5
   foo own string cat
 Internal properties
   [[PrimitiveValue]] number 5
+  [[StableObjectId]]: <stableObjectId>
 
 Running test: testNotOwn
   __defineGetter__ inherited function undefined
@@ -23,6 +24,8 @@ Running test: testNotOwn
   toLocaleString inherited function undefined
   toString inherited function undefined
   valueOf inherited function undefined
+Internal properties
+  [[StableObjectId]]: <stableObjectId>
 
 Running test: testAccessorsOnly
   b own no value, getter, setter
@@ -34,6 +37,8 @@ Running test: testArray
   2 own string blue
   __proto__ own object undefined
   length own number 3
+Internal properties
+  [[StableObjectId]]: <stableObjectId>
 
 Running test: testBound
   __proto__ own function undefined
@@ -42,14 +47,19 @@ Running test: testBound
 Internal properties
   [[BoundArgs]] object undefined
   [[BoundThis]] object undefined
+  [[StableObjectId]]: <stableObjectId>
   [[TargetFunction]] function undefined
 
 Running test: testObjectThrowsLength
   __proto__ own object undefined
   length own no value, getter
+Internal properties
+  [[StableObjectId]]: <stableObjectId>
 
 Running test: testTypedArrayWithoutLength
   __proto__ own object undefined
+Internal properties
+  [[StableObjectId]]: <stableObjectId>
 
 Running test: testArrayBuffer
 [[Int8Array]]
@@ -62,6 +72,8 @@ Running test: testArrayBuffer
   6 own number 1
   7 own number 1
   __proto__ own object undefined
+Internal properties
+  [[StableObjectId]]: <stableObjectId>
 [[Uint8Array]]
   0 own number 1
   1 own number 1
@@ -72,18 +84,26 @@ Running test: testArrayBuffer
   6 own number 1
   7 own number 1
   __proto__ own object undefined
+Internal properties
+  [[StableObjectId]]: <stableObjectId>
 [[Int16Array]]
   0 own number 257
   1 own number 257
   2 own number 257
   3 own number 257
   __proto__ own object undefined
+Internal properties
+  [[StableObjectId]]: <stableObjectId>
 [[Int32Array]]
   0 own number 16843009
   1 own number 16843009
   __proto__ own object undefined
+Internal properties
+  [[StableObjectId]]: <stableObjectId>
 
 Running test: testArrayBufferWithBrokenUintCtor
   [[Int8Array]] own object undefined
   [[Uint8Array]] own object undefined
   __proto__ own object undefined
+Internal properties
+  [[StableObjectId]]: <stableObjectId>

--- a/deps/v8/test/inspector/runtime/get-properties-on-proxy-expected.txt
+++ b/deps/v8/test/inspector/runtime/get-properties-on-proxy-expected.txt
@@ -54,6 +54,10 @@ Testing regular Proxy
                     value : false
                 }
             }
+            [3] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
         ]
         result : [
         ]
@@ -114,6 +118,10 @@ Testing revocable Proxy
                     value : false
                 }
             }
+            [3] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
         ]
         result : [
         ]
@@ -165,6 +173,10 @@ Testing revocable Proxy
                     type : boolean
                     value : true
                 }
+            }
+            [3] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
             }
         ]
         result : [

--- a/deps/v8/test/inspector/runtime/get-properties.js
+++ b/deps/v8/test/inspector/runtime/get-properties.js
@@ -94,7 +94,10 @@ async function logGetPropertiesResult(objectId, flags = { ownProperties: true })
     for (var i = 0; i < internalPropertyArray.length; i++) {
       var p = internalPropertyArray[i];
       var v = p.value;
-      InspectorTest.log("  " + p.name + " " + v.type + " " + v.value);
+      if (p.name !== '[[StableObjectId]]')
+        InspectorTest.log("  " + p.name + " " + v.type + " " + v.value);
+      else
+        InspectorTest.log("  [[StableObjectId]]: <stableObjectId>");
     }
   }
 

--- a/deps/v8/test/inspector/runtime/internal-properties-entries-expected.txt
+++ b/deps/v8/test/inspector/runtime/internal-properties-entries-expected.txt
@@ -15,6 +15,12 @@ expression: new Map([[1,2],[3,4]])
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -65,6 +71,12 @@ expression: new Map()
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : false
@@ -97,6 +109,12 @@ expression: new Map([[1,2],[3,4]]).entries()
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -151,6 +169,12 @@ expression: it = new Map([[1,2],[3,4]]).entries(); it.next(); it
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -190,6 +214,12 @@ expression: it = new Map([[1,2],[3,4]]).keys(); it.next(); it
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -229,6 +259,12 @@ expression: it = new Map([[1,2],[3,4]]).values(); it.next(); it
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -265,6 +301,12 @@ expression: it = new Map([[1,2],[3,4]]).entries(); it.next(); it.next(); it
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : false
@@ -295,6 +337,12 @@ expression: new Set([1,2])
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -345,6 +393,12 @@ expression: new Set()
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : false
@@ -375,6 +429,12 @@ expression: new Set([1,2]).values()
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -428,6 +488,12 @@ expression: it = new Set([1,2]).values(); it.next(); it
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -467,6 +533,12 @@ expression: it = new Set([1,2]).keys(); it.next(); it
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -506,6 +578,12 @@ expression: it = new Set([1,2]).entries(); it.next(); it
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -542,6 +620,12 @@ expression: it = new Set([1,2]).values(); it.next(); it.next(); it
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : false
@@ -566,6 +650,12 @@ expression: new WeakMap()
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : false
@@ -594,6 +684,12 @@ expression: new WeakMap([[{ a: 2 }, 42]])
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -632,6 +728,12 @@ expression: new WeakSet()
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : false
@@ -659,6 +761,12 @@ expression: new WeakSet([{a:2}])
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true

--- a/deps/v8/test/inspector/runtime/internal-properties-expected.txt
+++ b/deps/v8/test/inspector/runtime/internal-properties-expected.txt
@@ -7,6 +7,10 @@ expression: (function* foo() { yield 1 })
     result : {
         internalProperties : [
             [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+            [1] : {
                 name : [[FunctionLocation]]
                 value : {
                     description : Object
@@ -19,14 +23,14 @@ expression: (function* foo() { yield 1 })
                     }
                 }
             }
-            [1] : {
+            [2] : {
                 name : [[IsGenerator]]
                 value : {
                     type : boolean
                     value : true
                 }
             }
-            [2] : {
+            [3] : {
                 name : [[Scopes]]
                 value : {
                     className : Array
@@ -47,6 +51,10 @@ expression: (function foo() {})
     result : {
         internalProperties : [
             [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+            [1] : {
                 name : [[FunctionLocation]]
                 value : {
                     description : Object
@@ -59,7 +67,7 @@ expression: (function foo() {})
                     }
                 }
             }
-            [1] : {
+            [2] : {
                 name : [[Scopes]]
                 value : {
                     className : Array
@@ -87,6 +95,10 @@ expression: new Number(239)
                     value : 239
                 }
             }
+            [1] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
         ]
     }
 }
@@ -102,6 +114,10 @@ expression: new Boolean(false)
                     value : false
                 }
             }
+            [1] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
         ]
     }
 }
@@ -116,6 +132,10 @@ expression: new String('abc')
                     type : string
                     value : abc
                 }
+            }
+            [1] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
             }
         ]
     }
@@ -133,6 +153,10 @@ expression: Object(Symbol(42))
                     type : symbol
                 }
             }
+            [1] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
         ]
     }
 }
@@ -148,6 +172,10 @@ expression: Object(BigInt(2))
                     type : bigint
                     unserializableValue : 2n
                 }
+            }
+            [1] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
             }
         ]
     }
@@ -174,6 +202,10 @@ expression: Promise.resolve(42)
                     value : 42
                 }
             }
+            [2] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
         ]
     }
 }
@@ -194,6 +226,10 @@ expression: new Promise(() => undefined)
                 value : {
                     type : undefined
                 }
+            }
+            [2] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
             }
         ]
     }
@@ -231,6 +267,10 @@ expression: gen1
                 }
             }
             [3] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+            [4] : {
                 name : [[GeneratorLocation]]
                 value : {
                     description : Object
@@ -243,7 +283,7 @@ expression: gen1
                     }
                 }
             }
-            [4] : {
+            [5] : {
                 name : [[Scopes]]
                 value : {
                     className : Array
@@ -287,6 +327,10 @@ expression: gen1.next();gen1
                 }
             }
             [3] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+            [4] : {
                 name : [[GeneratorLocation]]
                 value : {
                     description : Object
@@ -299,7 +343,7 @@ expression: gen1.next();gen1
                     }
                 }
             }
-            [4] : {
+            [5] : {
                 name : [[Scopes]]
                 value : {
                     className : Array
@@ -343,6 +387,10 @@ expression: gen1.next();gen1
                 }
             }
             [3] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+            [4] : {
                 name : [[GeneratorLocation]]
                 value : {
                     description : Object
@@ -391,6 +439,10 @@ expression: gen2
                 }
             }
             [3] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+            [4] : {
                 name : [[GeneratorLocation]]
                 value : {
                     description : Object
@@ -403,7 +455,7 @@ expression: gen2
                     }
                 }
             }
-            [4] : {
+            [5] : {
                 name : [[Scopes]]
                 value : {
                     className : Array
@@ -447,6 +499,10 @@ expression: gen2.next();gen2
                 }
             }
             [3] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+            [4] : {
                 name : [[GeneratorLocation]]
                 value : {
                     description : Object
@@ -459,7 +515,7 @@ expression: gen2.next();gen2
                     }
                 }
             }
-            [4] : {
+            [5] : {
                 name : [[Scopes]]
                 value : {
                     className : Array
@@ -503,6 +559,10 @@ expression: gen2.next();gen2
                 }
             }
             [3] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+            [4] : {
                 name : [[GeneratorLocation]]
                 value : {
                     description : Object
@@ -548,6 +608,10 @@ expression: (new Map([[1,2]])).entries()
                 }
             }
             [3] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+            [4] : {
                 name : [[Entries]]
                 value : {
                     className : Array
@@ -588,6 +652,10 @@ expression: (new Set([[1,2]])).entries()
                 }
             }
             [3] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+            [4] : {
                 name : [[Entries]]
                 value : {
                     className : Array

--- a/deps/v8/test/inspector/runtime/stable-object-id-expected.txt
+++ b/deps/v8/test/inspector/runtime/stable-object-id-expected.txt
@@ -1,0 +1,14 @@
+Checks that protocol returns the same RemoteObjectId for the same object
+
+Running test: testGlobal
+Compare global evaluated twice: true
+
+Running test: testObject
+Compare object evaluated twice: true
+
+Running test: testObjectInArray
+Compare first and second element: true
+
+Running test: testObjectOnPause
+Compare global and this: true
+Compare a and a on pause: true

--- a/deps/v8/test/inspector/runtime/stable-object-id.js
+++ b/deps/v8/test/inspector/runtime/stable-object-id.js
@@ -1,0 +1,77 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+let {session, contextGroup, Protocol} = InspectorTest.start(
+    'Checks that protocol returns the same RemoteObjectId for the same object');
+
+InspectorTest.runAsyncTestSuite([
+  async function testGlobal() {
+    const {result:{result:{objectId:firstId}}} =
+        await Protocol.Runtime.evaluate({expression: 'this'});
+    const firstStableId = await stableObjectId(firstId);
+    const {result:{result:{objectId:secondId}}} =
+        await Protocol.Runtime.evaluate({expression: 'this'});
+    const secondStableId = await stableObjectId(secondId);
+    InspectorTest.log(
+        `Compare global evaluated twice: ${firstStableId === secondStableId}`);
+  },
+
+  async function testObject() {
+    const {result:{result:{objectId:firstId}}} =
+        await Protocol.Runtime.evaluate({expression: 'this.a = {}, this.a'});
+    const firstStableId = await stableObjectId(firstId);
+    const {result:{result:{objectId:secondId}}} =
+        await Protocol.Runtime.evaluate({expression: 'this.a'});
+    const secondStableId = await stableObjectId(secondId);
+    InspectorTest.log(
+        `Compare object evaluated twice: ${firstStableId === secondStableId}`);
+  },
+
+  async function testObjectInArray() {
+    await Protocol.Runtime.evaluate({expression: 'this.b = [this.a, this.a]'});
+    const {result:{result:{objectId:firstId}}} =
+        await Protocol.Runtime.evaluate({expression: 'this.b[0]'});
+    const firstStableId = await stableObjectId(firstId);
+    const {result:{result:{objectId:secondId}}} =
+        await Protocol.Runtime.evaluate({expression: 'this.b[1]'});
+    const secondStableId = await stableObjectId(secondId);
+    InspectorTest.log(
+        `Compare first and second element: ${firstStableId === secondStableId}`);
+  },
+
+  async function testObjectOnPause() {
+    const {result:{result:{objectId:globalId}}} =
+        await Protocol.Runtime.evaluate({expression: 'this'});
+    const globalStableId = await stableObjectId(globalId);
+    const {result:{result:{objectId:aId}}} =
+        await Protocol.Runtime.evaluate({expression: 'this.a'});
+    const aStableId = await stableObjectId(aId);
+    await Protocol.Debugger.enable();
+    Protocol.Runtime.evaluate({expression: 'debugger'});
+    const {params:{callFrames:[topFrame]}} =
+        await Protocol.Debugger.oncePaused();
+    const topFrameThisStableId = await stableObjectId(topFrame.this.objectId);
+    InspectorTest.log(
+        `Compare global and this: ${globalStableId === topFrameThisStableId}`);
+
+    const {result:{result: props}} = await Protocol.Runtime.getProperties({
+      objectId: topFrame.scopeChain[0].object.objectId
+    });
+    const {value:{objectId: aIdOnPause}} = props.find(prop => prop.name === 'a');
+    const aStableIdOnPause = await stableObjectId(aIdOnPause);
+    InspectorTest.log(`Compare a and a on pause: ${
+        aStableId === aStableIdOnPause}`);
+  }
+]);
+
+async function stableObjectId(objectId) {
+  const {result:{
+    internalProperties: props
+  }} = await Protocol.Runtime.getProperties({
+    objectId,
+    ownProperties: true,
+    generatePreview: false
+  });
+  return props.find(prop => prop.name === '[[StableObjectId]]').value.value;
+}

--- a/deps/v8/test/inspector/sessions/runtime-remote-object-expected.txt
+++ b/deps/v8/test/inspector/sessions/runtime-remote-object-expected.txt
@@ -5,6 +5,12 @@ Retrieving properties in 2
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -38,6 +44,12 @@ Retrieving properties in 1
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true
@@ -72,6 +84,12 @@ Retrieving properties in 1
 {
     id : <messageId>
     result : {
+        internalProperties : [
+            [0] : {
+                name : [[StableObjectId]]
+                value : <StablectObjectId>
+            }
+        ]
         result : [
             [0] : {
                 configurable : true


### PR DESCRIPTION
Original commit message:

	inspector: return [[StableObjectId]] as internal property

	This property might be useful for fast '===' check.

	R=dgozman@chromium.org,yangguo@chromium.org

	Bug: none
	Cq-Include-Trybots: luci.chromium.try:linux_chromium_headless_rel;luci.chromium.try:linux_chromium_rel_ng;master.tryserver.blink:linux_trusty_blink_rel
	Change-Id: Iabc3555ce1ec2c14cf0ccd40b7d964ae144e7352
	Reviewed-on: https://chromium-review.googlesource.com/1226411
	Reviewed-by: Dmitry Gozman <dgozman@chromium.org>
	Reviewed-by: Yang Guo <yangguo@chromium.org>
	Reviewed-by: Jakob Gruber <jgruber@chromium.org>
	Commit-Queue: Aleksey Kozyatinskiy <kozyatinskiy@chromium.org>
	Cr-Commit-Position: refs/heads/master@{#56095}

See: #23886

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
