### PR TITLE
worker: remove undocumented .onclose property

### DIFF
--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -102,12 +102,6 @@ Object.defineProperty(MessagePort.prototype, onInitSymbol, {
 
 // This is called after the underlying `uv_async_t` has been closed.
 function onclose() {
-  if (typeof this.onclose === 'function') {
-    // Not part of the Web standard yet, but there aren't many reasonable
-    // alternatives in a non-EventEmitter usage setting.
-    // Refs: https://github.com/whatwg/html/issues/1766
-    this.onclose();
-  }
   this.emit('close');
 }
 


### PR DESCRIPTION
Remove setting of a 'close' event handler on MessagePort through the use
of an `.onclose` property. We don't use this convention anywhere else in
our codebase for 'close' events, this feature is undocumented, and we
don't test it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
