### PR TITLE
test: fix and refactor test-fs-watch-non-recursive

### DIFF
--- a/test/pummel/test-fs-watch-non-recursive.js
+++ b/test/pummel/test-fs-watch-non-recursive.js
@@ -24,7 +24,7 @@ const common = require('../common');
 const path = require('path');
 const fs = require('fs');
 
-const tmpdir = require('tmpdir');
+const tmpdir = require('../common/tmpdir');
 
 const testDir = tmpdir.path;
 const testsubdir = path.join(testDir, 'testsubdir');

--- a/test/pummel/test-fs-watch-non-recursive.js
+++ b/test/pummel/test-fs-watch-non-recursive.js
@@ -25,19 +25,13 @@ const path = require('path');
 const fs = require('fs');
 
 const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const testDir = tmpdir.path;
 const testsubdir = path.join(testDir, 'testsubdir');
 const filepath = path.join(testsubdir, 'watch.txt');
 
-function cleanup() {
-  try { fs.unlinkSync(filepath); } catch { }
-  try { fs.rmdirSync(testsubdir); } catch { }
-}
-process.on('exit', cleanup);
-cleanup();
-
-try { fs.mkdirSync(testsubdir, 0o700); } catch {}
+fs.mkdirSync(testsubdir, 0o700);
 
 // Need a grace period, else the mkdirSync() above fires off an event.
 setTimeout(function() {


### PR DESCRIPTION
test-fs-watch-non-recursive was loading the `common/tmpdir` module as if
it were a built-in and was failing because of it. Fix the path. The test
now works.

The test was duplicating some functionality in the `tmpdir` module. Use `tmpdir` module instead.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
