### PR TITLE
src: add lock to inspector `MainThreadHandle` dtor

### DIFF
--- a/src/inspector/main_thread_interface.h
+++ b/src/inspector/main_thread_interface.h
@@ -45,6 +45,7 @@ class MainThreadHandle : public std::enable_shared_from_this<MainThreadHandle> {
                             : main_thread_(main_thread) {
   }
   ~MainThreadHandle() {
+    Mutex::ScopedLock scoped_lock(block_lock_);
     CHECK_NULL(main_thread_);  // main_thread_ should have called Reset
   }
   std::unique_ptr<InspectorSession> Connect(


### PR DESCRIPTION
Otherwise, the `CHECK` is reported to be a race condition
by automated tooling. It’s not easy to tell from looking at
the source code whether that is actually the case or not,
but adding this lock should be a safe way to resolve it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
