### PR TITLE
benchmark: refactor for consistent style

### DIFF
--- a/benchmark/.eslintrc.yaml
+++ b/benchmark/.eslintrc.yaml
@@ -1,0 +1,10 @@
+## Benchmark-specific linter rules
+
+rules:
+  comma-dangle: 
+    - error
+    - arrays: 'always-multiline'
+      objects: 'only-multiline'
+      imports: 'only-multiline'
+      exports: 'only-multiline'
+  prefer-arrow-callback: error

--- a/benchmark/_cli.js
+++ b/benchmark/_cli.js
@@ -6,10 +6,8 @@ const path = require('path');
 // Create an object of all benchmark scripts
 const benchmarks = {};
 fs.readdirSync(__dirname)
-  .filter(function(name) {
-    return fs.statSync(path.resolve(__dirname, name)).isDirectory();
-  })
-  .forEach(function(category) {
+  .filter((name) => fs.statSync(path.resolve(__dirname, name)).isDirectory())
+  .forEach((category) => {
     benchmarks[category] = fs.readdirSync(path.resolve(__dirname, category))
       .filter((filename) => filename[0] !== '.' && filename[0] !== '_');
   });

--- a/benchmark/buffers/buffer-bytelength.js
+++ b/benchmark/buffers/buffer-bytelength.js
@@ -12,7 +12,7 @@ const chars = [
   'hello brendan!!!', // 1 byte
   'ΰαβγδεζηθικλμνξο', // 2 bytes
   '挰挱挲挳挴挵挶挷挸挹挺挻挼挽挾挿', // 3 bytes
-  '𠜎𠜱𠝹𠱓𠱸𠲖𠳏𠳕𠴕𠵼𠵿𠸎𠸏𠹷𠺝𠺢' // 4 bytes
+  '𠜎𠜱𠝹𠱓𠱸𠲖𠳏𠳕𠴕𠵼𠵿𠸎𠸏𠹷𠺝𠺢', // 4 bytes
 ];
 
 function main({ n, len, encoding }) {
@@ -33,9 +33,7 @@ function main({ n, len, encoding }) {
     }
 
     // Check the result to ensure it is *properly* optimized
-    results = strings.map(function(val) {
-      return Buffer.byteLength(val, encoding);
-    });
+    results = strings.map((val) => Buffer.byteLength(val, encoding));
   }
 
   bench.start();

--- a/benchmark/buffers/buffer-fill.js
+++ b/benchmark/buffers/buffer-fill.js
@@ -12,7 +12,7 @@ const bench = common.createBenchmark(main, {
     'fill("t", "utf8")',
     'fill("t", 0, "utf8")',
     'fill("t", 0)',
-    'fill(Buffer.alloc(1), 0)'
+    'fill(Buffer.alloc(1), 0)',
   ],
   size: [2 ** 8, 2 ** 13, 2 ** 16],
   n: [2e4]

--- a/benchmark/buffers/buffer-from.js
+++ b/benchmark/buffers/buffer-from.js
@@ -12,7 +12,7 @@ const bench = common.createBenchmark(main, {
     'string',
     'string-utf8',
     'string-base64',
-    'object'
+    'object',
   ],
   len: [10, 2048],
   n: [2048]

--- a/benchmark/buffers/buffer-indexof.js
+++ b/benchmark/buffers/buffer-indexof.js
@@ -18,7 +18,7 @@ const searchStrings = [
   'Soo--oop',
   'aaaaaaaaaaaaaaaaa',
   'venture to go near the house till she had brought herself down to',
-  '</i> to the Caterpillar'
+  '</i> to the Caterpillar',
 ];
 
 const bench = common.createBenchmark(main, {

--- a/benchmark/buffers/buffer-normalize-encoding.js
+++ b/benchmark/buffers/buffer-normalize-encoding.js
@@ -25,7 +25,7 @@ const bench = common.createBenchmark(main, {
     'utf16le',
     'UTF16LE',
     'utf8',
-    'UTF8'
+    'UTF8',
   ],
   n: [1e6]
 }, {

--- a/benchmark/buffers/buffer-read-with-byteLength.js
+++ b/benchmark/buffers/buffer-read-with-byteLength.js
@@ -5,7 +5,7 @@ const types = [
   'IntBE',
   'IntLE',
   'UIntBE',
-  'UIntLE'
+  'UIntLE',
 ];
 
 const bench = common.createBenchmark(main, {

--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -15,7 +15,7 @@ const types = [
   'FloatLE',
   'FloatBE',
   'DoubleLE',
-  'DoubleBE'
+  'DoubleBE',
 ];
 
 const bench = common.createBenchmark(main, {

--- a/benchmark/buffers/buffer-write-string.js
+++ b/benchmark/buffers/buffer-write-string.js
@@ -3,7 +3,7 @@
 const common = require('../common.js');
 const bench = common.createBenchmark(main, {
   encoding: [
-    '', 'utf8', 'ascii', 'hex', 'UCS-2', 'utf16le', 'latin1', 'binary'
+    '', 'utf8', 'ascii', 'hex', 'UCS-2', 'utf16le', 'latin1', 'binary',
   ],
   args: [ '', 'offset', 'offset+length' ],
   len: [10, 2048],

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -19,7 +19,7 @@ const types = [
   'FloatLE',
   'FloatBE',
   'DoubleLE',
-  'DoubleBE'
+  'DoubleBE',
 ];
 
 const bench = common.createBenchmark(main, {

--- a/benchmark/buffers/dataview-set.js
+++ b/benchmark/buffers/dataview-set.js
@@ -15,7 +15,7 @@ const types = [
   'Float32LE',
   'Float32BE',
   'Float64LE',
-  'Float64BE'
+  'Float64BE',
 ];
 
 const bench = common.createBenchmark(main, {

--- a/benchmark/child_process/child-process-read-ipc.js
+++ b/benchmark/child_process/child-process-read-ipc.js
@@ -13,7 +13,7 @@ if (process.argv[2] === 'child') {
   const bench = common.createBenchmark(main, {
     len: [
       64, 256, 1024, 4096, 16384, 65536,
-      65536 << 4, 65536 << 8
+      65536 << 4, 65536 << 8,
     ],
     dur: [5]
   });
@@ -27,11 +27,9 @@ if (process.argv[2] === 'child') {
                         [process.argv[1], 'child', len], options);
 
     var bytes = 0;
-    child.on('message', function(msg) {
-      bytes += msg.length;
-    });
+    child.on('message', (msg) => { bytes += msg.length; });
 
-    setTimeout(function() {
+    setTimeout(() => {
       child.kill();
       bench.end(bytes);
     }, dur * 1000);

--- a/benchmark/child_process/child-process-read.js
+++ b/benchmark/child_process/child-process-read.js
@@ -25,11 +25,11 @@ function main({ dur, len }) {
   const child = child_process.spawn('yes', [msg], options);
 
   var bytes = 0;
-  child.stdout.on('data', function(msg) {
+  child.stdout.on('data', (msg) => {
     bytes += msg.length;
   });
 
-  setTimeout(function() {
+  setTimeout(() => {
     if (process.platform === 'win32') {
       // Sometimes there's a yes.exe process left hanging around on Windows...
       child_process.execSync(`taskkill /f /t /pid ${child.pid}`);

--- a/benchmark/child_process/spawn-echo.js
+++ b/benchmark/child_process/spawn-echo.js
@@ -15,7 +15,7 @@ function go(n, left) {
     return bench.end(n);
 
   const child = spawn('echo', ['hello']);
-  child.on('exit', function(code) {
+  child.on('exit', (code) => {
     if (code)
       process.exit(code);
     else

--- a/benchmark/cluster/echo.js
+++ b/benchmark/cluster/echo.js
@@ -61,7 +61,7 @@ if (cluster.isMaster) {
     }
   }
 } else {
-  process.on('message', function(msg) {
+  process.on('message', (msg) => {
     process.send(msg);
   });
 }

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -72,7 +72,7 @@ if (showProgress) {
     execPath: cli.optional[job.binary]
   });
 
-  child.on('message', function(data) {
+  child.on('message', (data) => {
     if (data.type === 'report') {
       // Construct configuration string, " A=a, B=b, ..."
       let conf = '';
@@ -95,7 +95,7 @@ if (showProgress) {
     }
   });
 
-  child.once('close', function(code) {
+  child.once('close', (code) => {
     if (code) {
       process.exit(code);
       return;

--- a/benchmark/crypto/cipher-stream.js
+++ b/benchmark/crypto/cipher-stream.js
@@ -66,11 +66,11 @@ function main({ api, cipher, type, len, writes }) {
 
 function streamWrite(alice, bob, message, encoding, writes) {
   var written = 0;
-  bob.on('data', function(c) {
+  bob.on('data', (c) => {
     written += c.length;
   });
 
-  bob.on('end', function() {
+  bob.on('end', () => {
     // Gbits
     const bits = written * 8;
     const gbits = bits / (1024 * 1024 * 1024);

--- a/benchmark/crypto/rsa-encrypt-decrypt-throughput.js
+++ b/benchmark/crypto/rsa-encrypt-decrypt-throughput.js
@@ -9,7 +9,7 @@ const keylen_list = ['1024', '2048', '4096'];
 const RSA_PublicPem = {};
 const RSA_PrivatePem = {};
 
-keylen_list.forEach(function(key) {
+keylen_list.forEach((key) => {
   RSA_PublicPem[key] =
     fs.readFileSync(`${fixtures_keydir}/rsa_public_${key}.pem`);
   RSA_PrivatePem[key] =

--- a/benchmark/crypto/rsa-sign-verify-throughput.js
+++ b/benchmark/crypto/rsa-sign-verify-throughput.js
@@ -9,7 +9,7 @@ const keylen_list = ['1024', '2048'];
 const RSA_PublicPem = {};
 const RSA_PrivatePem = {};
 
-keylen_list.forEach(function(key) {
+keylen_list.forEach((key) => {
   RSA_PublicPem[key] =
     fs.readFileSync(`${fixtures_keydir}/rsa_public_${key}.pem`);
   RSA_PrivatePem[key] =

--- a/benchmark/dgram/array-vs-concat.js
+++ b/benchmark/dgram/array-vs-concat.js
@@ -43,11 +43,11 @@ function main({ dur, len, num, type, chunks }) {
     }
   }
 
-  socket.on('listening', function() {
+  socket.on('listening', () => {
     bench.start();
     onsend();
 
-    setTimeout(function() {
+    setTimeout(() => {
       const bytes = sent * len;
       const gbits = (bytes * 8) / (1024 * 1024 * 1024);
       bench.end(gbits);

--- a/benchmark/dgram/multi-buffer.js
+++ b/benchmark/dgram/multi-buffer.js
@@ -33,11 +33,11 @@ function main({ dur, len, num, type, chunks }) {
     }
   }
 
-  socket.on('listening', function() {
+  socket.on('listening', () => {
     bench.start();
     onsend();
 
-    setTimeout(function() {
+    setTimeout(() => {
       const bytes = (type === 'send' ? sent : received) * len;
       const gbits = (bytes * 8) / (1024 * 1024 * 1024);
       bench.end(gbits);
@@ -45,7 +45,7 @@ function main({ dur, len, num, type, chunks }) {
     }, dur * 1000);
   });
 
-  socket.on('message', function() {
+  socket.on('message', () => {
     received++;
   });
 

--- a/benchmark/dgram/offset-length.js
+++ b/benchmark/dgram/offset-length.js
@@ -29,11 +29,11 @@ function main({ dur, len, num, type }) {
     }
   }
 
-  socket.on('listening', function() {
+  socket.on('listening', () => {
     bench.start();
     onsend();
 
-    setTimeout(function() {
+    setTimeout(() => {
       const bytes = (type === 'send' ? sent : received) * chunk.length;
       const gbits = (bytes * 8) / (1024 * 1024 * 1024);
       bench.end(gbits);
@@ -41,7 +41,7 @@ function main({ dur, len, num, type }) {
     }, dur * 1000);
   });
 
-  socket.on('message', function() {
+  socket.on('message', () => {
     received++;
   });
 

--- a/benchmark/dgram/single-buffer.js
+++ b/benchmark/dgram/single-buffer.js
@@ -29,11 +29,11 @@ function main({ dur, len, num, type }) {
     }
   }
 
-  socket.on('listening', function() {
+  socket.on('listening', () => {
     bench.start();
     onsend();
 
-    setTimeout(function() {
+    setTimeout(() => {
       const bytes = (type === 'send' ? sent : received) * chunk.length;
       const gbits = (bytes * 8) / (1024 * 1024 * 1024);
       bench.end(gbits);
@@ -41,7 +41,7 @@ function main({ dur, len, num, type }) {
     }, dur * 1000);
   });
 
-  socket.on('message', function() {
+  socket.on('message', () => {
     received++;
   });
 

--- a/benchmark/es/map-bench.js
+++ b/benchmark/es/map-bench.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const bench = common.createBenchmark(main, {
   method: [
     'object', 'nullProtoObject', 'nullProtoLiteralObject', 'storageObject',
-    'fakeMap', 'map'
+    'fakeMap', 'map',
   ],
   n: [1e6]
 });

--- a/benchmark/events/ee-add-remove.js
+++ b/benchmark/events/ee-add-remove.js
@@ -10,7 +10,7 @@ function main({ n }) {
 
   var k;
   for (k = 0; k < 10; k += 1)
-    listeners.push(function() {});
+    listeners.push(() => {});
 
   bench.start();
   for (var i = 0; i < n; i += 1) {

--- a/benchmark/events/ee-emit.js
+++ b/benchmark/events/ee-emit.js
@@ -12,7 +12,7 @@ function main({ n, argc, listeners }) {
   const ee = new EventEmitter();
 
   for (var k = 0; k < listeners; k += 1)
-    ee.on('dummy', function() {});
+    ee.on('dummy', () => {});
 
   var i;
   switch (argc) {

--- a/benchmark/events/ee-listener-count-on-prototype.js
+++ b/benchmark/events/ee-listener-count-on-prototype.js
@@ -8,8 +8,8 @@ function main({ n }) {
   const ee = new EventEmitter();
 
   for (var k = 0; k < 5; k += 1) {
-    ee.on('dummy0', function() {});
-    ee.on('dummy1', function() {});
+    ee.on('dummy0', () => {});
+    ee.on('dummy1', () => {});
   }
 
   bench.start();

--- a/benchmark/events/ee-listeners-many.js
+++ b/benchmark/events/ee-listeners-many.js
@@ -9,8 +9,8 @@ function main({ n }) {
   ee.setMaxListeners(101);
 
   for (var k = 0; k < 50; k += 1) {
-    ee.on('dummy0', function() {});
-    ee.on('dummy1', function() {});
+    ee.on('dummy0', () => {});
+    ee.on('dummy1', () => {});
   }
 
   bench.start();

--- a/benchmark/events/ee-listeners.js
+++ b/benchmark/events/ee-listeners.js
@@ -8,8 +8,8 @@ function main({ n }) {
   const ee = new EventEmitter();
 
   for (var k = 0; k < 5; k += 1) {
-    ee.on('dummy0', function() {});
-    ee.on('dummy1', function() {});
+    ee.on('dummy0', () => {});
+    ee.on('dummy1', () => {});
   }
 
   bench.start();

--- a/benchmark/fixtures/simple-http-server.js
+++ b/benchmark/fixtures/simple-http-server.js
@@ -13,14 +13,14 @@ const useDomains = process.env.NODE_USE_DOMAINS;
 if (useDomains) {
   var domain = require('domain');
   const gdom = domain.create();
-  gdom.on('error', function(er) {
+  gdom.on('error', (er) => {
     console.error('Error on global domain', er);
     throw er;
   });
   gdom.enter();
 }
 
-module.exports = http.createServer(function(req, res) {
+module.exports = http.createServer((req, res) => {
   if (useDomains) {
     const dom = domain.create();
     dom.add(req);

--- a/benchmark/fs/bench-readdir.js
+++ b/benchmark/fs/bench-readdir.js
@@ -17,7 +17,7 @@ function main({ n, dir, withFileTypes }) {
   (function r(cntr) {
     if (cntr-- <= 0)
       return bench.end(n);
-    fs.readdir(fullPath, { withFileTypes }, function() {
+    fs.readdir(fullPath, { withFileTypes }, () => {
       r(cntr);
     });
   }(n));

--- a/benchmark/fs/bench-realpath.js
+++ b/benchmark/fs/bench-realpath.js
@@ -24,7 +24,7 @@ function relativePath(n) {
   (function r(cntr) {
     if (cntr-- <= 0)
       return bench.end(n);
-    fs.realpath(relative_path, function() {
+    fs.realpath(relative_path, () => {
       r(cntr);
     });
   }(n));
@@ -34,7 +34,7 @@ function resolvedPath(n) {
   (function r(cntr) {
     if (cntr-- <= 0)
       return bench.end(n);
-    fs.realpath(resolved_path, function() {
+    fs.realpath(resolved_path, () => {
       r(cntr);
     });
   }(n));

--- a/benchmark/fs/bench-stat.js
+++ b/benchmark/fs/bench-stat.js
@@ -24,7 +24,7 @@ function main({ n, statType }) {
         fs.closeSync(arg);
       return;
     }
-    fn(arg, function() {
+    fn(arg, () => {
       r(cntr, fn);
     });
   }(n, fs[statType]));

--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -45,16 +45,16 @@ function runTest() {
     encoding: encoding
   });
 
-  rs.on('open', function() {
+  rs.on('open', () => {
     bench.start();
   });
 
   var bytes = 0;
-  rs.on('data', function(chunk) {
+  rs.on('data', (chunk) => {
     bytes += chunk.length;
   });
 
-  rs.on('end', function() {
+  rs.on('end', () => {
     try { fs.unlinkSync(filename); } catch {}
     // MB/sec
     bench.end(bytes / (1024 * 1024));

--- a/benchmark/fs/readfile-partitioned.js
+++ b/benchmark/fs/readfile-partitioned.js
@@ -35,7 +35,7 @@ function main(conf) {
   var zips = 0;
   var benchEnded = false;
   bench.start();
-  setTimeout(function() {
+  setTimeout(() => {
     const totalOps = reads + zips;
     benchEnded = true;
     bench.end(totalOps);

--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -25,7 +25,7 @@ function main({ len, dur, concurrent }) {
   var reads = 0;
   var benchEnded = false;
   bench.start();
-  setTimeout(function() {
+  setTimeout(() => {
     benchEnded = true;
     bench.end(reads);
     try { fs.unlinkSync(filename); } catch {}

--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -42,7 +42,7 @@ function main({ dur, encodingType, size }) {
   f.on('drain', write);
   f.on('open', write);
   f.on('close', done);
-  f.on('finish', function() {
+  f.on('finish', () => {
     ended = true;
     const written = fs.statSync(filename).size / 1024;
     try { fs.unlinkSync(filename); } catch {}
@@ -53,7 +53,7 @@ function main({ dur, encodingType, size }) {
   function write() {
     if (!started) {
       started = true;
-      setTimeout(function() {
+      setTimeout(() => {
         f.end();
       }, dur * 1000);
       bench.start();

--- a/benchmark/http/_chunky_http_client.js
+++ b/benchmark/http/_chunky_http_client.js
@@ -54,11 +54,11 @@ function main({ len, n }) {
   const add = 11;
   var count = 0;
   const PIPE = process.env.PIPE_NAME;
-  var socket = net.connect(PIPE, function() {
+  var socket = net.connect(PIPE, () => {
     bench.start();
     WriteHTTPHeaders(socket, 1, len);
     socket.setEncoding('utf8');
-    socket.on('data', function(d) {
+    socket.on('data', (d) => {
       var did = false;
       var pattern = 'HTTP/1.1 200 OK\r\n';
       if ((d.length === pattern.length && d === pattern) ||
@@ -84,11 +84,11 @@ function main({ len, n }) {
         }
       }
     });
-    socket.on('close', function() {
+    socket.on('close', () => {
       console.log('Connection closed');
     });
 
-    socket.on('error', function() {
+    socket.on('error', () => {
       throw new Error('Connection error');
     });
   });

--- a/benchmark/http/check_invalid_header_char.js
+++ b/benchmark/http/check_invalid_header_char.js
@@ -18,7 +18,7 @@ const groupedInputs = {
     'sessionid=; Path=/', 'text/html; charset=utf-8',
     'text/html; charset=utf-8', '10', 'W/"a-eda64de5"', 'OK', 'Express',
     'Express', 'X-HTTP-Method-Override', 'sessionid=; Path=/',
-    'application/json'
+    'application/json',
   ],
 
   // Put it here so the benchmark result lines will not be super long.
@@ -45,7 +45,7 @@ const inputs = [
   // Invalid
   '中文呢', // unicode
   'foo\nbar',
-  '\x7F'
+  '\x7F',
 ];
 
 const bench = common.createBenchmark(main, {

--- a/benchmark/http/check_is_http_token.js
+++ b/benchmark/http/check_is_http_token.js
@@ -35,7 +35,7 @@ const bench = common.createBenchmark(main, {
     '中文呢', // unicode
     '((((())))', // invalid
     ':alternate-protocol', // fast bailout
-    'alternate-protocol:' // slow bailout
+    'alternate-protocol:', // slow bailout
   ],
   n: [1e6],
 });

--- a/benchmark/http/chunked.js
+++ b/benchmark/http/chunked.js
@@ -20,21 +20,21 @@ function main({ len, n, c }) {
   const http = require('http');
   const chunk = Buffer.alloc(len, '8');
 
-  const server = http.createServer(function(req, res) {
+  const server = http.createServer((req, res) => {
     function send(left) {
       if (left === 0) return res.end();
       res.write(chunk);
-      setTimeout(function() {
+      setTimeout(() => {
         send(left - 1);
       }, 0);
     }
     send(n);
   });
 
-  server.listen(common.PORT, function() {
+  server.listen(common.PORT, () => {
     bench.http({
       connections: c
-    }, function() {
+    }, () => {
       server.close();
     });
   });

--- a/benchmark/http/client-request-body.js
+++ b/benchmark/http/client-request-body.js
@@ -37,17 +37,17 @@ function main({ dur, len, type, method }) {
     method: 'POST'
   };
 
-  const server = http.createServer(function(req, res) {
+  const server = http.createServer((req, res) => {
     res.end();
   });
-  server.listen(options.port, options.host, function() {
+  server.listen(options.port, options.host, () => {
     setTimeout(done, dur * 1000);
     bench.start();
     pummel();
   });
 
   function pummel() {
-    const req = http.request(options, function(res) {
+    const req = http.request(options, (res) => {
       nreqs++;
       pummel();  // Line up next request.
       res.resume();

--- a/benchmark/http/cluster.js
+++ b/benchmark/http/cluster.js
@@ -21,18 +21,18 @@ function main({ type, len, c }) {
   const w1 = cluster.fork();
   const w2 = cluster.fork();
 
-  cluster.on('listening', function() {
+  cluster.on('listening', () => {
     workers++;
     if (workers < 2)
       return;
 
-    setImmediate(function() {
+    setImmediate(() => {
       const path = `/${type}/${len}`;
 
       bench.http({
         path: path,
         connections: c
-      }, function() {
+      }, () => {
         w1.destroy();
         w2.destroy();
       });

--- a/benchmark/http/end-vs-write-end.js
+++ b/benchmark/http/end-vs-write-end.js
@@ -43,14 +43,14 @@ function main({ len, type, method, c }) {
 
   const fn = method === 'write' ? write : end;
 
-  const server = http.createServer(function(req, res) {
+  const server = http.createServer((req, res) => {
     fn(res);
   });
 
-  server.listen(common.PORT, function() {
+  server.listen(common.PORT, () => {
     bench.http({
       connections: c
-    }, function() {
+    }, () => {
       server.close();
     });
   });

--- a/benchmark/http/headers.js
+++ b/benchmark/http/headers.js
@@ -21,15 +21,15 @@ function main({ duplicates, n }) {
     }
   }
 
-  const server = http.createServer(function(req, res) {
+  const server = http.createServer((req, res) => {
     res.writeHead(200, headers);
     res.end();
   });
-  server.listen(common.PORT, function() {
+  server.listen(common.PORT, () => {
     bench.http({
       path: '/',
       connections: 10
-    }, function() {
+    }, () => {
       server.close();
     });
   });

--- a/benchmark/http/http_server_for_chunky_client.js
+++ b/benchmark/http/http_server_for_chunky_client.js
@@ -12,7 +12,7 @@ tmpdir.refresh();
 
 var server;
 
-server = http.createServer(function(req, res) {
+server = http.createServer((req, res) => {
   const headers = {
     'content-type': 'text/plain',
     'content-length': '2'
@@ -21,7 +21,7 @@ server = http.createServer(function(req, res) {
   res.end('ok');
 });
 
-server.on('error', function(err) {
+server.on('error', (err) => {
   throw new Error(`server error: ${err}`);
 });
 server.listen(PIPE);
@@ -31,7 +31,7 @@ const child = fork(
   process.argv.slice(2)
 );
 child.on('message', common.sendResult);
-child.on('close', function(code) {
+child.on('close', (code) => {
   server.close();
   assert.strictEqual(code, 0);
 });

--- a/benchmark/http/set-header.js
+++ b/benchmark/http/set-header.js
@@ -19,13 +19,13 @@ function main({ res }) {
   process.env.PORT = PORT;
   var server = require('../fixtures/simple-http-server.js')
   .listen(PORT)
-  .on('listening', function() {
+  .on('listening', () => {
     const path = `/${type}/${len}/${chunks}/normal/${chunkedEnc}`;
 
     bench.http({
       path: path,
       connections: c
-    }, function() {
+    }, () => {
       server.close();
     });
   });

--- a/benchmark/http/set_header.js
+++ b/benchmark/http/set_header.js
@@ -11,7 +11,7 @@ const bench = common.createBenchmark(main, {
     'Content-Type',
     'Content-Length',
     'Connection',
-    'Transfer-Encoding'
+    'Transfer-Encoding',
   ],
   n: [1e6],
 });

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -13,13 +13,13 @@ const bench = common.createBenchmark(main, {
 function main({ type, len, chunks, c, chunkedEnc, res }) {
   var server = require('../fixtures/simple-http-server.js')
   .listen(common.PORT)
-  .on('listening', function() {
+  .on('listening', () => {
     const path = `/${type}/${len}/${chunks}/normal/${chunkedEnc}`;
 
     bench.http({
       path: path,
       connections: c
-    }, function() {
+    }, () => {
       server.close();
     });
   });

--- a/benchmark/http/upgrade.js
+++ b/benchmark/http/upgrade.js
@@ -21,14 +21,14 @@ const resData = 'HTTP/1.1 101 Web Socket Protocol Handshake\r\n' +
 function main({ n }) {
   var server = require('../fixtures/simple-http-server.js')
     .listen(common.PORT)
-    .on('listening', function() {
+    .on('listening', () => {
       bench.start();
-      doBench(server.address(), n, function() {
+      doBench(server.address(), n, () => {
         bench.end(n);
         server.close();
       });
     })
-    .on('upgrade', function(req, socket, upgradeHead) {
+    .on('upgrade', (req, socket, upgradeHead) => {
       socket.resume();
       socket.write(resData);
       socket.end();
@@ -45,7 +45,7 @@ function doBench(address, count, done) {
   conn.write(reqData);
   conn.resume();
 
-  conn.on('end', function() {
+  conn.on('end', () => {
     doBench(address, count - 1, done);
   });
 }

--- a/benchmark/misc/arguments.js
+++ b/benchmark/misc/arguments.js
@@ -7,7 +7,7 @@ const methods = [
   'restAndSpread',
   'argumentsAndApply',
   'restAndApply',
-  'predefined'
+  'predefined',
 ];
 
 const bench = createBenchmark(main, {

--- a/benchmark/misc/punycode.js
+++ b/benchmark/misc/punycode.js
@@ -32,7 +32,7 @@ const bench = common.createBenchmark(main, {
     'éire.icom.museum',
     'איקו״ם.ישראל.museum',
     '日本.icom.museum',
-    'الأردن.icom.museum'
+    'الأردن.icom.museum',
   ]
 });
 

--- a/benchmark/misc/startup.js
+++ b/benchmark/misc/startup.js
@@ -60,7 +60,7 @@ function main({ dur, script, mode }) {
     throughput: 0
   };
 
-  setTimeout(function() {
+  setTimeout(() => {
     state.go = false;
   }, dur * 1000);
 

--- a/benchmark/net/net-c2s-cork.js
+++ b/benchmark/net/net-c2s-cork.js
@@ -34,19 +34,19 @@ function main({ dur, len, type }) {
   const writer = new Writer();
 
   // the actual benchmark.
-  const server = net.createServer(function(socket) {
+  const server = net.createServer((socket) => {
     socket.pipe(writer);
   });
 
-  server.listen(PORT, function() {
+  server.listen(PORT, () => {
     const socket = net.connect(PORT);
-    socket.on('connect', function() {
+    socket.on('connect', () => {
       bench.start();
 
       socket.on('drain', send);
       send();
 
-      setTimeout(function() {
+      setTimeout(() => {
         const bytes = writer.received;
         const gbits = (bytes * 8) / (1024 * 1024 * 1024);
         bench.end(gbits);

--- a/benchmark/net/net-c2s.js
+++ b/benchmark/net/net-c2s.js
@@ -35,18 +35,18 @@ function main({ dur, len, type }) {
   const writer = new Writer();
 
   // the actual benchmark.
-  const server = net.createServer(function(socket) {
+  const server = net.createServer((socket) => {
     socket.pipe(writer);
   });
 
-  server.listen(PORT, function() {
+  server.listen(PORT, () => {
     const socket = net.connect(PORT);
-    socket.on('connect', function() {
+    socket.on('connect', () => {
       bench.start();
 
       reader.pipe(socket);
 
-      setTimeout(function() {
+      setTimeout(() => {
         const bytes = writer.received;
         const gbits = (bytes * 8) / (1024 * 1024 * 1024);
         bench.end(gbits);

--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -35,19 +35,19 @@ function main({ dur, len, type }) {
   const writer = new Writer();
 
   // the actual benchmark.
-  const server = net.createServer(function(socket) {
+  const server = net.createServer((socket) => {
     socket.pipe(socket);
   });
 
-  server.listen(PORT, function() {
+  server.listen(PORT, () => {
     const socket = net.connect(PORT);
-    socket.on('connect', function() {
+    socket.on('connect', () => {
       bench.start();
 
       reader.pipe(socket);
       socket.pipe(writer);
 
-      setTimeout(function() {
+      setTimeout(() => {
         // Multiply by 2 since we're sending it first one way
         // then then back again.
         const bytes = writer.received * 2;

--- a/benchmark/net/net-s2c.js
+++ b/benchmark/net/net-s2c.js
@@ -34,18 +34,18 @@ function main({ dur, len, type }) {
   const writer = new Writer();
 
   // the actual benchmark.
-  const server = net.createServer(function(socket) {
+  const server = net.createServer((socket) => {
     reader.pipe(socket);
   });
 
-  server.listen(PORT, function() {
+  server.listen(PORT, () => {
     const socket = net.connect(PORT);
-    socket.on('connect', function() {
+    socket.on('connect', () => {
       bench.start();
 
       socket.pipe(writer);
 
-      setTimeout(function() {
+      setTimeout(() => {
         const bytes = writer.received;
         const gbits = (bytes * 8) / (1024 * 1024 * 1024);
         bench.end(gbits);

--- a/benchmark/net/net-wrap-js-stream-passthrough.js
+++ b/benchmark/net/net-wrap-js-stream-passthrough.js
@@ -44,7 +44,7 @@ function main({ dur, len, type }) {
   reader.pipe(fakeSocket);
   fakeSocket.pipe(writer);
 
-  setTimeout(function() {
+  setTimeout(() => {
     const bytes = writer.received;
     const gbits = (bytes * 8) / (1024 * 1024 * 1024);
     bench.end(gbits);

--- a/benchmark/net/tcp-raw-c2s.js
+++ b/benchmark/net/tcp-raw-c2s.js
@@ -40,7 +40,7 @@ function main({ dur, len, type }) {
     bench.start();
     var bytes = 0;
 
-    setTimeout(function() {
+    setTimeout(() => {
       // report in Gb/sec
       bench.end((bytes * 8) / (1024 * 1024 * 1024));
       process.exit(0);

--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -104,7 +104,7 @@ function main({ dur, len, type }) {
 
     clientHandle.readStart();
 
-    setTimeout(function() {
+    setTimeout(() => {
       // Multiply by 2 since we're sending it first one way
       // then then back again.
       bench.end(2 * (bytes * 8) / (1024 * 1024 * 1024));

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -78,7 +78,7 @@ function main({ dur, len, type }) {
       if (err) {
         fail(err, 'write');
       } else if (!writeReq.async) {
-        process.nextTick(function() {
+        process.nextTick(() => {
           afterWrite(0, clientHandle);
         });
       }
@@ -125,7 +125,7 @@ function main({ dur, len, type }) {
       // the meat of the benchmark is right here:
       bench.start();
 
-      setTimeout(function() {
+      setTimeout(() => {
         // report in Gb/sec
         bench.end((bytes * 8) / (1024 * 1024 * 1024));
         process.exit(0);

--- a/benchmark/path/basename-posix.js
+++ b/benchmark/path/basename-posix.js
@@ -13,7 +13,7 @@ const bench = common.createBenchmark(main, {
     'foo/bar.',
     ['foo/bar.', '.'].join('|'),
     '/foo/bar/baz/asdf/quux.html',
-    ['/foo/bar/baz/asdf/quux.html', '.html'].join('|')
+    ['/foo/bar/baz/asdf/quux.html', '.html'].join('|'),
   ],
   n: [1e6]
 });

--- a/benchmark/path/basename-win32.js
+++ b/benchmark/path/basename-win32.js
@@ -13,7 +13,7 @@ const bench = common.createBenchmark(main, {
     'foo\\bar.',
     ['foo\\bar.', '.'].join('|'),
     '\\foo\\bar\\baz\\asdf\\quux.html',
-    ['\\foo\\bar\\baz\\asdf\\quux.html', '.html'].join('|')
+    ['\\foo\\bar\\baz\\asdf\\quux.html', '.html'].join('|'),
   ],
   n: [1e6]
 });

--- a/benchmark/path/dirname-posix.js
+++ b/benchmark/path/dirname-posix.js
@@ -10,7 +10,7 @@ const bench = common.createBenchmark(main, {
     '/foo/bar',
     'foo',
     'foo/bar',
-    '/foo/bar/baz/asdf/quux'
+    '/foo/bar/baz/asdf/quux',
   ],
   n: [1e6]
 });

--- a/benchmark/path/dirname-win32.js
+++ b/benchmark/path/dirname-win32.js
@@ -10,7 +10,7 @@ const bench = common.createBenchmark(main, {
     'C:\\foo\\bar',
     'foo',
     'foo\\bar',
-    'D:\\foo\\bar\\baz\\asdf\\quux'
+    'D:\\foo\\bar\\baz\\asdf\\quux',
   ],
   n: [1e6]
 });

--- a/benchmark/path/extname-posix.js
+++ b/benchmark/path/extname-posix.js
@@ -13,7 +13,7 @@ const bench = common.createBenchmark(main, {
     'foo/bar/..baz.quux',
     'foo/bar/...baz.quux',
     '/foo/bar/baz/asdf/quux',
-    '/foo/bar/baz/asdf/quux.foobarbazasdfquux'
+    '/foo/bar/baz/asdf/quux.foobarbazasdfquux',
   ],
   n: [1e6]
 });

--- a/benchmark/path/extname-win32.js
+++ b/benchmark/path/extname-win32.js
@@ -13,7 +13,7 @@ const bench = common.createBenchmark(main, {
     'foo\\bar\\..baz.quux',
     'foo\\bar\\...baz.quux',
     'D:\\foo\\bar\\baz\\asdf\\quux',
-    '\\foo\\bar\\baz\\asdf\\quux.foobarbazasdfquux'
+    '\\foo\\bar\\baz\\asdf\\quux.foobarbazasdfquux',
   ],
   n: [1e6]
 });

--- a/benchmark/path/format-posix.js
+++ b/benchmark/path/format-posix.js
@@ -4,7 +4,7 @@ const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   props: [
-    ['/', '/home/user/dir', 'index.html', '.html', 'index'].join('|')
+    ['/', '/home/user/dir', 'index.html', '.html', 'index'].join('|'),
   ],
   n: [1e7]
 });

--- a/benchmark/path/format-win32.js
+++ b/benchmark/path/format-win32.js
@@ -4,7 +4,7 @@ const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   props: [
-    ['C:\\', 'C:\\path\\dir', 'index.html', '.html', 'index'].join('|')
+    ['C:\\', 'C:\\path\\dir', 'index.html', '.html', 'index'].join('|'),
   ],
   n: [1e7]
 });

--- a/benchmark/path/isAbsolute-posix.js
+++ b/benchmark/path/isAbsolute-posix.js
@@ -8,7 +8,7 @@ const bench = common.createBenchmark(main, {
     '.',
     '/foo/bar',
     '/baz/..',
-    'bar/baz'
+    'bar/baz',
   ],
   n: [1e6]
 });

--- a/benchmark/path/isAbsolute-win32.js
+++ b/benchmark/path/isAbsolute-win32.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
     '//server',
     'C:\\baz\\..',
     'C:baz\\..',
-    'bar\\baz'
+    'bar\\baz',
   ],
   n: [1e6]
 });

--- a/benchmark/path/join-posix.js
+++ b/benchmark/path/join-posix.js
@@ -4,7 +4,7 @@ const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   paths: [
-    ['/foo', 'bar', '', 'baz/asdf', 'quux', '..'].join('|')
+    ['/foo', 'bar', '', 'baz/asdf', 'quux', '..'].join('|'),
   ],
   n: [1e6]
 });

--- a/benchmark/path/join-win32.js
+++ b/benchmark/path/join-win32.js
@@ -4,7 +4,7 @@ const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   paths: [
-    ['C:\\foo', 'bar', '', 'baz\\asdf', 'quux', '..'].join('|')
+    ['C:\\foo', 'bar', '', 'baz\\asdf', 'quux', '..'].join('|'),
   ],
   n: [1e6]
 });

--- a/benchmark/path/makeLong-win32.js
+++ b/benchmark/path/makeLong-win32.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
     'foo\\bar',
     'C:\\foo',
     '\\\\foo\\bar',
-    '\\\\?\\foo'
+    '\\\\?\\foo',
   ],
   n: [1e6]
 });

--- a/benchmark/path/normalize-posix.js
+++ b/benchmark/path/normalize-posix.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
     '/../',
     '/foo',
     '/foo/bar',
-    '/foo/bar//baz/asdf/quux/..'
+    '/foo/bar//baz/asdf/quux/..',
   ],
   n: [1e6]
 });

--- a/benchmark/path/normalize-win32.js
+++ b/benchmark/path/normalize-win32.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
     'C:\\..\\',
     'C:\\foo',
     'C:\\foo\\bar',
-    'C:\\foo\\bar\\\\baz\\asdf\\quux\\..'
+    'C:\\foo\\bar\\\\baz\\asdf\\quux\\..',
   ],
   n: [1e6]
 });

--- a/benchmark/path/parse-posix.js
+++ b/benchmark/path/parse-posix.js
@@ -10,7 +10,7 @@ const bench = common.createBenchmark(main, {
     '/foo/bar.baz',
     'foo/.bar.baz',
     'foo/bar',
-    '/foo/bar/baz/asdf/.quux'
+    '/foo/bar/baz/asdf/.quux',
   ],
   n: [1e6]
 });

--- a/benchmark/path/parse-win32.js
+++ b/benchmark/path/parse-win32.js
@@ -11,7 +11,7 @@ const bench = common.createBenchmark(main, {
     'E:\\foo\\bar.baz',
     'foo\\.bar.baz',
     'foo\\bar',
-    '\\foo\\bar\\baz\\asdf\\.quux'
+    '\\foo\\bar\\baz\\asdf\\.quux',
   ],
   n: [1e6]
 });

--- a/benchmark/path/relative-posix.js
+++ b/benchmark/path/relative-posix.js
@@ -10,7 +10,7 @@ const bench = common.createBenchmark(main, {
     ['/var', '/bin'].join('|'),
     ['/foo/bar/baz/quux', '/'].join('|'),
     ['/foo/bar/baz/quux', '/foo/bar/baz/quux'].join('|'),
-    ['/foo/bar/baz/quux', '/var/log'].join('|')
+    ['/foo/bar/baz/quux', '/var/log'].join('|'),
   ],
   n: [1e6]
 });

--- a/benchmark/path/relative-win32.js
+++ b/benchmark/path/relative-win32.js
@@ -8,7 +8,7 @@ const bench = common.createBenchmark(main, {
     ['C:\\', 'D:\\'].join('|'),
     ['C:\\foo\\bar\\baz', 'C:\\foo\\bar\\baz'].join('|'),
     ['C:\\foo\\BAR\\BAZ', 'C:\\foo\\bar\\baz'].join('|'),
-    ['C:\\foo\\bar\\baz\\quux', 'C:\\'].join('|')
+    ['C:\\foo\\bar\\baz\\quux', 'C:\\'].join('|'),
   ],
   n: [1e6]
 });

--- a/benchmark/path/resolve-posix.js
+++ b/benchmark/path/resolve-posix.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
     '',
     ['', ''].join('|'),
     ['foo/bar', '/tmp/file/', '..', 'a/../subfile'].join('|'),
-    ['a/b/c/', '../../..'].join('|')
+    ['a/b/c/', '../../..'].join('|'),
   ],
   n: [1e6]
 });

--- a/benchmark/path/resolve-win32.js
+++ b/benchmark/path/resolve-win32.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
     '',
     ['', ''].join('|'),
     ['c:/ignore', 'd:\\a/b\\c/d', '\\e.exe'].join('|'),
-    ['c:/blah\\blah', 'd:/games', 'c:../a'].join('|')
+    ['c:/blah\\blah', 'd:/games', 'c:../a'].join('|'),
   ],
   n: [1e6]
 });

--- a/benchmark/querystring/querystring-unescapebuffer.js
+++ b/benchmark/querystring/querystring-unescapebuffer.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
     'there is nothing to unescape here',
     'there%20are%20several%20spaces%20that%20need%20to%20be%20unescaped',
     'there%2Qare%0-fake%escaped values in%%%%this%9Hstring',
-    '%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%30%31%32%33%34%35%36%37'
+    '%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%30%31%32%33%34%35%36%37',
   ],
   n: [10e6],
 });

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -41,7 +41,7 @@ if (format === 'csv') {
     console.log(filename);
   }
 
-  child.on('message', function(data) {
+  child.on('message', (data) => {
     if (data.type !== 'report') {
       return;
     }
@@ -64,7 +64,7 @@ if (format === 'csv') {
     }
   });
 
-  child.once('close', function(code) {
+  child.once('close', (code) => {
     if (code) {
       process.exit(code);
       return;

--- a/benchmark/scatter.js
+++ b/benchmark/scatter.js
@@ -39,7 +39,7 @@ function csvEncodeValue(value) {
 (function recursive(i) {
   const child = fork(path.resolve(__dirname, filepath), cli.optional.set);
 
-  child.on('message', function(data) {
+  child.on('message', (data) => {
     if (data.type !== 'report') {
       return;
     }
@@ -61,7 +61,7 @@ function csvEncodeValue(value) {
     console.log(`"${name}", ${confData}, ${data.rate}, ${data.time}`);
   });
 
-  child.once('close', function(code) {
+  child.once('close', (code) => {
     if (code) {
       process.exit(code);
       return;

--- a/benchmark/string_decoder/string-decoder-create.js
+++ b/benchmark/string_decoder/string-decoder-create.js
@@ -4,7 +4,7 @@ const StringDecoder = require('string_decoder').StringDecoder;
 
 const bench = common.createBenchmark(main, {
   encoding: [
-    'ascii', 'utf8', 'utf-8', 'base64', 'ucs2', 'UTF-8', 'AscII', 'UTF-16LE'
+    'ascii', 'utf8', 'utf-8', 'base64', 'ucs2', 'UTF-8', 'AscII', 'UTF-16LE',
   ],
   n: [25e6]
 });

--- a/benchmark/string_decoder/string-decoder.js
+++ b/benchmark/string_decoder/string-decoder.js
@@ -54,7 +54,7 @@ function main({ encoding, inLen, chunkLen, n }) {
       }
       str = Buffer.concat([
         str,
-        buf.slice(start % buf.length, end % buf.length)
+        buf.slice(start % buf.length, end % buf.length),
       ]);
     }
   }

--- a/benchmark/timers/set-immediate-breadth-args.js
+++ b/benchmark/timers/set-immediate-breadth-args.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n }) {
 
-  process.on('exit', function() {
+  process.on('exit', () => {
     bench.end(n);
   });
 

--- a/benchmark/timers/set-immediate-breadth.js
+++ b/benchmark/timers/set-immediate-breadth.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n }) {
 
-  process.on('exit', function() {
+  process.on('exit', () => {
     bench.end(n);
   });
 

--- a/benchmark/timers/set-immediate-depth-args.js
+++ b/benchmark/timers/set-immediate-depth-args.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n }) {
 
-  process.on('exit', function() {
+  process.on('exit', () => {
     bench.end(n);
   });
 

--- a/benchmark/tls/throughput.js
+++ b/benchmark/tls/throughput.js
@@ -41,9 +41,9 @@ function main({ dur, type, size }) {
 
   server = tls.createServer(options, onConnection);
   var conn;
-  server.listen(common.PORT, function() {
+  server.listen(common.PORT, () => {
     const opt = { port: common.PORT, rejectUnauthorized: false };
-    conn = tls.connect(opt, function() {
+    conn = tls.connect(opt, () => {
       setTimeout(done, dur * 1000);
       bench.start();
       conn.on('drain', write);
@@ -57,7 +57,7 @@ function main({ dur, type, size }) {
 
   var received = 0;
   function onConnection(conn) {
-    conn.on('data', function(chunk) {
+    conn.on('data', (chunk) => {
       received += chunk.length;
     });
   }

--- a/benchmark/tls/tls-connect.js
+++ b/benchmark/tls/tls-connect.js
@@ -46,9 +46,9 @@ function makeConnection() {
     port: common.PORT,
     rejectUnauthorized: false
   };
-  var conn = tls.connect(options, function() {
+  var conn = tls.connect(options, () => {
     clientConn++;
-    conn.on('error', function(er) {
+    conn.on('error', (er) => {
       console.error('client error', er);
       throw er;
     });

--- a/benchmark/util/inspect.js
+++ b/benchmark/util/inspect.js
@@ -23,7 +23,7 @@ const bench = common.createBenchmark(main, {
     'Array',
     'TypedArray',
     'TypedArray_extra',
-    'Number'
+    'Number',
   ],
   option: Object.keys(opts)
 });

--- a/benchmark/util/normalize-encoding.js
+++ b/benchmark/util/normalize-encoding.js
@@ -16,7 +16,7 @@ const inputs = [
   '', 'utf8', 'utf-8', 'UTF-8', 'UTF8', 'Utf8',
   'ucs2', 'UCS2', 'utf16le', 'UTF16LE',
   'binary', 'BINARY', 'latin1', 'base64', 'BASE64',
-  'hex', 'HEX', 'foo', 'undefined'
+  'hex', 'HEX', 'foo', 'undefined',
 ];
 
 const bench = common.createBenchmark(main, {

--- a/benchmark/v8/get-stats.js
+++ b/benchmark/v8/get-stats.js
@@ -6,7 +6,7 @@ const v8 = require('v8');
 const bench = common.createBenchmark(main, {
   method: [
     'getHeapStatistics',
-    'getHeapSpaceStatistics'
+    'getHeapSpaceStatistics',
   ],
   n: [1e6]
 });

--- a/benchmark/zlib/creation.js
+++ b/benchmark/zlib/creation.js
@@ -5,7 +5,7 @@ const zlib = require('zlib');
 const bench = common.createBenchmark(main, {
   type: [
     'Deflate', 'DeflateRaw', 'Inflate', 'InflateRaw', 'Gzip', 'Gunzip', 'Unzip',
-    'BrotliCompress', 'BrotliDecompress'
+    'BrotliCompress', 'BrotliDecompress',
   ],
   options: ['true', 'false'],
   n: [5e5]


### PR DESCRIPTION
Code in benchmark directory sometimes uses `function () {}` for anonymous
callbacks and sometimes uses `() => {}`. Multi-line arrays sometimes
have a trailing comma and sometimes do not. Update to always use arrow
functions for anonymous callbacks and trailing commas for multiline
arrays.

This is more churn than I was expecting, but after looking it over, it's right at the edge of my churn-tolerance, so I'm good with it. I'll be happy to do the backports to 11/10/8/6 as necessary, although probably `dont-land-on` labels are fine for code in the `benchmark` directory. 
¯\\_(ツ)_/¯

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
