### PR TITLE
process: expose process.features.inspector

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -268,12 +268,13 @@ process.assert = deprecate(
 
 // TODO(joyeecheung): this property has not been well-maintained, should we
 // deprecate it in favor of a better API?
-const { isDebugBuild, hasOpenSSL } = config;
+const { isDebugBuild, hasOpenSSL, hasInspector } = config;
 Object.defineProperty(process, 'features', {
   enumerable: true,
   writable: false,
   configurable: false,
   value: {
+    inspector: hasInspector,
     debug: isDebugBuild,
     uv: true,
     ipv6: true,  // TODO(bnoordhuis) ping libuv

--- a/lib/internal/util/inspector.js
+++ b/lib/internal/util/inspector.js
@@ -3,8 +3,8 @@
 let session;
 function sendInspectorCommand(cb, onError) {
   const { hasInspector } = internalBinding('config');
-  const inspector = hasInspector ? require('inspector') : undefined;
   if (!hasInspector) return onError();
+  const inspector = require('inspector');
   if (session === undefined) session = new inspector.Session();
   try {
     session.connect();

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -57,17 +57,17 @@ static void Initialize(Local<Object> target,
   READONLY_TRUE_PROPERTY(target, "hasTracing");
 #endif
 
-#if HAVE_INSPECTOR
-  READONLY_TRUE_PROPERTY(target, "hasInspector");
-#else
-  READONLY_FALSE_PROPERTY(target, "hasInspector");
-#endif
-
 #if !defined(NODE_WITHOUT_NODE_OPTIONS)
   READONLY_TRUE_PROPERTY(target, "hasNodeOptions");
 #endif
 
 #endif  // NODE_HAVE_I18N_SUPPORT
+
+#if HAVE_INSPECTOR
+  READONLY_TRUE_PROPERTY(target, "hasInspector");
+#else
+  READONLY_FALSE_PROPERTY(target, "hasInspector");
+#endif
 
   if (env->abort_on_uncaught_exception())
     READONLY_TRUE_PROPERTY(target, "shouldAbortOnUncaughtException");

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -80,8 +80,7 @@ if (process.argv.length === 2 &&
           hasCrypto &&
           // If the binary is build without `intl` the inspect option is
           // invalid. The test itself should handle this case.
-          (process.config.variables.v8_enable_inspector !== 0 ||
-            !flag.startsWith('--inspect'))) {
+          (process.features.inspector || !flag.startsWith('--inspect'))) {
         throw new Error(`Test has to be started with the flag: '${flag}'`);
       }
     }
@@ -618,8 +617,14 @@ function expectsError(fn, settings, exact) {
 }
 
 function skipIfInspectorDisabled() {
-  if (process.config.variables.v8_enable_inspector === 0) {
+  if (!process.features.inspector) {
     skip('V8 inspector is disabled');
+  }
+}
+
+function skipIfInspectorEnabled() {
+  if (process.features.inspector) {
+    skip('V8 inspector is enabled');
   }
 }
 
@@ -754,6 +759,7 @@ module.exports = {
   skipIf32Bits,
   skipIfEslintMissing,
   skipIfInspectorDisabled,
+  skipIfInspectorEnabled,
   skipIfReportDisabled,
   skipIfWorker,
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -622,12 +622,6 @@ function skipIfInspectorDisabled() {
   }
 }
 
-function skipIfInspectorEnabled() {
-  if (process.features.inspector) {
-    skip('V8 inspector is enabled');
-  }
-}
-
 function skipIfReportDisabled() {
   if (!process.config.variables.node_report) {
     skip('Node Report is disabled');
@@ -759,7 +753,6 @@ module.exports = {
   skipIf32Bits,
   skipIfEslintMissing,
   skipIfInspectorDisabled,
-  skipIfInspectorEnabled,
   skipIfReportDisabled,
   skipIfWorker,
 

--- a/test/known_issues/test-inspector-cluster-port-clash.js
+++ b/test/known_issues/test-inspector-cluster-port-clash.js
@@ -13,7 +13,7 @@ const assert = require('assert');
 
 // This following check should be replaced by common.skipIfInspectorDisabled()
 // if moved out of the known_issues directory.
-if (process.config.variables.v8_enable_inspector === 0) {
+if (!process.features.inspector) {
   // When the V8 inspector is disabled, using either --without-inspector or
   // --without-ssl, this test will not fail which it is expected to do.
   // The following fail will allow this test to be skipped by failing it.

--- a/test/parallel/test-cli-bad-options.js
+++ b/test/parallel/test-cli-bad-options.js
@@ -6,7 +6,7 @@ require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawnSync;
 
-if (process.config.variables.v8_enable_inspector === 1) {
+if (process.features.inspector) {
   requiresArgument('--inspect-port');
   requiresArgument('--inspect-port=');
   requiresArgument('--debug-port');

--- a/test/parallel/test-cli-node-print-help.js
+++ b/test/parallel/test-cli-node-print-help.js
@@ -22,10 +22,9 @@ function startPrintHelpTest() {
 }
 
 function validateNodePrintHelp() {
-  const config = process.config;
   const HAVE_OPENSSL = common.hasCrypto;
   const NODE_HAVE_I18N_SUPPORT = common.hasIntl;
-  const HAVE_INSPECTOR = config.variables.v8_enable_inspector === 1;
+  const HAVE_INSPECTOR = process.features.inspector;
 
   const cliHelpOptions = [
     { compileConstant: HAVE_OPENSSL,

--- a/test/parallel/test-module-cjs-helpers.js
+++ b/test/parallel/test-module-cjs-helpers.js
@@ -5,7 +5,5 @@ require('../common');
 const assert = require('assert');
 const { builtinLibs } = require('internal/modules/cjs/helpers');
 
-const hasInspector = process.config.variables.v8_enable_inspector === 1;
-
-const expectedLibs = hasInspector ? 34 : 33;
+const expectedLibs = process.features.inspector ? 34 : 33;
 assert.strictEqual(builtinLibs.length, expectedLibs);

--- a/test/parallel/test-process-env-allowed-flags.js
+++ b/test/parallel/test-process-env-allowed-flags.js
@@ -16,7 +16,7 @@ require('../common');
     'r',
     '--stack-trace-limit=100',
     '--stack-trace-limit=-=xX_nodejs_Xx=-',
-  ].concat(process.config.variables.v8_enable_inspector ? [
+  ].concat(process.features.inspector ? [
     '--inspect-brk',
     'inspect-brk',
     '--inspect_brk',

--- a/test/parallel/test-process-features.js
+++ b/test/parallel/test-process-features.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const keys = new Set(Object.keys(process.features));
 
 assert.deepStrictEqual(keys, new Set([
+  'inspector',
   'debug',
   'uv',
   'ipv6',

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -29,7 +29,7 @@ const {
 } = require('../common/hijackstdio');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
-const hasInspector = process.config.variables.v8_enable_inspector === 1;
+const hasInspector = process.features.inspector;
 
 if (!common.isMainThread)
   common.skip('process.chdir is not available in Workers');

--- a/test/parallel/test-v8-coverage.js
+++ b/test/parallel/test-v8-coverage.js
@@ -1,6 +1,6 @@
 'use strict';
 
-if (!process.config.variables.v8_enable_inspector) return;
+if (!process.features.inspector) return;
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -289,8 +289,7 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
   testInitialized(req, 'SendWrap');
 }
 
-if (process.config.variables.v8_enable_inspector !== 0 &&
-    common.isMainThread) {
+if (process.features.inspector && common.isMainThread) {
   const binding = internalBinding('inspector');
   const handle = new binding.Connection(() => {});
   testInitialized(handle, 'Connection');

--- a/test/sequential/test-inspector-has-inspector-false.js
+++ b/test/sequential/test-inspector-has-inspector-false.js
@@ -3,7 +3,9 @@
 
 const common = require('../common');
 
-common.skipIfInspectorEnabled();
+if (process.features.inspector) {
+  common.skip('V8 inspector is enabled');
+}
 
 const inspector = require('internal/util/inspector');
 

--- a/test/sequential/test-inspector-has-inspector-false.js
+++ b/test/sequential/test-inspector-has-inspector-false.js
@@ -3,10 +3,8 @@
 
 const common = require('../common');
 
-// This is to ensure that the sendInspectorCommand function calls the error
-// function if its called with the v8_enable_inspector is disabled
+common.skipIfInspectorEnabled();
 
-process.config.variables.v8_enable_inspector = 0;
 const inspector = require('internal/util/inspector');
 
 inspector.sendInspectorCommand(

--- a/tools/test.py
+++ b/tools/test.py
@@ -1654,7 +1654,7 @@ def Main():
   # We want to skip the inspector tests if node was built without the inspector.
   has_inspector = Execute([vm,
       '-p', 'process.features.inspector'], context)
-   if has_inspector.stdout.rstrip() == 'false':
+  if has_inspector.stdout.rstrip() == 'false':
     context.v8_enable_inspector = False
 
   has_crypto = Execute([vm,

--- a/tools/test.py
+++ b/tools/test.py
@@ -1654,7 +1654,7 @@ def Main():
   # We want to skip the inspector tests if node was built without the inspector.
   has_inspector = Execute([vm,
       '-p', 'process.features.inspector'], context)
-  if has_inspector.stdout.rstrip() == '0':
+   if has_inspector.stdout.rstrip() == 'false':
     context.v8_enable_inspector = False
 
   has_crypto = Execute([vm,

--- a/tools/test.py
+++ b/tools/test.py
@@ -1653,7 +1653,7 @@ def Main():
 
   # We want to skip the inspector tests if node was built without the inspector.
   has_inspector = Execute([vm,
-      '-p', 'process.config.variables.v8_enable_inspector'], context)
+      '-p', 'process.features.inspector'], context)
   if has_inspector.stdout.rstrip() == '0':
     context.v8_enable_inspector = False
 


### PR DESCRIPTION
Instead of using process.config.variables.v8_enable_inspector
to detect whether inspector is enabled in the build.

Refs: https://github.com/nodejs/node/issues/25343

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
