### PR TITLE
test: ensure npm version is not release candidate

### DIFF
--- a/test/parallel/test-npm-version.js
+++ b/test/parallel/test-npm-version.js
@@ -1,0 +1,18 @@
+'use strict';
+require('../common');
+
+const path = require('path');
+const assert = require('assert');
+
+const npmPathPackageJson = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'deps',
+  'npm',
+  'package.json'
+);
+
+const pkg = require(npmPathPackageJson);
+assert(pkg.version.match(/^\d+\.\d+\.\d+$/),
+       `unexpected version number: ${pkg.version}`);


### PR DESCRIPTION
v11.6.0 ended up shipping with an npm version `6.5.0-next.0`.
This test should avoid it happening in the future.