### PR TITLE
src: apply clang-tidy rule modernize-use-override

### DIFF
--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -109,7 +109,7 @@ class AsyncWrap : public BaseObject {
             ProviderType provider,
             double execution_async_id = -1);
 
-  virtual ~AsyncWrap();
+  ~AsyncWrap() override;
 
   static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
       Environment* env);
@@ -169,7 +169,7 @@ class AsyncWrap : public BaseObject {
       v8::Local<v8::Value>* argv);
 
   virtual std::string diagnostic_name() const;
-  virtual std::string MemoryInfoName() const;
+  std::string MemoryInfoName() const override;
 
   static void WeakCallback(const v8::WeakCallbackInfo<DestroyParam> &info);
 

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -38,7 +38,7 @@ class BaseObject : public MemoryRetainer {
   // Associates this object with `object`. It uses the 0th internal field for
   // that, and in particular aborts if there is no such field.
   inline BaseObject(Environment* env, v8::Local<v8::Object> object);
-  virtual inline ~BaseObject();
+  inline ~BaseObject() override;
 
   // Returns the wrapped object.  Returns an empty handle when
   // persistent.IsEmpty() is true.

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -149,7 +149,7 @@ using node_ares_task_list =
 class ChannelWrap : public AsyncWrap {
  public:
   ChannelWrap(Environment* env, Local<Object> object);
-  ~ChannelWrap();
+  ~ChannelWrap() override;
 
   static void New(const FunctionCallbackInfo<Value>& args);
 

--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -42,7 +42,7 @@ class CreateObjectRequest : public Request {
   CreateObjectRequest(int object_id, Factory factory)
                       : object_id_(object_id), factory_(std::move(factory)) {}
 
-  void Call(MainThreadInterface* thread) {
+  void Call(MainThreadInterface* thread) override {
     thread->AddObject(object_id_, WrapInDeletable(factory_(thread)));
   }
 

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -228,7 +228,7 @@ class ChannelImpl final : public v8_inspector::V8Inspector::Channel,
     worker_agent_->Wire(node_dispatcher_.get());
   }
 
-  virtual ~ChannelImpl() {
+  ~ChannelImpl() override {
     tracing_agent_->disable();
     tracing_agent_.reset();  // Dispose before the dispatchers
     worker_agent_->disable();

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -215,7 +215,7 @@ class InspectorIoDelegate: public node::inspector::SocketServerDelegate {
                       const std::string& target_id,
                       const std::string& script_path,
                       const std::string& script_name);
-  ~InspectorIoDelegate() {
+  ~InspectorIoDelegate() override {
   }
 
   void StartSession(int session_id, const std::string& target_id) override;

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -184,7 +184,7 @@ class SocketSession {
    public:
     Delegate(InspectorSocketServer* server, int session_id)
              : server_(server), session_id_(session_id) { }
-    ~Delegate() {
+    ~Delegate() override {
       server_->SessionTerminated(session_id_);
     }
     void OnHttpGet(const std::string& host, const std::string& path) override;

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -61,7 +61,7 @@ class ModuleWrap : public BaseObject {
              v8::Local<v8::Object> object,
              v8::Local<v8::Module> module,
              v8::Local<v8::String> url);
-  ~ModuleWrap();
+  ~ModuleWrap() override;
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Link(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node.h
+++ b/src/node.h
@@ -220,7 +220,7 @@ class Environment;
 
 class NODE_EXTERN MultiIsolatePlatform : public v8::Platform {
  public:
-  virtual ~MultiIsolatePlatform() { }
+  ~MultiIsolatePlatform() override { }
   // Returns true if work was dispatched or executed. New tasks that are
   // posted during flushing of the queue are postponed until the next
   // flushing.

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -128,7 +128,7 @@ class ThreadSafeFunction : public node::AsyncResource {
     env->Ref();
   }
 
-  ~ThreadSafeFunction() {
+  ~ThreadSafeFunction() override {
     node::RemoveEnvironmentCleanupHook(env->isolate, Cleanup, this);
     env->Unref();
   }
@@ -832,7 +832,7 @@ class Work : public node::AsyncResource, public node::ThreadPoolWork {
       _complete(complete) {
   }
 
-  virtual ~Work() { }
+  ~Work() override { }
 
  public:
   static Work* New(node_napi_env env,

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -108,7 +108,7 @@ class ContextifyScript : public BaseObject {
   SET_SELF_SIZE(ContextifyScript)
 
   ContextifyScript(Environment* env, v8::Local<v8::Object> object);
-  ~ContextifyScript();
+  ~ContextifyScript() override;
 
   static void Init(Environment* env, v8::Local<v8::Object> target);
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -40,7 +40,7 @@ namespace crypto {
 // (a.k.a. std::unique_ptr<BIO>).
 class NodeBIO : public MemoryRetainer {
  public:
-  ~NodeBIO();
+  ~NodeBIO() override;
 
   static BIOPointer New(Environment* env = nullptr);
 

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -365,7 +365,7 @@ class FileHandle : public AsyncWrap, public StreamBase {
   static FileHandle* New(Environment* env,
                          int fd,
                          v8::Local<v8::Object> obj = v8::Local<v8::Object>());
-  virtual ~FileHandle();
+  ~FileHandle() override;
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -105,10 +105,10 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
  public:
   inline uint32_t* zero_fill_field() { return &zero_fill_field_; }
 
-  virtual void* Allocate(size_t size);  // Defined in src/node.cc
-  virtual void* AllocateUninitialized(size_t size)
+  void* Allocate(size_t size) override;  // Defined in src/node.cc
+  void* AllocateUninitialized(size_t size) override
     { return node::UncheckedMalloc(size); }
-  virtual void Free(void* data, size_t) { free(data); }
+  void Free(void* data, size_t) override { free(data); }
 
  private:
   uint32_t zero_fill_field_ = 1;  // Boolean but exposed as uint32 to JS land.

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -78,7 +78,7 @@ class Message : public MemoryRetainer {
 class MessagePortData : public MemoryRetainer {
  public:
   explicit MessagePortData(MessagePort* owner);
-  ~MessagePortData();
+  ~MessagePortData() override;
 
   MessagePortData(MessagePortData&& other) = delete;
   MessagePortData& operator=(MessagePortData&& other) = delete;
@@ -138,7 +138,7 @@ class MessagePort : public HandleWrap {
   MessagePort(Environment* env,
               v8::Local<v8::Context> context,
               v8::Local<v8::Object> wrap);
-  ~MessagePort();
+  ~MessagePort() override;
 
   // Create a new message port instance, optionally over an existing
   // `MessagePortData` object.

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -79,7 +79,7 @@ class DebugOptions : public Options {
     return break_first_line || break_node_first_line;
   }
 
-  void CheckOptions(std::vector<std::string>* errors);
+  void CheckOptions(std::vector<std::string>* errors) override;
 };
 
 class EnvironmentOptions : public Options {
@@ -125,7 +125,7 @@ class EnvironmentOptions : public Options {
 
   inline DebugOptions* get_debug_options();
   inline const DebugOptions& debug_options() const;
-  void CheckOptions(std::vector<std::string>* errors);
+  void CheckOptions(std::vector<std::string>* errors) override;
 
  private:
   DebugOptions debug_options_;
@@ -146,7 +146,7 @@ class PerIsolateOptions : public Options {
   bool report_verbose;
 #endif  //  NODE_REPORT
   inline EnvironmentOptions* get_per_env_options();
-  void CheckOptions(std::vector<std::string>* errors);
+  void CheckOptions(std::vector<std::string>* errors) override;
 };
 
 class PerProcessOptions : public Options {
@@ -192,7 +192,7 @@ class PerProcessOptions : public Options {
 #endif  //  NODE_REPORT
 
   inline PerIsolateOptions* get_per_isolate_options();
-  void CheckOptions(std::vector<std::string>* errors);
+  void CheckOptions(std::vector<std::string>* errors) override;
 };
 
 // The actual options parser, as opposed to the structs containing them:

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -56,7 +56,7 @@ class PerIsolatePlatformData :
     public std::enable_shared_from_this<PerIsolatePlatformData> {
  public:
   PerIsolatePlatformData(v8::Isolate* isolate, uv_loop_t* loop);
-  ~PerIsolatePlatformData();
+  ~PerIsolatePlatformData() override;
 
   void PostTask(std::unique_ptr<v8::Task> task) override;
   void PostIdleTask(std::unique_ptr<v8::IdleTask> task) override;
@@ -123,7 +123,7 @@ class NodePlatform : public MultiIsolatePlatform {
  public:
   NodePlatform(int thread_pool_size,
                node::tracing::TracingController* tracing_controller);
-  virtual ~NodePlatform() {}
+  ~NodePlatform() override {}
 
   void DrainTasks(v8::Isolate* isolate) override;
   void CancelPendingDelayedTasks(v8::Isolate* isolate) override;

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -33,7 +33,7 @@ class SerializerContext : public BaseObject,
   SerializerContext(Environment* env,
                     Local<Object> wrap);
 
-  ~SerializerContext() {}
+  ~SerializerContext() override {}
 
   void ThrowDataCloneError(Local<String> message) override;
   Maybe<bool> WriteHostObject(Isolate* isolate, Local<Object> object) override;
@@ -68,7 +68,7 @@ class DeserializerContext : public BaseObject,
                       Local<Object> wrap,
                       Local<Value> buffer);
 
-  ~DeserializerContext() {}
+  ~DeserializerContext() override {}
 
   MaybeLocal<Object> ReadHostObject(Isolate* isolate) override;
 

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -18,7 +18,7 @@ class Worker : public AsyncWrap {
          v8::Local<v8::Object> wrap,
          const std::string& url,
          std::shared_ptr<PerIsolateOptions> per_isolate_opts);
-  ~Worker();
+  ~Worker() override;
 
   // Run the worker. This is only called from the worker thread.
   void Run();

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -82,7 +82,7 @@ class WriteWrap : public StreamReq {
             v8::Local<v8::Object> req_wrap_obj)
     : StreamReq(stream, req_wrap_obj) { }
 
-  ~WriteWrap() {
+  ~WriteWrap() override {
     free(storage_);
   }
 

--- a/src/stream_pipe.h
+++ b/src/stream_pipe.h
@@ -10,7 +10,7 @@ namespace node {
 class StreamPipe : public AsyncWrap {
  public:
   StreamPipe(StreamBase* source, StreamBase* sink, v8::Local<v8::Object> obj);
-  ~StreamPipe();
+  ~StreamPipe() override;
 
   void Unpipe();
 

--- a/src/tracing/node_trace_buffer.h
+++ b/src/tracing/node_trace_buffer.h
@@ -51,7 +51,7 @@ class InternalTraceBuffer {
 class NodeTraceBuffer : public TraceBuffer {
  public:
   NodeTraceBuffer(size_t max_chunks, Agent* agent, uv_loop_t* tracing_loop);
-  ~NodeTraceBuffer();
+  ~NodeTraceBuffer() override;
 
   TraceObject* AddTraceEvent(uint64_t* handle) override;
   TraceObject* GetEventByHandle(uint64_t handle) override;

--- a/src/tracing/node_trace_writer.h
+++ b/src/tracing/node_trace_writer.h
@@ -17,7 +17,7 @@ using v8::platform::tracing::TraceWriter;
 class NodeTraceWriter : public AsyncTraceWriter {
  public:
   explicit NodeTraceWriter(const std::string& log_file_pattern);
-  ~NodeTraceWriter();
+  ~NodeTraceWriter() override;
 
   void InitializeOnThread(uv_loop_t* loop) override;
   void AppendTraceEvent(TraceObject* trace_event) override;

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -84,14 +84,14 @@ class NodeTestFixture : public ::testing::Test {
     CHECK_EQ(0, uv_loop_close(&current_loop));
   }
 
-  virtual void SetUp() {
+  void SetUp() override {
     allocator = ArrayBufferUniquePtr(node::CreateArrayBufferAllocator(),
                                      &node::FreeArrayBufferAllocator);
     isolate_ = NewIsolate(allocator.get(), &current_loop);
     CHECK_NE(isolate_, nullptr);
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     isolate_->Dispose();
     platform->UnregisterIsolate(isolate_);
     isolate_ = nullptr;

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -16,7 +16,7 @@ static std::string cb_1_arg;  // NOLINT(runtime/string)
 
 class EnvironmentTest : public EnvironmentTestFixture {
  private:
-  virtual void TearDown() {
+  void TearDown() override {
     NodeTestFixture::TearDown();
     called_cb_1 = false;
     called_cb_2 = false;

--- a/test/cctest/test_inspector_socket.cc
+++ b/test/cctest/test_inspector_socket.cc
@@ -107,7 +107,7 @@ class TestInspectorDelegate : public InspectorSocket::Delegate {
                             handshake_delegate_(stop_if_stop_path),
                             fail_on_ws_frame_(false) { }
 
-  ~TestInspectorDelegate() {
+  ~TestInspectorDelegate() override {
     assert_is_delegate(this);
     delegate = nullptr;
   }
@@ -353,7 +353,7 @@ static void on_connection(uv_connect_t* connect, int status) {
 
 class InspectorSocketTest : public ::testing::Test {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     connected = false;
     GTEST_ASSERT_EQ(0, uv_loop_init(&loop));
     server = uv_tcp_t();
@@ -375,7 +375,7 @@ class InspectorSocketTest : public ::testing::Test {
     really_close(reinterpret_cast<uv_handle_t*>(&server));
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     really_close(reinterpret_cast<uv_handle_t*>(&client_socket));
     SPIN_WHILE(delegate != nullptr);
     const int err = uv_loop_close(&loop);

--- a/test/cctest/test_inspector_socket_server.cc
+++ b/test/cctest/test_inspector_socket_server.cc
@@ -305,7 +305,7 @@ class TestSocketServerDelegate : public SocketServerDelegate {
         targets_(target_ids),
         session_id_(0) {}
 
-  ~TestSocketServerDelegate() {
+  ~TestSocketServerDelegate() override {
     harness_->Done();
   }
 


### PR DESCRIPTION
See https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-override.html.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
