### PR TITLE
test: remove s_client from test-tls-ci-reneg-attack

### DIFF
--- a/test/pummel/test-tls-ci-reneg-attack.js
+++ b/test/pummel/test-tls-ci-reneg-attack.js
@@ -28,7 +28,6 @@ if (!common.opensslCli)
   common.skip('node compiled without OpenSSL CLI.');
 
 const assert = require('assert');
-const spawn = require('child_process').spawn;
 const tls = require('tls');
 const fixtures = require('../common/fixtures');
 
@@ -51,63 +50,49 @@ function test(next) {
     key: fixtures.readSync('test_key.pem')
   };
 
-  let seenError = false;
-
   const server = tls.createServer(options, function(conn) {
     conn.on('error', function(err) {
       console.error(`Caught exception: ${err}`);
       assert(/TLS session renegotiation attack/.test(err));
       conn.destroy();
-      seenError = true;
     });
     conn.pipe(conn);
   });
 
-  server.listen(common.PORT, function() {
-    const args = (`s_client -connect 127.0.0.1:${common.PORT}`).split(' ');
-    const child = spawn(common.opensslCli, args);
+  server.listen(0, function() {
+    const options = {
+      host: server.address().host,
+      port: server.address().port,
+      rejectUnauthorized: false
+    };
+    const client = tls.connect(options, spam);
 
-    child.stdout.resume();
-    child.stderr.resume();
-
-    // Count handshakes, start the attack after the initial handshake is done
-    let handshakes = 0;
     let renegs = 0;
 
-    child.stderr.on('data', function(data) {
-      if (seenError) return;
-      handshakes += ((String(data)).match(/verify return:1/g) || []).length;
-      if (handshakes === 2) spam();
-      renegs += ((String(data)).match(/RENEGOTIATING/g) || []).length;
-    });
-
-    child.on('exit', function() {
+    client.on('close', function() {
       assert.strictEqual(renegs, tls.CLIENT_RENEG_LIMIT + 1);
       server.close();
       process.nextTick(next);
     });
 
-    let closed = false;
-    child.stdin.on('error', function(err) {
-      switch (err.code) {
-        case 'ECONNRESET':
-        case 'EPIPE':
-          break;
-        default:
-          assert.strictEqual(err.code, 'ECONNRESET');
-          break;
-      }
-      closed = true;
+    client.on('error', function(err) {
+      console.log('CLIENT ERR', err);
+      throw err;
     });
-    child.stdin.on('close', function() {
-      closed = true;
+
+    client.on('close', function(hadErr) {
+      assert.strictEqual(hadErr, false);
     });
 
     // simulate renegotiation attack
     function spam() {
-      if (closed) return;
-      child.stdin.write('R\n');
-      setTimeout(spam, 50);
+      client.write('');
+      client.renegotiate({}, (err) => {
+        assert.ifError(err);
+        assert.ok(renegs <= tls.CLIENT_RENEG_LIMIT);
+        spam();
+      });
+      renegs++;
     }
   });
 }


### PR DESCRIPTION
Rewrite test-tls-ci-reneg-attack to use tls.renegotiate() instead of
external (and potentially unpredictable/quirky/buggy) s_client.

Refs: https://github.com/nodejs/node/pull/25676#issuecomment-457307881

This test is currently broken (due to a quirk in a recent s_client update that we haven't worked around yet, see Ref above) and this change fixes it. The test is only run once a day in CI (because it's in pummel) so the breakage went unnoticed when the OpenSSL update landed a few days ago. A subsequent PR could probably move this test out of pummel. It seems like it could reasonably run in sequential or maybe even parallel.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
