### PR TITLE
tls: do not free cert in `.getCertificate()`

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1963,10 +1963,10 @@ void SSLWrap<Base>::GetCertificate(
 
   Local<Object> result;
 
-  X509Pointer cert(SSL_get_certificate(w->ssl_.get()));
+  X509* cert = SSL_get_certificate(w->ssl_.get());
 
-  if (cert)
-    result = X509ToObject(env, cert.get());
+  if (cert != nullptr)
+    result = X509ToObject(env, cert);
 
   args.GetReturnValue().Set(result);
 }

--- a/test/parallel/test-tls-pfx-authorizationerror.js
+++ b/test/parallel/test-tls-pfx-authorizationerror.js
@@ -37,8 +37,13 @@ const server = tls
         rejectUnauthorized: false
       },
       function() {
-        assert.strictEqual(client.getCertificate().serialNumber,
-                           'ECC9B856270DA9A8');
+        for (let i = 0; i < 10; ++i) {
+          // Calling this repeatedly is a regression test that verifies
+          // that .getCertificate() does not accidentally decrease the
+          // reference count of the X509* certificate on the native side.
+          assert.strictEqual(client.getCertificate().serialNumber,
+                             'ECC9B856270DA9A8');
+        }
         client.end();
         server.close();
       }


### PR DESCRIPTION
The documentation of `SSL_get_certificate` states that it returns
an internal pointer that must not be freed by the caller.

Therefore, using a smart pointer to take ownership is incorrect.

Refs: https://man.openbsd.org/SSL_get_certificate.3
Refs: https://github.com/nodejs/node/pull/24261

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
