### PR TITLE
doc: remove outdated s_client information in tls.md

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -136,10 +136,6 @@ threshold is exceeded. The limits are configurable:
 The default renegotiation limits should not be modified without a full
 understanding of the implications and risks.
 
-To test the renegotiation limits on a server, connect to it using the OpenSSL
-command-line client (`openssl s_client -connect address:port`) then input
-`R<CR>` (i.e., the letter `R` followed by a carriage return) multiple times.
-
 ### Session Resumption
 
 Establishing a TLS session can be relatively slow. The process can be sped


### PR DESCRIPTION
There is a description of how to use s_client for testing of
renegotiation limits in the `tls` module documentation. The information
is somewhat out of scope, but it also may be somewhat problematic due to
changes/peculiarities (bugs?) in recent s_client. Remove the text.

Refs: https://github.com/nodejs/node/pull/25381#issuecomment-457067137

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
