### PR TITLE
test: tune test-uv-threadpool-schedule

### DIFF
--- a/test/internet/test-uv-threadpool-schedule.js
+++ b/test/internet/test-uv-threadpool-schedule.js
@@ -15,7 +15,7 @@ const assert = require('assert');
 
 const start = Date.now();
 
-const slowIOmax = 100;
+const slowIOmax = 10;
 let slowIOcount = 0;
 let fastIOdone = false;
 let slowIOend, fastIOend;
@@ -37,7 +37,7 @@ function onResolve() {
     // highly load / platform dependent, so don't be very greedy.
     const fastIOtime = fastIOend - start;
     const slowIOtime = slowIOend - start;
-    const expectedMax = slowIOtime / 100;
+    const expectedMax = slowIOtime / 10;
     assert.ok(fastIOtime < expectedMax,
               'fast I/O took longer to complete, ' +
               `actual: ${fastIOtime}, expected: ${expectedMax}`);

--- a/test/internet/test-uv-threadpool-schedule.js
+++ b/test/internet/test-uv-threadpool-schedule.js
@@ -15,7 +15,7 @@ const assert = require('assert');
 
 const start = Date.now();
 
-const slowIOmax = 10;
+const slowIOmax = 100;
 let slowIOcount = 0;
 let fastIOdone = false;
 let slowIOend, fastIOend;
@@ -31,13 +31,13 @@ function onResolve() {
               'fast I/O was throttled due to threadpool congestion.');
 
     // More realistic expectation: finish disc I/O at least within
-    // a time duration that is 1/100th of net I/O.
+    // a time duration that is half of net I/O.
     // Ideally the slow I/O should not affect the fast I/O as those
     // have two different thread-pool buckets. However, this could be
     // highly load / platform dependent, so don't be very greedy.
     const fastIOtime = fastIOend - start;
     const slowIOtime = slowIOend - start;
-    const expectedMax = slowIOtime / 10;
+    const expectedMax = slowIOtime / 2;
     assert.ok(fastIOtime < expectedMax,
               'fast I/O took longer to complete, ' +
               `actual: ${fastIOtime}, expected: ${expectedMax}`);


### PR DESCRIPTION
test-uv-threadpool-schedule has been failing consistently in
node-daily-master CI. It also fails consistently on my personal laptop.
These changes make it pass consistently with current master but fail
consistently with Node.js 10.11 (which was the last release in the 10.x
line before the fix that the test is for). It succeeds/fails as expected
whether or not I am connected to the network.

Fixes: https://github.com/nodejs/node/issues/25305

/ping @gireeshpunathil 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
