### PR TITLE
crypto: remove deprecated crypto._toBuf

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2161,15 +2161,18 @@ release.
 ### DEP0114: crypto._toBuf()
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/???
+    description: End-of-Life.
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/22501
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-Of-Life
 
 The `crypto._toBuf()` function was not designed to be used by modules outside
-of Node.js core and will be removed in the future.
+of Node.js core and was removed.
 
 <a id="DEP0115"></a>
 ### DEP0115: crypto.prng(), crypto.pseudoRandomBytes(), crypto.rng()

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -94,8 +94,7 @@ const {
   getHashes,
   setDefaultEncoding,
   setEngine,
-  timingSafeEqual,
-  toBuf
+  timingSafeEqual
 } = require('internal/crypto/util');
 const Certificate = require('internal/crypto/certificate');
 
@@ -216,10 +215,6 @@ function getFipsForced() {
 }
 
 Object.defineProperties(exports, {
-  _toBuf: {
-    enumerable: false,
-    value: deprecate(toBuf, 'crypto._toBuf is deprecated.', 'DEP0114')
-  },
   createCipher: {
     enumerable: false,
     value: deprecate(createCipher,

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -27,8 +27,7 @@ if (!common.hasCrypto)
 
 common.expectWarning({
   DeprecationWarning: [
-    ['crypto.createCipher is deprecated.', 'DEP0106'],
-    ['crypto._toBuf is deprecated.', 'DEP0114']
+    ['crypto.createCipher is deprecated.', 'DEP0106']
   ]
 });
 
@@ -301,8 +300,3 @@ testEncoding({
 testEncoding({
   defaultEncoding: 'latin1'
 }, assertionHashLatin1);
-
-{
-  // Test that the exported _toBuf function is deprecated.
-  crypto._toBuf(Buffer.alloc(0));
-}


### PR DESCRIPTION
This function has never been documented and was runtime-deprecated in node 11. It is trivial to implement and I cannot find any usage outside of node core.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
