### PR TITLE
docs: document that stream.on('close') was changed in Node 10.

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -219,13 +219,19 @@ added: v0.9.4
 ##### Event: 'close'
 <!-- YAML
 added: v0.9.4
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18438
+    description: Add `emitClose` option to specify if `'close'` is emitted on
+                 destroy.
 -->
 
 The `'close'` event is emitted when the stream and any of its underlying
 resources (a file descriptor, for example) have been closed. The event indicates
 that no more events will be emitted, and no further computation will occur.
 
-Not all `Writable` streams will emit the `'close'` event.
+A [`Writable`][] stream will always emit the `'close'` event if it is
+created with the `emitClose` option.
 
 ##### Event: 'drain'
 <!-- YAML
@@ -704,13 +710,19 @@ added: v0.9.4
 ##### Event: 'close'
 <!-- YAML
 added: v0.9.4
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18438
+    description: Add `emitClose` option to specify if `'close'` is emitted on
+                 destroy.
 -->
 
 The `'close'` event is emitted when the stream and any of its underlying
 resources (a file descriptor, for example) have been closed. The event indicates
 that no more events will be emitted, and no further computation will occur.
 
-Not all [`Readable`][] streams will emit the `'close'` event.
+A [`Readable`][] stream will always emit the `'close'` event if it is
+created with the `emitClose` option.
 
 ##### Event: 'data'
 <!-- YAML


### PR DESCRIPTION
See: https://github.com/nodejs/node/issues/25373
See: https://github.com/nodejs/node/pull/18438

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
