### PR TITLE
src: remove `process.binding('config').debugOptions`

### DIFF
--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -6,9 +6,7 @@
 
 namespace node {
 
-using v8::Boolean;
 using v8::Context;
-using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::Number;
@@ -72,19 +70,6 @@ static void Initialize(Local<Object> target,
   READONLY_PROPERTY(target,
                     "bits",
                     Number::New(env->isolate(), 8 * sizeof(intptr_t)));
-
-  Local<Object> debug_options_obj = Object::New(isolate);
-  READONLY_PROPERTY(target, "debugOptions", debug_options_obj);
-
-  const DebugOptions& debug_options = env->options()->debug_options();
-  READONLY_PROPERTY(debug_options_obj,
-                    "inspectorEnabled",
-                    Boolean::New(isolate, debug_options.inspector_enabled));
-  READONLY_STRING_PROPERTY(
-      debug_options_obj, "host", debug_options.host_port.host());
-  READONLY_PROPERTY(debug_options_obj,
-                    "port",
-                    Integer::New(isolate, debug_options.host_port.port()));
 }  // InitConfig
 
 }  // namespace node

--- a/test/sequential/test-inspector-port-cluster.js
+++ b/test/sequential/test-inspector-port-cluster.js
@@ -1,5 +1,7 @@
 'use strict';
 
+// Flags: --expose-internals
+
 const common = require('../common');
 
 common.skipIfInspectorDisabled();
@@ -205,7 +207,7 @@ function testRunnerMain() {
 }
 function masterProcessMain() {
   const workers = JSON.parse(process.env.workers);
-  const clusterSettings = JSON.parse(process.env.clusterSettings);
+  const clusterSettings = JSON.parse(process.env.clusterSettings) || {};
   const badPortError = { type: RangeError, code: 'ERR_SOCKET_BAD_PORT' };
   let debugPort = process.debugPort;
 
@@ -224,77 +226,80 @@ function masterProcessMain() {
       params.expectedHost = worker.expectedHost;
     }
 
-    if (clusterSettings) {
-      if (clusterSettings.inspectPort === 'addTwo') {
-        clusterSettings.inspectPort = common.mustCall(
-          () => { return debugPort += 2; },
-          workers.length
-        );
-      } else if (clusterSettings.inspectPort === 'string') {
-        clusterSettings.inspectPort = 'string';
-        cluster.setupMaster(clusterSettings);
+    clusterSettings.execArgv = clusterSettings.execArgv ?
+      clusterSettings.execArgv.concat(['--expose-internals']) :
+      process.execArgv.concat(['--expose-internals']);
 
-        common.expectsError(() => {
-          cluster.fork(params).on('exit', common.mustCall(checkExitCode));
-        }, badPortError);
-
-        return;
-      } else if (clusterSettings.inspectPort === 'null') {
-        clusterSettings.inspectPort = null;
-        cluster.setupMaster(clusterSettings);
-
-        common.expectsError(() => {
-          cluster.fork(params).on('exit', common.mustCall(checkExitCode));
-        }, badPortError);
-
-        return;
-      } else if (clusterSettings.inspectPort === 'bignumber') {
-        clusterSettings.inspectPort = 1293812;
-        cluster.setupMaster(clusterSettings);
-
-        common.expectsError(() => {
-          cluster.fork(params).on('exit', common.mustCall(checkExitCode));
-        }, badPortError);
-
-        return;
-      } else if (clusterSettings.inspectPort === 'negativenumber') {
-        clusterSettings.inspectPort = -9776;
-        cluster.setupMaster(clusterSettings);
-
-        common.expectsError(() => {
-          cluster.fork(params).on('exit', common.mustCall(checkExitCode));
-        }, badPortError);
-
-        return;
-      } else if (clusterSettings.inspectPort === 'bignumberfunc') {
-        clusterSettings.inspectPort = common.mustCall(
-          () => 123121,
-          workers.length
-        );
-
-        cluster.setupMaster(clusterSettings);
-
-        common.expectsError(() => {
-          cluster.fork(params).on('exit', common.mustCall(checkExitCode));
-        }, badPortError);
-
-        return;
-      } else if (clusterSettings.inspectPort === 'strfunc') {
-        clusterSettings.inspectPort = common.mustCall(
-          () => 'invalidPort',
-          workers.length
-        );
-
-        cluster.setupMaster(clusterSettings);
-
-        common.expectsError(() => {
-          cluster.fork(params).on('exit', common.mustCall(checkExitCode));
-        }, badPortError);
-
-        return;
-      }
+    if (clusterSettings.inspectPort === 'addTwo') {
+      clusterSettings.inspectPort = common.mustCall(
+        () => { return debugPort += 2; },
+        workers.length
+      );
+    } else if (clusterSettings.inspectPort === 'string') {
+      clusterSettings.inspectPort = 'string';
       cluster.setupMaster(clusterSettings);
+
+      common.expectsError(() => {
+        cluster.fork(params).on('exit', common.mustCall(checkExitCode));
+      }, badPortError);
+
+      return;
+    } else if (clusterSettings.inspectPort === 'null') {
+      clusterSettings.inspectPort = null;
+      cluster.setupMaster(clusterSettings);
+
+      common.expectsError(() => {
+        cluster.fork(params).on('exit', common.mustCall(checkExitCode));
+      }, badPortError);
+
+      return;
+    } else if (clusterSettings.inspectPort === 'bignumber') {
+      clusterSettings.inspectPort = 1293812;
+      cluster.setupMaster(clusterSettings);
+
+      common.expectsError(() => {
+        cluster.fork(params).on('exit', common.mustCall(checkExitCode));
+      }, badPortError);
+
+      return;
+    } else if (clusterSettings.inspectPort === 'negativenumber') {
+      clusterSettings.inspectPort = -9776;
+      cluster.setupMaster(clusterSettings);
+
+      common.expectsError(() => {
+        cluster.fork(params).on('exit', common.mustCall(checkExitCode));
+      }, badPortError);
+
+      return;
+    } else if (clusterSettings.inspectPort === 'bignumberfunc') {
+      clusterSettings.inspectPort = common.mustCall(
+        () => 123121,
+        workers.length
+      );
+
+      cluster.setupMaster(clusterSettings);
+
+      common.expectsError(() => {
+        cluster.fork(params).on('exit', common.mustCall(checkExitCode));
+      }, badPortError);
+
+      return;
+    } else if (clusterSettings.inspectPort === 'strfunc') {
+      clusterSettings.inspectPort = common.mustCall(
+        () => 'invalidPort',
+        workers.length
+      );
+
+      cluster.setupMaster(clusterSettings);
+
+      common.expectsError(() => {
+        cluster.fork(params).on('exit', common.mustCall(checkExitCode));
+      }, badPortError);
+
+      return;
     }
+
+    cluster.setupMaster(clusterSettings);
 
     cluster.fork(params).on('exit', common.mustCall(checkExitCode));
   }
@@ -302,7 +307,8 @@ function masterProcessMain() {
 
 function workerProcessMain() {
   const { expectedPort, expectedInitialPort, expectedHost } = process.env;
-  const debugOptions = process.binding('config').debugOptions;
+  const debugOptions =
+    require('internal/options').getOptionValue('--inspect-port');
 
   if ('expectedPort' in process.env) {
     assert.strictEqual(process.debugPort, +expectedPort);
@@ -327,7 +333,7 @@ function spawnMaster({ execArgv, workers, clusterSettings = {} }) {
         clusterSettings: JSON.stringify(clusterSettings),
         testProcess: true
       }),
-      execArgv
+      execArgv: execArgv.concat(['--expose-internals'])
     }).on('exit', common.mustCall((code, signal) => {
       checkExitCode(code, signal);
       resolve();


### PR DESCRIPTION
`process.binding('config').debugOptions`, which contains the initial
values of parsed debugger-related CLI options, has been used for
internal testing. This patch removes them and uses `internal/options`
to query the values in the tests instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
