### PR TITLE
build: make compress_json python3 compatible

### DIFF
--- a/tools/compress_json.py
+++ b/tools/compress_json.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
 
   step = 20
   slices = (data[i:i+step] for i in xrange(0, len(data), step))
-  slices = map(lambda s: ','.join(str(ord(c)) for c in s), slices)
+  slices = [','.join(str(ord(c)) for c in s) for s in slices]
   text = ',\n'.join(slices)
 
   fp = open(sys.argv[2], 'w')


### PR DESCRIPTION
This patch replaces a usage of `map` with list comprehension,
which makes the script Python 3 compatiable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

---

cc @nodejs/python @cclauss 