### PR TITLE
test: do not use uninitialized memory in common flags check

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -58,9 +58,9 @@ if (process.argv.length === 2 &&
   const bytesToRead = 1500;
   const buffer = Buffer.allocUnsafe(bytesToRead);
   const fd = fs.openSync(module.parent.filename, 'r');
-  fs.readSync(fd, buffer, 0, bytesToRead);
+  const bytesRead = fs.readSync(fd, buffer, 0, bytesToRead);
   fs.closeSync(fd);
-  const source = buffer.toString();
+  const source = buffer.toString('utf8', 0, bytesRead);
 
   const flagStart = source.indexOf('// Flags: --') + 10;
   if (flagStart !== 9) {


### PR DESCRIPTION
Only use the amount of data that was actually read from the test file.
Otherwise, there is a small risk of getting false positives, and
generally reading uninitialized memory makes using automated
memory error detection tools harder.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
