### PR TITLE
test: use fipsMode in test-crypto-fips

### DIFF
--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -1,3 +1,4 @@
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto)
@@ -7,6 +8,8 @@ const assert = require('assert');
 const spawnSync = require('child_process').spawnSync;
 const path = require('path');
 const fixtures = require('../common/fixtures');
+const { internalBinding } = require('internal/test/binding');
+const { fipsMode } = internalBinding('config');
 
 const FIPS_ENABLED = 1;
 const FIPS_DISABLED = 0;
@@ -24,7 +27,7 @@ const CNF_FIPS_OFF = fixtures.path('openssl_fips_disabled.cnf');
 let num_children_ok = 0;
 
 function compiledWithFips() {
-  return process.config.variables.openssl_fips ? true : false;
+  return fipsMode ? true : false;
 }
 
 function sharedOpenSSL() {


### PR DESCRIPTION
This commit updates test/parallel/test-crypto-fips.js to use `fipsMode`
instead of `process.config.variables.openssl_fips`.

The motivation for this is that since the addition of the
`--openssl-is-fips` configuration flag, it is possible to dynamically
link with a FIPS compliant OpenSSL library. Using `fipsMode` allows for
determining if there is FIPS support when statically or dynamically
linking against a FIPS compatible OpenSSL library.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
