### PR TITLE
test: use emitter.listenerCount() in test-http-connect

### DIFF
--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -31,11 +31,11 @@ server.on('connect', common.mustCall((req, socket, firstBodyChunk) => {
   assert.strictEqual(req.url, 'google.com:443');
 
   // Make sure this socket has detached.
-  assert.strictEqual(socket.listeners('close').length, 0);
-  assert.strictEqual(socket.listeners('drain').length, 0);
-  assert.strictEqual(socket.listeners('data').length, 0);
-  assert.strictEqual(socket.listeners('end').length, 1);
-  assert.strictEqual(socket.listeners('error').length, 0);
+  assert.strictEqual(socket.listenerCount('close'), 0);
+  assert.strictEqual(socket.listenerCount('drain'), 0);
+  assert.strictEqual(socket.listenerCount('data'), 0);
+  assert.strictEqual(socket.listenerCount('end'), 1);
+  assert.strictEqual(socket.listenerCount('error'), 0);
 
   socket.write('HTTP/1.1 200 Connection established\r\n\r\n');
 
@@ -72,14 +72,14 @@ server.listen(0, common.mustCall(() => {
     assert(!socket.ondata);
     assert(!socket.onend);
     assert.strictEqual(socket._httpMessage, null);
-    assert.strictEqual(socket.listeners('connect').length, 0);
-    assert.strictEqual(socket.listeners('data').length, 0);
-    assert.strictEqual(socket.listeners('drain').length, 0);
-    assert.strictEqual(socket.listeners('end').length, 1);
-    assert.strictEqual(socket.listeners('free').length, 0);
-    assert.strictEqual(socket.listeners('close').length, 0);
-    assert.strictEqual(socket.listeners('error').length, 0);
-    assert.strictEqual(socket.listeners('agentRemove').length, 0);
+    assert.strictEqual(socket.listenerCount('connect'), 0);
+    assert.strictEqual(socket.listenerCount('data'), 0);
+    assert.strictEqual(socket.listenerCount('drain'), 0);
+    assert.strictEqual(socket.listenerCount('end'), 1);
+    assert.strictEqual(socket.listenerCount('free'), 0);
+    assert.strictEqual(socket.listenerCount('close'), 0);
+    assert.strictEqual(socket.listenerCount('error'), 0);
+    assert.strictEqual(socket.listenerCount('agentRemove'), 0);
 
     let data = firstBodyChunk.toString();
     socket.on('data', (buf) => {


### PR DESCRIPTION
Use `emitter.listenerCount()` instead of the `length` property of the
array returned by `emitter.listeners()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
