### PR TITLE
policy: ensure workers do not read fs for policy

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -181,7 +181,7 @@ function startup() {
 
   // TODO(joyeecheung): move this down further to get better snapshotting
   const experimentalPolicy = getOptionValue('--experimental-policy');
-  if (experimentalPolicy) {
+  if (isMainThread && experimentalPolicy) {
     process.emitWarning('Policies are experimental.',
                         'ExperimentalWarning');
     const { pathToFileURL, URL } = NativeModule.require('url');
@@ -348,8 +348,6 @@ function startup() {
 }
 
 function startWorkerThreadExecution() {
-  prepareUserCodeExecution();
-
   // If we are in a worker thread, execute the script sent through the
   // message port.
   const {
@@ -366,7 +364,9 @@ function startWorkerThreadExecution() {
   debug(`[${threadId}] is setting up worker child environment`);
 
   const port = getEnvMessagePort();
-  port.on('message', createMessageHandler(port));
+  port.on('message', createMessageHandler(
+    port,
+    prepareUserCodeExecution));
   port.start();
 
   // Overwrite fatalException
@@ -460,7 +460,7 @@ function prepareUserCodeExecution() {
 
   // For user code, we preload modules if `-r` is passed
   const preloadModules = getOptionValue('--require');
-  if (preloadModules) {
+  if (preloadModules.length) {
     const {
       _preloadModules
     } = NativeModule.require('internal/modules/cjs/loader');

--- a/lib/internal/process/policy.js
+++ b/lib/internal/process/policy.js
@@ -5,10 +5,14 @@ const {
 } = require('internal/errors').codes;
 const { Manifest } = require('internal/policy/manifest');
 let manifest;
+let manifestSrc;
+let manifestURL;
 
 module.exports = Object.freeze({
   __proto__: null,
   setup(src, url) {
+    manifestSrc = src;
+    manifestURL = url;
     if (src === null) {
       manifest = null;
       return;
@@ -29,6 +33,20 @@ module.exports = Object.freeze({
       throw new ERR_MANIFEST_TDZ();
     }
     return manifest;
+  },
+
+  get src() {
+    if (typeof manifestSrc === 'undefined') {
+      throw new ERR_MANIFEST_TDZ();
+    }
+    return manifestSrc;
+  },
+
+  get url() {
+    if (typeof manifestURL === 'undefined') {
+      throw new ERR_MANIFEST_TDZ();
+    }
+    return manifestURL;
   },
 
   assertIntegrity(moduleURL, content) {

--- a/lib/internal/process/worker_thread_only.js
+++ b/lib/internal/process/worker_thread_only.js
@@ -43,12 +43,24 @@ function initializeWorkerStdio() {
   };
 }
 
-function createMessageHandler(port) {
+function createMessageHandler(port, prepareUserCodeExecution) {
   const publicWorker = require('worker_threads');
 
   return function(message) {
     if (message.type === messageTypes.LOAD_SCRIPT) {
-      const { filename, doEval, workerData, publicPort, hasStdin } = message;
+      const {
+        filename,
+        doEval,
+        workerData,
+        publicPort,
+        manifestSrc,
+        manifestURL,
+        hasStdin
+      } = message;
+      if (manifestSrc) {
+        require('internal/process/policy').setup(manifestSrc, manifestURL);
+      }
+      prepareUserCodeExecution();
       publicWorker.parentPort = publicPort;
       publicWorker.workerData = workerData;
 

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -12,6 +12,7 @@ const {
   ERR_INVALID_ARG_TYPE,
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
+const { getOptionValue } = require('internal/options');
 
 const {
   drainMessagePort,
@@ -112,6 +113,9 @@ class Worker extends EventEmitter {
       doEval: !!options.eval,
       workerData: options.workerData,
       publicPort: port2,
+      manifestSrc: getOptionValue('--experimental-policy') ?
+        require('internal/process/policy').src :
+        null,
       hasStdin: !!options.stdin
     }, [port2]);
     // Actually start the new thread now that everything is in place.


### PR DESCRIPTION
This prevents a main thread from rewriting the policy file and loading
a worker that has a different policy from the main thread.

This prevents a main file of:

```mjs
// find the file
const policyPath = findPath(process.execArgv);

// rewrite with out new escalated privileges
fs.writeFileSync(policyPath, modifiedPolicy);

// spawn worker to get the modified policy
new Worker(...);
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
