### PR TITLE
repl: Improved doc for disabling REPL history on Windows

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -540,8 +540,10 @@ environment variables:
 
  - `NODE_REPL_HISTORY` - When a valid path is given, persistent REPL history
    will be saved to the specified file rather than `.node_repl_history` in the
-   user's home directory. Setting this value to `''` will disable persistent
-   REPL history. Whitespace will be trimmed from the value.
+   user's home directory. Setting this value to `''` (an empty string) will
+   disable persistent REPL history. Whitespace will be trimmed from the value.
+   On Windows platforms environment variables with empty values are invalid so
+   set this variable to one or more spaces to disable persistent REPL history.
  - `NODE_REPL_HISTORY_SIZE` - Controls how many lines of history will be
    persisted if history is available. Must be a positive number.
    **Default:** `1000`.


### PR DESCRIPTION
Environment variables with empty values are not permitted on Windows. As
such, to disable persistent REPL history one or more spaces should be
used. Node will trim whitespace from the variable, resulting in a blank
variable at runtime and the desired behaviour.

Fixes: #25661

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
