### PR TITLE
src: mitigate MSVC dynamic initialization bug

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -107,6 +107,20 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
 
 namespace options_parser {
 
+// Explicitly access the singelton instances in their dependancy order.
+// This was moved here to workaround a compiler bug.
+// Refs: https://github.com/nodejs/node/issues/25593
+
+#if HAVE_INSPECTOR
+const DebugOptionsParser DebugOptionsParser::instance;
+#endif  // HAVE_INSPECTOR
+
+const EnvironmentOptionsParser EnvironmentOptionsParser::instance;
+
+const PerIsolateOptionsParser PerIsolateOptionsParser::instance;
+
+const PerProcessOptionsParser PerProcessOptionsParser::instance;
+
 // XXX: If you add an option here, please also add it to doc/node.1 and
 // doc/api/cli.md
 // TODO(addaleax): Make that unnecessary.
@@ -142,10 +156,6 @@ DebugOptionsParser::DebugOptionsParser() {
   Implies("--debug-brk", "--debug");
   AddAlias("--debug-brk=", { "--inspect-port", "--debug-brk" });
 }
-
-#if HAVE_INSPECTOR
-const DebugOptionsParser DebugOptionsParser::instance;
-#endif  // HAVE_INSPECTOR
 
 EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--experimental-modules",
@@ -282,8 +292,6 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
 #endif  // HAVE_INSPECTOR
 }
 
-const EnvironmentOptionsParser EnvironmentOptionsParser::instance;
-
 PerIsolateOptionsParser::PerIsolateOptionsParser() {
   AddOption("--track-heap-objects",
             "track heap object allocations for heap snapshots",
@@ -340,8 +348,6 @@ PerIsolateOptionsParser::PerIsolateOptionsParser() {
   Insert(&EnvironmentOptionsParser::instance,
          &PerIsolateOptions::get_per_env_options);
 }
-
-const PerIsolateOptionsParser PerIsolateOptionsParser::instance;
 
 PerProcessOptionsParser::PerProcessOptionsParser() {
   AddOption("--title",
@@ -448,8 +454,6 @@ PerProcessOptionsParser::PerProcessOptionsParser() {
   Insert(&PerIsolateOptionsParser::instance,
          &PerProcessOptions::get_per_isolate_options);
 }
-
-const PerProcessOptionsParser PerProcessOptionsParser::instance;
 
 inline std::string RemoveBrackets(const std::string& host) {
   if (!host.empty() && host.front() == '[' && host.back() == ']')


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/25593
Refs: https://developercommunity.visualstudio.com/content/problem/432157/dynamic-initializers-out-of-order.html

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
