### PR TITLE
n-api: change #ifdef to #if in node_api_types

### DIFF
--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -10,7 +10,7 @@ typedef struct napi_async_work__* napi_async_work;
 typedef struct napi_threadsafe_function__* napi_threadsafe_function;
 #endif  // NAPI_VERSION >= 4
 
-#ifdef NAPI_VERSION >= 4
+#if NAPI_VERSION >= 4
 typedef enum {
   napi_tsfn_release,
   napi_tsfn_abort
@@ -27,7 +27,7 @@ typedef void (*napi_async_execute_callback)(napi_env env,
 typedef void (*napi_async_complete_callback)(napi_env env,
                                              napi_status status,
                                              void* data);
-#ifdef NAPI_VERSION >= 4
+#if NAPI_VERSION >= 4
 typedef void (*napi_threadsafe_function_call_js)(napi_env env,
                                                  napi_value js_callback,
                                                  void* context,


### PR DESCRIPTION
Currently, there are a number of compiler warnings like the following:
```console
In file included from ../src/node_api.h:11:
../src/node_api_types.h:13:21:x
 warning: extra tokens at end of #ifdef directive [-Wextra-tokens]
 #ifdef NAPI_VERSION >= 4
```
This commit changes the `#ifdef` macros to `#if`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
