### PR TITLE
worker: throw for duplicates in transfer list

### DIFF
--- a/test/parallel/test-worker-message-port-transfer-duplicate.js
+++ b/test/parallel/test-worker-message-port-transfer-duplicate.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { MessageChannel } = require('worker_threads');
+
+// Test that passing duplicate transferrables in the transfer list throws
+// DataCloneError exceptions.
+
+{
+  const { port1, port2 } = new MessageChannel();
+  port2.once('message', common.mustNotCall());
+
+  const port3 = new MessageChannel().port1;
+  assert.throws(() => {
+    port1.postMessage(port3, [port3, port3]);
+  }, /^DataCloneError: Transfer list contains duplicate MessagePort$/);
+  port1.close();
+}
+
+{
+  const { port1, port2 } = new MessageChannel();
+  port2.once('message', common.mustNotCall());
+
+  const buf = new Uint8Array(10);
+  assert.throws(() => {
+    port1.postMessage(buf, [buf.buffer, buf.buffer]);
+  }, /^DataCloneError: Transfer list contains duplicate ArrayBuffer$/);
+  port1.close();
+}


### PR DESCRIPTION
Throw a `DataCloneError` exception when encountering duplicate
`ArrayBuffer`s or `MessagePort`s in the transfer list.

Fixes: https://github.com/nodejs/node/issues/25786

(Fyi @chjj)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
