### PR TITLE
src: handle errors while printing error objects

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -9,6 +9,7 @@
 
 namespace node {
 
+using errors::TryCatchScope;
 using v8::Context;
 using v8::Exception;
 using v8::Function;
@@ -207,8 +208,10 @@ void ReportException(Environment* env,
   } else {
     Local<Object> err_obj = er->ToObject(env->context()).ToLocalChecked();
 
-    trace_value = err_obj->Get(env->context(),
-                               env->stack_string()).ToLocalChecked();
+    if (!err_obj->Get(env->context(), env->stack_string())
+             .ToLocal(&trace_value)) {
+      trace_value = Undefined(env->isolate());
+    }
     arrow =
         err_obj->GetPrivate(env->context(), env->arrow_message_private_symbol())
             .ToLocalChecked();
@@ -228,27 +231,25 @@ void ReportException(Environment* env,
     // this really only happens for RangeErrors, since they're the only
     // kind that won't have all this info in the trace, or when non-Error
     // objects are thrown manually.
-    Local<Value> message;
-    Local<Value> name;
+    MaybeLocal<Value> message;
+    MaybeLocal<Value> name;
 
     if (er->IsObject()) {
       Local<Object> err_obj = er.As<Object>();
-      message = err_obj->Get(env->context(),
-                             env->message_string()).ToLocalChecked();
-      name = err_obj->Get(env->context(),
-          FIXED_ONE_BYTE_STRING(env->isolate(), "name")).ToLocalChecked();
+      message = err_obj->Get(env->context(), env->message_string());
+      name = err_obj->Get(env->context(), env->name_string());
     }
 
-    if (message.IsEmpty() || message->IsUndefined() || name.IsEmpty() ||
-        name->IsUndefined()) {
+    if (message.IsEmpty() || message.ToLocalChecked()->IsUndefined() ||
+        name.IsEmpty() || name.ToLocalChecked()->IsUndefined()) {
       // Not an error object. Just print as-is.
       String::Utf8Value message(env->isolate(), er);
 
       PrintErrorString("%s\n",
                        *message ? *message : "<toString() threw exception>");
     } else {
-      node::Utf8Value name_string(env->isolate(), name);
-      node::Utf8Value message_string(env->isolate(), message);
+      node::Utf8Value name_string(env->isolate(), name.ToLocalChecked());
+      node::Utf8Value message_string(env->isolate(), message.ToLocalChecked());
 
       if (arrow.IsEmpty() || !arrow->IsString() || decorated) {
         PrintErrorString("%s: %s\n", *name_string, *message_string);
@@ -686,8 +687,8 @@ void DecorateErrorStack(Environment* env,
   if (IsExceptionDecorated(env, err_obj)) return;
 
   AppendExceptionLine(env, exception, try_catch.Message(), CONTEXTIFY_ERROR);
-  Local<Value> stack =
-      err_obj->Get(env->context(), env->stack_string()).ToLocalChecked();
+  TryCatchScope try_catch_scope(env);  // Ignore exceptions below.
+  MaybeLocal<Value> stack = err_obj->Get(env->context(), env->stack_string());
   MaybeLocal<Value> maybe_value =
       err_obj->GetPrivate(env->context(), env->arrow_message_private_symbol());
 
@@ -696,7 +697,7 @@ void DecorateErrorStack(Environment* env,
     return;
   }
 
-  if (stack.IsEmpty() || !stack->IsString()) {
+  if (stack.IsEmpty() || !stack.ToLocalChecked()->IsString()) {
     return;
   }
 
@@ -705,8 +706,8 @@ void DecorateErrorStack(Environment* env,
       String::Concat(env->isolate(),
                      arrow.As<String>(),
                      FIXED_ONE_BYTE_STRING(env->isolate(), "\n")),
-      stack.As<String>());
-  err_obj->Set(env->context(), env->stack_string(), decorated_stack).FromJust();
+      stack.ToLocalChecked().As<String>());
+  USE(err_obj->Set(env->context(), env->stack_string(), decorated_stack));
   err_obj->SetPrivate(
       env->context(), env->decorated_private_symbol(), True(env->isolate()));
 }

--- a/test/message/throw_error_with_getter_throw.js
+++ b/test/message/throw_error_with_getter_throw.js
@@ -1,0 +1,10 @@
+'use strict';
+require('../common');
+throw {  // eslint-disable-line no-throw-literal
+  get stack() {
+    throw new Error('weird throw but ok');
+  },
+  get name() {
+    throw new Error('weird throw but ok');
+  },
+};

--- a/test/message/throw_error_with_getter_throw.out
+++ b/test/message/throw_error_with_getter_throw.out
@@ -1,0 +1,5 @@
+
+*:3
+throw {  // eslint-disable-line no-throw-literal
+^
+[object Object]


### PR DESCRIPTION
Handle situations where accessing `.name` or `.stack` on an object
fails.

Fixes: https://github.com/nodejs/node/issues/25718

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
