### PR TITLE
http: make timeout event work with agent timeout

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -653,7 +653,10 @@ function tickOnSocket(req, socket) {
   socket.on('end', socketOnEnd);
   socket.on('close', socketCloseListener);
 
-  if (req.timeout !== undefined) {
+  if (
+    req.timeout !== undefined ||
+    (req.agent && req.agent.options && req.agent.options.timeout)
+  ) {
     listenSocketTimeout(req);
   }
   req.emit('socket', socket);

--- a/test/parallel/test-http-agent-timeout-option.js
+++ b/test/parallel/test-http-agent-timeout-option.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const { expectsError, mustCall } = require('../common');
+const { Agent, get } = require('http');
+
+// Test that the `'timeout'` event is emitted on the `ClientRequest` instance
+// when the socket timeout set via the `timeout` option of the `Agent` expires.
+
+const request = get({
+  agent: new Agent({ timeout: 500 }),
+  // Non-routable IP address to prevent the connection from being established.
+  host: '192.0.2.1'
+});
+
+request.on('error', expectsError({
+  type: Error,
+  code: 'ECONNRESET',
+  message: 'socket hang up'
+}));
+
+request.on('timeout', mustCall(() => {
+  request.abort();
+}));


### PR DESCRIPTION
The `'timeout'` event is currently not emitted on the `ClientRequest`
instance when the socket timeout expires if only the `timeout` option
of the agent is set. This happens because, under these circumstances,
`listenSocketTimeout()` is not called.

This commit fixes the issue by calling it also when only the agent
`timeout` option is set.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
