### PR TITLE
test: remove potential race condition in https renegotiation test

### DIFF
--- a/test/pummel/test-https-ci-reneg-attack.js
+++ b/test/pummel/test-https-ci-reneg-attack.js
@@ -52,15 +52,12 @@ function test(next) {
     key: fixtures.readSync('test_key.pem')
   };
 
-  let seenError = false;
-
   const server = https.createServer(options, function(req, res) {
     const conn = req.connection;
     conn.on('error', function(err) {
       console.error(`Caught exception: ${err}`);
       assert(/TLS session renegotiation attack/.test(err));
       conn.destroy();
-      seenError = true;
     });
     res.end('ok');
   });
@@ -77,7 +74,6 @@ function test(next) {
     let renegs = 0;
 
     child.stderr.on('data', function(data) {
-      if (seenError) return;
       handshakes += ((String(data)).match(/verify return:1/g) || []).length;
       if (handshakes === 2) spam();
       renegs += ((String(data)).match(/RENEGOTIATING/g) || []).length;


### PR DESCRIPTION
In test/pummel/test-https-ci-reneg-attack.js, there is a boolean that is
set by the server and checked by the client, which is a separate process
launched with child_process.spawn(). The boolean is not actually
required by the client and might even be causing a race condition on
some operating systems. Remove it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
