### PR TITLE
inspector: print all listening addresses

### DIFF
--- a/src/inspector_socket_server.h
+++ b/src/inspector_socket_server.h
@@ -73,10 +73,10 @@ class InspectorSocketServer {
     return server_sockets_.empty() && connected_sessions_.empty();
   }
 
- private:
   static void CloseServerSocket(ServerSocket*);
   using ServerSocketPtr = DeleteFnPtr<ServerSocket, CloseServerSocket>;
 
+ private:
   void SendListResponse(InspectorSocket* socket, const std::string& host,
                         SocketSession* session);
   std::string GetFrontendURL(bool is_compat,


### PR DESCRIPTION
Some hostnames have multiple interfaces. Before this commit, the
inspector only printed the first one. Now, it prints them all.

No test. I can't think of a reliable way to test this on the CI matrix.

Fixes: https://github.com/nodejs/node/issues/13772

CI: https://ci.nodejs.org/job/node-test-pull-request/20671/ - test failures possible, some tests probably assume the current output. Everything passes for me locally though.