### PR TITLE
test: fix test-repl timeout and tmpdir refresh

### DIFF
--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -22,6 +22,7 @@
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const net = require('net');
 const repl = require('repl');
@@ -823,6 +824,8 @@ function startUnixRepl() {
     resolveReplServer(replServer);
   }));
 
+  tmpdir.refresh();
+
   server.listen(common.PIPE, common.mustCall(() => {
     const client = net.createConnection(common.PIPE);
 
@@ -852,7 +855,7 @@ function event(ee, expected) {
       const data = inspect(expected, { compact: false });
       const msg = `The REPL did not reply as expected for:\n\n${data}`;
       reject(new Error(msg));
-    }, 500);
+    }, common.platformTimeout(500));
     ee.once('data', common.mustCall((...args) => {
       clearTimeout(timeout);
       resolve(...args);


### PR DESCRIPTION
I could not find a way to stress test this on the pi1 as armv6 (and armv7 for that matter) seems to not be a selectable target in Jenkins, although armv8/arm64 targets are?

Anyway, what prompted this was this recent CI failure on pi1-docker:

```
15:05:58 not ok 229 parallel/test-repl
15:05:58   ---
15:05:58   duration_ms: 7.962
15:05:58   severity: fail
15:05:58   exitcode: 1
15:05:58   stack: |-
15:05:58     out: ""
15:05:58     in: ""
15:05:58     out: "message"
15:05:58     in: "'Read, Eval, Print Loop'"
15:05:58     out: "invoke_me(987)"
15:05:58     in: "'invoked 987'"
15:05:58     out: "a = 12345"
15:05:58     in: "12345"
15:05:58     out: "{a:1}"
15:05:58     in: "{ a: 1 }"
15:05:58     out: "throw new Error('test error');"
15:05:58     in: "Thrown:"
15:05:58     in: "Error: test error"
15:05:58     out: "throw { foo: 'bar' };"
15:05:58     in: "Thrown: { foo: 'bar' }"
15:05:58     out: "function test_func() {"
15:05:58     /home/iojs/build/workspace/node-test-binary-arm/test/common/index.js:689
15:05:58     const crashOnUnhandledRejection = (err) => { throw err; };
15:05:58                                                  ^
15:05:58     
15:05:58     Error: The REPL did not reply as expected for:
15:05:58     
15:05:58     '... '
15:05:58         at Timeout.setTimeout [as _onTimeout] (/home/iojs/build/workspace/node-test-binary-arm/test/parallel/test-repl.js:854:14)
15:05:58         at listOnTimeout (timers.js:324:15)
15:05:58         at processTimers (timers.js:268:5)
```

The tmpdir addition was to allow running the test by itself, outside of a `make test`.

CI: https://ci.nodejs.org/job/node-test-pull-request/20036/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
