### PR TITLE
doc: add metadata to report docs

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -1,5 +1,12 @@
 # Diagnostic Report
 
+<!--introduced_in=v11.8.0-->
+<!-- type=misc -->
+
+> Stability: 1 - Experimental
+
+<!-- name=report -->
+
 Delivers a JSON-formatted diagnostic summary, written to a file.
 
 The report is intended for development, test and production use, to capture


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/25682

I based the metadata based on the other files in `doc/` (we don't seem to have much (any?) documentation on what metadata should be included).

cc @nodejs/documentation 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
