### PR TITLE
test: reduce test-hash-seed run time by half

### DIFF
--- a/test/fixtures/guess-hash-seed.js
+++ b/test/fixtures/guess-hash-seed.js
@@ -1,13 +1,4 @@
 'use strict';
-function min(arr) {
-  let res = arr[0];
-  for (let i = 1; i < arr.length; i++) {
-    const val = arr[i];
-    if (val < res)
-      res = val;
-  }
-  return res;
-}
 function run_repeated(n, fn) {
   const res = [];
   for (let i = 0; i < n; i++) res.push(fn());
@@ -118,11 +109,11 @@ let tester_set_treshold;
 
   // calibrate Set access times for accessing the full bucket / an empty bucket
   const pos_time =
-    min(run_repeated(10000, time_set_lookup.bind(null, tester_set,
-                                                 positive_test_value)));
+    Math.min(...run_repeated(10000, time_set_lookup.bind(null, tester_set,
+                                                         positive_test_value)));
   const neg_time =
-    min(run_repeated(10000, time_set_lookup.bind(null, tester_set,
-                                                 negative_test_value)));
+    Math.min(...run_repeated(10000, time_set_lookup.bind(null, tester_set,
+                                                         negative_test_value)));
   tester_set_treshold = (pos_time + neg_time) / 2;
   // console.log(`pos_time: ${pos_time}, neg_time: ${neg_time},`,
   //             `threshold: ${tester_set_treshold}`);

--- a/test/pummel/test-hash-seed.js
+++ b/test/pummel/test-hash-seed.js
@@ -2,19 +2,30 @@
 
 // Check that spawn child doesn't create duplicated entries
 require('../common');
+const Countdown = require('../common/countdown');
 const REPETITIONS = 2;
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
-const { spawnSync } = require('child_process');
+const { spawn } = require('child_process');
 const targetScript = fixtures.path('guess-hash-seed.js');
 const seeds = [];
 
-for (let i = 0; i < REPETITIONS; ++i) {
-  const seed = spawnSync(process.execPath, [targetScript], {
-    encoding: 'utf8'
-  }).stdout.trim();
-  seeds.push(seed);
-}
+const requiredCallback = () => {
+  console.log(`Seeds: ${seeds}`);
+  assert.strictEqual(new Set(seeds).size, seeds.length);
+  assert.strictEqual(seeds.length, REPETITIONS);
+};
 
-console.log(`Seeds: ${seeds}`);
-assert.strictEqual(new Set(seeds).size, seeds.length);
+const countdown = new Countdown(REPETITIONS, requiredCallback);
+
+for (let i = 0; i < REPETITIONS; ++i) {
+  let result = '';
+  const subprocess = spawn(process.execPath, [targetScript]);
+  subprocess.stdout.setEncoding('utf8');
+  subprocess.stdout.on('data', (data) => { result += data; });
+
+  subprocess.on('exit', () => {
+    seeds.push(result.trim());
+    countdown.dec();
+  });
+}


### PR DESCRIPTION
Reduce the time it takes to run test/pummel/test-hash-seed by switching
from spawnSync() to spawn(). On my computer, this reduces the runtime
from about 80 seconds to about 40 seconds. This test is not (yet) run
regularly on CI, but when it was run recently, it timed out.

While we're in there,  replace min() function with Math.min(...). It's in a separate commit because it's unrelated, but I couldn't bring myself to not do it at all.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
