### PR TITLE
WIP src: print stack of Error object with --abort-on-uncaught-exception

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -518,12 +518,18 @@ void* ArrayBufferAllocator::Allocate(size_t size) {
 
 namespace {
 
-bool ShouldAbortOnUncaughtException(Isolate* isolate) {
+bool ShouldAbortOnUncaughtException(Isolate* isolate, Local<Message> message,
+                                    Local<Value> error) {
   HandleScope scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
-  return env != nullptr &&
-         env->should_abort_on_uncaught_toggle()[0] &&
-         !env->inside_should_not_abort_on_uncaught_scope();
+
+  if (env != nullptr && env->should_abort_on_uncaught_toggle()[0] &&
+      !env->inside_should_not_abort_on_uncaught_scope()) {
+    ReportException(env, error, message);
+    return true;
+  }
+
+  return false;
 }
 
 }  // anonymous namespace

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -38,6 +38,10 @@ void PrintErrorString(const char* format, ...);
 
 void ReportException(Environment* env, const v8::TryCatch& try_catch);
 
+void ReportException(Environment* env,
+                     v8::Local<v8::Value> er,
+                     v8::Local<v8::Message> message);
+
 void FatalException(v8::Isolate* isolate,
                     v8::Local<v8::Value> error,
                     v8::Local<v8::Message> message);

--- a/test/abort/test-abort-uncaught-exception-stack-trace.js
+++ b/test/abort/test-abort-uncaught-exception-stack-trace.js
@@ -1,0 +1,22 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+function thrower() {
+  throw new Error();
+}
+
+try {
+  thrower();
+} catch (err) {
+  if (process.argv.includes('child')) {
+    throw err;
+  }
+
+  const args = ['--abort-on-uncaught-exception', __filename, 'child'];
+  const child = spawnSync(process.execPath, args);
+  const stackTrace = child.stderr.toString();
+  assert(stackTrace.includes(err.stack), 'Error.stack not present in stderr');
+}


### PR DESCRIPTION
**DO NOT LAND YET. This depends on an upstream pull request: https://chromium-review.googlesource.com/c/v8/v8/+/1412115**

When `--abort-on-uncaught-exception` is set and an exception is thrown but
uncaught, V8 will print the stack trace of the crash site right before
exiting. This behavior differs from the default, which will print the
stack trace of the thrown error object. This is especially problematic
when we're crashing because of a rethrown error.

These changes use a new signature for the
AbortOnUncaughtExceptionCallback which also receives the Message and
Error objects to print the Error stack trace before aborting.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] ~documentation is changed or added~
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
