### PR TITLE
src: use same parameter name in node_report.cc

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -80,7 +80,7 @@ static void WriteNodeReport(Isolate* isolate,
                             const std::string& filename,
                             std::ostream& out,
                             Local<String> stackstr,
-                            TIME_TYPE* time);
+                            TIME_TYPE* tm_struct);
 static void PrintVersionInformation(JSONWriter* writer);
 static void PrintJavaScriptStack(JSONWriter* writer,
                                  Isolate* isolate,


### PR DESCRIPTION
Fix clang-tidy issue, use same parameter name, see
https://github.com/nodejs/node/blob/9c86e7443137badef956d6b24640c3d84f0f44f7/src/node_report.cc#L233

Also found that function declaration is located in `.cc` file. Any special reason for this file ?
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
