### PR TITLE
benchmark: remove unreachable return

### DIFF
--- a/benchmark/_cli.js
+++ b/benchmark/_cli.js
@@ -72,7 +72,6 @@ function CLI(usage, settings) {
     } else {
       // Bad case, abort
       this.abort(usage);
-      return;
     }
   }
 }

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -169,7 +169,6 @@ Benchmark.prototype._run = function() {
     child.on('close', (code) => {
       if (code) {
         process.exit(code);
-        return;
       }
 
       if (queueIndex + 1 < self.queue.length) {

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -25,7 +25,6 @@ const cli = CLI(`usage: ./node compare.js [options] [--] <category> ...
 
 if (!cli.optional.new || !cli.optional.old) {
   cli.abort(cli.usage);
-  return;
 }
 
 const binaries = ['old', 'new'];
@@ -98,7 +97,6 @@ if (showProgress) {
   child.once('close', function(code) {
     if (code) {
       process.exit(code);
-      return;
     }
     if (showProgress) {
       progress.completeRun(job);

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -67,7 +67,6 @@ if (format === 'csv') {
   child.once('close', function(code) {
     if (code) {
       process.exit(code);
-      return;
     }
 
     // If there are more benchmarks execute the next

--- a/benchmark/scatter.js
+++ b/benchmark/scatter.js
@@ -17,7 +17,6 @@ const cli = CLI(`usage: ./node scatter.js [options] [--] <filename>
 
 if (cli.items.length !== 1) {
   cli.abort(cli.usage);
-  return;
 }
 
 // Create queue from the benchmarks list such both node versions are tested


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Remove the unreachable `return` since `this.abort` has `process.exit(1)`.

https://github.com/nodejs/node/blob/0f8e8f7c6b9e7a8bdae53c831f37b2034d1c9fa7/benchmark/_cli.js#L74-L84

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
