### PR TITLE
test: mark test-trace-events-fs-sync as FLAKY

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -14,8 +14,12 @@ test-trace-events-api-worker-disabled: PASS,FLAKY
 test-http2-pipe: PASS,FLAKY
 test-worker-syntax-error: PASS,FLAKY
 test-worker-syntax-error-file: PASS,FLAKY
+
 # https://github.com/nodejs/node/issues/23277
 test-worker-memory: PASS,FLAKY
+
+# https://github.com/nodejs/node/issues/25512
+test-trace-events-fs-sync: PASS,FLAKY
 
 [$system==linux]
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/25512

Flake frequency ebbs and flows but it's still a pain.
Marking as FLAKY until we solve the underling issue.

/CC @nodejs/testing @gireeshpunathil @addaleax 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
