### PR TITLE
doc: `os.networkInterfaces()` example outdated

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -286,6 +286,7 @@ The properties available on the assigned network address object include:
       netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
       family: 'IPv6',
       mac: '00:00:00:00:00:00',
+      scopeid: 0,
       internal: true,
       cidr: '::1/128'
     }
@@ -304,6 +305,7 @@ The properties available on the assigned network address object include:
       netmask: 'ffff:ffff:ffff:ffff::',
       family: 'IPv6',
       mac: '01:02:03:0a:0b:0c',
+      scopeid: 1,
       internal: false,
       cidr: 'fe80::a00:27ff:fe4e:66a1/64'
     }


### PR DESCRIPTION
The os.networkInterfaces() example was outdated
as the IPv6 interfaces did not include the `scopeid` property,
now they do.

Fixes: https://github.com/nodejs/node/issues/25408

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
