### PR TITLE
test: remove setTimeout from https renegotiation test

### DIFF
--- a/test/pummel/test-https-ci-reneg-attack.js
+++ b/test/pummel/test-https-ci-reneg-attack.js
@@ -79,7 +79,7 @@ function test(next) {
     child.stderr.on('data', function(data) {
       if (seenError) return;
       handshakes += ((String(data)).match(/verify return:1/g) || []).length;
-      if (handshakes === 2) spam();
+      if (handshakes > 1) spam();
       renegs += ((String(data)).match(/RENEGOTIATING/g) || []).length;
     });
 
@@ -109,7 +109,6 @@ function test(next) {
     function spam() {
       if (closed) return;
       child.stdin.write('R\n');
-      setTimeout(spam, 50);
     }
   });
 }


### PR DESCRIPTION
Replace a `setTimeout()` with an arbitrary-ish 50ms delay with immediate
calls to the relevant function in test-https-ci-reneg-attack. Arbitrary
timers are often a cause for unreliable tests, especially on very fast
or very slow platforms, as they create race conditions. Regardless if
that's the case here, the timer is unnecessary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
