### PR TITLE
deps: patch to fix *.onion MX query on c-ares

### DIFF
--- a/deps/cares/src/ares_create_query.c
+++ b/deps/cares/src/ares_create_query.c
@@ -94,13 +94,13 @@ int ares_create_query(const char *name, int dnsclass, int type,
   size_t buflen;
   unsigned char *buf;
 
-  /* Per RFC 7686, reject queries for ".onion" domain names with NXDOMAIN. */
-  if (ares__is_onion_domain(name))
-    return ARES_ENOTFOUND;
-
   /* Set our results early, in case we bail out early with an error. */
   *buflenp = 0;
   *bufp = NULL;
+
+  /* Per RFC 7686, reject queries for ".onion" domain names with NXDOMAIN. */
+  if (ares__is_onion_domain(name))
+    return ARES_ENOTFOUND;
 
   /* Allocate a memory area for the maximum size this packet might need. +2
    * is for the length byte and zero termination if no dots or ecscaping is

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -314,3 +314,13 @@ common.expectsError(() => {
   code: 'ERR_INVALID_CALLBACK',
   type: TypeError
 });
+
+{
+  dns.resolveMx('foo.onion', function(err) {
+    assert.deepStrictEqual(err.errno, 'ENOTFOUND');
+    assert.deepStrictEqual(err.code, 'ENOTFOUND');
+    assert.deepStrictEqual(err.syscall, 'queryMx');
+    assert.deepStrictEqual(err.hostname, 'foo.onion');
+    assert.deepStrictEqual(err.message, 'queryMx ENOTFOUND foo.onion');
+  });
+}


### PR DESCRIPTION
c-ares rejects *.onion MX query but forgot to set `*bufp` to NULL. This
will occur SegmentFault when free `*bufp`.

I make this quick fix and then will make a PR for c-ares either.

Fixes: https://github.com/nodejs/node/issues/25839
Refs: https://github.com/c-ares/c-ares/blob/955df98/ares_create_query.c#L97-L103
Refs: https://github.com/c-ares/c-ares/blob/955df98/ares_query.c#L124

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
