### PR TITLE
inspector, test: verify reported console message

### DIFF
--- a/test/parallel/test-inspector-console-top-frame.js
+++ b/test/parallel/test-inspector-console-top-frame.js
@@ -1,4 +1,10 @@
 'use strict';
+
+// Verify that the line containing console.log is reported as a top stack frame
+// of the consoleAPICalled notification.
+// Changing this will break many Inspector protocol clients, including
+// debuggers that use that value for navigating from console messages to code.
+
 const common = require('../common');
 common.skipIfInspectorDisabled();
 
@@ -22,4 +28,4 @@ logMessage();  // Triggers Inspector notification
 
 session.disconnect();
 assert.strictEqual(basename(topFrame.url), basename(__filename));
-assert.strictEqual(topFrame.lineNumber, 9);
+assert.strictEqual(topFrame.lineNumber, 15);

--- a/test/parallel/test-inspector-console-top-frame.js
+++ b/test/parallel/test-inspector-console-top-frame.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { Session } = require('inspector');
+const { basename } = require('path');
+
+function logMessage() {
+  console.log('Log a message');
+}
+
+const session = new Session();
+let topFrame;
+session.once('Runtime.consoleAPICalled', (notification) => {
+  topFrame = (notification.params.stackTrace.callFrames[0]);
+});
+session.connect();
+session.post('Runtime.enable');
+
+logMessage();  // Triggers Inspector notification
+
+session.disconnect();
+assert.strictEqual(basename(topFrame.url), basename(__filename));
+assert.strictEqual(topFrame.lineNumber, 9);


### PR DESCRIPTION
Many Inspector protocol clients rely on the top frame reported for the
console messages. This test makes sure correct location is reported.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
