### PR TITLE
src: remove has_experimental_policy option

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -180,10 +180,10 @@ function startup() {
   }
 
   // TODO(joyeecheung): move this down further to get better snapshotting
-  if (getOptionValue('[has_experimental_policy]')) {
+  const experimentalPolicy = getOptionValue('--experimental-policy');
+  if (experimentalPolicy) {
     process.emitWarning('Policies are experimental.',
                         'ExperimentalWarning');
-    const experimentalPolicy = getOptionValue('--experimental-policy');
     const { pathToFileURL, URL } = NativeModule.require('url');
     // URL here as it is slightly different parsing
     // no bare specifiers for now

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -45,7 +45,7 @@ const { getOptionValue } = require('internal/options');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const experimentalModules = getOptionValue('--experimental-modules');
-const manifest = getOptionValue('[has_experimental_policy]') ?
+const manifest = getOptionValue('--experimental-policy') ?
   require('internal/process/policy').manifest :
   null;
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -127,15 +127,11 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental ES Module support and caching modules",
             &EnvironmentOptions::experimental_modules,
             kAllowedInEnvironment);
-  AddOption("[has_experimental_policy]",
-            "",
-            &EnvironmentOptions::has_experimental_policy);
   AddOption("--experimental-policy",
             "use the specified file as a "
             "security policy",
             &EnvironmentOptions::experimental_policy,
             kAllowedInEnvironment);
-  Implies("--experimental-policy", "[has_experimental_policy]");
   AddOption("--experimental-repl-await",
             "experimental await keyword support in REPL",
             &EnvironmentOptions::experimental_repl_await,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -95,7 +95,6 @@ class EnvironmentOptions : public Options {
   bool abort_on_uncaught_exception = false;
   bool experimental_modules = false;
   std::string experimental_policy;
-  bool has_experimental_policy;
   bool experimental_repl_await = false;
   bool experimental_vm_modules = false;
   bool expose_internals = false;


### PR DESCRIPTION
This would be set when `--experimental-policy` was set,
but since an empty string does not refer to a valid file,
we can just check the value of `--experimental-policy`
directly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
