### PR TITLE
doc: add metadata about ecdh curve options

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1174,6 +1174,10 @@ changes:
   - version: v9.3.0
     pr-url: https://github.com/nodejs/node/pull/14903
     description: The `options` parameter can now include `clientCertEngine`.
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/15206
+    description: The `ecdhCurve` option can now be multiple `':'` separated
+                 curve names or `'auto'`.
   - version: v7.3.0
     pr-url: https://github.com/nodejs/node/pull/10294
     description: If the `key` option is an array, individual entries do not
@@ -1402,6 +1406,10 @@ console.log(tls.getCiphers()); // ['AES128-SHA', 'AES256-SHA', ...]
 ## tls.DEFAULT_ECDH_CURVE
 <!-- YAML
 added: v0.11.13
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/16853
+    description: Default value changed to `'auto'`.
 -->
 
 The default curve name to use for ECDH key agreement in a tls server. The


### PR DESCRIPTION
- DEFAULT_ECDH_CURVE default changed to 'auto' for 10.0.0
- ecdhCurve parameter allowed multiple values and 'auto' from 9.0.0

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
