### PR TITLE
src: extract common sockaddr creation code

### DIFF
--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -175,10 +175,10 @@ void UDPWrap::GetFD(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(fd);
 }
 
-int uv_sockaddr_for_family(int address_family,
-                           const char* address,
-                           const unsigned short port,
-                           struct sockaddr_storage* addr) {
+int sockaddr_for_family(int address_family,
+                        const char* address,
+                        const unsigned short port,
+                        struct sockaddr_storage* addr) {
   switch (address_family) {
   case AF_INET:
     return uv_ip4_addr(address, port, reinterpret_cast<sockaddr_in*>(addr));
@@ -205,7 +205,7 @@ void UDPWrap::DoBind(const FunctionCallbackInfo<Value>& args, int family) {
       !args[2]->Uint32Value(ctx).To(&flags))
     return;
   struct sockaddr_storage addr_storage;
-  int err = uv_sockaddr_for_family(family, address.out(), port, &addr_storage);
+  int err = sockaddr_for_family(family, address.out(), port, &addr_storage);
   if (err == 0) {
     err = uv_udp_bind(&wrap->handle_,
                       reinterpret_cast<const sockaddr*>(&addr_storage),
@@ -393,7 +393,7 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
   req_wrap->msg_size = msg_size;
 
   struct sockaddr_storage addr_storage;
-  int err = uv_sockaddr_for_family(family, address.out(), port, &addr_storage);
+  int err = sockaddr_for_family(family, address.out(), port, &addr_storage);
   if (err == 0) {
     err = req_wrap->Dispatch(uv_udp_send,
                              &wrap->handle_,

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -186,7 +186,6 @@ int uv_sockaddr_for_family(int address_family,
     return uv_ip6_addr(address, port, reinterpret_cast<sockaddr_in6*>(addr));
   default:
     CHECK(0 && "unexpected address family");
-    ABORT();
   }
 }
 


### PR DESCRIPTION
This commit extracts code to create sockaddr which is shared by both
`UDPWrap::DoBind` and `UDPWrap::DoSend`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
