### PR TITLE
test: fix test-benchmark-zlib

### DIFF
--- a/test/benchmark/test-benchmark-zlib.js
+++ b/test/benchmark/test-benchmark-zlib.js
@@ -6,6 +6,7 @@ const runBenchmark = require('../common/benchmark');
 
 runBenchmark('zlib',
              [
+               'algorithm=brotli',
                'method=deflate',
                'n=1',
                'options=true',


### PR DESCRIPTION
The addition of brotli to zlib benchmarks means that test-benchmark-zlib
needs to be modified. This is that modification.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
