### PR TITLE
deps: remove OpenSSL git and travis configuration

### DIFF
--- a/deps/openssl/config/Makefile
+++ b/deps/openssl/config/Makefile
@@ -27,7 +27,6 @@ COPTS =  no-comp no-shared no-afalgeng
 # disable platform check in Configure
 NO_WARN_ENV = CONFIGURE_CHECKER_WARN=1
 
-GITIGNORE = $(OPSSL_SRC)/.gitignore
 GENERATE = ./generate_gypi.pl
 
 OPSSL_SRC = ../openssl
@@ -45,8 +44,9 @@ all: $(ARCHS) replace
 
 # Configure and generate openssl asm files for each archs
 $(ARCHS):
-# Remove openssl .gitignore to follow nodejs .gitignore
-	if [ -e $(GITIGNORE) ]; then rm $(GITIGNORE); fi
+# Remove openssl git and travis configuration, nodejs has its own (and they
+# should not have been packaged by upstream).
+	rm -rf $(OPSSL_SRC)/.git* $(OPSSL_SRC)/.travis*
 	cd $(OPSSL_SRC); $(NO_WARN_ENV) CC=$(CC) $(PERL) $(CONFIGURE) $(COPTS) $@;
 	$(PERL) -w -I$(OPSSL_SRC) $(GENERATE) asm $@
 # Confgure asm_avx2 and generate upto avx2 support


### PR DESCRIPTION
OpenSSL is packaging its git and travis configuration files. Remove
them, Node.js has its own.

This will remove .gitmodules, .gitattributes, .travis.yml, .travis-create-release.sh, .travis-apt-pin.preference from being present in https://github.com/nodejs/node/tree/master/deps/openssl/openssl

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
