### PR TITLE
src: make watchdog async callback a lambda

### DIFF
--- a/src/node_watchdog.cc
+++ b/src/node_watchdog.cc
@@ -39,7 +39,11 @@ Watchdog::Watchdog(v8::Isolate* isolate, uint64_t ms, bool* timed_out)
                "Failed to initialize uv loop.");
   }
 
-  rc = uv_async_init(loop_, &async_, &Watchdog::Async);
+  rc = uv_async_init(loop_, &async_, [](uv_async_t* signal) {
+    Watchdog* w = ContainerOf(&Watchdog::async_, signal);
+    uv_stop(w->loop_);
+  });
+
   CHECK_EQ(0, rc);
 
   rc = uv_timer_init(loop_, &timer_);
@@ -79,13 +83,6 @@ void Watchdog::Run(void* arg) {
   // Close the timer handle on this side and let ~Watchdog() close async_
   uv_close(reinterpret_cast<uv_handle_t*>(&wd->timer_), nullptr);
 }
-
-
-void Watchdog::Async(uv_async_t* async) {
-  Watchdog* w = ContainerOf(&Watchdog::async_, async);
-  uv_stop(w->loop_);
-}
-
 
 void Watchdog::Timer(uv_timer_t* timer) {
   Watchdog* w = ContainerOf(&Watchdog::timer_, timer);

--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -45,7 +45,6 @@ class Watchdog {
 
  private:
   static void Run(void* arg);
-  static void Async(uv_async_t* async);
   static void Timer(uv_timer_t* timer);
 
   v8::Isolate* isolate_;


### PR DESCRIPTION
`Watchdog::Async` features only once for the async callback, so make it a lambda.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
