### PR TITLE
http2: improve compat performance

### DIFF
--- a/benchmark/http2/compat.js
+++ b/benchmark/http2/compat.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const common = require('../common.js');
+const path = require('path');
+const fs = require('fs');
+const file = path.join(path.resolve(__dirname, '../fixtures'), 'alice.html');
+
+const bench = common.createBenchmark(main, {
+  requests: [100, 1000, 5000],
+  streams: [1, 10, 20, 40, 100, 200],
+  clients: [2],
+  benchmarker: ['h2load']
+}, { flags: ['--no-warnings'] });
+
+function main({ requests, streams, clients }) {
+  const http2 = require('http2');
+  const server = http2.createServer();
+  server.on('request', (req, res) => {
+    const out = fs.createReadStream(file);
+    res.setHeader('content-type', 'text/html');
+    out.pipe(res);
+    out.on('error', (err) => {
+      res.destroy();
+    });
+  });
+  server.listen(common.PORT, () => {
+    bench.http({
+      path: '/',
+      requests,
+      maxConcurrentStreams: streams,
+      clients,
+      threads: clients
+    }, () => { server.close(); });
+  });
+}

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -18,18 +18,16 @@ const {
   ERR_INVALID_HTTP_TOKEN
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
-const { kSocket } = require('internal/http2/util');
+const { kSocket, kRequest, kProxySocket } = require('internal/http2/util');
 
 const kBeginSend = Symbol('begin-send');
 const kState = Symbol('state');
 const kStream = Symbol('stream');
-const kRequest = Symbol('request');
 const kResponse = Symbol('response');
 const kHeaders = Symbol('headers');
 const kRawHeaders = Symbol('rawHeaders');
 const kTrailers = Symbol('trailers');
 const kRawTrailers = Symbol('rawTrailers');
-const kProxySocket = Symbol('proxySocket');
 const kSetHeader = Symbol('setHeader');
 const kAborted = Symbol('aborted');
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -96,6 +96,8 @@ const {
   getStreamState,
   isPayloadMeaningless,
   kSocket,
+  kRequest,
+  kProxySocket,
   mapToHeaders,
   NghttpError,
   sessionName,
@@ -118,6 +120,8 @@ const {
   validateTimerDuration
 } = require('internal/timers');
 const { isArrayBufferView } = require('internal/util/types');
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 const { FileHandle } = internalBinding('fs');
 const binding = internalBinding('http2');
@@ -157,7 +161,6 @@ const kOwner = owner_symbol;
 const kOrigin = Symbol('origin');
 const kProceed = Symbol('proceed');
 const kProtocol = Symbol('protocol');
-const kProxySocket = Symbol('proxy-socket');
 const kRemoteSettings = Symbol('remote-settings');
 const kSelectPadding = Symbol('select-padding');
 const kSentHeaders = Symbol('sent-headers');
@@ -1624,6 +1627,10 @@ class Http2Stream extends Duplex {
       endAfterHeaders: false
     };
 
+    // Fields used by the compat API to avoid megamorphisms.
+    this[kRequest] = null;
+    this[kProxySocket] = null;
+
     this.on('pause', streamOnPause);
   }
 
@@ -2001,9 +2008,20 @@ class Http2Stream extends Duplex {
   }
 }
 
-function processHeaders(headers) {
-  assertIsObject(headers, 'headers');
-  headers = Object.assign(Object.create(null), headers);
+function processHeaders(oldHeaders) {
+  assertIsObject(oldHeaders, 'headers');
+  const headers = Object.create(null);
+
+  if (oldHeaders !== null && oldHeaders !== undefined) {
+    const hop = hasOwnProperty.bind(oldHeaders);
+    // This loop is here for performance reason. Do not change.
+    for (var key in oldHeaders) {
+      if (hop(key)) {
+        headers[key] = oldHeaders[key];
+      }
+    }
+  }
+
   const statusCode =
     headers[HTTP2_HEADER_STATUS] =
       headers[HTTP2_HEADER_STATUS] | 0 || HTTP_STATUS_OK;

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -10,6 +10,8 @@ const {
 } = require('internal/errors').codes;
 
 const kSocket = Symbol('socket');
+const kProxySocket = Symbol('proxySocket');
+const kRequest = Symbol('request');
 
 const {
   NGHTTP2_SESSION_CLIENT,
@@ -499,12 +501,12 @@ class NghttpError extends Error {
   }
 }
 
-function assertIsObject(value, name, types = 'Object') {
+function assertIsObject(value, name, types) {
   if (value !== undefined &&
       (value === null ||
        typeof value !== 'object' ||
        Array.isArray(value))) {
-    const err = new ERR_INVALID_ARG_TYPE(name, types, value);
+    const err = new ERR_INVALID_ARG_TYPE(name, types || 'Object', value);
     Error.captureStackTrace(err, assertIsObject);
     throw err;
   }
@@ -592,6 +594,8 @@ module.exports = {
   getStreamState,
   isPayloadMeaningless,
   kSocket,
+  kProxySocket,
+  kRequest,
   mapToHeaders,
   NghttpError,
   sessionName,

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -63,11 +63,29 @@ void LibuvStreamWrap::Initialize(Local<Object> target,
   };
   Local<FunctionTemplate> sw =
       FunctionTemplate::New(env->isolate(), is_construct_call_callback);
-  sw->InstanceTemplate()->SetInternalFieldCount(StreamReq::kStreamReqField + 1);
+  sw->InstanceTemplate()->SetInternalFieldCount(
+      StreamReq::kStreamReqField + 1 + 3);
   Local<String> wrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "ShutdownWrap");
   sw->SetClassName(wrapString);
+
+  // we need to set handle and callback to null,
+  // so that those fields are created and functions
+  // do not become megamorphic
+  // Fields:
+  // - oncomplete
+  // - callback
+  // - handle
+  sw->InstanceTemplate()->Set(
+      FIXED_ONE_BYTE_STRING(env->isolate(), "oncomplete"),
+      v8::Null(env->isolate()));
+  sw->InstanceTemplate()->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "callback"),
+      v8::Null(env->isolate()));
+  sw->InstanceTemplate()->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "handle"),
+      v8::Null(env->isolate()));
+
   sw->Inherit(AsyncWrap::GetConstructorTemplate(env));
+
   target->Set(env->context(),
               wrapString,
               sw->GetFunction(env->context()).ToLocalChecked()).FromJust();


### PR DESCRIPTION
This bunch of commits help me improve the performance of a http2
server by 8-10%. The benchmarks reports several 1-2% improvements in
various areas.

<details><summary>Benchmarks</summary>

```
                                                                                   confidence improvement accuracy (*)    (**)   (***)
 http2/compat.js benchmarker='h2load' clients=2 streams=1 requests=100                             0.33 %       ±0.99%  ±1.31%  ±1.71%
 http2/compat.js benchmarker='h2load' clients=2 streams=1 requests=1000                           -0.28 %       ±0.81%  ±1.08%  ±1.41%
 http2/compat.js benchmarker='h2load' clients=2 streams=1 requests=5000                            0.69 %       ±2.06%  ±2.74%  ±3.56%
 http2/compat.js benchmarker='h2load' clients=2 streams=10 requests=100                            0.64 %       ±0.91%  ±1.22%  ±1.58%
 http2/compat.js benchmarker='h2load' clients=2 streams=10 requests=1000                           0.60 %       ±1.06%  ±1.41%  ±1.84%
 http2/compat.js benchmarker='h2load' clients=2 streams=10 requests=5000                           0.76 %       ±1.43%  ±1.91%  ±2.49%
 http2/compat.js benchmarker='h2load' clients=2 streams=100 requests=100                           3.03 %       ±9.95% ±13.24% ±17.24%
 http2/compat.js benchmarker='h2load' clients=2 streams=100 requests=1000                          0.39 %       ±3.41%  ±4.54%  ±5.91%
 http2/compat.js benchmarker='h2load' clients=2 streams=100 requests=5000                   *      1.76 %       ±1.56%  ±2.08%  ±2.70%
 http2/compat.js benchmarker='h2load' clients=2 streams=20 requests=100                            2.31 %       ±4.51%  ±6.00%  ±7.82%
 http2/compat.js benchmarker='h2load' clients=2 streams=20 requests=1000                          -0.06 %       ±1.77%  ±2.36%  ±3.07%
 http2/compat.js benchmarker='h2load' clients=2 streams=20 requests=5000                           0.02 %       ±2.14%  ±2.85%  ±3.72%
 http2/compat.js benchmarker='h2load' clients=2 streams=200 requests=100                           6.43 %       ±9.24% ±12.30% ±16.01%
 http2/compat.js benchmarker='h2load' clients=2 streams=200 requests=1000                          1.73 %       ±2.94%  ±3.92%  ±5.10%
 http2/compat.js benchmarker='h2load' clients=2 streams=200 requests=5000                          1.11 %       ±1.64%  ±2.18%  ±2.84%
 http2/compat.js benchmarker='h2load' clients=2 streams=40 requests=100                            5.04 %       ±8.48% ±11.29% ±14.72%
 http2/compat.js benchmarker='h2load' clients=2 streams=40 requests=1000                          -1.15 %       ±2.79%  ±3.72%  ±4.84%
 http2/compat.js benchmarker='h2load' clients=2 streams=40 requests=5000                          -0.55 %       ±1.93%  ±2.56%  ±3.34%
 http2/headers.js nheaders=0 n=1000                                                               -0.08 %       ±0.80%  ±1.07%  ±1.39%
 http2/headers.js nheaders=10 n=1000                                                              -0.41 %       ±0.58%  ±0.78%  ±1.01%
 http2/headers.js nheaders=100 n=1000                                                             -0.26 %       ±0.51%  ±0.67%  ±0.88%
 http2/headers.js nheaders=1000 n=1000                                                            -0.15 %       ±0.24%  ±0.32%  ±0.42%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=1 requests=100             *      2.44 %       ±2.03%  ±2.70%  ±3.52%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=1 requests=1000                   0.22 %       ±1.73%  ±2.30%  ±3.00%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=1 requests=5000                   0.54 %       ±1.61%  ±2.14%  ±2.79%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=10 requests=100                   0.15 %       ±1.41%  ±1.87%  ±2.44%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=10 requests=1000                 -0.15 %       ±1.45%  ±1.94%  ±2.54%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=10 requests=5000                  0.46 %       ±0.82%  ±1.09%  ±1.42%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=100 requests=100         ***      1.87 %       ±1.01%  ±1.35%  ±1.76%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=100 requests=1000          *      1.26 %       ±1.25%  ±1.67%  ±2.17%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=100 requests=5000                -0.52 %       ±1.32%  ±1.76%  ±2.29%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=20 requests=100                   0.03 %       ±0.74%  ±0.98%  ±1.28%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=20 requests=1000                  0.28 %       ±0.85%  ±1.14%  ±1.48%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=20 requests=5000                 -0.09 %       ±0.81%  ±1.08%  ±1.41%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=200 requests=100           *      1.24 %       ±1.10%  ±1.46%  ±1.90%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=200 requests=1000                -0.47 %       ±1.28%  ±1.70%  ±2.22%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=200 requests=5000          *      1.16 %       ±1.14%  ±1.51%  ±1.97%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=40 requests=100                  -0.86 %       ±0.93%  ±1.24%  ±1.62%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=40 requests=1000                  0.06 %       ±1.12%  ±1.49%  ±1.95%
 http2/respond-with-fd.js benchmarker='h2load' clients=2 streams=40 requests=5000         ***      1.22 %       ±0.52%  ±0.69%  ±0.90%
 http2/simple.js benchmarker='h2load' clients=2 streams=1 requests=100                      *     -0.91 %       ±0.73%  ±0.97%  ±1.27%
 http2/simple.js benchmarker='h2load' clients=2 streams=1 requests=1000                           -0.53 %       ±1.23%  ±1.64%  ±2.14%
 http2/simple.js benchmarker='h2load' clients=2 streams=1 requests=5000                            1.49 %       ±2.06%  ±2.74%  ±3.57%
 http2/simple.js benchmarker='h2load' clients=2 streams=10 requests=100                     *      0.99 %       ±0.90%  ±1.20%  ±1.57%
 http2/simple.js benchmarker='h2load' clients=2 streams=10 requests=1000                           0.64 %       ±1.10%  ±1.46%  ±1.90%
 http2/simple.js benchmarker='h2load' clients=2 streams=10 requests=5000                           1.19 %       ±1.34%  ±1.78%  ±2.31%
 http2/simple.js benchmarker='h2load' clients=2 streams=100 requests=100                           2.60 %       ±9.65% ±12.85% ±16.74%
 http2/simple.js benchmarker='h2load' clients=2 streams=100 requests=1000                          0.19 %       ±2.91%  ±3.87%  ±5.04%
 http2/simple.js benchmarker='h2load' clients=2 streams=100 requests=5000                          1.13 %       ±1.93%  ±2.57%  ±3.35%
 http2/simple.js benchmarker='h2load' clients=2 streams=20 requests=100                            1.03 %       ±2.41%  ±3.21%  ±4.19%
 http2/simple.js benchmarker='h2load' clients=2 streams=20 requests=1000                          -0.14 %       ±1.08%  ±1.43%  ±1.87%
 http2/simple.js benchmarker='h2load' clients=2 streams=20 requests=5000                           1.10 %       ±1.40%  ±1.86%  ±2.42%
 http2/simple.js benchmarker='h2load' clients=2 streams=200 requests=100                           1.81 %      ±10.09% ±13.43% ±17.48%
 http2/simple.js benchmarker='h2load' clients=2 streams=200 requests=1000                         -1.01 %       ±3.39%  ±4.51%  ±5.87%
 http2/simple.js benchmarker='h2load' clients=2 streams=200 requests=5000                         -0.43 %       ±1.72%  ±2.29%  ±2.98%
 http2/simple.js benchmarker='h2load' clients=2 streams=40 requests=100                            7.06 %       ±8.88% ±11.83% ±15.42%
 http2/simple.js benchmarker='h2load' clients=2 streams=40 requests=1000                           1.38 %       ±2.88%  ±3.83%  ±4.98%
 http2/simple.js benchmarker='h2load' clients=2 streams=40 requests=5000                           0.75 %       ±1.74%  ±2.32%  ±3.02%
 http2/write.js benchmarker='h2load' size=100000 length=1048576 streams=100                        0.16 %       ±0.22%  ±0.30%  ±0.39%
 http2/write.js benchmarker='h2load' size=100000 length=1048576 streams=1000                       0.16 %       ±0.34%  ±0.45%  ±0.58%
 http2/write.js benchmarker='h2load' size=100000 length=1048576 streams=200                        0.12 %       ±0.18%  ±0.24%  ±0.31%
 http2/write.js benchmarker='h2load' size=100000 length=131072 streams=100                         0.86 %       ±1.54%  ±2.05%  ±2.68%
 http2/write.js benchmarker='h2load' size=100000 length=131072 streams=1000                        0.35 %       ±2.25%  ±2.99%  ±3.90%
 http2/write.js benchmarker='h2load' size=100000 length=131072 streams=200                         0.26 %       ±1.88%  ±2.50%  ±3.26%
 http2/write.js benchmarker='h2load' size=100000 length=262144 streams=100                         0.03 %       ±1.73%  ±2.31%  ±3.00%
 http2/write.js benchmarker='h2load' size=100000 length=262144 streams=1000                       -0.40 %       ±1.84%  ±2.45%  ±3.19%
 http2/write.js benchmarker='h2load' size=100000 length=262144 streams=200                         1.58 %       ±1.73%  ±2.31%  ±3.00%
 http2/write.js benchmarker='h2load' size=100000 length=65536 streams=100                         -0.06 %       ±0.75%  ±1.00%  ±1.31%
 http2/write.js benchmarker='h2load' size=100000 length=65536 streams=1000                         0.69 %       ±0.85%  ±1.14%  ±1.48%
 http2/write.js benchmarker='h2load' size=100000 length=65536 streams=200                          0.71 %       ±0.77%  ±1.03%  ±1.34%
```

</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
