### PR TITLE
test: use stronger curves for keygen

### DIFF
--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -283,7 +283,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   // Test async elliptic curve key generation, e.g. for ECDSA, with an encrypted
   // private key.
   generateKeyPair('ec', {
-    namedCurve: 'P-192',
+    namedCurve: 'P-256',
     paramEncoding: 'named',
     publicKeyEncoding: {
       type: 'spki',
@@ -691,7 +691,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 
   // It should recognize both NIST and standard curve names.
   generateKeyPair('ec', {
-    namedCurve: 'P-192',
+    namedCurve: 'P-256',
     publicKeyEncoding: { type: 'spki', format: 'pem' },
     privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
   }, common.mustCall((err, publicKey, privateKey) => {
@@ -699,7 +699,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }));
 
   generateKeyPair('ec', {
-    namedCurve: 'secp192k1',
+    namedCurve: 'secp256k1',
     publicKeyEncoding: { type: 'spki', format: 'pem' },
     privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
   }, common.mustCall((err, publicKey, privateKey) => {


### PR DESCRIPTION
This commit updates the named curves `P-192` (prime192v1), and `secp192k1`
to 256 bit versions.

The motivation for this is that in Red Hat Enterprise Linux (RHEL) all
ECC curves < 224 bits are removed from OpenSSL provided by the system.
I'm not sure if other distributions do this but these 256 bit curves are
availalbe in OpenSSL 1.1.0j (current version on master) and OpenSSL
1.1.1 so as far as I can tell it should be safe change to make.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
