### PR TITLE
[v11.x backport] deps: v8, cherry-pick 9365d09

### DIFF
--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -1564,6 +1564,8 @@ v8_source_set("v8_base") {
     "src/ast/prettyprinter.h",
     "src/ast/scopes.cc",
     "src/ast/scopes.h",
+    "src/ast/source-range-ast-visitor.cc",
+    "src/ast/source-range-ast-visitor.h",
     "src/ast/variables.cc",
     "src/ast/variables.h",
     "src/bailout-reason.cc",

--- a/deps/v8/gypfiles/v8.gyp
+++ b/deps/v8/gypfiles/v8.gyp
@@ -548,6 +548,8 @@
         '../src/ast/prettyprinter.h',
         '../src/ast/scopes.cc',
         '../src/ast/scopes.h',
+        '../src/ast/source-range-ast-visitor.cc',
+        '../src/ast/source-range-ast-visitor.h',
         '../src/ast/variables.cc',
         '../src/ast/variables.h',
         '../src/bailout-reason.cc',

--- a/deps/v8/src/ast/source-range-ast-visitor.cc
+++ b/deps/v8/src/ast/source-range-ast-visitor.cc
@@ -1,0 +1,68 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "src/ast/source-range-ast-visitor.h"
+
+#include "src/ast/ast-source-ranges.h"
+
+namespace v8 {
+namespace internal {
+
+SourceRangeAstVisitor::SourceRangeAstVisitor(uintptr_t stack_limit,
+                                             Expression* root,
+                                             SourceRangeMap* source_range_map)
+    : AstTraversalVisitor(stack_limit, root),
+      source_range_map_(source_range_map) {}
+
+void SourceRangeAstVisitor::VisitBlock(Block* stmt) {
+  AstTraversalVisitor::VisitBlock(stmt);
+  ZonePtrList<Statement>* stmts = stmt->statements();
+  AstNodeSourceRanges* enclosingSourceRanges = source_range_map_->Find(stmt);
+  if (enclosingSourceRanges != nullptr) {
+    CHECK(enclosingSourceRanges->HasRange(SourceRangeKind::kContinuation));
+    MaybeRemoveLastContinuationRange(stmts);
+  }
+}
+
+void SourceRangeAstVisitor::VisitFunctionLiteral(FunctionLiteral* expr) {
+  AstTraversalVisitor::VisitFunctionLiteral(expr);
+  ZonePtrList<Statement>* stmts = expr->body();
+  MaybeRemoveLastContinuationRange(stmts);
+}
+
+bool SourceRangeAstVisitor::VisitNode(AstNode* node) {
+  AstNodeSourceRanges* range = source_range_map_->Find(node);
+
+  if (range == nullptr) return true;
+  if (!range->HasRange(SourceRangeKind::kContinuation)) return true;
+
+  // Called in pre-order. In case of conflicting continuation ranges, only the
+  // outermost range may survive.
+
+  SourceRange continuation = range->GetRange(SourceRangeKind::kContinuation);
+  if (continuation_positions_.find(continuation.start) !=
+      continuation_positions_.end()) {
+    range->RemoveContinuationRange();
+  } else {
+    continuation_positions_.emplace(continuation.start);
+  }
+
+  return true;
+}
+
+void SourceRangeAstVisitor::MaybeRemoveLastContinuationRange(
+    ZonePtrList<Statement>* statements) {
+  if (statements == nullptr || statements->is_empty()) return;
+
+  Statement* last_statement = statements->last();
+  AstNodeSourceRanges* last_range = source_range_map_->Find(last_statement);
+  if (last_range == nullptr) return;
+
+  if (last_range->HasRange(SourceRangeKind::kContinuation)) {
+    last_range->RemoveContinuationRange();
+  }
+}
+
+}  // namespace internal
+}  // namespace v8

--- a/deps/v8/src/ast/source-range-ast-visitor.h
+++ b/deps/v8/src/ast/source-range-ast-visitor.h
@@ -1,0 +1,49 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_AST_SOURCE_RANGE_AST_VISITOR_H_
+#define V8_AST_SOURCE_RANGE_AST_VISITOR_H_
+
+#include <unordered_set>
+
+#include "src/ast/ast-traversal-visitor.h"
+
+namespace v8 {
+namespace internal {
+
+class SourceRangeMap;
+
+// Post-processes generated source ranges while the AST structure still exists.
+//
+// In particular, SourceRangeAstVisitor
+//
+// 1. deduplicates continuation source ranges, only keeping the outermost one.
+// See also: https://crbug.com/v8/8539.
+//
+// 2. removes the source range associated with the final statement in a block
+// or function body if the parent itself has a source range associated with it.
+// See also: https://crbug.com/v8/8381.
+class SourceRangeAstVisitor final
+    : public AstTraversalVisitor<SourceRangeAstVisitor> {
+ public:
+  SourceRangeAstVisitor(uintptr_t stack_limit, Expression* root,
+                        SourceRangeMap* source_range_map);
+
+ private:
+  friend class AstTraversalVisitor<SourceRangeAstVisitor>;
+
+  void VisitBlock(Block* stmt);
+  void VisitFunctionLiteral(FunctionLiteral* expr);
+  bool VisitNode(AstNode* node);
+
+  void MaybeRemoveLastContinuationRange(ZonePtrList<Statement>* stmts);
+
+  SourceRangeMap* source_range_map_ = nullptr;
+  std::unordered_set<int> continuation_positions_;
+};
+
+}  // namespace internal
+}  // namespace v8
+
+#endif  // V8_AST_SOURCE_RANGE_AST_VISITOR_H_

--- a/deps/v8/src/interpreter/bytecode-generator.cc
+++ b/deps/v8/src/interpreter/bytecode-generator.cc
@@ -368,7 +368,6 @@ class BytecodeGenerator::ControlScopeForBreakable final
  protected:
   bool Execute(Command command, Statement* statement,
                int source_position) override {
-    control_builder_->set_needs_continuation_counter();
     if (statement != statement_) return false;
     switch (command) {
       case CMD_BREAK:

--- a/deps/v8/src/interpreter/control-flow-builders.cc
+++ b/deps/v8/src/interpreter/control-flow-builders.cc
@@ -13,7 +13,7 @@ namespace interpreter {
 BreakableControlFlowBuilder::~BreakableControlFlowBuilder() {
   BindBreakTarget();
   DCHECK(break_labels_.empty() || break_labels_.is_bound());
-  if (block_coverage_builder_ != nullptr && needs_continuation_counter()) {
+  if (block_coverage_builder_ != nullptr) {
     block_coverage_builder_->IncrementBlockCounter(
         node_, SourceRangeKind::kContinuation);
   }

--- a/deps/v8/src/interpreter/control-flow-builders.h
+++ b/deps/v8/src/interpreter/control-flow-builders.h
@@ -58,11 +58,6 @@ class V8_EXPORT_PRIVATE BreakableControlFlowBuilder
 
   BytecodeLabels* break_labels() { return &break_labels_; }
 
-  void set_needs_continuation_counter() { needs_continuation_counter_ = true; }
-  bool needs_continuation_counter() const {
-    return needs_continuation_counter_;
-  }
-
  protected:
   void EmitJump(BytecodeLabels* labels);
   void EmitJumpIfTrue(BytecodeArrayBuilder::ToBooleanMode mode,
@@ -81,7 +76,6 @@ class V8_EXPORT_PRIVATE BreakableControlFlowBuilder
   // A continuation counter (for block coverage) is needed e.g. when
   // encountering a break statement.
   AstNode* node_;
-  bool needs_continuation_counter_ = false;
   BlockCoverageBuilder* block_coverage_builder_;
 };
 
@@ -107,7 +101,6 @@ class V8_EXPORT_PRIVATE LoopBuilder final : public BreakableControlFlowBuilder {
       : BreakableControlFlowBuilder(builder, block_coverage_builder, node),
         continue_labels_(builder->zone()) {
     if (block_coverage_builder_ != nullptr) {
-      set_needs_continuation_counter();
       block_coverage_body_slot_ =
           block_coverage_builder_->AllocateBlockCoverageSlot(
               node, SourceRangeKind::kBody);

--- a/deps/v8/test/inspector/cpu-profiler/coverage-block-expected.txt
+++ b/deps/v8/test/inspector/cpu-profiler/coverage-block-expected.txt
@@ -34,7 +34,7 @@ Running test: testPreciseCountCoverage
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -60,13 +60,8 @@ Running test: testPreciseCountCoverage
                             }
                             [2] : {
                                 count : 7
-                                endOffset : 71
-                                startOffset : 41
-                            }
-                            [3] : {
-                                count : 0
                                 endOffset : 72
-                                startOffset : 71
+                                startOffset : 41
                             }
                         ]
                     }
@@ -90,11 +85,6 @@ Running test: testPreciseCountCoverage
                                 endOffset : 208
                                 startOffset : 177
                             }
-                            [1] : {
-                                count : 0
-                                endOffset : 207
-                                startOffset : 206
-                            }
                         ]
                     }
                 ]
@@ -104,7 +94,7 @@ Running test: testPreciseCountCoverage
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -116,7 +106,7 @@ Running test: testPreciseCountCoverage
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -147,7 +137,7 @@ Running test: testPreciseCountCoverageIncremental
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -173,13 +163,8 @@ Running test: testPreciseCountCoverageIncremental
                             }
                             [2] : {
                                 count : 7
-                                endOffset : 71
-                                startOffset : 41
-                            }
-                            [3] : {
-                                count : 0
                                 endOffset : 72
-                                startOffset : 71
+                                startOffset : 41
                             }
                         ]
                     }
@@ -202,11 +187,6 @@ Running test: testPreciseCountCoverageIncremental
                                 count : 1
                                 endOffset : 208
                                 startOffset : 177
-                            }
-                            [1] : {
-                                count : 0
-                                endOffset : 207
-                                startOffset : 206
                             }
                         ]
                     }
@@ -267,13 +247,8 @@ Running test: testPreciseCountCoverageIncremental
                             }
                             [2] : {
                                 count : 10945
-                                endOffset : 71
-                                startOffset : 41
-                            }
-                            [3] : {
-                                count : 0
                                 endOffset : 72
-                                startOffset : 71
+                                startOffset : 41
                             }
                         ]
                     }
@@ -291,11 +266,6 @@ Running test: testPreciseCountCoverageIncremental
                                 endOffset : 156
                                 startOffset : 143
                             }
-                            [2] : {
-                                count : 0
-                                endOffset : 174
-                                startOffset : 173
-                            }
                         ]
                     }
                 ]
@@ -305,7 +275,7 @@ Running test: testPreciseCountCoverageIncremental
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -317,12 +287,12 @@ Running test: testPreciseCountCoverageIncremental
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
             [2] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -334,7 +304,7 @@ Running test: testPreciseCountCoverageIncremental
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -403,7 +373,7 @@ Running test: testBestEffortCoverageWithPreciseBinaryEnabled
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -453,7 +423,7 @@ Running test: testBestEffortCoverageWithPreciseBinaryEnabled
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -465,7 +435,7 @@ Running test: testBestEffortCoverageWithPreciseBinaryEnabled
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -477,7 +447,7 @@ Running test: testBestEffortCoverageWithPreciseBinaryEnabled
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -527,7 +497,7 @@ Running test: testBestEffortCoverageWithPreciseBinaryEnabled
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -539,7 +509,7 @@ Running test: testBestEffortCoverageWithPreciseBinaryEnabled
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -563,7 +533,7 @@ Running test: testBestEffortCoverageWithPreciseCountEnabled
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -613,7 +583,7 @@ Running test: testBestEffortCoverageWithPreciseCountEnabled
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -625,7 +595,7 @@ Running test: testBestEffortCoverageWithPreciseCountEnabled
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -637,7 +607,7 @@ Running test: testBestEffortCoverageWithPreciseCountEnabled
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -687,7 +657,7 @@ Running test: testBestEffortCoverageWithPreciseCountEnabled
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -699,7 +669,7 @@ Running test: testBestEffortCoverageWithPreciseCountEnabled
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -721,7 +691,7 @@ Running test: testEnablePreciseCountCoverageAtPause
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -733,7 +703,7 @@ Running test: testEnablePreciseCountCoverageAtPause
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -757,7 +727,7 @@ Running test: testPreciseBinaryCoverage
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -775,11 +745,6 @@ Running test: testPreciseBinaryCoverage
                                 count : 1
                                 endOffset : 73
                                 startOffset : 1
-                            }
-                            [1] : {
-                                count : 0
-                                endOffset : 72
-                                startOffset : 71
                             }
                         ]
                     }
@@ -802,11 +767,6 @@ Running test: testPreciseBinaryCoverage
                                 count : 1
                                 endOffset : 208
                                 startOffset : 177
-                            }
-                            [1] : {
-                                count : 0
-                                endOffset : 207
-                                startOffset : 206
                             }
                         ]
                     }
@@ -862,7 +822,7 @@ Running test: testPreciseBinaryCoverage
                             }
                             [1] : {
                                 count : 1
-                                endOffset : 71
+                                endOffset : 72
                                 startOffset : 32
                             }
                         ]
@@ -876,11 +836,6 @@ Running test: testPreciseBinaryCoverage
                                 endOffset : 175
                                 startOffset : 74
                             }
-                            [1] : {
-                                count : 0
-                                endOffset : 174
-                                startOffset : 173
-                            }
                         ]
                     }
                 ]
@@ -890,7 +845,7 @@ Running test: testPreciseBinaryCoverage
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -902,12 +857,12 @@ Running test: testPreciseBinaryCoverage
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
             [2] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -919,7 +874,7 @@ Running test: testPreciseBinaryCoverage
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -950,7 +905,7 @@ Running test: testPreciseCountCoveragePartial
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -969,11 +924,6 @@ Running test: testPreciseCountCoveragePartial
                                 endOffset : 224
                                 startOffset : 10
                             }
-                            [1] : {
-                                count : 0
-                                endOffset : 223
-                                startOffset : 222
-                            }
                         ]
                     }
                     [2] : {
@@ -984,11 +934,6 @@ Running test: testPreciseCountCoveragePartial
                                 count : 1
                                 endOffset : 176
                                 startOffset : 31
-                            }
-                            [1] : {
-                                count : 0
-                                endOffset : 175
-                                startOffset : 172
                             }
                         ]
                     }
@@ -1001,11 +946,6 @@ Running test: testPreciseCountCoveragePartial
                                 endOffset : 172
                                 startOffset : 64
                             }
-                            [1] : {
-                                count : 0
-                                endOffset : 171
-                                startOffset : 166
-                            }
                         ]
                     }
                     [4] : {
@@ -1016,11 +956,6 @@ Running test: testPreciseCountCoveragePartial
                                 count : 1
                                 endOffset : 166
                                 startOffset : 99
-                            }
-                            [1] : {
-                                count : 0
-                                endOffset : 165
-                                startOffset : 158
                             }
                         ]
                     }
@@ -1068,11 +1003,6 @@ Running test: testPreciseCountCoveragePartial
                                 endOffset : 172
                                 startOffset : 64
                             }
-                            [1] : {
-                                count : 0
-                                endOffset : 171
-                                startOffset : 166
-                            }
                         ]
                     }
                     [1] : {
@@ -1093,7 +1023,7 @@ Running test: testPreciseCountCoveragePartial
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -1105,7 +1035,7 @@ Running test: testPreciseCountCoveragePartial
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }

--- a/deps/v8/test/mjsunit/code-coverage-block-opt.js
+++ b/deps/v8/test/mjsunit/code-coverage-block-opt.js
@@ -17,7 +17,7 @@ f(); f(); f(); f(); f(); f();             // 0150
 `,
 [{"start":0,"end":199,"count":1},
  {"start":0,"end":33,"count":4},   // TODO(jgruber): Invocation count is off.
- {"start":25,"end":32,"count":16},
+ {"start":25,"end":31,"count":16},
  {"start":50,"end":76,"count":2}]  // TODO(jgruber): Invocation count is off.
 );
 
@@ -39,7 +39,7 @@ TestCoverage("Partial coverage collection",
 }();                                      // 0400
 `,
 [{"start":52,"end":153,"count":0},
- {"start":121,"end":152,"count":1}]
+ {"start":121,"end":137,"count":1}]
 );
 
 %DebugToggleBlockCoverage(false);

--- a/deps/v8/test/mjsunit/code-coverage-block.js
+++ b/deps/v8/test/mjsunit/code-coverage-block.js
@@ -246,8 +246,7 @@ function g() {}                           // 0000
  {"start":224,"end":237,"count":12},
  {"start":273,"end":277,"count":0},
  {"start":412,"end":416,"count":12},
- {"start":462,"end":475,"count":12},
- {"start":620,"end":622,"count":0}]
+ {"start":462,"end":475,"count":12}]
 );
 
 TestCoverage(
@@ -357,7 +356,7 @@ TestCoverage(
  {"start":219,"end":222,"count":0},
  {"start":254,"end":274,"count":0},
  {"start":369,"end":372,"count":0},
- {"start":390,"end":404,"count":0},
+ {"start":403,"end":404,"count":0},
  {"start":513,"end":554,"count":0}]
 );
 
@@ -376,10 +375,10 @@ TestCoverage("try/catch/finally statements with early return",
 [{"start":0,"end":449,"count":1},
  {"start":1,"end":151,"count":1},
  {"start":67,"end":70,"count":0},
- {"start":89,"end":150,"count":0},
+ {"start":91,"end":150,"count":0},
  {"start":201,"end":401,"count":1},
  {"start":267,"end":270,"count":0},
- {"start":319,"end":400,"count":0}]
+ {"start":321,"end":400,"count":0}]
 );
 
 TestCoverage(
@@ -411,11 +410,11 @@ TestCoverage(
 [{"start":0,"end":1099,"count":1},
  {"start":1,"end":151,"count":1},
  {"start":67,"end":70,"count":0},
- {"start":89,"end":150,"count":0},
+ {"start":91,"end":150,"count":0},
  {"start":201,"end":351,"count":1},
- {"start":284,"end":350,"count":0},
+ {"start":286,"end":350,"count":0},
  {"start":401,"end":701,"count":1},
- {"start":569,"end":700,"count":0},
+ {"start":603,"end":700,"count":0},
  {"start":561,"end":568,"count":0},  // TODO(jgruber): Sorting.
  {"start":751,"end":1051,"count":1},
  {"start":817,"end":820,"count":0},
@@ -437,7 +436,7 @@ TestCoverage(
 [{"start":0,"end":399,"count":1},
  {"start":1,"end":351,"count":1},
  {"start":154,"end":204,"count":0},
- {"start":226,"end":303,"count":0}]
+ {"start":226,"end":350,"count":0}]
 );
 
 TestCoverage(
@@ -467,11 +466,7 @@ TestCoverage(
 [{"start":0,"end":999,"count":1},
  {"start":1,"end":951,"count":1},
  {"start":152,"end":202,"count":0},
- {"start":285,"end":353,"count":0},
- {"start":472,"end":503,"count":0},
- {"start":626,"end":653,"count":0},
- {"start":768,"end":803,"count":0},
- {"start":867,"end":869,"count":0}]
+ {"start":285,"end":353,"count":0}]
 );
 
 TestCoverage(
@@ -496,11 +491,8 @@ TestCoverage(
 [{"start":0,"end":749,"count":1},
  {"start":1,"end":701,"count":1},
  {"start":87,"end":153,"count":2},
- {"start":125,"end":153,"count":0},
  {"start":271,"end":403,"count":2},
- {"start":379,"end":403,"count":0},
- {"start":509,"end":653,"count":2},
- {"start":621,"end":653,"count":0}]
+ {"start":509,"end":653,"count":2}]
 );
 
 TestCoverage(
@@ -570,6 +562,7 @@ try {                                     // 0200
 } catch (e) {}                            // 0450
 `,
 [{"start":0,"end":499,"count":1},
+ {"start":451,"end":452,"count":0},
  {"start":12,"end":101,"count":3},
  {"start":60,"end":100,"count":0},
  {"start":264,"end":353,"count":3},
@@ -648,6 +641,7 @@ try {                                     // 0200
 } catch (e) {}                            // 0450
 `,
 [{"start":0,"end":499,"count":1},
+ {"start":451,"end":452,"count":0},
  {"start":12,"end":101,"count":3},
  {"start":65,"end":100,"count":0},
  {"start":264,"end":353,"count":3},
@@ -846,8 +840,7 @@ Util.escape("foo.bar");                   // 0400
 `,
 [{"start":0,"end":449,"count":1},
  {"start":64,"end":351,"count":1},
- {"start":112,"end":203,"count":0},
- {"start":268,"end":350,"count":0}]
+ {"start":112,"end":203,"count":0}]
 );
 
 TestCoverage(
@@ -879,17 +872,136 @@ TestCoverage(
  {"start":1,"end":151,"count":1},
  {"start":118,"end":137,"count":0},
  {"start":201,"end":351,"count":1},
- {"start":277,"end":318,"count":0},
+ {"start":279,"end":318,"count":0},
  {"start":401,"end":525,"count":1},
  {"start":475,"end":486,"count":0},
  {"start":503,"end":523,"count":0},
  {"start":551,"end":651,"count":1},
  {"start":622,"end":639,"count":0},
  {"start":701,"end":801,"count":1},
- {"start":773,"end":791,"count":0},
+ {"start":774,"end":791,"count":0},
  {"start":851,"end":1001,"count":1},
  {"start":920,"end":928,"count":0},
  {"start":929,"end":965,"count":0}]
+);
+
+TestCoverage(
+"terminal break statement",
+`
+while (true) {                            // 0000
+  const b = false                         // 0050
+  break                                   // 0100
+}                                         // 0150
+let stop = false                          // 0200
+while (true) {                            // 0250
+  if (stop) {                             // 0300
+    break                                 // 0350
+  }                                       // 0400
+  stop = true                             // 0450
+}                                         // 0500
+`,
+[{"start":0,"end":549,"count":1},
+ {"start":263,"end":501,"count":2},
+ {"start":312,"end":501,"count":1}]
+);
+
+TestCoverage(
+"terminal return statement",
+`
+function a () {                           // 0000
+  const b = false                         // 0050
+  return 1                                // 0100
+}                                         // 0150
+const b = (early) => {                    // 0200
+  if (early) {                            // 0250
+    return 2                              // 0300
+  }                                       // 0350
+  return 3                                // 0400
+}                                         // 0450
+const c = () => {                         // 0500
+  if (true) {                             // 0550
+    return                                // 0600
+  }                                       // 0650
+}                                         // 0700
+a(); b(false); b(true); c()               // 0750
+`,
+[{"start":0,"end":799,"count":1},
+ {"start":0,"end":151,"count":1},
+ {"start":210,"end":451,"count":2},
+ {"start":263,"end":450,"count":1},
+ {"start":510,"end":701,"count":1}]
+);
+
+TestCoverage(
+"terminal blocks",
+`
+function a () {                           // 0000
+  {                                       // 0050
+    return 'a'                            // 0100
+  }                                       // 0150
+}                                         // 0200
+function b () {                           // 0250
+  {                                       // 0300
+    {                                     // 0350
+      return 'b'                          // 0400
+    }                                     // 0450
+  }                                       // 0500
+}                                         // 0550
+a(); b()                                  // 0600
+`,
+[{"start":0,"end":649,"count":1},
+ {"start":0,"end":201,"count":1},
+ {"start":250,"end":551,"count":1}]
+);
+
+TestCoverage(
+"terminal if statements",
+`
+function a (branch) {                     // 0000
+  if (branch) {                           // 0050
+    return 'a'                            // 0100
+  } else {                                // 0150
+    return 'b'                            // 0200
+  }                                       // 0250
+}                                         // 0300
+function b (branch) {                     // 0350
+  if (branch) {                           // 0400
+    if (branch) {                         // 0450
+      return 'c'                          // 0500
+    }                                     // 0550
+  }                                       // 0600
+}                                         // 0650
+function c (branch) {                     // 0700
+  if (branch) {                           // 0750
+    return 'c'                            // 0800
+  } else {                                // 0850
+    return 'd'                            // 0900
+  }                                       // 0950
+}                                         // 1000
+function d (branch) {                     // 1050
+  if (branch) {                           // 1100
+    if (!branch) {                        // 1150
+      return 'e'                          // 1200
+    } else {                              // 1250
+      return 'f'                          // 1300
+    }                                     // 1350
+  } else {                                // 1400
+    // noop                               // 1450
+  }                                       // 1500
+}                                         // 1550
+a(true); a(false); b(true); b(false)      // 1600
+c(true); d(true);                         // 1650
+`,
+[{"start":0,"end":1699,"count":1},
+ {"start":0,"end":301,"count":2},
+ {"start":64,"end":253,"count":1},
+ {"start":350,"end":651,"count":2},
+ {"start":414,"end":603,"count":1},
+ {"start":700,"end":1001,"count":1},
+ {"start":853,"end":953,"count":0},
+ {"start":1050,"end":1551,"count":1},
+ {"start":1167,"end":1255,"count":0},
+ {"start":1403,"end":1503,"count":0}]
 );
 
 %DebugToggleBlockCoverage(false);


### PR DESCRIPTION
backport fixes for terminal return statements (https://chromium-review.googlesource.com/c/v8/v8/+/1339119).

doesn't apply cleanly, so would appreciate eyes of @hashseed, @schuay

see: https://github.com/nodejs/node/pull/25429

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
