### PR TITLE
test: change ciphers from 'RC4' to 'no-such-cipher'

### DIFF
--- a/test/parallel/test-tls-handshake-error.js
+++ b/test/parallel/test-tls-handshake-error.js
@@ -19,7 +19,7 @@ const server = tls.createServer({
   assert.throws(() => {
     tls.connect({
       port: this.address().port,
-      ciphers: 'missing'
+      ciphers: 'no-such-cipher'
     }, common.mustNotCall());
   }, /no cipher match/i);
 

--- a/test/parallel/test-tls-handshake-error.js
+++ b/test/parallel/test-tls-handshake-error.js
@@ -19,7 +19,7 @@ const server = tls.createServer({
   assert.throws(() => {
     tls.connect({
       port: this.address().port,
-      ciphers: 'RC4'
+      ciphers: 'missing'
     }, common.mustNotCall());
   }, /no cipher match/i);
 


### PR DESCRIPTION
This commit updates option ciphers from 'RC4' to 'no-such-cipher' in
test/parallel/test-tls-handshake-error.js.

The motivation for this change is that this test is verifying that a
'no ciphers match' error be thrown, but 'RC4' might be among the ciphers
supported by the OpenSSL version when dynamically linking. I ran into
this specific issue when dynamically linking against OpenSSL 1.1.1 on
RHEL8 using https://github.com/nodejs/node/pull/25381.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
