### PR TITLE
tools: lint for use of internalBinding()

### DIFF
--- a/test/parallel/test-eslint-crypto-check.js
+++ b/test/parallel/test-eslint-crypto-check.js
@@ -19,6 +19,12 @@ new RuleTester().run('crypto-check', rule, {
       common.skip("missing crypto");
     }
     require("crypto");
+    `,
+    `
+    if (!common.hasCrypto) {
+      common.skip("missing crypto");
+    }
+    internalBinding("crypto");
     `
   ],
   invalid: [
@@ -51,6 +57,18 @@ new RuleTester().run('crypto-check', rule, {
               '}\n' +
               'if (common.foo) {}\n' +
               'require("crypto")'
+    },
+    {
+      code: 'require("common")\n' +
+            'if (common.foo) {}\n' +
+            'internalBinding("crypto")',
+      errors: [{ message }],
+      output: 'require("common")\n' +
+              'if (!common.hasCrypto) {' +
+              ' common.skip("missing crypto");' +
+              '}\n' +
+              'if (common.foo) {}\n' +
+              'internalBinding("crypto")'
     }
   ]
 });

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -33,14 +33,15 @@ module.exports.isCommonModule = function(node) {
 
 /**
  * Returns true if any of the passed in modules are used in
- * binding calls.
+ * process.binding() or internalBinding() calls.
  */
 module.exports.isBinding = function(node, modules) {
-  if (node.callee.object) {
-    return node.callee.object.name === 'process' &&
-           node.callee.property.name === 'binding' &&
-           modules.includes(node.arguments[0].value);
-  }
+  const isProcessBinding = node.callee.object &&
+                           node.callee.object.name === 'process' &&
+                           node.callee.property.name === 'binding';
+
+  return (isProcessBinding || node.callee.name === 'internalBinding') &&
+         modules.includes(node.arguments[0].value);
 };
 
 /**


### PR DESCRIPTION
Use of `process.binding()` has largely been replaced by `internalBinding()`. This commit updates the custom crypto check ESLint rule to check for both `process.binding()` and `internalBinding()`.

Refs: https://github.com/nodejs/node/pull/24952#issuecomment-452327452

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
