### PR TITLE
util: end of life console lookalike runtime deprecations

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -611,6 +611,9 @@ Type: End-of-Life
 ### DEP0028: util.debug()
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/xxxxx
+    description: End-of-Life.
   - version:
     - v4.8.6
     - v6.12.0
@@ -621,10 +624,9 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-The [`util.debug()`][] API is deprecated. Please use [`console.error()`][]
-instead.
+`util.debug()` has been removed. Please use [`console.error()`][] instead.
 
 <a id="DEP0029"></a>
 ### DEP0029: util.error()
@@ -2395,7 +2397,6 @@ Setting the TLS ServerName to an IP address is not permitted by
 [`url.parse()`]: url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
 [`url.resolve()`]: url.html#url_url_resolve_from_to
 [`util._extend()`]: util.html#util_util_extend_target_source
-[`util.debug()`]: util.html#util_util_debug_string
 [`util.error()`]: util.html#util_util_error_strings
 [`util.getSystemErrorName()`]: util.html#util_util_getsystemerrorname_err
 [`util.inspect()`]: util.html#util_util_inspect_object_options

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -590,6 +590,9 @@ Type: End-of-Life
 ### DEP0027: util.puts()
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/xxxxx
+    description: End-of-Life.
   - version:
     - v4.8.6
     - v6.12.0
@@ -600,9 +603,9 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-The [`util.puts()`][] API is deprecated. Please use [`console.log()`][] instead.
+`util.puts()` has been removed. Please use [`console.log()`][] instead.
 
 <a id="DEP0028"></a>
 ### DEP0028: util.debug()
@@ -2413,7 +2416,6 @@ Setting the TLS ServerName to an IP address is not permitted by
 [`util.isSymbol()`]: util.html#util_util_issymbol_object
 [`util.isUndefined()`]: util.html#util_util_isundefined_object
 [`util.log()`]: util.html#util_util_log_string
-[`util.puts()`]: util.html#util_util_puts_strings
 [`util.types`]: util.html#util_util_types
 [`util`]: util.html
 [`worker.exitedAfterDisconnect`]: cluster.html#cluster_worker_exitedafterdisconnect

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -632,6 +632,9 @@ Type: End-of-Life
 ### DEP0029: util.error()
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/xxxxx
+    description: End-of-Life.
   - version:
     - v4.8.6
     - v6.12.0
@@ -642,10 +645,9 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-The [`util.error()`][] API is deprecated. Please use [`console.error()`][]
-instead.
+`util.error()` has been removed. Please use [`console.error()`][] instead.
 
 <a id="DEP0030"></a>
 ### DEP0030: SlowBuffer
@@ -2397,7 +2399,6 @@ Setting the TLS ServerName to an IP address is not permitted by
 [`url.parse()`]: url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
 [`url.resolve()`]: url.html#url_url_resolve_from_to
 [`util._extend()`]: util.html#util_util_extend_target_source
-[`util.error()`]: util.html#util_util_error_strings
 [`util.getSystemErrorName()`]: util.html#util_util_getsystemerrorname_err
 [`util.inspect()`]: util.html#util_util_inspect_object_options
 [`util.inspect.custom`]: util.html#util_util_inspect_custom

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -569,6 +569,9 @@ The `sys` module is deprecated. Please use the [`util`][] module instead.
 ### DEP0026: util.print()
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/xxxxx
+    description: End-of-Life.
   - version:
     - v4.8.6
     - v6.12.0
@@ -579,10 +582,9 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-The [`util.print()`][] API is deprecated. Please use [`console.log()`][]
-instead.
+`util.print()` has been removed. Please use [`console.log()`][] instead.
 
 <a id="DEP0027"></a>
 ### DEP0027: util.puts()
@@ -2411,7 +2413,6 @@ Setting the TLS ServerName to an IP address is not permitted by
 [`util.isSymbol()`]: util.html#util_util_issymbol_object
 [`util.isUndefined()`]: util.html#util_util_isundefined_object
 [`util.log()`]: util.html#util_util_log_string
-[`util.print()`]: util.html#util_util_print_strings
 [`util.puts()`]: util.html#util_util_puts_strings
 [`util.types`]: util.html#util_util_types
 [`util`]: util.html

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2167,16 +2167,6 @@ const util = require('util');
 util.log('Timestamped message.');
 ```
 
-### util.puts([...strings])
-<!-- YAML
-added: v0.3.0
-deprecated: v0.11.3
--->
-
-> Stability: 0 - Deprecated: Use [`console.log()`][] instead.
-
-Deprecated predecessor of `console.log`.
-
 [`'uncaughtException'`]: process.html#process_event_uncaughtexception
 [`'warning'`]: process.html#process_event_warning
 [`Array.isArray()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray
@@ -2207,7 +2197,6 @@ Deprecated predecessor of `console.log`.
 [`WebAssembly.Module`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
 [`assert.deepStrictEqual()`]: assert.html#assert_assert_deepstrictequal_actual_expected_message
 [`console.error()`]: console.html#console_console_error_data_args
-[`console.log()`]: console.html#console_console_log_data_args
 [`target` and `handler`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#Terminology
 [`util.format()`]: #util_util_format_format_args
 [`util.inspect()`]: #util_util_inspect_object_options

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1714,18 +1714,6 @@ Node.js modules. The community found and used it anyway.
 It is deprecated and should not be used in new code. JavaScript comes with very
 similar built-in functionality through [`Object.assign()`].
 
-### util.error([...strings])
-<!-- YAML
-added: v0.3.0
-deprecated: v0.11.3
--->
-
-> Stability: 0 - Deprecated: Use [`console.error()`][] instead.
-
-* `...strings` {string} The message to print to `stderr`
-
-Deprecated predecessor of `console.error`.
-
 ### util.isArray(object)
 <!-- YAML
 added: v0.6.0

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1714,18 +1714,6 @@ Node.js modules. The community found and used it anyway.
 It is deprecated and should not be used in new code. JavaScript comes with very
 similar built-in functionality through [`Object.assign()`].
 
-### util.debug(string)
-<!-- YAML
-added: v0.3.0
-deprecated: v0.11.3
--->
-
-> Stability: 0 - Deprecated: Use [`console.error()`][] instead.
-
-* `string` {string} The message to print to `stderr`
-
-Deprecated predecessor of `console.error`.
-
 ### util.error([...strings])
 <!-- YAML
 added: v0.3.0

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2167,16 +2167,6 @@ const util = require('util');
 util.log('Timestamped message.');
 ```
 
-### util.print([...strings])
-<!-- YAML
-added: v0.3.0
-deprecated: v0.11.3
--->
-
-> Stability: 0 - Deprecated: Use [`console.log()`][] instead.
-
-Deprecated predecessor of `console.log`.
-
 ### util.puts([...strings])
 <!-- YAML
 added: v0.3.0

--- a/lib/util.js
+++ b/lib/util.js
@@ -326,12 +326,6 @@ function _extend(target, source) {
 
 // Deprecated old stuff.
 
-function print(...args) {
-  for (var i = 0, len = args.length; i < len; ++i) {
-    process.stdout.write(String(args[i]));
-  }
-}
-
 function puts(...args) {
   for (var i = 0, len = args.length; i < len; ++i) {
     process.stdout.write(`${args[i]}\n`);
@@ -447,9 +441,6 @@ module.exports = exports = {
   error: deprecate(error,
                    'util.error is deprecated. Use console.error instead.',
                    'DEP0029'),
-  print: deprecate(print,
-                   'util.print is deprecated. Use console.log instead.',
-                   'DEP0026'),
   puts: deprecate(puts,
                   'util.puts is deprecated. Use console.log instead.',
                   'DEP0027')

--- a/lib/util.js
+++ b/lib/util.js
@@ -326,12 +326,6 @@ function _extend(target, source) {
 
 // Deprecated old stuff.
 
-function puts(...args) {
-  for (var i = 0, len = args.length; i < len; ++i) {
-    process.stdout.write(`${args[i]}\n`);
-  }
-}
-
 function debug(x) {
   process.stderr.write(`DEBUG: ${x}\n`);
 }
@@ -440,8 +434,5 @@ module.exports = exports = {
                    'DEP0028'),
   error: deprecate(error,
                    'util.error is deprecated. Use console.error instead.',
-                   'DEP0029'),
-  puts: deprecate(puts,
-                  'util.puts is deprecated. Use console.log instead.',
-                  'DEP0027')
+                   'DEP0029')
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -325,11 +325,6 @@ function _extend(target, source) {
 }
 
 // Deprecated old stuff.
-
-function debug(x) {
-  process.stderr.write(`DEBUG: ${x}\n`);
-}
-
 function error(...args) {
   for (var i = 0, len = args.length; i < len; ++i) {
     process.stderr.write(`${args[i]}\n`);
@@ -429,9 +424,6 @@ module.exports = exports = {
   types,
 
   // Deprecated Old Stuff
-  debug: deprecate(debug,
-                   'util.debug is deprecated. Use console.error instead.',
-                   'DEP0028'),
   error: deprecate(error,
                    'util.error is deprecated. Use console.error instead.',
                    'DEP0029')

--- a/lib/util.js
+++ b/lib/util.js
@@ -324,13 +324,6 @@ function _extend(target, source) {
   return target;
 }
 
-// Deprecated old stuff.
-function error(...args) {
-  for (var i = 0, len = args.length; i < len; ++i) {
-    process.stderr.write(`${args[i]}\n`);
-  }
-}
-
 function callbackifyOnRejected(reason, cb) {
   // `!reason` guard inspired by bluebird (Ref: https://goo.gl/t5IS6M).
   // Because `null` is a special error value in callbacks which means "no error
@@ -421,10 +414,5 @@ module.exports = exports = {
   promisify,
   TextDecoder,
   TextEncoder,
-  types,
-
-  // Deprecated Old Stuff
-  error: deprecate(error,
-                   'util.error is deprecated. Use console.error instead.',
-                   'DEP0029')
+  types
 };

--- a/test/fixtures/deprecated.js
+++ b/test/fixtures/deprecated.js
@@ -1,1 +1,7 @@
-require('util').debug('This is deprecated');
+'use strict';
+const util = require('util');
+const deprecated = util.deprecate(() => {
+  console.error('This is deprecated');
+}, 'this function is deprecated');
+
+deprecated();

--- a/test/fixtures/test-init-index/index.js
+++ b/test/fixtures/test-init-index/index.js
@@ -20,6 +20,6 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 (function() {
-  require('util').print('Loaded successfully!');
+  process.stdout.write('Loaded successfully!');
 })();
 

--- a/test/fixtures/test-init-native/fs.js
+++ b/test/fixtures/test-init-native/fs.js
@@ -22,7 +22,7 @@
 (function() {
   const fs = require('fs');
   if (fs.readFile) {
-    require('util').print('fs loaded successfully');
+    process.stdout.write('fs loaded successfully');
   }
 })();
 

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -21,7 +21,7 @@
 
 'use strict';
 // Flags: --expose-internals
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const util = require('util');
 const errors = require('internal/errors');
@@ -143,12 +143,6 @@ assert.strictEqual(util.isFunction(() => {}), true);
 assert.strictEqual(util.isFunction(function() {}), true);
 assert.strictEqual(util.isFunction(), false);
 assert.strictEqual(util.isFunction('string'), false);
-
-common.expectWarning('DeprecationWarning', [
-  ['util.error is deprecated. Use console.error instead.', 'DEP0029']
-]);
-
-util.error('test');
 
 {
   assert.strictEqual(util.types.isNativeError(new Error()), true);

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -145,13 +145,11 @@ assert.strictEqual(util.isFunction(), false);
 assert.strictEqual(util.isFunction('string'), false);
 
 common.expectWarning('DeprecationWarning', [
-  ['util.print is deprecated. Use console.log instead.', 'DEP0026'],
   ['util.puts is deprecated. Use console.log instead.', 'DEP0027'],
   ['util.debug is deprecated. Use console.error instead.', 'DEP0028'],
   ['util.error is deprecated. Use console.error instead.', 'DEP0029']
 ]);
 
-util.print('test');
 util.puts('test');
 util.debug('test');
 util.error('test');

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -145,12 +145,10 @@ assert.strictEqual(util.isFunction(), false);
 assert.strictEqual(util.isFunction('string'), false);
 
 common.expectWarning('DeprecationWarning', [
-  ['util.puts is deprecated. Use console.log instead.', 'DEP0027'],
   ['util.debug is deprecated. Use console.error instead.', 'DEP0028'],
   ['util.error is deprecated. Use console.error instead.', 'DEP0029']
 ]);
 
-util.puts('test');
 util.debug('test');
 util.error('test');
 

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -145,11 +145,9 @@ assert.strictEqual(util.isFunction(), false);
 assert.strictEqual(util.isFunction('string'), false);
 
 common.expectWarning('DeprecationWarning', [
-  ['util.debug is deprecated. Use console.error instead.', 'DEP0028'],
   ['util.error is deprecated. Use console.error instead.', 'DEP0029']
 ]);
 
-util.debug('test');
 util.error('test');
 
 {

--- a/test/sequential/test-deprecation-flags.js
+++ b/test/sequential/test-deprecation-flags.js
@@ -44,7 +44,7 @@ execFile(node, normal, function(er, stdout, stderr) {
   console.error('normal: show deprecation warning');
   assert.strictEqual(er, null);
   assert.strictEqual(stdout, '');
-  assert(/util\.debug is deprecated/.test(stderr));
+  assert(/this function is deprecated/.test(stderr));
   console.log('normal ok');
 });
 
@@ -52,7 +52,7 @@ execFile(node, noDep, function(er, stdout, stderr) {
   console.error('--no-deprecation: silence deprecations');
   assert.strictEqual(er, null);
   assert.strictEqual(stdout, '');
-  assert.strictEqual(stderr, 'DEBUG: This is deprecated\n');
+  assert.strictEqual(stderr.trim(), 'This is deprecated');
   console.log('silent ok');
 });
 
@@ -62,10 +62,8 @@ execFile(node, traceDep, function(er, stdout, stderr) {
   assert.strictEqual(stdout, '');
   const stack = stderr.trim().split('\n');
   // just check the top and bottom.
-  assert(
-    /util\.debug is deprecated\. Use console\.error instead\./.test(stack[1])
-  );
-  assert(/DEBUG: This is deprecated/.test(stack[0]));
+  assert(/this function is deprecated/.test(stack[1]));
+  assert(/This is deprecated/.test(stack[0]));
   console.log('trace ok');
 });
 


### PR DESCRIPTION
`util.print()`, `util.puts()`, `util.debug()` and `util.error()` have been runtime deprecated for nearly 6 years (v0.11.3), and `console` is the universal/standard way to print things.

Since this is semver-major, ping @nodejs/tsc.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
