### PR TITLE
http: make ClientRequest#setTimeout() a no-op after end

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -731,6 +731,10 @@ function _deferToConnect(method, arguments_, cb) {
 }
 
 ClientRequest.prototype.setTimeout = function setTimeout(msecs, callback) {
+  if (this._ended) {
+    return this;
+  }
+
   listenSocketTimeout(this);
   msecs = validateTimerDuration(msecs);
   if (callback) this.once('timeout', callback);

--- a/test/parallel/test-http-client-set-timeout-after-end.js
+++ b/test/parallel/test-http-client-set-timeout-after-end.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// Test https://github.com/nodejs/node/issues/25499 fix.
+
+const { mustCall } = require('../common');
+
+const { Agent, createServer, get } = require('http');
+const { strictEqual } = require('assert');
+
+const server = createServer(mustCall((req, res) => {
+  res.end();
+}));
+
+server.listen(0, () => {
+  const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+  const port = server.address().port;
+
+  let socket;
+
+  const req = get({ agent, port }, (res) => {
+    res.on('end', () => {
+      strictEqual(req.setTimeout(0), req);
+      strictEqual(socket.listenerCount('timeout'), 0);
+      agent.destroy();
+      server.close();
+    });
+    res.resume();
+  });
+
+  req.on('socket', (sock) => {
+    socket = sock;
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/25499

Originally discovered and resolved by @szmarczak

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
