### PR TITLE
process: delay and simplify the setup of async hooks trace events

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -42,8 +42,6 @@ const { getOptionValue } = NativeModule.require('internal/options');
 const config = internalBinding('config');
 const { deprecate } = NativeModule.require('internal/util');
 
-setupTraceCategoryState();
-
 setupProcessObject();
 
 setupGlobalProxy();
@@ -314,35 +312,6 @@ if (getOptionValue('--experimental-report')) {
   if (config.events.includes('signal')) {
     process.on(config.signal, handleSignal);
   }
-}
-
-function setupTraceCategoryState() {
-  const {
-    traceCategoryState,
-    setTraceCategoryStateUpdateHandler
-  } = internalBinding('trace_events');
-  const kCategoryAsyncHooks = 0;
-  let traceEventsAsyncHook;
-
-  function toggleTraceCategoryState() {
-    // Dynamically enable/disable the traceEventsAsyncHook
-    const asyncHooksEnabled = !!traceCategoryState[kCategoryAsyncHooks];
-
-    if (asyncHooksEnabled) {
-      // Lazy load internal/trace_events_async_hooks only if the async_hooks
-      // trace event category is enabled.
-      if (!traceEventsAsyncHook) {
-        traceEventsAsyncHook =
-          NativeModule.require('internal/trace_events_async_hooks');
-      }
-      traceEventsAsyncHook.enable();
-    } else if (traceEventsAsyncHook) {
-      traceEventsAsyncHook.disable();
-    }
-  }
-
-  toggleTraceCategoryState();
-  setTraceCategoryStateUpdateHandler(toggleTraceCategoryState);
 }
 
 function setupProcessObject() {

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const { getOptionValue } = require('internal/options');
+// Lazy load internal/trace_events_async_hooks only if the async_hooks
+// trace event category is enabled.
+let traceEventsAsyncHook;
 
 function prepareMainThreadExecution() {
   setupTraceCategoryState();
@@ -27,30 +30,25 @@ function prepareMainThreadExecution() {
 
 function setupTraceCategoryState() {
   const {
-    traceCategoryState,
+    asyncHooksEnabledInitial,
     setTraceCategoryStateUpdateHandler
   } = internalBinding('trace_events');
-  const kCategoryAsyncHooks = 0;
-  let traceEventsAsyncHook;
 
-  function toggleTraceCategoryState() {
-    // Dynamically enable/disable the traceEventsAsyncHook
-    const asyncHooksEnabled = !!traceCategoryState[kCategoryAsyncHooks];
-
-    if (asyncHooksEnabled) {
-      // Lazy load internal/trace_events_async_hooks only if the async_hooks
-      // trace event category is enabled.
-      if (!traceEventsAsyncHook) {
-        traceEventsAsyncHook = require('internal/trace_events_async_hooks');
-      }
-      traceEventsAsyncHook.enable();
-    } else if (traceEventsAsyncHook) {
-      traceEventsAsyncHook.disable();
-    }
-  }
-
-  toggleTraceCategoryState();
+  toggleTraceCategoryState(asyncHooksEnabledInitial);
   setTraceCategoryStateUpdateHandler(toggleTraceCategoryState);
+}
+
+// Dynamically enable/disable the traceEventsAsyncHook
+function toggleTraceCategoryState(asyncHooksEnabled) {
+  if (asyncHooksEnabled) {
+    if (!traceEventsAsyncHook) {
+      traceEventsAsyncHook =
+        require('internal/trace_events_async_hooks').createHook();
+    }
+    traceEventsAsyncHook.enable();
+  } else if (traceEventsAsyncHook) {
+    traceEventsAsyncHook.disable();
+  }
 }
 
 // In general deprecations are intialized wherever the APIs are implemented,

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -3,6 +3,8 @@
 const { getOptionValue } = require('internal/options');
 
 function prepareMainThreadExecution() {
+  setupTraceCategoryState();
+
   // If the process is spawned with env NODE_CHANNEL_FD, it's probably
   // spawned by our child_process module, then initialize IPC.
   // This attaches some internal event listeners and creates:
@@ -21,6 +23,34 @@ function prepareMainThreadExecution() {
   initializeDeprecations();
   initializeESMLoader();
   loadPreloadModules();
+}
+
+function setupTraceCategoryState() {
+  const {
+    traceCategoryState,
+    setTraceCategoryStateUpdateHandler
+  } = internalBinding('trace_events');
+  const kCategoryAsyncHooks = 0;
+  let traceEventsAsyncHook;
+
+  function toggleTraceCategoryState() {
+    // Dynamically enable/disable the traceEventsAsyncHook
+    const asyncHooksEnabled = !!traceCategoryState[kCategoryAsyncHooks];
+
+    if (asyncHooksEnabled) {
+      // Lazy load internal/trace_events_async_hooks only if the async_hooks
+      // trace event category is enabled.
+      if (!traceEventsAsyncHook) {
+        traceEventsAsyncHook = require('internal/trace_events_async_hooks');
+      }
+      traceEventsAsyncHook.enable();
+    } else if (traceEventsAsyncHook) {
+      traceEventsAsyncHook.disable();
+    }
+  }
+
+  toggleTraceCategoryState();
+  setTraceCategoryStateUpdateHandler(toggleTraceCategoryState);
 }
 
 // In general deprecations are intialized wherever the APIs are implemented,
@@ -150,5 +180,6 @@ module.exports = {
   prepareMainThreadExecution,
   initializeDeprecations,
   initializeESMLoader,
-  loadPreloadModules
+  loadPreloadModules,
+  setupTraceCategoryState
 };

--- a/lib/internal/main/check_syntax.js
+++ b/lib/internal/main/check_syntax.js
@@ -22,14 +22,16 @@ if (process.argv[1] && process.argv[1] !== '-') {
   // Expand process.argv[1] into a full path.
   const path = require('path');
   process.argv[1] = path.resolve(process.argv[1]);
+
+  // TODO(joyeecheung): not every one of these are necessary
+  prepareMainThreadExecution();
+
   // Read the source.
   const filename = CJSModule._resolveFilename(process.argv[1]);
 
   const fs = require('fs');
   const source = fs.readFileSync(filename, 'utf-8');
 
-  // TODO(joyeecheung): not every one of these are necessary
-  prepareMainThreadExecution();
   markBootstrapComplete();
 
   checkScriptSyntax(source, filename);

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -6,7 +6,8 @@
 const {
   initializeDeprecations,
   initializeESMLoader,
-  loadPreloadModules
+  loadPreloadModules,
+  setupTraceCategoryState
 } = require('internal/bootstrap/pre_execution');
 
 const {
@@ -72,6 +73,8 @@ port.on('message', (message) => {
       manifestURL,
       hasStdin
     } = message;
+
+    setupTraceCategoryState();
     if (manifestSrc) {
       require('internal/process/policy').setup(manifestSrc, manifestURL);
     }

--- a/lib/internal/trace_events_async_hooks.js
+++ b/lib/internal/trace_events_async_hooks.js
@@ -83,4 +83,4 @@ function createHook() {
   };
 }
 
-module.exports = createHook();
+exports.createHook = createHook;

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -443,11 +443,6 @@ Environment::should_abort_on_uncaught_toggle() {
   return should_abort_on_uncaught_toggle_;
 }
 
-inline AliasedBuffer<uint8_t, v8::Uint8Array>&
-Environment::trace_category_state() {
-  return trace_category_state_;
-}
-
 inline AliasedBuffer<int32_t, v8::Int32Array>&
 Environment::stream_base_state() {
   return stream_base_state_;

--- a/src/env.h
+++ b/src/env.h
@@ -697,7 +697,6 @@ class Environment {
   inline AliasedBuffer<uint32_t, v8::Uint32Array>&
   should_abort_on_uncaught_toggle();
 
-  inline AliasedBuffer<uint8_t, v8::Uint8Array>& trace_category_state();
   inline AliasedBuffer<int32_t, v8::Int32Array>& stream_base_state();
 
   // The necessary API for async_hooks.
@@ -1006,8 +1005,6 @@ class Environment {
   AliasedBuffer<uint32_t, v8::Uint32Array> should_abort_on_uncaught_toggle_;
   int should_not_abort_scope_counter_ = 0;
 
-  // Attached to a Uint8Array that tracks the state of trace category
-  AliasedBuffer<uint8_t, v8::Uint8Array> trace_category_state_;
   std::unique_ptr<TrackingTraceStateObserver> trace_state_observer_;
 
   AliasedBuffer<int32_t, v8::Int32Array> stream_base_state_;

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -1,6 +1,7 @@
 #include "base_object-inl.h"
 #include "env.h"
 #include "node.h"
+#include "node_internals.h"
 #include "node_v8_platform-inl.h"
 #include "tracing/agent.h"
 
@@ -10,6 +11,7 @@
 namespace node {
 
 using v8::Array;
+using v8::Boolean;
 using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
@@ -148,9 +150,14 @@ void NodeCategorySet::Initialize(Local<Object> target,
   target->Set(context, trace,
               binding->Get(context, trace).ToLocalChecked()).FromJust();
 
-  target->Set(context,
-              FIXED_ONE_BYTE_STRING(env->isolate(), "traceCategoryState"),
-              env->trace_category_state().GetJSArray()).FromJust();
+  // Initial value of async hook trace events
+  bool async_hooks_enabled = (*(TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
+                                 TRACING_CATEGORY_NODE1(async_hooks)))) != 0;
+  target
+      ->Set(context,
+            FIXED_ONE_BYTE_STRING(env->isolate(), "asyncHooksEnabledInitial"),
+            Boolean::New(env->isolate(), async_hooks_enabled))
+      .FromJust();
 }
 
 }  // namespace node

--- a/test/parallel/test-trace-events-async-hooks-dynamic.js
+++ b/test/parallel/test-trace-events-async-hooks-dynamic.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const common = require('../common');
+if (!process.binding('config').hasTracing)
+  common.skip('missing trace events');
+
+const assert = require('assert');
+const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+const enable = `require("trace_events").createTracing(
+{ categories: ["node.async_hooks"] }).enable();`;
+const code =
+  'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
+
+const tmpdir = require('../common/tmpdir');
+const filename = path.join(tmpdir.path, 'node_trace.1.log');
+
+tmpdir.refresh();
+const proc = cp.spawnSync(
+  process.execPath,
+  ['-e', enable + code ],
+  {
+    cwd: tmpdir.path,
+    env: Object.assign({}, process.env, {
+      'NODE_DEBUG_NATIVE': 'tracing',
+      'NODE_DEBUG': 'tracing'
+    })
+  });
+console.log(proc.signal);
+console.log(proc.stderr.toString());
+assert.strictEqual(proc.status, 0);
+
+assert(fs.existsSync(filename));
+const data = fs.readFileSync(filename, 'utf-8');
+const traces = JSON.parse(data).traceEvents;
+assert(traces.length > 0);
+// V8 trace events should be generated.
+assert(!traces.some((trace) => {
+  if (trace.pid !== proc.pid)
+    return false;
+  if (trace.cat !== 'v8')
+    return false;
+  if (trace.name !== 'V8.ScriptCompiler')
+    return false;
+  return true;
+}));
+
+// C++ async_hooks trace events should be generated.
+assert(traces.some((trace) => {
+  if (trace.pid !== proc.pid)
+    return false;
+  if (trace.cat !== 'node,node.async_hooks')
+    return false;
+  return true;
+}));
+
+// JavaScript async_hooks trace events should be generated.
+assert(traces.some((trace) => {
+  if (trace.pid !== proc.pid)
+    return false;
+  if (trace.cat !== 'node,node.async_hooks')
+    return false;
+  if (trace.name !== 'Timeout')
+    return false;
+  return true;
+}));
+
+// Check args in init events
+const initEvents = traces.filter((trace) => {
+  return (trace.ph === 'b' && !trace.name.includes('_CALLBACK'));
+});
+for (const trace of initEvents) {
+  console.log(trace);
+  if (trace.args.data.executionAsyncId > 0 &&
+    trace.args.data.triggerAsyncId > 0) {
+    continue;
+  }
+  assert.fail('Unexpected initEvent: ',
+              util.inspect(trace, { depth: Infinity }));
+}

--- a/test/parallel/test-trace-events-async-hooks-worker.js
+++ b/test/parallel/test-trace-events-async-hooks-worker.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const common = require('../common');
+if (!process.binding('config').hasTracing)
+  common.skip('missing trace events');
+
+const assert = require('assert');
+const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+const code =
+  'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
+const worker = `const { Worker } = require('worker_threads');
+  const worker = new Worker('${code}',
+  { eval: true, stdout: true, stderr: true });
+  worker.stdout.on('data',
+    (chunk) => console.log('worker', chunk.toString()));
+  worker.stderr.on('data',
+    (chunk) => console.error('worker', chunk.toString()));`;
+
+const tmpdir = require('../common/tmpdir');
+const filename = path.join(tmpdir.path, 'node_trace.1.log');
+
+tmpdir.refresh();
+const proc = cp.spawnSync(
+  process.execPath,
+  [ '--trace-event-categories', 'node.async_hooks', '-e', worker ],
+  {
+    cwd: tmpdir.path,
+    env: Object.assign({}, process.env, {
+      'NODE_DEBUG_NATIVE': 'tracing',
+      'NODE_DEBUG': 'tracing'
+    })
+  });
+
+console.log(proc.signal);
+console.log(proc.stderr.toString());
+assert.strictEqual(proc.status, 0);
+
+assert(fs.existsSync(filename));
+const data = fs.readFileSync(filename, 'utf-8');
+const traces = JSON.parse(data).traceEvents;
+assert(traces.length > 0);
+// V8 trace events should be generated.
+assert(!traces.some((trace) => {
+  if (trace.pid !== proc.pid)
+    return false;
+  if (trace.cat !== 'v8')
+    return false;
+  if (trace.name !== 'V8.ScriptCompiler')
+    return false;
+  return true;
+}));
+
+// C++ async_hooks trace events should be generated.
+assert(traces.some((trace) => {
+  if (trace.pid !== proc.pid)
+    return false;
+  if (trace.cat !== 'node,node.async_hooks')
+    return false;
+  return true;
+}));
+
+// JavaScript async_hooks trace events should be generated.
+assert(traces.some((trace) => {
+  if (trace.pid !== proc.pid)
+    return false;
+  if (trace.cat !== 'node,node.async_hooks')
+    return false;
+  if (trace.name !== 'Timeout')
+    return false;
+  return true;
+}));
+
+// Check args in init events
+const initEvents = traces.filter((trace) => {
+  return (trace.ph === 'b' && !trace.name.includes('_CALLBACK'));
+});
+
+for (const trace of initEvents) {
+  if (trace.name === 'MESSAGEPORT' &&
+    trace.args.data.executionAsyncId === 0 &&
+    trace.args.data.triggerAsyncId === 0) {
+    continue;
+  }
+  if (trace.args.data.executionAsyncId > 0 &&
+    trace.args.data.triggerAsyncId > 0) {
+    continue;
+  }
+  assert.fail('Unexpected initEvent: ',
+              util.inspect(trace, { depth: Infinity }));
+}


### PR DESCRIPTION
#### src: move async hooks trace events setup to pre_execution.js

Reasons:

- Moves more environment-dependent setup out of bootstrap/node.js
- No async operations should be done before the call to
  the setup functions in pre_execution.js so no async hooks should be
  triggered before that. Therefore it is safe to delay the setup
  until then.

#### process: simplify the setup of async hooks trace events

- Remove `trace_category_state` from `Environment` - since this is
  only accessed in the bootstrap process and later in the
  trace category update handler, we could just pass the initial
  values into JS land via the trace_events binding, and pass
  the dynamic values directly to the handler later, instead of
  accessing them out-of-band via the AliasedBuffer.
- Instead of creating the hooks directly in
  `trace_events_async_hooks.js`, export the hook factory and
  create the hooks in trace category state toggle.

#### test: add test for node.async_hooks tracing in workers

#### test: add test for dynamically enabling node.async_hooks tracing

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
