### PR TITLE
worker: ignore --abort-on-uncaught-exception for terminate()

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -32,7 +32,9 @@ static bool AllowWasmCodeGenerationCallback(Local<Context> context,
 static bool ShouldAbortOnUncaughtException(Isolate* isolate) {
   HandleScope scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
-  return env != nullptr && env->should_abort_on_uncaught_toggle()[0] &&
+  return env != nullptr &&
+         (env->is_main_thread() || !env->is_stopping_worker()) &&
+         env->should_abort_on_uncaught_toggle()[0] &&
          !env->inside_should_not_abort_on_uncaught_scope();
 }
 

--- a/test/abort/test-worker-abort-uncaught-exception.js
+++ b/test/abort/test-worker-abort-uncaught-exception.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { spawn } = require('child_process');
+const { Worker } = require('worker_threads');
+
+// Tests that --abort-on-uncaught-exception applies to workers as well.
+
+if (process.argv[2] === 'child') {
+  new Worker('throw new Error("foo");', { eval: true });
+  return;
+}
+
+const child = spawn(process.execPath, [
+  '--abort-on-uncaught-exception', __filename, 'child'
+]);
+child.on('exit', common.mustCall((code, sig) => {
+  if (common.isWindows) {
+    assert.strictEqual(code, 0xC0000005);
+  } else {
+    assert(['SIGABRT', 'SIGTRAP', 'SIGILL'].includes(sig),
+           `Unexpected signal ${sig}`);
+  }
+}));

--- a/test/parallel/test-worker-abort-on-uncaught-exception-terminate.js
+++ b/test/parallel/test-worker-abort-on-uncaught-exception-terminate.js
@@ -1,0 +1,12 @@
+// Flags: --abort-on-uncaught-exception
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Tests that --abort-on-uncaught-exception does not apply to
+// termination exceptions.
+
+const w = new Worker('while(true);', { eval: true });
+w.on('online', common.mustCall(() => w.terminate()));
+w.on('exit', common.mustCall((code) => assert.strictEqual(code, 1)));


### PR DESCRIPTION
When running Worker threads with `--abort-on-uncaught-exception`,
do not abort the process when `worker.terminate()` is called.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
