### PR TITLE
test: check for tls renegotiation errors

### DIFF
--- a/test/parallel/test-tls-disable-renegotiation.js
+++ b/test/parallel/test-tls-disable-renegotiation.js
@@ -12,7 +12,7 @@ const tls = require('tls');
 
 const options = {
   key: fixtures.readKey('agent1-key.pem'),
-  cert: fixtures.readKey('agent1-cert.pem')
+  cert: fixtures.readKey('agent1-cert.pem'),
 };
 
 const server = tls.Server(options, common.mustCall((socket) => {
@@ -45,28 +45,26 @@ server.listen(0, common.mustCall(() => {
     rejectUnauthorized: false,
     port
   };
-  const client =
-    tls.connect(options, common.mustCall(() => {
-      client.write('');
-      // Negotiation is still permitted for this first
-      // attempt. This should succeed.
-      client.renegotiate(
-        { rejectUnauthorized: false },
-        common.mustCall(() => {
-          // Once renegotiation completes, we write some
-          // data to the socket, which triggers the on
-          // data event on the server. After that data
-          // is received, disableRenegotiation is called.
-          client.write('data', common.mustCall(() => {
-            client.write('');
-            // This second renegotiation attempt should fail
-            // and the callback should never be invoked. The
-            // server will simply drop the connection after
-            // emitting the error.
-            client.renegotiate(
-              { rejectUnauthorized: false },
-              common.mustNotCall());
-          }));
-        }));
+  const client = tls.connect(options, common.mustCall(() => {
+    client.write('');
+    // Negotiation is still permitted for this first
+    // attempt. This should succeed.
+    let ok = client.renegotiate(options, common.mustCall((err) => {
+      assert.ifError(err);
+      // Once renegotiation completes, we write some
+      // data to the socket, which triggers the on
+      // data event on the server. After that data
+      // is received, disableRenegotiation is called.
+      client.write('data', common.mustCall(() => {
+        client.write('');
+        // This second renegotiation attempt should fail
+        // and the callback should never be invoked. The
+        // server will simply drop the connection after
+        // emitting the error.
+        ok = client.renegotiate(options, common.mustNotCall());
+        assert.strictEqual(ok, true);
+      }));
     }));
+    assert.strictEqual(ok, true);
+  }));
 }));


### PR DESCRIPTION
Check that the return value and callback error for tls.renegotiate()
does not indicate a failure. Also, remove unnecessary line wrapping and
indentation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
