### PR TITLE
http: reduce multiple output arrays into one

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -374,10 +374,8 @@ function socketCloseListener() {
   // Too bad.  That output wasn't getting written.
   // This is pretty terrible that it doesn't raise an error.
   // Fixed better in v0.10
-  if (req.output)
-    req.output.length = 0;
-  if (req.outputEncodings)
-    req.outputEncodings.length = 0;
+  if (req.outputData)
+    req.outputData.length = 0;
 
   if (parser) {
     parser.finish();

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -799,7 +799,7 @@ OutgoingMessage.prototype._flushOutput = function _flushOutput(socket) {
 
   var outputData = this.outputData;
   socket.cork();
-  for (var i = 0; i < outputData.length; i++) {
+  for (var i = 0; i < outputLength; i++) {
     const { data, encoding, callback } = outputData[i];
     ret = socket.write(data, encoding, callback);
   }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -70,9 +70,7 @@ function OutgoingMessage() {
 
   // Queue that holds all currently pending data, until the response will be
   // assigned to the socket (until it will its turn in the HTTP pipeline).
-  this.output = [];
-  this.outputEncodings = [];
-  this.outputCallbacks = [];
+  this.outputData = [];
 
   // `outputSize` is an approximate measure of how much data is queued on this
   // response. `_onPendingData` will be invoked to update similar global
@@ -220,14 +218,18 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback) {
       data = this._header + data;
     } else {
       var header = this._header;
-      if (this.output.length === 0) {
-        this.output = [header];
-        this.outputEncodings = ['latin1'];
-        this.outputCallbacks = [null];
+      if (this.outputData.length === 0) {
+        this.outputData = [{
+          data: header,
+          encoding: 'latin1',
+          callback: null
+        }];
       } else {
-        this.output.unshift(header);
-        this.outputEncodings.unshift('latin1');
-        this.outputCallbacks.unshift(null);
+        this.outputData.unshift({
+          data: header,
+          encoding: 'latin1',
+          callback: null
+        });
       }
       this.outputSize += header.length;
       this._onPendingData(header.length);
@@ -254,7 +256,7 @@ function _writeRaw(data, encoding, callback) {
 
   if (conn && conn._httpMessage === this && conn.writable && !conn.destroyed) {
     // There might be pending data in the this.output buffer.
-    if (this.output.length) {
+    if (this.outputData.length) {
       this._flushOutput(conn);
     } else if (!data.length) {
       if (typeof callback === 'function') {
@@ -273,9 +275,7 @@ function _writeRaw(data, encoding, callback) {
     return conn.write(data, encoding, callback);
   }
   // Buffer, as long as we're not destroyed.
-  this.output.push(data);
-  this.outputEncodings.push(encoding);
-  this.outputCallbacks.push(callback);
+  this.outputData.push({ data, encoding, callback });
   this.outputSize += data.length;
   this._onPendingData(data.length);
   return false;
@@ -738,7 +738,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
   // There is the first message on the outgoing queue, and we've sent
   // everything to the socket.
   debug('outgoing message end.');
-  if (this.output.length === 0 &&
+  if (this.outputData.length === 0 &&
       this.connection &&
       this.connection._httpMessage === this) {
     this._finish();
@@ -793,22 +793,19 @@ OutgoingMessage.prototype._flush = function _flush() {
 
 OutgoingMessage.prototype._flushOutput = function _flushOutput(socket) {
   var ret;
-  var outputLength = this.output.length;
+  var outputLength = this.outputData.length;
   if (outputLength <= 0)
     return ret;
 
-  var output = this.output;
-  var outputEncodings = this.outputEncodings;
-  var outputCallbacks = this.outputCallbacks;
+  var outputData = this.outputData;
   socket.cork();
-  for (var i = 0; i < outputLength; i++) {
-    ret = socket.write(output[i], outputEncodings[i], outputCallbacks[i]);
+  for (var i = 0; i < outputData.length; i++) {
+    const { data, encoding, callback } = outputData[i];
+    ret = socket.write(data, encoding, callback);
   }
   socket.uncork();
 
-  this.output = [];
-  this.outputEncodings = [];
-  this.outputCallbacks = [];
+  this.outputData = [];
   this._onPendingData(-this.outputSize);
   this.outputSize = 0;
 

--- a/test/parallel/test-http-destroyed-socket-write2.js
+++ b/test/parallel/test-http-destroyed-socket-write2.js
@@ -69,8 +69,7 @@ server.listen(0, function() {
     }
 
 
-    assert.strictEqual(req.output.length, 0);
-    assert.strictEqual(req.outputEncodings.length, 0);
+    assert.strictEqual(req.outputData.length, 0);
     server.close();
   }));
 


### PR DESCRIPTION
Now we are using `output`, `outputEncodings` and `outputCallbacks` to hold pending data. Reducing them into one array `outputData` can slightly improve performance and reduce some redundant codes.

Here is the benchmark for client request:
<detail>

```
 http/create-clientrequest.js e=1 arg='options' url='idn'                           ***      2.72 %      ±0.93% ±1.23% ±1.61%
 http/create-clientrequest.js e=1 arg='options' url='long'                          ***      1.91 %      ±1.07% ±1.42% ±1.85%
 http/create-clientrequest.js e=1 arg='options' url='wpt'                           ***      2.61 %      ±1.33% ±1.77% ±2.30%
 http/create-clientrequest.js e=1 arg='string' url='idn'                              *      0.79 %      ±0.69% ±0.92% ±1.20%
 http/create-clientrequest.js e=1 arg='string' url='long'                                    0.54 %      ±0.69% ±0.92% ±1.21%
 http/create-clientrequest.js e=1 arg='string' url='wpt'                              *      0.83 %      ±0.79% ±1.05% ±1.37%
 http/create-clientrequest.js e=1 arg='URL' url='idn'                                        0.72 %      ±0.77% ±1.02% ±1.33%
 http/create-clientrequest.js e=1 arg='URL' url='long'                              ***      1.36 %      ±0.62% ±0.82% ±1.07%
 http/create-clientrequest.js e=1 arg='URL' url='wpt'                                 *      1.18 %      ±0.99% ±1.32% ±1.72%
```

</detail>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
