### PR TITLE
[v8.x-backport] build: add loader path to rpath for cctest

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -956,6 +956,11 @@
         ['OS=="solaris"', {
           'ldflags': [ '-I<(SHARED_INTERMEDIATE_DIR)' ]
         }],
+        [ 'node_shared=="true"', {
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [ '-Wl,-rpath,@loader_path', ],
+          },
+        }],
       ],
     }
   ], # end targets


### PR DESCRIPTION
Currently Node 8 MacOS shared libraray builds fail `test-ci` with `cctest` without this PR.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
