### PR TITLE
test: fix module loading error for AIX 7.1

### DIFF
--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -30,7 +30,8 @@ const errorMessagesByPlatform = {
   sunos: ['unknown file type', 'not an ELF file'],
   darwin: ['file too short'],
   aix: ['Cannot load module',
-        'Cannot run a file that does not have a valid format.']
+        'Cannot run a file that does not have a valid format.',
+        'Exec format error']
 };
 // If we don't know a priori what the error would be, we accept anything.
 const errorMessages = errorMessagesByPlatform[process.platform] || [''];


### PR DESCRIPTION
Building the current `master` on AIX 7.1 and `gcc 6.3.0` I get the following test failure:

```
not ok 1284 parallel/test-module-loading-error
  ---
  duration_ms: 0.782
  severity: fail
  exitcode: 1
  stack: |-
    assert.js:664
        throw actual;
        ^
    
    Error: Could not load module /home/riclau/sandbox/github/node/test/fixtures/module-loading-error.node.
    System error: Exec format error
        at Object.Module._extensions..node (internal/modules/cjs/loader.js:747:18)
        at Module.load (internal/modules/cjs/loader.js:617:32)
        at tryModuleLoad (internal/modules/cjs/loader.js:560:12)
        at Function.Module._load (internal/modules/cjs/loader.js:552:3)
        at Module.require (internal/modules/cjs/loader.js:654:17)
        at require (internal/modules/cjs/helpers.js:20:18)
        at assert.throws (/home/riclau/sandbox/github/node/test/parallel/test-module-loading-error.js:54:11)
        at getActual (assert.js:576:5)
        at Function.throws (assert.js:694:24)
        at Object.<anonymous> (/home/riclau/sandbox/github/node/test/parallel/test-module-loading-error.js:53:8)
  ...
```

I've verified using `python` (not all of the AIX machines that I have access to have the necessary environment set up to build/run Node.js) that the error message from `dlopen` is different on AIX 7.1 compared to AIX 6.1.

AIX 7.1:
```
bash-4.4$ python
Python 2.7.15 (default, Sep 28 2018, 03:58:41)
[GCC 6.3.0] on aix6
Type "help", "copyright", "credits" or "license" for more information.
>>> import dl
>>> dl.open("/home/riclau/sandbox/github/node/test/fixtures/module-loading-error.node")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
dl.error: Could not load module /home/riclau/sandbox/github/node/test/fixtures/module-loading-error.node.
System error: Exec format error
>>>
```

AIX 6.1:
```
-bash-4.4$ python
Python 2.7.13 (default, Oct 17 2017, 05:37:56) [C] on aix6
Type "help", "copyright", "credits" or "license" for more information.
>>> import dl
>>> dl.open("/home/riclau/sandbox/github/node/test/fixtures/module-loading-error.node")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
dl.error:       0509-022 Cannot load module /home/riclau/sandbox/github/node/test/fixtures/module-loading-error.node.
        0509-026 System error: Cannot run a file that does not have a valid format.
>>>
```
This PR adds another allowed error message for AIX to allow the test to pass.

Note that the CI AIX machines are currently AIX 6.1.

cc @nodejs/platform-aix 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
