### PR TITLE
 src: apply clang-tidy rule performance-unnecessary-value-param

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -37,6 +37,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <utility>
+
 namespace node {
 
 inline v8::Isolate* IsolateData::isolate() const {
@@ -395,7 +397,7 @@ inline uv_loop_t* Environment::event_loop() const {
 inline void Environment::TryLoadAddon(
     const char* filename,
     int flags,
-    std::function<bool(binding::DLib*)> was_loaded) {
+    const std::function<bool(binding::DLib*)>& was_loaded) {
   loaded_addons_.emplace_back(filename, flags);
   if (!was_loaded(&loaded_addons_.back())) {
     loaded_addons_.pop_back();
@@ -597,7 +599,7 @@ inline std::shared_ptr<PerIsolateOptions> IsolateData::options() {
 
 inline void IsolateData::set_options(
     std::shared_ptr<PerIsolateOptions> options) {
-  options_ = options;
+  options_ = std::move(options);
 }
 
 void Environment::CreateImmediate(native_immediate_callback cb,

--- a/src/env.h
+++ b/src/env.h
@@ -657,9 +657,10 @@ class Environment {
 
   inline v8::Isolate* isolate() const;
   inline uv_loop_t* event_loop() const;
-  inline void TryLoadAddon(const char* filename,
-                           int flags,
-                           std::function<bool(binding::DLib*)> was_loaded);
+  inline void TryLoadAddon(
+      const char* filename,
+      int flags,
+      const std::function<bool(binding::DLib*)>& was_loaded);
 
   static inline Environment* from_timer_handle(uv_timer_t* handle);
   inline uv_timer_t* timer_handle();

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2712,7 +2712,7 @@ static ParsePublicKeyResult TryParsePublicKey(
     const BIOPointer& bp,
     const char* name,
     // NOLINTNEXTLINE(runtime/int)
-    std::function<EVP_PKEY*(const unsigned char** p, long l)> parse) {
+    const std::function<EVP_PKEY*(const unsigned char** p, long l)>& parse) {
   unsigned char* der_data;
   long der_len;  // NOLINT(runtime/int)
 

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -147,7 +147,7 @@ MaybeLocal<Value> Message::Deserialize(Environment* env,
 }
 
 void Message::AddSharedArrayBuffer(
-    SharedArrayBufferMetadataReference reference) {
+    const SharedArrayBufferMetadataReference& reference) {
   shared_array_buffers_.push_back(reference);
 }
 

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -43,7 +43,7 @@ class Message : public MemoryRetainer {
 
   // Internal method of Message that is called when a new SharedArrayBuffer
   // object is encountered in the incoming value's structure.
-  void AddSharedArrayBuffer(SharedArrayBufferMetadataReference ref);
+  void AddSharedArrayBuffer(const SharedArrayBufferMetadataReference& ref);
   // Internal method of Message that is called once serialization finishes
   // and that transfers ownership of `data` to this message.
   void AddMessagePort(std::unique_ptr<MessagePortData>&& data);

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -182,7 +182,7 @@ void ClearMark(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-inline uint64_t GetPerformanceMark(Environment* env, std::string name) {
+inline uint64_t GetPerformanceMark(Environment* env, const std::string& name) {
   auto marks = env->performance_marks();
   auto res = marks->find(name);
   return res != marks->end() ? res->second : 0;

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -109,16 +109,16 @@ class URL {
     }
   }
 
-  explicit URL(std::string input) :
+  explicit URL(const std::string& input) :
       URL(input.c_str(), input.length()) {}
 
-  URL(std::string input, const URL* base) :
+  URL(const std::string& input, const URL* base) :
       URL(input.c_str(), input.length(), base) {}
 
-  URL(std::string input, const URL& base) :
+  URL(const std::string& input, const URL& base) :
       URL(input.c_str(), input.length(), &base) {}
 
-  URL(std::string input, std::string base) :
+  URL(const std::string& input, const std::string& base) :
       URL(input.c_str(), input.length(), base.c_str(), base.length()) {}
 
   int32_t flags() {

--- a/src/sharedarraybuffer_metadata.cc
+++ b/src/sharedarraybuffer_metadata.cc
@@ -1,4 +1,6 @@
 #include "sharedarraybuffer_metadata.h"
+
+#include <utility>
 #include "base_object.h"
 #include "base_object-inl.h"
 #include "node_errors.h"
@@ -43,7 +45,7 @@ class SABLifetimePartner : public BaseObject {
                      Local<Object> obj,
                      SharedArrayBufferMetadataReference r)
     : BaseObject(env, obj),
-      reference(r) {
+      reference(std::move(r)) {
     MakeWeak();
   }
 

--- a/src/util.h
+++ b/src/util.h
@@ -40,6 +40,7 @@
 #include <string>
 #include <array>
 #include <unordered_map>
+#include <utility>
 
 namespace node {
 
@@ -450,7 +451,7 @@ template <typename T> inline void USE(T&&) {}
 struct OnScopeLeave {
   std::function<void()> fn_;
 
-  explicit OnScopeLeave(std::function<void()> fn) : fn_(fn) {}
+  explicit OnScopeLeave(std::function<void()> fn) : fn_(std::move(fn)) {}
   ~OnScopeLeave() { fn_(); }
 };
 

--- a/test/cctest/test_inspector_socket_server.cc
+++ b/test/cctest/test_inspector_socket_server.cc
@@ -92,7 +92,7 @@ class SocketWrapper {
                                             connected_(false),
                                             sending_(false) { }
 
-  void Connect(std::string host, int port, bool v6 = false) {
+  void Connect(const std::string& host, int port, bool v6 = false) {
     closed_ = false;
     connection_failed_ = false;
     connected_ = false;
@@ -114,7 +114,7 @@ class SocketWrapper {
                   ReadCallback);
   }
 
-  void ExpectFailureToConnect(std::string host, int port) {
+  void ExpectFailureToConnect(const std::string& host, int port) {
     connected_ = false;
     connection_failed_ = false;
     closed_ = false;
@@ -243,7 +243,7 @@ class ServerHolder {
                : ServerHolder(has_targets, loop, HOST, port, nullptr) { }
 
   ServerHolder(bool has_targets, uv_loop_t* loop,
-               const std::string host, int port, FILE* out);
+               const std::string& host, int port, FILE* out);
 
   InspectorSocketServer* operator->() {
     return server_.get();
@@ -350,7 +350,7 @@ class TestSocketServerDelegate : public SocketServerDelegate {
 };
 
 ServerHolder::ServerHolder(bool has_targets, uv_loop_t* loop,
-                           const std::string host, int port, FILE* out) {
+                           const std::string& host, int port, FILE* out) {
   std::vector<std::string> targets;
   if (has_targets)
     targets = { MAIN_TARGET_ID };


### PR DESCRIPTION
Fix clang-tidy issue https://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
