### PR TITLE
doc: clarify socket and keepAliveTimeout interaction

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -901,6 +901,10 @@ also be accessed at `request.connection`.
 This event can also be explicitly emitted by users to inject connections
 into the HTTP server. In that case, any [`Duplex`][] stream can be passed.
 
+If `socket.setTimeout()` is called here, note that the timeout will
+be replaced with `server.keepAliveTimeout` when the socket has served
+a request (if `server.keepAliveTimeout` is non-zero).
+
 ### Event: 'request'
 <!-- YAML
 added: v0.1.0


### PR DESCRIPTION
doc: clarify socket and keepAliveTimeout interaction

Socket timeouts set using the `connection` event are replaced by
server.keepAliveTimeout when a response is handled.

Socket timeouts set in the `connection` event are replaced after a response is sent in the [`resOnFinish` handler](https://github.com/nodejs/node/blob/5571c0ddebe72e894e41bbee56c7165a55788288/lib/_http_server.js#L594)

```
server.on('connection', function(socket) {
  socket.setTimeout(60000);
});
```

In this case, the socket timeout is 60 seconds until a response is sent, at which point it becomes 5 seconds (the server.keepAliveTimeout default). This bit me when working with load balancers that maintain long-lived connections.

I have added a note to the `connection` event docs to the effect that is preferred to use `server.keepAliveTimeout`.

#### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)