### PR TITLE
repl: add welcome message

### DIFF
--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -19,6 +19,9 @@ if (require('internal/options').getOptionValue('--entry-type')) {
   process.exit(1);
 }
 
+console.log(`Welcome to Node.js ${process.version}.\n` +
+  'Type ".help" for more information.');
+
 const cliRepl = require('internal/repl');
 cliRepl.createInternalRepl(process.env, (err, repl) => {
   if (err) {

--- a/test/parallel/test-force-repl-with-eval.js
+++ b/test/parallel/test-force-repl-with-eval.js
@@ -12,7 +12,7 @@ cp.stdout.setEncoding('utf8');
 let output = '';
 cp.stdout.on('data', function(b) {
   output += b;
-  if (output === '> 42\n') {
+  if (output.endsWith('> 42\n')) {
     gotToEnd = true;
     cp.kill();
   }

--- a/test/parallel/test-force-repl.js
+++ b/test/parallel/test-force-repl.js
@@ -4,12 +4,19 @@ const assert = require('assert');
 const spawn = require('child_process').spawn;
 
 // Spawn a node child process in interactive mode (enabling the REPL) and
-// confirm the '> ' prompt is included in the output.
+// confirm the '> ' prompt and welcome message is included in the output.
 const cp = spawn(process.execPath, ['-i']);
 
 cp.stdout.setEncoding('utf8');
 
-cp.stdout.once('data', common.mustCall(function(b) {
-  assert.strictEqual(b, '> ');
-  cp.kill();
+let out = '';
+cp.stdout.on('data', (d) => {
+  out += d;
+});
+
+cp.stdout.on('end', common.mustCall(() => {
+  assert.strictEqual(out, `Welcome to Node.js ${process.version}.\n` +
+                        'Type ".help" for more information.\n> ');
 }));
+
+cp.stdin.end('');

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -86,7 +86,7 @@ const replProc = childProcess.spawn(
 );
 replProc.stdin.end('.exit\n');
 let replStdout = '';
-replProc.stdout.on('data', function(d) {
+replProc.stdout.on('data', (d) => {
   replStdout += d;
 });
 replProc.on('close', function(code) {
@@ -94,8 +94,9 @@ replProc.on('close', function(code) {
   const output = [
     'A',
     '> '
-  ].join('\n');
-  assert.strictEqual(replStdout, output);
+  ];
+  assert.ok(replStdout.startsWith(output[0]));
+  assert.ok(replStdout.endsWith(output[1]));
 });
 
 // Test that preload placement at other points in the cmdline
@@ -114,7 +115,7 @@ const interactive = childProcess.exec(
   `"${nodeBinary}" ${preloadOption([fixtureD])}-i`,
   common.mustCall(function(err, stdout, stderr) {
     assert.ifError(err);
-    assert.strictEqual(stdout, "> 'test'\n> ");
+    assert.ok(stdout.endsWith("> 'test'\n> "));
   })
 );
 

--- a/test/parallel/test-repl-harmony.js
+++ b/test/parallel/test-repl-harmony.js
@@ -30,19 +30,19 @@ const child = spawn(process.execPath, args);
 const input = '(function(){"use strict"; const y=1;y=2})()\n';
 // This message will vary based on JavaScript engine, so don't check the message
 // contents beyond confirming that the `Error` is a `TypeError`.
-const expectOut = /^> Thrown:\nTypeError: /;
+const expectOut = /> Thrown:\nTypeError: /;
 
 child.stderr.setEncoding('utf8');
-child.stderr.on('data', function(c) {
+child.stderr.on('data', (d) => {
   throw new Error('child.stderr be silent');
 });
 
 child.stdout.setEncoding('utf8');
 let out = '';
-child.stdout.on('data', function(c) {
-  out += c;
+child.stdout.on('data', (d) => {
+  out += d;
 });
-child.stdout.on('end', function() {
+child.stdout.on('end', () => {
   assert(expectOut.test(out));
   console.log('ok');
 });

--- a/test/parallel/test-repl-inspect-defaults.js
+++ b/test/parallel/test-repl-inspect-defaults.js
@@ -11,7 +11,7 @@ child.stdout.on('data', (data) => {
 });
 
 child.on('exit', common.mustCall(() => {
-  const results = output.replace(/^> /mg, '').split('\n');
+  const results = output.replace(/^> /mg, '').split('\n').slice(2);
   assert.deepStrictEqual(
     results,
     [

--- a/test/parallel/test-repl-require-after-write.js
+++ b/test/parallel/test-repl-require-after-write.js
@@ -25,7 +25,7 @@ child.stdout.on('data', (c) => {
   out += c;
 });
 child.stdout.on('end', common.mustCall(() => {
-  assert.strictEqual(out, '> 1\n> ');
+  assert.ok(out.endsWith('> 1\n> '));
 }));
 
 child.stdin.end(input);

--- a/test/parallel/test-repl-require-context.js
+++ b/test/parallel/test-repl-require-context.js
@@ -13,7 +13,7 @@ child.stdout.on('data', (data) => {
 });
 
 child.on('exit', common.mustCall(() => {
-  const results = output.replace(/^> /mg, '').split('\n');
+  const results = output.replace(/^> /mg, '').split('\n').slice(2);
   assert.deepStrictEqual(results, ['undefined', 'true', 'true', '']);
 }));
 

--- a/test/parallel/test-repl-unexpected-token-recoverable.js
+++ b/test/parallel/test-repl-unexpected-token-recoverable.js
@@ -12,20 +12,20 @@ const child = spawn(process.execPath, args);
 
 const input = 'var foo = "bar\\\nbaz"';
 // Match '...' as well since it marks a multi-line statement
-const expectOut = /^> \.\.\. undefined\n/;
+const expectOut = /> \.\.\. undefined\n/;
 
 child.stderr.setEncoding('utf8');
-child.stderr.on('data', function(c) {
+child.stderr.on('data', (d) => {
   throw new Error('child.stderr be silent');
 });
 
 child.stdout.setEncoding('utf8');
 let out = '';
-child.stdout.on('data', function(c) {
-  out += c;
+child.stdout.on('data', (d) => {
+  out += d;
 });
 
-child.stdout.on('end', function() {
+child.stdout.on('end', () => {
   assert(expectOut.test(out));
   console.log('ok');
 });


### PR DESCRIPTION
## Motivation
I want to make node more friendly for new user. Actually it take me very long to find out node repl can load script :)

Also I am not quite sure I put the change in best location in `repl.js`.

## Welcome message
The current welcome message is (copyed from windows powershell):
```bash
Welcome to Node.js v12.0.0-pre.
Type ".help" for more information.
```
Compare with other languages
In python (using `docker run --rm -it python`):
```bash
Python 3.7.2 (default, Jan 23 2019, 02:31:57) 
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
```
In java (use `docker run --rm -it openjdk:11`):
```bash
Feb 05, 2019 2:42:25 PM java.util.prefs.FileSystemPreferences$1 run
INFO: Created user preferences directory.
|  Welcome to JShell -- Version 11.0.1
|  For an introduction type: /help intro
```

May need port to Node 8 && 10.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
