### PR TITLE
meta: clarify EoL platform support

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -69,8 +69,10 @@ There are three support tiers:
 
 ### Supported platforms
 
-The community does not build or test against end-of-life distributions (EoL).
 For production applications, run Node.js on supported platforms only.
+
+Note that end-of-life (EoL) platforms are not supported even if listed below
+and can be removed at any moment.
 
 | System       | Support type | Version                         | Architectures    | Notes                         |
 | ------------ | ------------ | ------------------------------- | ---------------- | ----------------------------- |


### PR DESCRIPTION
Use stronger wording about EoL platforms. Make it clear they can be removed at any time, as should happen with Windows 7/2008R2 next year when it becomes EoL.

cc @nodejs/build 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
