### PR TITLE
lib: refactor ERR_SYNTHETIC

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1692,8 +1692,8 @@ length.
 <a id="ERR_SYNTHETIC"></a>
 #### ERR_SYNTHETIC
 
-An artificial error object used to capture call stack when diagnostic report
-is produced.
+An artificial error object used to capture the call stack for diagnostic
+reports.
 
 <a id="ERR_SYSTEM_ERROR"></a>
 ### ERR_SYSTEM_ERROR
@@ -2232,12 +2232,6 @@ size.
 
 This `Error` is thrown when a read is attempted on a TTY `WriteStream`,
 such as `process.stdout.on('data')`.
-
-<a id="ERR_SYNTHETIC"></a>
-#### ERR_SYNTHETIC
-
-An artifical error object used to capture call stack when diagnostic report
-is produced.
 
 
 [`'uncaughtException'`]: process.html#process_event_uncaughtexception

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -923,7 +923,7 @@ E('ERR_STREAM_UNSHIFT_AFTER_END_EVENT',
   'stream.unshift() after end event', Error);
 E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode', Error);
 E('ERR_STREAM_WRITE_AFTER_END', 'write after end', Error);
-E('ERR_SYNTHETIC', 'JavaScript Callstack: %s', Error);
+E('ERR_SYNTHETIC', 'JavaScript Callstack', Error);
 E('ERR_SYSTEM_ERROR', 'A system error occurred', SystemError);
 E('ERR_TLS_CERT_ALTNAME_INVALID',
   'Hostname/IP does not match certificate\'s altnames: %s', Error);

--- a/lib/internal/process/report.js
+++ b/lib/internal/process/report.js
@@ -101,13 +101,11 @@ exports.setup = function() {
       emitExperimentalWarning('report');
       if (err == null) {
         if (file == null) {
-          return nr.triggerReport(new ERR_SYNTHETIC(
-            'JavaScript Callstack').stack);
+          return nr.triggerReport(new ERR_SYNTHETIC().stack);
         }
         if (typeof file !== 'string')
           throw new ERR_INVALID_ARG_TYPE('file', 'String', file);
-        return nr.triggerReport(file, new ERR_SYNTHETIC(
-          'JavaScript Callstack').stack);
+        return nr.triggerReport(file, new ERR_SYNTHETIC().stack);
       }
       if (typeof err !== 'object')
         throw new ERR_INVALID_ARG_TYPE('err', 'Object', err);
@@ -120,7 +118,7 @@ exports.setup = function() {
     getReport(err) {
       emitExperimentalWarning('report');
       if (err == null) {
-        return nr.getReport(new ERR_SYNTHETIC('JavaScript Callstack').stack);
+        return nr.getReport(new ERR_SYNTHETIC().stack);
       } else if (typeof err !== 'object') {
         throw new ERR_INVALID_ARG_TYPE('err', 'Objct', err);
       } else {


### PR DESCRIPTION
- Tidy up description in docs.
- Remove a second definition in the docs.
- Remove unused string input parameter.
- Remove duplicate "JavaScript Callstack" in error messages.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
