### PR TITLE
test: capture stderr from child processes

### DIFF
--- a/test/parallel/test-child-process-pipe-dataflow.js
+++ b/test/parallel/test-child-process-pipe-dataflow.js
@@ -33,19 +33,17 @@ const MB = KB * KB;
   grep = spawn('grep', ['x'], { stdio: [cat.stdout, 'pipe', 'pipe'] });
   wc = spawn('wc', ['-c'], { stdio: [grep.stdout, 'pipe', 'pipe'] });
 
+  [cat, grep, wc].forEach((child, index) => {
+    child.stderr.on('data', (d) => {
+      // Don't want to assert here, as we might miss error code info.
+      console.error(`got unexpected data from child #${index}:\n${d}`);
+    });
+    child.on('exit', common.mustCall(function(code) {
+      assert.strictEqual(code, 0);
+    }));
+  });
+
   wc.stdout.on('data', common.mustCall(function(data) {
     assert.strictEqual(data.toString().trim(), MB.toString());
-  }));
-
-  cat.on('exit', common.mustCall(function(code) {
-    assert.strictEqual(code, 0);
-  }));
-
-  grep.on('exit', common.mustCall(function(code) {
-    assert.strictEqual(code, 0);
-  }));
-
-  wc.on('exit', common.mustCall(function(code) {
-    assert.strictEqual(code, 0);
   }));
 }


### PR DESCRIPTION
If the test fails with errors from the child commands,
there is no debug info. Suppliment the stderr data
so that we know what to look for.

Refs: https://github.com/nodejs/node/issues/25988

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
