### PR TITLE
test: fix test/pummel/test-fs-watch-file.js

### DIFF
--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -60,12 +60,8 @@ process.on('exit', function() {
 fs.writeFileSync(filepathOne, 'hello');
 
 assert.throws(
-  function() {
-    fs.watchFile(filepathOne);
-  },
-  function(e) {
-    return e.message === '"watchFile()" requires a listener function';
-  }
+  () => { fs.watchFile(filepathOne); },
+  { code: 'ERR_INVALID_ARG_TYPE' }
 );
 
 // Does not throw.
@@ -84,12 +80,8 @@ process.chdir(testDir);
 fs.writeFileSync(filepathTwoAbs, 'howdy');
 
 assert.throws(
-  function() {
-    fs.watchFile(filepathTwo);
-  },
-  function(e) {
-    return e.message === '"watchFile()" requires a listener function';
-  }
+  () => { fs.watchFile(filepathTwo); },
+  { code: 'ERR_INVALID_ARG_TYPE' }
 );
 
 { // Does not throw.
@@ -114,9 +106,10 @@ setTimeout(function() {
     fs.unwatchFile(filenameThree, b);
     ++watchSeenThree;
   }
-  fs.watchFile(filenameThree, common.mustNotCall());
+  const uncalledListener = common.mustNotCall();
+  fs.watchFile(filenameThree, uncalledListener);
   fs.watchFile(filenameThree, b);
-  fs.unwatchFile(filenameThree, common.mustNotCall());
+  fs.unwatchFile(filenameThree, uncalledListener);
 }
 
 setTimeout(function() {


### PR DESCRIPTION
test-fs-watch-file.js fails for two reasons. First, there are cases
where it is checking the error message for an error whose message has
changed since the test was written. Change these instances to check for
an error code instead.

Second, there is an instance where it tries to remove a listener but
fails because `common.mustNotCall()` returns a differnet instance of a
function on each call. Store the function in a variable name so it can
be removed as a listener on a file.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
