### PR TITLE
lib: move queueMicrotask to stable

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -114,8 +114,6 @@ added: v11.0.0
 
 <!-- type=global -->
 
-> Stability: 1 - Experimental
-
 * `callback` {Function} Function to be queued.
 
 The `queueMicrotask()` method queues a microtask to invoke `callback`. If

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -396,30 +396,12 @@ function createGlobalConsole(consoleFromVM) {
 }
 
 function setupQueueMicrotask() {
+  const { queueMicrotask } =
+    NativeModule.require('internal/queue_microtask');
   Object.defineProperty(global, 'queueMicrotask', {
-    get() {
-      process.emitWarning('queueMicrotask() is experimental.',
-                          'ExperimentalWarning');
-      const { queueMicrotask } =
-        NativeModule.require('internal/queue_microtask');
-
-      Object.defineProperty(global, 'queueMicrotask', {
-        value: queueMicrotask,
-        writable: true,
-        enumerable: false,
-        configurable: true,
-      });
-      return queueMicrotask;
-    },
-    set(v) {
-      Object.defineProperty(global, 'queueMicrotask', {
-        value: v,
-        writable: true,
-        enumerable: false,
-        configurable: true,
-      });
-    },
-    enumerable: false,
+    value: queueMicrotask,
+    writable: true,
+    enumerable: true,
     configurable: true,
   });
 }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -258,7 +258,8 @@ let knownGlobals = [
   global,
   setImmediate,
   setInterval,
-  setTimeout
+  setTimeout,
+  queueMicrotask,
 ];
 
 if (global.gc) {

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -43,6 +43,7 @@ builtinModules.forEach((moduleName) => {
 {
   const expected = [
     'global',
+    'queueMicrotask',
     'clearImmediate',
     'clearInterval',
     'clearTimeout',


### PR DESCRIPTION
IIRC the critera for stable was better support from other platforms, which has since been fulfilled by safari and chrome.

Closes #25592

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
