### PR TITLE
readline: Improve Unicode handling

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -459,11 +459,12 @@ Interface.prototype._insertString = function(c) {
     var beg = this.line.slice(0, this.cursor);
     var end = this.line.slice(this.cursor, this.line.length);
     this.line = beg + c + end;
-    this.cursor += c.length;
+    // Count Unicode code points
+    this.cursor += Array.from(c).length;
     this._refreshLine();
   } else {
     this.line += c;
-    this.cursor += c.length;
+    this.cursor += Array.from(c).length;
 
     if (this._getCursorPos().cols === 0) {
       this._refreshLine();
@@ -580,7 +581,7 @@ Interface.prototype._wordLeft = function() {
 Interface.prototype._wordRight = function() {
   if (this.cursor < this.line.length) {
     var trailing = this.line.slice(this.cursor);
-    var match = trailing.match(/^(?:\s+|\W+|\w+)\s*/);
+    var match = trailing.match(/^(?:\s+|[^\w\s]+|\w+)\s*/);
     this._moveCursor(match[0].length);
   }
 };
@@ -588,19 +589,29 @@ Interface.prototype._wordRight = function() {
 
 Interface.prototype._deleteLeft = function() {
   if (this.cursor > 0 && this.line.length > 0) {
-    this.line = this.line.slice(0, this.cursor - 1) +
+    // The Unicode code points prior to the cursor
+    const leading = Array.from(this.line.slice(0, this.cursor));
+    // The number of UTF-16 units comprising the character to the left
+    const charSize = leading[leading.length - 1].length;
+    this.line = this.line.slice(0, this.cursor - charSize) +
                 this.line.slice(this.cursor, this.line.length);
 
-    this.cursor--;
+    this.cursor -= charSize;
     this._refreshLine();
   }
 };
 
 
 Interface.prototype._deleteRight = function() {
-  this.line = this.line.slice(0, this.cursor) +
-              this.line.slice(this.cursor + 1, this.line.length);
-  this._refreshLine();
+  if (this.cursor < this.line.length) {
+    // The Unicode code points after the cursor
+    const ending = Array.from(this.line.slice(this.cursor, this.line.length));
+    // The number of UTF-16 units comprising the character to the left
+    const charSize = ending[0].length;
+    this.line = this.line.slice(0, this.cursor) +
+      this.line.slice(this.cursor + charSize, this.line.length);
+    this._refreshLine();
+  }
 };
 
 
@@ -952,11 +963,25 @@ Interface.prototype._ttyWrite = function(s, key) {
         break;
 
       case 'left':
-        this._moveCursor(-1);
+        if (this.cursor > 0) {
+          // The Unicode code points prior to the cursor
+          const leading = Array.from(this.line.slice(0, this.cursor));
+          // The number of UTF-16 units comprising the character to the left
+          const charSize = leading[leading.length - 1].length;
+          this._moveCursor(-charSize);
+        }
         break;
 
       case 'right':
-        this._moveCursor(+1);
+        if (this.cursor < this.line.length) {
+          // The Unicode code points after the cursor
+          const ending = Array.from(
+            this.line.slice(this.cursor, this.line.length)
+          );
+          // The number of UTF-16 units comprising the character to the left
+          const charSize = ending[0].length;
+          this._moveCursor(+charSize);
+        }
         break;
 
       case 'home':

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -454,17 +454,27 @@ Interface.prototype._normalWrite = function(b) {
   }
 };
 
+// Count the Unicode code points in a string.
+function codePointLen(str) {
+  let count = 0;
+  // eslint-disable-next-line no-unused-vars
+  for (const char of str) {
+    count++;
+  }
+  return count;
+}
+
 Interface.prototype._insertString = function(c) {
   if (this.cursor < this.line.length) {
     var beg = this.line.slice(0, this.cursor);
     var end = this.line.slice(this.cursor, this.line.length);
     this.line = beg + c + end;
     // Count Unicode code points
-    this.cursor += Array.from(c).length;
+    this.cursor += codePointLen(c);
     this._refreshLine();
   } else {
     this.line += c;
-    this.cursor += Array.from(c).length;
+    this.cursor += codePointLen(c);
 
     if (this._getCursorPos().cols === 0) {
       this._refreshLine();
@@ -586,13 +596,35 @@ Interface.prototype._wordRight = function() {
   }
 };
 
+function codePointLeftOf(i, str) {
+  // obtain the code point to the left
+  let previousChar;
+  let len = 0;
+  for (const char of str) {
+    len += char.length;
+    previousChar = char;
+    if (len === i) {
+      return previousChar;
+    }
+  }
+}
+
+function codePointRightOf(i, str) {
+  // obtain the code point to the right
+  let len = 0;
+  for (const char of str) {
+    len += char.length;
+    if (len > i) {
+      // UTF-16 units comprising the character
+      return char;
+    }
+  }
+}
 
 Interface.prototype._deleteLeft = function() {
   if (this.cursor > 0 && this.line.length > 0) {
-    // The Unicode code points prior to the cursor
-    const leading = Array.from(this.line.slice(0, this.cursor));
     // The number of UTF-16 units comprising the character to the left
-    const charSize = leading[leading.length - 1].length;
+    const charSize = codePointLeftOf(this.cursor, this.line).length;
     this.line = this.line.slice(0, this.cursor - charSize) +
                 this.line.slice(this.cursor, this.line.length);
 
@@ -604,10 +636,8 @@ Interface.prototype._deleteLeft = function() {
 
 Interface.prototype._deleteRight = function() {
   if (this.cursor < this.line.length) {
-    // The Unicode code points after the cursor
-    const ending = Array.from(this.line.slice(this.cursor, this.line.length));
     // The number of UTF-16 units comprising the character to the left
-    const charSize = ending[0].length;
+    const charSize = codePointRightOf(this.cursor, this.line).length;
     this.line = this.line.slice(0, this.cursor) +
       this.line.slice(this.cursor + charSize, this.line.length);
     this._refreshLine();
@@ -964,23 +994,14 @@ Interface.prototype._ttyWrite = function(s, key) {
 
       case 'left':
         if (this.cursor > 0) {
-          // The Unicode code points prior to the cursor
-          const leading = Array.from(this.line.slice(0, this.cursor));
-          // The number of UTF-16 units comprising the character to the left
-          const charSize = leading[leading.length - 1].length;
-          this._moveCursor(-charSize);
+          // obtain the code point to the left
+          this._moveCursor(-codePointLeftOf(this.cursor, this.line).length);
         }
         break;
 
       case 'right':
         if (this.cursor < this.line.length) {
-          // The Unicode code points after the cursor
-          const ending = Array.from(
-            this.line.slice(this.cursor, this.line.length)
-          );
-          // The number of UTF-16 units comprising the character to the left
-          const charSize = ending[0].length;
-          this._moveCursor(+charSize);
+          this._moveCursor(+codePointRightOf(this.cursor, this.line).length);
         }
         break;
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -596,35 +596,26 @@ Interface.prototype._wordRight = function() {
   }
 };
 
-function codePointLeftOf(i, str) {
-  // obtain the code point to the left
-  let previousChar;
-  let len = 0;
-  for (const char of str) {
-    len += char.length;
-    previousChar = char;
-    if (len === i) {
-      return previousChar;
-    }
+function charLengthLeft(str, i) {
+  if (i <= 0)
+    return 0;
+  if (i > 1 && str.codePointAt(i - 2) > 2 ** 16 ||
+      str.codePointAt(i - 1) > 2 ** 16) {
+    return 2;
   }
+  return 1;
 }
 
-function codePointRightOf(i, str) {
-  // obtain the code point to the right
-  let len = 0;
-  for (const char of str) {
-    len += char.length;
-    if (len > i) {
-      // UTF-16 units comprising the character
-      return char;
-    }
-  }
+function charLengthAt(str, i) {
+  if (str.length <= i)
+    return 0;
+  return str.codePointAt(i) > 2 ** 16 ? 2 : 1;
 }
 
 Interface.prototype._deleteLeft = function() {
   if (this.cursor > 0 && this.line.length > 0) {
     // The number of UTF-16 units comprising the character to the left
-    const charSize = codePointLeftOf(this.cursor, this.line).length;
+    const charSize = charLengthLeft(this.line, this.cursor);
     this.line = this.line.slice(0, this.cursor - charSize) +
                 this.line.slice(this.cursor, this.line.length);
 
@@ -637,7 +628,7 @@ Interface.prototype._deleteLeft = function() {
 Interface.prototype._deleteRight = function() {
   if (this.cursor < this.line.length) {
     // The number of UTF-16 units comprising the character to the left
-    const charSize = codePointRightOf(this.cursor, this.line).length;
+    const charSize = charLengthAt(this.line, this.cursor);
     this.line = this.line.slice(0, this.cursor) +
       this.line.slice(this.cursor + charSize, this.line.length);
     this._refreshLine();
@@ -993,16 +984,12 @@ Interface.prototype._ttyWrite = function(s, key) {
         break;
 
       case 'left':
-        if (this.cursor > 0) {
-          // obtain the code point to the left
-          this._moveCursor(-codePointLeftOf(this.cursor, this.line).length);
-        }
+        // obtain the code point to the left
+        this._moveCursor(-charLengthLeft(this.line, this.cursor));
         break;
 
       case 'right':
-        if (this.cursor < this.line.length) {
-          this._moveCursor(+codePointRightOf(this.cursor, this.line).length);
-        }
+        this._moveCursor(+charLengthAt(this.line, this.cursor));
         break;
 
       case 'home':

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -454,27 +454,16 @@ Interface.prototype._normalWrite = function(b) {
   }
 };
 
-// Count the Unicode code points in a string.
-function codePointLen(str) {
-  let count = 0;
-  // eslint-disable-next-line no-unused-vars
-  for (const char of str) {
-    count++;
-  }
-  return count;
-}
-
 Interface.prototype._insertString = function(c) {
   if (this.cursor < this.line.length) {
     var beg = this.line.slice(0, this.cursor);
     var end = this.line.slice(this.cursor, this.line.length);
     this.line = beg + c + end;
-    // Count Unicode code points
-    this.cursor += codePointLen(c);
+    this.cursor += c.length;
     this._refreshLine();
   } else {
     this.line += c;
-    this.cursor += codePointLen(c);
+    this.cursor += c.length;
 
     if (this._getCursorPos().cols === 0) {
       this._refreshLine();

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -866,11 +866,11 @@ Interface.prototype._ttyWrite = function(s, key) {
         break;
 
       case 'b': // back one character
-        this._moveCursor(-1);
+        this._moveCursor(-charLengthLeft(this.line, this.cursor));
         break;
 
       case 'f': // forward one character
-        this._moveCursor(+1);
+        this._moveCursor(+charLengthAt(this.line, this.cursor));
         break;
 
       case 'l': // clear the whole screen

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -588,8 +588,8 @@ Interface.prototype._wordRight = function() {
 function charLengthLeft(str, i) {
   if (i <= 0)
     return 0;
-  if (i > 1 && str.codePointAt(i - 2) > 2 ** 16 ||
-      str.codePointAt(i - 1) > 2 ** 16) {
+  if (i > 1 && str.codePointAt(i - 2) >= 2 ** 16 ||
+      str.codePointAt(i - 1) >= 2 ** 16) {
     return 2;
   }
   return 1;
@@ -598,7 +598,7 @@ function charLengthLeft(str, i) {
 function charLengthAt(str, i) {
   if (str.length <= i)
     return 0;
-  return str.codePointAt(i) > 2 ** 16 ? 2 : 1;
+  return str.codePointAt(i) >= 2 ** 16 ? 2 : 1;
 }
 
 Interface.prototype._deleteLeft = function() {

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -650,6 +650,36 @@ function isWarned(emitter) {
       rli.close();
     }
 
+    // Back and Forward one astral character
+    {
+      const fi = new FakeInput();
+      const rli = new readline.Interface({
+        input: fi,
+        output: fi,
+        prompt: '',
+        terminal: terminal
+      });
+      fi.emit('data', '💻');
+
+      // move left one character/code point
+      fi.emit('keypress', '.', { name: 'left' });
+      let cursorPos = rli._getCursorPos();
+      assert.strictEqual(cursorPos.rows, 0);
+      assert.strictEqual(cursorPos.cols, 0);
+
+      // move right one character/code point
+      fi.emit('keypress', '.', { name: 'right' });
+      cursorPos = rli._getCursorPos();
+      assert.strictEqual(cursorPos.rows, 0);
+      assert.strictEqual(cursorPos.cols, 2);
+
+      rli.on('line', common.mustCall((line) => {
+        assert.strictEqual(line, '💻');
+      }));
+      fi.emit('data', '\n');
+      rli.close();
+    }
+
     {
       // `wordLeft` and `wordRight`
       const fi = new FakeInput();
@@ -791,6 +821,32 @@ function isWarned(emitter) {
       rli.close();
     }
 
+    // deleteLeft astral character
+    {
+      const fi = new FakeInput();
+      const rli = new readline.Interface({
+        input: fi,
+        output: fi,
+        prompt: '',
+        terminal: terminal
+      });
+      fi.emit('data', '💻');
+      let cursorPos = rli._getCursorPos();
+      assert.strictEqual(cursorPos.rows, 0);
+      assert.strictEqual(cursorPos.cols, 2);
+
+      // Delete left character
+      fi.emit('keypress', '.', { ctrl: true, name: 'h' });
+      cursorPos = rli._getCursorPos();
+      assert.strictEqual(cursorPos.rows, 0);
+      assert.strictEqual(cursorPos.cols, 0);
+      rli.on('line', common.mustCall((line) => {
+        assert.strictEqual(line, '');
+      }));
+      fi.emit('data', '\n');
+      rli.close();
+    }
+
     // deleteRight
     {
       const fi = new FakeInput();
@@ -820,6 +876,34 @@ function isWarned(emitter) {
       rli.close();
     }
 
+    // deleteRight astral character
+    {
+      const fi = new FakeInput();
+      const rli = new readline.Interface({
+        input: fi,
+        output: fi,
+        prompt: '',
+        terminal: terminal
+      });
+      fi.emit('data', '💻');
+
+      // Go to the start of the line
+      fi.emit('keypress', '.', { ctrl: true, name: 'a' });
+      let cursorPos = rli._getCursorPos();
+      assert.strictEqual(cursorPos.rows, 0);
+      assert.strictEqual(cursorPos.cols, 0);
+
+      // Delete right character
+      fi.emit('keypress', '.', { ctrl: true, name: 'd' });
+      cursorPos = rli._getCursorPos();
+      assert.strictEqual(cursorPos.rows, 0);
+      assert.strictEqual(cursorPos.cols, 0);
+      rli.on('line', common.mustCall((line) => {
+        assert.strictEqual(line, '');
+      }));
+      fi.emit('data', '\n');
+      rli.close();
+    }
 
     // deleteLineLeft
     {

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -671,7 +671,11 @@ function isWarned(emitter) {
       fi.emit('keypress', '.', { name: 'right' });
       cursorPos = rli._getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
-      assert.strictEqual(cursorPos.cols, 2);
+      if (common.hasIntl) {
+        assert.strictEqual(cursorPos.cols, 2);
+      } else {
+        assert.strictEqual(cursorPos.cols, 1);
+      }
 
       rli.on('line', common.mustCall((line) => {
         assert.strictEqual(line, '💻');
@@ -700,7 +704,14 @@ function isWarned(emitter) {
       fi.emit('data', '🐕');
       cursorPos = rli._getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
-      assert.strictEqual(cursorPos.cols, 2);
+
+      if (common.hasIntl) {
+        assert.strictEqual(cursorPos.cols, 2);
+      } else {
+        assert.strictEqual(cursorPos.cols, 1);
+        // fix cursor position without internationalization
+        fi.emit('keypress', '.', { name: 'left' });
+      }
 
       rli.on('line', common.mustCall((line) => {
         assert.strictEqual(line, '🐕💻');
@@ -724,12 +735,22 @@ function isWarned(emitter) {
       fi.emit('keypress', '.', { name: 'right' });
       let cursorPos = rli._getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
-      assert.strictEqual(cursorPos.cols, 2);
+      if (common.hasIntl) {
+        assert.strictEqual(cursorPos.cols, 2);
+      } else {
+        assert.strictEqual(cursorPos.cols, 1);
+        // fix cursor position without internationalization
+        fi.emit('keypress', '.', { name: 'right' });
+      }
 
       fi.emit('data', '🐕');
       cursorPos = rli._getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
-      assert.strictEqual(cursorPos.cols, 4);
+      if (common.hasIntl) {
+        assert.strictEqual(cursorPos.cols, 4);
+      } else {
+        assert.strictEqual(cursorPos.cols, 2);
+      }
 
       rli.on('line', common.mustCall((line) => {
         assert.strictEqual(line, '💻🐕');
@@ -891,8 +912,11 @@ function isWarned(emitter) {
       fi.emit('data', '💻');
       let cursorPos = rli._getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
-      assert.strictEqual(cursorPos.cols, 2);
-
+      if (common.hasIntl) {
+        assert.strictEqual(cursorPos.cols, 2);
+      } else {
+        assert.strictEqual(cursorPos.cols, 1);
+      }
       // Delete left character
       fi.emit('keypress', '.', { ctrl: true, name: 'h' });
       cursorPos = rli._getCursorPos();

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -680,6 +680,64 @@ function isWarned(emitter) {
       rli.close();
     }
 
+    // Two astral characters left
+    {
+      const fi = new FakeInput();
+      const rli = new readline.Interface({
+        input: fi,
+        output: fi,
+        prompt: '',
+        terminal: terminal
+      });
+      fi.emit('data', '💻');
+
+      // move left one character/code point
+      fi.emit('keypress', '.', { name: 'left' });
+      let cursorPos = rli._getCursorPos();
+      assert.strictEqual(cursorPos.rows, 0);
+      assert.strictEqual(cursorPos.cols, 0);
+
+      fi.emit('data', '🐕');
+      cursorPos = rli._getCursorPos();
+      assert.strictEqual(cursorPos.rows, 0);
+      assert.strictEqual(cursorPos.cols, 2);
+
+      rli.on('line', common.mustCall((line) => {
+        assert.strictEqual(line, '🐕💻');
+      }));
+      fi.emit('data', '\n');
+      rli.close();
+    }
+
+    // Two astral characters right
+    {
+      const fi = new FakeInput();
+      const rli = new readline.Interface({
+        input: fi,
+        output: fi,
+        prompt: '',
+        terminal: terminal
+      });
+      fi.emit('data', '💻');
+
+      // move left one character/code point
+      fi.emit('keypress', '.', { name: 'right' });
+      let cursorPos = rli._getCursorPos();
+      assert.strictEqual(cursorPos.rows, 0);
+      assert.strictEqual(cursorPos.cols, 2);
+
+      fi.emit('data', '🐕');
+      cursorPos = rli._getCursorPos();
+      assert.strictEqual(cursorPos.rows, 0);
+      assert.strictEqual(cursorPos.cols, 4);
+
+      rli.on('line', common.mustCall((line) => {
+        assert.strictEqual(line, '💻🐕');
+      }));
+      fi.emit('data', '\n');
+      rli.close();
+    }
+
     {
       // `wordLeft` and `wordRight`
       const fi = new FakeInput();


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/25693

+ Makes delete and backspace work upon unicode code points instead of UTF-16 code units.
+ Prevents moving left or right from placing the cursor in between  code units comprising a code point.

In plain english:  Deleting  and moving the cursor across emoji works now, but grapheme clusters/characters  like `👨‍👩‍👧‍👦` still have trailing blank spaces. 

Ideally grapheme clusters would be used instead of code points, but until the [proposal-intl-segmenter](https://github.com/tc39/proposal-intl-segmenter) lands node seems to be without  built in support for handling them.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
