### PR TITLE
src: use PauseOnNextJavascriptStatement to implement --inspect-brk-node

### DIFF
--- a/lib/internal/bootstrap/primordials.js
+++ b/lib/internal/bootstrap/primordials.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global breakAtBootstrap, primordials */
+/* global primordials */
 
 // This file subclasses and stores the JS builtins that come from the VM
 // so that Node.js's builtin modules do not need to later look these up from
@@ -11,10 +11,6 @@
 // (which falls back to a lookup in the global proxy) in favor of
 // `primordials.Object` where `primordials` is a lexical variable passed
 // by the native module compiler.
-
-if (breakAtBootstrap) {
-  debugger;  // eslint-disable-line no-debugger
-}
 
 function copyProps(src, dest) {
   for (const key of Reflect.ownKeys(src)) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -254,10 +254,13 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
   std::vector<Local<Value>> primordials_args = {
     env->primordials()
   };
+
+#if HAVE_INSPECTOR
   if (env->options()->debug_options().break_node_first_line) {
     env->inspector_agent()->PauseOnNextJavascriptStatement(
         "Break at bootstrap");
   }
+#endif  // HAVE_INSPECTOR
   MaybeLocal<Value> primordials_ret =
       ExecuteBootstrapper(env,
                           "internal/bootstrap/primordials",

--- a/src/node.cc
+++ b/src/node.cc
@@ -249,14 +249,15 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
   // Store primordials
   env->set_primordials(Object::New(isolate));
   std::vector<Local<String>> primordials_params = {
-    FIXED_ONE_BYTE_STRING(isolate, "breakAtBootstrap"),
     env->primordials_string()
   };
   std::vector<Local<Value>> primordials_args = {
-    Boolean::New(isolate,
-                  env->options()->debug_options().break_node_first_line),
     env->primordials()
   };
+  if (env->options()->debug_options().break_node_first_line) {
+    env->inspector_agent()->PauseOnNextJavascriptStatement(
+        "Break at bootstrap");
+  }
   MaybeLocal<Value> primordials_ret =
       ExecuteBootstrapper(env,
                           "internal/bootstrap/primordials",


### PR DESCRIPTION
Instead of using the `debugger;` statement which is visible in the
JS source code and makes primordials.js environment-dependent.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
