### PR TITLE
doc: fix keyObject.symmetricSize to be keyObject.symmetricKeySize

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1172,7 +1172,7 @@ encryption mechanism, PEM-level encryption is not supported when encrypting
 a PKCS#8 key. See [RFC 5208][] for PKCS#8 encryption and [RFC 1421][] for
 PKCS#1 and SEC1 encryption.
 
-### keyObject.symmetricSize
+### keyObject.symmetricKeySize
 <!-- YAML
 added: v11.6.0
 -->


### PR DESCRIPTION
This PR fixes wrong property in crypto documentation for an API added in 11.6.0

cc @tniessen 

```js
k = crypto.createSecretKey(Buffer.from('foo'))
// SecretKeyObject { [Symbol(kKeyType)]: 'secret' }
k.symmetricSize
// undefined
k.symmetricKeySize
// 3
```
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
