### PR TITLE
vm: do not overwrite error when creating context

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -171,7 +171,6 @@ MaybeLocal<Context> ContextifyContext::CreateV8Context(
   Local<Context> ctx = NewContext(env->isolate(), object_template);
 
   if (ctx.IsEmpty()) {
-    env->ThrowError("Could not instantiate context");
     return MaybeLocal<Context>();
   }
 

--- a/test/parallel/test-worker-vm-context-terminate.js
+++ b/test/parallel/test-worker-vm-context-terminate.js
@@ -8,7 +8,9 @@ const { Worker } = require('worker_threads');
 if (!process.env.HAS_STARTED_WORKER) {
   process.env.HAS_STARTED_WORKER = 1;
   const w = new Worker(__filename);
-  setTimeout(() => w.terminate(), 50);
+  w.on('online', common.mustCall(() => {
+    setTimeout(() => w.terminate(), 50);
+  }));
   w.on('error', common.mustNotCall());
   w.on('exit', common.mustCall((code) => assert.strictEqual(code, 1)));
 } else {

--- a/test/parallel/test-worker-vm-context-terminate.js
+++ b/test/parallel/test-worker-vm-context-terminate.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const vm = require('vm');
+const { Worker } = require('worker_threads');
+
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
+  const w = new Worker(__filename);
+  setTimeout(() => w.terminate(), 50);
+  w.on('error', common.mustNotCall());
+  w.on('exit', common.mustCall((code) => assert.strictEqual(code, 1)));
+} else {
+  while (true)
+    vm.runInNewContext('');
+}


### PR DESCRIPTION
An empty `Local<>` already indicates that an exception is pending,
so there is no need to throw an exception. In the case of Workers,
this could override a `.terminate()` call.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
