### PR TITLE
worker: use fake MessageEvent for port.onmessage

### DIFF
--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -61,11 +61,11 @@ MessagePort.prototype.unref = MessagePortPrototype.unref;
 // uv_async_t) which can receive information from other threads and emits
 // .onmessage events, and a function used for sending data to a MessagePort
 // in some other thread.
-MessagePort.prototype[kOnMessageListener] = function onmessage(payload) {
-  if (payload.type !== messageTypes.STDIO_WANTS_MORE_DATA)
-    debug(`[${threadId}] received message`, payload);
+MessagePort.prototype[kOnMessageListener] = function onmessage(event) {
+  if (event.data && event.data.type !== messageTypes.STDIO_WANTS_MORE_DATA)
+    debug(`[${threadId}] received message`, event);
   // Emit the deserialized object to userland.
-  this.emit('message', payload);
+  this.emit('message', event.data);
 };
 
 // This is for compatibility with the Web's MessagePort API. It makes sense to

--- a/src/env.h
+++ b/src/env.h
@@ -146,6 +146,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(crypto_ec_string, "ec")                                                    \
   V(crypto_rsa_string, "rsa")                                                  \
   V(cwd_string, "cwd")                                                         \
+  V(data_string, "data")                                                       \
   V(dest_string, "dest")                                                       \
   V(destroyed_string, "destroyed")                                             \
   V(detached_string, "detached")                                               \
@@ -293,6 +294,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(subject_string, "subject")                                                 \
   V(subjectaltname_string, "subjectaltname")                                   \
   V(syscall_string, "syscall")                                                 \
+  V(target_string, "target")                                                   \
   V(thread_id_string, "threadId")                                              \
   V(ticketkeycallback_string, "onticketkeycallback")                           \
   V(timeout_string, "timeout")                                                 \
@@ -361,6 +363,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(inspector_console_extension_installer, v8::Function)                       \
   V(libuv_stream_wrap_ctor_template, v8::FunctionTemplate)                     \
   V(message_port, v8::Object)                                                  \
+  V(message_event_object_template, v8::ObjectTemplate)                         \
   V(message_port_constructor_template, v8::FunctionTemplate)                   \
   V(native_module_require, v8::Function)                                       \
   V(performance_entry_callback, v8::Function)                                  \

--- a/test/parallel/test-worker-message-port-transfer-self.js
+++ b/test/parallel/test-worker-message-port-transfer-self.js
@@ -25,7 +25,7 @@ assert.throws(common.mustCall(() => {
 
 // The failed transfer should not affect the ports in anyway.
 port2.onmessage = common.mustCall((message) => {
-  assert.strictEqual(message, 2);
+  assert.strictEqual(message.data, 2);
 
   const inspectedPort1 = util.inspect(port1);
   const inspectedPort2 = util.inspect(port2);

--- a/test/parallel/test-worker-message-port.js
+++ b/test/parallel/test-worker-message-port.js
@@ -21,14 +21,15 @@ const { MessageChannel, MessagePort } = require('worker_threads');
   const { port1, port2 } = new MessageChannel();
 
   port1.onmessage = common.mustCall((message) => {
-    assert.strictEqual(message, 4);
+    assert.strictEqual(message.data, 4);
+    assert.strictEqual(message.target, port1);
     port2.close(common.mustCall());
   });
 
   port1.postMessage(2);
 
   port2.onmessage = common.mustCall((message) => {
-    port2.postMessage(message * 2);
+    port2.postMessage(message.data * 2);
   });
 }
 

--- a/test/parallel/test-worker-onmessage.js
+++ b/test/parallel/test-worker-onmessage.js
@@ -14,6 +14,6 @@ if (!process.env.HAS_STARTED_WORKER) {
   w.postMessage(2);
 } else {
   parentPort.onmessage = common.mustCall((message) => {
-    parentPort.postMessage(message * 2);
+    parentPort.postMessage(message.data * 2);
   });
 }


### PR DESCRIPTION
Instead of passing the payload for Workers directly to `.onmessage`,
perform something more similar to what the browser API provides,
namely create an event object with a `.data` property.

This does not make `MessagePort` implement the `EventTarget` API, nor
does it implement the full `MessageEvent` API, but it would make
such extensions non-breaking changes if we desire them at
some point in the future.

(This would be a breaking change if Workers were not experimental.
Currently, this method is also undocumented and only exists with
the idea of enabling some degree of Web compatibility.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
