### PR TITLE
test: run html/webappapis/microtask-queuing WPT in core

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -127,13 +127,15 @@ class StatusRuleSet {
 
 class WPTTest {
   /**
-   * @param {string} mod
-   * @param {string} filename
+   * @param {string} mod name of the WPT module, e.g.
+   *                     'html/webappapis/microtask-queuing'
+   * @param {string} filename path of the test, relative to mod, e.g.
+   *                          'test.any.js'
    * @param {StatusRule[]} rules
    */
   constructor(mod, filename, rules) {
-    this.module = mod; // name of the WPT module, e.g. 'url'
-    this.filename = filename;  // name of the test file
+    this.module = mod;
+    this.filename = filename;
 
     this.requires = new Set();
     this.failReasons = [];
@@ -204,6 +206,9 @@ const intlRequirements = new IntlRequirement();
 
 
 class StatusLoader {
+  /**
+   * @param {string} path relative path of the WPT subset
+   */
   constructor(path) {
     this.path = path;
     this.loaded = false;

--- a/test/fixtures/wpt/README.md
+++ b/test/fixtures/wpt/README.md
@@ -15,6 +15,7 @@ Last update:
 - url: https://github.com/web-platform-tests/wpt/tree/75b0f336c5/url
 - resources: https://github.com/web-platform-tests/wpt/tree/679a364421/resources
 - interfaces: https://github.com/web-platform-tests/wpt/tree/712c9f275e/interfaces
+- html/webappapis/microtask-queuing: https://github.com/web-platform-tests/wpt/tree/0c3bed38df/html/webappapis/microtask-queuing
 
 [Web Platform Tests]: https://github.com/web-platform-tests/wpt
 [`git node wpt`]: https://github.com/nodejs/node-core-utils/blob/master/docs/git-node.md#git-node-wpt

--- a/test/fixtures/wpt/html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js
+++ b/test/fixtures/wpt/html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js
@@ -1,0 +1,15 @@
+// META: global=window,worker
+"use strict";
+
+setup({
+  allow_uncaught_exception: true
+});
+
+async_test(t => {
+  const error = new Error("boo");
+  self.addEventListener("error", t.step_func_done(ev => {
+    assert_equals(ev.error, error);
+  }));
+
+  queueMicrotask(() => { throw error; });
+}, "It rethrows exceptions");

--- a/test/fixtures/wpt/html/webappapis/microtask-queuing/queue-microtask.any.js
+++ b/test/fixtures/wpt/html/webappapis/microtask-queuing/queue-microtask.any.js
@@ -1,0 +1,39 @@
+// META: global=window,worker
+"use strict";
+
+test(() => {
+  assert_equals(typeof queueMicrotask, "function");
+}, "It exists and is a function");
+
+test(() => {
+  assert_throws(new TypeError(), () => queueMicrotask(), "no argument");
+  assert_throws(new TypeError(), () => queueMicrotask(undefined), "undefined");
+  assert_throws(new TypeError(), () => queueMicrotask(null), "null");
+  assert_throws(new TypeError(), () => queueMicrotask(0), "0");
+  assert_throws(new TypeError(), () => queueMicrotask({ handleEvent() { } }), "an event handler object");
+  assert_throws(new TypeError(), () => queueMicrotask("window.x = 5;"), "a string");
+}, "It throws when given non-functions");
+
+async_test(t => {
+  let called = false;
+  queueMicrotask(t.step_func_done(() => {
+    called = true;
+  }));
+  assert_false(called);
+}, "It calls the callback asynchronously");
+
+async_test(t => {
+  queueMicrotask(t.step_func_done(function () { // note: intentionally not an arrow function
+    assert_array_equals(arguments, []);
+  }), "x", "y");
+}, "It does not pass any arguments");
+
+async_test(t => {
+  const happenings = [];
+  Promise.resolve().then(() => happenings.push("a"));
+  queueMicrotask(() => happenings.push("b"));
+  Promise.reject().catch(() => happenings.push("c"));
+  queueMicrotask(t.step_func_done(() => {
+    assert_array_equals(happenings, ["a", "b", "c"]);
+  }));
+}, "It interleaves with promises as expected");

--- a/test/fixtures/wpt/html/webappapis/microtask-queuing/queue-microtask.window.js
+++ b/test/fixtures/wpt/html/webappapis/microtask-queuing/queue-microtask.window.js
@@ -1,0 +1,45 @@
+"use strict";
+
+// This does not work as you expect because mutation observer compound microtasks are confusing.
+// Basically you can only use it once per test.
+function queueMicrotaskViaMO(cb) {
+  const observer = new MutationObserver(cb);
+  const node = document.createTextNode("");
+  observer.observe(node, { characterData: true });
+  node.data = "foo";
+}
+
+// Need to use promise_test to get sequential ordering; otherwise the global mutation observer
+// compound microtask business screws us over.
+
+promise_test(() => {
+  return new Promise(resolve => {
+    const happenings = [];
+
+    queueMicrotaskViaMO(() => happenings.push("x"));
+    queueMicrotask(() => happenings.push("a"));
+
+    queueMicrotask(() => {
+      assert_array_equals(happenings, ["x", "a"]);
+      resolve();
+    });
+  });
+}, "It interleaves with MutationObservers as expected");
+
+promise_test(() => {
+  return new Promise(resolve => {
+    const happenings = [];
+
+    queueMicrotask(() => happenings.push("a"));
+    Promise.reject().catch(() => happenings.push("x"));
+    queueMicrotaskViaMO(() => happenings.push(1));
+    Promise.resolve().then(() => happenings.push("y"));
+    queueMicrotask(() => happenings.push("b"));
+    queueMicrotask(() => happenings.push("c"));
+
+    queueMicrotask(() => {
+      assert_array_equals(happenings, ["a", "x", 1, "y", "b", "c"]);
+      resolve();
+    });
+  });
+}, "It interleaves with MutationObservers and promises together as expected");

--- a/test/fixtures/wpt/versions.json
+++ b/test/fixtures/wpt/versions.json
@@ -18,5 +18,9 @@
   "interfaces": {
     "commit": "712c9f275e83997884749dbcaa503f12c0ff5bba",
     "path": "interfaces"
+  },
+  "html/webappapis/microtask-queuing": {
+    "commit": "0c3bed38df6d9dcd1441873728fb5c1bb59c92df",
+    "path": "html/webappapis/microtask-queuing"
   }
 }

--- a/test/wpt/status/html/webappapis/microtask-queuing.json
+++ b/test/wpt/status/html/webappapis/microtask-queuing.json
@@ -1,0 +1,8 @@
+{
+  "queue-microtask-exceptions.any.js": {
+    "fail": "Node.js does not have a global addEventListener function"
+  },
+  "queue-microtask.window.js": {
+    "fail": "MutationObserver is not implemented"
+  }
+}

--- a/test/wpt/test-microtask-queuing.js
+++ b/test/wpt/test-microtask-queuing.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// Flags: --expose-internals
+
+require('../common');
+const { WPTRunner } = require('../common/wpt');
+
+const runner = new WPTRunner('html/webappapis/microtask-queuing');
+
+// Copy global descriptors from the global object
+runner.copyGlobalsFromObject(global, ['queueMicrotask']);
+
+runner.runJsTests();


### PR DESCRIPTION
#### test: pull html/webappapis/microtask-queuing WPT

With the command:

```
git node wpt html/webappapis/microtask-queuing
```

#### test: run html/webappapis/microtask-queuing WPT

#### test: clarify the path relativeness of WPT runner classes


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
