### PR TITLE
process: normalize process.execPath in CreateProcessObject()

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -212,13 +212,6 @@ if (browserGlobals) {
 
 setupDOMException();
 
-// On OpenBSD process.execPath will be relative unless we
-// get the full path before process.execPath is used.
-if (process.platform === 'openbsd') {
-  const { realpathSync } = NativeModule.require('fs');
-  process.execPath = realpathSync.native(process.execPath);
-}
-
 Object.defineProperty(process, 'argv0', {
   enumerable: true,
   configurable: false,

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -273,21 +273,34 @@ MaybeLocal<Object> CreateProcessObject(
 
   // process.execPath
   {
-    size_t exec_path_len = 2 * PATH_MAX;
-    std::vector<char> exec_path(exec_path_len);
-    Local<String> exec_path_value;
-    if (uv_exepath(exec_path.data(), &exec_path_len) == 0) {
-      exec_path_value = String::NewFromUtf8(env->isolate(),
-                                            exec_path.data(),
-                                            NewStringType::kInternalized,
-                                            exec_path_len).ToLocalChecked();
+    char exec_path_buf[2 * PATH_MAX];
+    size_t exec_path_len = sizeof(exec_path_buf);
+    std::string exec_path;
+    if (uv_exepath(exec_path_buf, &exec_path_len) == 0) {
+      exec_path = std::string(exec_path_buf, exec_path_len);
     } else {
-      exec_path_value = String::NewFromUtf8(env->isolate(), args[0].c_str(),
-          NewStringType::kInternalized).ToLocalChecked();
+      exec_path = args[0];
     }
-    process->Set(env->context(),
-                 FIXED_ONE_BYTE_STRING(env->isolate(), "execPath"),
-                 exec_path_value).FromJust();
+    // On OpenBSD process.execPath will be relative unless we
+    // get the full path before process.execPath is used.
+#if defined(__OpenBSD__)
+    uv_fs_t req;
+    req.ptr = nullptr;
+    if (0 ==
+        uv_fs_realpath(env->event_loop(), &req, exec_path.c_str(), nullptr)) {
+      CHECK_NOT_NULL(req.ptr);
+      exec_path = std::string(static_cast<char*>(req.ptr));
+    }
+#endif
+    process
+        ->Set(env->context(),
+              FIXED_ONE_BYTE_STRING(env->isolate(), "execPath"),
+              String::NewFromUtf8(env->isolate(),
+                                  exec_path.c_str(),
+                                  NewStringType::kInternalized,
+                                  exec_path.size())
+                  .ToLocalChecked())
+        .FromJust();
   }
 
   // process.debugPort


### PR DESCRIPTION
Directly normalize `process.execPath` using `uv_fs_realpath`
on OpenBSD before serializing it into the process object,
instead of using `require('fs')` to normalize and override
the path in `bootstrap/node.js`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
