### PR TITLE
src: pass along errors from object instantiations

### DIFF
--- a/src/connection_wrap.cc
+++ b/src/connection_wrap.cc
@@ -48,9 +48,10 @@ void ConnectionWrap<WrapType, UVType>::OnConnection(uv_stream_t* handle,
 
   if (status == 0) {
     // Instantiate the client javascript object and handle.
-    Local<Object> client_obj = WrapType::Instantiate(env,
-                                                     wrap_data,
-                                                     WrapType::SOCKET);
+    Local<Object> client_obj;
+    if (!WrapType::Instantiate(env, wrap_data, WrapType::SOCKET)
+             .ToLocal(&client_obj))
+      return;
 
     // Unwrap the client javascript object.
     WrapType* wrap;

--- a/src/env.cc
+++ b/src/env.cc
@@ -289,28 +289,9 @@ Environment::~Environment() {
   }
 }
 
-void Environment::Start(const std::vector<std::string>& args,
-                        const std::vector<std::string>& exec_args,
-                        bool start_profiler_idle_notifier) {
+void Environment::Start(bool start_profiler_idle_notifier) {
   HandleScope handle_scope(isolate());
   Context::Scope context_scope(context());
-
-  if (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
-      TRACING_CATEGORY_NODE1(environment)) != 0) {
-    auto traced_value = tracing::TracedValue::Create();
-    traced_value->BeginArray("args");
-    for (const std::string& arg : args)
-      traced_value->AppendString(arg);
-    traced_value->EndArray();
-    traced_value->BeginArray("exec_args");
-    for (const std::string& arg : exec_args)
-      traced_value->AppendString(arg);
-    traced_value->EndArray();
-    TRACE_EVENT_NESTABLE_ASYNC_BEGIN1(
-      TRACING_CATEGORY_NODE1(environment),
-      "Environment", this,
-      "args", std::move(traced_value));
-  }
 
   CHECK_EQ(0, uv_timer_init(event_loop(), timer_handle()));
   uv_unref(reinterpret_cast<uv_handle_t*>(timer_handle()));
@@ -346,12 +327,35 @@ void Environment::Start(const std::vector<std::string>& args,
     StartProfilerIdleNotifier();
   }
 
-  Local<Object> process_object = CreateProcessObject(this, args, exec_args);
-  set_process_object(process_object);
-
   static uv_once_t init_once = UV_ONCE_INIT;
   uv_once(&init_once, InitThreadLocalOnce);
   uv_key_set(&thread_local_env, this);
+}
+
+MaybeLocal<Object> Environment::CreateProcessObject(
+    const std::vector<std::string>& args,
+    const std::vector<std::string>& exec_args) {
+  if (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
+          TRACING_CATEGORY_NODE1(environment)) != 0) {
+    auto traced_value = tracing::TracedValue::Create();
+    traced_value->BeginArray("args");
+    for (const std::string& arg : args) traced_value->AppendString(arg);
+    traced_value->EndArray();
+    traced_value->BeginArray("exec_args");
+    for (const std::string& arg : exec_args) traced_value->AppendString(arg);
+    traced_value->EndArray();
+    TRACE_EVENT_NESTABLE_ASYNC_BEGIN1(TRACING_CATEGORY_NODE1(environment),
+                                      "Environment",
+                                      this,
+                                      "args",
+                                      std::move(traced_value));
+  }
+
+  Local<Object> process_object =
+      node::CreateProcessObject(this, args, exec_args)
+          .FromMaybe(Local<Object>());
+  set_process_object(process_object);
+  return process_object;
 }
 
 void Environment::RegisterHandleCleanups() {

--- a/src/env.h
+++ b/src/env.h
@@ -610,9 +610,10 @@ class Environment {
               v8::Local<v8::Context> context);
   ~Environment();
 
-  void Start(const std::vector<std::string>& args,
-             const std::vector<std::string>& exec_args,
-             bool start_profiler_idle_notifier);
+  void Start(bool start_profiler_idle_notifier);
+  v8::MaybeLocal<v8::Object> CreateProcessObject(
+      const std::vector<std::string>& args,
+      const std::vector<std::string>& exec_args);
 
   typedef void (*HandleCleanupCb)(Environment* env,
                                   uv_handle_t* handle,

--- a/src/node.cc
+++ b/src/node.cc
@@ -1213,7 +1213,8 @@ Environment* CreateEnvironment(IsolateData* isolate_data,
   std::vector<std::string> args(argv, argv + argc);
   std::vector<std::string> exec_args(exec_argv, exec_argv + exec_argc);
   Environment* env = new Environment(isolate_data, context);
-  env->Start(args, exec_args, per_process::v8_is_profiling);
+  env->Start(per_process::v8_is_profiling);
+  env->CreateProcessObject(args, exec_args);
   return env;
 }
 
@@ -1287,7 +1288,8 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   Local<Context> context = NewContext(isolate);
   Context::Scope context_scope(context);
   Environment env(isolate_data, context);
-  env.Start(args, exec_args, per_process::v8_is_profiling);
+  env.Start(per_process::v8_is_profiling);
+  env.CreateProcessObject(args, exec_args);
 
   const char* path = args.size() > 1 ? args[1].c_str() : nullptr;
   StartInspector(&env, path);

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -23,9 +23,10 @@ class ContextifyContext {
                     v8::Local<v8::Object> sandbox_obj,
                     const ContextOptions& options);
 
-  v8::Local<v8::Value> CreateDataWrapper(Environment* env);
-  v8::Local<v8::Context> CreateV8Context(Environment* env,
-      v8::Local<v8::Object> sandbox_obj, const ContextOptions& options);
+  v8::MaybeLocal<v8::Object> CreateDataWrapper(Environment* env);
+  v8::MaybeLocal<v8::Context> CreateV8Context(Environment* env,
+                                              v8::Local<v8::Object> sandbox_obj,
+                                              const ContextOptions& options);
   static void Init(Environment* env, v8::Local<v8::Object> target);
 
   static ContextifyContext* ContextFromContextifiedSandbox(

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3327,15 +3327,18 @@ Local<Function> KeyObject::Initialize(Environment* env, Local<Object> target) {
   return function;
 }
 
-Local<Object> KeyObject::Create(Environment* env,
-                                KeyType key_type,
-                                const ManagedEVPPKey& pkey) {
+MaybeLocal<Object> KeyObject::Create(Environment* env,
+                                     KeyType key_type,
+                                     const ManagedEVPPKey& pkey) {
   CHECK_NE(key_type, kKeyTypeSecret);
   Local<Value> type = Integer::New(env->isolate(), key_type);
-  Local<Object> obj =
-      env->crypto_key_object_constructor()->NewInstance(env->context(),
-                                                        1, &type)
-      .ToLocalChecked();
+  Local<Object> obj;
+  if (!env->crypto_key_object_constructor()
+           ->NewInstance(env->context(), 1, &type)
+           .ToLocal(&obj)) {
+    return MaybeLocal<Object>();
+  }
+
   KeyObject* key = Unwrap<KeyObject>(obj);
   CHECK(key);
   if (key_type == kKeyTypePublic)
@@ -5823,24 +5826,22 @@ class GenerateKeyPairJob : public CryptoJob {
     if (public_key_encoding_.output_key_object_) {
       // Note that this has the downside of containing sensitive data of the
       // private key.
-      *pubkey = KeyObject::Create(env, kKeyTypePublic, pkey_);
-    } else {
-      MaybeLocal<Value> maybe_pubkey =
-          WritePublicKey(env, pkey_.get(), public_key_encoding_);
-      if (maybe_pubkey.IsEmpty())
+      if (!KeyObject::Create(env, kKeyTypePublic, pkey_).ToLocal(pubkey))
         return false;
-      *pubkey = maybe_pubkey.ToLocalChecked();
+    } else {
+      if (!WritePublicKey(env, pkey_.get(), public_key_encoding_)
+               .ToLocal(pubkey))
+        return false;
     }
 
     // Now do the same for the private key.
     if (private_key_encoding_.output_key_object_) {
-      *privkey = KeyObject::Create(env, kKeyTypePrivate, pkey_);
-    } else {
-      MaybeLocal<Value> maybe_privkey =
-          WritePrivateKey(env, pkey_.get(), private_key_encoding_);
-      if (maybe_privkey.IsEmpty())
+      if (!KeyObject::Create(env, kKeyTypePrivate, pkey_).ToLocal(privkey))
         return false;
-      *privkey = maybe_privkey.ToLocalChecked();
+    } else {
+      if (!WritePrivateKey(env, pkey_.get(), private_key_encoding_)
+               .ToLocal(privkey))
+        return false;
     }
 
     return true;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -442,9 +442,9 @@ class KeyObject : public BaseObject {
   static v8::Local<v8::Function> Initialize(Environment* env,
                                             v8::Local<v8::Object> target);
 
-  static v8::Local<v8::Object> Create(Environment* env,
-                                      KeyType type,
-                                      const ManagedEVPPKey& pkey);
+  static v8::MaybeLocal<v8::Object> Create(Environment* env,
+                                           KeyType type,
+                                           const ManagedEVPPKey& pkey);
 
   // TODO(tniessen): track the memory used by OpenSSL types
   SET_NO_MEMORY_INFO()

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -17,6 +17,7 @@ using v8::EscapableHandleScope;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
+using v8::MaybeLocal;
 using v8::Name;
 using v8::NamedPropertyHandlerConfiguration;
 using v8::NewStringType;
@@ -209,15 +210,13 @@ static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
   info.GetReturnValue().Set(envarr);
 }
 
-Local<Object> CreateEnvVarProxy(Local<Context> context,
-                                Isolate* isolate,
-                                Local<Value> data) {
+MaybeLocal<Object> CreateEnvVarProxy(Local<Context> context,
+                                     Isolate* isolate,
+                                     Local<Value> data) {
   EscapableHandleScope scope(isolate);
   Local<ObjectTemplate> env_proxy_template = ObjectTemplate::New(isolate);
   env_proxy_template->SetHandler(NamedPropertyHandlerConfiguration(
       EnvGetter, EnvSetter, EnvQuery, EnvDeleter, EnvEnumerator, data));
-  Local<Object> env_proxy =
-      env_proxy_template->NewInstance(context).ToLocalChecked();
-  return scope.Escape(env_proxy);
+  return scope.EscapeMaybe(env_proxy_template->NewInstance(context));
 }
 }  // namespace node

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -697,7 +697,8 @@ void Http2Stream::EmitStatistics() {
     }
     buffer[IDX_STREAM_STATS_SENTBYTES] = entry->sent_bytes();
     buffer[IDX_STREAM_STATS_RECEIVEDBYTES] = entry->received_bytes();
-    entry->Notify(entry->ToObject());
+    Local<Object> obj;
+    if (entry->ToObject().ToLocal(&obj)) entry->Notify(obj);
   }, static_cast<void*>(entry));
 }
 
@@ -726,7 +727,8 @@ void Http2Session::EmitStatistics() {
     buffer[IDX_SESSION_STATS_DATA_RECEIVED] = entry->data_received();
     buffer[IDX_SESSION_STATS_MAX_CONCURRENT_STREAMS] =
         entry->max_concurrent_streams();
-    entry->Notify(entry->ToObject());
+    Local<Object> obj;
+    if (entry->ToObject().ToLocal(&obj)) entry->Notify(obj);
   }, static_cast<void*>(entry));
 }
 

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -171,6 +171,11 @@ class ConverterObject : public BaseObject, Converter {
     Environment* env = Environment::GetCurrent(args);
     HandleScope scope(env->isolate());
 
+    Local<ObjectTemplate> t = ObjectTemplate::New(env->isolate());
+    t->SetInternalFieldCount(1);
+    Local<Object> obj;
+    if (!t->NewInstance(env->context()).ToLocal(&obj)) return;
+
     CHECK_GE(args.Length(), 2);
     Utf8Value label(env->isolate(), args[0]);
     int flags = args[1]->Uint32Value(env->context()).ToChecked();
@@ -190,9 +195,6 @@ class ConverterObject : public BaseObject, Converter {
                           nullptr, nullptr, nullptr, &status);
     }
 
-    Local<ObjectTemplate> t = ObjectTemplate::New(env->isolate());
-    t->SetInternalFieldCount(1);
-    Local<Object> obj = t->NewInstance(env->context()).ToLocalChecked();
     new ConverterObject(env, obj, conv, ignoreBOM);
     args.GetReturnValue().Set(obj);
   }

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -20,6 +20,7 @@ using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
+using v8::MaybeLocal;
 using v8::Name;
 using v8::NewStringType;
 using v8::Number;
@@ -102,10 +103,13 @@ inline void InitObject(const PerformanceEntry& entry, Local<Object> obj) {
 }
 
 // Create a new PerformanceEntry object
-const Local<Object> PerformanceEntry::ToObject() const {
-  Local<Object> obj =
-      env_->performance_entry_template()
-          ->NewInstance(env_->context()).ToLocalChecked();
+MaybeLocal<Object> PerformanceEntry::ToObject() const {
+  Local<Object> obj;
+  if (!env_->performance_entry_template()
+           ->NewInstance(env_->context())
+           .ToLocal(&obj)) {
+    return MaybeLocal<Object>();
+  }
   InitObject(*this, obj);
   return obj;
 }
@@ -154,7 +158,8 @@ void Mark(const FunctionCallbackInfo<Value>& args) {
       *name, now / 1000);
 
   PerformanceEntry entry(env, *name, "mark", now, now);
-  Local<Object> obj = entry.ToObject();
+  Local<Object> obj;
+  if (!entry.ToObject().ToLocal(&obj)) return;
   PerformanceEntry::Notify(env, entry.kind(), obj);
   args.GetReturnValue().Set(obj);
 }
@@ -217,7 +222,8 @@ void Measure(const FunctionCallbackInfo<Value>& args) {
       *name, *name, endTimestamp / 1000);
 
   PerformanceEntry entry(env, *name, "measure", startTimestamp, endTimestamp);
-  Local<Object> obj = entry.ToObject();
+  Local<Object> obj;
+  if (!entry.ToObject().ToLocal(&obj)) return;
   PerformanceEntry::Notify(env, entry.kind(), obj);
   args.GetReturnValue().Set(obj);
 }
@@ -242,14 +248,16 @@ void SetupPerformanceObservers(const FunctionCallbackInfo<Value>& args) {
 
 // Creates a GC Performance Entry and passes it to observers
 void PerformanceGCCallback(Environment* env, void* ptr) {
-  GCPerformanceEntry* entry = static_cast<GCPerformanceEntry*>(ptr);
+  std::unique_ptr<GCPerformanceEntry> entry{
+      static_cast<GCPerformanceEntry*>(ptr)};
   HandleScope scope(env->isolate());
   Local<Context> context = env->context();
 
   AliasedBuffer<uint32_t, Uint32Array>& observers =
       env->performance_state()->observers;
   if (observers[NODE_PERFORMANCE_ENTRY_TYPE_GC]) {
-    Local<Object> obj = entry->ToObject();
+    Local<Object> obj;
+    if (!entry->ToObject().ToLocal(&obj)) return;
     PropertyAttribute attr =
         static_cast<PropertyAttribute>(ReadOnly | DontDelete);
     obj->DefineOwnProperty(context,
@@ -258,8 +266,6 @@ void PerformanceGCCallback(Environment* env, void* ptr) {
                            attr).FromJust();
     PerformanceEntry::Notify(env, entry->kind(), obj);
   }
-
-  delete entry;
 }
 
 // Marks the start of a GC cycle
@@ -354,7 +360,8 @@ void TimerFunctionCall(const FunctionCallbackInfo<Value>& args) {
     return;
 
   PerformanceEntry entry(env, *name, "function", start, end);
-  Local<Object> obj = entry.ToObject();
+  Local<Object> obj;
+  if (!entry.ToObject().ToLocal(&obj)) return;
   for (idx = 0; idx < count; idx++)
     obj->Set(context, idx, args[idx]).FromJust();
   PerformanceEntry::Notify(env, entry.kind(), obj);

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -75,7 +75,7 @@ class PerformanceEntry {
 
   virtual ~PerformanceEntry() { }
 
-  virtual const Local<Object> ToObject() const;
+  virtual v8::MaybeLocal<Object> ToObject() const;
 
   Environment* env() const { return env_; }
 

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -7,9 +7,9 @@
 
 namespace node {
 
-v8::Local<v8::Object> CreateEnvVarProxy(v8::Local<v8::Context> context,
-                                        v8::Isolate* isolate,
-                                        v8::Local<v8::Value> data);
+v8::MaybeLocal<v8::Object> CreateEnvVarProxy(v8::Local<v8::Context> context,
+                                             v8::Isolate* isolate,
+                                             v8::Local<v8::Value> data);
 
 // Most of the time, it's best to use `console.error` to write
 // to the process.stderr stream.  However, in some cases, such as
@@ -31,7 +31,7 @@ v8::Maybe<bool> ProcessEmitDeprecationWarning(Environment* env,
                                               const char* warning,
                                               const char* deprecation_code);
 
-v8::Local<v8::Object> CreateProcessObject(
+v8::MaybeLocal<v8::Object> CreateProcessObject(
     Environment* env,
     const std::vector<std::string>& args,
     const std::vector<std::string>& exec_args);

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -132,9 +132,9 @@ Worker::Worker(Environment* env,
     env_->set_worker_context(this);
     env_->set_thread_id(thread_id_);
 
-    env_->Start(std::vector<std::string>{},
-                std::vector<std::string>{},
-                env->profiler_idle_notifier_started());
+    env_->Start(env->profiler_idle_notifier_started());
+    env_->CreateProcessObject(std::vector<std::string>{},
+                              std::vector<std::string>{});
     // Done while on the parent thread
     AddWorkerInspector(env, env_.get(), thread_id_, url_);
   }

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -42,16 +42,16 @@ using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Int32;
 using v8::Local;
+using v8::MaybeLocal;
 using v8::Object;
 using v8::String;
 using v8::Value;
 
 using AsyncHooks = Environment::AsyncHooks;
 
-
-Local<Object> PipeWrap::Instantiate(Environment* env,
-                                    AsyncWrap* parent,
-                                    PipeWrap::SocketType type) {
+MaybeLocal<Object> PipeWrap::Instantiate(Environment* env,
+                                         AsyncWrap* parent,
+                                         PipeWrap::SocketType type) {
   EscapableHandleScope handle_scope(env->isolate());
   AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(parent);
   CHECK_EQ(false, env->pipe_constructor_template().IsEmpty());
@@ -60,9 +60,8 @@ Local<Object> PipeWrap::Instantiate(Environment* env,
                                     .ToLocalChecked();
   CHECK_EQ(false, constructor.IsEmpty());
   Local<Value> type_value = Int32::New(env->isolate(), type);
-  Local<Object> instance =
-      constructor->NewInstance(env->context(), 1, &type_value).ToLocalChecked();
-  return handle_scope.Escape(instance);
+  return handle_scope.EscapeMaybe(
+      constructor->NewInstance(env->context(), 1, &type_value));
 }
 
 

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -38,9 +38,9 @@ class PipeWrap : public ConnectionWrap<PipeWrap, uv_pipe_t> {
     IPC
   };
 
-  static v8::Local<v8::Object> Instantiate(Environment* env,
-                                           AsyncWrap* parent,
-                                           SocketType type);
+  static v8::MaybeLocal<v8::Object> Instantiate(Environment* env,
+                                                AsyncWrap* parent,
+                                                SocketType type);
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
                          v8::Local<v8::Context> context,

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -44,6 +44,7 @@ using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Local;
+using v8::MaybeLocal;
 using v8::Object;
 using v8::ReadOnly;
 using v8::Signature;
@@ -195,10 +196,9 @@ void LibuvStreamWrap::OnUvAlloc(size_t suggested_size, uv_buf_t* buf) {
   *buf = EmitAlloc(suggested_size);
 }
 
-
-
 template <class WrapType>
-static Local<Object> AcceptHandle(Environment* env, LibuvStreamWrap* parent) {
+static MaybeLocal<Object> AcceptHandle(Environment* env,
+                                       LibuvStreamWrap* parent) {
   static_assert(std::is_base_of<LibuvStreamWrap, WrapType>::value ||
                 std::is_base_of<UDPWrap, WrapType>::value,
                 "Can only accept stream handles");
@@ -206,8 +206,7 @@ static Local<Object> AcceptHandle(Environment* env, LibuvStreamWrap* parent) {
   EscapableHandleScope scope(env->isolate());
   Local<Object> wrap_obj;
 
-  wrap_obj = WrapType::Instantiate(env, parent, WrapType::SOCKET);
-  if (wrap_obj.IsEmpty())
+  if (!WrapType::Instantiate(env, parent, WrapType::SOCKET).ToLocal(&wrap_obj))
     return Local<Object>();
 
   HandleWrap* wrap = Unwrap<HandleWrap>(wrap_obj);
@@ -237,7 +236,7 @@ void LibuvStreamWrap::OnUvRead(ssize_t nread, const uv_buf_t* buf) {
   CHECK_EQ(persistent().IsEmpty(), false);
 
   if (nread > 0) {
-    Local<Object> pending_obj;
+    MaybeLocal<Object> pending_obj;
 
     if (type == UV_TCP) {
       pending_obj = AcceptHandle<TCPWrap>(env(), this);
@@ -250,9 +249,11 @@ void LibuvStreamWrap::OnUvRead(ssize_t nread, const uv_buf_t* buf) {
     }
 
     if (!pending_obj.IsEmpty()) {
-      object()->Set(env()->context(),
-                    env()->pending_handle_string(),
-                    pending_obj).FromJust();
+      object()
+          ->Set(env()->context(),
+                env()->pending_handle_string(),
+                pending_obj.ToLocalChecked())
+          .FromJust();
     }
   }
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -46,6 +46,7 @@ using v8::HandleScope;
 using v8::Int32;
 using v8::Integer;
 using v8::Local;
+using v8::MaybeLocal;
 using v8::Object;
 using v8::String;
 using v8::Uint32;
@@ -53,10 +54,9 @@ using v8::Value;
 
 using AsyncHooks = Environment::AsyncHooks;
 
-
-Local<Object> TCPWrap::Instantiate(Environment* env,
-                                   AsyncWrap* parent,
-                                   TCPWrap::SocketType type) {
+MaybeLocal<Object> TCPWrap::Instantiate(Environment* env,
+                                        AsyncWrap* parent,
+                                        TCPWrap::SocketType type) {
   EscapableHandleScope handle_scope(env->isolate());
   AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(parent);
   CHECK_EQ(env->tcp_constructor_template().IsEmpty(), false);
@@ -65,9 +65,8 @@ Local<Object> TCPWrap::Instantiate(Environment* env,
                                     .ToLocalChecked();
   CHECK_EQ(constructor.IsEmpty(), false);
   Local<Value> type_value = Int32::New(env->isolate(), type);
-  Local<Object> instance =
-      constructor->NewInstance(env->context(), 1, &type_value).ToLocalChecked();
-  return handle_scope.Escape(instance);
+  return handle_scope.EscapeMaybe(
+      constructor->NewInstance(env->context(), 1, &type_value));
 }
 
 

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -37,9 +37,9 @@ class TCPWrap : public ConnectionWrap<TCPWrap, uv_tcp_t> {
     SERVER
   };
 
-  static v8::Local<v8::Object> Instantiate(Environment* env,
-                                           AsyncWrap* parent,
-                                           SocketType type);
+  static v8::MaybeLocal<v8::Object> Instantiate(Environment* env,
+                                                AsyncWrap* parent,
+                                                SocketType type);
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
                          v8::Local<v8::Context> context,

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -30,12 +30,12 @@ namespace node {
 
 using v8::Array;
 using v8::Context;
-using v8::EscapableHandleScope;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
+using v8::MaybeLocal;
 using v8::Object;
 using v8::PropertyAttribute;
 using v8::Signature;
@@ -518,18 +518,14 @@ void UDPWrap::OnRecv(uv_udp_t* handle,
   wrap->MakeCallback(env->onmessage_string(), arraysize(argv), argv);
 }
 
-
-Local<Object> UDPWrap::Instantiate(Environment* env,
-                                   AsyncWrap* parent,
-                                   UDPWrap::SocketType type) {
-  EscapableHandleScope scope(env->isolate());
+MaybeLocal<Object> UDPWrap::Instantiate(Environment* env,
+                                        AsyncWrap* parent,
+                                        UDPWrap::SocketType type) {
   AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(parent);
 
   // If this assert fires then Initialize hasn't been called yet.
   CHECK_EQ(env->udp_constructor_function().IsEmpty(), false);
-  Local<Object> instance = env->udp_constructor_function()
-      ->NewInstance(env->context()).ToLocalChecked();
-  return scope.Escape(instance);
+  return env->udp_constructor_function()->NewInstance(env->context());
 }
 
 

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -61,9 +61,9 @@ class UDPWrap: public HandleWrap {
   static void SetTTL(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void BufferSize(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  static v8::Local<v8::Object> Instantiate(Environment* env,
-                                           AsyncWrap* parent,
-                                           SocketType type);
+  static v8::MaybeLocal<v8::Object> Instantiate(Environment* env,
+                                                AsyncWrap* parent,
+                                                SocketType type);
   SET_NO_MEMORY_INFO()
   SET_MEMORY_INFO_NAME(UDPWrap)
   SET_SELF_SIZE(UDPWrap)


### PR DESCRIPTION
Calling `Function::NewInstance()` can always fail in the presence of termination exceptions, so we need to check for error conditions when calling it.

This PR does not address all of those cases, but at least some of them.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
