### PR TITLE
doc: clarify effect of stream.destroy() on write()

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -369,12 +369,17 @@ See also: [`writable.uncork()`][].
 added: v8.0.0
 -->
 
-* `error` {Error}
+* `error` {Error} Optional, an error to emit with `'error'` event.
 * Returns: {this}
 
-Destroy the stream, and emit the passed `'error'` and a `'close'` event.
+Destroy the stream. Optionally emit an `'error'` event, and always emit
+a `'close'` event.
 After this call, the writable stream has ended and subsequent calls
 to `write()` or `end()` will result in an `ERR_STREAM_DESTROYED` error.
+This is a destructive and immediate way to destroy a stream. Previous calls to
+`write()` may not have drained, and may trigger an `ERR_STREAM_DESTROYED` error.
+Use `end()` instead of destroy if data should flush before close, or wait for
+the `'drain'` event before destroying the stream.
 Implementors should not override this method,
 but instead implement [`writable._destroy()`][writable-_destroy].
 


### PR DESCRIPTION
@mcollina or @addaleax or @nodejs/streams 

I'd like some clarification on the expected interaction of `destroy()` and `write()`.  I am going through my final rounds of test cleanups on my TLS1.3 WIP, and the remaining failures are mostly about stream interactions, and I'm not sure if they are bugs or invalid tests. The docs aren't clear on the expected behaviour, so I propose some text in this PR, but I'm not sure if its correct - though it is what I observe.

https://github.com/nodejs/node/blob/a046ae5ceddcaaf695df60be5dbc9d725beb6f22/test/parallel/test-tls-destroy-stream.js#L26-L27

I'm getting `ERR_STREAM_DESTROYED` from the above. I will do detailed analysis tomorrow, but I suspect it is because after the `secureConnection` event, with TLS1.3, the SSL context is going to write some key update messages, so it slows down the flushing of CONTENT, and .destroy() causes the flushing to fail. Again, have to confirm that I understand what is happening, but either way, is the test valid? Note it passes if rewritten as:

```
socket.write(CONTENT, () => {                                                
   socket.destroy(new Error('hi, sam'));                                      
}); 
```

https://github.com/nodejs/node/blob/a046ae5ceddcaaf695df60be5dbc9d725beb6f22/test/parallel/test-tls-invoke-queued.js#L39-L44

In this case, the `destroy()` doesn't error... but the `'end'` event on the client happens before *ANY* `'data'` events occur ... `received` is `''` at https://github.com/nodejs/node/blob/a046ae5ceddcaaf695df60be5dbc9d725beb6f22/test/parallel/test-tls-invoke-queued.js#L56

Again, I have to do detailed analysis to see why the data was dropped, but this seems to me to be an invalid test case. Unlike `end()` which is guaranteed to be serialized with any preceeding `write()`s, I don't think `destroy()` has any such guarantee.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
