### PR TITLE
src: remove unused assignments

### DIFF
--- a/src/tracing/node_trace_buffer.cc
+++ b/src/tracing/node_trace_buffer.cc
@@ -100,12 +100,10 @@ NodeTraceBuffer::NodeTraceBuffer(size_t max_chunks,
       buffer2_(max_chunks, 1, agent) {
   current_buf_.store(&buffer1_);
 
-  flush_signal_.data = this;
   int err = uv_async_init(tracing_loop_, &flush_signal_,
                           NonBlockingFlushSignalCb);
   CHECK_EQ(err, 0);
 
-  exit_signal_.data = this;
   err = uv_async_init(tracing_loop_, &exit_signal_, ExitSignalCb);
   CHECK_EQ(err, 0);
 }

--- a/src/tracing/node_trace_writer.cc
+++ b/src/tracing/node_trace_writer.cc
@@ -15,7 +15,6 @@ void NodeTraceWriter::InitializeOnThread(uv_loop_t* loop) {
   CHECK_NULL(tracing_loop_);
   tracing_loop_ = loop;
 
-  flush_signal_.data = this;
   int err = uv_async_init(tracing_loop_, &flush_signal_,
                           [](uv_async_t* signal) {
     NodeTraceWriter* trace_writer =
@@ -24,7 +23,6 @@ void NodeTraceWriter::InitializeOnThread(uv_loop_t* loop) {
   });
   CHECK_EQ(err, 0);
 
-  exit_signal_.data = this;
   err = uv_async_init(tracing_loop_, &exit_signal_, ExitSignalCb);
   CHECK_EQ(err, 0);
 }


### PR DESCRIPTION
When invoking C++ member methods through async callbacks, the `this`
pointer is passed through the async signal strcture. Now with recent
changes, in the callback we are obtaining the his pointer reflectively
through applying pointer arithmetic on the async field, effectively
making this assignments redundant.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
