### PR TITLE
cluster: migrate round_robin_handle to internal assert

### DIFF
--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -6,4 +6,10 @@ function assert(value, message) {
   }
 }
 
+function fail(message) {
+  require('assert').fail(message);
+}
+
+assert.fail = fail;
+
 module.exports = assert;

--- a/lib/internal/cluster/round_robin_handle.js
+++ b/lib/internal/cluster/round_robin_handle.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert');
+const assert = require('internal/assert');
 const net = require('net');
 const { sendHelper } = require('internal/cluster/utils');
 const uv = internalBinding('uv');

--- a/test/parallel/test-internal-assert.js
+++ b/test/parallel/test-internal-assert.js
@@ -13,3 +13,5 @@ internalAssert(true, 'fhqwhgads');
 assert.throws(() => { internalAssert(false); }, assert.AssertionError);
 assert.throws(() => { internalAssert(false, 'fhqwhgads'); },
               { code: 'ERR_ASSERTION', message: 'fhqwhgads' });
+assert.throws(() => { internalAssert.fail('fhqwhgads'); },
+              { code: 'ERR_ASSERTION', message: 'fhqwhgads' });


### PR DESCRIPTION
Use smaller internal assert module for round_robin_handle.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
