### PR TITLE
[v10.x] src: dispose of V8 platform in `process.exit()`

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -673,10 +673,13 @@ void Environment::AsyncHooks::grow_async_ids_stack() {
 uv_key_t Environment::thread_local_env = {};
 
 void Environment::Exit(int exit_code) {
-  if (is_main_thread())
+  if (is_main_thread()) {
+    stop_sub_worker_contexts();
+    DisposePlatform();
     exit(exit_code);
-  else
+  } else {
     worker_context_->Exit(exit_code);
+  }
 }
 
 void Environment::stop_sub_worker_contexts() {

--- a/src/node.cc
+++ b/src/node.cc
@@ -383,6 +383,10 @@ static struct {
 #endif  //  !NODE_USE_V8_PLATFORM || !HAVE_INSPECTOR
 } v8_platform;
 
+void DisposePlatform() {
+  v8_platform.Dispose();
+}
+
 #ifdef __POSIX__
 static const unsigned kMaxSignal = 32;
 #endif

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -538,6 +538,8 @@ int ThreadPoolWork::CancelWork() {
   return uv_cancel(reinterpret_cast<uv_req_t*>(&work_req_));
 }
 
+void DisposePlatform();
+
 static inline const char* errno_string(int errorno) {
 #define ERRNO_CASE(e)  case e: return #e;
   switch (errorno) {

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -259,7 +259,6 @@ void PerIsolatePlatformData::Shutdown() {
   if (flush_tasks_ == nullptr)
     return;
 
-  while (FlushForegroundTasksInternal()) {}
   CancelPendingDelayedTasks();
 
   uv_close(reinterpret_cast<uv_handle_t*>(flush_tasks_),


### PR DESCRIPTION
Calling `process.exit()` calls the C `exit()` function, which in turn
calls the destructors of static C++ objects. This can lead to race
conditions with other concurrently executing threads; disposing of all
Worker threads and then the V8 platform instance helps with this
(although it might not be a full solution for all problems of
this kind).

Refs: https://github.com/nodejs/node/issues/24403
Refs: https://github.com/nodejs/node/issues/25007

PR-URL: https://github.com/nodejs/node/pull/25061
Reviewed-By: Gireesh Punathil <gpunathi@in.ibm.com>
Reviewed-By: Joyee Cheung <joyeec9h3@gmail.com>
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>