### PR TITLE
test: enable marking of failing coverage tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ coverage-test: coverage-build
 	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/gen/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/src/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/src/tracing/*.gcda
-	NODE_V8_COVERAGE=out/$(BUILDTYPE)/.coverage FLAKY_TESTS="dontcare" \
+	-NODE_V8_COVERAGE=out/$(BUILDTYPE)/.coverage FLAKY_TESTS="dontcare" \
                 TEST_CI_ARGS="$(TEST_CI_ARGS) --type=coverage" $(MAKE) $(COVTESTS)
 	$(MAKE) coverage-report-js
 	-(cd out && "../gcovr/scripts/gcovr" --gcov-exclude='.*deps' \

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,8 @@ coverage-test: coverage-build
 	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/gen/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/src/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/src/tracing/*.gcda
-	-NODE_V8_COVERAGE=out/$(BUILDTYPE)/.coverage $(MAKE) $(COVTESTS)
+	NODE_V8_COVERAGE=out/$(BUILDTYPE)/.coverage FLAKY_TESTS="dontcare" \
+                TEST_CI_ARGS="$(TEST_CI_ARGS) --type=coverage" $(MAKE) $(COVTESTS)
 	$(MAKE) coverage-report-js
 	-(cd out && "../gcovr/scripts/gcovr" --gcov-exclude='.*deps' \
 		--gcov-exclude='.*usr' -v -r Release/obj.target \
@@ -277,7 +278,7 @@ coverage-run-js:
 	$(RM) -r out/$(BUILDTYPE)/.coverage
 	$(MAKE) coverage-build-js
 	-NODE_V8_COVERAGE=out/$(BUILDTYPE)/.coverage CI_SKIP_TESTS=$(COV_SKIP_TESTS) \
-	  $(MAKE) jstest
+	        TEST_CI_ARGS="$(TEST_CI_ARGS) --type=coverage" $(MAKE) jstest
 	$(MAKE) coverage-report-js
 
 .PHONY: test

--- a/test/js-native-api/js-native-api.status
+++ b/test/js-native-api/js-native-api.status
@@ -21,5 +21,5 @@ prefix js-native-api
 [$system==aix]
 
 [$type==coverage]
-test_function/test: PASS,FLAKY
-test_general/testFinalizer: PASS,FLAKY
+test_function/test: PASS,FAIL,CRASH
+test_general/testFinalizer: PASS,FAIL,CRASH

--- a/test/js-native-api/js-native-api.status
+++ b/test/js-native-api/js-native-api.status
@@ -1,0 +1,25 @@
+prefix js-native-api
+
+# To mark a test as flaky, list the test name in the appropriate section
+# below, without ".js", followed by ": PASS,FLAKY". Example:
+# sample-test                        : PASS,FLAKY
+
+[true] # This section applies to all platforms
+
+[$system==win32]
+
+[$system==linux]
+
+[$system==macos]
+
+[$arch==arm || $arch==arm64]
+
+[$system==solaris] # Also applies to SmartOS
+
+[$system==freebsd]
+
+[$system==aix]
+
+[$type==coverage]
+test_function/test: PASS,FLAKY
+test_general/testFinalizer: PASS,FLAKY

--- a/tools/test.py
+++ b/tools/test.py
@@ -1388,7 +1388,7 @@ def BuildOptions():
       help='Send SIGABRT instead of SIGTERM to kill processes that time out',
       default=False, action="store_true", dest="abort_on_timeout")
   result.add_option("--type",
-      help="Type of build (simple, fips)",
+      help="Type of build (simple, fips, coverage)",
       default=None)
   return result
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Enable marking of coverage tests so that we can
allow some tests to fail without blocking the generation
of coverage data. This will later allow us to
fail the coverage job if other kinds of errors occur and
to capture which tests we believe are not running properly
with coverage enabled.

This is step 1 of the following
- [ ] allow us to run coverage and have failing tests not block generation of results
- [ ] add support for a coverage level check (ex 90%) that will cause a failure @bcoe is working on that
- [ ] add job to main PR regression test that will run coverage to make sure new failing tests are
       not introduced
 - [ ] Update makefile so that we don't use '-' for the coverage target.  At this point we will fail is
       some other problem occurs but not if one of the known tests that affects coverage fails.

Note that this re-uses the '--type' option that we used for fips testing so that we can have entries
in the status files.  The downside is that we would not be able to run coverage on FIPs as they
would conflict trying to use different types. I could add another option '--test-type' but I was
not sure if the added code/complexity is what people would want so I started with this approach.



