### PR TITLE
meta: bump minimal supported Windows version

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -77,7 +77,7 @@ For production applications, run Node.js on supported platforms only.
 | GNU/Linux    | Tier 1       | kernel >= 2.6.32, glibc >= 2.12 | x64, arm         |                               |
 | GNU/Linux    | Tier 1       | kernel >= 3.10, glibc >= 2.17   | arm64            |                               |
 | macOS/OS X   | Tier 1       | >= 10.11                        | x64              |                               |
-| Windows      | Tier 1       | >= Windows 7/2008 R2/2012 R2    | x86, x64         | [2](#fn2),[3](#fn3),[4](#fn4) |
+| Windows      | Tier 1       | >= Windows 8.1/2012 R2          | x86, x64         | [2](#fn2),[3](#fn3),[4](#fn4) |
 | SmartOS      | Tier 2       | >= 15 < 16.4                    | x86, x64         | [1](#fn1)                     |
 | FreeBSD      | Tier 2       | >= 11                           | x64              |                               |
 | GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19 | ppc64le >=power8 |                               |


### PR DESCRIPTION
Microsoft has announced that on January 14, 2020 it will end it's support for Windows 7 and Windows Server 2008 R2.

This semver-major PR bumps the stated minimal supported versions to Windows8.1/Server2012R2 so that we will be explicit with our support plan, and not state that we support and EOL platform for the next LTS node version.

As per:
https://github.com/nodejs/node/blob/715df64b467469d669f4db2b0824851168479be5/BUILDING.md#L72

/CC @nodejs/platform-windows @nodejs/tsc 

Refs: https://support.microsoft.com/en-us/help/4487594
Refs: https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet#section-2
Refs: https://github.com/nodejs/build/issues/1663

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
