### PR TITLE
test: refactor test-*-ci-reneg-attack.js

### DIFF
--- a/test/pummel/test-https-ci-reneg-attack.js
+++ b/test/pummel/test-https-ci-reneg-attack.js
@@ -73,11 +73,13 @@ function test(next) {
     // Count handshakes, start the attack after the initial handshake is done
     let handshakes = 0;
     let renegs = 0;
+    let stderrStuff = '';
 
     child.stderr.on('data', function(data) {
-      handshakes += ((String(data)).match(/verify return:1/g) || []).length;
+      stderrStuff += data.toString();
+      handshakes = (stderrStuff.match(/verify return:1/g) || []).length;
       if (handshakes === 2) spam();
-      renegs += ((String(data)).match(/RENEGOTIATING/g) || []).length;
+      renegs = (stderrStuff.match(/RENEGOTIATING/g) || []).length;
     });
 
     child.on('exit', function() {


### PR DESCRIPTION
Refactor test-tls-ci-reneg-attack:

* Use port 0 (OS-assigned available port) rather than common.PORT
* Remove unnecessary boolean that causes race condition failure on some
  operating systems

Refactor that test and test-https-ci-reneg-attack:

* Check all stderr, not just the chunk coming in now, in case it breaks
  up chunks in the middle of where the regexps are supposed to match.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
