### PR TITLE
fs, src, lib: fix `blksize` & `blocks` on Windows

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3427,8 +3427,7 @@ to compare `curr.mtime` and `prev.mtime`.
 
 When an `fs.watchFile` operation results in an `ENOENT` error, it
 will invoke the listener once, with all the fields zeroed (or, for dates, the
-Unix Epoch). In Windows, `blksize` and `blocks` fields will be `undefined`,
-instead of zero. If the file is created later on, the listener will be called
+Unix Epoch). If the file is created later on, the listener will be called
 again, with the latest stat objects. This is a change in functionality since
 v0.10.
 

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -315,9 +315,9 @@ Stats.prototype.isSocket = function() {
 function getStatsFromBinding(stats, offset = 0) {
   return new Stats(stats[0 + offset], stats[1 + offset], stats[2 + offset],
                    stats[3 + offset], stats[4 + offset], stats[5 + offset],
-                   isWindows ? undefined : stats[6 + offset],  // blksize
+                   stats[6 + offset],  // blksize
                    stats[7 + offset], stats[8 + offset],
-                   isWindows ? undefined : stats[9 + offset],  // blocks
+                   stats[9 + offset],  // blocks
                    stats[10 + offset], stats[11 + offset],
                    stats[12 + offset], stats[13 + offset]);
 }

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -199,18 +199,10 @@ constexpr void FillStatsArray(AliasedBuffer<NativeT, V8T>* fields,
   fields->SetValue(offset + 3, s->st_uid);
   fields->SetValue(offset + 4, s->st_gid);
   fields->SetValue(offset + 5, s->st_rdev);
-#if defined(__POSIX__)
   fields->SetValue(offset + 6, s->st_blksize);
-#else
-  fields->SetValue(offset + 6, 0);
-#endif
   fields->SetValue(offset + 7, s->st_ino);
   fields->SetValue(offset + 8, s->st_size);
-#if defined(__POSIX__)
   fields->SetValue(offset + 9, s->st_blocks);
-#else
-  fields->SetValue(offset + 9, 0);
-#endif
 // Dates.
   fields->SetValue(offset + 10, ToNative<NativeT>(s->st_atim));
   fields->SetValue(offset + 11, ToNative<NativeT>(s->st_mtim));

--- a/test/parallel/test-fs-stat-bigint.js
+++ b/test/parallel/test-fs-stat-bigint.js
@@ -59,9 +59,6 @@ function verifyStats(bigintStats, numStats) {
         bigintStats.isSymbolicLink(),
         numStats.isSymbolicLink()
       );
-    } else if (common.isWindows && (key === 'blksize' || key === 'blocks')) {
-      assert.strictEqual(bigintStats[key], undefined);
-      assert.strictEqual(numStats[key], undefined);
     } else if (Number.isSafeInteger(val)) {
       assert.strictEqual(
         bigintStats[key], BigInt(val),

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -94,16 +94,13 @@ fs.stat(__filename, common.mustCall(function(err, s) {
   assert.strictEqual(s.isSymbolicLink(), false);
   const keys = [
     'dev', 'mode', 'nlink', 'uid',
-    'gid', 'rdev', 'ino', 'size',
+    'gid', 'rdev', 'blksize', 'ino', 'size', 'blocks',
     'atime', 'mtime', 'ctime', 'birthtime',
     'atimeMs', 'mtimeMs', 'ctimeMs', 'birthtimeMs'
   ];
-  if (!common.isWindows) {
-    keys.push('blocks', 'blksize');
-  }
   const numberFields = [
-    'dev', 'mode', 'nlink', 'uid', 'gid', 'rdev', 'ino', 'size',
-    'atimeMs', 'mtimeMs', 'ctimeMs', 'birthtimeMs'
+    'dev', 'mode', 'nlink', 'uid', 'gid', 'rdev', 'blksize', 'ino', 'size',
+    'blocks', 'atimeMs', 'mtimeMs', 'ctimeMs', 'birthtimeMs'
   ];
   const dateFields = ['atime', 'mtime', 'ctime', 'birthtime'];
   keys.forEach(function(k) {

--- a/test/parallel/test-fs-watchfile-bigint.js
+++ b/test/parallel/test-fs-watchfile-bigint.js
@@ -15,10 +15,10 @@ const expectedStatObject = new fs.Stats(
   0n,                                        // uid
   0n,                                        // gid
   0n,                                        // rdev
-  common.isWindows ? undefined : 0n,         // blksize
+  0n,                                        // blksize
   0n,                                        // ino
   0n,                                        // size
-  common.isWindows ? undefined : 0n,         // blocks
+  0n,                                        // blocks
   0n,                                        // atim_msec
   0n,                                        // mtim_msec
   0n,                                        // ctim_msec

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -38,10 +38,10 @@ const expectedStatObject = new fs.Stats(
   0,                                        // uid
   0,                                        // gid
   0,                                        // rdev
-  common.isWindows ? undefined : 0,         // blksize
+  0,                                        // blksize
   0,                                        // ino
   0,                                        // size
-  common.isWindows ? undefined : 0,         // blocks
+  0,                                        // blocks
   Date.UTC(1970, 0, 1, 0, 0, 0),            // atime
   Date.UTC(1970, 0, 1, 0, 0, 0),            // mtime
   Date.UTC(1970, 0, 1, 0, 0, 0),            // ctime


### PR DESCRIPTION
libuv returns values for `blksize` and `blocks` on stat calls so
do not coerce them into `undefined` on Windows.

Fixes: https://github.com/nodejs/node/issues/25913

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
