### PR TITLE
worker: spin uv_run twice before closing loop

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -150,7 +150,10 @@ class WorkerThreadData {
 
     isolate->Dispose();
 
-    // Need to run the loop one more time to close the platform's uv_async_t
+    // Need to run the loop twice more to close the platform's uv_async_t
+    // TODO(addaleax): It would be better for the platform itself to provide
+    // some kind of notification when it has fully cleaned up.
+    uv_run(&loop_, UV_RUN_ONCE);
     uv_run(&loop_, UV_RUN_ONCE);
 
     CheckedUvLoopClose(&loop_);


### PR DESCRIPTION
On Windows, the Platform’s `uv_async_t` may need two iterations
before closing when it was previously in use.

Refs: https://github.com/nodejs/node/pull/26089
Refs: https://github.com/nodejs/node/pull/26006

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
