### PR TITLE
crypto: fix key handle extraction

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -215,7 +215,7 @@ function parsePrivateKeyEncoding(enc, keyType, objName) {
 
 function getKeyObjectHandle(key, isPublic, allowKeyObject) {
   if (!allowKeyObject) {
-    return new ERR_INVALID_ARG_TYPE(
+    throw new ERR_INVALID_ARG_TYPE(
       'key',
       ['string', 'Buffer', 'TypedArray', 'DataView'],
       key

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -59,6 +59,17 @@ const privatePem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
 }
 
 {
+  // Passing an existing key object should throw.
+  const publicKey = createPublicKey(publicPem);
+  common.expectsError(() => createPublicKey(publicKey), {
+    type: TypeError,
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "key" argument must be one of type string, Buffer, ' +
+             'TypedArray, or DataView. Received type object'
+  });
+}
+
+{
   const publicKey = createPublicKey(publicPem);
   assert.strictEqual(publicKey.type, 'public');
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');


### PR DESCRIPTION
I guess I don't need to say much about the commit itself. This causes the crash described in a comment in #25217, so it would be awesome if this could make it into 11.7.0 somehow, cc @BridgeAR.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
