### PR TITLE
tls: fix malloc mismatch in SSL_set_tlsext_status_ocsp_resp call

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -326,6 +326,14 @@ bool EntropySource(unsigned char* buffer, size_t length) {
 }
 
 
+template <typename T>
+static T* MallocOpenSSL(size_t count) {
+  void* mem = OPENSSL_malloc(MultiplyWithOverflowCheck(count, sizeof(T)));
+  CHECK_IMPLIES(mem == nullptr, count == 0);
+  return static_cast<T*>(mem);
+}
+
+
 void SecureContext::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
@@ -2472,11 +2480,11 @@ int SSLWrap<Base>::TLSExtStatusCallback(SSL* s, void* arg) {
     size_t len = Buffer::Length(obj);
 
     // OpenSSL takes control of the pointer after accepting it
-    char* data = node::Malloc(len);
+    unsigned char* data = MallocOpenSSL<unsigned char>(len);
     memcpy(data, resp, len);
 
     if (!SSL_set_tlsext_status_ocsp_resp(s, data, len))
-      free(data);
+      OPENSSL_free(data);
     w->ocsp_response_.Reset();
 
     return SSL_TLSEXT_ERR_OK;
@@ -2696,13 +2704,6 @@ static bool IsSupportedAuthenticatedMode(const EVP_CIPHER* cipher) {
 static bool IsSupportedAuthenticatedMode(const EVP_CIPHER_CTX* ctx) {
   const EVP_CIPHER* cipher = EVP_CIPHER_CTX_cipher(ctx);
   return IsSupportedAuthenticatedMode(cipher);
-}
-
-template <typename T>
-static T* MallocOpenSSL(size_t count) {
-  void* mem = OPENSSL_malloc(MultiplyWithOverflowCheck(count, sizeof(T)));
-  CHECK_IMPLIES(mem == nullptr, count == 0);
-  return static_cast<T*>(mem);
 }
 
 enum class ParsePublicKeyResult {


### PR DESCRIPTION
`SSL_set_tlsext_status_ocsp_resp` expects the data to be allocated with `OPENSSL_malloc`, not libc `malloc`, so use `OpenSSLMalloc`.

Additionally, though OpenSSL doesn't type-check due to it being a macro, the function is documented to take an `unsigned char` pointer:
https://www.openssl.org/docs/man1.1.0/ssl/SSL_set_tlsext_status_ocsp_resp.html

(By default, `OPENSSL_malloc` is the same as libc `malloc`, but it is possible to customize this.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
