### PR TITLE
tls: renegotiate should take care of its own state

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -621,6 +621,9 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
     this._requestCert = requestCert;
     this._rejectUnauthorized = rejectUnauthorized;
   }
+  // Ensure that we'll cycle through internal openssl's state
+  this.write('');
+
   if (!this._handle.renegotiate()) {
     if (callback) {
       process.nextTick(callback, new ERR_TLS_RENEGOTIATE());

--- a/test/parallel/test-tls-disable-renegotiation.js
+++ b/test/parallel/test-tls-disable-renegotiation.js
@@ -46,7 +46,6 @@ server.listen(0, common.mustCall(() => {
     port
   };
   const client = tls.connect(options, common.mustCall(() => {
-    client.write('');
 
     common.expectsError(() => client.renegotiate(), {
       code: 'ERR_INVALID_ARG_TYPE',
@@ -78,7 +77,6 @@ server.listen(0, common.mustCall(() => {
       // data event on the server. After that data
       // is received, disableRenegotiation is called.
       client.write('data', common.mustCall(() => {
-        client.write('');
         // This second renegotiation attempt should fail
         // and the callback should never be invoked. The
         // server will simply drop the connection after


### PR DESCRIPTION
In the initial version of this test there were two zero-length writes to
force tls state to cycle. The second is not necessary, at least not now,
but the first was. The renegotiate() API should ensure that packet
exchange takes place, not its users, so move the zero-length write into
tls.

See: https://github.com/nodejs/node/pull/14239
See: https://github.com/nodejs/node/commit/b1909d3a70f9

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
