### PR TITLE
test: fix test-net-connect-econnrefused (again)

### DIFF
--- a/test/pummel/test-net-connect-econnrefused.js
+++ b/test/pummel/test-net-connect-econnrefused.js
@@ -50,7 +50,8 @@ function pummel() {
 function check() {
   setTimeout(function() {
     assert.strictEqual(process._getActiveRequests().length, 0);
-    assert.strictEqual(process._getActiveHandles().length, 1); // the timer
+    const activeHandles = process._getActiveHandles();
+    assert.ok(activeHandles.every((val) => val.constructor.name !== 'Socket'));
     check_called = true;
   }, 0);
 }


### PR DESCRIPTION
test-net-connect-econnrefused was recently fixed, but only in certain
circumstances. This change allows it to succeed whether it is invoked
with `node` or `tools/test.py`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
