### PR TITLE
test: add TTY + assert test

### DIFF
--- a/test/pseudo-tty/test-assert-position-indicator.js
+++ b/test/pseudo-tty/test-assert-position-indicator.js
@@ -1,0 +1,18 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+process.env.NODE_DISABLE_COLORS = true;
+process.stderr.columns = 20;
+
+// Confirm that there is no position indicator.
+assert.throws(
+  () => { assert.deepStrictEqual('a'.repeat(30), 'a'.repeat(31)); },
+  (err) => !err.message.includes('^')
+);
+
+// Confirm that there is a position indicator.
+assert.throws(
+  () => { assert.deepStrictEqual('aaa', 'aaaa'); },
+  (err) => err.message.includes('^')
+);


### PR DESCRIPTION
This test adds coverage for a ternary in assertion_error.js that checks
if stderr is a TTY.

The line in question is https://github.com/nodejs/node/blob/e154176b7cc397399ccb939b920b308f8d5cb874/lib/internal/assert/assertion_error.js#L108.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
