### PR TITLE
events: show inspected error in uncaught 'error' message

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -154,11 +154,10 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
 
   // If there is no 'error' event listener then throw.
   if (doError) {
-    let er, stringifiedEr;
+    let er;
     if (args.length > 0)
       er = args[0];
     if (er instanceof Error) {
-      stringifiedEr = er;
       try {
         const { kExpandStackSymbol } = require('internal/util');
         const capture = {};
@@ -172,14 +171,16 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
       // Note: The comments on the `throw` lines are intentional, they show
       // up in Node's output if this results in an unhandled exception.
       throw er; // Unhandled 'error' event
-    } else {
-      const { inspect } = require('internal/util/inspect');
-      try {
-        stringifiedEr = inspect(er);
-      } catch {
-        stringifiedEr = er;
-      }
     }
+
+    let stringifiedEr;
+    const { inspect } = require('internal/util/inspect');
+    try {
+      stringifiedEr = inspect(er);
+    } catch {
+      stringifiedEr = er;
+    }
+
     // At least give some kind of context to the user
     const errors = lazyErrors();
     const err = new errors.ERR_UNHANDLED_ERROR(stringifiedEr);

--- a/lib/events.js
+++ b/lib/events.js
@@ -154,10 +154,11 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
 
   // If there is no 'error' event listener then throw.
   if (doError) {
-    let er;
+    let er, stringifiedEr;
     if (args.length > 0)
       er = args[0];
     if (er instanceof Error) {
+      stringifiedEr = er;
       try {
         const { kExpandStackSymbol } = require('internal/util');
         const capture = {};
@@ -171,10 +172,17 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
       // Note: The comments on the `throw` lines are intentional, they show
       // up in Node's output if this results in an unhandled exception.
       throw er; // Unhandled 'error' event
+    } else {
+      const { inspect } = require('internal/util/inspect');
+      try {
+        stringifiedEr = inspect(er);
+      } catch {
+        stringifiedEr = er;
+      }
     }
     // At least give some kind of context to the user
     const errors = lazyErrors();
-    const err = new errors.ERR_UNHANDLED_ERROR(er);
+    const err = new errors.ERR_UNHANDLED_ERROR(stringifiedEr);
     err.context = er;
     throw err; // Unhandled 'error' event
   }

--- a/test/parallel/test-event-emitter-errors.js
+++ b/test/parallel/test-event-emitter-errors.js
@@ -26,11 +26,11 @@ common.expectsError(
 common.expectsError(
   () => EE.emit('error', {
     message: 'Error!',
-    [util.inspect.custom]() { throw null; }
+    [util.inspect.custom]() { throw new Error(); }
   }),
   {
     code: 'ERR_UNHANDLED_ERROR',
     type: Error,
-    message: "Unhandled error. ([object Object])"
+    message: 'Unhandled error. ([object Object])'
   }
 );

--- a/test/parallel/test-event-emitter-errors.js
+++ b/test/parallel/test-event-emitter-errors.js
@@ -1,6 +1,7 @@
 'use strict';
 const common = require('../common');
 const EventEmitter = require('events');
+const util = require('util');
 
 const EE = new EventEmitter();
 
@@ -9,7 +10,7 @@ common.expectsError(
   {
     code: 'ERR_UNHANDLED_ERROR',
     type: Error,
-    message: 'Unhandled error. (Accepts a string)'
+    message: "Unhandled error. ('Accepts a string')"
   }
 );
 
@@ -18,6 +19,18 @@ common.expectsError(
   {
     code: 'ERR_UNHANDLED_ERROR',
     type: Error,
-    message: 'Unhandled error. ([object Object])'
+    message: "Unhandled error. ({ message: 'Error!' })"
+  }
+);
+
+common.expectsError(
+  () => EE.emit('error', {
+    message: 'Error!',
+    [util.inspect.custom]() { throw null; }
+  }),
+  {
+    code: 'ERR_UNHANDLED_ERROR',
+    type: Error,
+    message: "Unhandled error. ([object Object])"
   }
 );


### PR DESCRIPTION
If there is no handler for `.emit('error', value)` and `value`
is not an `Error` object, we currently just call `.toString()`
on it.

Almost always, using `util.inspect()` provides better information
for diagnostic purposes, so prefer to use that instead.

Refs: https://github.com/nodejs/help/issues/1729

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
