### PR TITLE
[v10.x] n-api: finalize during second-pass callback

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -471,9 +471,24 @@ class Reference : private Finalizer {
   }
 
  private:
+  // The N-API finalizer callback may make calls into the engine. V8's heap is
+  // not in a consistent state during the weak callback, and therefore it does
+  // not support calls back into it. However, it provides a mechanism for adding
+  // a finalizer which may make calls back into the engine by allowing us to
+  // attach such a second-pass finalizer from the first pass finalizer. Thus,
+  // we do that here to ensure that the N-API finalizer callback is free to call
+  // into the engine.
   static void FinalizeCallback(const v8::WeakCallbackInfo<Reference>& data) {
     Reference* reference = data.GetParameter();
+
+    // The reference must be reset during the first pass.
     reference->_persistent.Reset();
+
+    data.SetSecondPassCallback(SecondPassCallback);
+  }
+
+  static void SecondPassCallback(const v8::WeakCallbackInfo<Reference>& data) {
+    Reference* reference = data.GetParameter();
 
     napi_env env = reference->_env;
 


### PR DESCRIPTION
Calling into the engine from a weak callback is unsafe, however, the
engine offers a way to attach a second-pass weak callback which gets
called when it is safe to call into JavaScript. This moves the point
at which the N-API finalize callback gets called to this latter point.

Fixes: https://github.com/nodejs/node/issues/25927
PR-URL: https://github.com/nodejs/node/pull/25992

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
