### PR TITLE
src: use nullptr in node_buffer.cc

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -99,7 +99,7 @@ class CallbackInfo {
                                   Local<ArrayBuffer> object,
                                   FreeCallback callback,
                                   char* data,
-                                  void* hint = 0);
+                                  void* hint = nullptr);
  private:
   static void WeakCallback(const WeakCallbackInfo<CallbackInfo>&);
   inline void WeakCallback(Isolate* isolate);


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
