### PR TITLE
report: separate release metadata

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -39,6 +39,8 @@ is provided below for reference.
     "glibcVersionRuntime": "2.17",
     "glibcVersionCompiler": "2.17",
     "wordSize": "64 bit",
+    "arch": "x64",
+    "platform": "linux",
     "componentVersions": {
       "node": "12.0.0-pre",
       "v8": "7.1.302.28-node.5",
@@ -50,10 +52,10 @@ is provided below for reference.
       "napi": "3",
       "llhttp": "1.0.1",
       "http_parser": "2.8.0",
-      "openssl": "1.1.0j",
-      "arch": "x64",
-      "platform": "linux",
-      "release": "node"
+      "openssl": "1.1.0j"
+    },
+    "release": {
+      "name": "node"
     },
     "osVersion": "Linux 3.10.0-862.el7.x86_64 #1 SMP Wed Mar 21 18:14:51 EDT 2018",
     "machine": "Linux 3.10.0-862.el7.x86_64 #1 SMP Wed Mar 21 18:14:51 EDT 2018test_machine x86_64"

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -34,6 +34,9 @@ function validateContent(data) {
    'libuv', 'environmentVariables', 'sharedObjects'].forEach((section) => {
     assert(report.hasOwnProperty(section));
   });
+
+  assert.deepStrictEqual(report.header.componentVersions, process.versions);
+  assert.deepStrictEqual(report.header.release, process.release);
 }
 
 module.exports = { findReports, validate, validateContent };


### PR DESCRIPTION
Report release metadata separately from `componentVersions`.
Test `componentVersions` and `release` values in the report.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
