### PR TITLE
tools: improve valgrind support

### DIFF
--- a/tools/run-valgrind.py
+++ b/tools/run-valgrind.py
@@ -37,7 +37,9 @@ NODE_ROOT = path.dirname(path.dirname(path.abspath(__file__)))
 VALGRIND_ARGUMENTS = [
   'valgrind',
   '--error-exitcode=1',
-  '--smc-check=all',
+  '--smc-check=all-non-file',
+  '--suppressions=' + path.join(NODE_ROOT, 'tools', 'valgrind.supp'),
+  '--gen-suppressions=all',
 ]
 
 if len(sys.argv) < 2:
@@ -50,7 +52,8 @@ if not path.exists(executable):
   sys.exit(1)
 
 # Compute the command line.
-command = VALGRIND_ARGUMENTS + [executable] + sys.argv[2:]
+command = VALGRIND_ARGUMENTS + [executable, '--zero-fill-buffers']
+command += sys.argv[2:]
 
 # Run valgrind.
 process = subprocess.Popen(command, stderr=subprocess.PIPE)

--- a/tools/valgrind.supp
+++ b/tools/valgrind.supp
@@ -1,0 +1,106 @@
+{
+   <PW_trace_event>
+   Helgrind:Race
+   ...
+   fun:_ZN4node12_GLOBAL__N_1L20PlatformWorkerThreadEPv
+   ...
+}
+{
+   <tracing_group>
+   Helgrind:Race
+   ...
+   fun:_ZN2v88platform7tracing17TracingController31GetCategoryGroupEnabledInternalEPKc
+   ...
+}
+{
+   <locker_is_active>
+   Helgrind:Race
+   ...
+   fun:_ZN2v86Locker8IsActiveEv
+   ...
+}
+{
+   <locker_initialize>
+   Helgrind:Race
+   ...
+   fun:_ZN2v86Locker10InitializeEPNS_7IsolateE
+   ...
+}
+{
+   <set_embedded_blob>
+   Helgrind:Race
+   ...
+   fun:_ZN2v88internal7Isolate15SetEmbeddedBlobEPKhj
+   ...
+}
+{
+   <set_stack_limits>
+   Helgrind:Race
+   ...
+   fun:_ZN2v88internal4Heap14SetStackLimitsEv
+   ...
+}
+{
+   <current_embedded_blob_size>
+   Helgrind:Race
+   ...
+   fun:_ZN2v88internal7Isolate23CurrentEmbeddedBlobSizeEv
+   ...
+}
+{
+   <current_embedded_blob>
+   Helgrind:Race
+   ...
+   fun:_ZN2v88internal7Isolate19CurrentEmbeddedBlobEv
+   ...
+}
+{
+   <epoll_invalid_param>
+   Memcheck:Param
+   epoll_ctl(event)
+   fun:epoll_ctl
+   fun:uv__io_poll
+   ...
+   obj:/home/sqrt/src/node/master/out/Release/node
+}
+{
+   <frame_ptr_ne>
+   Memcheck:Cond
+   ...
+   fun:_ZN2v88internal9ExitFrame23GetStateForFramePointerEmPNS0_10StackFrame5StateE
+   ...
+}
+{
+   <debug_signal_thread_stack_storage>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:pthread_create*
+   fun:_ZN4node9inspector12_GLOBAL__N_1L23StartDebugSignalHandlerEv
+   ...
+}
+{
+   <copyfile_ioctl>
+   Memcheck:Param
+   ioctl(generic)
+   fun:*
+   fun:uv__fs_copyfile
+   ...
+}
+{
+   <epoll_pwait>
+   Memcheck:Param
+   epoll_pwait(sigmask)
+   fun:*
+   fun:uv__io_poll
+   ...
+}
+{
+   <platform_worker_threads_uv_loop_close_after_async_send>
+   Helgrind:Race
+   ...
+   fun:uv_loop_close
+   fun:_ZN4node18CheckedUvLoopCloseEP9uv_loop_s
+   fun:_ZZN4node23WorkerThreadsTaskRunner20DelayedTaskScheduler5StartEvENUlPvE_4_FUNES2_
+   ...
+}


### PR DESCRIPTION
- Generate and use a list of suppressions that reduce noisiness for
  known (non-)issues.
- Use `--zero-fill-buffers` for tests, as they sometimes use
  `Buffer.allocUnsafe()` and valgrind reports that as usage
  of uninitialized memory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
