### PR TITLE
test: improve code coverage for i18n

### DIFF
--- a/test/parallel/test-icu-punycode.js
+++ b/test/parallel/test-icu-punycode.js
@@ -9,6 +9,12 @@ const { internalBinding } = require('internal/test/binding');
 const icu = internalBinding('icu');
 const assert = require('assert');
 
+// test hasConverter method
+assert(icu.hasConverter('utf-8'),
+       'hasConverter should report coverter exists for utf-8');
+assert(!icu.hasConverter('x'),
+       'hasConverter should report coverter does not exist for x');
+
 const tests = require('../fixtures/url-idna.js');
 const fixtures = require('../common/fixtures');
 const wptToASCIITests = require(


### PR DESCRIPTION
Coverage report for src/node_i18n.cc shows that the
Has() method is not covered. This test adds coverage
for that method.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
