### PR TITLE
win, build: arm64 port script and doc changes

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -416,9 +416,19 @@ Prerequisites:
   and tools which can be included in the global `PATH`.
 * The [NetWide Assembler](http://www.nasm.us/), for OpenSSL assembler modules.
   If not installed in the default location, it needs to be manually added
-  to `PATH`. A build with the `openssl-no-asm` option does not need this.
+  to `PATH`. A build with the `openssl-no-asm` option does not need this, nor
+  does a build targeting ARM64 Windows.
 * **Optional** (to build the MSI): the [WiX Toolset v3.11](http://wixtoolset.org/releases/)
   and the [Wix Toolset Visual Studio 2017 Extension](https://marketplace.visualstudio.com/items?itemName=RobMensching.WixToolsetVisualStudio2017Extension).
+* **Optional** Requirements for compiling for Windows 10 on ARM (ARM64):
+    * ARM64 Windows build machine
+        * Due to a GYP limitation, this is required to run compiled code
+          generation tools (like V8's builtins and mksnapshot tools)
+    * Visual Studio 15.9.0 or newer
+    * Visual Studio optional components
+        * Visual C++ compilers and libraries for ARM64
+        * Visual C++ ATL for ARM64
+    * Windows 10 SDK 10.0.17763.0 or newer
 
 If the path to your build directory contains a space or a non-ASCII character,
 the build will likely fail.

--- a/common.gypi
+++ b/common.gypi
@@ -271,6 +271,14 @@
               }],
             ],
           }],
+          ['target_arch=="arm64"', {
+            'TargetMachine' : 0, # /MACHINE:ARM64 is inferred from the input files.
+            'target_conditions': [
+              ['_type=="executable"', {
+                'AdditionalOptions': [ '/SubSystem:Console' ],
+              }],
+            ],
+          }],
         ],
         'GenerateDebugInformation': 'true',
         'SuppressStartupBanner': 'true',
@@ -295,6 +303,9 @@
     'conditions': [
       [ 'target_arch=="x64"', {
         'msvs_configuration_platform': 'x64',
+      }],
+      [ 'target_arch=="arm64"', {
+        'msvs_configuration_platform': 'arm64',
       }],
       ['asan == 1 and OS != "mac"', {
         'cflags+': [

--- a/configure.py
+++ b/configure.py
@@ -748,7 +748,7 @@ def get_gas_version(cc):
 # quite prepared to go that far yet.
 def check_compiler(o):
   if sys.platform == 'win32':
-    if not options.openssl_no_asm:
+    if not options.openssl_no_asm and options.dest_cpu in ('x86', 'x64'):
       nasm_version = get_nasm_version('nasm')
       o['variables']['nasm_version'] = nasm_version
       if nasm_version == 0:

--- a/tools/bootstrap/README.md
+++ b/tools/bootstrap/README.md
@@ -23,7 +23,7 @@ get-boxstarter -Force
 Install-BoxstarterPackage https://raw.githubusercontent.com/nodejs/node/master/tools/bootstrap/windows_boxstarter -DisableReboots
 ```
 
-Entire installation will take up about 8 GB of disk space.
+Entire installation will take up about 10 GB of disk space.
 
 ## Linux
 

--- a/tools/bootstrap/windows_boxstarter
+++ b/tools/bootstrap/windows_boxstarter
@@ -18,7 +18,7 @@ choco install python2 -y
 
 # Installs VS 2017 Build Tools
 choco install visualstudio2017buildtools -y
-choco install visualstudio2017-workload-vctools -y
+choco install visualstudio2017-workload-vctools -y --params="--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64"
 
 # NASM
 choco install nasm -y

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -67,6 +67,7 @@ if /i "%1"=="clean"         set target=Clean&goto arg-ok
 if /i "%1"=="ia32"          set target_arch=x86&goto arg-ok
 if /i "%1"=="x86"           set target_arch=x86&goto arg-ok
 if /i "%1"=="x64"           set target_arch=x64&goto arg-ok
+if /i "%1"=="arm64"         set target_arch=arm64&goto arg-ok
 if /i "%1"=="vs2017"        set target_env=vs2017&goto arg-ok
 if /i "%1"=="noprojgen"     set noprojgen=1&goto arg-ok
 if /i "%1"=="projgen"       set projgen=1&goto arg-ok
@@ -192,7 +193,8 @@ if "%target%"=="Clean" rmdir /S /Q %~dp0deps\icu
 call tools\msvs\find_python.cmd
 if errorlevel 1 goto :exit
 
-if not defined openssl_no_asm call tools\msvs\find_nasm.cmd
+REM NASM is only needed on IA32 and x86_64.
+if not defined openssl_no_asm if "%target_arch%" NEQ "arm64" call tools\msvs\find_nasm.cmd
 if errorlevel 1 echo Could not find NASM, install it or build with openssl-no-asm. See BUILDING.md.
 
 call :getnodeversion || exit /b 1
@@ -303,6 +305,7 @@ set "msbcpu=/m:2"
 if "%NUMBER_OF_PROCESSORS%"=="1" set "msbcpu=/m:1"
 set "msbplatform=Win32"
 if "%target_arch%"=="x64" set "msbplatform=x64"
+if "%target_arch%"=="arm64" set "msbplatform=ARM64"
 if "%target%"=="Build" (
   if defined no_cctest set target=rename_node_bin_win
   if "%test_args%"=="" set target=rename_node_bin_win


### PR DESCRIPTION
This change lays the groundwork for ARM64 Windows ("Windows 10 on ARM") builds of Node.js.

Build script and configuration files gets new ARM64 Windows sections. The arch-specific check for NASM is scoped to the architectures that rely on it.

The bootstrap script arguments for Visual Studio tool installation are expanded to include ARM64 tools.

Documentation is updated to reflect all of these changes.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
    - ARM64 vcbuild requires other changes, but Windows x64 passes.
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
