### PR TITLE
src: remove unused field in node_http2.h

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -343,9 +343,6 @@ enum session_state_flags {
   SESSION_STATE_SENDING = 0x10,
 };
 
-// This allows for 4 default-sized frames with their frame headers
-static const size_t kAllocBufferSize = 4 * (16384 + 9);
-
 typedef uint32_t(*get_setting)(nghttp2_session* session,
                                nghttp2_settings_id id);
 


### PR DESCRIPTION
The field is no longer needed after this refactor: https://github.com/nodejs/node/commit/0625627d824fb539cf02e797c6aab2b17b6df99f. 

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
