### PR TITLE
doc: add clarification for exception behaviour

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -531,10 +531,10 @@ In many cases when an N-API function is called and an exception is
 already pending, the function will return immediately with a
 `napi_status` of `napi_pending_exception`. However, this is not the case
 for all functions. N-API allows a subset of the functions to be
-called to allow for some minimal cleanup
-before returning to JavaScript. In that case, `napi_status` will reflect
-the status for the function. It will not reflect previous pending exceptions.
-To avoid confusion, check the error status after every function call.
+called to allow for some minimal cleanup before returning to JavaScript.
+In that case, `napi_status` will reflect the status for the function. It
+will not reflect previous pending exceptions. To avoid confusion, check
+the error status after every function call.
 
 When an exception is pending one of two approaches can be employed.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -531,7 +531,7 @@ In many cases when an N-API function is called and an exception is
 already pending, the function will return immediately with a
 `napi_status` of `napi_pending_exception`. However, this is not the case
 for all functions. N-API allows a subset of the functions to be
-called in order to allow for some minimal cleanup to be completed
+called to allow for some minimal cleanup
 before returning to JavaScript. For those functions, `napi_status`
 will reflect the success/error/exception for that function, irrespective of
 whether an exception was pending when the function was called.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -528,7 +528,7 @@ instead of simply returning immediately, [`napi_is_exception_pending`][]
 must be called in order to determine if an exception is pending or not.
 
 In many cases when an N-API function is called and an exception is
-already pending the function will return immediately with a
+already pending, the function will return immediately with a
 `napi_status` of `napi_pending_exception`. However, this is not the case
 for all functions. N-API allows a subset of the functions to be
 called in order to allow for some minimal cleanup to be completed

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -532,11 +532,9 @@ already pending, the function will return immediately with a
 `napi_status` of `napi_pending_exception`. However, this is not the case
 for all functions. N-API allows a subset of the functions to be
 called to allow for some minimal cleanup
-before returning to JavaScript. For those functions, `napi_status`
-will reflect the success/error/exception for that function, irrespective of
-whether an exception was pending when the function was called.
-To avoid confusion, check the
-error status after every function call.
+before returning to JavaScript. In that case, `napi_status` will reflect
+the status for the function. It will not reflect previous pending exceptions.
+To avoid confusion, check the error status after every function call.
 
 When an exception is pending one of two approaches can be employed.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -535,7 +535,7 @@ called in order to allow for some minimal cleanup to be completed
 before returning to JavaScript. For those functions, `napi_status`
 will reflect the success/error/exception for that function, irrespective of
 whether an exception was pending when the function was called.
-In order to avoid confusion it is important to check the
+To avoid confusion, check the
 error status after every function call.
 
 When an exception is pending one of two approaches can be employed.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -527,6 +527,17 @@ exception is pending and no additional action is required. If the
 instead of simply returning immediately, [`napi_is_exception_pending`][]
 must be called in order to determine if an exception is pending or not.
 
+In many cases when an N-API function is called and an exception is
+already pending the function will return immediately with a
+`napi_status` of `napi_pending_exception`. However, this is not the case
+for all functions. N-API allows a subset of the functions to be
+called in order to allow for some minimal cleanup to be completed
+before returning to JavaScript. For those functions, `napi_status`
+will reflect the success/error/exception for that function, irrespective of
+whether an exception was pending when the function was called.
+In order to avoid confusion it is important to check the
+error status after every function call.
+
 When an exception is pending one of two approaches can be employed.
 
 The first approach is to do any appropriate cleanup and then return so that


### PR DESCRIPTION
Refs: https://github.com/nodejs/abi-stable-node/issues/356

Document current behaviour where some methods can be called
when an exception is pending, while others cannot and explain
the behaviour.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
