### PR TITLE
doc: add documentation for request.path

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -638,7 +638,7 @@ Limits maximum response headers count. If set to 0, no limit will be applied.
 added: v0.3.6
 -->
 
-* {string} The request path. Read only.
+* {string} The request path. Read-only.
 
 ### request.removeHeader(name)
 <!-- YAML

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -633,6 +633,13 @@ const cookie = request.getHeader('Cookie');
 
 Limits maximum response headers count. If set to 0, no limit will be applied.
 
+### request.path
+<!-- YAML
+added: v0.3.6
+-->
+
+* {string} The request path. Read only.
+
 ### request.removeHeader(name)
 <!-- YAML
 added: v1.6.0

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -635,7 +635,7 @@ Limits maximum response headers count. If set to 0, no limit will be applied.
 
 ### request.path
 <!-- YAML
-added: v0.3.6
+added: v0.4.0
 -->
 
 * {string} The request path. Read-only.


### PR DESCRIPTION
The field has been added in v0.4.0.

Refs: https://github.com/nodejs/node/commit/b09c5889bee8388a6710ecf75d76ca242e0684bd#diff-1c0f1c434b17b7f8795d44a51a14320aR814
Refs: [/test/parallel/test-http-client-defaults.js](https://github.com/nodejs/node/blob/380929ec0c4c4004b522bed5e3800ebce2b68bfd/test/parallel/test-http-client-defaults.js)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

I ran `make -j4 test` on macOS. But I got the message below:

```
=== release test-fs-stat-bigint ===                                           
Path: parallel/test-fs-stat-bigint
(node:95776) ExperimentalWarning: The fs.promises API is experimental
assert.js:351
    throw err;
    ^

AssertionError [ERR_ASSERTION]: atimeMs is not a safe integer, difference should < 1.
Number version 1548759595527.3901, BigInt version 1548759595525n
    at verifyStats (/Users/itok/node/test/parallel/test-fs-stat-bigint.js:72:7)
    at fs.stat (/Users/itok/node/test/parallel/test-fs-stat-bigint.js:109:7)
    at FSReqCallback.oncomplete (fs.js:160:5)
Command: out/Release/node /Users/itok/node/test/parallel/test-fs-stat-bigint.js
[04:35|% 100|+ 2518|-   1]: Done
make[1]: *** [jstest] Error 1
make: *** [test] Error 2
```