### PR TITLE
worker: keep stdio after exit

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -171,7 +171,6 @@ class Worker extends EventEmitter {
     this[kPublicPort] = null;
 
     const { stdout, stderr } = this[kParentSideStdio];
-    this[kParentSideStdio] = null;
 
     if (!stdout._readableState.ended) {
       debug(`[${threadId}] explicitly closes stdout for ${this.threadId}`);
@@ -221,20 +220,14 @@ class Worker extends EventEmitter {
   }
 
   get stdin() {
-    if (this[kParentSideStdio] === null) return null;
-
     return this[kParentSideStdio].stdin;
   }
 
   get stdout() {
-    if (this[kParentSideStdio] === null) return null;
-
     return this[kParentSideStdio].stdout;
   }
 
   get stderr() {
-    if (this[kParentSideStdio] === null) return null;
-
     return this[kParentSideStdio].stderr;
   }
 }

--- a/test/parallel/test-worker-safe-getters.js
+++ b/test/parallel/test-worker-safe-getters.js
@@ -12,6 +12,8 @@ if (isMainThread) {
     stderr: true
   });
 
+  const { stdin, stdout, stderr } = w;
+
   w.on('exit', common.mustCall((code) => {
     assert.strictEqual(code, 0);
 
@@ -21,17 +23,11 @@ if (isMainThread) {
     w.ref();
     w.unref();
 
-    // Although not browser specific, probably wise to
-    // make sure the stream getters don't throw either.
-    w.stdin;
-    w.stdout;
-    w.stderr;
-
     // Sanity check.
     assert.strictEqual(w.threadId, -1);
-    assert.strictEqual(w.stdin, null);
-    assert.strictEqual(w.stdout, null);
-    assert.strictEqual(w.stderr, null);
+    assert.strictEqual(w.stdin, stdin);
+    assert.strictEqual(w.stdout, stdout);
+    assert.strictEqual(w.stderr, stderr);
   }));
 } else {
   process.exit(0);


### PR DESCRIPTION
This addresses review comments from https://github.com/nodejs/node/pull/25871.

Refs: https://github.com/nodejs/node/pull/25871

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
