### PR TITLE
test,tracing: use close event to wait for stdio

### DIFF
--- a/test/parallel/test-trace-events-category-used.js
+++ b/test/parallel/test-trace-events-category-used.js
@@ -28,7 +28,7 @@ let procEnabledOutput = '';
 
 procEnabled.stdout.on('data', (data) => procEnabledOutput += data);
 procEnabled.stderr.pipe(process.stderr);
-procEnabled.once('exit', common.mustCall(() => {
+procEnabled.once('close', common.mustCall(() => {
   assert.strictEqual(procEnabledOutput, 'true\n');
 }));
 
@@ -46,6 +46,6 @@ let procDisabledOutput = '';
 
 procDisabled.stdout.on('data', (data) => procDisabledOutput += data);
 procDisabled.stderr.pipe(process.stderr);
-procDisabled.once('exit', common.mustCall(() => {
+procDisabled.once('close', common.mustCall(() => {
   assert.strictEqual(procDisabledOutput, 'false\n');
 }));


### PR DESCRIPTION
Use `'close'` rather than `'exit'` to make sure that all stdio
has been captured by the time that the event handler is run.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
