### PR TITLE
src: Add new perf flags in NODE_OPTIONS

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -727,6 +727,7 @@ V8 options that are allowed are:
 - `--abort-on-uncaught-exception`
 - `--max-old-space-size`
 - `--perf-basic-prof`
+- `--perf-basic-prof-only-functions`
 - `--perf-prof`
 - `--stack-trace-limit`
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -729,6 +729,7 @@ V8 options that are allowed are:
 - `--perf-basic-prof`
 - `--perf-basic-prof-only-functions`
 - `--perf-prof`
+- `--perf-prof-unwinding-info`
 - `--stack-trace-limit`
 
 ### `NODE_PATH=path[:…]`

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -289,6 +289,10 @@ PerIsolateOptionsParser::PerIsolateOptionsParser() {
             kAllowedInEnvironment);
   AddOption("--max-old-space-size", "", V8Option{}, kAllowedInEnvironment);
   AddOption("--perf-basic-prof", "", V8Option{}, kAllowedInEnvironment);
+  AddOption("--perf-basic-prof-only-functions",
+            "",
+            V8Option{},
+            kAllowedInEnvironment);
   AddOption("--perf-prof", "", V8Option{}, kAllowedInEnvironment);
   AddOption("--stack-trace-limit", "", V8Option{}, kAllowedInEnvironment);
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -294,6 +294,10 @@ PerIsolateOptionsParser::PerIsolateOptionsParser() {
             V8Option{},
             kAllowedInEnvironment);
   AddOption("--perf-prof", "", V8Option{}, kAllowedInEnvironment);
+  AddOption("--perf-prof-unwinding-info",
+            "",
+            V8Option{},
+            kAllowedInEnvironment);
   AddOption("--stack-trace-limit", "", V8Option{}, kAllowedInEnvironment);
 
 #ifdef NODE_REPORT

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -38,6 +38,7 @@ expect('--trace-event-file-pattern {pid}-${rotation}.trace_events ' +
 
 if (!common.isWindows) {
   expect('--perf-basic-prof', 'B\n');
+  expect('--perf-basic-prof-only-functions', 'B\n');
 }
 
 if (common.isLinux && ['arm', 'x64'].includes(process.arch)) {

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -44,6 +44,7 @@ if (!common.isWindows) {
 if (common.isLinux && ['arm', 'x64'].includes(process.arch)) {
   // PerfJitLogger is only implemented in Linux.
   expect('--perf-prof', 'B\n');
+  expect('--perf-prof-unwinding-info', 'B\n');
 }
 
 if (common.hasCrypto) {


### PR DESCRIPTION
I have added the following flags to be whitelisted for inclusion in NODE_OPTIONS:

- `--perf-basic-prof-only-functions`
- `--perf-prof-unwinding-info`

docs, src and tests having been updated.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

---

Tests are failing on my machine, but they don't seem relevant to the changes I have made, also the tests on CI have passed.

```
=== release test-exception ===                                               
Path: node-report/test-exception                      
undefined:223                      
    "LESS_TERMCAP_me": "",
                        ^                                      
                                                                         
SyntaxError: Unexpected token n JSON at position 6966
    at JSON.parse (<anonymous>)                                             
    at Object.validateContent (/home/tomgco/Projects/node/test/common/report.js:36:23)            
    at fs.readFile (/home/tomgco/Projects/node/test/common/report.js:30:10)
    at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:54:3)
Command: out/Release/node /home/tomgco/Projects/node/test/node-report/test-exception.js  
```