### PR TITLE
test: add check for wrk to test-keep-alive

### DIFF
--- a/test/pummel/test-keep-alive.js
+++ b/test/pummel/test-keep-alive.js
@@ -23,11 +23,13 @@
 
 // This test requires the program 'wrk'
 const common = require('../common');
-if (common.isWindows)
-  common.skip('no `wrk` on windows');
+
+const child_process = require('child_process');
+const result = child_process.spawnSync('wrk', ['-h']);
+if (result.error && result.error.code === 'ENOENT')
+  common.skip('test requires `wrk` to be installed first');
 
 const assert = require('assert');
-const spawn = require('child_process').spawn;
 const http = require('http');
 const url = require('url');
 
@@ -60,7 +62,7 @@ const runAb = (opts, callback) => {
   args.push(url.format({ hostname: '127.0.0.1',
                          port: common.PORT, protocol: 'http' }));
 
-  const child = spawn('wrk', args);
+  const child = child_process.spawn('wrk', args);
   child.stderr.pipe(process.stderr);
   child.stdout.setEncoding('utf8');
 


### PR DESCRIPTION
test/pummel/test-keep-alive.js requires `wrk` to be installed. Check if
it is, and skip the test if it isn't.

This is yet another step in preparation for running pummel tests in CI
daily.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
