### PR TITLE
process: use rest parameters

### DIFF
--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -89,8 +89,7 @@ class TickObject {
     // on the hidden class, revisit in V8 versions after 6.2
     this.callback = null;
     this.callback = callback;
-    if (args.length > 0)
-      this.args = args;
+    this.args = args.length !== 0 ? args : undefined;
 
     const asyncId = newAsyncId();
     this[async_id_symbol] = asyncId;

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -89,7 +89,8 @@ class TickObject {
     // on the hidden class, revisit in V8 versions after 6.2
     this.callback = null;
     this.callback = callback;
-    this.args = args;
+    if (args.length > 0)
+      this.args = args;
 
     const asyncId = newAsyncId();
     this[async_id_symbol] = asyncId;
@@ -106,24 +107,12 @@ class TickObject {
 
 // `nextTick()` will not enqueue any callback when the process is about to
 // exit since the callback would not have a chance to be executed.
-function nextTick(callback) {
+function nextTick(callback, ...args) {
   if (typeof callback !== 'function')
     throw new ERR_INVALID_CALLBACK();
 
   if (process._exiting)
     return;
-
-  var args;
-  switch (arguments.length) {
-    case 1: break;
-    case 2: args = [arguments[1]]; break;
-    case 3: args = [arguments[1], arguments[2]]; break;
-    case 4: args = [arguments[1], arguments[2], arguments[3]]; break;
-    default:
-      args = new Array(arguments.length - 1);
-      for (var i = 1; i < arguments.length; i++)
-        args[i - 1] = arguments[i];
-  }
 
   if (queue.isEmpty())
     setHasTickScheduled(true);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Using rest parameters instead of manual switching can improve performance of `nextTick()`.

```
 process/next-tick-breadth-args.js n=4000000          ***     27.61 %      ±0.89% ±1.19% ±1.55%
 process/next-tick-breadth.js n=4000000               ***      5.08 %      ±0.96% ±1.28% ±1.68%
 process/next-tick-depth-args.js n=12000000           ***      6.86 %      ±0.77% ±1.02% ±1.34%
 process/next-tick-depth.js n=12000000                         1.21 %      ±1.28% ±1.70% ±2.22%
 process/next-tick-exec-args.js n=5000000             ***      3.10 %      ±1.18% ±1.58% ±2.06%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
