### PR TITLE
src: nullcheck on trace controller

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -208,8 +208,7 @@ Environment::Environment(IsolateData* isolate_data,
   if (tracing::AgentWriterHandle* writer = GetTracingAgentWriter()) {
     trace_state_observer_ = std::make_unique<TrackingTraceStateObserver>(this);
     TracingController* tracing_controller = writer->GetTracingController();
-    if (tracing_controller != nullptr)
-      tracing_controller->AddTraceStateObserver(trace_state_observer_.get());
+    tracing_controller->AddTraceStateObserver(trace_state_observer_.get());
   }
 
   destroy_async_id_list_.reserve(512);
@@ -272,8 +271,7 @@ Environment::~Environment() {
     tracing::AgentWriterHandle* writer = GetTracingAgentWriter();
     CHECK_NOT_NULL(writer);
     TracingController* tracing_controller = writer->GetTracingController();
-    if (tracing_controller != nullptr)
-      tracing_controller->RemoveTraceStateObserver(trace_state_observer_.get());
+    tracing_controller->RemoveTraceStateObserver(trace_state_observer_.get());
   }
 
   delete[] heap_statistics_buffer_;

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -459,6 +459,7 @@ double NodePlatform::CurrentClockTimeMillis() {
 }
 
 TracingController* NodePlatform::GetTracingController() {
+  CHECK_NOT_NULL(tracing_controller_);
   return tracing_controller_;
 }
 

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -81,7 +81,9 @@ class Agent {
   ~Agent();
 
   TracingController* GetTracingController() {
-    return tracing_controller_.get();
+    TracingController* controller = tracing_controller_.get();
+    CHECK_NOT_NULL(controller);
+    return controller;
   }
 
   enum UseDefaultCategoryMode {


### PR DESCRIPTION
Insert a NULLCHECK prior to return. Ideally we do this in the caller,
but the TraceController object is somewhat special as:
1. It is accessed by most threads
2. It's life cycle is managed by Agent::Agent
3. It's getter is invoked through Base Methods (upstream)

Refs: https://github.com/nodejs/node/issues/25814

cc @addaleax 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
