### PR TITLE
test: replace common.PORT with `0` in https renegotiation test

### DIFF
--- a/test/pummel/test-https-ci-reneg-attack.js
+++ b/test/pummel/test-https-ci-reneg-attack.js
@@ -65,8 +65,9 @@ function test(next) {
     res.end('ok');
   });
 
-  server.listen(common.PORT, function() {
-    const args = (`s_client -connect 127.0.0.1:${common.PORT}`).split(' ');
+  server.listen(0, function() {
+    const cmd = `s_client -connect 127.0.0.1:${server.address().port}`;
+    const args = cmd.split(' ');
     const child = spawn(common.opensslCli, args);
 
     child.stdout.resume();


### PR DESCRIPTION
Repeated use of common.PORT was resulting in sporadic failures on some
operating systems.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
