### PR TITLE
build: make install.py python 3 compatiable

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -72,8 +72,13 @@ def try_remove(path, dst):
   try_unlink(target_path)
   try_rmdir_r(os.path.dirname(target_path))
 
-def install(paths, dst): map(lambda path: try_copy(path, dst), paths)
-def uninstall(paths, dst): map(lambda path: try_remove(path, dst), paths)
+def install(paths, dst):
+  for path in paths:
+    try_copy(path, dst)
+
+def uninstall(paths, dst):
+  for path in paths:
+    try_remove(path, dst)
 
 def npm_files(action):
   target_path = 'lib/node_modules/npm/'
@@ -85,7 +90,7 @@ def npm_files(action):
   # npm has a *lot* of files and it'd be a pain to maintain a fixed list here
   # so we walk its source directory instead...
   for dirname, subdirs, basenames in os.walk('deps/npm', topdown=True):
-    subdirs[:] = filter('test'.__ne__, subdirs) # skip test suites
+    subdirs[:] = [subdir for subdir in subdirs if subdir != 'test']
     paths = [os.path.join(dirname, basename) for basename in basenames]
     action(paths, target_path + dirname[9:] + '/')
 
@@ -162,7 +167,7 @@ def headers(action):
       'deps/v8/include/v8-inspector.h',
       'deps/v8/include/v8-inspector-protocol.h'
     ]
-    files = filter(lambda name: name not in inspector_headers, files)
+    files = [name for name in files if name not in inspector_headers]
     action(files, dest)
 
   action([


### PR DESCRIPTION
This patch replaces usage of `filter` in such a way that it will be
compatible with Python 3. Also, this patch replaces the usage of `map`
to do a side-effect work with normal `for` loop.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

---

cc @nodejs/python @cclauss 