### PR TITLE
test: Fix zlib-brotli output assumptions

### DIFF
--- a/test/parallel/test-zlib-brotli-from-string.js
+++ b/test/parallel/test-zlib-brotli-from-string.js
@@ -14,21 +14,25 @@ const inputString = 'ΩΩLorem ipsum dolor sit amet, consectetur adipiscing eli'
                     ' diam ipsum. Suspendisse nec ullamcorper odio. Vestibulu' +
                     'm arcu mi, sodales non suscipit id, ultrices ut massa. S' +
                     'ed ac sem sit amet arcu malesuada fermentum. Nunc sed. ';
-const expectedBase64Compress = 'G/gBQBwHdky2aHV5KK9Snf05//1pPdmNw/7232fnIm1IB' +
-                               'K1AA8RsN8OB8Nb7Lpgk3UWWUlzQXZyHQeBBbXMTQXC1j7' +
-                               'wg3LJs9LqOGHRH2bj/a2iCTLLx8hBOyTqgoVuD1e+Qqdn' +
-                               'f1rkUNyrWq6LtOhWgxP3QUwdhKGdZm3rJWaDDBV7+pDk1' +
-                               'MIkrmjp4ma2xVi5MsgJScA3tP1I7mXeby6MELozrwoBQD' +
-                               'mVTnEAicZNj4lkGqntJe2qSnGyeMmcFgraK94vCg/4iLu' +
-                               'Tw5RhKhnVY++dZ6niUBmRqIutsjf5TzwF5iAg8a9UkjF5' +
-                               '2eZ0tB2vo6v8SqVfNMkBmmhxr0NT9LkYF69aEjlYzj7IE' +
-                               'KmEUQf1HBogRYhFIt4ymRNEgHAIzOyNEsQM=';
+const compressedString = 'G/gBQBwHdky2aHV5KK9Snf05//1pPdmNw/7232fnIm1IB' +
+                         'K1AA8RsN8OB8Nb7Lpgk3UWWUlzQXZyHQeBBbXMTQXC1j7' +
+                         'wg3LJs9LqOGHRH2bj/a2iCTLLx8hBOyTqgoVuD1e+Qqdn' +
+                         'f1rkUNyrWq6LtOhWgxP3QUwdhKGdZm3rJWaDDBV7+pDk1' +
+                         'MIkrmjp4ma2xVi5MsgJScA3tP1I7mXeby6MELozrwoBQD' +
+                         'mVTnEAicZNj4lkGqntJe2qSnGyeMmcFgraK94vCg/4iLu' +
+                         'Tw5RhKhnVY++dZ6niUBmRqIutsjf5TzwF5iAg8a9UkjF5' +
+                         '2eZ0tB2vo6v8SqVfNMkBmmhxr0NT9LkYF69aEjlYzj7IE' +
+                         'KmEUQf1HBogRYhFIt4ymRNEgHAIzOyNEsQM=';
 
 zlib.brotliCompress(inputString, common.mustCall((err, buffer) => {
-  assert.strictEqual(buffer.toString('base64'), expectedBase64Compress);
+  assert(inputString.length > buffer.length);
+
+  zlib.brotliDecompress(buffer, common.mustCall((err, buffer) => {
+    assert.strictEqual(buffer.toString(), inputString);
+  }));
 }));
 
-const buffer = Buffer.from(expectedBase64Compress, 'base64');
+const buffer = Buffer.from(compressedString, 'base64');
 zlib.brotliDecompress(buffer, common.mustCall((err, buffer) => {
   assert.strictEqual(buffer.toString(), inputString);
 }));


### PR DESCRIPTION
On different architectures, it's possible for the compression algorithm
to produce slightly different outputs. So, don't assume we will
always get the same compressed output on all architectures. Instead,
verify that the decompressing pre-compressed string functions
correctly.

Fixes: https://github.com/nodejs/node/issues/25568

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
