### PR TITLE
test, tools: suppress addon function cast warnings

### DIFF
--- a/test/addons/async-hello-world/binding.gyp
+++ b/test/addons/async-hello-world/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/async-hello-world/binding.gyp
+++ b/test/addons/async-hello-world/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/async-hello-world/binding.gyp
+++ b/test/addons/async-hello-world/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/async-hooks-id/binding.gyp
+++ b/test/addons/async-hooks-id/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/async-hooks-id/binding.gyp
+++ b/test/addons/async-hooks-id/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/async-hooks-id/binding.gyp
+++ b/test/addons/async-hooks-id/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/async-hooks-promise/binding.gyp
+++ b/test/addons/async-hooks-promise/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/async-hooks-promise/binding.gyp
+++ b/test/addons/async-hooks-promise/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/async-hooks-promise/binding.gyp
+++ b/test/addons/async-hooks-promise/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/async-resource/binding.gyp
+++ b/test/addons/async-resource/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/async-resource/binding.gyp
+++ b/test/addons/async-resource/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/async-resource/binding.gyp
+++ b/test/addons/async-resource/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/at-exit/binding.gyp
+++ b/test/addons/at-exit/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/at-exit/binding.gyp
+++ b/test/addons/at-exit/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/at-exit/binding.gyp
+++ b/test/addons/at-exit/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/buffer-free-callback/binding.gyp
+++ b/test/addons/buffer-free-callback/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/buffer-free-callback/binding.gyp
+++ b/test/addons/buffer-free-callback/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/buffer-free-callback/binding.gyp
+++ b/test/addons/buffer-free-callback/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/callback-scope/binding.gyp
+++ b/test/addons/callback-scope/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/callback-scope/binding.gyp
+++ b/test/addons/callback-scope/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/callback-scope/binding.gyp
+++ b/test/addons/callback-scope/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/common.gypi
+++ b/test/addons/common.gypi
@@ -1,0 +1,8 @@
+{
+  'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+  'conditions': [
+    [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+      'cflags': ['-Wno-cast-function-type'],
+    }],
+  ],
+}

--- a/test/addons/dlopen-ping-pong/binding.gyp
+++ b/test/addons/dlopen-ping-pong/binding.gyp
@@ -19,7 +19,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/dlopen-ping-pong/binding.gyp
+++ b/test/addons/dlopen-ping-pong/binding.gyp
@@ -17,13 +17,8 @@
     },
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/dlopen-ping-pong/binding.gyp
+++ b/test/addons/dlopen-ping-pong/binding.gyp
@@ -19,6 +19,7 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/errno-exception/binding.gyp
+++ b/test/addons/errno-exception/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/errno-exception/binding.gyp
+++ b/test/addons/errno-exception/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/errno-exception/binding.gyp
+++ b/test/addons/errno-exception/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/heap-profiler/binding.gyp
+++ b/test/addons/heap-profiler/binding.gyp
@@ -5,7 +5,11 @@
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
       'win_delay_load_hook': 'false',
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/heap-profiler/binding.gyp
+++ b/test/addons/heap-profiler/binding.gyp
@@ -2,14 +2,9 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
       'win_delay_load_hook': 'false',
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/heap-profiler/binding.gyp
+++ b/test/addons/heap-profiler/binding.gyp
@@ -4,7 +4,8 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'win_delay_load_hook': 'false'
+      'win_delay_load_hook': 'false',
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/hello-world-esm/binding.gyp
+++ b/test/addons/hello-world-esm/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/hello-world-esm/binding.gyp
+++ b/test/addons/hello-world-esm/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/hello-world-esm/binding.gyp
+++ b/test/addons/hello-world-esm/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/hello-world-function-export/binding.gyp
+++ b/test/addons/hello-world-function-export/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/hello-world-function-export/binding.gyp
+++ b/test/addons/hello-world-function-export/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/hello-world-function-export/binding.gyp
+++ b/test/addons/hello-world-function-export/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/hello-world/binding.gyp
+++ b/test/addons/hello-world/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/hello-world/binding.gyp
+++ b/test/addons/hello-world/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/hello-world/binding.gyp
+++ b/test/addons/hello-world/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/load-long-path/binding.gyp
+++ b/test/addons/load-long-path/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/load-long-path/binding.gyp
+++ b/test/addons/load-long-path/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/load-long-path/binding.gyp
+++ b/test/addons/load-long-path/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/make-callback-domain-warning/binding.gyp
+++ b/test/addons/make-callback-domain-warning/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/make-callback-domain-warning/binding.gyp
+++ b/test/addons/make-callback-domain-warning/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/make-callback-domain-warning/binding.gyp
+++ b/test/addons/make-callback-domain-warning/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/make-callback-recurse/binding.gyp
+++ b/test/addons/make-callback-recurse/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/make-callback-recurse/binding.gyp
+++ b/test/addons/make-callback-recurse/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/make-callback-recurse/binding.gyp
+++ b/test/addons/make-callback-recurse/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/make-callback/binding.gyp
+++ b/test/addons/make-callback/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/make-callback/binding.gyp
+++ b/test/addons/make-callback/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/make-callback/binding.gyp
+++ b/test/addons/make-callback/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/new-target/binding.gyp
+++ b/test/addons/new-target/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/new-target/binding.gyp
+++ b/test/addons/new-target/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/new-target/binding.gyp
+++ b/test/addons/new-target/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/node-module-version/binding.gyp
+++ b/test/addons/node-module-version/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/node-module-version/binding.gyp
+++ b/test/addons/node-module-version/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/node-module-version/binding.gyp
+++ b/test/addons/node-module-version/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/non-node-context/binding.gyp
+++ b/test/addons/non-node-context/binding.gyp
@@ -2,7 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'sources': ['binding.cc']
+      'sources': ['binding.cc'],
+      'cflags': ['-Wno-cast-function-type'],
     },
   ]
 }

--- a/test/addons/non-node-context/binding.gyp
+++ b/test/addons/non-node-context/binding.gyp
@@ -3,11 +3,7 @@
     {
       'target_name': 'binding',
       'sources': ['binding.cc'],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     },
   ]
 }

--- a/test/addons/non-node-context/binding.gyp
+++ b/test/addons/non-node-context/binding.gyp
@@ -3,7 +3,11 @@
     {
       'target_name': 'binding',
       'sources': ['binding.cc'],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     },
   ]
 }

--- a/test/addons/not-a-binding/binding.gyp
+++ b/test/addons/not-a-binding/binding.gyp
@@ -3,11 +3,7 @@
     {
       'target_name': 'binding',
       'sources': [ 'not_a_binding.c' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/not-a-binding/binding.gyp
+++ b/test/addons/not-a-binding/binding.gyp
@@ -2,7 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'sources': [ 'not_a_binding.c' ]
+      'sources': [ 'not_a_binding.c' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/not-a-binding/binding.gyp
+++ b/test/addons/not-a-binding/binding.gyp
@@ -3,7 +3,11 @@
     {
       'target_name': 'binding',
       'sources': [ 'not_a_binding.c' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/null-buffer-neuter/binding.gyp
+++ b/test/addons/null-buffer-neuter/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/null-buffer-neuter/binding.gyp
+++ b/test/addons/null-buffer-neuter/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/null-buffer-neuter/binding.gyp
+++ b/test/addons/null-buffer-neuter/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/openssl-binding/binding.gyp
+++ b/test/addons/openssl-binding/binding.gyp
@@ -6,9 +6,11 @@
         ['node_use_openssl=="true"', {
           'sources': ['binding.cc'],
           'include_dirs': ['../../../deps/openssl/openssl/include'],
-        }]
+        }],
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
       ],
-      'cflags': ['-Wno-cast-function-type'],
     },
   ]
 }

--- a/test/addons/openssl-binding/binding.gyp
+++ b/test/addons/openssl-binding/binding.gyp
@@ -7,7 +7,8 @@
           'sources': ['binding.cc'],
           'include_dirs': ['../../../deps/openssl/openssl/include'],
         }]
-      ]
+      ],
+      'cflags': ['-Wno-cast-function-type'],
     },
   ]
 }

--- a/test/addons/openssl-binding/binding.gyp
+++ b/test/addons/openssl-binding/binding.gyp
@@ -2,13 +2,11 @@
   'targets': [
     {
       'target_name': 'binding',
+      'includes': ['../common.gypi'],
       'conditions': [
         ['node_use_openssl=="true"', {
           'sources': ['binding.cc'],
           'include_dirs': ['../../../deps/openssl/openssl/include'],
-        }],
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
         }],
       ],
     },

--- a/test/addons/openssl-client-cert-engine/binding.gyp
+++ b/test/addons/openssl-client-cert-engine/binding.gyp
@@ -18,7 +18,10 @@
               '../../../../out/<(PRODUCT_DIR)/<(openssl_product)'
             ]
           },
-        }]
+        }],
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
       ]
     }
   ]

--- a/test/addons/openssl-client-cert-engine/binding.gyp
+++ b/test/addons/openssl-client-cert-engine/binding.gyp
@@ -3,6 +3,7 @@
     {
       'target_name': 'testengine',
       'type': 'none',
+      'cflags': ['-Wno-cast-function-type'],
       'conditions': [
         ['OS=="mac" and '
          'node_use_openssl=="true" and '

--- a/test/addons/openssl-client-cert-engine/binding.gyp
+++ b/test/addons/openssl-client-cert-engine/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'testengine',
       'type': 'none',
-      'cflags': ['-Wno-cast-function-type'],
+      'includes': ['../common.gypi'],
       'conditions': [
         ['OS=="mac" and '
          'node_use_openssl=="true" and '
@@ -18,9 +18,6 @@
               '../../../../out/<(PRODUCT_DIR)/<(openssl_product)'
             ]
           },
-        }],
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
         }],
       ]
     }

--- a/test/addons/parse-encoding/binding.gyp
+++ b/test/addons/parse-encoding/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/parse-encoding/binding.gyp
+++ b/test/addons/parse-encoding/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/parse-encoding/binding.gyp
+++ b/test/addons/parse-encoding/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/repl-domain-abort/binding.gyp
+++ b/test/addons/repl-domain-abort/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/repl-domain-abort/binding.gyp
+++ b/test/addons/repl-domain-abort/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/repl-domain-abort/binding.gyp
+++ b/test/addons/repl-domain-abort/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/stringbytes-external-exceed-max/binding.gyp
+++ b/test/addons/stringbytes-external-exceed-max/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/stringbytes-external-exceed-max/binding.gyp
+++ b/test/addons/stringbytes-external-exceed-max/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/stringbytes-external-exceed-max/binding.gyp
+++ b/test/addons/stringbytes-external-exceed-max/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/symlinked-module/binding.gyp
+++ b/test/addons/symlinked-module/binding.gyp
@@ -3,11 +3,7 @@
     {
       'target_name': 'binding',
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/symlinked-module/binding.gyp
+++ b/test/addons/symlinked-module/binding.gyp
@@ -2,7 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/symlinked-module/binding.gyp
+++ b/test/addons/symlinked-module/binding.gyp
@@ -3,7 +3,11 @@
     {
       'target_name': 'binding',
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/uv-handle-leak/binding.gyp
+++ b/test/addons/uv-handle-leak/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/uv-handle-leak/binding.gyp
+++ b/test/addons/uv-handle-leak/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/uv-handle-leak/binding.gyp
+++ b/test/addons/uv-handle-leak/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/worker-addon/binding.gyp
+++ b/test/addons/worker-addon/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     }
   ]
 }

--- a/test/addons/worker-addon/binding.gyp
+++ b/test/addons/worker-addon/binding.gyp
@@ -3,7 +3,8 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'cflags': ['-Wno-cast-function-type'],
     }
   ]
 }

--- a/test/addons/worker-addon/binding.gyp
+++ b/test/addons/worker-addon/binding.gyp
@@ -2,13 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/zlib-binding/binding.gyp
+++ b/test/addons/zlib-binding/binding.gyp
@@ -4,6 +4,7 @@
       'target_name': 'binding',
       'sources': ['binding.cc'],
       'include_dirs': ['../../../deps/zlib'],
+      'cflags': ['-Wno-cast-function-type'],
     },
   ]
 }

--- a/test/addons/zlib-binding/binding.gyp
+++ b/test/addons/zlib-binding/binding.gyp
@@ -4,11 +4,7 @@
       'target_name': 'binding',
       'sources': ['binding.cc'],
       'include_dirs': ['../../../deps/zlib'],
-      'conditions': [
-        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-          'cflags': ['-Wno-cast-function-type'],
-        }],
-      ],
+      'includes': ['../common.gypi'],
     },
   ]
 }

--- a/test/addons/zlib-binding/binding.gyp
+++ b/test/addons/zlib-binding/binding.gyp
@@ -4,7 +4,11 @@
       'target_name': 'binding',
       'sources': ['binding.cc'],
       'include_dirs': ['../../../deps/zlib'],
-      'cflags': ['-Wno-cast-function-type'],
+      'conditions': [
+        [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+          'cflags': ['-Wno-cast-function-type'],
+        }],
+      ],
     },
   ]
 }

--- a/tools/doc/addon-verify.js
+++ b/tools/doc/addon-verify.js
@@ -79,13 +79,8 @@ ${files[name].replace(
       targets: [
         {
           target_name: 'addon',
-          defines: [ 'V8_DEPRECATION_WARNINGS=1' ],
           sources: files.map(({ name }) => name),
-          conditions: [
-            [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
-              cflags: ['-Wno-cast-function-type'],
-            }],
-          ],
+          includes: ['../common.gypi'],
         }
       ]
     })

--- a/tools/doc/addon-verify.js
+++ b/tools/doc/addon-verify.js
@@ -81,7 +81,11 @@ ${files[name].replace(
           target_name: 'addon',
           defines: [ 'V8_DEPRECATION_WARNINGS=1' ],
           sources: files.map(({ name }) => name),
-          cflags: [ '-Wno-cast-function-type' ]
+          conditions: [
+            [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+              cflags: ['-Wno-cast-function-type'],
+            }],
+          ],
         }
       ]
     })

--- a/tools/doc/addon-verify.js
+++ b/tools/doc/addon-verify.js
@@ -80,7 +80,8 @@ ${files[name].replace(
         {
           target_name: 'addon',
           defines: [ 'V8_DEPRECATION_WARNINGS=1' ],
-          sources: files.map(({ name }) => name)
+          sources: files.map(({ name }) => name),
+          cflags: [ '-Wno-cast-function-type' ]
         }
       ]
     })


### PR DESCRIPTION
Currently, there are a number of compiler warnings generated when
building the addons on Linux, for example:
```console
make[1]: Entering directory '/node/test/addons/zlib-binding/build'
  CXX(target) Release/obj.target/binding/binding.o
  SOLINK_MODULE(target) Release/obj.target/binding.node
  COPY Release/binding.node
make[1]: Leaving directory '/node/test/addons/zlib-binding/build'
In file included from ../binding.cc:1:
/node/src/node.h:515:51: warning:
cast between incompatible function types from
'void (*)(v8::Local<v8::Object>,
          v8::Local<v8::Value>,
          v8::Local<v8::Context>)' to
'node::addon_context_register_func' {aka
'void (*)(v8::Local<v8::Object>,
          v8::Local<v8::Value>,
          v8::Local<v8::Context>,
          void*)'} [-Wcast-function-type]
(node::addon_context_register_func) (regfunc), \
					   ^
/node/src/node.h:533:3:
note: in expansion of macro 'NODE_MODULE_CONTEXT_AWARE_X'
   NODE_MODULE_CONTEXT_AWARE_X(modname, regfunc, NULL, 0)
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
../binding.cc:58:1:
note: in expansion of macro 'NODE_MODULE_CONTEXT_AWARE'
 NODE_MODULE_CONTEXT_AWARE(NODE_GYP_MODULE_NAME, Initialize)
 ^~~~~~~~~~~~~~~~~~~~~~~~~
```
This commit adds the flag `-Wno-cast-function-type` to suppress these
warnings. With this change the warnings are not displayed anymore and
the output matches that of osx when running
`make -j8 test/addons/.buildstamp`


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
