### PR TITLE
path: join refactor

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -368,20 +368,19 @@ const win32 = {
     if (args.length === 0)
       return '.';
 
-    let joined;
-    let firstPart;
-    for (let i = 0; i < args.length; ++i) {
-      const arg = args[i];
+    let joined = null;
+    let firstPart = null;
+    for (const arg of args) {
       validateString(arg, 'path');
       if (arg.length > 0) {
-        if (joined === undefined)
+        if (joined === null)
           joined = firstPart = arg;
         else
           joined += `\\${arg}`;
       }
     }
 
-    if (joined === undefined)
+    if (joined === null)
       return '.';
 
     // Make sure that the joined path doesn't start with two slashes, because


### PR DESCRIPTION
Change variables init from var to let/const, added destructurization to function arguments and change old ```for``` to new ```for of```

##### Local bench tests join
```
                                                                         confidence improvement accuracy (*)   (**)   (***)
 path/join-posix.js n=1000000 paths='/foo|bar||baz/asdf|quux|..'                         2.42 %       ±7.16% ±9.54% ±12.42%
 path/join-win32.js n=1000000 paths='C:\\\\foo|bar||baz\\\\asdf|quux|..'                -0.92 %       ±5.18% ±6.90%  ±8.98%

```

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
