### PR TITLE
doc: add a sentence about REPLACEME in code changes

### DIFF
--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -116,9 +116,8 @@ time to ensure that the changes follow the Node.js code style guide.
 Any documentation you write (including code comments and API documentation)
 should follow the [Style Guide](../../STYLE_GUIDE.md). Code samples included
 in the API docs will also be checked when running `make lint` (or
-`vcbuild.bat lint` on Windows). If you are adding to or deprecating the API,
-be sure to use `REPLACEME` for the version numbers as specified in
-[releases.md](../../releases.md#step-3-update-any-replaceme-and-dep00xx-tags-in-the-docs).
+`vcbuild.bat lint` on Windows). If you are adding to or deprecating an API,
+use `REPLACEME` for the version number in the documentation YAML.
 
 For contributing C++ code, you may want to look at the
 [C++ Style Guide](../../../CPP_STYLE_GUIDE.md).

--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -116,7 +116,9 @@ time to ensure that the changes follow the Node.js code style guide.
 Any documentation you write (including code comments and API documentation)
 should follow the [Style Guide](../../STYLE_GUIDE.md). Code samples included
 in the API docs will also be checked when running `make lint` (or
-`vcbuild.bat lint` on Windows).
+`vcbuild.bat lint` on Windows). If you are adding to or deprecating the API,
+be sure to use `REPLACEME` for the version numbers as specified in
+[releases.md](../../releases.md#step-3-update-any-replaceme-and-dep00xx-tags-in-the-docs).
 
 For contributing C++ code, you may want to look at the
 [C++ Style Guide](../../../CPP_STYLE_GUIDE.md).


### PR DESCRIPTION
When adding to the REPL API recently, I was unsure what to put as a
version number for the new method I added. This change adds a reference
to `releases.md` where the use of `REPLACEME` is discussed.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
