### PR TITLE
doc: revise breaking changes material in COLLABORATOR_GUIDE

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -270,23 +270,13 @@ For more information, see [Deprecations](#deprecations).
 #### Breaking Changes to Internal Elements
 
 Breaking changes to internal elements may occur in semver-patch or semver-minor
-commits. Collaborators should take significant care when making and reviewing
-such changes. An effort must be made to determine the potential impact of the
-change in the ecosystem. Use
+commits. Take significant care when making and reviewing such changes. Make
+an effort to determine the potential impact of the change in the ecosystem. Use
 [Canary in the Goldmine](https://github.com/nodejs/citgm) to test such changes.
 If a change will cause ecosystem breakage, then it is semver-major. Consider
 providing a Public API in such cases.
 
 #### When Breaking Changes Actually Break Things
-
-Because breaking (semver-major) changes are permitted to land on the master
-branch at any time, at least some subset of the user ecosystem may be adversely
-affected in the short term when attempting to build and use Node.js directly
-from the master branch. This potential instability is why Node.js offers
-distinct Current and LTS release streams that offer explicit stability
-guarantees.
-
-Specifically:
 
 * Breaking changes should *never* land in Current or LTS except when:
   * Resolving critical security issues.


### PR DESCRIPTION
* Remove unnecessary paragraph explaining why Current and LTS have
  stability guarantees that master branch does not. (Leave material
  explaining what those stability guarantees are.)
* Upgrade advisory and passive "Collaborators should take significant
  care" to more direct "Take significant care".

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
