### PR TITLE
http: remove default 'timeout' listener on upgrade

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -458,6 +458,10 @@ function socketOnData(d) {
     socket.removeListener('data', socketOnData);
     socket.removeListener('end', socketOnEnd);
     socket.removeListener('drain', ondrain);
+
+    if (req.timeoutCb)
+      socket.removeListener('timeout', req.timeoutCb);
+
     parser.finish();
     freeParser(parser, req, socket);
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -549,6 +549,7 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
     socket.removeListener('drain', state.onDrain);
     socket.removeListener('drain', ondrain);
     socket.removeListener('error', socketOnError);
+    socket.removeListener('timeout', socketOnTimeout);
     unconsume(parser, socket);
     parser.finish();
     freeParser(parser, req, socket);

--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -36,6 +36,7 @@ server.on('connect', common.mustCall((req, socket, firstBodyChunk) => {
   assert.strictEqual(socket.listenerCount('data'), 0);
   assert.strictEqual(socket.listenerCount('end'), 1);
   assert.strictEqual(socket.listenerCount('error'), 0);
+  assert.strictEqual(socket.listenerCount('timeout'), 0);
 
   socket.write('HTTP/1.1 200 Connection established\r\n\r\n');
 
@@ -53,7 +54,8 @@ server.listen(0, common.mustCall(() => {
   const req = http.request({
     port: server.address().port,
     method: 'CONNECT',
-    path: 'google.com:443'
+    path: 'google.com:443',
+    timeout: 20000
   }, common.mustNotCall());
 
   req.on('socket', common.mustCall((socket) => {
@@ -80,6 +82,7 @@ server.listen(0, common.mustCall(() => {
     assert.strictEqual(socket.listenerCount('close'), 0);
     assert.strictEqual(socket.listenerCount('error'), 0);
     assert.strictEqual(socket.listenerCount('agentRemove'), 0);
+    assert.strictEqual(socket.listenerCount('timeout'), 0);
 
     let data = firstBodyChunk.toString();
     socket.on('data', (buf) => {


### PR DESCRIPTION
Remove the default listener of the `'timeout'` event from the socket before emitting the `'connect'` or `'upgrade'` event.
    
Fixes: https://github.com/nodejs/node/issues/23857

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
