### PR TITLE
test: replace Google servers with localhost

### DIFF
--- a/test/parallel/test-dns-setserver-when-querying.js
+++ b/test/parallel/test-dns-setserver-when-querying.js
@@ -4,10 +4,7 @@ const common = require('../common');
 
 const dns = require('dns');
 
-const goog = [
-  '8.8.8.8',
-  '8.8.4.4',
-];
+const localhost = [ '127.0.0.1' ];
 
 {
   // Fix https://github.com/nodejs/node/issues/14734
@@ -16,7 +13,7 @@ const goog = [
     const resolver = new dns.Resolver();
     resolver.resolve('localhost', common.mustCall());
 
-    common.expectsError(resolver.setServers.bind(resolver, goog), {
+    common.expectsError(resolver.setServers.bind(resolver, localhost), {
       code: 'ERR_DNS_SET_SERVERS_FAILED',
       message: /^c-ares failed to set servers: "There are pending queries\." \[.+\]$/g
     });
@@ -26,6 +23,6 @@ const goog = [
     dns.resolve('localhost', common.mustCall());
 
     // should not throw
-    dns.setServers(goog);
+    dns.setServers(localhost);
   }
 }


### PR DESCRIPTION
Replace Google DNS servers with 127.0.0.1 in
test-dns-setserver-when-querying.

Refs: https://github.com/nodejs/node/issues/25664

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
