### PR TITLE
src: unify uptime base used across the code base

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -228,9 +228,8 @@ Environment::Environment(IsolateData* isolate_data,
   performance_state_.reset(new performance::performance_state(isolate()));
   performance_state_->Mark(
       performance::NODE_PERFORMANCE_MILESTONE_ENVIRONMENT);
-  performance_state_->Mark(
-      performance::NODE_PERFORMANCE_MILESTONE_NODE_START,
-      performance::performance_node_start);
+  performance_state_->Mark(performance::NODE_PERFORMANCE_MILESTONE_NODE_START,
+                           per_process::node_start_time);
   performance_state_->Mark(
       performance::NODE_PERFORMANCE_MILESTONE_V8_START,
       performance::performance_v8_start);

--- a/src/node.cc
+++ b/src/node.cc
@@ -144,8 +144,8 @@ unsigned int reverted_cve = 0;
 bool v8_initialized = false;
 
 // node_internals.h
-// process-relative uptime base, initialized at start-up
-double prog_start_time;
+// process-relative uptime base in nanoseconds, initialized in node::Start()
+uint64_t node_start_time;
 // Tells whether --prof is passed.
 bool v8_is_profiling = false;
 
@@ -594,9 +594,6 @@ int ProcessGlobalArgs(std::vector<std::string>* args,
 int Init(std::vector<std::string>* argv,
          std::vector<std::string>* exec_argv,
          std::vector<std::string>* errors) {
-  // Initialize prog_start_time to get relative uptime.
-  per_process::prog_start_time = static_cast<double>(uv_now(uv_default_loop()));
-
   // Register built-in modules
   binding::RegisterBuiltinModules();
 
@@ -874,7 +871,7 @@ inline int Start(uv_loop_t* event_loop,
 int Start(int argc, char** argv) {
   atexit([] () { uv_tty_reset_mode(); });
   PlatformInit();
-  performance::performance_node_start = PERFORMANCE_NOW();
+  per_process::node_start_time = uv_hrtime();
 
   CHECK_GT(argc, 0);
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -55,7 +55,7 @@ class NativeModuleLoader;
 
 namespace per_process {
 extern Mutex env_var_mutex;
-extern double prog_start_time;
+extern uint64_t node_start_time;
 extern bool v8_is_profiling;
 }  // namespace per_process
 

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -46,7 +46,6 @@ using v8::Value;
 const uint64_t timeOrigin = PERFORMANCE_NOW();
 // https://w3c.github.io/hr-time/#dfn-time-origin-timestamp
 const double timeOriginTimestamp = GetCurrentTimeInMicroseconds();
-uint64_t performance_node_start;
 uint64_t performance_v8_start;
 
 void performance_state::Mark(enum PerformanceMilestone milestone,

--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -18,7 +18,6 @@ namespace performance {
 
 // These occur before the environment is created. Cache them
 // here and add them to the milestones when the env is init'd.
-extern uint64_t performance_node_start;
 extern uint64_t performance_v8_start;
 
 #define NODE_PERFORMANCE_MILESTONES(V)                                        \


### PR DESCRIPTION
This patch joins `per_process::prog_start_time` (a double)
and `performance::performance_node_start` (a uint64_t) into a
`per_process::node_start_time` (a uint64_t) which gets initialized
in `node::Start()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
