### PR TITLE
test: increase coverage for assertion_error.js

### DIFF
--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -653,14 +653,20 @@ assertDeepAndStrictEqual(-0, -0);
 
 assert.deepEqual(new Date(2000, 3, 14), new Date(2000, 3, 14));
 
-assert.throws(() => assert.deepEqual(new Date(), new Date(2000, 3, 14)),
+assert.throws(() => { assert.deepEqual(new Date(), new Date(2000, 3, 14)); },
               AssertionError,
               'deepEqual(new Date(), new Date(2000, 3, 14))');
 
 assert.throws(
-  () => assert.notDeepEqual(new Date(2000, 3, 14), new Date(2000, 3, 14)),
+  () => { assert.notDeepEqual(new Date(2000, 3, 14), new Date(2000, 3, 14)); },
   AssertionError,
   'notDeepEqual(new Date(2000, 3, 14), new Date(2000, 3, 14))'
+);
+
+assert.throws(
+  () => { assert.notDeepEqual('a'.repeat(1024), 'a'.repeat(1024)); },
+  AssertionError,
+  'notDeepEqual("a".repeat(1024), "a".repeat(1024))'
 );
 
 assert.notDeepEqual(new Date(), new Date(2000, 3, 14));


### PR DESCRIPTION
Add a test for long strings and assert.notDeepEqual() to cover code that
truncates output when it is longer than 1024 characters.

This introduces coverage for https://coverage.nodejs.org/coverage-0a4c69a5c5e8ba93/lib/internal/assert/assertion_error.js.html#L370.

I standardized nearby arrow functions to use braces when they are not intended to return a value.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
