### PR TITLE
[v8.x backport] build: set `-blibpath:` for AIX

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -88,6 +88,19 @@
           ['OS=="aix"', {
             'cflags': [ '-gxcoff' ],
             'ldflags': [ '-Wl,-bbigtoc' ],
+            'conditions': [
+              ['target_arch=="ppc64"', {
+                'ldflags': [
+                  '-Wl,-blibpath:/usr/lib:/lib:'
+                    '/opt/freeware/lib/pthread/ppc64'
+                ],
+              }],
+              ['target_arch=="ppc"', {
+                'ldflags': [
+                  '-Wl,-blibpath:/usr/lib:/lib:/opt/freeware/lib/pthread'
+                ],
+              }],
+            ],
           }],
           ['OS == "android"', {
             'cflags': [ '-fPIE' ],
@@ -337,11 +350,18 @@
           [ 'OS=="aix"', {
             'conditions': [
               [ 'target_arch=="ppc"', {
-                'ldflags': [ '-Wl,-bmaxdata:0x60000000/dsa' ],
+                'ldflags': [
+                  '-Wl,-bmaxdata:0x60000000/dsa',
+                  '-Wl,-blibpath:/usr/lib:/lib:/opt/freeware/lib/pthread',
+                 ],
               }],
               [ 'target_arch=="ppc64"', {
                 'cflags': [ '-maix64' ],
-                'ldflags': [ '-maix64' ],
+                'ldflags': [
+                  '-maix64',
+                  '-Wl,-blibpath:/usr/lib:/lib:'
+                    '/opt/freeware/lib/pthread/ppc64',
+                ],
               }],
             ],
             'ldflags': [ '-Wl,-bbigtoc' ],


### PR DESCRIPTION
https://github.com/nodejs/node/pull/17604 refactored the gyp files
so that `-blibpath:` on AIX was only set if `node_shared=="true"`.
Restore the setting for non-shared builds.

Fixes: https://github.com/nodejs/node/issues/25444

PR-URL: https://github.com/nodejs/node/pull/25447
Reviewed-By: Gireesh Punathil <gpunathi@in.ibm.com>
Reviewed-By: Michael Dawson <michael_dawson@ca.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
