### PR TITLE
test: fix test-net-connect-econnrefused

### DIFF
--- a/test/pummel/test-net-connect-econnrefused.js
+++ b/test/pummel/test-net-connect-econnrefused.js
@@ -34,8 +34,6 @@ let reqs = 0;
 pummel();
 
 function pummel() {
-  console.log('Round', rounds, '/', ROUNDS);
-
   let pending;
   for (pending = 0; pending < ATTEMPTS_PER_ROUND; pending++) {
     net.createConnection(common.PORT).on('error', function(err) {


### PR DESCRIPTION
test/pummel/test-net-connect-econnrefuse.js was failing because
`console.log()` resulted in an extra handle being returned by
`process._getActiveHandles()`. Remove the unnecessary `console.log()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
