### PR TITLE
tools: update crypo check rule

### DIFF
--- a/test/parallel/test-eslint-crypto-check.js
+++ b/test/parallel/test-eslint-crypto-check.js
@@ -24,6 +24,14 @@ new RuleTester().run('crypto-check', rule, {
   invalid: [
     {
       code: 'require("common")\n' +
+            'require("crypto")\n' +
+            'if (!common.hasCrypto) {\n' +
+            '  common.skip("missing crypto");\n' +
+            '}',
+      errors: [{ message }]
+    },
+    {
+      code: 'require("common")\n' +
             'require("crypto")',
       errors: [{ message }],
       output: 'require("common")\n' +

--- a/tools/eslint-rules/crypto-check.js
+++ b/tools/eslint-rules/crypto-check.js
@@ -66,6 +66,22 @@ module.exports = function(context) {
 
   function reportIfMissingCheck() {
     if (hasSkipCall) {
+      // There is a skip, which is good, but verify that the require() calls
+      // in question come after at least one check.
+      if (missingCheckNodes.length > 0) {
+        requireNodes.forEach((requireNode) => {
+          const beforeAllChecks = missingCheckNodes.every((checkNode) => {
+            return requireNode.start < checkNode.start;
+          });
+
+          if (beforeAllChecks) {
+            context.report({
+              node: requireNode,
+              message: msg
+            });
+          }
+        });
+      }
       return;
     }
 


### PR DESCRIPTION
This commit updates the custom crypto-check ESLint rule to detect `require()` calls that come before all `hasCrypto` checks.

Refs: https://github.com/nodejs/node/pull/25388

Note: This will fail CI until https://github.com/nodejs/node/pull/25388 lands.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
