### PR TITLE
net: allow reading data into a static buffer

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -593,6 +593,9 @@ for the [`'connect'`][] event **once**.
 <!-- YAML
 added: v0.1.90
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/25436
+    description: Added `onread` option.
   - version: v6.0.0
     pr-url: https://github.com/nodejs/node/pull/6021
     description: The `hints` option defaults to `0` in all cases now.
@@ -628,6 +631,39 @@ For [IPC][] connections, available `options` are:
 * `path` {string} Required. Path the client should connect to.
   See [Identifying paths for IPC connections][]. If provided, the TCP-specific
   options above are ignored.
+
+For both types, available `options` include:
+
+* `onread` {Object} - If specified, incoming data is stored in a single `buffer`
+  and passed to the supplied `callback` when data arrives on the socket.
+  Note: this will cause the streaming functionality to not provide any data,
+  however events like `'error'`, `'end'`, and `'close'` will still be emitted
+  as normal and methods like `pause()` and `resume()` will also behave as
+  expected.
+  * `buffer` {Buffer|Uint8Array|Function} - Either a reusable chunk of memory to
+    use for storing incoming data or a function that returns such.
+  * `callback` {Function} This function is called for every chunk of incoming
+    data. Two arguments are passed to it: the number of bytes written to
+    `buffer` and a reference to `buffer`. Return `false` from this function to
+    implicitly `pause()` the socket. This function will be executed in the
+    global context.
+
+Following is an example of a client using the `onread` option:
+
+```js
+const net = require('net');
+net.connect({
+  port: 80,
+  onread: {
+    // Reuses a 4KiB Buffer for every read from the socket
+    buffer: Buffer.alloc(4 * 1024),
+    callback: function(nread, buf) {
+      // Received data is available in `buf` from 0 to `nread`
+      console.log(buf.toString('utf8', 0, nread));
+    }
+  }
+});
+```
 
 #### socket.connect(path[, connectListener])
 

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -23,6 +23,7 @@ const {
   setUnrefTimeout,
   getTimerDuration
 } = require('internal/timers');
+const { isUint8Array } = require('internal/util/types');
 const { clearTimeout } = require('timers');
 
 const kMaybeDestroy = Symbol('kMaybeDestroy');
@@ -32,6 +33,9 @@ const kHandle = Symbol('kHandle');
 const kSession = Symbol('kSession');
 
 const debug = require('internal/util/debuglog').debuglog('stream');
+const kBuffer = Symbol('kBuffer');
+const kBufferGen = Symbol('kBufferGen');
+const kBufferCb = Symbol('kBufferCb');
 
 function handleWriteReq(req, data, encoding) {
   const { handle } = req;
@@ -161,9 +165,23 @@ function onStreamRead(arrayBuffer) {
   stream[kUpdateTimer]();
 
   if (nread > 0 && !stream.destroyed) {
-    const offset = streamBaseState[kArrayBufferOffset];
-    const buf = new FastBuffer(arrayBuffer, offset, nread);
-    if (!stream.push(buf)) {
+    let ret;
+    let result;
+    const userBuf = stream[kBuffer];
+    if (userBuf) {
+      result = (stream[kBufferCb](nread, userBuf) !== false);
+      const bufGen = stream[kBufferGen];
+      if (bufGen !== null) {
+        const nextBuf = bufGen();
+        if (isUint8Array(nextBuf))
+          stream[kBuffer] = ret = nextBuf;
+      }
+    } else {
+      const offset = streamBaseState[kArrayBufferOffset];
+      const buf = new FastBuffer(arrayBuffer, offset, nread);
+      result = stream.push(buf);
+    }
+    if (!result) {
       handle.reading = false;
       if (!stream.destroyed) {
         const err = handle.readStop();
@@ -172,7 +190,7 @@ function onStreamRead(arrayBuffer) {
       }
     }
 
-    return;
+    return ret;
   }
 
   if (nread === 0) {
@@ -241,5 +259,8 @@ module.exports = {
   kUpdateTimer,
   kHandle,
   kSession,
-  setStreamTimeout
+  setStreamTimeout,
+  kBuffer,
+  kBufferCb,
+  kBufferGen
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -67,7 +67,10 @@ const {
   kAfterAsyncWrite,
   kHandle,
   kUpdateTimer,
-  setStreamTimeout
+  setStreamTimeout,
+  kBuffer,
+  kBufferCb,
+  kBufferGen
 } = require('internal/stream_base_commons');
 const {
   codes: {
@@ -86,6 +89,7 @@ const {
   exceptionWithHostPort,
   uvExceptionWithHostPort
 } = require('internal/errors');
+const { isUint8Array } = require('internal/util/types');
 const { validateInt32, validateString } = require('internal/validators');
 const kLastWriteQueueSize = Symbol('lastWriteQueueSize');
 const {
@@ -225,6 +229,18 @@ function initSocketHandle(self) {
     self._handle[owner_symbol] = self;
     self._handle.onread = onStreamRead;
     self[async_id_symbol] = getNewAsyncId(self._handle);
+
+    let userBuf = self[kBuffer];
+    if (userBuf) {
+      const bufGen = self[kBufferGen];
+      if (bufGen !== null) {
+        userBuf = bufGen();
+        if (!isUint8Array(userBuf))
+          return;
+        self[kBuffer] = userBuf;
+      }
+      self._handle.useUserBuffer(userBuf);
+    }
   }
 }
 
@@ -247,6 +263,9 @@ function Socket(options) {
   this._host = null;
   this[kLastWriteQueueSize] = 0;
   this[kTimeout] = null;
+  this[kBuffer] = null;
+  this[kBufferCb] = null;
+  this[kBufferGen] = null;
 
   if (typeof options === 'number')
     options = { fd: options }; // Legacy interface.
@@ -271,40 +290,55 @@ function Socket(options) {
   if (options.handle) {
     this._handle = options.handle; // private
     this[async_id_symbol] = getNewAsyncId(this._handle);
-  } else if (options.fd !== undefined) {
-    const { fd } = options;
-    let err;
+  } else {
+    const onread = options.onread;
+    if (onread !== null && typeof onread === 'object' &&
+        (isUint8Array(onread.buffer) || typeof onread.buffer === 'function') &&
+        typeof onread.callback === 'function') {
+      if (typeof onread.buffer === 'function') {
+        this[kBuffer] = true;
+        this[kBufferGen] = onread.buffer;
+      } else {
+        this[kBuffer] = onread.buffer;
+      }
+      this[kBufferCb] = onread.callback;
+    }
+    if (options.fd !== undefined) {
+      const { fd } = options;
+      let err;
 
-    // createHandle will throw ERR_INVALID_FD_TYPE if `fd` is not
-    // a valid `PIPE` or `TCP` descriptor
-    this._handle = createHandle(fd, false);
+      // createHandle will throw ERR_INVALID_FD_TYPE if `fd` is not
+      // a valid `PIPE` or `TCP` descriptor
+      this._handle = createHandle(fd, false);
 
-    err = this._handle.open(fd);
+      err = this._handle.open(fd);
 
-    // While difficult to fabricate, in some architectures
-    // `open` may return an error code for valid file descriptors
-    // which cannot be opened. This is difficult to test as most
-    // un-openable fds will throw on `createHandle`
-    if (err)
-      throw errnoException(err, 'open');
-
-    this[async_id_symbol] = this._handle.getAsyncId();
-
-    if ((fd === 1 || fd === 2) &&
-        (this._handle instanceof Pipe) &&
-        process.platform === 'win32') {
-      // Make stdout and stderr blocking on Windows
-      err = this._handle.setBlocking(true);
+      // While difficult to fabricate, in some architectures
+      // `open` may return an error code for valid file descriptors
+      // which cannot be opened. This is difficult to test as most
+      // un-openable fds will throw on `createHandle`
       if (err)
-        throw errnoException(err, 'setBlocking');
+        throw errnoException(err, 'open');
 
-      this._writev = null;
-      this._write = makeSyncWrite(fd);
-      // makeSyncWrite adjusts this value like the original handle would, so
-      // we need to let it do that by turning it into a writable, own property.
-      Object.defineProperty(this._handle, 'bytesWritten', {
-        value: 0, writable: true
-      });
+      this[async_id_symbol] = this._handle.getAsyncId();
+
+      if ((fd === 1 || fd === 2) &&
+          (this._handle instanceof Pipe) &&
+          process.platform === 'win32') {
+        // Make stdout and stderr blocking on Windows
+        err = this._handle.setBlocking(true);
+        if (err)
+          throw errnoException(err, 'setBlocking');
+
+        this._writev = null;
+        this._write = makeSyncWrite(fd);
+        // makeSyncWrite adjusts this value like the original handle would, so
+        // we need to let it do that by turning it into a writable, own
+        // property.
+        Object.defineProperty(this._handle, 'bytesWritten', {
+          value: 0, writable: true
+        });
+      }
     }
   }
 
@@ -514,6 +548,15 @@ Object.defineProperty(Socket.prototype, kUpdateTimer, {
 });
 
 
+function tryReadStart(socket) {
+  // Not already reading, start the flow
+  debug('Socket._handle.readStart');
+  socket._handle.reading = true;
+  var err = socket._handle.readStart();
+  if (err)
+    socket.destroy(errnoException(err, 'read'));
+}
+
 // Just call handle.readStart until we have enough in the buffer
 Socket.prototype._read = function(n) {
   debug('_read');
@@ -522,12 +565,7 @@ Socket.prototype._read = function(n) {
     debug('_read wait for connection');
     this.once('connect', () => this._read(n));
   } else if (!this._handle.reading) {
-    // Not already reading, start the flow
-    debug('Socket._read readStart');
-    this._handle.reading = true;
-    var err = this._handle.readStart();
-    if (err)
-      this.destroy(errnoException(err, 'read'));
+    tryReadStart(this);
   }
 };
 
@@ -536,6 +574,38 @@ Socket.prototype.end = function(data, encoding, callback) {
   stream.Duplex.prototype.end.call(this, data, encoding, callback);
   DTRACE_NET_STREAM_END(this);
   return this;
+};
+
+
+Socket.prototype.pause = function() {
+  if (this[kBuffer] && !this.connecting && this._handle &&
+      this._handle.reading) {
+    this._handle.reading = false;
+    if (!this.destroyed) {
+      const err = this._handle.readStop();
+      if (err)
+        this.destroy(errnoException(err, 'read'));
+    }
+  }
+  return stream.Duplex.prototype.pause.call(this);
+};
+
+
+Socket.prototype.resume = function() {
+  if (this[kBuffer] && !this.connecting && this._handle &&
+      !this._handle.reading) {
+    tryReadStart(this);
+  }
+  return stream.Duplex.prototype.resume.call(this);
+};
+
+
+Socket.prototype.read = function(n) {
+  if (this[kBuffer] && !this.connecting && this._handle &&
+      !this._handle.reading) {
+    tryReadStart(this);
+  }
+  return stream.Duplex.prototype.read.call(this, n);
 };
 
 

--- a/test/parallel/test-net-onread-static-buffer.js
+++ b/test/parallel/test-net-onread-static-buffer.js
@@ -1,0 +1,186 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const message = Buffer.from('hello world');
+
+// Test typical usage
+net.createServer(common.mustCall(function(socket) {
+  this.close();
+  socket.end(message);
+})).listen(0, function() {
+  let received = 0;
+  const buffers = [];
+  const sockBuf = Buffer.alloc(8);
+  net.connect({
+    port: this.address().port,
+    onread: {
+      buffer: sockBuf,
+      callback: function(nread, buf) {
+        assert.strictEqual(buf, sockBuf);
+        received += nread;
+        buffers.push(Buffer.from(buf.slice(0, nread)));
+      }
+    }
+  }).on('data', common.mustNotCall()).on('end', common.mustCall(() => {
+    assert.strictEqual(received, message.length);
+    assert.deepStrictEqual(Buffer.concat(buffers), message);
+  }));
+});
+
+// Test Uint8Array support
+net.createServer(common.mustCall(function(socket) {
+  this.close();
+  socket.end(message);
+})).listen(0, function() {
+  let received = 0;
+  let incoming = new Uint8Array(0);
+  const sockBuf = new Uint8Array(8);
+  net.connect({
+    port: this.address().port,
+    onread: {
+      buffer: sockBuf,
+      callback: function(nread, buf) {
+        assert.strictEqual(buf, sockBuf);
+        received += nread;
+        const newIncoming = new Uint8Array(incoming.length + nread);
+        newIncoming.set(incoming);
+        newIncoming.set(buf.slice(0, nread), incoming.length);
+        incoming = newIncoming;
+      }
+    }
+  }).on('data', common.mustNotCall()).on('end', common.mustCall(() => {
+    assert.strictEqual(received, message.length);
+    assert.deepStrictEqual(incoming, new Uint8Array(message));
+  }));
+});
+
+// Test Buffer callback usage
+net.createServer(common.mustCall(function(socket) {
+  this.close();
+  socket.end(message);
+})).listen(0, function() {
+  let received = 0;
+  const incoming = [];
+  const bufPool = [ Buffer.alloc(2), Buffer.alloc(2), Buffer.alloc(2) ];
+  let bufPoolIdx = -1;
+  let bufPoolUsage = 0;
+  net.connect({
+    port: this.address().port,
+    onread: {
+      buffer: () => {
+        ++bufPoolUsage;
+        bufPoolIdx = (bufPoolIdx + 1) % bufPool.length;
+        return bufPool[bufPoolIdx];
+      },
+      callback: function(nread, buf) {
+        assert.strictEqual(buf, bufPool[bufPoolIdx]);
+        received += nread;
+        incoming.push(Buffer.from(buf.slice(0, nread)));
+      }
+    }
+  }).on('data', common.mustNotCall()).on('end', common.mustCall(() => {
+    assert.strictEqual(received, message.length);
+    assert.deepStrictEqual(Buffer.concat(incoming), message);
+    assert.strictEqual(bufPoolUsage, 7);
+  }));
+});
+
+// Test Uint8Array callback support
+net.createServer(common.mustCall(function(socket) {
+  this.close();
+  socket.end(message);
+})).listen(0, function() {
+  let received = 0;
+  let incoming = new Uint8Array(0);
+  const bufPool = [ new Uint8Array(2), new Uint8Array(2), new Uint8Array(2) ];
+  let bufPoolIdx = -1;
+  let bufPoolUsage = 0;
+  net.connect({
+    port: this.address().port,
+    onread: {
+      buffer: () => {
+        ++bufPoolUsage;
+        bufPoolIdx = (bufPoolIdx + 1) % bufPool.length;
+        return bufPool[bufPoolIdx];
+      },
+      callback: function(nread, buf) {
+        assert.strictEqual(buf, bufPool[bufPoolIdx]);
+        received += nread;
+        const newIncoming = new Uint8Array(incoming.length + nread);
+        newIncoming.set(incoming);
+        newIncoming.set(buf.slice(0, nread), incoming.length);
+        incoming = newIncoming;
+      }
+    }
+  }).on('data', common.mustNotCall()).on('end', common.mustCall(() => {
+    assert.strictEqual(received, message.length);
+    assert.deepStrictEqual(incoming, new Uint8Array(message));
+    assert.strictEqual(bufPoolUsage, 7);
+  }));
+});
+
+// Test explicit socket pause
+net.createServer(common.mustCall(function(socket) {
+  this.close();
+  socket.end(message);
+})).listen(0, function() {
+  let received = 0;
+  const buffers = [];
+  const sockBuf = Buffer.alloc(8);
+  let paused = false;
+  net.connect({
+    port: this.address().port,
+    onread: {
+      buffer: sockBuf,
+      callback: function(nread, buf) {
+        assert.strictEqual(paused, false);
+        assert.strictEqual(buf, sockBuf);
+        received += nread;
+        buffers.push(Buffer.from(buf.slice(0, nread)));
+        paused = true;
+        this.pause();
+        setTimeout(() => {
+          paused = false;
+          this.resume();
+        }, 100);
+      }
+    }
+  }).on('data', common.mustNotCall()).on('end', common.mustCall(() => {
+    assert.strictEqual(received, message.length);
+    assert.deepStrictEqual(Buffer.concat(buffers), message);
+  }));
+});
+
+// Test implicit socket pause
+net.createServer(common.mustCall(function(socket) {
+  this.close();
+  socket.end(message);
+})).listen(0, function() {
+  let received = 0;
+  const buffers = [];
+  const sockBuf = Buffer.alloc(8);
+  let paused = false;
+  net.connect({
+    port: this.address().port,
+    onread: {
+      buffer: sockBuf,
+      callback: function(nread, buf) {
+        assert.strictEqual(paused, false);
+        assert.strictEqual(buf, sockBuf);
+        received += nread;
+        buffers.push(Buffer.from(buf.slice(0, nread)));
+        paused = true;
+        setTimeout(() => {
+          paused = false;
+          this.resume();
+        }, 100);
+        return false;
+      }
+    }
+  }).on('data', common.mustNotCall()).on('end', common.mustCall(() => {
+    assert.strictEqual(received, message.length);
+    assert.deepStrictEqual(Buffer.concat(buffers), message);
+  }));
+});


### PR DESCRIPTION
This is more or less the changes I described in https://github.com/nodejs/node-eps/pull/27 with some updates since the C++ side had changed a fair amount. I thought I would put this out there to see if there was still interest in merging a feature like this (even if it's not this PR as-is).

This implementation is opt-in, only for `net` (although it could obviously be adapted for other places where dynamic buffers are used), and it goes the simple and easy route and completely bypasses the data streaming feature of sockets (although `'end'` and other such non-data-related events are still emitted as usual).

Having this kind of power is obviously not for all use cases, but for network protocol implementations it can make things a lot faster because the connection data is typically parsed synchronously and any raw data that needs to be passed on to end users could simply be copied.

Here are some example benchmark results (`recvbuflen=0` indicates old/current behavior of allocating a new buffer for each chunk read):

```
net/net-s2c.js dur=5 recvbuflen=0 type="buf" sendchunklen=256: 1.071279628253138
net/net-s2c.js dur=5 recvbuflen=65536 type="buf" sendchunklen=256: 1.1356590323233846
net/net-s2c.js dur=5 recvbuflen=1048576 type="buf" sendchunklen=256: 1.129328387002154
net/net-s2c.js dur=5 recvbuflen=0 type="buf" sendchunklen=32768: 19.848600557880395
net/net-s2c.js dur=5 recvbuflen=65536 type="buf" sendchunklen=32768: 28.77196840127128
net/net-s2c.js dur=5 recvbuflen=1048576 type="buf" sendchunklen=32768: 28.674568832052028
net/net-s2c.js dur=5 recvbuflen=0 type="buf" sendchunklen=131072: 23.3627596199997
net/net-s2c.js dur=5 recvbuflen=65536 type="buf" sendchunklen=131072: 36.92736185280725
net/net-s2c.js dur=5 recvbuflen=1048576 type="buf" sendchunklen=131072: 39.21447761809467
net/net-s2c.js dur=5 recvbuflen=0 type="buf" sendchunklen=16777216: 21.913559134252168
net/net-s2c.js dur=5 recvbuflen=65536 type="buf" sendchunklen=16777216: 35.96126656747849
net/net-s2c.js dur=5 recvbuflen=1048576 type="buf" sendchunklen=16777216: 36.709655230358784
```

I did not add documentation or tests yet because API is not set in stone.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
