### PR TITLE
lib: fix the typo error 

### DIFF
--- a/lib/internal/repl/recoverable.js
+++ b/lib/internal/repl/recoverable.js
@@ -10,7 +10,7 @@ const { tokTypes: tt, Parser: AcornParser } = acorn;
 function isRecoverableError(e, code) {
   let recoverable = false;
 
-  // Determine if the point of the any error raised is at the end of the input.
+  // Determine if the point of any error raised is at the end of the input.
   // There are two cases to consider:
   //
   //   1.  Any error raised after we have encountered the 'eof' token.


### PR DESCRIPTION
For `recoverable.js`: fix a typo error ('the' before 'any').

---

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
