### PR TITLE
process: fix call process.reallyExit, vs., binding

### DIFF
--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -149,7 +149,10 @@ function wrapProcessMethods(binding) {
       process._exiting = true;
       process.emit('exit', process.exitCode || 0);
     }
-    binding.reallyExit(process.exitCode || 0);
+    // FIXME(joyeecheung): This is an undocumented API that gets monkey-patched
+    // in the user land. Either document it, or deprecate it in favor of a
+    // better public alternative.
+    process.reallyExit(process.exitCode || 0);
   }
 
   function kill(pid, sig) {

--- a/test/parallel/test-process-really-exit.js
+++ b/test/parallel/test-process-really-exit.js
@@ -1,0 +1,17 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+// ensure that the reallyExit hook is executed.
+// see: https://github.com/nodejs/node/issues/25650
+if (process.argv[2] === 'subprocess') {
+  process.reallyExit = function() {
+    console.info('really exited');
+  };
+  process.exit();
+} else {
+  const { spawnSync } = require('child_process');
+  const out = spawnSync(process.execPath, [__filename, 'subprocess']);
+  const observed = out.output[1].toString('utf8').trim();
+  assert.strictEqual(observed, 'really exited');
+}


### PR DESCRIPTION
Some user-land modules, e.g., nyc, mocha, currently rely on patching
process.reallyExit.

---

Node@11.7.0 breaks the interaction between nyc and mocha; ultimately it appears as though the problem is that nyc relies on overriding `process.reallyExit` to output coverage to disk, which was replaced with `binding.reallyExit` (dde71520ba7439741c3314b719ea88dc0ed8b9a7).

fixes: https://github.com/nodejs/node/issues/25650

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
