### PR TITLE
lib: simplify 'umask'

### DIFF
--- a/lib/internal/process/main_thread_only.js
+++ b/lib/internal/process/main_thread_only.js
@@ -26,11 +26,9 @@ function wrapProcessMethods(binding) {
   }
 
   function umask(mask) {
-    if (mask === undefined) {
-      // Get the mask
-      return binding.umask(mask);
+    if (mask !== undefined) {
+      mask = validateMode(mask, 'mask');
     }
-    mask = validateMode(mask, 'mask');
     return binding.umask(mask);
   }
 


### PR DESCRIPTION
Just check: if 'mask' is not undefined, just call 'validateMode' and
then return the unmask value, we don't need split them into two returns.

---

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
