### PR TITLE
crypto: fix public key encoding name in comment

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2746,7 +2746,7 @@ static ParsePublicKeyResult ParsePublicKeyPEM(EVPKeyPointer* pkey,
 
   ParsePublicKeyResult ret;
 
-  // Try PKCS#8 first.
+  // Try parsing as a SubjectPublicKeyInfo first.
   ret = TryParsePublicKey(pkey, bp, "PUBLIC KEY",
       [](const unsigned char** p, long l) {  // NOLINT(runtime/int)
         return d2i_PUBKEY(nullptr, p, l);


### PR DESCRIPTION
Crypto encodings can be so needlessly confusing... :-)

PKCS#8 describes an encoding for private keys, not public keys. Using
the name as a format usually refers to the PrivateKeyInfo structure it
defines. (Or sometimes the EncryptedPrivateKeyInfo variant or the
little-used OneAsymmetricKey extension defined in RFC 5958.) None of
these structures can hold public keys to begin with.

d2i_PUBKEY actually parses the public key analogous format defined in
X.509, SubjectPublicKeyInfo. This function already uses "X.509" to refer
to an entire certificate, so say SubjectPublicKeyInfo in the comment.

(The abbreviation SPKI sometimes refers to SubjectPublicKeyInfo, e.g. in
RFC 7469, but it can also an alternate S-expression-based PKI to X.509,
Simple Public Key Infrastructure. To avoid confusion, stick with the
expanded name.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
