### PR TITLE
build: add check for empty openssl-fips flag

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1235,7 +1235,7 @@ def configure_openssl(o):
   if options.openssl_no_asm and options.shared_openssl:
     error('--openssl-no-asm is incompatible with --shared-openssl')
 
-  if options.openssl_fips:
+  if options.openssl_fips or options.openssl_fips == '':
      error('FIPS is not supported in this version of Node.js')
 
   configure_library('openssl', o)


### PR DESCRIPTION
Currently, when specifying the `--openssl-fips` flag without any path
, or an empty path, does not generate an error. If a path is specified
then the following error is generated:
```console
ERROR: FIPS is not supported in this version of Node.js
```
This commit adds a check so that the error is generated even if the
path is empty.

@nodejs/build-files 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
