### PR TITLE
lib: improve error message on missing module

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1964,7 +1964,12 @@ an `Error` with this code will be emitted.
 
 <a id="MODULE_NOT_FOUND"></a>
 ### MODULE_NOT_FOUND
-
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/25690
+    description: Added `requireStack` property.
+-->
 A module file could not be resolved while attempting a [`require()`][] or
 `import` operation.
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -612,8 +612,12 @@ Module._resolveFilename = function(request, parent, isMain, options) {
       cursor = cursor.parent) {
       requireStack.push(cursor.filename || cursor.id);
     }
+    let message = `Cannot find module '${request}'`;
+    if (requireStack.length > 0) {
+      message = message + '\nRequire stack:\n- ' + requireStack.join('\n- ');
+    }
     // eslint-disable-next-line no-restricted-syntax
-    var err = new Error(`Cannot find module '${request}'`);
+    var err = new Error(message);
     err.code = 'MODULE_NOT_FOUND';
     err.requireStack = requireStack;
     throw err;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -606,9 +606,16 @@ Module._resolveFilename = function(request, parent, isMain, options) {
   // Look up the filename first, since that's the cache key.
   var filename = Module._findPath(request, paths, isMain);
   if (!filename) {
+    const requireStack = [];
+    for (var cursor = parent;
+      cursor;
+      cursor = cursor.parent) {
+      requireStack.push(cursor.filename || cursor.id);
+    }
     // eslint-disable-next-line no-restricted-syntax
     var err = new Error(`Cannot find module '${request}'`);
     err.code = 'MODULE_NOT_FOUND';
+    err.requireStack = requireStack;
     throw err;
   }
   return filename;

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -66,8 +66,11 @@ function resolve(specifier, parentURL) {
                  parentURL || pathToFileURL(`${process.cwd()}/`).href);
   } catch (e) {
     if (typeof e.message === 'string' &&
-        StringStartsWith(e.message, 'Cannot find module'))
+        StringStartsWith(e.message, 'Cannot find module')) {
       e.code = 'MODULE_NOT_FOUND';
+      // TODO: also add e.requireStack to match behavior with CJS
+      // MODULE_NOT_FOUND.
+    }
     throw e;
   }
 

--- a/test/fixtures/require-resolve.js
+++ b/test/fixtures/require-resolve.js
@@ -15,21 +15,21 @@ assert.strictEqual(
 // Verify that existing paths are removed.
 assert.throws(() => {
   require.resolve('bar', { paths: [] })
-}, /^Error: Cannot find module 'bar'$/);
+}, /^Error: Cannot find module 'bar'/);
 
 // Verify that resolution path can be overwritten.
 {
   // three.js cannot be loaded from this file by default.
   assert.throws(() => {
     require.resolve('three')
-  }, /^Error: Cannot find module 'three'$/);
+  }, /^Error: Cannot find module 'three'/);
 
   // If the nested-index directory is provided as a resolve path, 'three'
   // cannot be found because nested-index is used as a starting point and not
   // a searched directory.
   assert.throws(() => {
     require.resolve('three', { paths: [nestedIndex] })
-  }, /^Error: Cannot find module 'three'$/);
+  }, /^Error: Cannot find module 'three'/);
 
   // Resolution from nested index directory also checks node_modules.
   assert.strictEqual(

--- a/test/parallel/test-internal-modules.js
+++ b/test/parallel/test-internal-modules.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 assert.throws(function() {
   require('internal/freelist');
-}, /^Error: Cannot find module 'internal\/freelist'$/);
+}, /^Error: Cannot find module 'internal\/freelist'/);
 
 assert.strictEqual(
   require(fixtures.path('internal-modules')),

--- a/test/parallel/test-loaders-hidden-from-users.js
+++ b/test/parallel/test-loaders-hidden-from-users.js
@@ -9,7 +9,7 @@ common.expectsError(
     require('internal/bootstrap/loaders');
   }, {
     code: 'MODULE_NOT_FOUND',
-    message: 'Cannot find module \'internal/bootstrap/loaders\''
+    message: /Cannot find module 'internal\/bootstrap\/loaders'/
   }
 );
 
@@ -20,6 +20,6 @@ common.expectsError(
     require('owo');
   }, {
     code: 'MODULE_NOT_FOUND',
-    message: 'Cannot find module \'owo\''
+    message: /Cannot find module 'owo'/
   }
 );

--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -80,9 +80,10 @@ common.expectsError(
     message: 'The argument \'id\' must be a non-empty string. Received \'\''
   });
 
-common.expectsError(
+assert.throws(
   () => { require('../fixtures/packages/is-dir'); },
   {
     code: 'MODULE_NOT_FOUND',
-    message: 'Cannot find module \'../fixtures/packages/is-dir\''
-  });
+    message: /Cannot find module '\.\.\/fixtures\/packages\/is-dir'/
+  }
+);

--- a/test/parallel/test-module-multi-extensions.js
+++ b/test/parallel/test-module-multi-extensions.js
@@ -35,7 +35,7 @@ fs.writeFileSync(dotfileWithExtension, 'console.log(__filename);', 'utf8');
   require(modulePath);
   assert.throws(
     () => require(`${modulePath}.foo`),
-    new Error(`Cannot find module '${modulePath}.foo'`)
+    (err) => err.message.startsWith(`Cannot find module '${modulePath}.foo'`)
   );
   require(`${modulePath}.foo.bar`);
   delete require.cache[file];
@@ -47,7 +47,7 @@ fs.writeFileSync(dotfileWithExtension, 'console.log(__filename);', 'utf8');
   const modulePath = path.join(tmpdir.path, 'test-extensions');
   assert.throws(
     () => require(modulePath),
-    new Error(`Cannot find module '${modulePath}'`)
+    (err) => err.message.startsWith(`Cannot find module '${modulePath}'`)
   );
   delete require.cache[file];
   Module._pathCache = Object.create(null);
@@ -69,7 +69,7 @@ fs.writeFileSync(dotfileWithExtension, 'console.log(__filename);', 'utf8');
   const modulePath = path.join(tmpdir.path, 'test-extensions.foo');
   assert.throws(
     () => require(modulePath),
-    new Error(`Cannot find module '${modulePath}'`)
+    (err) => err.message.startsWith(`Cannot find module '${modulePath}'`)
   );
   delete require.extensions['.foo.bar'];
   Module._pathCache = Object.create(null);

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -534,6 +534,8 @@ const errorTests = [
     expect: [
       'Thrown:',
       /^{ Error: Cannot find module 'internal\/repl'/,
+      /^Require stack:/,
+      /^- <repl>/,
       /^    at .*/,
       /^    at .*/,
       /^    at .*/,

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -131,7 +131,7 @@ require('../fixtures/node_modules/foo');
   assert.ok(my_path.path_func instanceof Function);
   // this one does not exist and should throw
   assert.throws(function() { require('./utils'); },
-                /^Error: Cannot find module '\.\/utils'$/);
+                /^Error: Cannot find module '\.\/utils'/);
 }
 
 let errorThrown = false;
@@ -170,12 +170,13 @@ assert.strictEqual(require('../fixtures/registerExt2').custom, 'passed');
 assert.strictEqual(require('../fixtures/foo').foo, 'ok');
 
 // Should not attempt to load a directory
-try {
-  tmpdir.refresh();
-  require(tmpdir.path);
-} catch (err) {
-  assert.strictEqual(err.message, `Cannot find module '${tmpdir.path}'`);
-}
+assert.throws(
+  () => {
+    tmpdir.refresh();
+    require(tmpdir.path);
+  },
+  (err) => err.message.startsWith(`Cannot find module '${tmpdir.path}`)
+);
 
 {
   // Check load order is as expected


### PR DESCRIPTION
The error message we provide when a module is missing is not very useful, specially for new users. Consider:

```
$ node index.js
internal/modules/cjs/loader.js:605
    throw err;
    ^

Error: Cannot find module 'this-module-does-not-exist'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:603:15)
    at Function.Module._load (internal/modules/cjs/loader.js:529:25)
    at Module.require (internal/modules/cjs/loader.js:657:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/Users/ofrobots/tmp/require-error/who-loaded-dis.js:1:63)
    at Module._compile (internal/modules/cjs/loader.js:721:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:732:10)
    at Module.load (internal/modules/cjs/loader.js:620:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:560:12)
    at Function.Module._load (internal/modules/cjs/loader.js:552:3)
```

This has a lot internal details and very little useful information for the user. The key information relevant to the user in the above is the line `at Object.<anonymous> (/Users/ofrobots/tmp/require-error/who-loaded-dis.js:1:63)`. It is less than obvious that this is what the user should pay attention to. In deeply nested dependencies it may not be clear to the user where this require itself came from. Users have to start grepping their `node_modules` at this point.

This PR proposes to change this to something like:

```
$ node index.js
internal/modules/cjs/loader.js:625
    throw err;
    ^

Error: Cannot find module 'this-module-does-not-exist'
Require stack:
- /Users/ofrobots/tmp/require-error/who-loaded-dis.js
- /Users/ofrobots/tmp/require-error/deeply-nested-module.js
- /Users/ofrobots/tmp/require-error/direct-dependency.js
- /Users/ofrobots/tmp/require-error/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:622:15)
    at Function.Module._load (internal/modules/cjs/loader.js:541:25)
    at Module.require (internal/modules/cjs/loader.js:677:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/Users/ofrobots/tmp/require-error/who-loaded-dis.js:1:63)
    at Module._compile (internal/modules/cjs/loader.js:748:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:759:10)
    at Module.load (internal/modules/cjs/loader.js:640:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:572:12)
    at Function.Module._load (internal/modules/cjs/loader.js:564:3)

```

I'm somewhat on the fence about the new lines `error.message`. I think this is the most useful presentation we can give to the user, but I do recognize that user-space may not be expecting newlines before the stacktrace (or have we crossed this bridge already in a different core error message?). Putting the entire string on the same line is possible, but that becomes less readable.

We have been telling users to not rely overly on the precise string, but rather the [error codes](https://nodejs.org/api/errors.html#errors_node_js_error_codes), but I'm not sure if the ecosystem has absorbed that fully. If not, this would be considered a semver-major.

~~CI: https://ci.nodejs.org/job/node-test-pull-request/20767/~~
CI: https://ci.nodejs.org/job/node-test-pull-request/20771/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
