### PR TITLE
test: refactor test-http-client-timeout-option-with-agent

### DIFF
--- a/test/parallel/test-http-client-timeout-option-with-agent.js
+++ b/test/parallel/test-http-client-timeout-option-with-agent.js
@@ -30,8 +30,8 @@ server.listen(0, options.host, () => {
 
 function doRequest() {
   options.port = server.address().port;
+  const start = process.hrtime.bigint();
   const req = http.request(options);
-  const start = Date.now();
   req.on('error', () => {
     // This space is intentionally left blank.
   });
@@ -40,11 +40,11 @@ function doRequest() {
   let timeout_events = 0;
   req.on('timeout', common.mustCall(() => {
     timeout_events += 1;
-    const duration = Date.now() - start;
+    const duration = process.hrtime.bigint() - start;
     // The timeout event cannot be precisely timed. It will delay
     // some number of milliseconds.
     assert.ok(
-      duration >= HTTP_CLIENT_TIMEOUT,
+      duration >= BigInt(HTTP_CLIENT_TIMEOUT * 1e6),
       `duration ${duration}ms less than timeout ${HTTP_CLIENT_TIMEOUT}ms`
     );
   }));


### PR DESCRIPTION
* Switch from Date.now() to process.hrtime.bigint().
* Move start time recording to before the request is created, not after.

Fixes: https://github.com/nodejs/node/issues/25746

@devsnek @nodejs/http @nodejs/testing 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
