### PR TITLE
worker: use correct ctor for error serialization

### DIFF
--- a/lib/internal/error-serdes.js
+++ b/lib/internal/error-serdes.js
@@ -86,7 +86,7 @@ function serializeError(error) {
     if (typeof error === 'object' &&
         ObjectPrototypeToString(error) === '[object Error]') {
       const constructors = GetConstructors(error);
-      for (var i = constructors.length - 1; i >= 0; i--) {
+      for (var i = 0; i < constructors.length; i++) {
         const name = GetName(constructors[i]);
         if (errorConstructorNames.has(name)) {
           try { error.stack; } catch {}

--- a/test/parallel/test-worker-syntax-error-file.js
+++ b/test/parallel/test-worker-syntax-error-file.js
@@ -10,6 +10,7 @@ if (!process.env.HAS_STARTED_WORKER) {
   const w = new Worker(fixtures.path('syntax', 'bad_syntax.js'));
   w.on('message', common.mustNotCall());
   w.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.constructor, SyntaxError);
     assert(/SyntaxError/.test(err));
   }));
 } else {

--- a/test/parallel/test-worker-syntax-error.js
+++ b/test/parallel/test-worker-syntax-error.js
@@ -9,6 +9,7 @@ if (!process.env.HAS_STARTED_WORKER) {
   const w = new Worker('abc)', { eval: true });
   w.on('message', common.mustNotCall());
   w.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.constructor, SyntaxError);
     assert(/SyntaxError/.test(err));
   }));
 } else {


### PR DESCRIPTION
When serializing errors, use the error constructor that is
closest to the object itself in the prototype chain.

The previous practice of walking downwards meant that
`Error` would usually be the first constructor that is used,
even when a more specific one would be available/appropriate,
because it is the base class of the other common error types.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
