### PR TITLE
doc: remove outdated COLLABORATOR_GUIDE sentence about breaking changes

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -282,7 +282,6 @@ providing a Public API in such cases.
   * Resolving critical security issues.
   * Fixing a critical bug (e.g. fixing a memory leak) requires a breaking
     change.
-  * There is TSC consensus that the change is required.
 * If a breaking commit does accidentally land in a Current or LTS branch, an
   attempt to fix the issue will be made before the next release; If no fix is
   provided then the commit will be reverted.


### PR DESCRIPTION
The TSC has delegated authority over LTS and Current branches to the
Release WG. Remove the bullet point about TSC having authority to
determine that a breaking change is necessary on LTS and Current release
branches. Retaining that authority would require de-chartering the
Release WG.

Fixes: https://github.com/nodejs/TSC/issues/660

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
