### PR TITLE
Makes http(2) response.writehead return this

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1446,6 +1446,9 @@ the request body should be sent. See the [`'checkContinue'`][] event on
 <!-- YAML
 added: v0.1.30
 changes:
+  - version: ???
+    pr-url: https://github.com/nodejs/node/pull/25974
+    description: Return `this` from `writeHead` to allow chaining with `end`.
   - version: v5.11.0, v4.4.5
     pr-url: https://github.com/nodejs/node/pull/6291
     description: A `RangeError` is thrown if `statusCode` is not a number in
@@ -1455,17 +1458,23 @@ changes:
 * `statusCode` {number}
 * `statusMessage` {string}
 * `headers` {Object}
+* Returns: {http.ServerResponse}
 
 Sends a response header to the request. The status code is a 3-digit HTTP
 status code, like `404`. The last argument, `headers`, are the response headers.
 Optionally one can give a human-readable `statusMessage` as the second
 argument.
 
+Returns a reference to the `ServerResponse`, so that calls can be chained.
+
 ```js
 const body = 'hello world';
-response.writeHead(200, {
-  'Content-Length': Buffer.byteLength(body),
-  'Content-Type': 'text/plain' });
+response
+  .writeHead(200, {
+    'Content-Length': Buffer.byteLength(body),
+    'Content-Type': 'text/plain'
+  })
+  .end(body);
 ```
 
 This method must only be called once on a message and it must

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1446,7 +1446,7 @@ the request body should be sent. See the [`'checkContinue'`][] event on
 <!-- YAML
 added: v0.1.30
 changes:
-  - version: ???
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/25974
     description: Return `this` from `writeHead` to allow chaining with `end`.
   - version: v5.11.0, v4.4.5

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1448,7 +1448,8 @@ added: v0.1.30
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/25974
-    description: Return `this` from `writeHead` to allow chaining with `end`.
+    description: Return `this` from `writeHead()` to allow chaining with
+                 `end()`.
   - version: v5.11.0, v4.4.5
     pr-url: https://github.com/nodejs/node/pull/6291
     description: A `RangeError` is thrown if `statusCode` is not a number in

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3284,7 +3284,7 @@ should be sent. See the [`'checkContinue'`][] event on `Http2Server` and
 <!-- YAML
 added: v8.4.0
 changes:
-  - version: ???
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/25974
     description: Return `this` from `writeHead` to allow chaining with `end`.
 -->

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3286,7 +3286,8 @@ added: v8.4.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/25974
-    description: Return `this` from `writeHead` to allow chaining with `end`.
+    description: Return `this` from `writeHead()` to allow chaining with
+                 `end()`.
 -->
 
 * `statusCode` {number}

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3283,14 +3283,21 @@ should be sent. See the [`'checkContinue'`][] event on `Http2Server` and
 #### response.writeHead(statusCode[, statusMessage][, headers])
 <!-- YAML
 added: v8.4.0
+changes:
+  - version: ???
+    pr-url: https://github.com/nodejs/node/pull/25974
+    description: Return `this` from `writeHead` to allow chaining with `end`.
 -->
 
 * `statusCode` {number}
 * `statusMessage` {string}
 * `headers` {Object}
+* Returns: {http2.Http2ServerResponse}
 
 Sends a response header to the request. The status code is a 3-digit HTTP
 status code, like `404`. The last argument, `headers`, are the response headers.
+
+Returns a reference to the `ServerResponse`, so that calls can be chained.
 
 For compatibility with [HTTP/1][], a human-readable `statusMessage` may be
 passed as the second argument. However, because the `statusMessage` has no

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3298,7 +3298,7 @@ changes:
 Sends a response header to the request. The status code is a 3-digit HTTP
 status code, like `404`. The last argument, `headers`, are the response headers.
 
-Returns a reference to the `ServerResponse`, so that calls can be chained.
+Returns a reference to the `Http2ServerResponse`, so that calls can be chained.
 
 For compatibility with [HTTP/1][], a human-readable `statusMessage` may be
 passed as the second argument. However, because the `statusMessage` has no

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -270,6 +270,8 @@ function writeHead(statusCode, reason, obj) {
   }
 
   this._storeHeader(statusLine, headers);
+
+  return this;
 }
 
 // Docs-only deprecated: DEP0063

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -568,10 +568,8 @@ class Http2ServerResponse extends Stream {
     if (this[kStream].headersSent)
       throw new ERR_HTTP2_HEADERS_SENT();
 
-    // If the stream is destroyed, we return false,
-    // like require('http').
     if (this.stream.destroyed)
-      return false;
+      return this;
 
     if (typeof statusMessage === 'string')
       statusMessageWarn();
@@ -596,6 +594,8 @@ class Http2ServerResponse extends Stream {
 
     state.statusCode = statusCode;
     this[kBeginSend]();
+
+    return this;
   }
 
   write(chunk, encoding, cb) {

--- a/test/parallel/test-http-response-writehead-returns-this.js
+++ b/test/parallel/test-http-response-writehead-returns-this.js
@@ -1,0 +1,22 @@
+'use strict';
+require('../common');
+const http = require('http');
+const assert = require('assert');
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'a-header': 'a-header-value' }).end('abc');
+});
+
+server.listen(0, () => {
+  http.get({ port: server.address().port }, (res) => {
+    assert.strictEqual(res.headers['a-header'], 'a-header-value');
+
+    const chunks = [];
+
+    res.on('data', (chunk) => chunks.push(chunk));
+    res.on('end', () => {
+      assert.strictEqual(Buffer.concat(chunks).toString(), 'abc');
+      server.close();
+    });
+  });
+});

--- a/test/parallel/test-http2-compat-serverresponse-writehead-array.js
+++ b/test/parallel/test-http2-compat-serverresponse-writehead-array.js
@@ -12,10 +12,11 @@ const server = h2.createServer();
 server.listen(0, common.mustCall(() => {
   const port = server.address().port;
   server.once('request', common.mustCall((request, response) => {
-    response.writeHead(200, [
+    const returnVal = response.writeHead(200, [
       ['foo', 'bar'],
       ['ABC', 123]
     ]);
+    assert.strictEqual(returnVal, response);
     response.end(common.mustCall(() => { server.close(); }));
   }));
 

--- a/test/parallel/test-http2-compat-serverresponse-writehead.js
+++ b/test/parallel/test-http2-compat-serverresponse-writehead.js
@@ -13,7 +13,11 @@ server.listen(0, common.mustCall(function() {
   const port = server.address().port;
   server.once('request', common.mustCall(function(request, response) {
     response.setHeader('foo-bar', 'def456');
-    response.writeHead(418, { 'foo-bar': 'abc123' }); // Override
+
+    // Override
+    const returnVal = response.writeHead(418, { 'foo-bar': 'abc123' });
+
+    assert.strictEqual(returnVal, response);
 
     common.expectsError(() => { response.writeHead(300); }, {
       code: 'ERR_HTTP2_HEADERS_SENT'


### PR DESCRIPTION
Addresses #25935.

I chose in the end to go with the lightest touch and only update `writeHead` (this is the most useful to change in my experience). I'm happy to extend this to `res.setHeader` too, but it may suggest updating other similar methods (`flushHeaders`, `removeHeader`, etc.)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
