### PR TITLE
worker: remove duplicate call

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -217,8 +217,6 @@ void Worker::Run() {
           stopped_ = true;
         }
 
-        env_->RunCleanup();
-
         // This call needs to be made while the `Environment` is still alive
         // because we assume that it is available for async tracking in the
         // NodePlatform implementation.


### PR DESCRIPTION
`Environment::RunCleanup` is invoked twice in a row, remove one.

cc @nodejs/workers 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
