### PR TITLE
crypto: make ConvertKey clear openssl error stack

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -6122,6 +6122,7 @@ void ExportChallenge(const FunctionCallbackInfo<Value>& args) {
 
 // Convert the input public key to compressed, uncompressed, or hybrid formats.
 void ConvertKey(const FunctionCallbackInfo<Value>& args) {
+  MarkPopErrorOnReturn mark_pop_error_on_return;
   Environment* env = Environment::GetCurrent(args);
 
   CHECK_EQ(args.Length(), 3);


### PR DESCRIPTION
Failed ConvertKey() operations should not leave errors on OpenSSL's
error stack because that's observable by subsequent cryptographic
operations. More to the point, it makes said operations fail with
an unrelated error.

Fixes: https://github.com/nodejs/node/issues/26133
CI: https://ci.nodejs.org/job/node-test-pull-request/20818/