### PR TITLE
perf_hooks: only enable GC tracking when it's requested

### DIFF
--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -11,7 +11,8 @@ const {
   timeOrigin,
   timeOriginTimestamp,
   timerify,
-  constants
+  constants,
+  setupGarbageCollectionTracking
 } = internalBinding('performance');
 
 const {
@@ -273,6 +274,8 @@ class PerformanceObserverEntryList {
   }
 }
 
+let gcTrackingIsEnabled = false;
+
 class PerformanceObserver extends AsyncResource {
   constructor(callback) {
     if (typeof callback !== 'function') {
@@ -333,6 +336,11 @@ class PerformanceObserver extends AsyncResource {
     const entryTypes = options.entryTypes.filter(filterTypes).map(mapTypes);
     if (entryTypes.length === 0) {
       throw new errors.ERR_VALID_PERFORMANCE_ENTRY_TYPE();
+    }
+    if (entryTypes.includes(NODE_PERFORMANCE_ENTRY_TYPE_GC) &&
+      !gcTrackingIsEnabled) {
+      setupGarbageCollectionTracking();
+      gcTrackingIsEnabled = true;
     }
     this.disconnect();
     this[kBuffer][kEntries] = [];

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -296,8 +296,10 @@ void MarkGarbageCollectionEnd(Isolate* isolate,
                          entry);
 }
 
+static void SetupGarbageCollectionTracking(
+    const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
 
-inline void SetupGarbageCollectionTracking(Environment* env) {
   env->isolate()->AddGCPrologueCallback(MarkGarbageCollectionStart,
                                         static_cast<void*>(env));
   env->isolate()->AddGCEpilogueCallback(MarkGarbageCollectionEnd,
@@ -416,6 +418,8 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "markMilestone", MarkMilestone);
   env->SetMethod(target, "setupObservers", SetupPerformanceObservers);
   env->SetMethod(target, "timerify", Timerify);
+  env->SetMethod(
+      target, "setupGarbageCollectionTracking", SetupGarbageCollectionTracking);
 
   Local<Object> constants = Object::New(isolate);
 
@@ -452,8 +456,6 @@ void Initialize(Local<Object> target,
                             env->constants_string(),
                             constants,
                             attr).ToChecked();
-
-  SetupGarbageCollectionTracking(env);
 }
 
 }  // namespace performance


### PR DESCRIPTION
Previously a GC prologue callback and a GC epilogue callback
are always unconditionally enabled during bootstrap when
the `performance` binding is loaded, even when the user does
not use the performance timeline API to enable GC tracking.
This patch makes the callback addition conditional and only
enables them when the user explicitly requests
`observer.observe(['gc'])` to avoid the overhead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
