### PR TITLE
src,lib: remove dead `process.binding()` code

### DIFF
--- a/lib/internal/bootstrap/cache.js
+++ b/lib/internal/bootstrap/cache.js
@@ -9,7 +9,7 @@ const { NativeModule } = require('internal/bootstrap/loaders');
 const {
   getCodeCache, compileFunction
 } = internalBinding('native_module');
-const { hasTracing, hasInspector } = process.binding('config');
+const { hasTracing, hasInspector } = internalBinding('config');
 
 // Modules with source code compiled in js2c that
 // cannot be compiled with the code cache.

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -41,7 +41,7 @@
 
 // This file is compiled as if it's wrapped in a function with arguments
 // passed by node::RunBootstrapping()
-/* global process, getBinding, getLinkedBinding, getInternalBinding */
+/* global process, getLinkedBinding, getInternalBinding */
 /* global experimentalModules, exposeInternals, primordials */
 
 const {
@@ -108,12 +108,8 @@ const internalBindingWhitelist = new SafeSet([
     if (internalBindingWhitelist.has(module)) {
       return internalBinding(module);
     }
-    let mod = bindingObj[module];
-    if (typeof mod !== 'object') {
-      mod = bindingObj[module] = getBinding(module);
-      moduleLoadList.push(`Binding ${module}`);
-    }
-    return mod;
+    // eslint-disable-next-line no-restricted-syntax
+    throw new Error(`No such module: ${module}`);
   };
 
   process._linkedBinding = function _linkedBinding(module) {

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -19,7 +19,7 @@ const {
   DiffieHellmanGroup: _DiffieHellmanGroup,
   ECDH: _ECDH,
   ECDHConvertKey: _ECDHConvertKey
-} = process.binding('crypto');
+} = internalBinding('crypto');
 const {
   POINT_CONVERSION_COMPRESSED,
   POINT_CONVERSION_HYBRID,

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -3,7 +3,7 @@
 const {
   Hash: _Hash,
   Hmac: _Hmac
-} = process.binding('crypto');
+} = internalBinding('crypto');
 
 const {
   getDefaultEncoding,

--- a/src/node.cc
+++ b/src/node.cc
@@ -282,7 +282,6 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
   // Create binding loaders
   std::vector<Local<String>> loaders_params = {
       env->process_string(),
-      FIXED_ONE_BYTE_STRING(isolate, "getBinding"),
       FIXED_ONE_BYTE_STRING(isolate, "getLinkedBinding"),
       FIXED_ONE_BYTE_STRING(isolate, "getInternalBinding"),
       // --experimental-modules
@@ -292,9 +291,6 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
       env->primordials_string()};
   std::vector<Local<Value>> loaders_args = {
       process,
-      env->NewFunctionTemplate(binding::GetBinding)
-          ->GetFunction(context)
-          .ToLocalChecked(),
       env->NewFunctionTemplate(binding::GetLinkedBinding)
           ->GetFunction(context)
           .ToLocalChecked(),

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -15,7 +15,7 @@
 #include "v8.h"
 
 enum {
-  NM_F_BUILTIN = 1 << 0,
+  NM_F_BUILTIN = 1 << 0,  // Unused.
   NM_F_LINKED = 1 << 1,
   NM_F_INTERNAL = 1 << 2,
 };
@@ -32,9 +32,6 @@ enum {
       priv,                                                                    \
       nullptr};                                                                \
   void _register_##modname() { node_module_register(&_module); }
-
-#define NODE_BUILTIN_MODULE_CONTEXT_AWARE(modname, regfunc)                    \
-  NODE_MODULE_CONTEXT_AWARE_CPP(modname, regfunc, nullptr, NM_F_BUILTIN)
 
 void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
                                     v8::Local<v8::Value> module,
@@ -83,7 +80,6 @@ class DLib {
 // use the __attribute__((constructor)). Need to
 // explicitly call the _register* functions.
 void RegisterBuiltinModules();
-void GetBinding(const v8::FunctionCallbackInfo<v8::Value>& args);
 void GetInternalBinding(const v8::FunctionCallbackInfo<v8::Value>& args);
 void GetLinkedBinding(const v8::FunctionCallbackInfo<v8::Value>& args);
 void DLOpen(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -91,8 +87,6 @@ void DLOpen(const v8::FunctionCallbackInfo<v8::Value>& args);
 }  // namespace binding
 
 }  // namespace node
-
-#include "node_binding.h"
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 #endif  // SRC_NODE_BINDING_H_


### PR DESCRIPTION
There are no non-internal builtin modules left, so this
should be safe to remove to a large degree.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
