### PR TITLE
worker: set up child Isolate inside Worker thread

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -186,8 +186,7 @@ Environment::Environment(IsolateData* isolate_data,
       trace_category_state_(isolate_, kTraceCategoryCount),
       stream_base_state_(isolate_, StreamBase::kNumStreamBaseStateFields),
       flags_(flags),
-      thread_id_(thread_id == static_cast<uint64_t>(-1) ?
-          AllocateThreadId() : thread_id),
+      thread_id_(thread_id == kNoThreadId ? AllocateThreadId() : thread_id),
       fs_stats_field_array_(isolate_, kFsStatsBufferLength),
       fs_stats_field_bigint_array_(isolate_, kFsStatsBufferLength),
       context_(context->GetIsolate(), context) {

--- a/src/env.cc
+++ b/src/env.cc
@@ -169,9 +169,14 @@ void Environment::TrackingTraceStateObserver::UpdateTraceCategoryState() {
 
 static std::atomic<uint64_t> next_thread_id{0};
 
+uint64_t Environment::AllocateThreadId() {
+  return next_thread_id++;
+}
+
 Environment::Environment(IsolateData* isolate_data,
                          Local<Context> context,
-                         Flags flags)
+                         Flags flags,
+                         uint64_t thread_id)
     : isolate_(context->GetIsolate()),
       isolate_data_(isolate_data),
       immediate_info_(context->GetIsolate()),
@@ -181,7 +186,8 @@ Environment::Environment(IsolateData* isolate_data,
       trace_category_state_(isolate_, kTraceCategoryCount),
       stream_base_state_(isolate_, StreamBase::kNumStreamBaseStateFields),
       flags_(flags),
-      thread_id_(next_thread_id++),
+      thread_id_(thread_id == static_cast<uint64_t>(-1) ?
+          AllocateThreadId() : thread_id),
       fs_stats_field_array_(isolate_, kFsStatsBufferLength),
       fs_stats_field_bigint_array_(isolate_, kFsStatsBufferLength),
       context_(context->GetIsolate(), context) {

--- a/src/env.h
+++ b/src/env.h
@@ -618,7 +618,8 @@ class Environment {
 
   Environment(IsolateData* isolate_data,
               v8::Local<v8::Context> context,
-              Flags flags = Flags());
+              Flags flags = Flags(),
+              uint64_t thread_id = static_cast<uint64_t>(-1));
   ~Environment();
 
   void Start(bool start_profiler_idle_notifier);
@@ -768,6 +769,8 @@ class Environment {
 
   inline bool has_run_bootstrapping_code() const;
   inline void set_has_run_bootstrapping_code(bool has_run_bootstrapping_code);
+
+  static uint64_t AllocateThreadId();
 
   inline bool is_main_thread() const;
   inline bool owns_process_state() const;

--- a/src/env.h
+++ b/src/env.h
@@ -619,7 +619,7 @@ class Environment {
   Environment(IsolateData* isolate_data,
               v8::Local<v8::Context> context,
               Flags flags = Flags(),
-              uint64_t thread_id = static_cast<uint64_t>(-1));
+              uint64_t thread_id = kNoThreadId);
   ~Environment();
 
   void Start(bool start_profiler_idle_notifier);
@@ -771,6 +771,7 @@ class Environment {
   inline void set_has_run_bootstrapping_code(bool has_run_bootstrapping_code);
 
   static uint64_t AllocateThreadId();
+  static constexpr uint64_t kNoThreadId = -1;
 
   inline bool is_main_thread() const;
   inline bool owns_process_state() const;

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -885,12 +885,14 @@ bool Agent::IsActive() {
   return io_ != nullptr || client_->IsActive();
 }
 
-void Agent::AddWorkerInspector(int thread_id,
-                               const std::string& url,
-                               Agent* agent) {
-  CHECK_NOT_NULL(client_);
-  agent->parent_handle_ =
-      client_->getWorkerManager()->NewParentHandle(thread_id, url);
+void Agent::SetParentHandle(
+    std::unique_ptr<ParentInspectorHandle> parent_handle) {
+  parent_handle_ = std::move(parent_handle);
+}
+
+std::unique_ptr<ParentInspectorHandle> Agent::GetParentHandle(
+    int thread_id, const std::string& url) {
+  return client_->getWorkerManager()->NewParentHandle(thread_id, url);
 }
 
 void Agent::WaitForConnect() {

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -85,7 +85,9 @@ class Agent {
   void EnableAsyncHook();
   void DisableAsyncHook();
 
-  void AddWorkerInspector(int thread_id, const std::string& url, Agent* agent);
+  void SetParentHandle(std::unique_ptr<ParentInspectorHandle> parent_handle);
+  std::unique_ptr<ParentInspectorHandle> GetParentHandle(
+      int thread_id, const std::string& url);
 
   // Called to create inspector sessions that can be used from the main thread.
   // The inspector responds by using the delegate to send messages back.

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -8,6 +8,10 @@
 #include "async_wrap.h"
 #include "async_wrap-inl.h"
 
+#if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
+#include "inspector/worker_inspector.h"  // ParentInspectorHandle
+#endif
+
 #include <string>
 #include <vector>
 
@@ -35,34 +39,21 @@ namespace worker {
 namespace {
 
 #if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
-void StartWorkerInspector(Environment* child, const std::string& url) {
+void StartWorkerInspector(
+    Environment* child,
+    std::unique_ptr<inspector::ParentInspectorHandle> parent_handle,
+    const std::string& url) {
+  child->inspector_agent()->SetParentHandle(std::move(parent_handle));
   child->inspector_agent()->Start(url,
                                   child->options()->debug_options(),
                                   child->inspector_host_port(),
                                   false);
 }
 
-void AddWorkerInspector(Environment* parent,
-                        Environment* child,
-                        int id,
-                        const std::string& url) {
-  parent->inspector_agent()->AddWorkerInspector(id, url,
-                                                child->inspector_agent());
-}
-
 void WaitForWorkerInspectorToStop(Environment* child) {
   child->inspector_agent()->WaitForDisconnect();
   child->inspector_agent()->Stop();
 }
-
-#else
-// No-ops
-void StartWorkerInspector(Environment* child, const std::string& url) {}
-void AddWorkerInspector(Environment* parent,
-                        Environment* child,
-                        int id,
-                        const std::string& url) {}
-void WaitForWorkerInspectorToStop(Environment* child) {}
 #endif
 
 }  // anonymous namespace
@@ -71,9 +62,13 @@ Worker::Worker(Environment* env,
                Local<Object> wrap,
                const std::string& url,
                std::shared_ptr<PerIsolateOptions> per_isolate_opts)
-    : AsyncWrap(env, wrap, AsyncWrap::PROVIDER_WORKER), url_(url),
+    : AsyncWrap(env, wrap, AsyncWrap::PROVIDER_WORKER),
+      url_(url),
+      per_isolate_opts_(per_isolate_opts),
+      platform_(env->isolate_data()->platform()),
+      profiler_idle_notifier_started_(env->profiler_idle_notifier_started()),
       thread_id_(Environment::AllocateThreadId()) {
-  Debug(this, "Creating new worker instance at %p", static_cast<void*>(this));
+  Debug(this, "Creating new worker instance with thread id %llu", thread_id_);
 
   // Set up everything that needs to be set up in the parent environment.
   parent_port_ = MessagePort::New(env, env->context());
@@ -89,57 +84,17 @@ Worker::Worker(Environment* env,
                 env->message_port_string(),
                 parent_port_->object()).FromJust();
 
-  array_buffer_allocator_.reset(CreateArrayBufferAllocator());
-
-  CHECK_EQ(uv_loop_init(&loop_), 0);
-  isolate_ = NewIsolate(array_buffer_allocator_.get(), &loop_);
-  CHECK_NOT_NULL(isolate_);
-
-  {
-    // Enter an environment capable of executing code in the child Isolate
-    // (and only in it).
-    Locker locker(isolate_);
-    Isolate::Scope isolate_scope(isolate_);
-    HandleScope handle_scope(isolate_);
-
-    isolate_data_.reset(CreateIsolateData(isolate_,
-                                          &loop_,
-                                          env->isolate_data()->platform(),
-                                          array_buffer_allocator_.get()));
-    if (per_isolate_opts != nullptr) {
-      isolate_data_->set_options(per_isolate_opts);
-    }
-    CHECK(isolate_data_);
-
-    Local<Context> context = NewContext(isolate_);
-    Context::Scope context_scope(context);
-
-    // TODO(addaleax): Use CreateEnvironment(), or generally another public API.
-    env_.reset(new Environment(
-        isolate_data_.get(), context, Flags::kNoFlags, thread_id_));
-    CHECK_NOT_NULL(env_);
-    env_->set_abort_on_uncaught_exception(false);
-    env_->set_worker_context(this);
-
-    env_->Start(env->profiler_idle_notifier_started());
-    env_->ProcessCliArgs(std::vector<std::string>{},
-                            std::vector<std::string>{});
-    // Done while on the parent thread
-    AddWorkerInspector(env, env_.get(), thread_id_, url_);
-  }
-
-  // The new isolate won't be bothered on this thread again.
-  isolate_->DiscardThreadSpecificMetadata();
-
-  wrap->Set(env->context(),
-            env->thread_id_string(),
-            Number::New(env->isolate(), static_cast<double>(thread_id_)))
+  object()->Set(env->context(),
+                env->thread_id_string(),
+                Number::New(env->isolate(), static_cast<double>(thread_id_)))
       .FromJust();
 
-  Debug(this,
-        "Set up worker at %p with id %llu",
-        static_cast<void*>(this),
-        thread_id_);
+#if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
+  inspector_parent_handle_ =
+      env->inspector_agent()->GetParentHandle(thread_id_, url);
+#endif
+
+  Debug(this, "Preparation for worker %llu finished", thread_id_);
 }
 
 bool Worker::is_stopped() const {
@@ -147,14 +102,76 @@ bool Worker::is_stopped() const {
   return stopped_;
 }
 
+class WorkerThreadData {
+ public:
+  explicit WorkerThreadData(Worker* w)
+    : w_(w),
+      array_buffer_allocator_(CreateArrayBufferAllocator()) {
+    CHECK_EQ(uv_loop_init(&loop_), 0);
+
+    Isolate* isolate = NewIsolate(array_buffer_allocator_.get(), &loop_);
+    CHECK_NOT_NULL(isolate);
+
+    {
+      Locker locker(isolate);
+      Isolate::Scope isolate_scope(isolate);
+      HandleScope handle_scope(isolate);
+      isolate_data_.reset(CreateIsolateData(isolate,
+                                            &loop_,
+                                            w_->platform_,
+                                            array_buffer_allocator_.get()));
+      CHECK(isolate_data_);
+      if (w_->per_isolate_opts_)
+        isolate_data_->set_options(std::move(w_->per_isolate_opts_));
+    }
+
+    Mutex::ScopedLock lock(w_->mutex_);
+    w_->isolate_ = isolate;
+  }
+
+  ~WorkerThreadData() {
+    Debug(w_, "Worker %llu dispose isolate", w_->thread_id_);
+    Isolate* isolate;
+    {
+      Mutex::ScopedLock lock(w_->mutex_);
+      isolate = w_->isolate_;
+      w_->isolate_ = nullptr;
+    }
+
+    w_->platform_->CancelPendingDelayedTasks(isolate);
+
+    isolate_data_.reset();
+    w_->platform_->UnregisterIsolate(isolate);
+
+    isolate->Dispose();
+
+    // Need to run the loop one more time to close the platform's uv_async_t
+    uv_run(&loop_, UV_RUN_ONCE);
+
+    CheckedUvLoopClose(&loop_);
+  }
+
+ private:
+  Worker* w_;
+  uv_loop_t loop_;
+  DeleteFnPtr<ArrayBufferAllocator, FreeArrayBufferAllocator>
+    array_buffer_allocator_;
+  DeleteFnPtr<IsolateData, FreeIsolateData> isolate_data_;
+
+  friend class Worker;
+};
+
 void Worker::Run() {
   std::string name = "WorkerThread ";
   name += std::to_string(thread_id_);
   TRACE_EVENT_METADATA1(
       "__metadata", "thread_name", "name",
       TRACE_STR_COPY(name.c_str()));
-  MultiIsolatePlatform* platform = isolate_data_->platform();
-  CHECK_NOT_NULL(platform);
+  CHECK_NOT_NULL(platform_);
+
+  Debug(this, "Creating isolate for worker with id %llu", thread_id_);
+
+  WorkerThreadData data(this);
 
   Debug(this, "Starting worker with id %llu", thread_id_);
   {
@@ -163,10 +180,73 @@ void Worker::Run() {
     SealHandleScope outer_seal(isolate_);
     bool inspector_started = false;
 
-    {
-      Context::Scope context_scope(env_->context());
-      HandleScope handle_scope(isolate_);
+    DeleteFnPtr<Environment, FreeEnvironment> env_;
+    OnScopeLeave cleanup_env([&]{
+      if (!env_) return;
+      env_->set_can_call_into_js(false);
+      Isolate::DisallowJavascriptExecutionScope disallow_js(isolate_,
+          Isolate::DisallowJavascriptExecutionScope::THROW_ON_FAILURE);
 
+      // Grab the parent-to-child channel and render is unusable.
+      MessagePort* child_port;
+      {
+        Mutex::ScopedLock lock(mutex_);
+        child_port = child_port_;
+        child_port_ = nullptr;
+      }
+
+      {
+        Context::Scope context_scope(env_->context());
+        if (child_port != nullptr)
+          child_port->Close();
+        env_->stop_sub_worker_contexts();
+        env_->RunCleanup();
+        RunAtExit(env_.get());
+#if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
+          if (inspector_started)
+            WaitForWorkerInspectorToStop(env_.get());
+#endif
+
+        {
+          Mutex::ScopedLock stopped_lock(stopped_mutex_);
+          stopped_ = true;
+        }
+
+        env_->RunCleanup();
+
+        // This call needs to be made while the `Environment` is still alive
+        // because we assume that it is available for async tracking in the
+        // NodePlatform implementation.
+        platform_->DrainTasks(isolate_);
+      }
+    });
+
+    {
+      HandleScope handle_scope(isolate_);
+      Local<Context> context = NewContext(isolate_);
+      if (is_stopped()) return;
+
+      CHECK(!context.IsEmpty());
+      Context::Scope context_scope(context);
+      {
+        // TODO(addaleax): Use CreateEnvironment(), or generally another
+        // public API.
+        env_.reset(new Environment(data.isolate_data_.get(),
+                                   context,
+                                   Environment::kNoFlags,
+                                   thread_id_));
+        CHECK_NOT_NULL(env_);
+        env_->set_abort_on_uncaught_exception(false);
+        env_->set_worker_context(this);
+
+        env_->Start(profiler_idle_notifier_started_);
+        env_->ProcessCliArgs(std::vector<std::string>{},
+                             std::vector<std::string>{});
+      }
+
+      Debug(this, "Created Environment for worker with id %llu", thread_id_);
+
+      if (is_stopped()) return;
       {
         HandleScope handle_scope(isolate_);
         Mutex::ScopedLock lock(mutex_);
@@ -182,8 +262,13 @@ void Worker::Run() {
         Debug(this, "Created message port for worker %llu", thread_id_);
       }
 
-      if (!is_stopped()) {
-        StartWorkerInspector(env_.get(), url_);
+      if (is_stopped()) return;
+      {
+#if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
+        StartWorkerInspector(env_.get(),
+                             std::move(inspector_parent_handle_),
+                             url_);
+#endif
         inspector_started = true;
 
         HandleScope handle_scope(isolate_);
@@ -198,6 +283,7 @@ void Worker::Run() {
         Debug(this, "Loaded environment for worker %llu", thread_id_);
       }
 
+      if (is_stopped()) return;
       {
         SealHandleScope seal(isolate_);
         bool more;
@@ -205,12 +291,12 @@ void Worker::Run() {
             node::performance::NODE_PERFORMANCE_MILESTONE_LOOP_START);
         do {
           if (is_stopped()) break;
-          uv_run(&loop_, UV_RUN_DEFAULT);
+          uv_run(&data.loop_, UV_RUN_DEFAULT);
           if (is_stopped()) break;
 
-          platform->DrainTasks(isolate_);
+          platform_->DrainTasks(isolate_);
 
-          more = uv_loop_alive(&loop_);
+          more = uv_loop_alive(&data.loop_);
           if (more && !is_stopped())
             continue;
 
@@ -218,7 +304,7 @@ void Worker::Run() {
 
           // Emit `beforeExit` if the loop became alive either after emitting
           // event, or after running some callbacks.
-          more = uv_loop_alive(&loop_);
+          more = uv_loop_alive(&data.loop_);
         } while (more == true);
         env_->performance_state()->Mark(
             node::performance::NODE_PERFORMANCE_MILESTONE_LOOP_EXIT);
@@ -237,77 +323,9 @@ void Worker::Run() {
       Debug(this, "Exiting thread for worker %llu with exit code %d",
             thread_id_, exit_code_);
     }
-
-    env_->set_can_call_into_js(false);
-    Isolate::DisallowJavascriptExecutionScope disallow_js(isolate_,
-        Isolate::DisallowJavascriptExecutionScope::THROW_ON_FAILURE);
-
-    // Grab the parent-to-child channel and render is unusable.
-    MessagePort* child_port;
-    {
-      Mutex::ScopedLock lock(mutex_);
-      child_port = child_port_;
-      child_port_ = nullptr;
-    }
-
-    {
-      Context::Scope context_scope(env_->context());
-      child_port->Close();
-      env_->stop_sub_worker_contexts();
-      env_->RunCleanup();
-      RunAtExit(env_.get());
-      if (inspector_started)
-        WaitForWorkerInspectorToStop(env_.get());
-
-      {
-        Mutex::ScopedLock stopped_lock(stopped_mutex_);
-        stopped_ = true;
-      }
-
-      env_->RunCleanup();
-
-      // This call needs to be made while the `Environment` is still alive
-      // because we assume that it is available for async tracking in the
-      // NodePlatform implementation.
-      platform->DrainTasks(isolate_);
-    }
-
-    env_.reset();
-  }
-
-  DisposeIsolate();
-
-  {
-    Mutex::ScopedLock lock(mutex_);
-    CHECK(thread_exit_async_);
-    scheduled_on_thread_stopped_ = true;
-    uv_async_send(thread_exit_async_.get());
   }
 
   Debug(this, "Worker %llu thread stops", thread_id_);
-}
-
-void Worker::DisposeIsolate() {
-  if (env_) {
-    CHECK_NOT_NULL(isolate_);
-    Locker locker(isolate_);
-    Isolate::Scope isolate_scope(isolate_);
-    env_.reset();
-  }
-
-  if (isolate_ == nullptr)
-    return;
-
-  Debug(this, "Worker %llu dispose isolate", thread_id_);
-  CHECK(isolate_data_);
-  MultiIsolatePlatform* platform = isolate_data_->platform();
-  platform->CancelPendingDelayedTasks(isolate_);
-
-  isolate_data_.reset();
-  platform->UnregisterIsolate(isolate_);
-
-  isolate_->Dispose();
-  isolate_ = nullptr;
 }
 
 void Worker::JoinThread() {
@@ -340,7 +358,6 @@ void Worker::OnThreadStopped() {
       CHECK(stopped_);
     }
 
-    CHECK_NULL(child_port_);
     parent_port_ = nullptr;
   }
 
@@ -370,16 +387,9 @@ Worker::~Worker() {
 
   CHECK(stopped_);
   CHECK(thread_joined_);
-  CHECK_NULL(child_port_);
 
   // This has most likely already happened within the worker thread -- this
   // is just in case Worker creation failed early.
-  DisposeIsolate();
-
-  // Need to run the loop one more time to close the platform's uv_async_t
-  uv_run(&loop_, UV_RUN_ONCE);
-
-  CheckedUvLoopClose(&loop_);
 
   Debug(this, "Worker %llu destroyed", thread_id_);
 }
@@ -476,7 +486,13 @@ void Worker::StartThread(const FunctionCallbackInfo<Value>& args) {
   }), 0);
 
   CHECK_EQ(uv_thread_create(&w->tid_, [](void* arg) {
-    static_cast<Worker*>(arg)->Run();
+    Worker* w = static_cast<Worker*>(arg);
+    w->Run();
+
+    Mutex::ScopedLock lock(w->mutex_);
+    CHECK(w->thread_exit_async_);
+    w->scheduled_on_thread_stopped_ = true;
+    uv_async_send(w->thread_exit_async_.get());
   }, static_cast<void*>(w)), 0);
 }
 
@@ -510,12 +526,12 @@ void Worker::Exit(int code) {
   Debug(this, "Worker %llu called Exit(%d)", thread_id_, code);
 
   if (!stopped_) {
-    CHECK_NOT_NULL(env_);
     stopped_ = true;
     exit_code_ = code;
     if (child_port_ != nullptr)
       child_port_->StopEventLoop();
-    isolate_->TerminateExecution();
+    if (isolate_ != nullptr)
+      isolate_->TerminateExecution();
   }
 }
 

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -102,6 +102,9 @@ bool Worker::is_stopped() const {
   return stopped_;
 }
 
+// This class contains data that is only relevant to the child thread itself,
+// and only while it is running.
+// (Eventually, the Environment instance should probably also be moved here.)
 class WorkerThreadData {
  public:
   explicit WorkerThreadData(Worker* w)

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -203,8 +203,8 @@ void Worker::Run() {
         env_->RunCleanup();
         RunAtExit(env_.get());
 #if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
-          if (inspector_started)
-              WaitForWorkerInspectorToStop(env_.get());
+        if (inspector_started)
+          WaitForWorkerInspectorToStop(env_.get());
 #endif
 
         {

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -152,7 +152,7 @@ class WorkerThreadData {
   }
 
  private:
-  Worker* w_;
+  Worker* const w_;
   uv_loop_t loop_;
   DeleteFnPtr<ArrayBufferAllocator, FreeArrayBufferAllocator>
     array_buffer_allocator_;
@@ -181,7 +181,7 @@ void Worker::Run() {
     bool inspector_started = false;
 
     DeleteFnPtr<Environment, FreeEnvironment> env_;
-    OnScopeLeave cleanup_env([&]{
+    OnScopeLeave cleanup_env([&]() {
       if (!env_) return;
       env_->set_can_call_into_js(false);
       Isolate::DisallowJavascriptExecutionScope disallow_js(isolate_,
@@ -204,7 +204,7 @@ void Worker::Run() {
         RunAtExit(env_.get());
 #if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
           if (inspector_started)
-            WaitForWorkerInspectorToStop(env_.get());
+              WaitForWorkerInspectorToStop(env_.get());
 #endif
 
         {

--- a/test/parallel/test-worker-prof.js
+++ b/test/parallel/test-worker-prof.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const fs = require('fs');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const { Worker } = require('worker_threads');
+
+if (!common.isMainThread)
+  common.skip('process.chdir is not available in Workers');
+
+// Test that --prof also tracks Worker threads.
+// Refs: https://github.com/nodejs/node/issues/24016
+
+if (process.argv[2] === 'child') {
+  const spin = `
+  const start = Date.now();
+  while (Date.now() - start < 200);
+  `;
+  new Worker(spin, { eval: true });
+  eval(spin);
+  return;
+}
+
+tmpdir.refresh();
+process.chdir(tmpdir.path);
+spawnSync(process.execPath, ['--prof', __filename, 'child']);
+const logfiles = fs.readdirSync('.').filter((name) => /\.log$/.test(name));
+assert.strictEqual(logfiles.length, 2);  // Parent thread + child thread.
+
+for (const logfile of logfiles) {
+  const lines = fs.readFileSync(logfile, 'utf8').split('\n');
+  const ticks = lines.filter((line) => /^tick,/.test(line)).length;
+
+  // Test that at least 20 ticks have been recorded for both parent and child
+  // threads. When not tracking Worker threads, only 1 or 2 ticks would
+  // have been recorded.
+  // When running locally on x64 Linux, this number is usually at least 150
+  // for both threads, so 15 seems like a very safe threshold.
+  assert(ticks >= 15, `${ticks} >= 15`);
+}


### PR DESCRIPTION
**worker: pre-allocate thread id**

Allocate a thread id before actually creating the Environment instance.

**worker: set up child Isolate inside Worker thread**

Refs: https://github.com/nodejs/node/issues/24016

**test: add `Worker` + `--prof` regression test**

Fixes: https://github.com/nodejs/node/issues/24016

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
