### PR TITLE
test,worker_threads: simplify common.isMainThread

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -38,13 +38,7 @@ const noop = () => {};
 
 const hasCrypto = Boolean(process.versions.openssl);
 
-const isMainThread = (() => {
-  if (require('module').builtinModules.includes('worker_threads')) {
-    return require('worker_threads').isMainThread;
-  }
-  // Worker module not enabled → only a single main thread exists.
-  return true;
-})();
+const { isMainThread } = require('worker_threads');
 
 // Check for flags. Skip this for workers (both, the `cluster` module and
 // `worker_threads`) and child processes.


### PR DESCRIPTION
Now that `worker_threads` do not require a flag, the logic around
loading `isMainThread` can be removed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
