### PR TITLE
build: update prerequisites on progress towards Python 3

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -166,8 +166,8 @@ explains how to install all prerequisites.
 * `clang` and `clang++` 3.4.2 or newer (macOS: latest Xcode Command Line Tools)
 * Python 2.6 or 2.7
     * Python 2.6 reached its end of life in 2013 so its use is discouraged.
-    * Python 2.7 reaches its end of life at the end of 2019 so a transition to Python 3 is underway
-    * Python 3.5, 3.6, and 3.7 are intended to be supported in the near future
+    * Python 2.7 end of life is in 2019 so a transition to Python 3 is underway.
+    * Python 3.5, 3.6, and 3.7 are intended to be supported in the near future.
 * GNU Make 3.81 or newer
 
 On macOS, install the `Xcode Command Line Tools` by running
@@ -196,7 +196,7 @@ may reduce build time. For more information, see the
 [GNU Make Documentation](https://www.gnu.org/software/make/manual/html_node/Parallel.html).
 
 Note that the above requires that `python` resolve to Python 2.6 or 2.7
-and not a newer version.  See the above notes on __Prerequisites__.
+and not a newer version.  See the above notes on **Prerequisites**.
 
 After building, setting up [firewall rules](tools/macos-firewall.sh) can avoid
 popups asking to accept incoming network connections when running tests.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -167,7 +167,7 @@ explains how to install all prerequisites.
 * Python 2.6 or 2.7
     * Python 2.6 reached its end of life in 2013 so its use is discouraged.
     * Python 2.7 reaches its end of life at the end of 2019 so a transition to Python 3 is underway
-    * Python 3.5, 3.6, nad 3.7 are intended to be supported in the near future
+    * Python 3.5, 3.6, and 3.7 are intended to be supported in the near future
 * GNU Make 3.81 or newer
 
 On macOS, install the `Xcode Command Line Tools` by running

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -196,7 +196,7 @@ may reduce build time. For more information, see the
 [GNU Make Documentation](https://www.gnu.org/software/make/manual/html_node/Parallel.html).
 
 Note that the above requires that `python` resolve to Python 2.6 or 2.7
-and not a newer version.  See the above notes on **Prerequisites**.
+and not a newer version.  See [Prerequisites](#prerequisites).
 
 After building, setting up [firewall rules](tools/macos-firewall.sh) can avoid
 popups asking to accept incoming network connections when running tests.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -165,6 +165,9 @@ explains how to install all prerequisites.
 * `gcc` and `g++` 4.9.4 or newer, or
 * `clang` and `clang++` 3.4.2 or newer (macOS: latest Xcode Command Line Tools)
 * Python 2.6 or 2.7
+    * Python 2.6 reached its end of life in 2013 so its use is discouraged.
+    * Python 2.7 reaches its end of life at the end of 2019 so a transition to Python 3 is underway
+    * Python 3.5, 3.6, nad 3.7 are intended to be supported in the near future
 * GNU Make 3.81 or newer
 
 On macOS, install the `Xcode Command Line Tools` by running
@@ -193,7 +196,7 @@ may reduce build time. For more information, see the
 [GNU Make Documentation](https://www.gnu.org/software/make/manual/html_node/Parallel.html).
 
 Note that the above requires that `python` resolve to Python 2.6 or 2.7
-and not a newer version.
+and not a newer version.  See the above notes on __Prerequisites__.
 
 After building, setting up [firewall rules](tools/macos-firewall.sh) can avoid
 popups asking to accept incoming network connections when running tests.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -164,10 +164,9 @@ explains how to install all prerequisites.
 
 * `gcc` and `g++` 4.9.4 or newer, or
 * `clang` and `clang++` 3.4.2 or newer (macOS: latest Xcode Command Line Tools)
-* Python 2.6 or 2.7
-    * Python 2.6 reached its end of life in 2013 so its use is discouraged.
+* Python 2.7
     * Python 2.7 end of life is in 2019 so a transition to Python 3 is underway.
-    * Python 3.5, 3.6, and 3.7 are intended to be supported in the near future.
+    * Python 3.5, 3.6, and 3.7 are experimental.
 * GNU Make 3.81 or newer
 
 On macOS, install the `Xcode Command Line Tools` by running
@@ -195,8 +194,8 @@ The `-j4` option will cause `make` to run 4 simultaneous compilation jobs which
 may reduce build time. For more information, see the
 [GNU Make Documentation](https://www.gnu.org/software/make/manual/html_node/Parallel.html).
 
-Note that the above requires that `python` resolve to Python 2.6 or 2.7
-and not a newer version.  See [Prerequisites](#prerequisites).
+Note that the above requires that `python` resolve to Python 2.7 and not a newer
+version.  See [Prerequisites](#prerequisites).
 
 After building, setting up [firewall rules](tools/macos-firewall.sh) can avoid
 popups asking to accept incoming network connections when running tests.
@@ -403,7 +402,7 @@ $ backtrace
 
 Prerequisites:
 
-* [Python 2.6 or 2.7](https://www.python.org/downloads/)
+* [Python 2.7](https://www.python.org/downloads/)
 * The "Desktop development with C++" workload from
   [Visual Studio 2017](https://www.visualstudio.com/downloads/) or the
   "Visual C++ build tools" workload from the


### PR DESCRIPTION
As recommended at https://github.com/nodejs/node/pull/25759#issuecomment-458139766
* Python 2.6 end of life statement in 2013: https://www.python.org/dev/peps/pep-0361/#release-lifespan
* Python 2.7 end of life statement in 2019: https://www.python.org/dev/peps/pep-0373/#update
* Python 3.4 reaches it end of life in < 50 days so it should not be a target: https://devguide.python.org/#branchstatus

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
