### PR TITLE
benchmark: refactor _http-benchmarkers.js

### DIFF
--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -25,7 +25,7 @@ class AutocannonBenchmarker {
       '-c', options.connections,
       '-j',
       '-n',
-      `http://127.0.0.1:${options.port}${options.path}`
+      `http://127.0.0.1:${options.port}${options.path}`,
     ];
     const child = child_process.spawn(this.executable, args);
     return child;
@@ -59,7 +59,7 @@ class WrkBenchmarker {
       '-d', options.duration,
       '-c', options.connections,
       '-t', 8,
-      `http://127.0.0.1:${options.port}${options.path}`
+      `http://127.0.0.1:${options.port}${options.path}`,
     ];
     const child = child_process.spawn(this.executable, args);
     return child;
@@ -170,7 +170,7 @@ const http_benchmarkers = [
   new AutocannonBenchmarker(),
   new TestDoubleBenchmarker('http'),
   new TestDoubleBenchmarker('http2'),
-  new H2LoadBenchmarker()
+  new H2LoadBenchmarker(),
 ];
 
 const benchmarkers = {};
@@ -188,7 +188,7 @@ exports.run = function(options, callback) {
     path: '/',
     connections: 100,
     duration: 5,
-    benchmarker: exports.default_http_benchmarker
+    benchmarker: exports.default_http_benchmarker,
   }, options);
   if (!options.benchmarker) {
     callback(new Error('Could not locate required http benchmarker. See ' +
@@ -216,7 +216,7 @@ exports.run = function(options, callback) {
   let stdout = '';
   child.stdout.on('data', (chunk) => stdout += chunk.toString());
 
-  child.once('close', function(code) {
+  child.once('close', (code) => {
     const elapsed = process.hrtime(benchmarker_start);
     if (code) {
       let error_message = `${options.benchmarker} failed with ${code}.`;


### PR DESCRIPTION
Refactor _http-benchmarkers.js:

* The file used a mixture of inline callbacks with the `function`
  keyword and arrow functions. Use arrow functions for consistency.
* The file used a mixture of trailing commas and no trailing commas. Use
  trailing commas for consistency.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
