### PR TITLE
src: use bool instead of integer literal in connection_wrap.cc

### DIFF
--- a/src/connection_wrap.cc
+++ b/src/connection_wrap.cc
@@ -94,7 +94,7 @@ void ConnectionWrap<WrapType, UVType>::AfterConnect(uv_connect_t* req,
   bool readable, writable;
 
   if (status) {
-    readable = writable = 0;
+    readable = writable = false;
   } else {
     readable = uv_is_readable(req->handle) != 0;
     writable = uv_is_writable(req->handle) != 0;


### PR DESCRIPTION
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
