### PR TITLE
test: revoke flaky designation for tests

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -5,12 +5,8 @@ prefix parallel
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
-# https://github.com/nodejs/node/issues/25029
-test-child-process-execfile: PASS,FLAKY
 # https://github.com/nodejs/node/issues/23207
 test-net-connect-options-port: PASS,FLAKY
-# https://github.com/nodejs/node/issues/25033
-test-child-process-exit-code: PASS,FLAKY
 # https://github.com/nodejs/node/issues/24305
 test-trace-events-api-worker-disabled: PASS,FLAKY
 
@@ -34,7 +30,3 @@ test-cli-node-options: PASS,FLAKY
 [$system==freebsd]
 
 [$system==aix]
-# https://github.com/nodejs/node/issues/25029
-test-child-process-execfile: PASS,FLAKY
-# https://github.com/nodejs/node/issues/25068
-test-util-callbackify: PASS,FLAKY

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -7,11 +7,6 @@ prefix sequential
 [true] # This section applies to all platforms
 # https://github.com/nodejs/node/issues/22336
 test-gc-http-client: PASS,FLAKY
-# https://github.com/nodejs/node/issues/24403
-test-cli-syntax-bad: PASS,FLAKY
-test-cli-syntax-file-not-found: PASS,FLAKY
-test-cli-syntax-good: PASS,FLAKY
-test-cli-syntax-require: PASS,FLAKY
 
 [$system==win32]
 # https://github.com/nodejs/node/issues/22327
@@ -26,9 +21,5 @@ test-http2-large-file: PASS, FLAKY
 [$system==freebsd]
 
 [$system==aix]
-# https://github.com/nodejs/node/issues/24921
-test-child-process-execsync: PASS, FLAKY
-# https://github.com/nodejs/node/issues/25047
-test-inspector-debug-end: PASS, FLAKY
 
 [$arch==arm]


### PR DESCRIPTION
A number of tests that were `flaked` recently are proved to have failing reason identified in
https://github.com/nodejs/node/issues/25007 and resolution
identified in https://github.com/nodejs/node/pull/25061

Revoke flaky designation of all these tests as the said PR is landed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
