### PR TITLE
src: make deleted functions public in node.h

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -653,14 +653,14 @@ class NODE_EXTERN CallbackScope {
                 async_context asyncContext);
   ~CallbackScope();
 
- private:
-  InternalCallbackScope* private_;
-  v8::TryCatch try_catch_;
-
   void operator=(const CallbackScope&) = delete;
   void operator=(CallbackScope&&) = delete;
   CallbackScope(const CallbackScope&) = delete;
   CallbackScope(CallbackScope&&) = delete;
+
+ private:
+  InternalCallbackScope* private_;
+  v8::TryCatch try_catch_;
 };
 
 /* An API specific to emit before/after callbacks is unnecessary because


### PR DESCRIPTION
Expert from Effective Modern C++ Items 11: Prefer deleted functions to private undefined ones
> By convention, deleted functions are declared public, not private. There’s a reason for that. When client code tries to use a member function, C++ checks accessibility before deleted status. When client code tries to use a deleted private function, some compilers complain only about the function being private, even though the function’s accessibility doesn’t really affect whether it can be used. It’s worth bearing this in mind when revising legacy code to replace private-and-not-defined member functions with deleted ones, because making the new functions public will generally result in better error messages.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
