### PR TITLE
test: fix renegotiation tests in pummel

### DIFF
--- a/test/pummel/test-https-ci-reneg-attack.js
+++ b/test/pummel/test-https-ci-reneg-attack.js
@@ -73,10 +73,14 @@ function test(next) {
     // Count handshakes, start the attack after the initial handshake is done
     let handshakes = 0;
     let renegs = 0;
+    let waitingToSpam = true;
 
     child.stderr.on('data', function(data) {
       handshakes += ((String(data)).match(/verify return:1/g) || []).length;
-      if (handshakes === 2) spam();
+      if (handshakes === 2 && waitingToSpam) {
+        waitingToSpam = false;
+        spam();
+      }
       renegs += ((String(data)).match(/RENEGOTIATING/g) || []).length;
     });
 

--- a/test/pummel/test-tls-ci-reneg-attack.js
+++ b/test/pummel/test-tls-ci-reneg-attack.js
@@ -73,11 +73,15 @@ function test(next) {
     // Count handshakes, start the attack after the initial handshake is done
     let handshakes = 0;
     let renegs = 0;
+    let waitingToSpam = true;
 
     child.stderr.on('data', function(data) {
       if (seenError) return;
       handshakes += ((String(data)).match(/verify return:1/g) || []).length;
-      if (handshakes === 2) spam();
+      if (handshakes === 2 && waitingToSpam) {
+        waitingToSpam = false;
+        spam();
+      }
       renegs += ((String(data)).match(/RENEGOTIATING/g) || []).length;
     });
 


### PR DESCRIPTION
With a recent OpenSSL update to core, a change in the behavior of
`s_client` result in pummel test failures because they spam with
renegotiation requests before the renegotiation is complete. Modify
tests to reduce initial spamming.

This fixes the TLS renegotiation test. While it fixes the bug in the
HTTPS test too, that is still failing with the OpenSSL update for other
(too-be-determined) reasons.

Refs: https://github.com/nodejs/node/pull/25381#issuecomment-456822479

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
