### PR TITLE
test: use fipsMode instead of common.hasFipsCrypto

### DIFF
--- a/test/parallel/test-cli-node-print-help.js
+++ b/test/parallel/test-cli-node-print-help.js
@@ -1,3 +1,4 @@
+// Flags: --expose-internals
 'use strict';
 
 const common = require('../common');
@@ -7,6 +8,8 @@ const common = require('../common');
 
 const assert = require('assert');
 const { exec } = require('child_process');
+const { internalBinding } = require('internal/test/binding');
+const { fipsMode } = internalBinding('config');
 let stdOut;
 
 
@@ -21,7 +24,7 @@ function startPrintHelpTest() {
 function validateNodePrintHelp() {
   const config = process.config;
   const HAVE_OPENSSL = common.hasCrypto;
-  const NODE_FIPS_MODE = common.hasFipsCrypto;
+  const NODE_FIPS_MODE = fipsMode;
   const NODE_HAVE_I18N_SUPPORT = common.hasIntl;
   const HAVE_INSPECTOR = config.variables.v8_enable_inspector === 1;
 

--- a/test/parallel/test-cli-node-print-help.js
+++ b/test/parallel/test-cli-node-print-help.js
@@ -24,7 +24,6 @@ function startPrintHelpTest() {
 function validateNodePrintHelp() {
   const config = process.config;
   const HAVE_OPENSSL = common.hasCrypto;
-  const NODE_FIPS_MODE = fipsMode;
   const NODE_HAVE_I18N_SUPPORT = common.hasIntl;
   const HAVE_INSPECTOR = config.variables.v8_enable_inspector === 1;
 
@@ -32,7 +31,7 @@ function validateNodePrintHelp() {
     { compileConstant: HAVE_OPENSSL,
       flags: [ '--openssl-config=...', '--tls-cipher-list=...',
                '--use-bundled-ca', '--use-openssl-ca' ] },
-    { compileConstant: NODE_FIPS_MODE,
+    { compileConstant: fipsMode,
       flags: [ '--enable-fips', '--force-fips' ] },
     { compileConstant: NODE_HAVE_I18N_SUPPORT,
       flags: [ '--icu-data-dir=...', 'NODE_ICU_DATA' ] },


### PR DESCRIPTION
Currently, `test-cli-node-print-help` uses `common.hasFipsCrypto` to
determine if the test should check for the existence of FIPS related
options (`--enable-fips`, and `--force-fips`). The FIPS options are
available when node has been compiled against an OpenSSL library with
FIPS support in which case the test would verify that these  options
are available. But by using crypto.fips (which uses crypto.getFips())
this would only be checked when fips has been enabled, but these
options are available regardless if FIPS is enabled or disabled.

This commit updates the test to use fipsMode from config to determine
if the FIPS options existence should be checked.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
