### PR TITLE
src: use `visibility("default")` for exports on POSIX

### DIFF
--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -22,7 +22,7 @@
   #ifdef _WIN32
     #define NAPI_EXTERN __declspec(dllexport)
   #else
-    #define NAPI_EXTERN /* nothing */
+    #define NODE_EXTERN __attribute__((visibility("default")))
   #endif
 #endif
 

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -22,7 +22,7 @@
   #ifdef _WIN32
     #define NAPI_EXTERN __declspec(dllexport)
   #else
-    #define NODE_EXTERN __attribute__((visibility("default")))
+    #define NAPI_EXTERN __attribute__((visibility("default")))
   #endif
 #endif
 

--- a/src/node.h
+++ b/src/node.h
@@ -29,7 +29,7 @@
 #   define NODE_EXTERN __declspec(dllimport)
 # endif
 #else
-# define NODE_EXTERN /* nothing */
+# define NODE_EXTERN __attribute__((visibility("default")))
 #endif
 
 #ifdef BUILDING_NODE_EXTENSION


### PR DESCRIPTION
Electron uses this because Chromium builds with symbols
hidden by default.

Refs: https://github.com/electron/node/commit/88b494191c2a5b50b01dab80cd61ba3c0e0fbeb9
Refs: https://github.com/electron/node/commit/1293d1d7d0c33d3925da11ceccdce4eb2e927a43

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
