### PR TITLE
src: add missing includes to build with vtune support

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -9,6 +9,10 @@
 #include "node_v8_platform-inl.h"
 #include "uv.h"
 
+#ifdef NODE_ENABLE_VTUNE_PROFILING
+#include "../deps/v8/src/third_party/vtune/v8-vtune.h"
+#endif
+
 namespace node {
 using v8::Context;
 using v8::Function;


### PR DESCRIPTION
Added missing includes (v8-vtune.h) in environment.cc to be able to build with vtune profiling support.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
