### PR TITLE
tools: add openssl-cli to macos-firewall.sh

### DIFF
--- a/tools/macos-firewall.sh
+++ b/tools/macos-firewall.sh
@@ -18,6 +18,8 @@ NODE_DEBUG="$OUTDIR/Debug/node"
 NODE_LINK="$ROOTDIR/node"
 CCTEST_RELEASE="$OUTDIR/Release/cctest"
 CCTEST_DEBUG="$OUTDIR/Debug/cctest"
+OPENSSL_CLI_RELEASE="$OUTDIR/Release/openssl-cli"
+OPENSSL_CLI_DEBUG="$OUTDIR/Debug/openssl-cli"
 
 if [ -f $SFW ];
 then
@@ -31,18 +33,24 @@ then
   $SFW --remove "$NODE_LINK"
   $SFW --remove "$CCTEST_DEBUG"
   $SFW --remove "$CCTEST_RELEASE"
+  $SFW --remove "$OPENSSL_CLI_DEBUG"
+  $SFW --remove "$OPENSSL_CLI_RELEASE"
 
   $SFW --add "$NODE_DEBUG"
   $SFW --add "$NODE_RELEASE"
   $SFW --add "$NODE_LINK"
   $SFW --add "$CCTEST_DEBUG"
   $SFW --add "$CCTEST_RELEASE"
+  $SFW --add "$OPENSSL_CLI_DEBUG"
+  $SFW --add "$OPENSSL_CLI_RELEASE"
 
   $SFW --unblock "$NODE_DEBUG"
   $SFW --unblock "$NODE_RELEASE"
   $SFW --unblock "$NODE_LINK"
   $SFW --unblock "$CCTEST_DEBUG"
   $SFW --unblock "$CCTEST_RELEASE"
+  $SFW --unblock "$OPENSSL_CLI_DEBUG"
+  $SFW --unblock "$OPENSSL_CLI_RELEASE"
 else
   echo "SocketFirewall not found in location: $SFW"
 fi


### PR DESCRIPTION
Currently, there is a new popup asking to accept incoming connections
for openssl-cli when running tests on macos. I believe the reason
for this not being noticed before is that test-tls-securepair-client.js
was moved recently from the pummel directory to sequential.

This commit adds openssl-cli to the firewall script.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
