### PR TITLE
DO NOT LAND STILL VALIDATING test: revert fail `coverage` target if tests fail"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ coverage-test: coverage-build
 	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/gen/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/src/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/src/tracing/*.gcda
-	$(MAKE) $(COVTESTS)
+	-$(MAKE) $(COVTESTS)
 	mv lib lib__
 	mv lib_ lib
 	mkdir -p coverage .cov_tmp


### PR DESCRIPTION
This reverts commit f216d5bbb1595f2fbed29517ba87b80e8c02f3c0.
Seems like it breaks the nightly job so reverting until
we figure that out.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
