### PR TITLE
meta: bump minimal supported GCC version to 5

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -118,7 +118,7 @@ Depending on the host platform, the selection of toolchains may vary.
 
 #### Unix
 
-* GCC 4.9.4 or newer
+* GCC 5.1 or newer
 * Clang 3.4.2 or newer
 
 #### AIX

--- a/configure.py
+++ b/configure.py
@@ -765,8 +765,8 @@ def check_compiler(o):
     warn('failed to autodetect C++ compiler version (CXX=%s)' % CXX)
   elif sys.platform.startswith('aix') and gcc_version < (6, 3, 0):
     warn('C++ compiler too old, need g++ 6.3.0 (CXX=%s)' % CXX)
-  elif clang_version < (3, 4, 2) if is_clang else gcc_version < (4, 9, 4):
-    warn('C++ compiler too old, need g++ 4.9.4 or clang++ 3.4.2 (CXX=%s)' % CXX)
+  elif clang_version < (3, 4, 2) if is_clang else gcc_version < (5, 1, 0):
+    warn('C++ compiler too old, need g++ 5.1.0 or clang++ 3.4.2 (CXX=%s)' % CXX)
 
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CC, 'c')
   if not ok:

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -148,13 +148,6 @@ class FSReqCallback : public FSReqBase {
   DISALLOW_COPY_AND_ASSIGN(FSReqCallback);
 };
 
-// Wordaround a GCC4.9 bug that C++14 N3652 was not implemented
-// Refs: https://www.gnu.org/software/gcc/projects/cxx-status.html#cxx14
-// Refs: https://isocpp.org/files/papers/N3652.html
-#if __cpp_constexpr < 201304
-#  define constexpr inline
-#endif
-
 template <typename NativeT,
           // SFINAE limit NativeT to arithmetic types
           typename = std::enable_if<std::is_arithmetic<NativeT>::value>>


### PR DESCRIPTION
V8 is going to require full support for C++14.

/cc @hashseed @nodejs/v8 @nodejs/build

I don't actually know if there is a version 5.1.0. Happy to put another higher number.