### PR TITLE
esm: fixup process Proxy to handle toString correctly

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -319,6 +319,12 @@ function setupProcessObject() {
   const origProcProto = Object.getPrototypeOf(process);
   Object.setPrototypeOf(origProcProto, EventEmitter.prototype);
   EventEmitter.call(process);
+  Object.defineProperty(process, Symbol.toStringTag, {
+    enumerable: false,
+    writable: false,
+    configurable: false,
+    value: 'process'
+  });
   // Make process globally available to users by putting it on the global proxy
   Object.defineProperty(global, 'process', {
     value: process,

--- a/test/es-module/test-esm-process.mjs
+++ b/test/es-module/test-esm-process.mjs
@@ -1,0 +1,6 @@
+// Flags: --experimental-modules
+import '../common';
+import assert from 'assert';
+import process from 'process';
+
+assert.strictEqual(Object.prototype.toString.call(process), '[object process]');


### PR DESCRIPTION
This fixes the following `--experimental-modules` bug:

```js
import process from 'process';
// returns [object Object] instead of [object process]
console.log(Object.prototype.toString.call(process));
```

//cc @devsnek

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
