### PR TITLE
test: improve test coverage of native crypto code

### DIFF
--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -205,3 +205,15 @@ for (let n = 1; n < 256; n += 1) {
   if (common.hasFipsCrypto && n < 12) continue;
   crypto.createCipheriv('aes-128-gcm', Buffer.alloc(16), Buffer.alloc(n));
 }
+
+{
+  // Passing an invalid cipher name should throw.
+  assert.throws(
+    () => crypto.createCipheriv('aes-127', Buffer.alloc(16), null),
+    /Unknown cipher/);
+
+  // Passing a key with an invalid length should throw.
+  assert.throws(
+    () => crypto.createCipheriv('aes-128-ecb', Buffer.alloc(17), null),
+    /Invalid key length/);
+}

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -449,3 +449,9 @@ common.expectsError(
     assert.deepStrictEqual(h.digest('latin1'), '');
   }
 }
+
+{
+  assert.throws(
+    () => crypto.createHmac('sha7', 'key'),
+    /Unknown message digest/);
+}

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -363,3 +363,9 @@ common.expectsError(
     assert.throws(() => verify.verify('test', input), errObj);
   });
 }
+
+{
+  assert.throws(
+    () => crypto.createSign('sha8'),
+    /Unknown message digest/);
+}


### PR DESCRIPTION
These error conditions are currently not being tested:
- Creating a cipher with an invalid algorithm.
- Creating a cipher with an invalid key length.
- Creating an HMAC with an invalid algorithm.
- Signing with an invalid algorithm.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
