### PR TITLE
src: remove unused method in js_stream.h

### DIFF
--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -41,12 +41,6 @@ class JSStream : public AsyncWrap, public StreamBase {
   static void ReadBuffer(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void EmitEOF(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  static void OnAllocImpl(size_t size, uv_buf_t* buf, void* ctx);
-  static void OnReadImpl(ssize_t nread,
-                         const uv_buf_t* buf,
-                         uv_handle_type pending,
-                         void* ctx);
-
   template <class Wrap>
   static void Finish(const v8::FunctionCallbackInfo<v8::Value>& args);
 };


### PR DESCRIPTION
not used anymore after this patch: https://github.com/nodejs/node/commit/7c4b09b24bbe7d6a8cbad256f47b30a101a909ea.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
