### PR TITLE
build,test: fail `coverage` target if tests fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ coverage-test: coverage-build
 	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/gen/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/src/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/src/tracing/*.gcda
-	-$(MAKE) $(COVTESTS)
+	$(MAKE) $(COVTESTS)
 	mv lib lib__
 	mv lib_ lib
 	mkdir -p coverage .cov_tmp


### PR DESCRIPTION
Part of fix for https://github.com/nodejs/node/issues/24966
Make the `coverage-test` target fail if running the tests fail. This way we get early warning that something is borked and we don't publish spurious results.

/CC @nodejs/build-files @nodejs/benchmarking @nodejs/testing 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
