### PR TITLE
src: add debug CHECKs against empty handles

### DIFF
--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -139,6 +139,11 @@ MaybeLocal<Value> InternalMakeCallback(Environment* env,
                                        Local<Value> argv[],
                                        async_context asyncContext) {
   CHECK(!recv.IsEmpty());
+#ifdef DEBUG
+  for (int i = 0; i < argc; i++)
+    CHECK(!argv[i].IsEmpty());
+#endif
+
   InternalCallbackScope scope(env, recv, asyncContext);
   if (scope.Failed()) {
     return MaybeLocal<Value>();

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -710,6 +710,7 @@ void DecorateErrorStack(Environment* env,
 void FatalException(Isolate* isolate,
                     Local<Value> error,
                     Local<Message> message) {
+  CHECK(!error.IsEmpty());
   HandleScope scope(isolate);
 
   Environment* env = Environment::GetCurrent(isolate);


### PR DESCRIPTION
These checks were useful while investigating other issues;
using empty `Local<>`s can be very un-debuggable, because that
typically does not lead to assertions with debugging information
but rather crashes based on accessing invalid memory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
