### PR TITLE
tools: make mkssldef.py Python 3 compatible

### DIFF
--- a/tools/mkssldef.py
+++ b/tools/mkssldef.py
@@ -21,13 +21,13 @@ if __name__ == '__main__':
     elif option.startswith('-X'): excludes += option[2:].split(',')
     elif option.startswith('-B'): bases += option[2:].split(',')
 
-  excludes = map(re.compile, excludes)
+  excludes = [re.compile(exclude) for exclude in excludes]
   exported = []
 
   for filename in filenames:
     for line in open(filename).readlines():
       name, _, _, meta, _ = re.split('\s+', line)
-      if any(map(lambda p: p.match(name), excludes)): continue
+      if any([p.match(name) for p in excludes]): continue
       meta = meta.split(':')
       assert meta[0] in ('EXIST', 'NOEXIST')
       assert meta[2] in ('FUNCTION', 'VARIABLE')

--- a/tools/mkssldef.py
+++ b/tools/mkssldef.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
   for filename in filenames:
     for line in open(filename).readlines():
       name, _, _, meta, _ = re.split('\s+', line)
-      if any([p.match(name) for p in excludes]): continue
+      if any(p.match(name) for p in excludes): continue
       meta = meta.split(':')
       assert meta[0] in ('EXIST', 'NOEXIST')
       assert meta[2] in ('FUNCTION', 'VARIABLE')


### PR DESCRIPTION
This patch replaces the usage of `map` in such a way that it will be
compatible with Python 3.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

---

cc @nodejs/python @cclauss 