### PR TITLE
doc: fs.mkdir('/') throws EPERM on Windows

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2212,6 +2212,15 @@ fs.mkdir('/tmp/a/apple', { recursive: true }, (err) => {
 });
 ```
 
+On Windows, using `fs.mkdir()` on the root directory even with recursion will
+result in an error:
+
+```js
+fs.mkdir('/', { recursive: true }, (err) => {
+  // => [Error: EPERM: operation not permitted, mkdir 'C:\']
+});
+```
+
 See also: mkdir(2).
 
 ## fs.mkdirSync(path[, options])


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/25110

##### Checklist

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

CC @bcoe @nodejs/fs