### PR TITLE
build: export deprecated OpenSSL symbols on Windows

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -703,7 +703,7 @@
               '-CAES,BF,BIO,DES,DH,DSA,EC,ECDH,ECDSA,ENGINE,EVP,HMAC,MD4,MD5,'
               'PSK,RC2,RC4,RSA,SHA,SHA0,SHA1,SHA256,SHA512,SOCK,STDIO,TLSEXT,'
               'FP_API,TLS1_METHOD,TLS1_1_METHOD,TLS1_2_METHOD,SCRYPT,OCSP,'
-              'NEXTPROTONEG,RMD160,CAST',
+              'NEXTPROTONEG,RMD160,CAST,DEPRECATEDIN_1_1_0,DEPRECATEDIN_1_2_0',
               # Defines.
               '-DWIN32',
               # Symbols to filter from the export list.

--- a/test/addons/openssl-binding/binding.cc
+++ b/test/addons/openssl-binding/binding.cc
@@ -1,6 +1,7 @@
 #include <node.h>
 #include <assert.h>
 #include <openssl/rand.h>
+#include <openssl/ssl.h>
 
 namespace {
 
@@ -28,6 +29,9 @@ inline void Initialize(v8::Local<v8::Object> exports,
                    ->GetFunction(context)
                    .ToLocalChecked();
   assert(exports->Set(context, key, value).IsJust());
+
+  const SSL_METHOD* method = TLSv1_2_server_method();
+  assert(method != nullptr);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
Methods such as `TLSv1_server_method` are categorized as
`DEPRECATEDIN_1_1_0`. Add the deprecated categories to
the list of categories to include passed to `mkssldef.py`.

Adds a regression test to `test/addons/openssl-binding`.

Refs: https://github.com/nodejs/node/issues/20369
Refs: https://github.com/nodejs/node/issues/25981

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
