### PR TITLE
test: silence compiler warning in openssl-binding

### DIFF
--- a/test/addons/openssl-binding/binding.gyp
+++ b/test/addons/openssl-binding/binding.gyp
@@ -8,6 +8,15 @@
           'sources': ['binding.cc'],
           'include_dirs': ['../../../deps/openssl/openssl/include'],
         }],
+        ['OS=="mac"', {
+          'xcode_settings': {
+            'OTHER_CFLAGS+': [
+              '-Wno-deprecated-declarations',
+            ],
+          },
+        }, {
+          'cflags': ['-Wno-deprecated-declarations'],
+        }],
       ],
     },
   ]


### PR DESCRIPTION
Currently, this test generated the following compiler warning:
```console
../binding.cc:33:30: warning:
'TLSv1_2_server_method' is deprecated [-Wdeprecated-declarations]
  const SSL_METHOD* method = TLSv1_2_server_method();
                             ^
/node/deps/openssl/openssl/include/openssl/ssl.h:1877:1:
note: 'TLSv1_2_server_method' has been explicitly marked deprecated here
DEPRECATEDIN_1_1_0(__owur const SSL_METHOD *TLSv1_2_server_method(void))
^
1 warning generated.
```
This commit adds `-Wno-deprecated-declarations` to silence this warning
for this test.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
