### PR TITLE
src: call `Environment::Exit()` for fatal exceptions

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -240,6 +240,7 @@ static struct {
   }
 
   void Dispose() {
+    StopTracingAgent();
     platform_->Shutdown();
     delete platform_;
     platform_ = nullptr;
@@ -579,7 +580,6 @@ static void WaitForInspectorDisconnect(Environment* env) {
 void Exit(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   WaitForInspectorDisconnect(env);
-  v8_platform.StopTracingAgent();
   int code = args[0]->Int32Value(env->context()).FromMaybe(0);
   env->Exit(code);
 }
@@ -1436,7 +1436,6 @@ int Start(int argc, char** argv) {
   per_process::v8_initialized = true;
   const int exit_code =
       Start(uv_default_loop(), args, exec_args);
-  v8_platform.StopTracingAgent();
   per_process::v8_initialized = false;
   V8::Dispose();
 

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -322,7 +322,7 @@ TryCatchScope::~TryCatchScope() {
   if (HasCaught() && !HasTerminated() && mode_ == CatchMode::kFatal) {
     HandleScope scope(env_->isolate());
     ReportException(env_, Exception(), Message());
-    exit(7);
+    env_->Exit(7);
   }
 }
 
@@ -381,7 +381,7 @@ void FatalException(Isolate* isolate,
     // Failed before the process._fatalException function was added!
     // this is probably pretty bad.  Nothing to do but report and exit.
     ReportException(env, error, message);
-    exit(6);
+    env->Exit(6);
   } else {
     errors::TryCatchScope fatal_try_catch(env);
 
@@ -397,7 +397,7 @@ void FatalException(Isolate* isolate,
     if (fatal_try_catch.HasCaught()) {
       // The fatal exception function threw, so we must exit
       ReportException(env, fatal_try_catch);
-      exit(7);
+      env->Exit(7);
 
     } else if (caught.ToLocalChecked()->IsFalse()) {
       ReportException(env, error, message);
@@ -408,9 +408,9 @@ void FatalException(Isolate* isolate,
       Local<Value> code;
       if (!process_object->Get(env->context(), exit_code).ToLocal(&code) ||
           !code->IsInt32()) {
-        exit(1);
+        env->Exit(1);
       }
-      exit(code.As<Int32>()->Value());
+      env->Exit(code.As<Int32>()->Value());
     }
   }
 }


### PR DESCRIPTION
Tests fail without the first commit, so they are in one PR.

**src: reset `StopTracingAgent()` before platform teardown**

This makes sure that `StopTracingAgent()` is always called
before tearing down the `tracing::Agent`,
since previously its destructor might have tried to access the
agent, which would be destroyed by the (earlier) `Dispose()` call.

**src: call `Environment::Exit()` for fatal exceptions**

Call `Environment::Exit()` rather than the process-wide
`exit()` function, since JS exceptions generally only affect
the current JS engine instance.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
