### PR TITLE
src: invoke per-isolate setters earlier

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -6,6 +6,7 @@
 #include "node_internals.h"
 #include "node_native_module.h"
 #include "node_options-inl.h"
+#include "node_perf.h"
 #include "node_platform.h"
 #include "node_process.h"
 #include "node_worker.h"
@@ -236,10 +237,10 @@ Environment::Environment(IsolateData* isolate_data,
   if (options_->no_force_async_hooks_checks) {
     async_hooks_.no_force_checks();
   }
-
-  // TODO(addaleax): the per-isolate state should not be controlled by
-  // a single Environment.
-  isolate()->SetPromiseRejectCallback(task_queue::PromiseRejectCallback);
+  isolate()->AddGCPrologueCallback(performance::MarkGarbageCollectionStart,
+                                   static_cast<void*>(this));
+  isolate()->AddGCEpilogueCallback(performance::MarkGarbageCollectionEnd,
+                                   static_cast<void*>(this));
 }
 
 Environment::~Environment() {

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -712,7 +712,7 @@ void ModuleWrap::Resolve(const FunctionCallbackInfo<Value>& args) {
     args.GetReturnValue().Set(obj.ToLocalChecked());
 }
 
-static MaybeLocal<Promise> ImportModuleDynamically(
+MaybeLocal<Promise> ModuleWrap::ImportModuleDynamically(
     Local<Context> context,
     Local<v8::ScriptOrModule> referrer,
     Local<String> specifier) {
@@ -784,8 +784,6 @@ void ModuleWrap::SetImportModuleDynamicallyCallback(
   CHECK(args[0]->IsFunction());
   Local<Function> import_callback = args[0].As<Function>();
   env->set_host_import_module_dynamically_callback(import_callback);
-
-  iso->SetHostImportModuleDynamicallyCallback(ImportModuleDynamically);
 }
 
 void ModuleWrap::HostInitializeImportMetaObjectCallback(
@@ -809,15 +807,10 @@ void ModuleWrap::HostInitializeImportMetaObjectCallback(
 void ModuleWrap::SetInitializeImportMetaObjectCallback(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
-
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsFunction());
   Local<Function> import_meta_callback = args[0].As<Function>();
   env->set_host_initialize_import_meta_object_callback(import_meta_callback);
-
-  isolate->SetHostInitializeImportMetaObjectCallback(
-      HostInitializeImportMetaObjectCallback);
 }
 
 void ModuleWrap::Initialize(Local<Object> target,

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -44,7 +44,10 @@ class ModuleWrap : public BaseObject {
       v8::Local<v8::Context> context,
       v8::Local<v8::Module> module,
       v8::Local<v8::Object> meta);
-
+  static v8::MaybeLocal<v8::Promise> ImportModuleDynamically(
+      v8::Local<v8::Context> context,
+      v8::Local<v8::ScriptOrModule> referrer,
+      v8::Local<v8::String> specifier);
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackField("url", url_);
     tracker->TrackField("resolve_cache", resolve_cache_);

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -247,15 +247,19 @@ void DTRACE_HTTP_CLIENT_RESPONSE(const FunctionCallbackInfo<Value>& args) {
   NODE_HTTP_CLIENT_RESPONSE(&conn, conn.remote, conn.port, conn.fd);
 }
 
-
-void dtrace_gc_start(Isolate* isolate, GCType type, GCCallbackFlags flags) {
+void DTraceGCStartCallback(Isolate* isolate,
+                           GCType type,
+                           GCCallbackFlags flags,
+                           void* data) {
   // Previous versions of this probe point only logged type and flags.
   // That's why for reasons of backwards compatibility the isolate goes last.
   NODE_GC_START(type, flags, isolate);
 }
 
-
-void dtrace_gc_done(Isolate* isolate, GCType type, GCCallbackFlags flags) {
+void DTraceGCEndCallback(Isolate* isolate,
+                         GCType type,
+                         GCCallbackFlags flags,
+                         void* data) {
   // Previous versions of this probe point only logged type and flags.
   // That's why for reasons of backwards compatibility the isolate goes last.
   NODE_GC_DONE(type, flags, isolate);
@@ -290,11 +294,5 @@ void InitDTrace(Environment* env, Local<Object> target) {
 #ifdef HAVE_ETW
   init_etw();
 #endif
-
-#if defined HAVE_DTRACE || defined HAVE_ETW
-  env->isolate()->AddGCPrologueCallback(dtrace_gc_start);
-  env->isolate()->AddGCEpilogueCallback(dtrace_gc_done);
-#endif
 }
-
 }  // namespace node

--- a/src/node_dtrace.h
+++ b/src/node_dtrace.h
@@ -78,6 +78,15 @@ namespace node {
 
 void InitDTrace(Environment* env, v8::Local<v8::Object> target);
 
+void DTraceGCStartCallback(v8::Isolate* isolate,
+                           v8::GCType type,
+                           v8::GCCallbackFlags flags,
+                           void* data);
+void DTraceGCEndCallback(v8::Isolate* isolate,
+                         v8::GCType type,
+                         v8::GCCallbackFlags flags,
+                         void* data);
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -290,14 +290,6 @@ void MarkGarbageCollectionEnd(Isolate* isolate,
                          entry);
 }
 
-
-inline void SetupGarbageCollectionTracking(Environment* env) {
-  env->isolate()->AddGCPrologueCallback(MarkGarbageCollectionStart,
-                                        static_cast<void*>(env));
-  env->isolate()->AddGCEpilogueCallback(MarkGarbageCollectionEnd,
-                                        static_cast<void*>(env));
-}
-
 // Gets the name of a function
 inline Local<Value> GetName(Local<Function> fn) {
   Local<Value> val = fn->GetDebugName();
@@ -440,8 +432,6 @@ void Initialize(Local<Object> target,
                             env->constants_string(),
                             constants,
                             attr).ToChecked();
-
-  SetupGarbageCollectionTracking(env);
 }
 
 }  // namespace performance

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -125,6 +125,15 @@ class GCPerformanceEntry : public PerformanceEntry {
   PerformanceGCKind gckind_;
 };
 
+void MarkGarbageCollectionStart(v8::Isolate* isolate,
+                                v8::GCType type,
+                                v8::GCCallbackFlags flags,
+                                void* data);
+void MarkGarbageCollectionEnd(v8::Isolate* isolate,
+                              v8::GCType type,
+                              v8::GCCallbackFlags flags,
+                              void* data);
+
 }  // namespace performance
 }  // namespace node
 


### PR DESCRIPTION
This patch moves the invocation of:

- `SetHostInitializeImportMetaObjectCallback`
- `SetHostImportModuleDynamicallyCallback`
- `SetPromiseRejectCallback`

and the DTrace-related:

- `AddGCPrologueCallback(DTraceGCStartCallback)`
- `AddGCEpilogueCallback(DTraceGCEndCallback)`.

into `node::NewIsolate()`, and moves the performance-timeline-related:

- `AddGCPrologueCallback(performance::MarkGarbageCollectionStart)`
- `AddGCEpilogueCallback(performance::MarkGarbageCollectionEnd)`

that needs per-Environment data into the `Environment` constructor,
instead of scattering the initialization code around in bindings.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
