### PR TITLE
[v10.x backport] src: re-sort the symbol macros

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -112,8 +112,8 @@ struct PackageConfig {
 // for the sake of convenience.
 #define PER_ISOLATE_SYMBOL_PROPERTIES(V)                                      \
   V(handle_onclose_symbol, "handle_onclose")                                  \
-  V(owner_symbol, "owner")                                                    \
   V(oninit_symbol, "oninit")                                                  \
+  V(owner_symbol, "owner")                                                    \
 
 // Strings are per-isolate primitives but Environment proxies them
 // for the sake of convenience.  Strings should be ASCII-only.
@@ -124,19 +124,18 @@ struct PackageConfig {
   V(async, "async")                                                           \
   V(async_ids_stack_string, "async_ids_stack")                                \
   V(buffer_string, "buffer")                                                  \
-  V(bytes_string, "bytes")                                                    \
   V(bytes_parsed_string, "bytesParsed")                                       \
   V(bytes_read_string, "bytesRead")                                           \
+  V(bytes_string, "bytes")                                                    \
   V(bytes_written_string, "bytesWritten")                                     \
-  V(cached_data_string, "cachedData")                                         \
   V(cached_data_produced_string, "cachedDataProduced")                        \
   V(cached_data_rejected_string, "cachedDataRejected")                        \
+  V(cached_data_string, "cachedData")                                         \
   V(change_string, "change")                                                  \
   V(channel_string, "channel")                                                \
   V(chunks_sent_since_last_write_string, "chunksSentSinceLastWrite")          \
-  V(constants_string, "constants")                                            \
-  V(oncertcb_string, "oncertcb")                                              \
   V(code_string, "code")                                                      \
+  V(constants_string, "constants")                                            \
   V(cwd_string, "cwd")                                                        \
   V(dest_string, "dest")                                                      \
   V(destroyed_string, "destroyed")                                            \
@@ -153,7 +152,6 @@ struct PackageConfig {
   V(dns_txt_string, "TXT")                                                    \
   V(duration_string, "duration")                                              \
   V(emit_warning_string, "emitWarning")                                       \
-  V(exchange_string, "exchange")                                              \
   V(encoding_string, "encoding")                                              \
   V(entries_string, "entries")                                                \
   V(entry_type_string, "entryType")                                           \
@@ -161,6 +159,7 @@ struct PackageConfig {
   V(env_var_settings_string, "envVarSettings")                                \
   V(errno_string, "errno")                                                    \
   V(error_string, "error")                                                    \
+  V(exchange_string, "exchange")                                              \
   V(exit_code_string, "exitCode")                                             \
   V(expire_string, "expire")                                                  \
   V(exponent_string, "exponent")                                              \
@@ -171,8 +170,8 @@ struct PackageConfig {
   V(fatal_exception_string, "_fatalException")                                \
   V(fd_string, "fd")                                                          \
   V(file_string, "file")                                                      \
-  V(fingerprint_string, "fingerprint")                                        \
   V(fingerprint256_string, "fingerprint256")                                  \
+  V(fingerprint_string, "fingerprint")                                        \
   V(flags_string, "flags")                                                    \
   V(fragment_string, "fragment")                                              \
   V(get_data_clone_error_string, "_getDataCloneError")                        \
@@ -198,9 +197,9 @@ struct PackageConfig {
   V(mac_string, "mac")                                                        \
   V(main_string, "main")                                                      \
   V(max_buffer_string, "maxBuffer")                                           \
-  V(message_string, "message")                                                \
-  V(message_port_string, "messagePort")                                       \
   V(message_port_constructor_string, "MessagePort")                           \
+  V(message_port_string, "messagePort")                                       \
+  V(message_string, "message")                                                \
   V(minttl_string, "minttl")                                                  \
   V(modulus_string, "modulus")                                                \
   V(name_string, "name")                                                      \
@@ -208,6 +207,7 @@ struct PackageConfig {
   V(nsname_string, "nsname")                                                  \
   V(ocsp_request_string, "OCSPRequest")                                       \
   V(onaltsvc_string, "onaltsvc")                                              \
+  V(oncertcb_string, "oncertcb")                                              \
   V(onchange_string, "onchange")                                              \
   V(onclienthello_string, "onclienthello")                                    \
   V(oncomplete_string, "oncomplete")                                          \
@@ -217,19 +217,19 @@ struct PackageConfig {
   V(onexit_string, "onexit")                                                  \
   V(onframeerror_string, "onframeerror")                                      \
   V(ongetpadding_string, "ongetpadding")                                      \
+  V(ongoawaydata_string, "ongoawaydata")                                      \
   V(onhandshakedone_string, "onhandshakedone")                                \
   V(onhandshakestart_string, "onhandshakestart")                              \
   V(onheaders_string, "onheaders")                                            \
   V(onmessage_string, "onmessage")                                            \
   V(onnewsession_string, "onnewsession")                                      \
   V(onocspresponse_string, "onocspresponse")                                  \
-  V(ongoawaydata_string, "ongoawaydata")                                      \
   V(onorigin_string, "onorigin")                                              \
+  V(onping_string, "onping")                                                  \
   V(onpriority_string, "onpriority")                                          \
   V(onread_string, "onread")                                                  \
   V(onreadstart_string, "onreadstart")                                        \
   V(onreadstop_string, "onreadstop")                                          \
-  V(onping_string, "onping")                                                  \
   V(onsettings_string, "onsettings")                                          \
   V(onshutdown_string, "onshutdown")                                          \
   V(onsignal_string, "onsignal")                                              \
@@ -239,19 +239,19 @@ struct PackageConfig {
   V(onwrite_string, "onwrite")                                                \
   V(openssl_error_stack, "opensslErrorStack")                                 \
   V(options_string, "options")                                                \
-  V(output_string, "output")                                                  \
   V(order_string, "order")                                                    \
+  V(output_string, "output")                                                  \
   V(parse_error_string, "Parse Error")                                        \
   V(password_string, "password")                                              \
   V(path_string, "path")                                                      \
   V(pending_handle_string, "pendingHandle")                                   \
   V(pid_string, "pid")                                                        \
+  V(pipe_source_string, "pipeSource")                                         \
   V(pipe_string, "pipe")                                                      \
   V(pipe_target_string, "pipeTarget")                                         \
-  V(pipe_source_string, "pipeSource")                                         \
-  V(port_string, "port")                                                      \
   V(port1_string, "port1")                                                    \
   V(port2_string, "port2")                                                    \
+  V(port_string, "port")                                                      \
   V(preference_string, "preference")                                          \
   V(priority_string, "priority")                                              \
   V(promise_string, "promise")                                                \
@@ -266,11 +266,11 @@ struct PackageConfig {
   V(replacement_string, "replacement")                                        \
   V(retry_string, "retry")                                                    \
   V(scheme_string, "scheme")                                                  \
-  V(serial_string, "serial")                                                  \
   V(scopeid_string, "scopeid")                                                \
   V(serial_number_string, "serialNumber")                                     \
-  V(service_string, "service")                                                \
+  V(serial_string, "serial")                                                  \
   V(servername_string, "servername")                                          \
+  V(service_string, "service")                                                \
   V(session_id_string, "sessionId")                                           \
   V(shell_string, "shell")                                                    \
   V(signal_string, "signal")                                                  \
@@ -309,7 +309,7 @@ struct PackageConfig {
   V(write_host_object_string, "_writeHostObject")                             \
   V(write_queue_size_string, "writeQueueSize")                                \
   V(x_forwarded_string, "x-forwarded-for")                                    \
-  V(zero_return_string, "ZERO_RETURN")
+  V(zero_return_string, "ZERO_RETURN")                                        \
 
 #define ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)                           \
   V(as_external, v8::External)                                                \
@@ -319,17 +319,17 @@ struct PackageConfig {
   V(async_hooks_destroy_function, v8::Function)                               \
   V(async_hooks_init_function, v8::Function)                                  \
   V(async_hooks_promise_resolve_function, v8::Function)                       \
-  V(async_wrap_object_ctor_template, v8::FunctionTemplate)                    \
   V(async_wrap_ctor_template, v8::FunctionTemplate)                           \
+  V(async_wrap_object_ctor_template, v8::FunctionTemplate)                    \
   V(buffer_prototype_object, v8::Object)                                      \
   V(context, v8::Context)                                                     \
   V(domain_callback, v8::Function)                                            \
   V(domexception_function, v8::Function)                                      \
-  V(fdclose_constructor_template, v8::ObjectTemplate)                         \
   V(fd_constructor_template, v8::ObjectTemplate)                              \
+  V(fdclose_constructor_template, v8::ObjectTemplate)                         \
   V(filehandlereadwrap_template, v8::ObjectTemplate)                          \
-  V(fsreqpromise_constructor_template, v8::ObjectTemplate)                    \
   V(fs_use_promises_symbol, v8::Symbol)                                       \
+  V(fsreqpromise_constructor_template, v8::ObjectTemplate)                    \
   V(handle_wrap_ctor_template, v8::FunctionTemplate)                          \
   V(host_import_module_dynamically_callback, v8::Function)                    \
   V(host_initialize_import_meta_object_callback, v8::Function)                \
@@ -341,9 +341,9 @@ struct PackageConfig {
   V(libuv_stream_wrap_ctor_template, v8::FunctionTemplate)                    \
   V(message_port, v8::Object)                                                 \
   V(message_port_constructor_template, v8::FunctionTemplate)                  \
-  V(pipe_constructor_template, v8::FunctionTemplate)                          \
   V(performance_entry_callback, v8::Function)                                 \
   V(performance_entry_template, v8::Function)                                 \
+  V(pipe_constructor_template, v8::FunctionTemplate)                          \
   V(process_object, v8::Object)                                               \
   V(promise_handler_function, v8::Function)                                   \
   V(promise_wrap_template, v8::ObjectTemplate)                                \
@@ -360,7 +360,7 @@ struct PackageConfig {
   V(tty_constructor_template, v8::FunctionTemplate)                           \
   V(udp_constructor_function, v8::Function)                                   \
   V(url_constructor_function, v8::Function)                                   \
-  V(write_wrap_template, v8::ObjectTemplate)
+  V(write_wrap_template, v8::ObjectTemplate)                                  \
 
 class Environment;
 


### PR DESCRIPTION
The symbol macros were almost lexically sorted, but some were misplaced.

PR-URL: https://github.com/nodejs/node/pull/24382
Reviewed-By: Gus Caplan <me@gus.host>
Reviewed-By: Refael Ackermann <refack@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Franziska Hinkelmann <franziska.hinkelmann@gmail.com>
Reviewed-By: Anna Henningsen <anna@addaleax.net>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
