### PR TITLE
[v8.x] http: attach reused parser to correct domain

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -509,12 +509,6 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
   var socket = this.socket;
   var req = socket._httpMessage;
 
-  // propagate "domain" setting...
-  if (req.domain && !res.domain) {
-    debug('setting "res.domain"');
-    res.domain = req.domain;
-  }
-
   debug('AGENT incoming response!');
 
   if (req.res) {
@@ -629,6 +623,9 @@ function tickOnSocket(req, socket) {
   req.socket = socket;
   req.connection = socket;
   parser.reinitialize(HTTPParser.RESPONSE, parser[is_reused_symbol]);
+  if (process.domain) {
+    process.domain.add(parser);
+  }
   parser.socket = socket;
   parser.incoming = null;
   parser.outgoing = req;

--- a/test/parallel/test-http-parser-reuse-domain.js
+++ b/test/parallel/test-http-parser-reuse-domain.js
@@ -50,7 +50,6 @@ function performHttpRequest(opts, cb) {
 
 function performHttpRequestInNewDomain(opts, cb) {
   const d = domain.create();
-  d._id = opts.id;
   d.run(() => {
     performHttpRequest(opts, cb);
   });

--- a/test/parallel/test-http-parser-reuse-domain.js
+++ b/test/parallel/test-http-parser-reuse-domain.js
@@ -10,8 +10,20 @@ const agent = new http.Agent({
   keepAlive: true
 });
 
+const reqSockets = new Set();
+
 function performHttpRequest(opts, cb) {
   const req = http.get({ port: server.address().port, agent }, (res) => {
+    if (!req.socket) {
+      console.log('missing socket property on req object, failing test');
+      markTestAsFailed();
+      req.abort();
+      cb(new Error('req.socket missing'));
+      return;
+    }
+
+    reqSockets.add(req.socket);
+
     // Consume the data from the response to make sure the 'end' event is
     // emitted.
     res.on('data', function noop() {});
@@ -24,11 +36,13 @@ function performHttpRequest(opts, cb) {
     });
 
     res.on('error', (resErr) => {
-      process.exit(1);
+      console.log('got error on response, failing test:', resErr);
+      markTestAsFailed();
     });
 
   }).on('error', (reqErr) => {
-    process.exit(1);
+    console.log('got error on request, failing test:', reqErr);
+    markTestAsFailed();
   });
 
   req.end();
@@ -52,6 +66,10 @@ server.listen(0, common.mustCall(function() {
   const d1 = performHttpRequestInNewDomain({
     shouldThrow: false
   }, common.mustCall((firstReqErr) => {
+    if (firstReqErr) {
+      markTestAsFailed();
+      return;
+    }
     // We want to schedule the second request on the next turn of the event
     // loop so that the parser from the first request is actually reused.
     setImmediate(common.mustCall(() => {
@@ -61,13 +79,19 @@ server.listen(0, common.mustCall(function() {
         // Since this request throws before its callback has the chance
         // to be called, we mark the test as failed if this callback is
         // called.
-        process.exit(1);
+        console.log('second request\'s cb called unexpectedly, failing test');
+        markTestAsFailed();
       });
 
       // The second request throws when its response's end event is
       // emitted. So we expect its domain to emit an error event.
       d2.on('error', common.mustCall((d2err) => {
         server.close();
+        if (reqSockets.size !== 1) {
+          console.log('more than 1 socket used for both requests, failing ' +
+            'test');
+          markTestAsFailed();
+        }
       }, 1));
     }));
   }));
@@ -75,6 +99,15 @@ server.listen(0, common.mustCall(function() {
   d1.on('error', (d1err) => {
     // d1 is the domain attached to the first request, which doesn't throw,
     // so we don't expect its error handler to be called.
-    process.exit(1);
+    console.log('first request\'s domain\'s error handler called, ' +
+      'failing test');
+    markTestAsFailed();
   });
 }));
+
+function markTestAsFailed() {
+  if (server) {
+    server.close();
+  }
+  process.exitCode = 1;
+}

--- a/test/parallel/test-http-parser-reuse-domain.js
+++ b/test/parallel/test-http-parser-reuse-domain.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const common = require('../common');
+const domain = require('domain');
+const http = require('http');
+
+const agent = new http.Agent({
+  // keepAlive is important here so that the underlying socket of all requests
+  // is reused and tied to the same domain.
+  keepAlive: true
+});
+
+function performHttpRequest(opts, cb) {
+  const req = http.get({ port: server.address().port, agent }, (res) => {
+    // Consume the data from the response to make sure the 'end' event is
+    // emitted.
+    res.on('data', function noop() {});
+    res.on('end', () => {
+      if (opts.shouldThrow) {
+        throw new Error('boom');
+      } else {
+        cb();
+      }
+    });
+
+    res.on('error', (resErr) => {
+      process.exit(1);
+    });
+
+  }).on('error', (reqErr) => {
+    process.exit(1);
+  });
+
+  req.end();
+}
+
+function performHttpRequestInNewDomain(opts, cb) {
+  const d = domain.create();
+  d._id = opts.id;
+  d.run(() => {
+    performHttpRequest(opts, cb);
+  });
+
+  return d;
+}
+
+const server = http.createServer((req, res) => {
+  res.end();
+});
+
+server.listen(0, common.mustCall(function() {
+  const d1 = performHttpRequestInNewDomain({
+    shouldThrow: false
+  }, common.mustCall((firstReqErr) => {
+    // We want to schedule the second request on the next turn of the event
+    // loop so that the parser from the first request is actually reused.
+    setImmediate(common.mustCall(() => {
+      const d2 = performHttpRequestInNewDomain({
+        shouldThrow: true
+      }, (secondReqErr) => {
+        // Since this request throws before its callback has the chance
+        // to be called, we mark the test as failed if this callback is
+        // called.
+        process.exit(1);
+      });
+
+      // The second request throws when its response's end event is
+      // emitted. So we expect its domain to emit an error event.
+      d2.on('error', common.mustCall((d2err) => {
+        server.close();
+      }, 1));
+    }));
+  }));
+
+  d1.on('error', (d1err) => {
+    // d1 is the domain attached to the first request, which doesn't throw,
+    // so we don't expect its error handler to be called.
+    process.exit(1);
+  });
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- ~~[ ] documentation is changed or added~~
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

----

Reused parsers can be attached to the domain that corresponds to the
active domain when the underlying socket was created, which is not
necessarily correct.

Instead, we attach parsers to the active domain if there is one when
they're reused from the pool.

Refs: https://github.com/nodejs/node/issues/25456