### PR TITLE
esm: initializeImportMeta loader hook

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -230,6 +230,20 @@ NODE_OPTIONS='--experimental-modules --loader ./custom-loader.mjs' node x.js
 would load the module `x.js` as an ES module with relative resolution support
 (with `node_modules` loading skipped in this example).
 
+### initializeImportMeta hook
+
+This hook is called to set custom `import.meta` metadata for each module:
+
+```js
+export function initializeImportMeta(meta) {
+  meta.customProp = 'value';
+  meta.url; // the existing import.meta.url value
+}
+```
+
+The default `import.meta` properties for Node.js will already be populated onto
+the `meta` object.
+
 ### Dynamic instantiate hook
 
 To create a custom dynamic module that doesn't correspond to one of the

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -48,6 +48,18 @@ class Loader {
     // an object with the same keys as `exports`, whose values are get/set
     // functions for the actual exported values.
     this._dynamicInstantiate = undefined;
+    // This hook is called when creating the import.meta object for a module.
+    // The hook has the signature:
+    // (meta: Object) => void
+    // where the meta object can be mutated by the loader.
+    // the default import.meta properties are always pre-populated
+    this._initializeImportMeta = undefined;
+  }
+
+  initializeImportMeta(meta, { url }) {
+    meta.url = url;
+    if (this._initializeImportMeta)
+      this._initializeImportMeta(meta);
   }
 
   async resolve(specifier, parentURL) {
@@ -101,12 +113,14 @@ class Loader {
     return module.namespace();
   }
 
-  hook({ resolve, dynamicInstantiate }) {
+  hook({ resolve, dynamicInstantiate, initializeImportMeta }) {
     // Use .bind() to avoid giving access to the Loader instance when called.
     if (resolve !== undefined)
       this._resolve = FunctionBind(resolve, null);
     if (dynamicInstantiate !== undefined)
       this._dynamicInstantiate = FunctionBind(dynamicInstantiate, null);
+    if (initializeImportMeta !== undefined)
+      this._initializeImportMeta = FunctionBind(initializeImportMeta, null);
   }
 
   async getModuleJob(specifier, parentURL) {

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -32,14 +32,13 @@ const debug = debuglog('esm');
 const translators = new SafeMap();
 module.exports = translators;
 
-function initializeImportMeta(meta, { url }) {
-  meta.url = url;
-}
-
-async function importModuleDynamically(specifier, { url }) {
-  const loader = await esmLoader.loaderPromise;
-  return loader.import(specifier, url);
-}
+// Loader is always guaranteed to have resolved by translator run
+let initializeImportMeta, importModuleDynamically;
+esmLoader.loaderPromise.then((loader) => {
+  initializeImportMeta = loader.initializeImportMeta.bind(loader);
+  importModuleDynamically =
+      (specifier, { url }) => loader.import(specifier, url);
+});
 
 // Strategy for loading a standard JavaScript module
 translators.set('esm', async (url) => {

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -1,5 +1,11 @@
 'use strict';
 
+// ensure this promise is available in cycles
+let loaderResolve;
+exports.loaderPromise = new Promise((resolve, reject) => {
+  loaderResolve = resolve;
+});
+
 const {
   callbackMap,
 } = internalBinding('module_wrap');
@@ -32,11 +38,6 @@ exports.importModuleDynamicallyCallback = async function(wrap, specifier) {
   }
   throw new ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING();
 };
-
-let loaderResolve;
-exports.loaderPromise = new Promise((resolve, reject) => {
-  loaderResolve = resolve;
-});
 
 exports.ESMLoader = undefined;
 

--- a/test/es-module/test-esm-loader-import-meta.mjs
+++ b/test/es-module/test-esm-loader-import-meta.mjs
@@ -1,0 +1,5 @@
+// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/import-meta-loader.mjs
+/* eslint-disable node-core/required-modules */
+import assert from 'assert';
+
+assert.strictEqual(import.meta.custom, 'custom-meta');

--- a/test/fixtures/es-module-loaders/import-meta-loader.mjs
+++ b/test/fixtures/es-module-loaders/import-meta-loader.mjs
@@ -1,0 +1,3 @@
+export function initializeImportMeta (meta) {
+  meta.custom = 'custom-meta';
+}


### PR DESCRIPTION
This creates a new loader hook for `--experimental-modules` that allows hooking into the `import.meta` object population.

While the loader API is likely still to change, it would be useful to be able to expose this functionality to users, as whatever form the loader API takes in future will likely also want this hook to be available.

//cc @nodejs/modules

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
