### PR TITLE
test: remove extraneous report validation argument

### DIFF
--- a/test/node-report/test-api-getreport.js
+++ b/test/node-report/test-api-getreport.js
@@ -21,8 +21,5 @@ if (process.argv[2] === 'child') {
     ' experimental feature. This feature could change at any time'), std_msg);
   const reportFiles = helper.findReports(child.pid, tmpdir.path);
   assert.deepStrictEqual(reportFiles, [], report_msg);
-  helper.validateContent(child.stdout, { pid: child.pid,
-                                         commandline: process.execPath +
-                                         ' ' + args.join(' ')
-  });
+  helper.validateContent(child.stdout);
 }

--- a/test/node-report/test-api-nohooks.js
+++ b/test/node-report/test-api-nohooks.js
@@ -23,8 +23,6 @@ if (process.argv[2] === 'child') {
     const reports = helper.findReports(child.pid, tmpdir.path);
     assert.strictEqual(reports.length, 1, report_msg);
     const report = reports[0];
-    helper.validate(report, { pid: child.pid,
-                              commandline: child.spawnargs.join(' ')
-    });
+    helper.validate(report);
   }));
 }

--- a/test/node-report/test-api-pass-error.js
+++ b/test/node-report/test-api-pass-error.js
@@ -25,9 +25,6 @@ if (process.argv[2] === 'child') {
     const reports = helper.findReports(child.pid, tmpdir.path);
     assert.strictEqual(reports.length, 1, report_msg);
     const report = reports[0];
-    helper.validate(report, { pid: child.pid,
-                              commandline: child.spawnargs.join(' '),
-                              expectedException: 'Testing error handling',
-    });
+    helper.validate(report);
   }));
 }

--- a/test/node-report/test-api-uvhandles.js
+++ b/test/node-report/test-api-uvhandles.js
@@ -126,8 +126,6 @@ if (process.argv[2] === 'child') {
     assert.deepStrictEqual(udp, 1, udp_msg);
 
     // Common report tests.
-    helper.validateContent(stdout, { pid: child.pid,
-                                     commandline: child.spawnargs.join(' ')
-    });
+    helper.validateContent(stdout);
   }));
 }

--- a/test/node-report/test-api.js
+++ b/test/node-report/test-api.js
@@ -22,8 +22,6 @@ if (process.argv[2] === 'child') {
     const reports = helper.findReports(child.pid, tmpdir.path);
     assert.strictEqual(reports.length, 1, report_msg);
     const report = reports[0];
-    helper.validate(report, { pid: child.pid,
-                              commandline: child.spawnargs.join(' ')
-    });
+    helper.validate(report);
   }));
 }

--- a/test/node-report/test-exception.js
+++ b/test/node-report/test-exception.js
@@ -37,8 +37,6 @@ if (process.argv[2] === 'child') {
     const reports = helper.findReports(child.pid, tmpdir.path);
     assert.strictEqual(reports.length, 1, report_msg);
     const report = reports[0];
-    helper.validate(report, { pid: child.pid,
-                              commandline: child.spawnargs.join(' ')
-    });
+    helper.validate(report);
   }));
 }

--- a/test/node-report/test-fatal-error.js
+++ b/test/node-report/test-fatal-error.js
@@ -33,12 +33,6 @@ if (process.argv[2] === 'child') {
     const reports = helper.findReports(child.pid, tmpdir.path);
     assert.strictEqual(reports.length, 1);
     const report = reports[0];
-    const options = { pid: child.pid };
-    // Node.js currently overwrites the command line on AIX
-    // https://github.com/nodejs/node/issues/10607
-    if (!(common.isAIX || common.isSunOS)) {
-      options.commandline = child.spawnargs.join(' ');
-    }
-    helper.validate(report, options);
+    helper.validate(report);
   }));
 }

--- a/test/node-report/test-signal.js
+++ b/test/node-report/test-signal.js
@@ -73,8 +73,6 @@ if (process.argv[2] === 'child') {
     const reports = helper.findReports(child.pid, tmpdir.path);
     assert.deepStrictEqual(reports.length, 1, report_msg);
     const report = reports[0];
-    helper.validate(report, { pid: child.pid,
-                              commandline: child.spawnargs.join(' ')
-    });
+    helper.validate(report);
   }));
 }


### PR DESCRIPTION
The second argument passed to `validate()` and `validateContent()` is not used for anything.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
