### PR TITLE
process: check env->EmitProcessEnvWarning() last

### DIFF
--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -72,8 +72,12 @@ static void EnvSetter(Local<Name> property,
                       Local<Value> value,
                       const PropertyCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
-  if (env->options()->pending_deprecation && env->EmitProcessEnvWarning() &&
-      !value->IsString() && !value->IsNumber() && !value->IsBoolean()) {
+  // calling env->EmitProcessEnvWarning() sets a variable indicating that
+  // warnings have been emitted. It should be called last after other
+  // conditions leading to a warning have been met.
+  if (env->options()->pending_deprecation && !value->IsString() &&
+      !value->IsNumber() && !value->IsBoolean() &&
+      env->EmitProcessEnvWarning()) {
     if (ProcessEmitDeprecationWarning(
             env,
             "Assigning any value other than a string, number, or boolean to a "

--- a/test/parallel/test-process-env-deprecation.js
+++ b/test/parallel/test-process-env-deprecation.js
@@ -12,5 +12,9 @@ common.expectWarning(
   'DEP0104'
 );
 
+// Make sure setting a valid environment variable doesn't
+// result in warning being suppressed, see:
+// https://github.com/nodejs/node/pull/25157
+process.env.FOO = 'apple';
 process.env.ABC = undefined;
 assert.strictEqual(process.env.ABC, 'undefined');


### PR DESCRIPTION
Calling env->EmitProcessEnvWarning() prevents additional warnings from being set
it should therefore be called only if a warning will emit.

Split this work out from https://github.com/nodejs/node/pull/25157, addressing @joyeecheung's concerns.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
