### PR TITLE
meta: update note about building on smartOS 16

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -77,8 +77,8 @@ For production applications, run Node.js on supported platforms only.
 | GNU/Linux    | Tier 1       | kernel >= 2.6.32, glibc >= 2.12 | x64, arm         |                               |
 | GNU/Linux    | Tier 1       | kernel >= 3.10, glibc >= 2.17   | arm64            |                               |
 | macOS/OS X   | Tier 1       | >= 10.11                        | x64              |                               |
-| Windows      | Tier 1       | >= Windows 7/2008 R2/2012 R2    | x86, x64         | [2](#fn2),[3](#fn3),[4](#fn4) |
-| SmartOS      | Tier 2       | >= 15 < 16.4                    | x86, x64         | [1](#fn1)                     |
+| Windows      | Tier 1       | >= Windows 7/2008 R2/2012 R2    | x86, x64         | [1](#fn1),[2](#fn2),[3](#fn3) |
+| SmartOS      | Tier 2       | >= 16                           | x64              |                               |
 | FreeBSD      | Tier 2       | >= 11                           | x64              |                               |
 | GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19 | ppc64le >=power8 |                               |
 | AIX          | Tier 2       | >= 7.1 TL04                     | ppc64be >=power7 |                               |
@@ -86,25 +86,16 @@ For production applications, run Node.js on supported platforms only.
 | GNU/Linux    | Experimental | kernel >= 2.6.32, glibc >= 2.12 | x86              | limited CI                    |
 | Linux (musl) | Experimental | musl >= 1.0                     | x64              |                               |
 
-<em id="fn1">1</em>: The gcc4.8-libs package needs to be installed, because node
-  binaries have been built with GCC 4.8, for which runtime libraries are not
-  installed by default. For these node versions, the recommended binaries
-  are the ones available in pkgsrc, not the one available from nodejs.org.
-  Note that the binaries downloaded from the pkgsrc repositories are not
-  officially supported by the Node.js project, and instead are supported
-  by Joyent. SmartOS images >= 16.4 are not supported because
-  GCC 4.8 runtime libraries are not available in their pkgsrc repository
-
-<em id="fn2">2</em>: Tier 1 support for building on Windows is only on 64-bit
+<em id="fn1">1</em>: Tier 1 support for building on Windows is only on 64-bit
   hosts. Support is experimental for 32-bit hosts.
 
-<em id="fn3">3</em>: On Windows, running Node.js in Windows terminal emulators
+<em id="fn2">2</em>: On Windows, running Node.js in Windows terminal emulators
   like `mintty` requires the usage of [winpty](https://github.com/rprichard/winpty)
   for the tty channels to work correctly (e.g. `winpty node.exe script.js`).
   In "Git bash" if you call the node shell alias (`node` without the `.exe`
   extension), `winpty` is used automatically.
 
-<em id="fn4">4</em>: The Windows Subsystem for Linux (WSL) is not directly
+<em id="fn3">3</em>: The Windows Subsystem for Linux (WSL) is not directly
   supported, but the GNU/Linux build process and binaries should work. The
   community will only address issues that reproduce on native GNU/Linux
   systems. Issues that only reproduce on WSL should be reported in the


### PR DESCRIPTION
Seems like note is outdated. ATM we run CI tests on smartOS 16 with GCC 4.9
https://github.com/nodejs/build/blob/383c09339779cb46a32c47909ed3cee3a1850001/ansible/roles/baselayout/vars/main.yml#L91-L94
and on smartOS17 with GCC7.
https://github.com/nodejs/build/blob/383c09339779cb46a32c47909ed3cee3a1850001/jenkins/scripts/VersionSelectorScript.groovy#L43-L48
I'm not sure if this note needs updating or complete removal.


/CC @nodejs/platform-smartos @nodejs/build 

Refs: https://github.com/nodejs/node/pull/25683

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
