### PR TITLE
mark scripts as shareable cross-origin

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -149,7 +149,7 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
     ScriptOrigin origin(url,
                         line_offset,                          // line offset
                         column_offset,                        // column offset
-                        False(isolate),                       // is cross origin
+                        True(isolate),                        // is cross origin
                         Local<Integer>(),                     // script id
                         Local<Value>(),                       // source map URL
                         False(isolate),                       // is opaque (?)

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -692,7 +692,7 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
   ScriptOrigin origin(filename,
                       line_offset,                          // line offset
                       column_offset,                        // column offset
-                      False(isolate),                       // is cross origin
+                      True(isolate),                        // is cross origin
                       Local<Integer>(),                     // script id
                       Local<Value>(),                       // source map URL
                       False(isolate),                       // is opaque (?)
@@ -1004,7 +1004,7 @@ void ContextifyContext::CompileFunction(
       data + cached_data_buf->ByteOffset(), cached_data_buf->ByteLength());
   }
 
-  ScriptOrigin origin(filename, line_offset, column_offset);
+  ScriptOrigin origin(filename, line_offset, column_offset, True(isolate));
   ScriptCompiler::Source source(code, origin, cached_data);
   ScriptCompiler::CompileOptions options;
   if (source.GetCachedData() == nullptr) {

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -215,7 +215,7 @@ MaybeLocal<Function> NativeModuleLoader::LookupAndCompile(
       OneByteString(isolate, filename_s.c_str(), filename_s.size());
   Local<Integer> line_offset = Integer::New(isolate, 0);
   Local<Integer> column_offset = Integer::New(isolate, 0);
-  ScriptOrigin origin(filename, line_offset, column_offset);
+  ScriptOrigin origin(filename, line_offset, column_offset, True(isolate));
 
   Mutex::ScopedLock lock(code_cache_mutex_);
 


### PR DESCRIPTION
This fixes an issue in Electron where errors were being incorrectly sanitized on their way to `window.onerror`. e.g.

```js
process.nextTick(() => throw new Error('hi'))
window.onerror = e => console.log(e)
```

was printing "Script error" instead of "Uncaught Error: hi"

This is due to origin-checking logic in Blink: https://chromium.googlesource.com/chromium/src/+/71.0.3578.123/third_party/blink/renderer/core/execution_context/execution_context.cc#114

cc @joyeecheung who is `blame` on a lot of this code :)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
