### PR TITLE
process: move worker execution to `executeUserCode()`

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -309,19 +309,6 @@ function startup() {
 // others like the debugger or running --eval arguments. Here we decide
 // which mode we run in.
 function startExecution() {
-  // This means we are in a Worker context, and any script execution
-  // will be directed by the worker module.
-  if (!isMainThread) {
-    const workerThreadSetup = NativeModule.require(
-      'internal/process/worker_thread_only'
-    );
-    // Set up the message port and start listening
-    const { workerFatalExeception } = workerThreadSetup.setup();
-    // Overwrite fatalException
-    process._fatalException = workerFatalExeception;
-    return;
-  }
-
   // To allow people to extend Node in different ways, this hook allows
   // one to drop a file lib/_third_party_main.js into the build
   // directory which will be executed instead of Node's normal loading.
@@ -392,6 +379,19 @@ function prepareUserCodeExecution() {
 }
 
 function executeUserCode() {
+  // If we are in a worker thread, execute the script sent through the
+  // message port.
+  if (!isMainThread) {
+    const workerThreadSetup = NativeModule.require(
+      'internal/process/worker_thread_only'
+    );
+    // Set up the message port and start listening
+    const { workerFatalExeception } = workerThreadSetup.setup();
+    // Overwrite fatalException
+    process._fatalException = workerFatalExeception;
+    return;
+  }
+
   // User passed `-e` or `--eval` arguments to Node without `-i` or
   // `--interactive`.
   // Note that the name `forceRepl` is merely an alias of `interactive`


### PR DESCRIPTION
As this part is executing a "main" script provided by users - the
difference is that the content is specified through a port instead
of through the CLI.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
