### PR TITLE
os: add fallback for undefined CPUs

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -86,7 +86,8 @@ function loadavg() {
 }
 
 function cpus() {
-  const data = getCPUs();
+  // [] is a bugfix for a regression introduced in 51cea61
+  const data = getCPUs() || [];
   const result = [];
   for (var i = 0; i < data.length; i += 7) {
     result.push({


### PR DESCRIPTION
Currently, for an unsupported OS, a call to `os.cpus()` throws an error within `os.cpus()` itself where it tries to get the length of undefined. This PR fixes the issue by adding fallback for undefined CPUs.
 
Fixes: https://github.com/nodejs/node/issues/25483

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
