### PR TITLE
fs: check start option more strict in createWriteStream

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1470,9 +1470,11 @@ returned by this method has a default `highWaterMark` of 64 kb.
 
 `options` can include `start` and `end` values to read a range of bytes from
 the file instead of the entire file. Both `start` and `end` are inclusive and
-start counting at 0. If `fd` is specified and `start` is omitted or `undefined`,
-`fs.createReadStream()` reads sequentially from the current file position.
-The `encoding` can be any one of those accepted by [`Buffer`][].
+start counting at 0, allowed values are in the
+[0, [`Number.MAX_SAFE_INTEGER`][]] range. If `fd` is specified and `start` is
+omitted or `undefined`, `fs.createReadStream()` reads sequentially from the
+current file position. The `encoding` can be any one of those accepted by
+[`Buffer`][].
 
 If `fd` is specified, `ReadStream` will ignore the `path` argument and will use
 the specified file descriptor. This means that no `'open'` event will be
@@ -1548,7 +1550,8 @@ changes:
 * Returns: {fs.WriteStream} See [Writable Stream][].
 
 `options` may also include a `start` option to allow writing data at
-some position past the beginning of the file. Modifying a file rather
+some position past the beginning of the file, allowed values are in the
+[0, [`Number.MAX_SAFE_INTEGER`][]] range. Modifying a file rather
 than replacing it may require a `flags` mode of `r+` rather than the
 default mode `w`. The `encoding` can be any one of those accepted by
 [`Buffer`][].
@@ -4953,3 +4956,4 @@ the file contents.
 [chcp]: https://ss64.com/nt/chcp.html
 [inode]: https://en.wikipedia.org/wiki/Inode
 [support of file system `flags`]: #fs_file_system_flags
+[`Number.MAX_SAFE_INTEGER`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -243,13 +243,7 @@ function WriteStream(path, options) {
   this.closed = false;
 
   if (this.start !== undefined) {
-    if (typeof this.start !== 'number') {
-      throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
-    }
-    if (this.start < 0) {
-      const errVal = `{start: ${this.start}}`;
-      throw new ERR_OUT_OF_RANGE('start', '>= 0', errVal);
-    }
+    checkPosition(this.start, 'start');
 
     this.pos = this.start;
   }

--- a/test/parallel/test-file-write-stream3.js
+++ b/test/parallel/test-file-write-stream3.js
@@ -161,6 +161,7 @@ function run_test_3() {
     assert.strictEqual(fileData, fileDataExpected_3);
 
     run_test_4();
+    run_test_5();
   });
 
   file.on('error', function(err) {
@@ -184,7 +185,22 @@ const run_test_4 = common.mustCall(function() {
   const err = {
     code: 'ERR_OUT_OF_RANGE',
     message: 'The value of "start" is out of range. ' +
-             'It must be >= 0. Received {start: -5}',
+             'It must be >= 0 and <= 2 ** 53 - 1. Received -5',
+    type: RangeError
+  };
+  common.expectsError(fn, err);
+});
+
+
+const run_test_5 = common.mustCall(function() {
+  //  Error: start must be <= 2 ** 53 - 1
+  const fn = () => {
+    fs.createWriteStream(filepath, { start: 2 ** 53, flags: 'r+' });
+  };
+  const err = {
+    code: 'ERR_OUT_OF_RANGE',
+    message: 'The value of "start" is out of range. ' +
+             'It must be >= 0 and <= 2 ** 53 - 1. Received 9007199254740992',
     type: RangeError
   };
   common.expectsError(fn, err);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Use `checkPosition` function to check the `start` option that passed into `fs.createWriteStream` more strictly, and be the same as the `start` option that passed into `fs.createReadStream`.

https://github.com/nodejs/node/blob/2e613a9c301165d121b19b86e382860323abc22f/lib/internal/fs/streams.js#L39-L50

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
