### PR TITLE
src: remove outdated `Neuter()` call in `node_buffer.cc`

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -402,11 +402,6 @@ MaybeLocal<Object> New(Environment* env,
   }
 
   Local<ArrayBuffer> ab = ArrayBuffer::New(env->isolate(), data, length);
-  // `Neuter()`ing is required here to prevent materialization of the backing
-  // store in v8. `nullptr` buffers are not writable, so this is semantically
-  // correct.
-  if (data == nullptr)
-    ab->Neuter();
   MaybeLocal<Uint8Array> ui = Buffer::New(env, ab, 0, length);
 
   CallbackInfo::New(env->isolate(), ab, callback, data, hint);


### PR DESCRIPTION
This call was introduced in 827ee498e332e3 to avoid a crash in a
later `Neuter()` call that has later been removed in ebbbc5a790db69,
rendering the original call unnecessary.

Refs: https://github.com/nodejs/node/pull/3624
Refs: https://github.com/nodejs/node/pull/5204

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
