### PR TITLE
report: catch internal segfaults

### DIFF
--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -22,6 +22,9 @@ void AppendExceptionLine(Environment* env,
 
 [[noreturn]] void FatalError(const char* location, const char* message);
 void OnFatalError(const char* location, const char* message);
+#ifndef _WIN32
+void OnSIGSEGV(int signo);
+#endif  //  _WIN32
 
 // Like a `TryCatch` but exits the process if an exception was caught.
 class FatalTryCatch : public v8::TryCatch {


### PR DESCRIPTION
`--diagnostic-report-on-fatalerror` does not capture internal
segfaults at present, instead limited to only faults that are
detected by the Node / v8. libuv's signal handler deliveres
result asynchronously which does not help for SIGSEGV as:
i) the synchronous sequence restarts the failing code,
ii) due to i) the callback is never delivered to the consumer.

Install a SIGSEGV handler in Node and follow the sequence of
fatalerror handling, as of now at least under report.

Fixes: https://github.com/nodejs/node/issues/25762

cc @addaleax @sam-github @bnoordhuis 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
