### PR TITLE
src: removed unused env_ field from env.h

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -517,8 +517,6 @@ class Environment {
     inline AsyncHooks();
     // Keep a list of all Persistent strings used for Provider types.
     v8::Eternal<v8::String> providers_[AsyncWrap::PROVIDERS_LENGTH];
-    // Keep track of the environment copy itself.
-    Environment* env_;
     // Stores the ids of the current execution context stack.
     AliasedBuffer<double, v8::Float64Array> async_ids_stack_;
     // Attached to a Uint32Array that tracks the number of active hooks for


### PR DESCRIPTION
Currently the following compiler warnings is generated:
```console
In file included from ../src/env-inl.h:28:
../src/env.h:521:18:
warning: private field 'env_' is not used [-Wunused-private-field]
    Environment* env_;
                 ^
1 warning generated.
```
This commit removes this unused field.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
