### PR TITLE
worker: set stack size for worker threads

### DIFF
--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -80,6 +80,12 @@ class Worker : public AsyncWrap {
   bool thread_joined_ = true;
   int exit_code_ = 0;
   uint64_t thread_id_ = -1;
+  uintptr_t stack_base_;
+
+  // Full size of the thread's stack.
+  static constexpr size_t kStackSize = 4 * 1024 * 1024;
+  // Stack buffer size that is not available to the JS engine.
+  static constexpr size_t kStackBufferSize = 192 * 1024;
 
   std::unique_ptr<MessagePortData> child_port_data_;
 

--- a/test/parallel/test-worker-stack-overflow.js
+++ b/test/parallel/test-worker-stack-overflow.js
@@ -1,0 +1,11 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+const worker = new Worker('function f() { f(); } f();', { eval: true });
+
+worker.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.constructor, RangeError);
+  assert.strictEqual(err.message, 'Maximum call stack size exceeded');
+}));


### PR DESCRIPTION
~~(The first commit is https://github.com/nodejs/node/pull/26037.)~~

This is so we can inform V8 about a known limit for the stack.

Otherwise, on some systems recursive functions may lead to
segmentation faults rather than “safe” failures.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
