### PR TITLE
src: move req_wrap_queue to base class of ReqWrap

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -410,7 +410,7 @@ void Environment::RegisterHandleCleanups() {
 }
 
 void Environment::CleanupHandles() {
-  for (ReqWrap<uv_req_t>* request : req_wrap_queue_)
+  for (ReqWrapBase* request : req_wrap_queue_)
     request->Cancel();
 
   for (HandleWrap* handle : handle_wrap_queue_)

--- a/src/env.h
+++ b/src/env.h
@@ -860,8 +860,7 @@ class Environment {
 #endif
 
   typedef ListHead<HandleWrap, &HandleWrap::handle_wrap_queue_> HandleWrapQueue;
-  typedef ListHead<ReqWrap<uv_req_t>, &ReqWrap<uv_req_t>::req_wrap_queue_>
-          ReqWrapQueue;
+  typedef ListHead<ReqWrapBase, &ReqWrapBase::req_wrap_queue_> ReqWrapQueue;
 
   inline HandleWrapQueue* handle_wrap_queue() { return &handle_wrap_queue_; }
   inline ReqWrapQueue* req_wrap_queue() { return &req_wrap_queue_; }

--- a/src/node_postmortem_metadata.cc
+++ b/src/node_postmortem_metadata.cc
@@ -28,15 +28,14 @@
   V(Environment_HandleWrapQueue, head_, ListNode_HandleWrap,                  \
     Environment::HandleWrapQueue::head_)                                      \
   V(ListNode_HandleWrap, next_, uintptr_t, ListNode<HandleWrap>::next_)       \
-  V(ReqWrap, req_wrap_queue_, ListNode_ReqWrapQueue,                          \
-    ReqWrap<uv_req_t>::req_wrap_queue_)                                       \
   V(Environment_ReqWrapQueue, head_, ListNode_ReqWrapQueue,                   \
     Environment::ReqWrapQueue::head_)                                         \
-  V(ListNode_ReqWrap, next_, uintptr_t, ListNode<ReqWrap<uv_req_t>>::next_)
+  V(ListNode_ReqWrap, next_, uintptr_t, ListNode<ReqWrapBase>::next_)
 
 extern "C" {
 int nodedbg_const_ContextEmbedderIndex__kEnvironment__int;
 uintptr_t nodedbg_offset_ExternalString__data__uintptr_t;
+uintptr_t nodedbg_offset_ReqWrap__req_wrap_queue___ListNode_ReqWrapQueue;
 
 #define V(Class, Member, Type, Accessor)                                      \
   NODE_EXTERN uintptr_t NODEDBG_OFFSET(Class, Member, Type);
@@ -51,6 +50,9 @@ int GenDebugSymbols() {
       ContextEmbedderIndex::kEnvironment;
 
   nodedbg_offset_ExternalString__data__uintptr_t = NODE_OFF_EXTSTR_DATA;
+  nodedbg_offset_ReqWrap__req_wrap_queue___ListNode_ReqWrapQueue =
+      OffsetOf<ListNode<ReqWrapBase>, ReqWrap<uv_req_t>>(
+          &ReqWrap<uv_req_t>::req_wrap_queue_);
 
   #define V(Class, Member, Type, Accessor)                                    \
     NODEDBG_OFFSET(Class, Member, Type) = OffsetOf(&Accessor);

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -251,7 +251,8 @@ static void GetActiveRequests(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   std::vector<Local<Value>> request_v;
-  for (auto w : *env->req_wrap_queue()) {
+  for (ReqWrapBase* req_wrap : *env->req_wrap_queue()) {
+    AsyncWrap* w = req_wrap->GetAsyncWrap();
     if (w->persistent().IsEmpty())
       continue;
     request_v.push_back(w->GetOwner());


### PR DESCRIPTION
Introduce a second base class for `ReqWrap` that does not
depend on a template parameter and move the `req_wrap_queue_`
field to it.

This addresses undefined behaviour that occurs when casting
to `ReqWrap<uv_req_t>` in the `ReqWrap` constructor.

Refs: https://github.com/nodejs/node/issues/26131

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
