### PR TITLE
os,report: use UV_MAXHOSTNAMESIZE

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -33,15 +33,8 @@
 
 #ifdef __POSIX__
 # include <limits.h>        // PATH_MAX on Solaris.
-# include <netdb.h>         // MAXHOSTNAMELEN on Solaris.
 # include <unistd.h>        // gethostname, sysconf
-# include <sys/param.h>     // MAXHOSTNAMELEN on Linux and the BSDs.
 #endif  // __POSIX__
-
-// Add Windows fallback.
-#ifndef MAXHOSTNAMELEN
-# define MAXHOSTNAMELEN 256
-#endif  // MAXHOSTNAMELEN
 
 namespace node {
 namespace os {
@@ -66,7 +59,7 @@ using v8::Value;
 
 static void GetHostname(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  char buf[MAXHOSTNAMELEN + 1];
+  char buf[UV_MAXHOSTNAMESIZE];
   size_t size = sizeof(buf);
   int r = uv_os_gethostname(buf, &size);
 

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -47,15 +47,6 @@
 extern char** environ;
 #endif
 
-#ifdef __POSIX__
-# include <netdb.h>         // MAXHOSTNAMELEN on Solaris.
-# include <sys/param.h>     // MAXHOSTNAMELEN on Linux and the BSDs.
-#endif  // __POSIX__
-
-#ifndef MAXHOSTNAMELEN
-# define MAXHOSTNAMELEN 256
-#endif  // MAXHOSTNAMELEN
-
 namespace report {
 using node::arraysize;
 using node::Environment;
@@ -377,7 +368,7 @@ static void PrintVersionInformation(JSONWriter* writer) {
     writer->json_keyvalue("osMachine", os_info.machine);
   }
 
-  char host[MAXHOSTNAMELEN + 1];
+  char host[UV_MAXHOSTNAMESIZE];
   size_t host_size = sizeof(host);
 
   if (uv_os_gethostname(host, &host_size) == 0)


### PR DESCRIPTION
~~Ignore the first commit, which is the libuv update from #26037.~~

`UV_MAXHOSTNAMESIZE` was introduced in libuv 1.26.0. Use this instead of including multiple header files, adding fallback `#ifdef` logic, and remembering to add one to the buffer size for the terminating nul character with `MAXHOSTNAMELEN`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
