### PR TITLE
[v11.x] backport: tls: do not confuse TLSSocket and Socket

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1224,7 +1224,7 @@ exports.connect = function connect(...args) {
 
   const context = options.secureContext || tls.createSecureContext(options);
 
-  var socket = new TLSSocket(options.socket, {
+  var tlssock = new TLSSocket(options.socket, {
     pipe: !!options.path,
     secureContext: context,
     isServer: false,
@@ -1235,12 +1235,14 @@ exports.connect = function connect(...args) {
     requestOCSP: options.requestOCSP
   });
 
-  socket[kConnectOptions] = options;
+  tlssock[kConnectOptions] = options;
 
   if (cb)
-    socket.once('secureConnect', cb);
+    tlssock.once('secureConnect', cb);
 
   if (!options.socket) {
+    // If user provided the socket, its their responsibility to manage its
+    // connectivity. If we created one internally, we connect it.
     const connectOpt = {
       path: options.path,
       port: options.port,
@@ -1249,22 +1251,22 @@ exports.connect = function connect(...args) {
       localAddress: options.localAddress,
       lookup: options.lookup
     };
-    socket.connect(connectOpt, socket._start);
+    tlssock.connect(connectOpt, tlssock._start);
   }
 
-  socket._releaseControl();
+  tlssock._releaseControl();
 
   if (options.session)
-    socket.setSession(options.session);
+    tlssock.setSession(options.session);
 
   if (options.servername)
-    socket.setServername(options.servername);
+    tlssock.setServername(options.servername);
 
   if (options.socket)
-    socket._start();
+    tlssock._start();
 
-  socket.on('secure', onConnectSecure);
-  socket.once('end', onConnectEnd);
+  tlssock.on('secure', onConnectSecure);
+  tlssock.once('end', onConnectEnd);
 
-  return socket;
+  return tlssock;
 };


### PR DESCRIPTION
This is a backport of https://github.com/nodejs/node/pull/25153. It was the only commit that was not already backported as all other commits where accidentally backported with a following backport and all other commits besides this one are empty (so I skipped them).

Original commit message:

Don't use "socket" to describe two different objects in the same
function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
