### PR TITLE
[v10.x-backport] n-api: mark thread-safe function as stable

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -223,7 +223,7 @@ This is an opaque pointer that is used to represent a JavaScript value.
 
 ### napi_threadsafe_function
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 This is an opaque pointer that represents a JavaScript function which can be
 called asynchronously from multiple threads via
@@ -231,7 +231,7 @@ called asynchronously from multiple threads via
 
 ### napi_threadsafe_function_release_mode
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 A value to be given to `napi_release_threadsafe_function()` to indicate whether
 the thread-safe function is to be closed immediately (`napi_tsfn_abort`) or
@@ -246,7 +246,7 @@ typedef enum {
 
 ### napi_threadsafe_function_call_mode
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 A value to be given to `napi_call_threadsafe_function()` to indicate whether
 the call should block whenever the queue associated with the thread-safe
@@ -341,7 +341,7 @@ typedef void (*napi_async_complete_callback)(napi_env env,
 
 #### napi_threadsafe_function_call_js
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 Function pointer used with asynchronous thread-safe function calls. The callback
 will be called on the main thread. Its purpose is to use a data item arriving
@@ -4455,7 +4455,7 @@ prevent the event loop from exiting. The APIs `napi_ref_threadsafe_function` and
 
 ### napi_create_threadsafe_function
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 <!-- YAML
 added: v10.6.0
@@ -4498,7 +4498,7 @@ parameters and with `undefined` as its `this` value.
 
 ### napi_get_threadsafe_function_context
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 <!-- YAML
 added: v10.6.0
@@ -4516,7 +4516,7 @@ This API may be called from any thread which makes use of `func`.
 
 ### napi_call_threadsafe_function
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 <!-- YAML
 added: v10.6.0
@@ -4544,7 +4544,7 @@ This API may be called from any thread which makes use of `func`.
 
 ### napi_acquire_threadsafe_function
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 <!-- YAML
 added: v10.6.0
@@ -4566,7 +4566,7 @@ This API may be called from any thread which will start making use of `func`.
 
 ### napi_release_threadsafe_function
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 <!-- YAML
 added: v10.6.0
@@ -4594,7 +4594,7 @@ This API may be called from any thread which will stop making use of `func`.
 
 ### napi_ref_threadsafe_function
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 <!-- YAML
 added: v10.6.0
@@ -4615,7 +4615,7 @@ This API may only be called from the main thread.
 
 ### napi_unref_threadsafe_function
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 <!-- YAML
 added: v10.6.0

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -3,9 +3,6 @@
 
 #include <stddef.h>
 #include <stdbool.h>
-#include "node_api_types.h"
-
-struct uv_loop_s;  // Forward declaration.
 
 #ifndef NAPI_VERSION
 #ifdef NAPI_EXPERIMENTAL
@@ -13,9 +10,13 @@ struct uv_loop_s;  // Forward declaration.
 #define NAPI_VERSION 2147483647
 #else
 // The baseline version for N-API
-#define NAPI_VERSION 3
+#define NAPI_VERSION 4
 #endif
 #endif
+
+#include "node_api_types.h"
+
+struct uv_loop_s;  // Forward declaration.
 
 #ifdef _WIN32
   #ifdef BUILDING_NODE_EXTENSION
@@ -633,7 +634,7 @@ NAPI_EXTERN napi_status napi_remove_env_cleanup_hook(napi_env env,
 
 #endif  // NAPI_VERSION >= 3
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 4
 
 // Calling into JS from other threads
 NAPI_EXTERN napi_status
@@ -670,6 +671,10 @@ napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 
 NAPI_EXTERN napi_status
 napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
+
+#endif  // NAPI_VERSION >= 4
+
+#ifdef NAPI_EXPERIMENTAL
 
 NAPI_EXTERN napi_status napi_create_bigint_int64(napi_env env,
                                                  int64_t value,

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -20,9 +20,9 @@ typedef struct napi_callback_info__* napi_callback_info;
 typedef struct napi_async_context__* napi_async_context;
 typedef struct napi_async_work__* napi_async_work;
 typedef struct napi_deferred__* napi_deferred;
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 4
 typedef struct napi_threadsafe_function__* napi_threadsafe_function;
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION >= 4
 
 typedef enum {
   napi_default = 0,
@@ -84,7 +84,7 @@ typedef enum {
   napi_bigint_expected,
 } napi_status;
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 4
 typedef enum {
   napi_tsfn_release,
   napi_tsfn_abort
@@ -94,7 +94,7 @@ typedef enum {
   napi_tsfn_nonblocking,
   napi_tsfn_blocking
 } napi_threadsafe_function_call_mode;
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION >= 4
 
 typedef napi_value (*napi_callback)(napi_env env,
                                     napi_callback_info info);
@@ -107,12 +107,12 @@ typedef void (*napi_async_complete_callback)(napi_env env,
                                              napi_status status,
                                              void* data);
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 4
 typedef void (*napi_threadsafe_function_call_js)(napi_env env,
                                                  napi_value js_callback,
                                                  void* context,
                                                  void* data);
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION >= 4
 
 typedef struct {
   // One of utf8name or name should be NULL.

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -114,6 +114,6 @@
 #define NODE_MODULE_VERSION 64
 
 // the NAPI_VERSION provided by this version of the runtime
-#define NAPI_VERSION  3
+#define NAPI_VERSION  4
 
 #endif  // SRC_NODE_VERSION_H_

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -33,8 +33,8 @@ assert.notStrictEqual(test_general.testGetPrototype(baseObject),
                       test_general.testGetPrototype(extendedObject));
 
 // test version management functions
-// expected version is currently 3
-assert.strictEqual(test_general.testGetVersion(), 3);
+// expected version is currently 4
+assert.strictEqual(test_general.testGetVersion(), 4);
 
 const [ major, minor, patch, release ] = test_general.testGetNodeVersion();
 assert.strictEqual(process.version.split('-')[0],

--- a/test/addons-napi/test_threadsafe_function/binding.c
+++ b/test/addons-napi/test_threadsafe_function/binding.c
@@ -4,7 +4,6 @@
 // which, in turn, may affect the ABI stability of the project despite its use
 // of N-API.
 #include <uv.h>
-#define NAPI_EXPERIMENTAL
 #include <node_api.h>
 #include "../common.h"
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/24249
PR-URL: https://github.com/nodejs/node/pull/25556

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
