### PR TITLE
report: use libuv calls for OS and machine info

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -57,8 +57,11 @@ is provided below for reference.
     "release": {
       "name": "node"
     },
-    "osVersion": "Linux 3.10.0-862.el7.x86_64 #1 SMP Wed Mar 21 18:14:51 EDT 2018",
-    "machine": "test_machine x86_64"
+    "osName": "Linux",
+    "osRelease": "3.10.0-862.el7.x86_64",
+    "osVersion": "#1 SMP Wed Mar 21 18:14:51 EDT 2018",
+    "osMachine": "x86_64",
+    "host": "test_machine"
   },
   "javascriptStack": {
     "message": "Error: *** test-exception.js: throwing uncaught Error",

--- a/node.gyp
+++ b/node.gyp
@@ -334,13 +334,11 @@
             ['OS=="win"', {
               'libraries': [
                 'dbghelp.lib',
-                'Netapi32.lib',
                 'PsApi.lib',
                 'Ws2_32.lib',
               ],
               'dll_files': [
                 'dbghelp.dll',
-                'Netapi32.dll',
                 'PsApi.dll',
                 'Ws2_32.dll',
               ],
@@ -676,13 +674,11 @@
             ['OS=="win"', {
               'libraries': [
                 'dbghelp.lib',
-                'Netapi32.lib',
                 'PsApi.lib',
                 'Ws2_32.lib',
               ],
               'dll_files': [
                 'dbghelp.dll',
-                'Netapi32.dll',
                 'PsApi.dll',
                 'Ws2_32.dll',
               ],
@@ -1041,13 +1037,11 @@
             ['OS=="win"', {
               'libraries': [
                 'dbghelp.lib',
-                'Netapi32.lib',
                 'PsApi.lib',
                 'Ws2_32.lib',
               ],
               'dll_files': [
                 'dbghelp.dll',
-                'Netapi32.dll',
                 'PsApi.dll',
                 'Ws2_32.dll',
               ],


### PR DESCRIPTION
Replace platform specific code with libuv calls. Note that currently `uv_os_uname()` doesn't report the full product name on Windows. There is an open PR to libuv that would add that information. I'm not sure if anyone feels strongly about this landing before that libuv update. It doesn't matter to me, but see https://github.com/nodejs/node/issues/25843.

Fixes: https://github.com/nodejs/node/issues/25843

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
