### PR TITLE
test: move client renegotiation tests to parallel

### DIFF
--- a/test/parallel/test-tls-client-renegotiation-limit.js
+++ b/test/parallel/test-tls-client-renegotiation-limit.js
@@ -29,7 +29,6 @@ if (!common.opensslCli)
 
 const assert = require('assert');
 const tls = require('tls');
-const https = require('https');
 const fixtures = require('../common/fixtures');
 
 // renegotiation limits to test
@@ -48,61 +47,52 @@ const LIMITS = [0, 1, 2, 3, 5, 10, 16];
 function test(next) {
   const options = {
     cert: fixtures.readSync('test_cert.pem'),
-    key: fixtures.readSync('test_key.pem')
+    key: fixtures.readSync('test_key.pem'),
   };
 
-  const server = https.createServer(options, function(req, res) {
-    const conn = req.connection;
-    conn.on('error', function(err) {
+  const server = tls.createServer(options, (conn) => {
+    conn.on('error', (err) => {
       console.error(`Caught exception: ${err}`);
       assert(/TLS session renegotiation attack/.test(err));
       conn.destroy();
     });
-    res.end('ok');
+    conn.pipe(conn);
   });
 
-  server.listen(0, function() {
-    const agent = https.Agent({
-      keepAlive: true,
-    });
+  server.listen(0, () => {
+    const options = {
+      host: server.address().host,
+      port: server.address().port,
+      rejectUnauthorized: false,
+    };
+    const client = tls.connect(options, spam);
 
-    let client;
     let renegs = 0;
 
-    const options = {
-      rejectUnauthorized: false,
-      agent
-    };
-
-    const { port } = server.address();
-
-    https.get(`https://localhost:${port}/`, options, (res) => {
-      client = res.socket;
-
-      client.on('close', function(hadErr) {
-        assert.strictEqual(hadErr, false);
-        assert.strictEqual(renegs, tls.CLIENT_RENEG_LIMIT + 1);
-        server.close();
-        process.nextTick(next);
-      });
-
-      client.on('error', function(err) {
-        console.log('CLIENT ERR', err);
-        throw err;
-      });
-
-      spam();
-
-      // simulate renegotiation attack
-      function spam() {
-        client.renegotiate({}, (err) => {
-          assert.ifError(err);
-          assert.ok(renegs <= tls.CLIENT_RENEG_LIMIT);
-          setImmediate(spam);
-        });
-        renegs++;
-      }
+    client.on('close', () => {
+      assert.strictEqual(renegs, tls.CLIENT_RENEG_LIMIT + 1);
+      server.close();
+      process.nextTick(next);
     });
 
+    client.on('error', (err) => {
+      console.log('CLIENT ERR', err);
+      throw err;
+    });
+
+    client.on('close', (hadErr) => {
+      assert.strictEqual(hadErr, false);
+    });
+
+    // simulate renegotiation attack
+    function spam() {
+      client.write('');
+      client.renegotiate({}, (err) => {
+        assert.ifError(err);
+        assert.ok(renegs <= tls.CLIENT_RENEG_LIMIT);
+        spam();
+      });
+      renegs++;
+    }
   });
 }


### PR DESCRIPTION
* Move client renegotiation limit tests from pummel to parallel.
* Rename tests to more accurately reflect what they do.
* Refactor to use  arrow functions for anonymouse callbacks and to be
  consistent about trailing commas.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
