### PR TITLE
doc: link nextTick docs to the nextTick guide

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1463,9 +1463,9 @@ changes:
 
 `process.nextTick()` adds `callback` to the "next tick queue". This queue is
 fully drained after the current operation on the JavaScript stack runs to
-completion and before the event loop is allowed to continue. As a result, it's
-possible to create an infinite loop if one were to recursively call
-`process.nextTick()`.
+completion and before the event loop is allowed to continue. It's possible to
+create an infinite loop if one were to recursively call `process.nextTick()`.
+See the [Event Loop] guide for more background.
 
 ```js
 console.log('start');
@@ -2265,6 +2265,7 @@ cases:
 [Child Process]: child_process.html
 [Cluster]: cluster.html
 [Duplex]: stream.html#stream_duplex_and_transform_streams
+[Event Loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#process-nexttick
 [LTS]: https://github.com/nodejs/Release
 [Readable]: stream.html#stream_readable_streams
 [Signal Events]: #process_signal_events

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -10,7 +10,7 @@ globals, there is no need to call `require('timers')` to use the API.
 
 The timer functions within Node.js implement a similar API as the timers API
 provided by Web Browsers but use a different internal implementation that is
-built around [the Node.js Event Loop][].
+built around the Node.js [Event Loop][].
 
 ## Class: Immediate
 
@@ -263,6 +263,7 @@ added: v0.0.1
 
 Cancels a `Timeout` object created by [`setTimeout()`][].
 
+[Event Loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout
 [`TypeError`]: errors.html#errors_class_typeerror
 [`clearImmediate()`]: timers.html#timers_clearimmediate_immediate
 [`clearInterval()`]: timers.html#timers_clearinterval_timeout
@@ -271,4 +272,3 @@ Cancels a `Timeout` object created by [`setTimeout()`][].
 [`setInterval()`]: timers.html#timers_setinterval_callback_delay_args
 [`setTimeout()`]: timers.html#timers_settimeout_callback_delay_args
 [`util.promisify()`]: util.html#util_util_promisify_original
-[the Node.js Event Loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/


### PR DESCRIPTION
Link the guide discussing timers and nextTick from the nextTick docs, as
it already was from the timers docs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
