### PR TITLE
src: stop using v8::Function in node_os.cc

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -52,7 +52,6 @@ using v8::ArrayBuffer;
 using v8::Boolean;
 using v8::Context;
 using v8::Float64Array;
-using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::Int32;
 using v8::Integer;


### PR DESCRIPTION
It is unused in the file.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
