### PR TITLE
util: don't show error stack inside objects

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -78,7 +78,6 @@ const propertyIsEnumerable = uncurryThis(Object.prototype.propertyIsEnumerable);
 const regExpToString = uncurryThis(RegExp.prototype.toString);
 const dateToISOString = uncurryThis(Date.prototype.toISOString);
 const dateToString = uncurryThis(Date.prototype.toString);
-const errorToString = uncurryThis(Error.prototype.toString);
 
 const bigIntValueOf = uncurryThis(BigInt.prototype.valueOf);
 const booleanValueOf = uncurryThis(Boolean.prototype.valueOf);
@@ -255,7 +254,7 @@ const escapeFn = (str) => meta[str.charCodeAt(0)];
 
 // Escape control characters, single quotes and the backslash.
 // This is similar to JSON stringify escaping.
-function strEscape(str) {
+function strEscape(str, quotes = true) {
   let escapeTest = strEscapeSequencesRegExp;
   let escapeReplace = strEscapeSequencesReplacer;
   let singleQuote = 39;
@@ -279,11 +278,18 @@ function strEscape(str) {
   }
 
   // Some magic numbers that worked out fine while benchmarking with v8 6.0
-  if (str.length < 5000 && !escapeTest.test(str))
-    return addQuotes(str, singleQuote);
+  if (str.length < 5000 && !escapeTest.test(str)) {
+    if (quotes) {
+      return addQuotes(str, singleQuote);
+    }
+    return str;
+  }
   if (str.length > 100) {
     str = str.replace(escapeReplace, escapeFn);
-    return addQuotes(str, singleQuote);
+    if (quotes) {
+      return addQuotes(str, singleQuote);
+    }
+    return str;
   }
 
   let result = '';
@@ -303,7 +309,10 @@ function strEscape(str) {
   if (last !== i) {
     result += str.slice(last);
   }
-  return addQuotes(result, singleQuote);
+  if (quotes) {
+    return addQuotes(result, singleQuote);
+  }
+  return result;
 }
 
 function stylizeWithColor(str, styleType) {
@@ -650,17 +659,25 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
         return ctx.stylize(base, 'date');
       }
     } else if (isError(value)) {
-      // Make error with message first say the error.
-      base = formatError(value);
+      // https://tc39.github.io/ecma262/#sec-error.prototype.tostring
+      const name = value.name === undefined ? 'Error' : `${value.name}`;
+      const message = value.message === undefined ? '' :
+        `${strEscape(value.message, false)}`;
+      if (!name) {
+        base = message;
+      } else if (!message) {
+        base = name;
+      } else {
+        base = `${name}: ${message}`;
+      }
+      if (value.stack && ctx.indentationLvl === 0) {
+        base = value.stack;
+      }
+
       // Wrap the error in brackets in case it has no stack trace.
       const stackStart = base.indexOf('\n    at');
       if (stackStart === -1) {
         base = `[${base}]`;
-      }
-      // The message and the stack have to be indented as well!
-      if (ctx.indentationLvl !== 0) {
-        const indentation = ' '.repeat(ctx.indentationLvl);
-        base = formatError(value).replace(/\n/g, `\n${indentation}`);
       }
       if (keys.length === 0)
         return base;
@@ -863,10 +880,6 @@ function formatPrimitive(fn, value, ctx) {
     return fn('undefined', 'undefined');
   // es6 symbol primitive
   return fn(value.toString(), 'symbol');
-}
-
-function formatError(value) {
-  return value.stack || errorToString(value);
 }
 
 function formatNamespaceObject(ctx, value, recurseTimes, keys) {

--- a/test/message/util_inspect_error.out
+++ b/test/message/util_inspect_error.out
@@ -1,52 +1,8 @@
-{ err:
-   Error: foo
-   bar
-       at *util_inspect_error*
-       at *
-       at *
-       at *
-       at *
-       at *
-       at *
-       at *
-       at *
-  nested:
-   { err:
-      Error: foo
-      bar
-          at *util_inspect_error*
-          at *
-          at *
-          at *
-          at *
-          at *
-          at *
-          at *
-          at * } }
+{ err: [Error: foo\nbar], nested: { err: [Error: foo\nbar] } }
 {
-  err: Error: foo
-  bar
-      at *util_inspect_error*
-      at *
-      at *
-      at *
-      at *
-      at *
-      at *
-      at *
-      at *,
+  err: [Error: foo\nbar],
   nested: {
-    err: Error: foo
-    bar
-        at *util_inspect_error*
-        at *
-        at *
-        at *
-        at *
-        at *
-        at *
-        at *
-        at *
+    err: [Error: foo\nbar]
   }
 }
 { Error: foo


### PR DESCRIPTION
This cleans up util.inspect with errors for readability and to help with getting #23926 shipped.

@nodejs/util 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
