### PR TITLE
tls: check arg types of renegotiate()

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -39,6 +39,7 @@ const { owner_symbol } = require('internal/async_hooks').symbols;
 const { SecureContext: NativeSecureContext } = internalBinding('crypto');
 const {
   ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_CALLBACK,
   ERR_MULTIPLE_CALLBACK,
   ERR_SOCKET_CLOSED,
   ERR_TLS_DH_PARAM_SIZE,
@@ -560,6 +561,11 @@ TLSSocket.prototype._init = function(socket, wrap) {
 };
 
 TLSSocket.prototype.renegotiate = function(options, callback) {
+  if (options === null || typeof options !== 'object')
+    throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
+  if (callback != null && typeof callback !== 'function')
+    throw new ERR_INVALID_CALLBACK();
+
   if (this.destroyed)
     return;
 

--- a/test/parallel/test-tls-disable-renegotiation.js
+++ b/test/parallel/test-tls-disable-renegotiation.js
@@ -47,6 +47,22 @@ server.listen(0, common.mustCall(() => {
   };
   const client = tls.connect(options, common.mustCall(() => {
     client.write('');
+
+    common.expectsError(() => client.renegotiate(), {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+    });
+
+    common.expectsError(() => client.renegotiate(common.mustNotCall()), {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+    });
+
+    common.expectsError(() => client.renegotiate({}, false), {
+      code: 'ERR_INVALID_CALLBACK',
+      type: TypeError,
+    });
+
     // Negotiation is still permitted for this first
     // attempt. This should succeed.
     let ok = client.renegotiate(options, common.mustCall((err) => {


### PR DESCRIPTION
Don't throw on invalid property access if options is not provided, and
ensure callback is a function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
