### PR TITLE
test: refactor pummel tests

### DIFF
--- a/test/pummel/test-keep-alive.js
+++ b/test/pummel/test-keep-alive.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-// This test requires the program 'wrk'
+// This test requires the program 'wrk'.
 const common = require('../common');
 if (common.isWindows)
   common.skip('no `wrk` on windows');
@@ -47,9 +47,9 @@ let normalReqSec = 0;
 
 const runAb = (opts, callback) => {
   const args = [
-    '-c', opts.concurrent || 100,
+    '-c', opts.concurrent || 50,
     '-t', opts.threads || 2,
-    '-d', opts.duration || '10s',
+    '-d', opts.duration || '5s',
   ];
 
   if (!opts.keepalive) {
@@ -58,7 +58,7 @@ const runAb = (opts, callback) => {
   }
 
   args.push(url.format({ hostname: '127.0.0.1',
-                         port: common.PORT, protocol: 'http' }));
+                         port: opts.port, protocol: 'http' }));
 
   const child = spawn('wrk', args);
   child.stderr.pipe(process.stderr);
@@ -90,11 +90,12 @@ const runAb = (opts, callback) => {
   });
 };
 
-server.listen(common.PORT, () => {
-  runAb({ keepalive: true }, (reqSec) => {
+server.listen(0, () => {
+  const port = server.address().port;
+  runAb({ keepalive: true, port: port }, (reqSec) => {
     keepAliveReqSec = reqSec;
 
-    runAb({ keepalive: false }, (reqSec) => {
+    runAb({ keepalive: false, port: port }, (reqSec) => {
       normalReqSec = reqSec;
       server.close();
     });

--- a/test/pummel/test-net-connect-econnrefused.js
+++ b/test/pummel/test-net-connect-econnrefused.js
@@ -20,14 +20,14 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-// verify that connect reqs are properly cleaned up
+// Verify that connect reqs are properly cleaned up.
 
 const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const ROUNDS = 10;
-const ATTEMPTS_PER_ROUND = 100;
+const ROUNDS = 5;
+const ATTEMPTS_PER_ROUND = 50;
 let rounds = 1;
 let reqs = 0;
 

--- a/test/pummel/test-net-many-clients.js
+++ b/test/pummel/test-net-many-clients.js
@@ -20,14 +20,14 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
 // settings
 const bytes = 1024 * 40;
-const concurrency = 100;
-const connections_per_client = 5;
+const concurrency = 50;
+const connections_per_client = 3;
 
 // measured
 let total_connections = 0;
@@ -35,15 +35,14 @@ let total_connections = 0;
 const body = 'C'.repeat(bytes);
 
 const server = net.createServer(function(c) {
-  console.log('connected');
   total_connections++;
-  console.log('#');
+  console.log('connected', total_connections);
   c.write(body);
   c.end();
 });
 
-function runClient(callback) {
-  const client = net.createConnection(common.PORT);
+function runClient(port, callback) {
+  const client = net.createConnection(port);
 
   client.connections = 0;
 
@@ -79,17 +78,17 @@ function runClient(callback) {
     assert.ok(!client.fd);
 
     if (this.connections < connections_per_client) {
-      this.connect(common.PORT);
+      this.connect(port);
     } else {
       callback();
     }
   });
 }
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   let finished_clients = 0;
   for (let i = 0; i < concurrency; i++) {
-    runClient(function() {
+    runClient(server.address().port, function() {
       if (++finished_clients === concurrency) server.close();
     });
   }

--- a/test/pummel/test-net-pingpong.js
+++ b/test/pummel/test-net-pingpong.js
@@ -26,7 +26,7 @@ const net = require('net');
 
 let tests_run = 0;
 
-function pingPongTest(port, host, on_complete) {
+function pingPongTest(host, on_complete) {
   const N = 1000;
   let count = 0;
   let sent_final_ping = false;
@@ -69,8 +69,8 @@ function pingPongTest(port, host, on_complete) {
     });
   });
 
-  server.listen(port, host, function() {
-    const client = net.createConnection(port, host);
+  server.listen(0, host, function() {
+    const client = net.createConnection(server.address().port, host);
 
     client.setEncoding('utf8');
 
@@ -110,12 +110,12 @@ function pingPongTest(port, host, on_complete) {
   });
 }
 
-/* All are run at once, so run on different ports */
-pingPongTest(common.PORT, 'localhost');
-pingPongTest(common.PORT + 1, null);
+// All are run at once and will run on different ports.
+pingPongTest('localhost');
+pingPongTest(null);
 
-// This IPv6 isn't working on Solaris
-if (!common.isSunOS) pingPongTest(common.PORT + 2, '::1');
+// This IPv6 isn't working on Solaris.
+if (!common.isSunOS) pingPongTest('::1');
 
 process.on('exit', function() {
   assert.strictEqual(tests_run, common.isSunOS ? 2 : 3);


### PR DESCRIPTION
This refactors 4 pummel tests as a hopefully final step before being able to enable pummel tests in node-daily-master. Currently, all pummel tests pass for me locally if run once at a time. However, if run with `tools/test.py pummel`, there will be some failures due to side effects (mostly network throttling, it would seem). These changes resolve that by reducing some of the pummel-iness of some tests and also moving some tests off of `common.PORT` and use port 0 (OS-assigned available port) instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
