### PR TITLE
Assert buf->base is not NULL

### DIFF
--- a/deps/uv/test/test-delayed-accept.c
+++ b/deps/uv/test/test-delayed-accept.c
@@ -32,6 +32,7 @@ static int connect_cb_called = 0;
 
 static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
   buf->base = malloc(size);
+  ASSERT(buf->base != NULL);
   buf->len = size;
 }
 


### PR DESCRIPTION
##### Checklist
- [ x] tests and/or benchmarks are included
- [ x] commit message follows [commit guidelines]
PR description:
Null pointer dereference is a danger operation with undefined behavior