### PR TITLE
test: simplify test-worker-syntax-error

### DIFF
--- a/test/parallel/test-worker-syntax-error.js
+++ b/test/parallel/test-worker-syntax-error.js
@@ -3,15 +3,9 @@ const common = require('../common');
 const assert = require('assert');
 const { Worker } = require('worker_threads');
 
-// Do not use isMainThread so that this test itself can be run inside a Worker.
-if (!process.env.HAS_STARTED_WORKER) {
-  process.env.HAS_STARTED_WORKER = 1;
-  const w = new Worker('abc)', { eval: true });
-  w.on('message', common.mustNotCall());
-  w.on('error', common.mustCall((err) => {
-    assert.strictEqual(err.constructor, SyntaxError);
-    assert(/SyntaxError/.test(err));
-  }));
-} else {
-  throw new Error('foo');
-}
+const w = new Worker('abc)', { eval: true });
+w.on('message', common.mustNotCall());
+w.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.constructor, SyntaxError);
+  assert(/SyntaxError/.test(err));
+}));


### PR DESCRIPTION
Remove extraneous code from test-worker-syntax-error. Because the worker
is called with `eval: true`, there is no need to set an environment
variable indicating whether the worker has started and so on. The test
file is only ever executed by the main thread.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
