### PR TITLE
doc: wrap and punctuate YAML description text

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -788,9 +788,8 @@ added: v0.9.4
 changes:
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/17979
-    description: >
-      The `'readable'` is always emitted in the next tick after `.push()`
-      is called
+    description: The `'readable'` is always emitted in the next tick after
+                 `.push()` is called.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18994
     description: Using `'readable'` requires calling `.read()`.
@@ -1510,13 +1509,12 @@ constructor and implement the `writable._write()` method. The
 changes:
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18438
-    description: >
-      Add `emitClose` option to specify if `'close'` is emitted on destroy
+    description: Add `emitClose` option to specify if `'close'` is emitted on
+                 destroy.
   - version: v11.2.0
     pr-url: https://github.com/nodejs/node/pull/22795
-    description: >
-      Add `autoDestroy` option to automatically `destroy()` the stream
-      when it emits `'finish'` or errors
+    description: Add `autoDestroy` option to automatically `destroy()` the
+                 stream when it emits `'finish'` or errors.
 -->
 
 * `options` {Object}
@@ -1782,9 +1780,8 @@ constructor and implement the `readable._read()` method.
 changes:
   - version: v11.2.0
     pr-url: https://github.com/nodejs/node/pull/22795
-    description: >
-      Add `autoDestroy` option to automatically `destroy()` the stream
-      when it emits `'end'` or errors
+    description: Add `autoDestroy` option to automatically `destroy()` the
+                 stream when it emits `'end'` or errors.
 -->
 
 * `options` {Object}
@@ -1848,7 +1845,7 @@ added: v0.9.4
 changes:
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/17979
-    description: call `_read()` only once per microtick
+    description: Call `_read()` only once per microtick.
 -->
 
 * `size` {number} Number of bytes to read asynchronously


### PR DESCRIPTION
stream.md was the only YAML in doc/api that was using `>` for line
continuation, and only used it for a few descriptions, most used the
same wrapping style the rest of the documentation does.

Also added punctuation and capitialization to a few description
sentences.

Fixes: https://github.com/nodejs/node/pull/25413#discussion_r246451003

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
