### PR TITLE
src: move process.reallyExit impl into node_process_methods.cc

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -118,7 +118,6 @@ using v8::Exception;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::HandleScope;
-using v8::Int32;
 using v8::Isolate;
 using v8::Just;
 using v8::Local;
@@ -163,7 +162,7 @@ struct V8Platform v8_platform;
 static const unsigned kMaxSignal = 32;
 #endif
 
-static void WaitForInspectorDisconnect(Environment* env) {
+void WaitForInspectorDisconnect(Environment* env) {
 #if HAVE_INSPECTOR
   if (env->inspector_agent()->IsActive()) {
     // Restore signal dispositions, the app is done and is no longer
@@ -181,13 +180,6 @@ static void WaitForInspectorDisconnect(Environment* env) {
     env->inspector_agent()->WaitForDisconnect();
   }
 #endif
-}
-
-void Exit(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  WaitForInspectorDisconnect(env);
-  int code = args[0]->Int32Value(env->context()).FromMaybe(0);
-  env->Exit(code);
 }
 
 void SignalExit(int signo) {

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -86,7 +86,7 @@ void GetSockOrPeerName(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(err);
 }
 
-void Exit(const v8::FunctionCallbackInfo<v8::Value>& args);
+void WaitForInspectorDisconnect(Environment* env);
 void SignalExit(int signo);
 #ifdef __POSIX__
 void RegisterSignalHandler(int signal,

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -385,6 +385,13 @@ static void DebugEnd(const FunctionCallbackInfo<Value>& args) {
 #endif
 }
 
+static void ReallyExit(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  WaitForInspectorDisconnect(env);
+  int code = args[0]->Int32Value(env->context()).FromMaybe(0);
+  env->Exit(code);
+}
+
 static void InitializeProcessMethods(Local<Object> target,
                                      Local<Value> unused,
                                      Local<Context> context,
@@ -416,7 +423,7 @@ static void InitializeProcessMethods(Local<Object> target,
 
   env->SetMethodNoSideEffect(target, "cwd", Cwd);
   env->SetMethod(target, "dlopen", binding::DLOpen);
-  env->SetMethod(target, "reallyExit", Exit);
+  env->SetMethod(target, "reallyExit", ReallyExit);
   env->SetMethodNoSideEffect(target, "uptime", Uptime);
 }
 


### PR DESCRIPTION
Because the part that is shared by `process.reallyExit` and the
Node.js teardown is `WaitForInspectorDisconnect()`, move that
into node_internals.h instead, and move the C++ binding code
into `node_process_methods.cc` since that's the only place
it's needed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
