### PR TITLE
process: add exitWithException()

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1177,6 +1177,44 @@ a code.
 Specifying a code to [`process.exit(code)`][`process.exit()`] will override any
 previous setting of `process.exitCode`.
 
+## process.exitWithException(error[, fromPromise])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `error` {any}
+* `fromPromise` {boolean}
+
+Exit with the provided error value as if it was thrown from its original
+context. This allows an error to re-enter Node.js's error logic unmodified,
+and will use the default formatted error printing.
+
+If an error stack is available on the value, this method of exiting does not add
+additional context, unlike re-throwing using [`throw`][].
+
+This method is particularly useful when listening to the
+[`'unhandledRejection'`][] process event.
+
+As an example:
+```js
+process.on('unhandledRejection', (err) => {
+  process.exitWithException(err);
+});
+
+Promise.reject(new Error('uh oh'));
+```
+
+Outputs something similar to the following, as is often desirable:
+```console
+throw.js:5
+Promise.reject(new Error('uh oh'));
+               ^
+
+Error: uh oh
+    at Object.<anonymous> (throw.js:5:16)
+    <more internal stack lines>
+```
+
 ## process.getegid()
 <!-- YAML
 added: v2.0.0
@@ -2291,6 +2329,7 @@ cases:
 [`'exit'`]: #process_event_exit
 [`'message'`]: child_process.html#child_process_event_message
 [`'uncaughtException'`]: #process_event_uncaughtexception
+[`'unhandledrejection'`]: #process_event_unhandledrejection
 [`ChildProcess.disconnect()`]: child_process.html#child_process_subprocess_disconnect
 [`ChildProcess.send()`]: child_process.html#child_process_subprocess_send_message_sendhandle_options_callback
 [`ChildProcess`]: child_process.html#child_process_class_childprocess
@@ -2318,6 +2357,7 @@ cases:
 [`require.main`]: modules.html#modules_accessing_the_main_module
 [`require.resolve()`]: modules.html#modules_require_resolve_request_options
 [`subprocess.kill()`]: child_process.html#child_process_subprocess_kill_signal
+[`throw`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw
 [`v8.setFlagsFromString()`]: v8.html#v8_v8_setflagsfromstring_flags
 [Android building]: https://github.com/nodejs/node/blob/master/BUILDING.md#androidandroid-based-devices-eg-firefox-os
 [Child Process]: child_process.html

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -95,6 +95,11 @@ if (isMainThread) {
   process.dlopen = rawMethods.dlopen;
   process.uptime = rawMethods.uptime;
 
+  Object.defineProperty(process, 'exitWithException', {
+    enumerable: true,
+    value: rawMethods.exitWithException
+  });
+
   // TODO(joyeecheung): either remove them or make them public
   process._getActiveRequests = rawMethods._getActiveRequests;
   process._getActiveHandles = rawMethods._getActiveHandles;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -819,7 +819,7 @@ Module.runMain = function() {
       return loader.import(pathToFileURL(process.argv[1]).pathname);
     })
     .catch((e) => {
-      internalBinding('task_queue').triggerFatalException(
+      internalBinding('process_methods').exitWithException(
         e,
         true /* fromPromise */
       );

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -13,8 +13,7 @@ const {
     kPromiseResolveAfterResolved,
     kPromiseRejectAfterResolved
   },
-  setPromiseRejectCallback,
-  triggerFatalException
+  setPromiseRejectCallback
 } = internalBinding('task_queue');
 
 // *Must* match Environment::TickInfo::Fields in src/env.h.
@@ -202,7 +201,7 @@ function fatalException(reason) {
     );
     err.code = 'ERR_UNHANDLED_REJECTION';
   }
-  triggerFatalException(err, true /* fromPromise */);
+  process.exitWithException(err, true /* fromPromise */);
 }
 
 function listenForRejections() {

--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -9,8 +9,7 @@ const {
   // Used to run V8's micro task queue.
   runMicrotasks,
   setTickCallback,
-  enqueueMicrotask,
-  triggerFatalException
+  enqueueMicrotask
 } = internalBinding('task_queue');
 
 const {
@@ -157,7 +156,7 @@ function runMicrotask() {
       // https://bugs.chromium.org/p/v8/issues/detail?id=8326
       // is resolved such that V8 triggers the fatal exception
       // handler for microtasks.
-      triggerFatalException(error, false /* fromPromise */);
+      process.exitWithException(error, false /* fromPromise */);
     } finally {
       this.emitDestroy();
     }

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -11,7 +11,6 @@ namespace node {
 
 using v8::Array;
 using v8::Context;
-using v8::Exception;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
@@ -122,19 +121,6 @@ static void SetPromiseRejectCallback(
   env->set_promise_reject_callback(args[0].As<Function>());
 }
 
-static void TriggerFatalException(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  Environment* env = Environment::GetCurrent(isolate);
-  Local<Value> exception = args[0];
-  Local<Message> message = Exception::CreateMessage(isolate, exception);
-  if (env != nullptr && env->abort_on_uncaught_exception()) {
-    ReportException(env, exception, message);
-    Abort();
-  }
-  bool from_promise = args[1]->IsTrue();
-  FatalException(isolate, exception, message, from_promise);
-}
-
 static void Initialize(Local<Object> target,
                        Local<Value> unused,
                        Local<Context> context,
@@ -142,7 +128,6 @@ static void Initialize(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
 
-  env->SetMethod(target, "triggerFatalException", TriggerFatalException);
   env->SetMethod(target, "enqueueMicrotask", EnqueueMicrotask);
   env->SetMethod(target, "setTickCallback", SetTickCallback);
   env->SetMethod(target, "runMicrotasks", RunMicrotasks);

--- a/test/message/process-exit-with-exception.js
+++ b/test/message/process-exit-with-exception.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const common = require('../common');
+common.disableCrashOnUnhandledRejection();
+
+process.on('unhandledRejection', (err) => {
+  process.exitWithException(err);
+});
+
+Promise.reject(new Error('uh oh'));
+
+setImmediate(common.mustNotCall);

--- a/test/message/process-exit-with-exception.out
+++ b/test/message/process-exit-with-exception.out
@@ -1,0 +1,12 @@
+*test*message*process-exit-with-exception.js:*
+Promise.reject(new Error('uh oh'));
+               ^
+
+Error: uh oh
+    at Object.<anonymous> (*test*message*process-exit-with-exception.js:*:*)
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *


### PR DESCRIPTION
Adds a public way to access `node::FatalException` from javascript, as `process.exitWithException()`.

If an error stack is available on the value, this method of exiting does not add additional context, unlike regular re-throwing, yet also uses the regular error printing logic. This behavior is particularly desirable when doing 'fatal exits' from the unhandledRejection event.

... Been wanting this for some months now. 🙃 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
