### PR TITLE
worker: serialize errors if stack getter throws

### DIFF
--- a/lib/internal/error-serdes.js
+++ b/lib/internal/error-serdes.js
@@ -36,7 +36,10 @@ function TryGetAllProperties(object, target = object) {
   Assign(all, TryGetAllProperties(GetPrototypeOf(object), target));
   const keys = GetOwnPropertyNames(object);
   ForEach(keys, (key) => {
-    const descriptor = GetOwnPropertyDescriptor(object, key);
+    let descriptor;
+    try {
+      descriptor = GetOwnPropertyDescriptor(object, key);
+    } catch { return; }
     const getter = descriptor.get;
     if (getter && key !== '__proto__') {
       try {
@@ -89,7 +92,6 @@ function serializeError(error) {
       for (var i = 0; i < constructors.length; i++) {
         const name = GetName(constructors[i]);
         if (errorConstructorNames.has(name)) {
-          try { error.stack; } catch {}
           const serialized = serialize({
             constructor: name,
             properties: TryGetAllProperties(error)

--- a/test/parallel/test-worker-error-stack-getter-throws.js
+++ b/test/parallel/test-worker-error-stack-getter-throws.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+const w = new Worker(
+  `const fn = (err) => {
+    if (err.message === 'fhqwhgads')
+      throw new Error('come on');
+    return 'This is my custom stack trace!';
+  };
+  Error.prepareStackTrace = fn;
+  throw new Error('fhqwhgads');
+  `,
+  { eval: true }
+);
+w.on('message', common.mustNotCall());
+w.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.stack, undefined);
+  assert.strictEqual(err.message, 'fhqwhgads');
+  assert.strictEqual(err.name, 'Error');
+}));


### PR DESCRIPTION
<strike>Remove an apparently unnecessary try/catch from the error
serialization/deserialization internal module used by worker_threads.

(If I'm wrong about this being unnecessary for some reason, I'll switch course and try to add a test and/or an explanatory comment. But it sure seems to effectively be a no-op?)</strike>

Current code that is intended to handle the stack getter throwing is untested. Add a test and adjust code to function as expected.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
