### PR TITLE
build: fixed clang's warning when building openssl.

### DIFF
--- a/deps/openssl/openssl_common.gypi
+++ b/deps/openssl/openssl_common.gypi
@@ -57,13 +57,16 @@
       ],
     }, {
       # linux and others
-      'cflags': ['-Wno-missing-field-initializers',
-                 ## TODO: check gcc_version>=4.3
-                 '-Wno-old-style-declaration'],
+      'cflags': ['-Wno-missing-field-initializers',],
       'defines': [
         'OPENSSLDIR="/etc/ssl"',
         'ENGINESDIR="/dev/null"',
         'TERMIOS',
+      ],
+      'conditions': [
+        [ 'llvm_version==0', {
+          'cflags': ['-Wno-old-style-declaration',],
+        }],
       ],
     }],
   ]


### PR DESCRIPTION
clang doesn't seem to support 'Wno-old-style-declaration', this
is a work-around.

Fixes: https://github.com/nodejs/node/issues/25550
Refs: https://github.com/nodejs/node-v0.x-archive/issues/4186

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
