### PR TITLE
test: Change expected file permissions in test

### DIFF
--- a/test/parallel/test-fs-open-mode-mask.js
+++ b/test/parallel/test-fs-open-mode-mask.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const mode = common.isWindows ? 0o444 : 0o644;
+const mode = common.isWindows ? 0o400 : 0o600;
 
 const maskToIgnore = 0o10000;
 
@@ -22,18 +22,18 @@ function test(mode, asString) {
   {
     const file = path.join(tmpdir.path, `openSync-${suffix}.txt`);
     const fd = fs.openSync(file, 'w+', input);
-    assert.strictEqual(fs.fstatSync(fd).mode & 0o777, mode);
+    assert.strictEqual(fs.fstatSync(fd).mode & 0o700, mode);
     fs.closeSync(fd);
-    assert.strictEqual(fs.statSync(file).mode & 0o777, mode);
+    assert.strictEqual(fs.statSync(file).mode & 0o700, mode);
   }
 
   {
     const file = path.join(tmpdir.path, `open-${suffix}.txt`);
     fs.open(file, 'w+', input, common.mustCall((err, fd) => {
       assert.ifError(err);
-      assert.strictEqual(fs.fstatSync(fd).mode & 0o777, mode);
+      assert.strictEqual(fs.fstatSync(fd).mode & 0o700, mode);
       fs.closeSync(fd);
-      assert.strictEqual(fs.statSync(file).mode & 0o777, mode);
+      assert.strictEqual(fs.statSync(file).mode & 0o700, mode);
     }));
   }
 }


### PR DESCRIPTION
The test in test/parallel/test-fs-open-mode-mask.js opens a new file in "w+" mode and then checks if
the file is created with the correct permissions. The expected permissions include read access for
everyone. With this PR I change the expected permissions to only include read and write access for the
owner of the file, as it is defined in the test. All other permissions come from the configuration of the
host system.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
