### PR TITLE
src: properly configure default heap limits

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -80,6 +80,15 @@ void FreeArrayBufferAllocator(ArrayBufferAllocator* allocator) {
 Isolate* NewIsolate(ArrayBufferAllocator* allocator, uv_loop_t* event_loop) {
   Isolate::CreateParams params;
   params.array_buffer_allocator = allocator;
+
+  double total_memory = uv_get_total_memory();
+  if (total_memory > 0) {
+    // V8 defaults to 700MB or 1.4GB on 32 and 64 bit platforms respectively.
+    // This default is based on browser use-cases. Tell V8 to configure the
+    // heap based on the actual physical memory.
+    params.constraints.ConfigureDefaults(total_memory, 0);
+  }
+
 #ifdef NODE_ENABLE_VTUNE_PROFILING
   params.code_event_handler = vTune::GetVtuneCodeEventHandler();
 #endif


### PR DESCRIPTION
Unless configured, V8 defaults to limiting the max heaps size to 700 MB
or 1400MB on 32 and 64-bit platforms respectively. This default is
based on the browser use-cases and doesn't make a lot of sense
generally. This change properly configures the heap size based on
actual available memory.

This should reduce the number of instances where we run out of memory processing larger data-sets. It is still possible to pass `--max-old-space-size` to use a different limit.

~~CI: https://ci.nodejs.org/job/node-test-pull-request/20203/~~
CI: https://ci.nodejs.org/job/node-test-pull-request/20310/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
