### PR TITLE
doc: revert incorrect change on readable._read.

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1846,10 +1846,6 @@ const myReadable = new Readable({
 #### readable.\_read(size)
 <!-- YAML
 added: v0.9.4
-changes:
-  - version: v10.0.0
-    pr-url: https://github.com/nodejs/node/pull/17979
-    description: Call `_read()` only once per microtick.
 -->
 
 * `size` {number} Number of bytes to read asynchronously
@@ -1869,9 +1865,7 @@ when `_read()` is called again after it has stopped should it resume pushing
 additional data onto the queue.
 
 Once the `readable._read()` method has been called, it will not be called again
-until the [`readable.push()`][stream-push] method is called. `readable._read()`
-is guaranteed to be called only once within a synchronous execution, i.e. a
-microtick.
+until the [`readable.push()`][stream-push] method is called.
 
 The `size` argument is advisory. For implementations where a "read" is a
 single operation that returns data can use the `size` argument to determine how


### PR DESCRIPTION
https://github.com/nodejs/node/pull/17979 introduced a change in the
doc that was not correct about _read always being called asynchronously.
This does not hold true when it is in flowing mode.

See: https://github.com/nodejs/node/pull/17979
Fixes: https://github.com/nodejs/node/issues/24919

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
