### PR TITLE
test: improve known_issues/test-vm-timeout-escape-queuemicrotask

### DIFF
--- a/test/known_issues/test-vm-timeout-escape-queuemicrotask.js
+++ b/test/known_issues/test-vm-timeout-escape-queuemicrotask.js
@@ -12,14 +12,17 @@ const NS_PER_MS = 1000000n;
 
 const hrtime = process.hrtime.bigint;
 
+const loopDuration = common.platformTimeout(100n);
+const timeout = common.platformTimeout(10);
+
 function loop() {
   const start = hrtime();
   while (1) {
     const current = hrtime();
     const span = (current - start) / NS_PER_MS;
-    if (span >= 100n) {
+    if (span >= loopDuration) {
       throw new Error(
-        `escaped timeout at ${span} milliseconds!`);
+        `escaped ${timeout}ms timeout at ${span}ms`);
     }
   }
 }
@@ -32,9 +35,9 @@ assert.throws(() => {
       queueMicrotask,
       loop
     },
-    { timeout: common.platformTimeout(5) }
+    { timeout }
   );
 }, {
   code: 'ERR_SCRIPT_EXECUTION_TIMEOUT',
-  message: 'Script execution timed out after 5ms'
+  message: `Script execution timed out after ${timeout}ms`
 });


### PR DESCRIPTION
Improve known_issues/test-vm-timeout-escape-queuemicrotask to mitigate
CI failures on ubuntu1604-arm64. Failures are due to a race condition.
Use `common.platformTimeout()` to help, adjust timeout to make sure
`queueMicrotasks()` has a chance to run, and improve error message.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
