### PR TITLE
src: silence compiler warning in node_report.cc

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -775,7 +775,7 @@ static void PrintSystemInformation(JSONWriter* writer) {
         snprintf(buf, sizeof(buf), "%lu", limit.rlim_max);
         hard = std::string(buf);
 #else
-        snprintf(buf, sizeof(buf), "%lu", limit.rlim_max);
+        snprintf(buf, sizeof(buf), "%llu", limit.rlim_max);
         hard = std::string(buf);
 #endif
       }


### PR DESCRIPTION
Currently the following compiler warnings is generated:
```console
../src/node_report.cc:778:43:
warning: format specifies type 'unsigned long' but the argument has
type 'rlim_t' (aka 'unsigned long long') [-Wformat]
        snprintf(buf, sizeof(buf), "%lu", limit.rlim_max);
                                    ~~~   ^~~~~~~~~~~~~~
                                    %llu
1 warning generated.
```
This commit changes the format specifier to $llu.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
