### PR TITLE
process: simplify report uncaught exception logic

### DIFF
--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -105,19 +105,14 @@ function createFatalException() {
     if (er == null || er.domain == null) {
       try {
         const report = internalBinding('report');
-        if (report != null) {
-          if (require('internal/options').getOptionValue(
-            '--experimental-report')) {
-            const config = {};
-            report.syncConfig(config, false);
-            if (Array.isArray(config.events) &&
-                config.events.includes('exception')) {
-              if (er) {
-                report.onUnCaughtException(er.stack);
-              } else {
-                report.onUnCaughtException(undefined);
-              }
-            }
+        if (report != null &&
+            require('internal/options')
+              .getOptionValue('--experimental-report')) {
+          const config = {};
+          report.syncConfig(config, false);
+          if (Array.isArray(config.events) &&
+              config.events.includes('exception')) {
+            report.onUnCaughtException(er ? er.stack : undefined);
           }
         }
       } catch {}  // NOOP, node_report unavailable.


### PR DESCRIPTION
This commit combines two `if` statements into a single `if` statement.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
