### PR TITLE
n-api: do not call into JS when that is not allowed

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -12,8 +12,13 @@ struct node_napi_env__ : public napi_env__ {
       napi_env__(context) {
     CHECK_NOT_NULL(node_env());
   }
+
   inline node::Environment* node_env() const {
     return node::Environment::GetCurrent(context());
+  }
+
+  bool can_call_into_js() const override {
+    return node_env()->can_call_into_js();
   }
 };
 

--- a/test/node-api/test_worker_terminate/binding.gyp
+++ b/test/node-api/test_worker_terminate/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_worker_terminate",
+      "sources": [ "test_worker_terminate.c" ]
+    }
+  ]
+}

--- a/test/node-api/test_worker_terminate/test.js
+++ b/test/node-api/test_worker_terminate/test.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const { Worker, isMainThread, workerData } = require('worker_threads');
+
+if (isMainThread) {
+  const counter = new Int32Array(new SharedArrayBuffer(4));
+  const worker = new Worker(__filename, { workerData: { counter } });
+  worker.on('exit', common.mustCall(() => {
+    assert.strictEqual(counter[0], 1);
+  }));
+  worker.on('error', common.mustNotCall());
+} else {
+  const { Test } = require(`./build/${common.buildType}/test_worker_terminate`);
+
+  const { counter } = workerData;
+  // Test() tries to call a function twice and asserts that the second call does
+  // not work because of a pending exception.
+  Test(() => {
+    Atomics.add(counter, 0, 1);
+    process.exit();
+  });
+}

--- a/test/node-api/test_worker_terminate/test_worker_terminate.c
+++ b/test/node-api/test_worker_terminate/test_worker_terminate.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <node_api.h>
+#include <assert.h>
+#include "../../js-native-api/common.h"
+
+napi_value Test(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value recv;
+  napi_value argv[1];
+  napi_status status;
+
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, &recv, NULL));
+  NAPI_ASSERT(env, argc >= 1, "Not enough arguments, expected 1.");
+
+  napi_valuetype t;
+  NAPI_CALL(env, napi_typeof(env, argv[0], &t));
+  NAPI_ASSERT(env, t == napi_function,
+      "Wrong first argument, function expected.");
+
+  status = napi_call_function(env, recv, argv[0], 0, NULL, NULL);
+  assert(status == napi_ok);
+  status = napi_call_function(env, recv, argv[0], 0, NULL, NULL);
+  assert(status == napi_pending_exception);
+
+  return NULL;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor properties[] = {
+    DECLARE_NAPI_PROPERTY("Test", Test)
+  };
+
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
Check whether calling into JS is allowed before doing so.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
