### PR TITLE
process: move deprecation warning initialization into pre_execution.js

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -229,29 +229,6 @@ Object.defineProperty(process, 'argv0', {
 });
 process.argv[0] = process.execPath;
 
-const { deprecate } = NativeModule.require('internal/util');
-{
-  // Install legacy getters on the `util` binding for typechecking.
-  // TODO(addaleax): Turn into a full runtime deprecation.
-  const pendingDeprecation = getOptionValue('--pending-deprecation');
-  const utilBinding = internalBinding('util');
-  const types = NativeModule.require('internal/util/types');
-  for (const name of [
-    'isArrayBuffer', 'isArrayBufferView', 'isAsyncFunction',
-    'isDataView', 'isDate', 'isExternal', 'isMap', 'isMapIterator',
-    'isNativeError', 'isPromise', 'isRegExp', 'isSet', 'isSetIterator',
-    'isTypedArray', 'isUint8Array', 'isAnyArrayBuffer'
-  ]) {
-    utilBinding[name] = pendingDeprecation ?
-      deprecate(types[name],
-                'Accessing native typechecking bindings of Node ' +
-                'directly is deprecated. ' +
-                `Please use \`util.types.${name}\` instead.`,
-                'DEP0103') :
-      types[name];
-  }
-}
-
 // process.allowedNodeEnvironmentFlags
 Object.defineProperty(process, 'allowedNodeEnvironmentFlags', {
   get() {
@@ -272,6 +249,8 @@ Object.defineProperty(process, 'allowedNodeEnvironmentFlags', {
   enumerable: true,
   configurable: true
 });
+
+const { deprecate } = NativeModule.require('internal/util');
 // process.assert
 process.assert = deprecate(
   perThreadSetup.assert,

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -2,6 +2,45 @@
 
 const { getOptionValue } = require('internal/options');
 
+// In general deprecations are intialized wherever the APIs are implemented,
+// this is used to deprecate APIs implemented in C++ where the deprecation
+// utitlities are not easily accessible.
+function initializeDeprecations() {
+  const { deprecate } = require('internal/util');
+  const pendingDeprecation = getOptionValue('--pending-deprecation');
+
+  // DEP0103: access to `process.binding('util').isX` type checkers
+  // TODO(addaleax): Turn into a full runtime deprecation.
+  const utilBinding = internalBinding('util');
+  const types = require('internal/util/types');
+  for (const name of [
+    'isArrayBuffer',
+    'isArrayBufferView',
+    'isAsyncFunction',
+    'isDataView',
+    'isDate',
+    'isExternal',
+    'isMap',
+    'isMapIterator',
+    'isNativeError',
+    'isPromise',
+    'isRegExp',
+    'isSet',
+    'isSetIterator',
+    'isTypedArray',
+    'isUint8Array',
+    'isAnyArrayBuffer'
+  ]) {
+    utilBinding[name] = pendingDeprecation ?
+      deprecate(types[name],
+                'Accessing native typechecking bindings of Node ' +
+                'directly is deprecated. ' +
+                `Please use \`util.types.${name}\` instead.`,
+                'DEP0103') :
+      types[name];
+  }
+}
+
 function initializeClusterIPC() {
   // If this is a worker in cluster mode, start up the communication
   // channel. This needs to be done before any user code gets executed
@@ -75,6 +114,7 @@ function loadPreloadModules() {
 }
 
 module.exports = {
+  initializeDeprecations,
   initializeClusterIPC,
   initializePolicy,
   initializeESMLoader,

--- a/lib/internal/main/check_syntax.js
+++ b/lib/internal/main/check_syntax.js
@@ -4,6 +4,7 @@
 // instead of actually running the file.
 
 const {
+  initializeDeprecations,
   initializeClusterIPC,
   initializePolicy,
   initializeESMLoader,
@@ -21,6 +22,7 @@ const {
 } = require('internal/modules/cjs/helpers');
 
 // TODO(joyeecheung): not every one of these are necessary
+initializeDeprecations();
 initializeClusterIPC();
 initializePolicy();
 initializeESMLoader();

--- a/lib/internal/main/eval_stdin.js
+++ b/lib/internal/main/eval_stdin.js
@@ -3,6 +3,7 @@
 // Stdin is not a TTY, we will read it and execute it.
 
 const {
+  initializeDeprecations,
   initializeClusterIPC,
   initializePolicy,
   initializeESMLoader,
@@ -14,6 +15,7 @@ const {
   readStdin
 } = require('internal/process/execution');
 
+initializeDeprecations();
 initializeClusterIPC();
 initializePolicy();
 initializeESMLoader();

--- a/lib/internal/main/eval_string.js
+++ b/lib/internal/main/eval_string.js
@@ -4,6 +4,7 @@
 // `--interactive`.
 
 const {
+  initializeDeprecations,
   initializeClusterIPC,
   initializePolicy,
   initializeESMLoader,
@@ -13,6 +14,7 @@ const { evalScript } = require('internal/process/execution');
 const { addBuiltinLibsToObject } = require('internal/modules/cjs/helpers');
 
 const source = require('internal/options').getOptionValue('--eval');
+initializeDeprecations();
 initializeClusterIPC();
 initializePolicy();
 initializeESMLoader();

--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -4,6 +4,7 @@
 // the main module is not specified and stdin is a TTY.
 
 const {
+  initializeDeprecations,
   initializeClusterIPC,
   initializePolicy,
   initializeESMLoader,
@@ -14,6 +15,7 @@ const {
   evalScript
 } = require('internal/process/execution');
 
+initializeDeprecations();
 initializeClusterIPC();
 initializePolicy();
 initializeESMLoader();

--- a/lib/internal/main/run_main_module.js
+++ b/lib/internal/main/run_main_module.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const {
+  initializeDeprecations,
   initializeClusterIPC,
   initializePolicy,
   initializeESMLoader,
   loadPreloadModules
 } = require('internal/bootstrap/pre_execution');
 
+initializeDeprecations();
 initializeClusterIPC();
 initializePolicy();
 initializeESMLoader();

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -4,6 +4,7 @@
 // message port.
 
 const {
+  initializeDeprecations,
   initializeClusterIPC,
   initializeESMLoader,
   loadPreloadModules
@@ -55,6 +56,7 @@ port.on('message', (message) => {
     if (manifestSrc) {
       require('internal/process/policy').setup(manifestSrc, manifestURL);
     }
+    initializeDeprecations();
     initializeClusterIPC();
     initializeESMLoader();
     loadPreloadModules();


### PR DESCRIPTION
Since this is only necessary when user code execution is expected.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
