### PR TITLE
test: refactor two http client timeout tests

### DIFF
--- a/test/parallel/test-http-client-set-timeout.js
+++ b/test/parallel/test-http-client-set-timeout.js
@@ -1,46 +1,48 @@
 'use strict';
-const common = require('../common');
 
-// Test that `req.setTimeout` will fired exactly once.
+// Test that the `'timeout'` event is emitted exactly once if the `timeout`
+// option and `request.setTimeout()` are used together.
 
-const assert = require('assert');
-const http = require('http');
+const { expectsError, mustCall } = require('../common');
+const { strictEqual } = require('assert');
+const { createServer, get } = require('http');
 
-const HTTP_CLIENT_TIMEOUT = 2000;
-
-const options = {
-  method: 'GET',
-  port: undefined,
-  host: '127.0.0.1',
-  path: '/',
-  timeout: HTTP_CLIENT_TIMEOUT,
-};
-
-const server = http.createServer(() => {
+const server = createServer(() => {
   // Never respond.
 });
 
-server.listen(0, options.host, function() {
-  doRequest();
-});
-
-function doRequest() {
-  options.port = server.address().port;
-  const req = http.request(options);
-  req.setTimeout(HTTP_CLIENT_TIMEOUT / 2);
-  req.on('error', () => {
-    // This space is intentionally left blank.
+server.listen(0, mustCall(() => {
+  const req = get({
+    port: server.address().port,
+    timeout: 2000,
   });
-  req.on('close', common.mustCall(() => server.close()));
 
-  let timeout_events = 0;
-  req.on('timeout', common.mustCall(() => {
-    timeout_events += 1;
+  req.setTimeout(1000);
+
+  req.on('socket', mustCall((socket) => {
+    strictEqual(socket.timeout, 2000);
+
+    socket.on('connect', mustCall(() => {
+      strictEqual(socket.timeout, 1000);
+
+      // Reschedule the timer to not wait 1 sec and make the test finish faster.
+      socket.setTimeout(10);
+      strictEqual(socket.timeout, 10);
+    }));
   }));
-  req.end();
 
-  setTimeout(function() {
+  req.on('error', expectsError({
+    type: Error,
+    code: 'ECONNRESET',
+    message: 'socket hang up'
+  }));
+
+  req.on('close', mustCall(() => {
+    server.close();
+  }));
+
+  req.on('timeout', mustCall(() => {
+    strictEqual(req.socket.listenerCount('timeout'), 0);
     req.destroy();
-    assert.strictEqual(timeout_events, 1);
-  }, common.platformTimeout(HTTP_CLIENT_TIMEOUT));
-}
+  }));
+}));


### PR DESCRIPTION
Refactor test-http-client-set-timeout and test-http-client-timeout-option-with-agent.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
