### PR TITLE
src: remove unused isolate variable

### DIFF
--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -90,7 +90,6 @@ void PromiseRejectCallback(PromiseRejectMessage message) {
 static void SetPromiseRejectCallback(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
 
   CHECK(args[0]->IsFunction());
   env->set_promise_reject_callback(args[0].As<Function>());


### PR DESCRIPTION
Currently the following compiler warning is generated:
```console
../src/node_task_queue.cc:93:12: warning:
unused variable 'isolate' [-Wunused-variable]
  Isolate* isolate = env->isolate();
           ^
1 warning generated.
```
This commit removes the unused variable.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
