### PR TITLE
inspector,vm: remove --eval wrapper

### DIFF
--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -33,26 +33,30 @@ function tryGetCwd() {
   }
 }
 
-function evalScript(name, body, breakFristLine) {
+function evalScript(name, body, breakFirstLine) {
   const CJSModule = require('internal/modules/cjs/loader');
-  if (breakFristLine) {
-    const fn = `function() {\n\n${body};\n\n}`;
-    body = `process.binding('inspector').callAndPauseOnStart(${fn}, {})`;
-  }
+  const { kVmBreakFirstLineSymbol } = require('internal/util');
 
   const cwd = tryGetCwd();
 
   const module = new CJSModule(name);
   module.filename = path.join(cwd, name);
   module.paths = CJSModule._nodeModulePaths(cwd);
-  const script = `global.__filename = ${JSON.stringify(name)};\n` +
-                  'global.exports = exports;\n' +
-                  'global.module = module;\n' +
-                  'global.__dirname = __dirname;\n' +
-                  'global.require = require;\n' +
-                  'return require("vm").runInThisContext(' +
-                  `${JSON.stringify(body)}, { filename: ` +
-                  `${JSON.stringify(name)}, displayErrors: true });\n`;
+  global.kVmBreakFirstLineSymbol = kVmBreakFirstLineSymbol;
+  const script = `
+    global.__filename = ${JSON.stringify(name)};
+    global.exports = exports;
+    global.module = module;
+    global.__dirname = __dirname;
+    global.require = require;
+    const { kVmBreakFirstLineSymbol } = global;
+    delete global.kVmBreakFirstLineSymbol;
+    return require("vm").runInThisContext(
+      ${JSON.stringify(body)}, {
+        filename: ${JSON.stringify(name)},
+        displayErrors: true,
+        [kVmBreakFirstLineSymbol]: ${!!breakFirstLine}
+      });\n`;
   const result = module._compile(script, `${name}-wrapper`);
   if (require('internal/options').getOptionValue('--print')) {
     console.log(result);

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -418,5 +418,6 @@ module.exports = {
   // Used by the buffer module to capture an internal reference to the
   // default isEncoding implementation, just in case userland overrides it.
   kIsEncodingSymbol: Symbol('kIsEncodingSymbol'),
-  kExpandStackSymbol: Symbol('kExpandStackSymbol')
+  kExpandStackSymbol: Symbol('kExpandStackSymbol'),
+  kVmBreakFirstLineSymbol: Symbol('kVmBreakFirstLineSymbol')
 };

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -38,6 +38,7 @@ const {
   validateUint32,
   validateString
 } = require('internal/validators');
+const { kVmBreakFirstLineSymbol } = require('internal/util');
 const kParsingContext = Symbol('script parsing context');
 
 const ArrayForEach = Function.call.bind(Array.prototype.forEach);
@@ -175,7 +176,8 @@ function getRunInContextArgs(options = {}) {
 
   const {
     displayErrors = true,
-    breakOnSigint = false
+    breakOnSigint = false,
+    [kVmBreakFirstLineSymbol]: breakFirstLine = false,
   } = options;
 
   if (typeof displayErrors !== 'boolean') {
@@ -189,7 +191,7 @@ function getRunInContextArgs(options = {}) {
 
   return {
     breakOnSigint,
-    args: [timeout, displayErrors, breakOnSigint]
+    args: [timeout, displayErrors, breakOnSigint, breakFirstLine]
   };
 }
 

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -121,6 +121,7 @@ class ContextifyScript : public BaseObject {
                           const int64_t timeout,
                           const bool display_errors,
                           const bool break_on_sigint,
+                          const bool break_on_first_line,
                           const v8::FunctionCallbackInfo<v8::Value>& args);
 
   inline uint32_t id() { return id_; }

--- a/test/sequential/test-inspector-async-hook-setup-at-inspect-brk.js
+++ b/test/sequential/test-inspector-async-hook-setup-at-inspect-brk.js
@@ -14,13 +14,13 @@ setTimeout(() => {
 `;
 
 async function skipBreakpointAtStart(session) {
-  await session.waitForBreakOnLine(3, '[eval]');
+  await session.waitForBreakOnLine(1, '[eval]');
   await session.send({ 'method': 'Debugger.resume' });
 }
 
 async function checkAsyncStackTrace(session) {
   console.error('[test]', 'Verify basic properties of asyncStackTrace');
-  const paused = await session.waitForBreakOnLine(4, '[eval]');
+  const paused = await session.waitForBreakOnLine(2, '[eval]');
   assert(paused.params.asyncStackTrace,
          `${Object.keys(paused.params)} contains "asyncStackTrace" property`);
   assert(paused.params.asyncStackTrace.description, 'Timeout');

--- a/test/sequential/test-inspector-async-stack-traces-promise-then.js
+++ b/test/sequential/test-inspector-async-stack-traces-promise-then.js
@@ -31,18 +31,18 @@ async function runTests() {
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
 
-  await session.waitForBreakOnLine(2, '[eval]');
+  await session.waitForBreakOnLine(0, '[eval]');
   await session.send({ 'method': 'Debugger.resume' });
 
   console.error('[test] Waiting for break1');
-  debuggerPausedAt(await session.waitForBreakOnLine(6, '[eval]'),
-                   'break1', 'runTest:5');
+  debuggerPausedAt(await session.waitForBreakOnLine(4, '[eval]'),
+                   'break1', 'runTest:3');
 
   await session.send({ 'method': 'Debugger.resume' });
 
   console.error('[test] Waiting for break2');
-  debuggerPausedAt(await session.waitForBreakOnLine(9, '[eval]'),
-                   'break2', 'runTest:8');
+  debuggerPausedAt(await session.waitForBreakOnLine(7, '[eval]'),
+                   'break2', 'runTest:6');
 
   await session.runToCompletion();
   assert.strictEqual((await instance.expectShutdown()).exitCode, 0);

--- a/test/sequential/test-inspector-async-stack-traces-set-interval.js
+++ b/test/sequential/test-inspector-async-stack-traces-set-interval.js
@@ -10,13 +10,13 @@ const script = 'setInterval(() => { debugger; }, 50);';
 
 async function skipFirstBreakpoint(session) {
   console.log('[test]', 'Skipping the first breakpoint in the eval script');
-  await session.waitForBreakOnLine(2, '[eval]');
+  await session.waitForBreakOnLine(0, '[eval]');
   await session.send({ 'method': 'Debugger.resume' });
 }
 
 async function checkAsyncStackTrace(session) {
   console.error('[test]', 'Verify basic properties of asyncStackTrace');
-  const paused = await session.waitForBreakOnLine(2, '[eval]');
+  const paused = await session.waitForBreakOnLine(0, '[eval]');
   assert(paused.params.asyncStackTrace,
          `${Object.keys(paused.params)} contains "asyncStackTrace" property`);
   assert(paused.params.asyncStackTrace.description, 'Timeout');

--- a/test/sequential/test-inspector-break-e.js
+++ b/test/sequential/test-inspector-break-e.js
@@ -14,7 +14,7 @@ async function runTests() {
     { 'method': 'Debugger.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
-  await session.waitForBreakOnLine(2, '[eval]');
+  await session.waitForBreakOnLine(0, '[eval]');
   await session.runToCompletion();
   assert.strictEqual((await instance.expectShutdown()).exitCode, 0);
 }

--- a/test/sequential/test-inspector-scriptparsed-context.js
+++ b/test/sequential/test-inspector-scriptparsed-context.js
@@ -51,28 +51,28 @@ async function runTests() {
     { 'method': 'Debugger.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
-  await session.waitForBreakOnLine(4, '[eval]');
+  await session.waitForBreakOnLine(2, '[eval]');
 
   await session.send({ 'method': 'Runtime.enable' });
   await getContext(session);
   await session.send({ 'method': 'Debugger.resume' });
   const childContext = await getContext(session);
-  await session.waitForBreakOnLine(13, '[eval]');
+  await session.waitForBreakOnLine(11, '[eval]');
 
   console.error('[test]', 'Script is unbound');
   await session.send({ 'method': 'Debugger.resume' });
-  await session.waitForBreakOnLine(17, '[eval]');
+  await session.waitForBreakOnLine(15, '[eval]');
 
   console.error('[test]', 'vm.runInContext associates script with context');
   await session.send({ 'method': 'Debugger.resume' });
   await checkScriptContext(session, childContext);
-  await session.waitForBreakOnLine(20, '[eval]');
+  await session.waitForBreakOnLine(18, '[eval]');
 
   console.error('[test]', 'vm.runInNewContext associates script with context');
   await session.send({ 'method': 'Debugger.resume' });
   const thirdContext = await getContext(session);
   await checkScriptContext(session, thirdContext);
-  await session.waitForBreakOnLine(23, '[eval]');
+  await session.waitForBreakOnLine(21, '[eval]');
 
   console.error('[test]', 'vm.runInNewContext can contain debugger statements');
   await session.send({ 'method': 'Debugger.resume' });


### PR DESCRIPTION
Report the actual source code when running with `--eval` and
`--inspect-brk`, by telling the vm module to break on the
first line of the script being executed rather than wrapping
the source code in a function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
