### PR TITLE
report: use consistent format for dumpEventTime

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -247,7 +247,7 @@ static void WriteNodeReport(Isolate* isolate,
 #ifdef _WIN32
   snprintf(timebuf,
            sizeof(timebuf),
-           "%4d/%02d/%02d %02d:%02d:%02d",
+           "%4d-%02d-%02dT%02d:%02d:%02dZ",
            tm_struct->wYear,
            tm_struct->wMonth,
            tm_struct->wDay,


### PR DESCRIPTION
Use the same JS-compatible format on both POSIX and Windows.

Side note: It might be nice to wrap up all the different date-handling pieces of code in a single place, with a single mechanism and using some standardized format(s).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
