### PR TITLE
tools: add test-all-suites to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -462,7 +462,7 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=debug,release --valgrind
 
 .PHONY: test-all-suites
-test-all-suites: | bench-addons-build ## Run all test suites.
+test-all-suites: test-build test-js-native-api test-node-api | bench-addons-build ## Run all test suites.
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) test/*
 
 CI_NATIVE_SUITES ?= addons js-native-api node-api

--- a/Makefile
+++ b/Makefile
@@ -461,6 +461,10 @@ test-all: test-build ## Run everything in test/.
 test-all-valgrind: test-build
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=debug,release --valgrind
 
+.PHONY: test-all-suites
+test-all-suites: | bench-addons-build
+	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) test/*
+
 CI_NATIVE_SUITES ?= addons js-native-api node-api
 CI_JS_SUITES ?= default
 CI_DOC := doctool

--- a/Makefile
+++ b/Makefile
@@ -455,14 +455,14 @@ test-build-js-native-api: all build-js-native-api-tests
 test-build-node-api: all build-node-api-tests
 
 .PHONY: test-all
-test-all: test-build ## Run everything in test/.
+test-all: test-build ## Run default tests with both Debug and Release builds.
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=debug,release
 
 test-all-valgrind: test-build
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=debug,release --valgrind
 
 .PHONY: test-all-suites
-test-all-suites: | bench-addons-build
+test-all-suites: | bench-addons-build ## Run all test suites.
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) test/*
 
 CI_NATIVE_SUITES ?= addons js-native-api node-api


### PR DESCRIPTION
There is currently no Makefile target that runs every test suite. This
adds one.

Didn't add it to `vcbuild.bat` because I'm not sure if `*` wildcard works the same way on Windows or not and I don't have Windows to test. Apparently 26 of the 46 targets in `Makefile` do not exist in `vcbuild.bat` so I suppose this is not a deal-breaker. But we can open a separate issue (and label it `good-first-contribution`) to have this added to `vcbuild.bat`. Or someone can add a commit to this branch to add it if they have Windows and can test their implementation. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
