### PR TITLE
benchmark: use consistent coding style in  assert/*

### DIFF
--- a/benchmark/assert/deepequal-buffer.js
+++ b/benchmark/assert/deepequal-buffer.js
@@ -6,10 +6,7 @@ const bench = common.createBenchmark(main, {
   n: [2e4],
   len: [1e2, 1e3],
   strict: [0, 1],
-  method: [
-    'deepEqual',
-    'notDeepEqual'
-  ]
+  method: [ 'deepEqual', 'notDeepEqual' ],
 });
 
 function main({ len, n, method, strict }) {

--- a/benchmark/assert/deepequal-map.js
+++ b/benchmark/assert/deepequal-map.js
@@ -14,8 +14,8 @@ const bench = common.createBenchmark(main, {
     'deepEqual_mixed',
     'notDeepEqual_primitiveOnly',
     'notDeepEqual_objectOnly',
-    'notDeepEqual_mixed'
-  ]
+    'notDeepEqual_mixed',
+  ],
 });
 
 function benchmark(method, n, values, values2) {

--- a/benchmark/assert/deepequal-object.js
+++ b/benchmark/assert/deepequal-object.js
@@ -7,10 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [5e3],
   size: [1e2, 1e3, 5e4],
   strict: [0, 1],
-  method: [
-    'deepEqual',
-    'notDeepEqual'
-  ]
+  method: [ 'deepEqual', 'notDeepEqual' ],
 });
 
 function createObj(source, add = '') {
@@ -21,8 +18,8 @@ function createObj(source, add = '') {
       a: [1, 2, 3],
       baz: n,
       c: {},
-      b: []
-    }
+      b: [],
+    },
   }));
 }
 

--- a/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
@@ -8,7 +8,7 @@ const primValues = {
   'string': 'a',
   'number': 1,
   'object': { 0: 'a' },
-  'array': [1, 2, 3]
+  'array': [1, 2, 3],
 };
 
 const bench = common.createBenchmark(main, {
@@ -20,8 +20,8 @@ const bench = common.createBenchmark(main, {
     'deepEqual_Array',
     'notDeepEqual_Array',
     'deepEqual_Set',
-    'notDeepEqual_Set'
-  ]
+    'notDeepEqual_Set',
+  ],
 });
 
 function run(fn, n, actual, expected) {

--- a/benchmark/assert/deepequal-prims-and-objs-big-loop.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-loop.js
@@ -6,17 +6,14 @@ const primValues = {
   'string': 'a',
   'number': 1,
   'object': { 0: 'a' },
-  'array': [1, 2, 3]
+  'array': [1, 2, 3],
 };
 
 const bench = common.createBenchmark(main, {
   primitive: Object.keys(primValues),
   n: [2e4],
   strict: [0, 1],
-  method: [
-    'deepEqual',
-    'notDeepEqual',
-  ]
+  method: [ 'deepEqual', 'notDeepEqual' ],
 });
 
 function main({ n, primitive, method, strict }) {

--- a/benchmark/assert/deepequal-set.js
+++ b/benchmark/assert/deepequal-set.js
@@ -14,8 +14,8 @@ const bench = common.createBenchmark(main, {
     'deepEqual_mixed',
     'notDeepEqual_primitiveOnly',
     'notDeepEqual_objectOnly',
-    'notDeepEqual_mixed'
-  ]
+    'notDeepEqual_mixed',
+  ],
 });
 
 function benchmark(method, n, values, values2) {

--- a/benchmark/assert/deepequal-typedarrays.js
+++ b/benchmark/assert/deepequal-typedarrays.js
@@ -16,7 +16,7 @@ const bench = common.createBenchmark(main, {
     'deepEqual',
     'notDeepEqual',
   ],
-  len: [1e2, 5e3]
+  len: [1e2, 5e3],
 });
 
 function main({ type, n, len, method, strict }) {

--- a/benchmark/assert/ok.js
+++ b/benchmark/assert/ok.js
@@ -3,9 +3,7 @@
 const common = require('../common.js');
 const assert = require('assert');
 
-const bench = common.createBenchmark(main, {
-  n: [1e5]
-});
+const bench = common.createBenchmark(main, { n: [1e5] });
 
 function main({ n }) {
   var i;

--- a/benchmark/assert/throws.js
+++ b/benchmark/assert/throws.js
@@ -5,11 +5,7 @@ const { throws, doesNotThrow } = require('assert');
 
 const bench = common.createBenchmark(main, {
   n: [1e4],
-  method: [
-    'doesNotThrow',
-    'throws_TypeError',
-    'throws_RegExp'
-  ]
+  method: [ 'doesNotThrow', 'throws_TypeError', 'throws_RegExp' ],
 });
 
 function main({ n, method }) {


### PR DESCRIPTION
Files in benchmark/assert/* were sometimes using trailing commas for
multi-line objects and sometimes not, mixing the approaches in the same
file sometimes. Standardize these files to always use trailing commas in
multi-line objects.

Additionally, remove some unnecessary line-wrapping (so that there are
fewer multi-line objects).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
