### PR TITLE
doc: NAPI `napi_open_callback_scope`

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -4109,7 +4109,7 @@ NAPI_EXTERN napi_status napi_open_callback_scope(napi_env env,
                                                  napi_callback_scope* result)
 ```
 - `[in] env`: The environment that the API is invoked under.
-- `[in] resource_object`: An optional object associated with the async work
+- `[in] resource_object`: An object associated with the async work
   that will be passed to possible `async_hooks` [`init` hooks][].
 - `[in] context`: Context for the async operation that is
 invoking the callback. This should be a value previously obtained


### PR DESCRIPTION
- parameter `resource_object` is mandatory

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Description

According to [documention](https://nodejs.org/api/n-api.html#n_api_napi_open_callback_scope) `napi_open_callback_scope`'s parameter `resource_object` is optional.

```
[in] resource_object: An optional object associated with the async work that will be passed to possible async_hooks init hooks.
```
, but when I do this:
```cpp
status = napi_open_callback_scope(env, nullptr, async_context, &scope);
```
I get `napi_invalid_arg` and when I do this:
```cpp
status = napi_open_callback_scope(env, resource_object, async_context, &scope);
```
it's `napi_ok`, so I checked impl and found this in [node_api.cc](https://github.com/nodejs/node/blob/master/src/node_api.cc#L565):
```
v8::Local<v8::Object> resource;
CHECK_TO_OBJECT(env, context, resource, resource_object);
```
which makes me think that documentation is wrong, so here the PR for documentation.