### PR TITLE
doc: os.userInfo throwing SystemError

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -451,6 +451,8 @@ system. This differs from the result of `os.homedir()`, which queries several
 environment variables for the home directory before falling back to the
 operating system response.
 
+Throws a [`SystemError`][] if a user has no `username` or `homedir`.
+
 ## OS Constants
 
 The following constants are exported by `os.constants`.
@@ -1313,6 +1315,7 @@ The following process scheduling constants are exported by
   </tr>
 </table>
 
+[`SystemError`]: errors.html#errors_system_errors
 [`process.arch`]: process.html#process_process_arch
 [`process.platform`]: process.html#process_process_platform
 [Android building]: https://github.com/nodejs/node/blob/master/BUILDING.md#androidandroid-based-devices-eg-firefox-os


### PR DESCRIPTION
`os.userInfo` throws an exception which was not documented in environments like:

`docker run --user $(id -u): $(id -g)`

Closes: #25714

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
