### PR TITLE
test: exclude additional test for coverage

### DIFF
--- a/test/root.status
+++ b/test/root.status
@@ -161,6 +161,7 @@ sequential/test-pipe: SLOW
 sequential/test-util-debug: SLOW
 
 [$type==coverage]
+async-hooks/test-callback-error: PASS,FAIL,CRASH
 js-native-api/test_function/test: PASS,FAIL,CRASH
 js-native-api/test_general/testFinalizer: PASS,FAIL,CRASH
-async-hooks/test-callback-error: PASS,FAIL,CRASH
+

--- a/test/root.status
+++ b/test/root.status
@@ -163,3 +163,4 @@ sequential/test-util-debug: SLOW
 [$type==coverage]
 js-native-api/test_function/test: PASS,FAIL,CRASH
 js-native-api/test_general/testFinalizer: PASS,FAIL,CRASH
+async-hooks/test-callback-error: PASS,FAIL,CRASH


### PR DESCRIPTION
Exclude async-hooks/test-callback-error as it seems
to fail consistently when run with coverage on
the docker ubuntu16 machines we plan to run the
coverage sanity test on.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
