### PR TITLE
repl: commands allowed only when not multiline

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2651,6 +2651,20 @@ written twice. This introduces a race condition between threads, and is a
 potential security vulnerability. There is no safe, cross-platform alternative
 API.
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: elimination of `.break` command in the `REPL`
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26076
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+The `.break` command will be eliminated from the `REPL` in a future
+version. Use `Ctrl-C` instead.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -32,11 +32,7 @@ feature set.
 
 The following special commands are supported by all REPL instances:
 
-* `.break`: When in the process of inputting a multi-line expression, entering
-  the `.break` command (or pressing the `<ctrl>-C` key combination) will abort
-  further input or processing of that expression.
-* `.clear`: Resets the REPL `context` to an empty object and clears any
-  multi-line expression currently being input.
+* `.clear`: Resets the REPL `context` to an empty object.
 * `.exit`: Close the I/O stream, causing the REPL to exit.
 * `.help`: Show this list of special commands.
 * `.save`: Save the current REPL session to a file:
@@ -61,16 +57,26 @@ welcome('Node.js User');
 
 The following key combinations in the REPL have these special effects:
 
-* `<ctrl>-C`: When pressed once, has the same effect as the `.break` command.
-  When pressed twice on a blank line, has the same effect as the `.exit`
-  command.
+* `<ctrl>-C`: When in the process of inputting a multi-line expression,
+  pressing the `<ctrl>-C` key combination will abort further input or
+  processing of that expression. When pressed twice on a blank line, has
+  the same effect as the `.exit` command.
 * `<ctrl>-D`: Has the same effect as the `.exit` command.
 * `<tab>`: When pressed on a blank line, displays global and local (scope)
   variables. When pressed while entering other input, displays relevant
   autocompletion options.
 
-For key bindings related to the reverse-i-search, see [`reverse-i-search`][].
-For all other key bindings, see [TTY keybindings][].
+### Deprecated Commands
+
+<!--
+deprecated: REPLACEME
+-->
+
+* `.break`: Deprecated. Use Ctrl-C instead. When in the process of inputting a
+  multi-line expression, the `.break` command will abort further input or
+  processing of that expression.
+
+> Stability: 0 - Deprecated.
 
 ### Default Evaluation
 
@@ -741,7 +747,5 @@ For an example of running a REPL instance over [curl(1)][], see:
 [`repl.ReplServer`]: #repl_class_replserver
 [`repl.start()`]: #repl_repl_start_options
 [`util.inspect()`]: util.html#util_util_inspect_object_options
-[`reverse-i-search`]: #repl_reverse_i_search
-[TTY keybindings]: readline.html#readline_tty_keybindings
 [curl(1)]: https://curl.haxx.se/docs/manpage.html
 [stream]: stream.html

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -77,9 +77,10 @@ const {
   deprecate
 } = require('internal/util');
 const { inspect } = require('internal/util/inspect');
-const vm = require('vm');
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
+const util = require('util');
+const vm = require('vm');
 const { Interface } = require('readline');
 const {
   commonPrefix
@@ -740,7 +741,8 @@ function REPLServer(prompt,
 
     // Check to see if a REPL keyword was used. If it returns true,
     // display next prompt and return.
-    if (trimmedCmd) {
+    if (trimmedCmd &&
+      (!self[kBufferedCommandSymbol] || trimmedCmd === '.break')) {
       if (trimmedCmd.charAt(0) === '.' && trimmedCmd.charAt(1) !== '.' &&
           NumberIsNaN(parseFloat(trimmedCmd))) {
         const matches = trimmedCmd.match(/^\.([^\s]+)\s*(.*)$/);
@@ -987,6 +989,7 @@ REPLServer.prototype.resetContext = function() {
   this.context = this.createContext();
   this.underscoreAssigned = false;
   this.underscoreErrAssigned = false;
+  this.line = '';
   this.lines = [];
   this.lines.level = [];
 
@@ -1481,20 +1484,14 @@ function _turnOffEditorMode(repl) {
 function defineDefaultCommands(repl) {
   repl.defineCommand('break', {
     help: 'Sometimes you get stuck, this gets you out',
-    action: function() {
+    action: util.deprecate(function() {
       this.clearBufferedCommand();
       this.displayPrompt();
-    }
+    }, 'The .break command is deprecated', 'REPLACEME')
   });
 
-  let clearMessage;
-  if (repl.useGlobal) {
-    clearMessage = 'Alias for .break';
-  } else {
-    clearMessage = 'Break, and also clear the local context';
-  }
   repl.defineCommand('clear', {
-    help: clearMessage,
+    help: 'Clear the local context',
     action: function() {
       this.clearBufferedCommand();
       if (!this.useGlobal) {

--- a/test/parallel/test-repl-break-deprecation.js
+++ b/test/parallel/test-repl-break-deprecation.js
@@ -1,0 +1,54 @@
+'use strict';
+const common = require('../common');
+const ArrayStream = require('../common/arraystream');
+const assert = require('assert');
+const repl = require('repl');
+
+testWithDeprecatedBreak();
+
+function testWithDeprecatedBreak() {
+  const inputStream = new ArrayStream();
+  const outputStream = new ArrayStream();
+
+  outputStream.write = (data) => {
+    output += data.replace('\r', '');
+  };
+
+  const input = [
+    '(_ => {',
+    'const x = { break: "dancing" };',
+    'return x;',
+    '.break',
+    '10'
+  ];
+  let output = '';
+
+  const r = repl.start({
+    prompt: '',
+    input: inputStream,
+    output: outputStream,
+    terminal: true,
+    useColors: false
+  });
+
+  const warn = 'The .break command is deprecated';
+  common.expectWarning('DeprecationWarning', warn, 'REPLACEME');
+
+  inputStream.run(input);
+  outputStream.write('\r');
+
+  const actual = output.split('\n');
+
+  // Validate the output, which contains terminal escape codes.
+  assert.strictEqual(actual.length, 7);
+  assert.ok(actual[0].endsWith(input[0]));
+  assert.ok(actual[1].includes('... '));
+  assert.ok(actual[1].endsWith(input[1]));
+  assert.ok(actual[2].endsWith(input[2]));
+  assert.ok(actual[3].endsWith(input[3]));
+  assert.ok(actual[4].endsWith(input[4]));
+  assert.strictEqual(actual[5], '10');
+  // Ignore the last line, which is nothing but escape codes.
+
+  r.close();
+}

--- a/test/parallel/test-repl-multiline-with-command.js
+++ b/test/parallel/test-repl-multiline-with-command.js
@@ -1,0 +1,50 @@
+'use strict';
+const common = require('../common');
+const ArrayStream = require('../common/arraystream');
+const assert = require('assert');
+const repl = require('repl');
+
+function runTest() {
+  const inputStream = new ArrayStream();
+  const outputStream = new ArrayStream();
+
+  outputStream.write = (data) => {
+    output += data.replace('\r', '');
+  };
+
+  const input = [
+    '(_ => {',
+    'const x = { help: "received" };',
+    'return x',
+    '.help',
+    '})()'
+  ];
+  let output = '';
+
+  const r = repl.start({
+    prompt: '',
+    input: inputStream,
+    output: outputStream,
+    terminal: true,
+    useColors: false
+  });
+
+  inputStream.run(input);
+
+  const actual = output.split('\n');
+
+  // Validate the output, which contains terminal escape codes.
+  assert.strictEqual(actual.length, 7);
+  assert.ok(actual[0].endsWith(input[0]));
+  assert.ok(actual[1].includes('... '));
+  assert.ok(actual[1].endsWith(input[1]));
+  assert.ok(actual[2].endsWith(input[2]));
+  assert.ok(actual[3].endsWith(input[3]));
+  assert.ok(actual[4].endsWith(input[4]));
+  assert.strictEqual(actual[5], '\'received\'');
+  // Ignore the last line, which is nothing but escape codes.
+
+  r.close();
+}
+
+common.mustCall(runTest)();

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -49,7 +49,6 @@ function getNoResultsFunction() {
   });
 }
 
-const works = [['inner.one'], 'inner.o'];
 const putIn = new ArrayStream();
 const testMe = repl.start('', putIn);
 
@@ -70,10 +69,10 @@ testMe.complete('console.lo', common.mustCall(function(error, data) {
 // Tab Complete will return globally scoped variables
 putIn.run(['};']);
 testMe.complete('inner.o', common.mustCall(function(error, data) {
-  assert.deepStrictEqual(data, works);
+  assert.deepStrictEqual(data, [['inner.one'], 'inner.o']);
 }));
 
-putIn.run(['.clear']);
+putIn.run([';', '.clear']);
 
 // Tab Complete will not break in an ternary operator with ()
 putIn.run([
@@ -82,8 +81,7 @@ putIn.run([
   '{one: 1} : '
 ]);
 testMe.complete('inner.o', getNoResultsFunction());
-
-putIn.run(['.clear']);
+putIn.run(['undefined)', '.clear']);
 
 // Tab Complete will return a simple local variable
 putIn.run([
@@ -94,7 +92,7 @@ testMe.complete('inner.o', getNoResultsFunction());
 
 // When you close the function scope tab complete will not return the
 // locally scoped variable
-putIn.run(['};']);
+putIn.run(['ne', '};']);
 testMe.complete('inner.o', getNoResultsFunction());
 
 putIn.run(['.clear']);
@@ -108,7 +106,7 @@ putIn.run([
 ]);
 testMe.complete('inner.o', getNoResultsFunction());
 
-putIn.run(['.clear']);
+putIn.run(['}', '.clear']);
 
 // Tab Complete will return a complex local variable even if the function
 // has parameters
@@ -120,7 +118,7 @@ putIn.run([
 ]);
 testMe.complete('inner.o', getNoResultsFunction());
 
-putIn.run(['.clear']);
+putIn.run(['}', '.clear']);
 
 // Tab Complete will return a complex local variable even if the
 // scope is nested inside an immediately executed function
@@ -133,12 +131,12 @@ putIn.run([
 ]);
 testMe.complete('inner.o', getNoResultsFunction());
 
-putIn.run(['.clear']);
+putIn.run(['})}', '.clear']);
 
 // The definition has the params and { on a separate line.
 putIn.run([
   'var top = function() {',
-  'r = function test (',
+  'var r = function test (',
   ' one, two) {',
   'var inner = {',
   ' one:1',
@@ -146,12 +144,12 @@ putIn.run([
 ]);
 testMe.complete('inner.o', getNoResultsFunction());
 
-putIn.run(['.clear']);
+putIn.run(['}}', '.clear']);
 
 // Currently does not work, but should not break, not the {
 putIn.run([
   'var top = function() {',
-  'r = function test ()',
+  'var r = function test ()',
   '{',
   'var inner = {',
   ' one:1',
@@ -159,7 +157,7 @@ putIn.run([
 ]);
 testMe.complete('inner.o', getNoResultsFunction());
 
-putIn.run(['.clear']);
+putIn.run(['}', '}', '.clear']);
 
 // Currently does not work, but should not break
 putIn.run([
@@ -173,7 +171,7 @@ putIn.run([
 ]);
 testMe.complete('inner.o', getNoResultsFunction());
 
-putIn.run(['.clear']);
+putIn.run(['}', '}', '.clear']);
 
 // Make sure tab completion works on non-Objects
 putIn.run([
@@ -377,8 +375,8 @@ testMe.complete('var log = console.lo', common.mustCall((error, data) => {
 // Tab completion for defined commands
 putIn.run(['.clear']);
 
-testMe.complete('.b', common.mustCall((error, data) => {
-  assert.deepStrictEqual(data, [['break'], 'b']);
+testMe.complete('.h', common.mustCall((error, data) => {
+  assert.deepStrictEqual(data, [['help'], 'h']);
 }));
 putIn.run(['.clear']);
 putIn.run(['var obj = {"hello, world!": "some string", "key": 123}']);


### PR DESCRIPTION
Allow commands such as `.help` only when the repl is not in multiline
mode, preventing erroneous evaluation of commands which could in fact
be valid JS code.

For example the following should output `'received'` and not be evaluated
on line 4 as the `.help` command.

```js
> (_ => {
  const x = { help: 'received' };
  return x
  .help ;
})()
```

Since the `.break` command is only used to get out of a bind in multiline
input, and `CTL-C` does the exact same thing, it has been removed.

Refs: https://github.com/nodejs/node/pull/20625

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
