### PR TITLE
[v8.x] deps: V8: cherry-pick 3cc6919

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 6
 #define V8_MINOR_VERSION 2
 #define V8_BUILD_NUMBER 414
-#define V8_PATCH_LEVEL 76
+#define V8_PATCH_LEVEL 77
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)


### PR DESCRIPTION
Original commit message:

    PPC: fix Regex addi overflow

    using add insetad of addi when Operand is more than 16 bits long

    Change-Id: I7f9452381ed8b321ec71e68d0d90485508b69885
    Reviewed-on: https://chromium-review.googlesource.com/c/1430619
    Commit-Queue: Junliang Yan <jyan@ca.ibm.com>
    Reviewed-by: Junliang Yan <jyan@ca.ibm.com>
    Cr-Commit-Position: refs/heads/master@{#59049}

Refs: https://github.com/v8/v8/commit/3cc69194b5ee967d0386fdd47de7a84141fef8cc

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
