### PR TITLE
meta: remove the useless GitHub Account

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -223,6 +223,7 @@ Leeseean Chiu <leeseean@qq.com>
 Luke Bayes <lbayes@patternpark.com>
 Lydia Kats <llkats@gmail.com> Lydia Katsamberis <llkats@gmail.com>
 Maciej Małecki <maciej.malecki@notimplemented.org> <me@mmalecki.com>
+MaleDong <maledong_github@outlook.com>
 Malte-Thorben Bruns <skenqbx@gmail.com> <skenqbx@googlemail.com>
 Malte-Thorben Bruns <skenqbx@gmail.com> skenqbx <skenqbx@gmail.com>
 Mandeep Singh <mandeep25894@gmail.com> <mandeep.singh@zomato.com>

--- a/.mailmap
+++ b/.mailmap
@@ -223,7 +223,7 @@ Leeseean Chiu <leeseean@qq.com>
 Luke Bayes <lbayes@patternpark.com>
 Lydia Kats <llkats@gmail.com> Lydia Katsamberis <llkats@gmail.com>
 Maciej Małecki <maciej.malecki@notimplemented.org> <me@mmalecki.com>
-MaleDong <maledong_github@outlook.com>
+MaleDong <maledong_github@outlook.com> <maledong_private@qq.com>
 Malte-Thorben Bruns <skenqbx@gmail.com> <skenqbx@googlemail.com>
 Malte-Thorben Bruns <skenqbx@gmail.com> skenqbx <skenqbx@gmail.com>
 Mandeep Singh <mandeep25894@gmail.com> <mandeep.singh@zomato.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -2249,7 +2249,6 @@ Sam Ruby <rubys@intertwingly.net>
 Haroon Khan <aitchkhan@gmail.com>
 Developer Davo <DeveloperDavo@users.noreply.github.com>
 Jacek Pospychała <jacek.pospychala@currency-one.com>
-MaleDong <maledong_private@qq.com>
 iwko <iwoczerniawski@gmail.com>
 Sohail Rajdev <sohailrajdev97@gmail.com>
 Niicck <niicck@users.noreply.github.com>


### PR DESCRIPTION
Due to `maledong_private@qq.com` is useless because I cannot log in
with the email address (GitHub doesn't support `qq` mail well), 
and I've successfully changed my email account to `maledong_github@outlook.com` 
instead. So I removed my old useless email address and keep the new one
for the same account 'MaleDong', because there're two 'MaleDong' Accounts and 
they are both pointing to me.

Here're the images:
![email](https://user-images.githubusercontent.com/40081831/52897947-29e2af00-3213-11e9-9fdd-ec45032ec883.PNG)

![profiles](https://user-images.githubusercontent.com/40081831/52897955-36670780-3213-11e9-9c1b-b323896822a3.PNG)

---
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)