### PR TITLE
lib: use `internal/options` to query `--abort-on-uncaught-exception`

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -4,6 +4,11 @@ const {
   ERR_ASYNC_TYPE,
   ERR_INVALID_ASYNC_ID
 } = require('internal/errors').codes;
+
+const { getOptionValue } = require('internal/options');
+const shouldAbortOnUncaughtException =
+  getOptionValue('--abort-on-uncaught-exception');
+
 const async_wrap = internalBinding('async_wrap');
 /* async_hook_fields is a Uint32Array wrapping the uint32_t array of
  * Environment::AsyncHooks::fields_[]. Each index tracks the number of active
@@ -107,7 +112,7 @@ function fatalError(e) {
     Error.captureStackTrace(o, fatalError);
     process._rawDebug(o.stack);
   }
-  if (internalBinding('config').shouldAbortOnUncaughtException) {
+  if (shouldAbortOnUncaughtException) {
     process.abort();
   }
   process.exit(1);

--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -25,7 +25,9 @@ const { entries } = Object;
 const kIntegrities = new SafeWeakMap();
 const kReactions = new SafeWeakMap();
 const kRelativeURLStringPattern = /^\.{0,2}\//;
-const { shouldAbortOnUncaughtException } = internalBinding('config');
+const { getOptionValue } = require('internal/options');
+const shouldAbortOnUncaughtException =
+  getOptionValue('--abort-on-uncaught-exception');
 const { abort, exit, _rawDebug } = process;
 
 function REACTION_THROW(error) {

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -69,9 +69,6 @@ static void Initialize(Local<Object> target,
   READONLY_FALSE_PROPERTY(target, "hasInspector");
 #endif
 
-  if (env->abort_on_uncaught_exception())
-    READONLY_TRUE_PROPERTY(target, "shouldAbortOnUncaughtException");
-
   READONLY_PROPERTY(target,
                     "bits",
                     Number::New(env->isolate(), 8 * sizeof(intptr_t)));

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -540,7 +540,14 @@ void GetOptions(const FunctionCallbackInfo<Value>& args) {
     switch (option_info.type) {
       case kNoOp:
       case kV8Option:
-        value = Undefined(isolate);
+        // Special case for --abort-on-uncaught-exception which is also
+        // respected by Node.js internals
+        if (item.first == "--abort-on-uncaught-exception") {
+          value = Boolean::New(
+            isolate, original_per_env->abort_on_uncaught_exception);
+        } else {
+          value = Undefined(isolate);
+        }
         break;
       case kBoolean:
         value = Boolean::New(isolate, *parser.Lookup<bool>(field, opts));


### PR DESCRIPTION
Instead of using
`internalBinding('config').shouldAbortOnUncaughtException`.
Also removes that property from the binding.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
