### PR TITLE
src: avoid race condition in tracing code

### DIFF
--- a/src/tracing/node_trace_writer.cc
+++ b/src/tracing/node_trace_writer.cc
@@ -138,8 +138,10 @@ void NodeTraceWriter::FlushPrivate() {
 
 void NodeTraceWriter::Flush(bool blocking) {
   Mutex::ScopedLock scoped_lock(request_mutex_);
-  if (!json_trace_writer_) {
-    return;
+  {
+    Mutex::ScopedLock stream_mutex_lock(stream_mutex_);
+    if (!json_trace_writer_)
+      return;
   }
   int request_id = ++num_write_requests_;
   int err = uv_async_send(&flush_signal_);

--- a/src/tracing/node_trace_writer.cc
+++ b/src/tracing/node_trace_writer.cc
@@ -139,6 +139,9 @@ void NodeTraceWriter::FlushPrivate() {
 void NodeTraceWriter::Flush(bool blocking) {
   Mutex::ScopedLock scoped_lock(request_mutex_);
   {
+    // We need to lock the mutexes here in a nested fashion; stream_mutex_
+    // protects json_trace_writer_, and without request_mutex_ there might be
+    // a time window in which the stream state changes?
     Mutex::ScopedLock stream_mutex_lock(stream_mutex_);
     if (!json_trace_writer_)
       return;

--- a/src/tracing/node_trace_writer.h
+++ b/src/tracing/node_trace_writer.h
@@ -45,7 +45,8 @@ class NodeTraceWriter : public AsyncTraceWriter {
   // Triggers callback to close async objects, ending the tracing thread.
   uv_async_t exit_signal_;
   // Prevents concurrent R/W on state related to serialized trace data
-  // before it's written to disk, namely stream_ and total_traces_.
+  // before it's written to disk, namely stream_ and total_traces_
+  // as well as json_trace_writer_.
   Mutex stream_mutex_;
   // Prevents concurrent R/W on state related to write requests.
   Mutex request_mutex_;

--- a/src/tracing/node_trace_writer.h
+++ b/src/tracing/node_trace_writer.h
@@ -49,6 +49,7 @@ class NodeTraceWriter : public AsyncTraceWriter {
   // as well as json_trace_writer_.
   Mutex stream_mutex_;
   // Prevents concurrent R/W on state related to write requests.
+  // If both mutexes are locked, request_mutex_ has to be locked first.
   Mutex request_mutex_;
   // Allows blocking calls to Flush() to wait on a condition for
   // trace events to be written to disk.


### PR DESCRIPTION
`json_trace_writer_` is protected by `stream_mutex_`,
but one access to it was not guarded by a lock on said mutex.

Refs: https://github.com/nodejs/node/issues/25512

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
