### PR TITLE
src: fix macro duplicate declaration in env.h

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -405,6 +405,7 @@ class IsolateData {
   PER_ISOLATE_SYMBOL_PROPERTIES(VY)
   PER_ISOLATE_STRING_PROPERTIES(VS)
 #undef V
+#undef VY
 #undef VS
 #undef VP
 
@@ -421,6 +422,7 @@ class IsolateData {
   PER_ISOLATE_SYMBOL_PROPERTIES(VY)
   PER_ISOLATE_STRING_PROPERTIES(VS)
 #undef V
+#undef VY
 #undef VS
 #undef VP
 


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
