### PR TITLE
util: protect against monkeypatched Object prototype for inspect()

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -65,6 +65,9 @@ const {
 
 const assert = require('internal/assert');
 
+// Avoid monkey-patched built-ins.
+const { Object } = primordials;
+
 const ReflectApply = Reflect.apply;
 
 // This function is borrowed from the function with the same name on V8 Extras'
@@ -76,9 +79,7 @@ function uncurryThis(func) {
   return (thisArg, ...args) => ReflectApply(func, thisArg, args);
 }
 
-const propertyIsEnumerable = uncurryThis(
-  primordials.Object.prototype.propertyIsEnumerable
-);
+const propertyIsEnumerable = uncurryThis(Object.prototype.propertyIsEnumerable);
 const regExpToString = uncurryThis(RegExp.prototype.toString);
 const dateToISOString = uncurryThis(Date.prototype.toISOString);
 const dateToString = uncurryThis(Date.prototype.toString);
@@ -93,10 +94,10 @@ const stringValueOf = uncurryThis(String.prototype.valueOf);
 const setValues = uncurryThis(Set.prototype.values);
 const mapEntries = uncurryThis(Map.prototype.entries);
 const dateGetTime = uncurryThis(Date.prototype.getTime);
-const hasOwnProperty = uncurryThis(primordials.Object.prototype.hasOwnProperty);
+const hasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty);
 let hexSlice;
 
-const inspectDefaultOptions = primordials.Object.seal({
+const inspectDefaultOptions = Object.seal({
   showHidden: false,
   depth: 2,
   colors: false,
@@ -189,7 +190,7 @@ function inspect(value, opts) {
     if (typeof opts === 'boolean') {
       ctx.showHidden = opts;
     } else if (opts) {
-      const optKeys = primordials.Object.keys(opts);
+      const optKeys = Object.keys(opts);
       for (var i = 0; i < optKeys.length; i++) {
         ctx[optKeys[i]] = opts[optKeys[i]];
       }
@@ -201,7 +202,7 @@ function inspect(value, opts) {
 }
 inspect.custom = customInspectSymbol;
 
-primordials.Object.defineProperty(inspect, 'defaultOptions', {
+Object.defineProperty(inspect, 'defaultOptions', {
   get() {
     return inspectDefaultOptions;
   },
@@ -209,12 +210,12 @@ primordials.Object.defineProperty(inspect, 'defaultOptions', {
     if (options === null || typeof options !== 'object') {
       throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
-    return primordials.Object.assign(inspectDefaultOptions, options);
+    return Object.assign(inspectDefaultOptions, options);
   }
 });
 
 // http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
-inspect.colors = primordials.Object.assign(primordials.Object.create(null), {
+inspect.colors = Object.assign(Object.create(null), {
   bold: [1, 22],
   italic: [3, 23],
   underline: [4, 24],
@@ -231,7 +232,7 @@ inspect.colors = primordials.Object.assign(primordials.Object.create(null), {
 });
 
 // Don't use 'blue' not visible on cmd.exe
-inspect.styles = primordials.Object.assign(primordials.Object.create(null), {
+inspect.styles = Object.assign(Object.create(null), {
   special: 'cyan',
   number: 'yellow',
   bigint: 'yellow',
@@ -331,15 +332,14 @@ function getEmptyFormatArray() {
 function getConstructorName(obj, ctx) {
   let firstProto;
   while (obj) {
-    const descriptor =
-      primordials.Object.getOwnPropertyDescriptor(obj, 'constructor');
+    const descriptor = Object.getOwnPropertyDescriptor(obj, 'constructor');
     if (descriptor !== undefined &&
         typeof descriptor.value === 'function' &&
         descriptor.value.name !== '') {
       return descriptor.value.name;
     }
 
-    obj = primordials.Object.getPrototypeOf(obj);
+    obj = Object.getPrototypeOf(obj);
     if (firstProto === undefined) {
       firstProto = obj;
     }
@@ -374,9 +374,9 @@ const getBoxedValue = formatPrimitive.bind(null, stylizeNoColor);
 // Look up the keys of the object.
 function getKeys(value, showHidden) {
   let keys;
-  const symbols = primordials.Object.getOwnPropertySymbols(value);
+  const symbols = Object.getOwnPropertySymbols(value);
   if (showHidden) {
-    keys = primordials.Object.getOwnPropertyNames(value);
+    keys = Object.getOwnPropertyNames(value);
     if (symbols.length !== 0)
       keys.push(...symbols);
   } else {
@@ -386,11 +386,11 @@ function getKeys(value, showHidden) {
     // TODO(devsnek): track https://github.com/tc39/ecma262/issues/1209
     // and modify this logic as needed.
     try {
-      keys = primordials.Object.keys(value);
+      keys = Object.keys(value);
     } catch (err) {
       assert(isNativeError(err) && err.name === 'ReferenceError' &&
              isModuleNamespaceObject(value));
-      keys = primordials.Object.getOwnPropertyNames(value);
+      keys = Object.getOwnPropertyNames(value);
     }
     if (symbols.length !== 0) {
       keys.push(...symbols.filter((key) => propertyIsEnumerable(value, key)));
@@ -455,8 +455,8 @@ function clazzWithNullPrototype(clazz, name) {
       return '';
     }
   }
-  primordials.Object.defineProperty(NullPrototype.prototype.constructor, 'name',
-                                    { value: `[${name}: null prototype]` });
+  Object.defineProperty(NullPrototype.prototype.constructor, 'name',
+                        { value: `[${name}: null prototype]` });
   lazyNullPrototypeCache.set(clazz, NullPrototype);
   return NullPrototype;
 }
@@ -478,9 +478,7 @@ function noPrototypeIterator(ctx, value, recurseTimes) {
     newVal = new clazz(value);
   }
   if (newVal !== undefined) {
-    primordials.Object.defineProperties(
-      newVal, primordials.Object.getOwnPropertyDescriptors(value)
-    );
+    Object.defineProperties(newVal, Object.getOwnPropertyDescriptors(value));
     return formatRaw(ctx, newVal, recurseTimes);
   }
 }
@@ -809,7 +807,7 @@ function handleMaxCallStackSize(ctx, err, constructor, tag, indentationLvl) {
 
 function formatNumber(fn, value) {
   // Format -0 as '-0'. Checking `value === -0` won't distinguish 0 from -0.
-  return fn(primordials.Object.is(value, -0) ? '-0' : `${value}`, 'number');
+  return fn(Object.is(value, -0) ? '-0' : `${value}`, 'number');
 }
 
 function formatBigInt(fn, value) {
@@ -897,7 +895,7 @@ function formatNamespaceObject(ctx, value, recurseTimes, keys) {
 
 // The array is sparse and/or has extra keys
 function formatSpecialArray(ctx, value, recurseTimes, maxLength, output, i) {
-  const keys = primordials.Object.keys(value);
+  const keys = Object.keys(value);
   let index = i;
   for (; i < keys.length && output.length < maxLength; i++) {
     const key = keys[i];
@@ -1128,7 +1126,7 @@ function formatPromise(ctx, value, recurseTimes) {
 function formatProperty(ctx, value, recurseTimes, key, type) {
   let name, str;
   let extra = ' ';
-  const desc = primordials.Object.getOwnPropertyDescriptor(value, key) ||
+  const desc = Object.getOwnPropertyDescriptor(value, key) ||
     { value: value[key], enumerable: true };
   if (desc.value !== undefined) {
     const diff = (type !== kObjectType || ctx.compact === false) ? 2 : 3;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -76,7 +76,9 @@ function uncurryThis(func) {
   return (thisArg, ...args) => ReflectApply(func, thisArg, args);
 }
 
-const propertyIsEnumerable = uncurryThis(Object.prototype.propertyIsEnumerable);
+const propertyIsEnumerable = uncurryThis(
+  primordials.Object.prototype.propertyIsEnumerable
+);
 const regExpToString = uncurryThis(RegExp.prototype.toString);
 const dateToISOString = uncurryThis(Date.prototype.toISOString);
 const dateToString = uncurryThis(Date.prototype.toString);
@@ -91,7 +93,7 @@ const stringValueOf = uncurryThis(String.prototype.valueOf);
 const setValues = uncurryThis(Set.prototype.values);
 const mapEntries = uncurryThis(Map.prototype.entries);
 const dateGetTime = uncurryThis(Date.prototype.getTime);
-const hasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty);
+const hasOwnProperty = uncurryThis(primordials.Object.prototype.hasOwnProperty);
 let hexSlice;
 
 const inspectDefaultOptions = primordials.Object.seal({
@@ -229,7 +231,7 @@ inspect.colors = primordials.Object.assign(primordials.Object.create(null), {
 });
 
 // Don't use 'blue' not visible on cmd.exe
-inspect.styles = primordials.Object.assign(Object.create(null), {
+inspect.styles = primordials.Object.assign(primordials.Object.create(null), {
   special: 'cyan',
   number: 'yellow',
   bigint: 'yellow',
@@ -807,7 +809,7 @@ function handleMaxCallStackSize(ctx, err, constructor, tag, indentationLvl) {
 
 function formatNumber(fn, value) {
   // Format -0 as '-0'. Checking `value === -0` won't distinguish 0 from -0.
-  return fn(Object.is(value, -0) ? '-0' : `${value}`, 'number');
+  return fn(primordials.Object.is(value, -0) ? '-0' : `${value}`, 'number');
 }
 
 function formatBigInt(fn, value) {

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -63,6 +63,8 @@ const {
   isBigUint64Array
 } = require('internal/util/types');
 
+const assert = require('internal/assert');
+
 const ReflectApply = Reflect.apply;
 
 // This function is borrowed from the function with the same name on V8 Extras'
@@ -92,7 +94,7 @@ const dateGetTime = uncurryThis(Date.prototype.getTime);
 const hasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty);
 let hexSlice;
 
-const inspectDefaultOptions = Object.seal({
+const inspectDefaultOptions = primordials.Object.seal({
   showHidden: false,
   depth: 2,
   colors: false,
@@ -185,7 +187,7 @@ function inspect(value, opts) {
     if (typeof opts === 'boolean') {
       ctx.showHidden = opts;
     } else if (opts) {
-      const optKeys = Object.keys(opts);
+      const optKeys = primordials.Object.keys(opts);
       for (var i = 0; i < optKeys.length; i++) {
         ctx[optKeys[i]] = opts[optKeys[i]];
       }
@@ -197,7 +199,7 @@ function inspect(value, opts) {
 }
 inspect.custom = customInspectSymbol;
 
-Object.defineProperty(inspect, 'defaultOptions', {
+primordials.Object.defineProperty(inspect, 'defaultOptions', {
   get() {
     return inspectDefaultOptions;
   },
@@ -205,12 +207,12 @@ Object.defineProperty(inspect, 'defaultOptions', {
     if (options === null || typeof options !== 'object') {
       throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
-    return Object.assign(inspectDefaultOptions, options);
+    return primordials.Object.assign(inspectDefaultOptions, options);
   }
 });
 
 // http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
-inspect.colors = Object.assign(Object.create(null), {
+inspect.colors = primordials.Object.assign(primordials.Object.create(null), {
   bold: [1, 22],
   italic: [3, 23],
   underline: [4, 24],
@@ -227,7 +229,7 @@ inspect.colors = Object.assign(Object.create(null), {
 });
 
 // Don't use 'blue' not visible on cmd.exe
-inspect.styles = Object.assign(Object.create(null), {
+inspect.styles = primordials.Object.assign(Object.create(null), {
   special: 'cyan',
   number: 'yellow',
   bigint: 'yellow',
@@ -327,14 +329,15 @@ function getEmptyFormatArray() {
 function getConstructorName(obj, ctx) {
   let firstProto;
   while (obj) {
-    const descriptor = Object.getOwnPropertyDescriptor(obj, 'constructor');
+    const descriptor =
+      primordials.Object.getOwnPropertyDescriptor(obj, 'constructor');
     if (descriptor !== undefined &&
         typeof descriptor.value === 'function' &&
         descriptor.value.name !== '') {
       return descriptor.value.name;
     }
 
-    obj = Object.getPrototypeOf(obj);
+    obj = primordials.Object.getPrototypeOf(obj);
     if (firstProto === undefined) {
       firstProto = obj;
     }
@@ -369,9 +372,9 @@ const getBoxedValue = formatPrimitive.bind(null, stylizeNoColor);
 // Look up the keys of the object.
 function getKeys(value, showHidden) {
   let keys;
-  const symbols = Object.getOwnPropertySymbols(value);
+  const symbols = primordials.Object.getOwnPropertySymbols(value);
   if (showHidden) {
-    keys = Object.getOwnPropertyNames(value);
+    keys = primordials.Object.getOwnPropertyNames(value);
     if (symbols.length !== 0)
       keys.push(...symbols);
   } else {
@@ -381,15 +384,11 @@ function getKeys(value, showHidden) {
     // TODO(devsnek): track https://github.com/tc39/ecma262/issues/1209
     // and modify this logic as needed.
     try {
-      keys = Object.keys(value);
+      keys = primordials.Object.keys(value);
     } catch (err) {
-      if (isNativeError(err) &&
-          err.name === 'ReferenceError' &&
-          isModuleNamespaceObject(value)) {
-        keys = Object.getOwnPropertyNames(value);
-      } else {
-        throw err;
-      }
+      assert(isNativeError(err) && err.name === 'ReferenceError' &&
+             isModuleNamespaceObject(value));
+      keys = primordials.Object.getOwnPropertyNames(value);
     }
     if (symbols.length !== 0) {
       keys.push(...symbols.filter((key) => propertyIsEnumerable(value, key)));
@@ -454,8 +453,8 @@ function clazzWithNullPrototype(clazz, name) {
       return '';
     }
   }
-  Object.defineProperty(NullPrototype.prototype.constructor, 'name',
-                        { value: `[${name}: null prototype]` });
+  primordials.Object.defineProperty(NullPrototype.prototype.constructor, 'name',
+                                    { value: `[${name}: null prototype]` });
   lazyNullPrototypeCache.set(clazz, NullPrototype);
   return NullPrototype;
 }
@@ -477,7 +476,9 @@ function noPrototypeIterator(ctx, value, recurseTimes) {
     newVal = new clazz(value);
   }
   if (newVal !== undefined) {
-    Object.defineProperties(newVal, Object.getOwnPropertyDescriptors(value));
+    primordials.Object.defineProperties(
+      newVal, primordials.Object.getOwnPropertyDescriptors(value)
+    );
     return formatRaw(ctx, newVal, recurseTimes);
   }
 }
@@ -894,7 +895,7 @@ function formatNamespaceObject(ctx, value, recurseTimes, keys) {
 
 // The array is sparse and/or has extra keys
 function formatSpecialArray(ctx, value, recurseTimes, maxLength, output, i) {
-  const keys = Object.keys(value);
+  const keys = primordials.Object.keys(value);
   let index = i;
   for (; i < keys.length && output.length < maxLength; i++) {
     const key = keys[i];
@@ -1125,7 +1126,7 @@ function formatPromise(ctx, value, recurseTimes) {
 function formatProperty(ctx, value, recurseTimes, key, type) {
   let name, str;
   let extra = ' ';
-  const desc = Object.getOwnPropertyDescriptor(value, key) ||
+  const desc = primordials.Object.getOwnPropertyDescriptor(value, key) ||
     { value: value[key], enumerable: true };
   if (desc.value !== undefined) {
     const diff = (type !== kObjectType || ctx.compact === false) ? 2 : 3;

--- a/test/parallel/test-util-primordial-monkeypatching.js
+++ b/test/parallel/test-util-primordial-monkeypatching.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// Monkeypatch Object.keys() so that it throws an unexpected error. This tests
+// that `util.inspect()` is unaffected by monkey-patching `Object`.
+
+require('../common');
+const assert = require('assert');
+const util = require('util');
+
+Object.keys = () => { throw new Error('fhqwhgads'); };
+assert.strictEqual(util.inspect({}), '{}');


### PR DESCRIPTION
Prevent affects of monkeypatching (for example) Object.keys() when calling util.inspect().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
