### PR TITLE
doc: correct my wrong note about buf.fill()

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1240,7 +1240,7 @@ console.log(b.toString());
 
 `value` is coerced to a `uint32` value if it is not a string, `Buffer`, or
 integer. If the resulting integer is greater than `255` (decimal), `buf` will be
-filled with `0`.
+filled with `value & 255`.
 
 If the final write of a `fill()` operation falls on a multi-byte character,
 then only the bytes of that character that fit into `buf` are written:


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Sorry, I've [misinterpreted](https://github.com/nodejs/node/pull/25547) this operation:

https://github.com/nodejs/node/blob/c1ac57888199ba13df7eda4912cdb53dcfb5a2ee/src/node_buffer.cc#L566

```
> Buffer.alloc(5).fill(255)
<Buffer ff ff ff ff ff>
> Buffer.alloc(5).fill(256)
<Buffer 00 00 00 00 00>
> Buffer.alloc(5).fill(257)
<Buffer 01 01 01 01 01>
> Buffer.alloc(5).fill(258)
<Buffer 02 02 02 02 02>
```