### PR TITLE
test: fix test/pummel/test-fs-largefile.js

### DIFF
--- a/test/pummel/test-fs-largefile.js
+++ b/test/pummel/test-fs-largefile.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 
 const assert = require('assert');
 const fs = require('fs');
@@ -46,7 +46,7 @@ assert.strictEqual(readBuf[0], 0);
 
 // Verify that floating point positions do not throw.
 fs.writeSync(fd, writeBuf, 0, writeBuf.length, 42.000001);
-fs.close(fd);
+fs.close(fd, common.mustCall());
 
 // Normally, we don't clean up tmp files at the end of a test, but we'll make an
 // exception for a 5 GB file.


### PR DESCRIPTION
test-fs-largefile.js calls `fs.close()` without a callback which results
in an error as of Node.js 10.0.0. Add a `common.mustCall()` callback so
the test passes again.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
