### PR TITLE
doc: simplify process.binding() deprecation message

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2135,8 +2135,7 @@ changes:
 
 Type: Documentation-only
 
-The `process.binding()` API is intended for use by Node.js internal code
-only. Use of `process.binding()` by userland code is unsupported.
+`process.binding()` is for use by Node.js internal code only.
 
 <a id="DEP0112"></a>
 ### DEP0112: dgram private APIs


### PR DESCRIPTION
Keep the process.binding() deprecation message short and direct. In
addition to the usual benefits of doing that, it also means the message
is less likely to line-wrap once we move to a runtime deprecation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
