### PR TITLE
doc: add TLSSocket.isSessionReused() docs

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -898,6 +898,15 @@ It may be useful for debugging.
 
 See [Session Resumption][] for more information.
 
+### tlsSocket.isSessionReused()
+<!-- YAML
+added: v0.5.6
+-->
+
+* Returns: {boolean} `true` if the session was reused, `false` otherwise.
+
+See [Session Resumption][] for more information.
+
 ### tlsSocket.localAddress
 <!-- YAML
 added: v0.11.4


### PR DESCRIPTION
The API has existed forever and is used in our unit tests. It is
supported for TLS1.3 as well as 1.2 and useful for troubleshooting, so
it should be documented.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
