### PR TITLE
test: add arg to narrow http benchmark test

### DIFF
--- a/test/benchmark/test-benchmark-http.js
+++ b/test/benchmark/test-benchmark-http.js
@@ -29,7 +29,8 @@ runBenchmark('http',
                'n=1',
                'res=normal',
                'type=asc',
-               'value=X-Powered-By'
+               'value=X-Powered-By',
+               'headerDuplicates=1',
              ],
              {
                NODEJS_BENCHMARK_ZERO_ALLOWED: 1,


### PR DESCRIPTION
Recent changes (https://github.com/nodejs/node/commit/da0dc51e396ea4a1f12f259a8149f4177ad674e8) added a new benchmark (`benchmark/http/incoming_headers.js`) which takes a new arg (`headerDuplicates`).
This PR passes a value for that arg so that during the sanity test this benchmark will run only once.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
