### PR TITLE
src: add handle scope to `OnFatalError()`

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -319,6 +319,7 @@ void OnFatalError(const char* location, const char* message) {
   }
 #ifdef NODE_REPORT
   Isolate* isolate = Isolate::GetCurrent();
+  HandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
   if (env != nullptr) {
     std::shared_ptr<PerIsolateOptions> options = env->isolate_data()->options();


### PR DESCRIPTION
For the report generation, we use `Environment::GetCurrent(isolate)`
which uses `isolate->GetCurrentContext()` under the hood, thus
allocates a handle. Without a `HandleScope`, this is invalid.

This might not strictly be allowed inside of `OnFatalError()`,
but it won’t make anything worse either.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
