### PR TITLE
lib: converted element to lowercase in tty.js

### DIFF
--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -37,7 +37,7 @@ const COLORS_16m = 24;
 // distribution of this file, with or without modification, are permitted
 // provided the copyright notice and this notice are preserved.
 const TERM_ENVS = [
-  'Eterm',
+  'eterm',
   'cons25',
   'console',
   'cygwin',


### PR DESCRIPTION
Converted the first element "Eterm" in TERM_ENVS array to "eterm"

Fixes: https://github.com/nodejs/node/issues/26077

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
