### PR TITLE
test: remove unnecessary skipIfWorker()

### DIFF
--- a/test/sequential/test-inspector-port-cluster.js
+++ b/test/sequential/test-inspector-port-cluster.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 
 common.skipIfInspectorDisabled();
-common.skipIfWorker();
 
 const assert = require('assert');
 const cluster = require('cluster');


### PR DESCRIPTION
test-inspector-port-cluster passes in workers. Remove skipIfWorker()
from the test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
