### PR TITLE
tls: introduce client 'session' event

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -214,6 +214,12 @@ function requestOCSPDone(socket) {
 }
 
 
+function onnewsessionclient(sessionId, session) {
+  debug('client onnewsessionclient', sessionId, session);
+  const owner = this[owner_symbol];
+  owner.emit('session', session);
+}
+
 function onnewsession(sessionId, session) {
   const owner = this[owner_symbol];
 
@@ -514,6 +520,21 @@ TLSSocket.prototype._init = function(socket, wrap) {
 
     if (options.session)
       ssl.setSession(options.session);
+
+    ssl.onnewsession = onnewsessionclient;
+
+    // Only call .onnewsession if there is a session listener.
+    this.on('newListener', newListener);
+
+    function newListener(event) {
+      if (event !== 'session')
+        return;
+
+      ssl.enableSessionCallbacks();
+
+      // Remover this listener since its no longer needed.
+      this.removeListener('newListener', newListener);
+    }
   }
 
   ssl.onerror = onerror;

--- a/lib/https.js
+++ b/lib/https.js
@@ -117,18 +117,20 @@ function createConnection(port, host, options) {
     }
   }
 
-  const socket = tls.connect(options, () => {
-    if (!options._agentKey)
-      return;
+  const socket = tls.connect(options);
 
-    this._cacheSession(options._agentKey, socket.getSession());
-  });
+  if (options._agentKey) {
+    // Cache new session for reuse
+    socket.on('session', (session) => {
+      this._cacheSession(options._agentKey, session);
+    });
 
-  // Evict session on error
-  socket.once('close', (err) => {
-    if (err)
-      this._evictSession(options._agentKey);
-  });
+    // Evict session on error
+    socket.once('close', (err) => {
+      if (err)
+        this._evictSession(options._agentKey);
+    });
+  }
 
   return socket;
 }

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -792,6 +792,11 @@ void TLSWrap::EnableSessionCallbacks(
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
   CHECK_NOT_NULL(wrap->ssl_);
   wrap->enable_session_callbacks();
+
+  // Clients don't use the HelloParser.
+  if (wrap->is_client())
+    return;
+
   crypto::NodeBIO::FromBIO(wrap->enc_in_)->set_initial(kMaxHelloLength);
   wrap->hello_parser_.Start(SSLWrap<TLSWrap>::OnClientHello,
                             OnClientHelloParseEnd,

--- a/test/parallel/test-https-client-resume.js
+++ b/test/parallel/test-https-client-resume.js
@@ -43,37 +43,34 @@ const server = https.createServer(options, common.mustCall((req, res) => {
 }, 2));
 
 // start listening
-server.listen(0, function() {
-
-  let session1 = null;
+server.listen(0, common.mustCall(function() {
   const client1 = tls.connect({
     port: this.address().port,
     rejectUnauthorized: false
-  }, () => {
+  }, common.mustCall(() => {
     console.log('connect1');
-    assert.ok(!client1.isSessionReused(), 'Session *should not* be reused.');
-    session1 = client1.getSession();
+    assert.strictEqual(client1.isSessionReused(), false);
     client1.write('GET / HTTP/1.0\r\n' +
                   'Server: 127.0.0.1\r\n' +
                   '\r\n');
-  });
+  }));
 
-  client1.on('close', () => {
-    console.log('close1');
+  client1.on('session', common.mustCall((session) => {
+    console.log('session');
 
     const opts = {
       port: server.address().port,
       rejectUnauthorized: false,
-      session: session1
+      session,
     };
 
-    const client2 = tls.connect(opts, () => {
+    const client2 = tls.connect(opts, common.mustCall(() => {
       console.log('connect2');
-      assert.ok(client2.isSessionReused(), 'Session *should* be reused.');
+      assert.strictEqual(client2.isSessionReused(), true);
       client2.write('GET / HTTP/1.0\r\n' +
                     'Server: 127.0.0.1\r\n' +
                     '\r\n');
-    });
+    }));
 
     client2.on('close', () => {
       console.log('close2');
@@ -81,7 +78,7 @@ server.listen(0, function() {
     });
 
     client2.resume();
-  });
+  }));
 
   client1.resume();
-});
+}));

--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -45,7 +45,6 @@ if (cluster.isMaster) {
       session: lastSession,
       rejectUnauthorized: false
     }, () => {
-      lastSession = c.getSession();
       c.end();
 
       if (++reqCount === expectedReqCount) {
@@ -55,6 +54,8 @@ if (cluster.isMaster) {
       } else {
         shoot();
       }
+    }).once('session', (session) => {
+      lastSession = session;
     });
   }
 

--- a/test/parallel/test-tls-ticket.js
+++ b/test/parallel/test-tls-ticket.js
@@ -81,6 +81,15 @@ const shared = net.createServer(function(c) {
   });
 });
 
+// 'session' events only occur for new sessions. The first connection is new.
+// After, for each set of 3 connections, the middle connection is made when the
+// server has random keys set, so the client's ticket is silently ignored, and a
+// new ticket is sent.
+const onNewSession = common.mustCall((s, session) => {
+  assert(session);
+  assert.strictEqual(session.compare(s.getSession()), 0);
+}, 4);
+
 function start(callback) {
   let sess = null;
   let left = servers.length;
@@ -99,6 +108,7 @@ function start(callback) {
       else
         connect();
     });
+    s.once('session', (session) => onNewSession(s, session));
   }
 
   connect();


### PR DESCRIPTION
OpenSSL has supported async notification of sessions and tickets since
1.1.0 using SSL_CTX_sess_set_new_cb(), for all versions of TLS. Using
the async API is optional for TLS1.2 and below, but for TLS1.3 it will
be mandatory. Future-proof applications should start to use async
notification immediately. In the future, for TLS1.3, applications that
don't use the async API will silently, but gracefully, fail to resume
sessions and instead do a full handshake.

See: https://wiki.openssl.org/index.php/TLS1.3#Sessions

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
