### PR TITLE
test: fix pummel/test-exec

### DIFF
--- a/test/pummel/test-exec.js
+++ b/test/pummel/test-exec.js
@@ -122,7 +122,7 @@ exec('python -c "print 200000*\'C\'"', { maxBuffer: 1000 },
      function(err, stdout, stderr) {
        assert.ok(err);
        assert.ok(/maxBuffer/.test(err.message));
-       assert.strictEqual(stdout, '');
+       assert.strictEqual(stdout, 'C'.repeat(1000));
        assert.strictEqual(stderr, '');
      });
 


### PR DESCRIPTION
Fix test/pummel/test-exec.js which broke as a result of
e47f972d6851b3196b3b2ba611929f25a5fcadb6
(https://github.com/nodejs/node/pull/24951).

(Until very recently, pummel tests were not run at all in CI and
currently only run nightly on master.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
