### PR TITLE
[v8.x-backport] build: skip cctest on Windows shared lib build

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -961,6 +961,10 @@
             'OTHER_LDFLAGS': [ '-Wl,-rpath,@loader_path', ],
           },
         }],
+        # Skip cctest while building shared lib node for Windows
+        [ 'OS=="win" and node_shared=="true"', {
+          'type': 'none',
+        }],
       ],
     }
   ], # end targets

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -474,6 +474,7 @@ if errorlevel 1 goto exit
 if "%test_args%"=="" goto test-v8
 if "%config%"=="Debug" set test_args=--mode=debug %test_args%
 if "%config%"=="Release" set test_args=--mode=release %test_args%
+if not exist %config%\cctest.exe goto run-test-py
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
 REM when building a static library there's no binary to run tests


### PR DESCRIPTION

Backport to resolve simple conflict and to ensure this change makes it into v8.x. 

cctest depends on some internal APIs which don't declare
`__declspec(dllexport)` and causes build failure when building
node as shared lib on Windows. Since we already have good test
coverage in static lib, we decide to skip the cctest in shared
lib build on Windows.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

PR-URL: https://github.com/nodejs/node/pull/21228
Reviewed-By: Refael Ackermann <refack@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
