### PR TITLE
module: do not use process.exit()

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -60,14 +60,12 @@ module.exports = Module;
 let asyncESM;
 let ModuleJob;
 let createDynamicModule;
-let decorateErrorStack;
 
 function lazyLoadESM() {
   asyncESM = require('internal/process/esm_loader');
   ModuleJob = require('internal/modules/esm/module_job');
   createDynamicModule = require(
     'internal/modules/esm/create_dynamic_module');
-  decorateErrorStack = require('internal/util').decorateErrorStack;
 }
 
 const {
@@ -794,13 +792,7 @@ Module.runMain = function() {
       return loader.import(pathToFileURL(process.argv[1]).pathname);
     })
     .catch((e) => {
-      // TODO(addaleax): This should, ideally, trigger a fatal exception
-      // instead. That should alread be doable for code in core now, but it's
-      // probably easier to wait until something like
-      // https://github.com/nodejs/node/pull/25715 lands?
-      decorateErrorStack(e);
-      console.error(e);
-      process.exitCode = 1;
+      internalBinding('util').triggerFatalException(e);
     });
   } else {
     Module._load(process.argv[1], null, true);

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -794,9 +794,13 @@ Module.runMain = function() {
       return loader.import(pathToFileURL(process.argv[1]).pathname);
     })
     .catch((e) => {
+      // TODO(addaleax): This should, ideally, trigger a fatal exception
+      // instead. That should alread be doable for code in core now, but it's
+      // probably easier to wait until something like
+      // https://github.com/nodejs/node/pull/25715 lands?
       decorateErrorStack(e);
       console.error(e);
-      process.exit(1);
+      process.exitCode = 1;
     });
   } else {
     Module._load(process.argv[1], null, true);

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -6,6 +6,8 @@ const { decorateErrorStack } = require('internal/util');
 const assert = require('assert');
 const resolvedPromise = SafePromise.resolve();
 
+function noop() {}
+
 /* A ModuleJob tracks the loading of a single Module, and the ModuleJobs of
  * its dependencies, over time. */
 class ModuleJob {
@@ -41,6 +43,9 @@ class ModuleJob {
     };
     // Promise for the list of all dependencyJobs.
     this.linked = link();
+    // This promise is awaited later anyway, so silence
+    // 'unhandled rejection' warnings.
+    this.linked.catch(noop);
 
     // instantiated == deep dependency jobs wrappers instantiated,
     // module wrapper instantiated

--- a/test/parallel/test-worker-esm-missing-main.js
+++ b/test/parallel/test-worker-esm-missing-main.js
@@ -5,13 +5,9 @@ const { Worker } = require('worker_threads');
 
 const worker = new Worker('./does-not-exist.js', {
   execArgv: ['--experimental-modules'],
-  stderr: true
 });
 
-let stderr = '';
-worker.stderr.setEncoding('utf8');
-worker.stderr.on('data', (chunk) => stderr += chunk);
-worker.stderr.on('end', common.mustCall(() => {
+worker.on('error', common.mustCall((err) => {
   // eslint-disable-next-line node-core/no-unescaped-regexp-dot
-  assert(/Cannot find module .+does-not-exist.js/.test(stderr), stderr);
+  assert(/Cannot find module .+does-not-exist.js/.test(err.message), err);
 }));

--- a/test/parallel/test-worker-esm-missing-main.js
+++ b/test/parallel/test-worker-esm-missing-main.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+const worker = new Worker('./does-not-exist.js', {
+  execArgv: ['--experimental-modules'],
+  stderr: true
+});
+
+let stderr = '';
+worker.stderr.setEncoding('utf8');
+worker.stderr.on('data', (chunk) => stderr += chunk);
+worker.stderr.on('end', common.mustCall(() => {
+  // eslint-disable-next-line node-core/no-unescaped-regexp-dot
+  assert(/Cannot find module .+does-not-exist.js/.test(stderr), stderr);
+}));


### PR DESCRIPTION
**module: silence ModuleJob unhandled rejection warnings**

This could otherwise print unhandled rejection warnings
if the process does not exit immediately inside an earlier
`.catch()` handler.

**module: do not use `process.exit()`**

Inside workers, using stdio is always asynchronous, so using
`process.exit()` always interrupts sending of messages to the
parent thread, including error messages presented over stdio.

Do not use `process.exit()` and instead ~~use the cleaner
`process.exitCode` directly~~ trigger a “real” uncaught exception.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
