### PR TITLE
tls: null not valid as a renegotiate callback

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -584,7 +584,7 @@ TLSSocket.prototype._init = function(socket, wrap) {
 TLSSocket.prototype.renegotiate = function(options, callback) {
   if (options === null || typeof options !== 'object')
     throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
-  if (callback != null && typeof callback !== 'function')
+  if (callback !== undefined && typeof callback !== 'function')
     throw new ERR_INVALID_CALLBACK();
 
   if (this.destroyed)

--- a/test/parallel/test-tls-disable-renegotiation.js
+++ b/test/parallel/test-tls-disable-renegotiation.js
@@ -63,6 +63,12 @@ server.listen(0, common.mustCall(() => {
       type: TypeError,
     });
 
+    common.expectsError(() => client.renegotiate({}, null), {
+      code: 'ERR_INVALID_CALLBACK',
+      type: TypeError,
+    });
+
+
     // Negotiation is still permitted for this first
     // attempt. This should succeed.
     let ok = client.renegotiate(options, common.mustCall((err) => {


### PR DESCRIPTION
Allow undefined as a callback, but do not allow null.

Belatedly respond to https://github.com/nodejs/node/pull/25876#discussion_r253266806

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
