### PR TITLE
worker: do not throw on property access or postMessage after termination

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -184,6 +184,8 @@ class Worker extends EventEmitter {
   }
 
   postMessage(...args) {
+    if (this[kPublicPort] === null) return;
+
     this[kPublicPort].postMessage(...args);
   }
 
@@ -219,14 +221,20 @@ class Worker extends EventEmitter {
   }
 
   get stdin() {
+    if (this[kParentSideStdio] === null) return null;
+
     return this[kParentSideStdio].stdin;
   }
 
   get stdout() {
+    if (this[kParentSideStdio] === null) return null;
+
     return this[kParentSideStdio].stdout;
   }
 
   get stderr() {
+    if (this[kParentSideStdio] === null) return null;
+
     return this[kParentSideStdio].stderr;
   }
 }

--- a/test/parallel/test-worker-safe-getters.js
+++ b/test/parallel/test-worker-safe-getters.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+const { Worker, isMainThread } = require('worker_threads');
+
+if (isMainThread) {
+  const w = new Worker(__filename, {
+    stdin: true,
+    stdout: true,
+    stderr: true
+  });
+
+  w.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+
+    // `postMessage` should not throw after termination
+    // (this mimics the browser behavior).
+    assert.doesNotThrow(() => w.postMessage('foobar'));
+    assert.doesNotThrow(() => w.ref());
+    assert.doesNotThrow(() => w.unref());
+
+    // Although not browser specific, probably wise to
+    // make sure the stream getters don't throw either.
+    assert.doesNotThrow(() => w.stdin);
+    assert.doesNotThrow(() => w.stdout);
+    assert.doesNotThrow(() => w.stderr);
+
+    // Sanity check.
+    assert.strictEqual(w.threadId, -1);
+    assert.strictEqual(w.stdin, null);
+    assert.strictEqual(w.stdout, null);
+    assert.strictEqual(w.stderr, null);
+  }));
+} else {
+  process.exit(0);
+}

--- a/test/parallel/test-worker-safe-getters.js
+++ b/test/parallel/test-worker-safe-getters.js
@@ -17,15 +17,15 @@ if (isMainThread) {
 
     // `postMessage` should not throw after termination
     // (this mimics the browser behavior).
-    assert.doesNotThrow(() => w.postMessage('foobar'));
-    assert.doesNotThrow(() => w.ref());
-    assert.doesNotThrow(() => w.unref());
+    w.postMessage('foobar');
+    w.ref();
+    w.unref();
 
     // Although not browser specific, probably wise to
     // make sure the stream getters don't throw either.
-    assert.doesNotThrow(() => w.stdin);
-    assert.doesNotThrow(() => w.stdout);
-    assert.doesNotThrow(() => w.stderr);
+    w.stdin;
+    w.stdout;
+    w.stderr;
 
     // Sanity check.
     assert.strictEqual(w.threadId, -1);


### PR DESCRIPTION
`Worker#postMessage`, `Worker#stdin`, `Worker#stdout`, and `Worker#stderr` currently throw if called/accessed after a worker is terminated.

`postMessage` silently fails in the browser after termination. It also seems cleaner if the stdio streams are set to `null` after termination. This PR implements that behavior.