### PR TITLE
test: add hasCrypto to worker-cleanexit-with-moduleload

### DIFF
--- a/test/parallel/test-worker-cleanexit-with-moduleload.js
+++ b/test/parallel/test-worker-cleanexit-with-moduleload.js
@@ -1,5 +1,7 @@
 'use strict';
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 // Harden the thread interactions on the exit path.
 // Ensure workers are able to bail out safe at

--- a/test/parallel/test-worker-cleanexit-with-moduleload.js
+++ b/test/parallel/test-worker-cleanexit-with-moduleload.js
@@ -1,7 +1,5 @@
 'use strict';
 const common = require('../common');
-if (!common.hasCrypto)
-  common.skip('missing crypto');
 
 // Harden the thread interactions on the exit path.
 // Ensure workers are able to bail out safe at
@@ -11,10 +9,15 @@ if (!common.hasCrypto)
 // preferrably in the C++ land.
 
 const { Worker } = require('worker_threads');
+const modules = [ 'fs', 'assert', 'async_hooks', 'buffer', 'child_process',
+  'net', 'http', 'os', 'path', 'v8', 'vm'
+];
+if (common.hasCrypto) {
+  modules.push('https');
+}
+
 for (let i = 0; i < 10; i++) {
-  new Worker("const modules = ['fs', 'assert', 'async_hooks'," +
-    "'buffer', 'child_process', 'net', 'http', 'https', 'os'," +
-    "'path', 'v8', 'vm'];" +
+  new Worker(`const modules = [${modules.map(m => `'${m}'`)}];` +
     'modules.forEach((module) => {' +
     'const m = require(module);' +
     '});', { eval: true });

--- a/test/parallel/test-worker-cleanexit-with-moduleload.js
+++ b/test/parallel/test-worker-cleanexit-with-moduleload.js
@@ -10,14 +10,14 @@ const common = require('../common');
 
 const { Worker } = require('worker_threads');
 const modules = [ 'fs', 'assert', 'async_hooks', 'buffer', 'child_process',
-  'net', 'http', 'os', 'path', 'v8', 'vm'
+                  'net', 'http', 'os', 'path', 'v8', 'vm'
 ];
 if (common.hasCrypto) {
   modules.push('https');
 }
 
 for (let i = 0; i < 10; i++) {
-  new Worker(`const modules = [${modules.map(m => `'${m}'`)}];` +
+  new Worker(`const modules = [${modules.map((m) => `'${m}'`)}];` +
     'modules.forEach((module) => {' +
     'const m = require(module);' +
     '});', { eval: true });


### PR DESCRIPTION
Currently, this test fails when configured `--without-ssl`:
```console
=== release test-worker-cleanexit-with-moduleload ===
Path: parallel/test-worker-cleanexit-with-moduleload
events.js:173
      throw er; // Unhandled 'error' event
      ^
internal/util.js:101
    throw new ERR_NO_CRYPTO();
    ^

Error [ERR_NO_CRYPTO]:
Node.js is not compiled with OpenSSL crypto support
```
This commit as a check for crypto so that this test is skipped if there
is no crypto support.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
