### PR TITLE
build: make configure.py compatible with python 3

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1139,8 +1139,8 @@ def configure_library(lib, output):
     if options.__dict__[shared_lib + '_includes']:
       output['include_dirs'] += [options.__dict__[shared_lib + '_includes']]
     elif pkg_cflags:
-      output['include_dirs'] += (
-          filter(None, map(str.strip, pkg_cflags.split('-I'))))
+      stripped_flags = [flag.strip() for flag in pkg_cflags.split('-I')]
+      output['include_dirs'] += [flag for flag in stripped_flags if flag]
 
     # libpath needs to be provided ahead libraries
     if options.__dict__[shared_lib + '_libpath']:
@@ -1156,7 +1156,7 @@ def configure_library(lib, output):
       output['libraries'] += [pkg_libpath]
 
     default_libs = getattr(options, shared_lib + '_libname')
-    default_libs = map('-l{0}'.format, default_libs.split(','))
+    default_libs = ['-l{0}'.format(lib) for lib in default_libs.split(',')]
 
     if default_libs:
       output['libraries'] += default_libs
@@ -1382,7 +1382,8 @@ def configure_intl(o):
     # safe to split, cannot contain spaces
     o['libraries'] += libs.split()
     if cflags:
-      o['include_dirs'] += filter(None, map(str.strip, cflags.split('-I')))
+      stripped_flags = [flag.strip() for flag in cflags.split('-I')]
+      o['include_dirs'] += [flag for flag in stripped_flags if flag]
     # use the "system" .gyp
     o['variables']['icu_gyp_path'] = 'tools/icu/icu-system.gyp'
     return
@@ -1663,7 +1664,7 @@ config = {
 if options.prefix:
   config['PREFIX'] = options.prefix
 
-config = '\n'.join(map('='.join, config.iteritems())) + '\n'
+config = '\n'.join(['='.join(item) for item in config.items()]) + '\n'
 
 # On Windows there's no reason to search for a different python binary.
 bin_override = None if sys.platform == 'win32' else make_bin_override()


### PR DESCRIPTION
This patch replaces the following

1. Usage of `filter` with `None` to remove falsy items.
2. Usage of `map` to create lists. (Replaced with List comprehensions).
3. Dictionary's `iteritems` which is removed in Python 3.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

---

@nodejs/python @cclauss 