### PR TITLE
src: add PrintLibuvHandleInformation debug helper

### DIFF
--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -282,20 +282,29 @@ void DumpBacktrace(FILE* fp) {
 void CheckedUvLoopClose(uv_loop_t* loop) {
   if (uv_loop_close(loop) == 0) return;
 
+  PrintLibuvHandleInformation(loop, stderr);
+
+  fflush(stderr);
+  // Finally, abort.
+  CHECK(0 && "uv_loop_close() while having open handles");
+}
+
+void PrintLibuvHandleInformation(uv_loop_t* loop, FILE* stream) {
   auto sym_ctx = NativeSymbolDebuggingContext::New();
 
-  fprintf(stderr, "uv loop at [%p] has active handles\n", loop);
+  fprintf(stream, "uv loop at [%p] has %d active handles\n",
+          loop, loop->active_handles);
 
   uv_walk(loop, [](uv_handle_t* handle, void* arg) {
     auto sym_ctx = static_cast<NativeSymbolDebuggingContext*>(arg);
 
-    fprintf(stderr, "[%p] %s\n", handle, uv_handle_type_name(handle->type));
+    fprintf(stream, "[%p] %s\n", handle, uv_handle_type_name(handle->type));
 
     void* close_cb = reinterpret_cast<void*>(handle->close_cb);
-    fprintf(stderr, "\tClose callback: %p %s\n",
+    fprintf(stream, "\tClose callback: %p %s\n",
         close_cb, sym_ctx->LookupSymbol(close_cb).Display().c_str());
 
-    fprintf(stderr, "\tData: %p %s\n",
+    fprintf(stream, "\tData: %p %s\n",
         handle->data, sym_ctx->LookupSymbol(handle->data).Display().c_str());
 
     // We are also interested in the first field of what `handle->data`
@@ -309,14 +318,10 @@ void CheckedUvLoopClose(uv_loop_t* loop) {
       first_field = *reinterpret_cast<void**>(handle->data);
 
     if (first_field != nullptr) {
-      fprintf(stderr, "\t(First field): %p %s\n",
+      fprintf(stream, "\t(First field): %p %s\n",
           first_field, sym_ctx->LookupSymbol(first_field).Display().c_str());
     }
   }, sym_ctx.get());
-
-  fflush(stderr);
-  // Finally, abort.
-  CHECK(0 && "uv_loop_close() while having open handles");
 }
 
 std::vector<std::string> NativeSymbolDebuggingContext::GetLoadedLibraries() {

--- a/src/debug_utils.h
+++ b/src/debug_utils.h
@@ -119,6 +119,7 @@ class NativeSymbolDebuggingContext {
 // about giving information on currently existing handles, if there are any,
 // but still aborts the process.
 void CheckedUvLoopClose(uv_loop_t* loop);
+void PrintLibuvHandleInformation(uv_loop_t* loop, FILE* stream);
 
 }  // namespace node
 

--- a/test/abort/test-addon-uv-handle-leak.js
+++ b/test/abort/test-addon-uv-handle-leak.js
@@ -89,7 +89,7 @@ if (process.argv[2] === 'child') {
 
     switch (state) {
       case 'initial':
-        assert(/^uv loop at \[.+\] has active handles$/.test(line), line);
+        assert(/^uv loop at \[.+\] has \d+ active handles$/.test(line), line);
         state = 'handle-start';
         break;
       case 'handle-start':


### PR DESCRIPTION
This function is not only helpful for debugging crashes,
but can also be used as an ad-hoc debugging statement.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes (probably)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
