### PR TITLE
test: add coverage for boxed bigints comparisons and edge cases

### DIFF
--- a/test/parallel/test-util-isDeepStrictEqual.js
+++ b/test/parallel/test-util-isDeepStrictEqual.js
@@ -447,6 +447,8 @@ assert.strictEqual(
   notUtilIsDeepStrict(boxedString, Object('test'));
   boxedSymbol.slow = true;
   notUtilIsDeepStrict(boxedSymbol, {});
+  utilIsDeepStrict(Object(BigInt(1)), Object(BigInt(1)));
+  notUtilIsDeepStrict(Object(BigInt(1)), Object(BigInt(2)));
 }
 
 // Minus zero

--- a/test/parallel/test-util-isDeepStrictEqual.js
+++ b/test/parallel/test-util-isDeepStrictEqual.js
@@ -449,6 +449,31 @@ assert.strictEqual(
   notUtilIsDeepStrict(boxedSymbol, {});
   utilIsDeepStrict(Object(BigInt(1)), Object(BigInt(1)));
   notUtilIsDeepStrict(Object(BigInt(1)), Object(BigInt(2)));
+
+  const booleanish = new Boolean(true);
+  Object.defineProperty(booleanish, Symbol.toStringTag, { value: 'String' });
+  Object.setPrototypeOf(booleanish, String.prototype);
+  notUtilIsDeepStrict(booleanish, new String('true'));
+
+  const numberish = new Number(42);
+  Object.defineProperty(numberish, Symbol.toStringTag, { value: 'String' });
+  Object.setPrototypeOf(numberish, String.prototype);
+  notUtilIsDeepStrict(numberish, new String('42'));
+
+  const stringish = new String('0');
+  Object.defineProperty(stringish, Symbol.toStringTag, { value: 'Number' });
+  Object.setPrototypeOf(stringish, Number.prototype);
+  notUtilIsDeepStrict(stringish, new Number(0));
+
+  const bigintish = new Object(BigInt(42));
+  Object.defineProperty(bigintish, Symbol.toStringTag, { value: 'String' });
+  Object.setPrototypeOf(bigintish, String.prototype);
+  notUtilIsDeepStrict(bigintish, new String('42'));
+
+  const symbolish = new Object(Symbol('fhqwhgads'));
+  Object.defineProperty(symbolish, Symbol.toStringTag, { value: 'String' });
+  Object.setPrototypeOf(symbolish, String.prototype);
+  notUtilIsDeepStrict(symbolish, new String('fhqwhgads'));
 }
 
 // Minus zero


### PR DESCRIPTION
First commit:

    test: add BigInt test for isDeepStrictEqual
    
    Add some BigInt tests for test-util-isDeepStrictEqual to get 100%
    coverage for lib/internal/util/comparisons.js.

<strike>Second commit:

    util: remove unnecessary conditions for isDeepStrictEqual
    
    The internal `isEqualBoxedPrimitive()` checks some conditions that are
    not necessary. Remove those conditions.
</strike>

Second commit:


    test: add util.isDeepStrictEqual edge case tests
    
    Test for deep strict equality when prototype and toStringTag
    have been modified in surprising ways.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
