### PR TITLE
os: improve networkInterfaces() performance

### DIFF
--- a/benchmark/os/networkInterfaces.js
+++ b/benchmark/os/networkInterfaces.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const common = require('../common.js');
+const networkInterfaces = require('os').networkInterfaces;
+
+const bench = common.createBenchmark(main, {
+  n: [1e4]
+});
+
+function main({ n }) {
+  bench.start();
+  for (var i = 0; i < n; ++i)
+    networkInterfaces();
+  bench.end(n);
+}

--- a/lib/os.js
+++ b/lib/os.js
@@ -143,18 +143,13 @@ endianness[Symbol.toPrimitive] = () => kEndianness;
 // Returns the number of ones in the binary representation of the decimal
 // number.
 function countBinaryOnes(n) {
-  let count = 0;
-  // Remove one "1" bit from n until n is the power of 2. This iterates k times
-  // while k is the number of "1" in the binary representation.
-  // For more check https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators
-  while (n !== 0) {
-    n = n & (n - 1);
-    count++;
-  }
-  return count;
+  // Count the number of bits set in parallel, which is faster than looping
+  n = n - ((n >>> 1) & 0x55555555);
+  n = (n & 0x33333333) + ((n >>> 2) & 0x33333333);
+  return ((n + (n >>> 4) & 0xF0F0F0F) * 0x1010101) >>> 24;
 }
 
-function getCIDR({ address, netmask, family }) {
+function getCIDR(address, netmask, family) {
   let ones = 0;
   let split = '.';
   let range = 10;
@@ -190,17 +185,33 @@ function getCIDR({ address, netmask, family }) {
 }
 
 function networkInterfaces() {
-  const interfaceAddresses = getInterfaceAddresses();
+  const data = getInterfaceAddresses();
+  const result = {};
 
-  const keys = Object.keys(interfaceAddresses);
-  for (var i = 0; i < keys.length; i++) {
-    const arr = interfaceAddresses[keys[i]];
-    for (var j = 0; j < arr.length; j++) {
-      arr[j].cidr = getCIDR(arr[j]);
-    }
+  if (data === undefined)
+    return result;
+  for (var i = 0; i < data.length; i += 7) {
+    const name = data[i];
+    const entry = {
+      address: data[i + 1],
+      netmask: data[i + 2],
+      family: data[i + 3],
+      mac: data[i + 4],
+      internal: data[i + 5],
+      cidr: getCIDR(data[i + 1], data[i + 2], data[i + 3])
+    };
+    const scopeid = data[i + 6];
+    if (scopeid !== -1)
+      entry.scopeid = scopeid;
+
+    const existing = result[name];
+    if (existing !== undefined)
+      existing.push(entry);
+    else
+      result[name] = [entry];
   }
 
-  return interfaceAddresses;
+  return result;
 }
 
 function setPriority(pid, priority) {


### PR DESCRIPTION
With included benchmark:

```
                                  confidence improvement accuracy (*)   (**)  (***)
 os/networkInterfaces.js n=10000        ***      3.86 %       ±0.26% ±0.34% ±0.44%
```

and also makes the C++ implementation mirror the C++ cpu enumeration code for whatever that's worth.

CI: https://ci.nodejs.org/job/node-test-pull-request/20031/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
