### PR TITLE
doc: update benchmark doc

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -23,13 +23,6 @@ directory, see [the guide on benchmarks](../doc/guides/writing-and-running-bench
   </thead>
   <tbody>
     <tr>
-      <td>arrays</td>
-      <td>
-        Benchmarks for various operations on array-like objects,
-        including <code>Array</code>, <code>Buffer</code>, and typed arrays.
-      </td>
-    </tr>
-    <tr>
       <td>assert</td>
       <td>
         Benchmarks for the <code>assert</code> subsystem.

--- a/doc/guides/writing-and-running-benchmarks.md
+++ b/doc/guides/writing-and-running-benchmarks.md
@@ -125,28 +125,28 @@ run `node benchmark/run.js`. Again this does not provide the statistical
 information to make any conclusions.
 
 ```console
-$ node benchmark/run.js arrays
+$ node benchmark/run.js assert
 
-arrays/var-int.js
-arrays/var-int.js n=25 type=Array: 71.90148040747789
-arrays/var-int.js n=25 type=Buffer: 92.89648382795582
+assert/deepequal-buffer.js
+assert/deepequal-buffer.js method="deepEqual" strict=0 len=100 n=20000: 773,200.4995493788
+assert/deepequal-buffer.js method="notDeepEqual" strict=0 len=100 n=20000: 964,411.712953848
 ...
 
-arrays/zero-float.js
-arrays/zero-float.js n=25 type=Array: 75.46208316171496
-arrays/zero-float.js n=25 type=Buffer: 101.62785630273159
+assert/deepequal-map.js
+assert/deepequal-map.js method="deepEqual_primitiveOnly" strict=0 len=500 n=500: 20,445.06368453332
+assert/deepequal-map.js method="deepEqual_objectOnly" strict=0 len=500 n=500: 1,393.3481642240833
 ...
 
-arrays/zero-int.js
-arrays/zero-int.js n=25 type=Array: 72.31023859816062
-arrays/zero-int.js n=25 type=Buffer: 90.49906662339653
+assert/deepequal-object.js
+assert/deepequal-object.js method="deepEqual" strict=0 size=100 n=5000: 1,053.1950937538475
+assert/deepequal-object.js method="notDeepEqual" strict=0 size=100 n=5000: 9,734.193251965213
 ...
 ```
 
 It is possible to execute more groups by adding extra process arguments.
 
 ```console
-$ node benchmark/run.js arrays buffers
+$ node benchmark/run.js assert async_hooks
 ```
 
 ### Comparing Node.js versions


### PR DESCRIPTION
Benchmark for arrays no longer exists, but it was still referenced in
documentation.

Refs: https://github.com/nodejs/node/pull/21831

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
