### PR TITLE
tools: improve prerequisites for test-all-suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=debug,release --valgrind
 
 .PHONY: test-all-suites
-test-all-suites: test-build test-js-native-api test-node-api | bench-addons-build ## Run all test suites.
+test-all-suites: | clear-stalled test-build bench-addons-build doc-only ## Run all test suites.
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) test/*
 
 CI_NATIVE_SUITES ?= addons js-native-api node-api


### PR DESCRIPTION
The prerequisistes for test-all-suites were running some tests
themselves. When one of those tests failed during a coverage run, it
resulted in artificially low coverage. Fix the prerequisites to only
build stuff, not test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
