### PR TITLE
test: refactor test/common/report.js

### DIFF
--- a/test/common/report.js
+++ b/test/common/report.js
@@ -1,43 +1,39 @@
+/* eslint-disable node-core/required-modules */
 'use strict';
-require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const REPORT_SECTIONS = [ 'header',
-                          'javascriptStack',
-                          'nativeStack',
-                          'javascriptHeap',
-                          'libuv',
-                          'environmentVariables',
-                          'sharedObjects' ];
-
-let tmppath = '';
-
-exports.findReports = (pid, path) => {
+function findReports(pid, dir) {
   // Default filenames are of the form
   // report.<date>.<time>.<pid>.<seq>.json
-  tmppath = path;
   const format = '^report\\.\\d+\\.\\d+\\.' + pid + '\\.\\d+\\.json$';
   const filePattern = new RegExp(format);
-  const files = fs.readdirSync(path);
-  return files.filter((file) => filePattern.test(file));
-};
+  const files = fs.readdirSync(dir);
+  const results = [];
 
-exports.validate = (report, options) => {
-  const jtmp = path.join(tmppath, report);
-  fs.readFile(jtmp, (err, data) => {
-    this.validateContent(data, options);
+  files.forEach((file) => {
+    if (filePattern.test(file))
+      results.push(path.join(dir, file));
   });
-};
 
+  return results;
+}
 
-exports.validateContent = function validateContent(data, options) {
+function validate(report) {
+  const data = fs.readFileSync(report, 'utf8');
+
+  validateContent(data);
+}
+
+function validateContent(data) {
   const report = JSON.parse(data);
-  const comp = Object.keys(report);
 
-  // Check all sections are present
-  REPORT_SECTIONS.forEach((section) => {
-    assert.ok(comp.includes(section));
+  // Verify that all sections are present.
+  ['header', 'javascriptStack', 'nativeStack', 'javascriptHeap',
+   'libuv', 'environmentVariables', 'sharedObjects'].forEach((section) => {
+    assert(report.hasOwnProperty(section));
   });
-};
+}
+
+module.exports = { findReports, validate, validateContent };


### PR DESCRIPTION
- Don't unnecessarily `require('../common')`.
- Eliminate state maintained in `tmppath`.
- `validate()` was being used synchronously, but was actually asynchronous. Make it synchronous.
- Other misc. drive by cleanup.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
