### PR TITLE
http: reuse noop function in socketOnError()

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -503,13 +503,14 @@ function onParserExecute(server, socket, parser, state, ret) {
   onParserExecuteCommon(server, socket, parser, state, ret, undefined);
 }
 
+const noop = () => {};
 const badRequestResponse = Buffer.from(
   `HTTP/1.1 400 ${STATUS_CODES[400]}${CRLF}${CRLF}`, 'ascii'
 );
 function socketOnError(e) {
   // Ignore further errors
   this.removeListener('error', socketOnError);
-  this.on('error', () => {});
+  this.on('error', noop);
 
   if (!this.server.emit('clientError', e, this)) {
     if (this.writable) {


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
