### PR TITLE
src: remove unused and unimplemented method in env.h

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -644,7 +644,6 @@ class Environment {
 
   inline v8::Isolate* isolate() const;
   inline uv_loop_t* event_loop() const;
-  inline uint32_t watched_providers() const;
   inline void TryLoadAddon(const char* filename,
                            int flags,
                            std::function<bool(binding::DLib*)> was_loaded);


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
