### PR TITLE
doc: fix http.Agent timeout option description

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -127,7 +127,7 @@ added: v0.3.4
     in a free state. Only relevant if `keepAlive` is set to `true`.
     **Default:** `256`.
   * `timeout` {number} Socket timeout in milliseconds.
-    This will set the timeout after the socket is connected.
+    This will set the timeout when the socket is created.
 
 `options` in [`socket.connect()`][] are also supported.
 


### PR DESCRIPTION
By default the agent options are passed to `net.createConnection()`
which sets the timeout on the socket immediately after creating it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
