### PR TITLE
src: remove unused AsyncResource constructor in node.h

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -710,16 +710,6 @@ class AsyncResource {
                                    trigger_async_id);
   }
 
-  AsyncResource(v8::Isolate* isolate,
-                v8::Local<v8::Object> resource,
-                v8::Local<v8::String> name,
-                async_id trigger_async_id = -1)
-      : isolate_(isolate),
-        resource_(isolate, resource) {
-    async_context_ = EmitAsyncInit(isolate, resource, name,
-                                   trigger_async_id);
-  }
-
   virtual ~AsyncResource() {
     EmitAsyncDestroy(isolate_, async_context_);
     resource_.Reset();


### PR DESCRIPTION
The AsyncResource has two constructors. The removed constructor is not used anymore. Also the other constructor can easily replace the removed one.
The diff is one used `const char* name`, the removed one use `v8::Local<v8::String> name`.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
