### PR TITLE
process: delay setup of global exception handlers

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -46,24 +46,6 @@ setupTraceCategoryState();
 
 setupProcessObject();
 
-// TODO(joyeecheung): this does not have to done so early, any fatal errors
-// thrown before user code execution should simply crash the process
-// and we do not care about any clean up at that point. We don't care
-// about emitting any events if the process crash upon bootstrap either.
-{
-  const {
-    fatalException,
-    setUncaughtExceptionCaptureCallback,
-    hasUncaughtExceptionCaptureCallback
-  } = NativeModule.require('internal/process/execution');
-
-  process._fatalException = fatalException;
-  process.setUncaughtExceptionCaptureCallback =
-    setUncaughtExceptionCaptureCallback;
-  process.hasUncaughtExceptionCaptureCallback =
-    hasUncaughtExceptionCaptureCallback;
-}
-
 setupGlobalProxy();
 setupBuffer();
 
@@ -264,6 +246,20 @@ Object.defineProperty(process, 'features', {
     tls: hasOpenSSL
   }
 });
+
+{
+  const {
+    fatalException,
+    setUncaughtExceptionCaptureCallback,
+    hasUncaughtExceptionCaptureCallback
+  } = NativeModule.require('internal/process/execution');
+
+  process._fatalException = fatalException;
+  process.setUncaughtExceptionCaptureCallback =
+    setUncaughtExceptionCaptureCallback;
+  process.hasUncaughtExceptionCaptureCallback =
+    hasUncaughtExceptionCaptureCallback;
+}
 
 // User-facing NODE_V8_COVERAGE environment variable that writes
 // ScriptCoverage to a specified file.


### PR DESCRIPTION
Since bootstrap/node.js performs the setup synchronously,
the process exception handlers do not have to setup so early in
the bootstrap process - any fatal errors thrown before user code
execution should simply crash the process, and we do not care
about any clean up at that point. We don't care about emitting any
events if the process crash upon bootstrap either.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
