### PR TITLE
build: introduce --openssl-is-fips flag

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -173,6 +173,11 @@ parser.add_option('--openssl-fips',
     dest='openssl_fips',
     help='Build OpenSSL using FIPS canister .o file in supplied folder')
 
+parser.add_option('--openssl-is-fips',
+    action='store_true',
+    dest='openssl_is_fips',
+    help='specifies that the OpenSSL library is FIPS compatible')
+
 parser.add_option('--openssl-use-def-ca-store',
     action='store_true',
     dest='use_openssl_ca_store',
@@ -1187,6 +1192,7 @@ def configure_openssl(o):
   variables = o['variables']
   variables['node_use_openssl'] = b(not options.without_ssl)
   variables['node_shared_openssl'] = b(options.shared_openssl)
+  variables['openssl_is_fips'] = b(options.openssl_is_fips)
   variables['openssl_fips'] = ''
 
   if options.openssl_no_asm:

--- a/node.gypi
+++ b/node.gypi
@@ -315,7 +315,7 @@
     [ 'node_use_openssl=="true"', {
       'defines': [ 'HAVE_OPENSSL=1' ],
       'conditions': [
-        ['openssl_fips != ""', {
+        ['openssl_fips != "" or openssl_is_fips=="true"', {
           'defines': [ 'NODE_FIPS_MODE' ],
         }],
         [ 'node_shared_openssl=="false"', {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4505,9 +4505,14 @@ Sign::SignResult Sign::SignFinal(
 
 #ifdef NODE_FIPS_MODE
   /* Validate DSA2 parameters from FIPS 186-4 */
-  if (FIPS_mode() && EVP_PKEY_DSA == pkey->type) {
-    size_t L = BN_num_bits(pkey->pkey.dsa->p);
-    size_t N = BN_num_bits(pkey->pkey.dsa->q);
+  if (FIPS_mode() && EVP_PKEY_DSA == EVP_PKEY_base_id(pkey.get())) {
+    DSA* dsa = EVP_PKEY_get0_DSA(pkey.get());
+    const BIGNUM* p;
+    DSA_get0_pqg(dsa, &p, nullptr, nullptr);
+    size_t L = BN_num_bits(p);
+    const BIGNUM* q;
+    DSA_get0_pqg(dsa, nullptr, &q, nullptr);
+    size_t N = BN_num_bits(q);
     bool result = false;
 
     if (L == 1024 && N == 160)
@@ -4520,7 +4525,7 @@ Sign::SignResult Sign::SignFinal(
       result = true;
 
     if (!result) {
-      return kSignPrivateKey;
+      return SignResult(kSignPrivateKey);
     }
   }
 #endif  // NODE_FIPS_MODE


### PR DESCRIPTION
This commit introduces a new configuration flag named
`--openssl-is-fips` which is intended to be used when linking against
an OpenSSL library that is FIPS compatible.

The motivation for this is that Red Hat Enterprise Linux 8 (RHEL8)
comes with OpenSSL 1.1.1 and includes FIPS support, and we would
like to be able to dynamically link against this version and also have
FIPS features enabled in node, like would be done when statically
linking and using the `--openssl-fips` flag.

The suggestion here is to introduce a new flag:
```console
$ ./configure --help
...
--openssl-is-fips specifies that the shared OpenSSL library is FIPS
                  compatible
```
This flag could be used in combination with the `--shared-openssl` flag:
```console
$ ./configure --shared-openssl --openssl-is-fips
```

This will enable FIPS support in node and the runtime flags will be
availalbe to enable FIPS (`--enable-fips`, `--force-fips`).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
