### PR TITLE
report: print libuv handle addresses as hex

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -171,49 +171,49 @@ is provided below for reference.
       "type": "async",
       "is_active": true,
       "is_referenced": false,
-      "address": "68090592",
+      "address": "0x0000000102910900",
       "details": ""
     },
     {
       "type": "timer",
       "is_active": false,
       "is_referenced": false,
-      "address": "140723513949920",
+      "address": "0x00007fff5fbfeab0",
       "details": "repeat: 0, timeout expired: 18075165916 ms ago"
     },
     {
       "type": "check",
       "is_active": true,
       "is_referenced": false,
-      "address": "140723513950072",
+      "address": "0x00007fff5fbfeb48",
       "details": ""
     },
     {
       "type": "idle",
       "is_active": false,
       "is_referenced": true,
-      "address": "140723513950192",
+      "address": "0x00007fff5fbfebc0",
       "details": ""
     },
     {
       "type": "prepare",
       "is_active": false,
       "is_referenced": false,
-      "address": "140723513950312",
+      "address": "0x00007fff5fbfec38",
       "details": ""
     },
     {
       "type": "check",
       "is_active": false,
       "is_referenced": false,
-      "address": "140723513950432",
+      "address": "0x00007fff5fbfecb0",
       "details": ""
     },
     {
       "type": "async",
       "is_active": true,
       "is_referenced": false,
-      "address": "39353856",
+      "address": "0x000000010188f2e0",
       "details": ""
     }
   ],

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -53,10 +53,12 @@ void GetNodeReport(v8::Isolate* isolate,
                    v8::Local<v8::String> stackstr,
                    std::ostream& out);
 
-// Function declarations - utility functions in src/utilities.cc
+// Function declarations - utility functions in src/node_report_utils.cc
 void ReportEndpoints(uv_handle_t* h, std::ostringstream& out);
 void WalkHandle(uv_handle_t* h, void* arg);
 std::string EscapeJsonChars(const std::string& str);
+template <typename T>
+std::string ValueToHexString(T value);
 
 // Function declarations - export functions in src/node_report_module.cc
 void TriggerReport(const v8::FunctionCallbackInfo<v8::Value>& info);

--- a/src/node_report_utils.cc
+++ b/src/node_report_utils.cc
@@ -209,9 +209,18 @@ void WalkHandle(uv_handle_t* h, void* arg) {
   writer->json_keyvalue("is_active", static_cast<bool>(uv_is_active(h)));
   writer->json_keyvalue("is_referenced", static_cast<bool>(uv_has_ref(h)));
   writer->json_keyvalue("address",
-                        std::to_string(reinterpret_cast<int64_t>(h)));
+                        ValueToHexString(reinterpret_cast<uint64_t>(h)));
   writer->json_keyvalue("details", data.str());
   writer->json_end();
+}
+
+template <typename T>
+std::string ValueToHexString(T value) {
+  std::stringstream hex;
+
+  hex << "0x" << std::setfill('0') << std::setw(sizeof(T) * 2) << std::hex <<
+    value;
+  return hex.str();
 }
 
 std::string EscapeJsonChars(const std::string& str) {


### PR DESCRIPTION
hex is more common than decimal when discussing addresses.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
