### PR TITLE
Fix crypto::Hash update method's error output

### DIFF
--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -62,7 +62,11 @@ Hash.prototype.update = function update(data, encoding) {
 
   if (typeof data !== 'string' && !isArrayBufferView(data)) {
     throw new ERR_INVALID_ARG_TYPE('data',
-                                   ['string', 'TypedArray', 'DataView'], data);
+                                   ['string',
+                                    'Buffer',
+                                    'TypedArray',
+                                    'DataView'],
+                                   data);
   }
 
   if (!this[kHandle].update(data, encoding || getDefaultEncoding()))

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -122,6 +122,17 @@ common.expectsError(
     message: 'boom'
   });
 
+// Issue https://github.com/nodejs/node/issues/25487: error message for invalid
+// arg type to update method should include all possible types
+common.expectsError(
+  () => crypto.createHash('sha256').update(),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "data" argument must be one of type string, Buffer, ' +
+      'TypedArray, or DataView. Received type undefined'
+  });
+
 // Default UTF-8 encoding
 const hutf8 = crypto.createHash('sha512').update('УТФ-8 text').digest('hex');
 assert.strictEqual(


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/25487

This PR adds `Buffer` to the list of possible input types for `Hash.update` in the error for invalid input type. One test was added for verifying the error output is as expected.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
