### PR TITLE
worker,etw: only enable ETW on the main thread

### DIFF
--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -288,7 +288,11 @@ void InitDTrace(Environment* env, Local<Object> target) {
   }
 
 #ifdef HAVE_ETW
-  init_etw();
+  // ETW is neither thread-safe nor does it clean up resources on exit,
+  // so we can use it only on the main thread.
+  if (env->is_main_thread()) {
+    init_etw();
+  }
 #endif
 
 #if defined HAVE_DTRACE || defined HAVE_ETW


### PR DESCRIPTION
The Windows ETW code is not written to be compatible with multi-threading,
and in particular it relies on global state like a single static
`uv_async_t`. Adding that to multiple threads would corrupt the
corresponding loops' handle queues.

This addresses the flakiness of at least `test-worker-exit-code` and
very likely other flaky tests that relate to Worker threads on Windows as well.

(I've marked the less-easy-to-reproduce flaky tests as likely fixed -- we can still re-open the issues if it turns they are still problematic.)

Fixes: https://github.com/nodejs/node/issues/25847
Fixes: https://github.com/nodejs/node/issues/25702 (likely)
Fixes: https://github.com/nodejs/node/issues/24005 (likely)
Fixes: https://github.com/nodejs/node/issues/23873 (likely)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes (probably)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
