### PR TITLE
src: apply clang-tidy rule modernize-deprecated-headers

### DIFF
--- a/src/api/exceptions.cc
+++ b/src/api/exceptions.cc
@@ -7,7 +7,7 @@
 #include "uv.h"
 #include "v8.h"
 
-#include <string.h>
+#include <cstring>
 
 namespace node {
 

--- a/src/api/utils.cc
+++ b/src/api/utils.cc
@@ -1,7 +1,7 @@
 #include "node.h"
 #include "node_internals.h"
 
-#include <signal.h>
+#include <csignal>
 
 namespace node {
 

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -27,7 +27,7 @@
 #include "base_object.h"
 #include "v8.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace node {
 

--- a/src/base64.h
+++ b/src/base64.h
@@ -5,8 +5,8 @@
 
 #include "util.h"
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 namespace node {
 //// Base 64 ////

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -28,8 +28,8 @@
 #include "util-inl.h"
 #include "uv.h"
 
-#include <errno.h>
-#include <string.h>
+#include <cerrno>
+#include <cstring>
 #include <vector>
 #include <unordered_set>
 

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -19,7 +19,7 @@
 #include <execinfo.h>
 #include <unistd.h>
 #include <sys/mman.h>
-#include <stdio.h>
+#include <cstdio>
 #endif
 
 #else  // __POSIX__

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -34,8 +34,8 @@
 #include "node_context_data.h"
 #include "node_worker.h"
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 namespace node {
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -14,7 +14,7 @@
 #include "tracing/traced_value.h"
 #include "v8-profiler.h"
 
-#include <stdio.h>
+#include <cstdio>
 #include <algorithm>
 #include <atomic>
 

--- a/src/env.h
+++ b/src/env.h
@@ -38,7 +38,7 @@
 #include "uv.h"
 #include "v8.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <unordered_map>

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -16,13 +16,13 @@
 
 #include "libplatform/libplatform.h"
 
-#include <string.h>
+#include <cstring>
 #include <sstream>
 #include <unordered_map>
 #include <vector>
 
 #ifdef __POSIX__
-#include <limits.h>  // PTHREAD_STACK_MIN
+#include <climits>  // PTHREAD_STACK_MIN
 #include <pthread.h>
 #endif  // __POSIX__
 

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -5,7 +5,7 @@
 
 #include <memory>
 
-#include <stddef.h>
+#include <cstddef>
 
 #if !HAVE_INSPECTOR
 #error("This header can only be used when inspector is enabled")

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -13,7 +13,7 @@
 #include "zlib.h"
 
 #include <deque>
-#include <string.h>
+#include <cstring>
 #include <vector>
 
 namespace node {

--- a/src/inspector_io.h
+++ b/src/inspector_io.h
@@ -8,7 +8,7 @@
 #include "uv.h"
 
 #include <memory>
-#include <stddef.h>
+#include <cstddef>
 
 #if !HAVE_INSPECTOR
 #error("This header can only be used when inspector is enabled")

--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -11,7 +11,7 @@
 #include "openssl/sha.h"  // Sha-1 hash
 
 #include <map>
-#include <string.h>
+#include <cstring>
 
 #define ACCEPT_KEY_LENGTH base64_encoded_size(20)
 #define BUFFER_GROWTH_CHUNK_SIZE 1024

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -1,5 +1,5 @@
 #include <algorithm>
-#include <limits.h>  // PATH_MAX
+#include <climits>  // PATH_MAX
 #include <sys/stat.h>  // S_IFDIR
 #include "module_wrap.h"
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -71,13 +71,13 @@
 #include "large_pages/node_large_page.h"
 #endif
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>  // _O_RDWR
-#include <limits.h>  // PATH_MAX
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <climits>  // PATH_MAX
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <sys/types.h>
 
 #include <string>

--- a/src/node.h
+++ b/src/node.h
@@ -178,8 +178,8 @@ NODE_DEPRECATED("Use MakeCallback(..., async_context)",
 
 }  // namespace node
 
-#include <assert.h>
-#include <stdint.h>
+#include <cassert>
+#include <cstdint>
 
 #ifndef NODE_STRINGIFY
 #define NODE_STRINGIFY(n) NODE_STRINGIFY_HELPER(n)

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -31,8 +31,8 @@
 #include "v8-profiler.h"
 #include "v8.h"
 
-#include <string.h>
-#include <limits.h>
+#include <cstring>
+#include <climits>
 
 #define THROW_AND_RETURN_UNLESS_BUFFER(env, obj)                            \
   THROW_AND_RETURN_IF_NOT_BUFFER(env, obj, "argument")                      \

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -24,12 +24,12 @@
 
 #include "zlib.h"
 
-#include <errno.h>
+#include <cerrno>
 #if !defined(_MSC_VER)
 #include <unistd.h>
 #endif
 #include <fcntl.h>
-#include <signal.h>
+#include <csignal>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <limits>

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -37,9 +37,9 @@
 #include "util-inl.h"
 #include "v8.h"
 
-#include <errno.h>
-#include <limits.h>  // INT_MAX
-#include <string.h>
+#include <cerrno>
+#include <climits>  // INT_MAX
+#include <cstring>
 
 #include <algorithm>
 #include <memory>

--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -22,8 +22,8 @@
 #include "node_crypto_bio.h"
 #include "openssl/bio.h"
 #include "util-inl.h"
-#include <limits.h>
-#include <string.h>
+#include <climits>
+#include <cstring>
 
 namespace node {
 namespace crypto {

--- a/src/node_crypto_clienthello.h
+++ b/src/node_crypto_clienthello.h
@@ -24,8 +24,8 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include <stddef.h>  // size_t
-#include <stdint.h>
+#include <cstddef>  // size_t
+#include <cstdint>
 
 namespace node {
 namespace crypto {

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -44,7 +44,7 @@
 
 #include "node_errors.h"
 
-#include <string.h>
+#include <cstring>
 
 namespace node {
 

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -1,5 +1,5 @@
-#include <errno.h>
-#include <stdarg.h>
+#include <cerrno>
+#include <cstdarg>
 
 #include "node_errors.h"
 #include "node_internals.h"

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -36,9 +36,9 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <string.h>
-#include <errno.h>
-#include <limits.h>
+#include <cstring>
+#include <cerrno>
+#include <climits>
 
 #if defined(__MINGW32__) || defined(_MSC_VER)
 # include <io.h>

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -4,7 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 // FIXME(joyeecheung): nghttp2.h needs stdint.h to compile on Windows
-#include <stdint.h>
+#include <cstdint>
 #include "nghttp2/nghttp2.h"
 
 #include "node_http2_state.h"

--- a/src/node_http_parser_impl.h
+++ b/src/node_http_parser_impl.h
@@ -35,8 +35,8 @@
 #include "util-inl.h"
 #include "v8.h"
 
-#include <stdlib.h>  // free()
-#include <string.h>  // strdup(), strchr()
+#include <cstdlib>  // free()
+#include <cstring>  // strdup(), strchr()
 
 #include "http_parser_adaptor.h"
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -34,8 +34,8 @@
 #include "uv.h"
 #include "v8.h"
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 #include <string>
 #include <vector>

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "node.h"
-#include <stdio.h>
+#include <cstdio>
 
 #ifdef _WIN32
 #include <windows.h>

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1,4 +1,4 @@
-#include <errno.h>
+#include <cerrno>
 #include "env-inl.h"
 #include "node_binding.h"
 #include "node_options-inl.h"

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -24,15 +24,15 @@
 #include "util.h"
 
 #include <array>
-#include <errno.h>
-#include <string.h>
+#include <cerrno>
+#include <cstring>
 
 #ifdef __MINGW32__
 # include <io.h>
 #endif  // __MINGW32__
 
 #ifdef __POSIX__
-# include <limits.h>        // PATH_MAX on Solaris.
+# include <climits>         // PATH_MAX on Solaris.
 # include <unistd.h>        // gethostname, sysconf
 #endif  // __POSIX__
 

--- a/src/node_process_events.cc
+++ b/src/node_process_events.cc
@@ -1,4 +1,4 @@
-#include <stdarg.h>
+#include <cstdarg>
 
 #include "env-inl.h"
 #include "node_process.h"

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -15,8 +15,8 @@
 #include "inspector_io.h"
 #endif
 
-#include <limits.h>  // PATH_MAX
-#include <stdio.h>
+#include <climits>  // PATH_MAX
+#include <cstdio>
 
 #if defined(_MSC_VER)
 #include <direct.h>

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -1,4 +1,4 @@
-#include <limits.h>  // PATH_MAX
+#include <climits>  // PATH_MAX
 
 #include "env-inl.h"
 #include "node_internals.h"

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -27,12 +27,12 @@
 #endif
 #include <cxxabi.h>
 #include <dlfcn.h>
-#include <inttypes.h>
+#include <cinttypes>
 #endif
 
 #include <fcntl.h>
-#include <string.h>
-#include <time.h>
+#include <cstring>
+#include <ctime>
 #include <iomanip>
 
 #ifndef _MSC_VER

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -14,8 +14,8 @@
 #include <vector>
 #include "v8.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 #include <sstream>

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -25,8 +25,8 @@
 #include "node_file.h"
 #include "util.h"
 
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 
 namespace node {
 

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -6,7 +6,7 @@
 
 #include <string>
 #include <vector>
-#include <stdio.h>
+#include <cstdio>
 #include <cmath>
 
 namespace node {

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -32,9 +32,9 @@
 #include "brotli/decode.h"
 #include "zlib.h"
 
-#include <errno.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
 #include <sys/types.h>
 #include <atomic>
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -24,8 +24,8 @@
 #include "stream_wrap.h"
 #include "util-inl.h"
 
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 
 namespace node {
 

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -25,7 +25,7 @@
 #include "node_internals.h"
 #include "string_bytes.h"
 
-#include <string.h>
+#include <cstring>
 
 
 namespace node {

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -10,7 +10,7 @@
 #include "util-inl.h"
 #include "v8.h"
 
-#include <limits.h>  // INT_MAX
+#include <climits>  // INT_MAX
 
 namespace node {
 

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -31,8 +31,8 @@
 #include "udp_wrap.h"
 #include "util-inl.h"
 
-#include <string.h>  // memcpy()
-#include <limits.h>  // INT_MAX
+#include <cstring>  // memcpy()
+#include <climits>  // INT_MAX
 
 
 namespace node {

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -27,8 +27,8 @@
 #include "node_errors.h"
 #include "util.h"
 
-#include <limits.h>
-#include <string.h>  // memcpy
+#include <climits>
+#include <cstring>  // memcpy
 
 #include <algorithm>
 #include <vector>

--- a/src/string_search.h
+++ b/src/string_search.h
@@ -9,7 +9,7 @@
 
 #include "util.h"
 
-#include <string.h>
+#include <cstring>
 #include <algorithm>
 
 namespace node {

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -31,7 +31,7 @@
 #include "stream_wrap.h"
 #include "util-inl.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 
 namespace node {

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -2,7 +2,7 @@
 #include "util.h"
 #include "v8.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace node {
 namespace {

--- a/src/tracing/node_trace_writer.cc
+++ b/src/tracing/node_trace_writer.cc
@@ -1,6 +1,6 @@
 #include "tracing/node_trace_writer.h"
 
-#include <string.h>
+#include <cstring>
 #include <fcntl.h>
 
 #include "util-inl.h"

--- a/src/tracing/traced_value.cc
+++ b/src/tracing/traced_value.cc
@@ -6,7 +6,7 @@
 
 #include <cmath>
 #include <sstream>
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 
 #if defined(NODE_HAVE_I18N_SUPPORT)

--- a/src/tracing/traced_value.h
+++ b/src/tracing/traced_value.h
@@ -9,7 +9,7 @@
 #include "util.h"
 #include "v8.h"
 
-#include <stddef.h>
+#include <cstddef>
 #include <memory>
 #include <string>
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <stdio.h>
+#include <cstdio>
 #include <sstream>
 #include "node_buffer.h"
 #include "node_errors.h"

--- a/src/util.h
+++ b/src/util.h
@@ -27,12 +27,12 @@
 #include "node_persistent.h"
 #include "v8.h"
 
-#include <assert.h>
-#include <signal.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cassert>
+#include <csignal>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include <functional>  // std::function
 #include <limits>

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -1,7 +1,7 @@
 #ifndef TEST_CCTEST_NODE_TEST_FIXTURE_H_
 #define TEST_CCTEST_NODE_TEST_FIXTURE_H_
 
-#include <stdlib.h>
+#include <cstdlib>
 #include "gtest/gtest.h"
 #include "node.h"
 #include "node_platform.h"

--- a/test/cctest/test_base64.cc
+++ b/test/cctest/test_base64.cc
@@ -1,7 +1,7 @@
 #include "base64.h"
 
-#include <stddef.h>
-#include <string.h>
+#include <cstddef>
+#include <cstring>
 
 #include "gtest/gtest.h"
 

--- a/test/cctest/test_traced_value.cc
+++ b/test/cctest/test_traced_value.cc
@@ -1,8 +1,8 @@
 #include "tracing/traced_value.h"
 
-#include <math.h>
-#include <stddef.h>
-#include <string.h>
+#include <cmath>
+#include <cstddef>
+#include <cstring>
 
 #include "gtest/gtest.h"
 

--- a/tools/icu/iculslocs.cc
+++ b/tools/icu/iculslocs.cc
@@ -50,12 +50,12 @@ Japanese, it doesn't *claim* to have Japanese.
 
 */
 
-#include "string.h"
+#include <cstring>
 #include "charstr.h"  // ICU internal header
 #include <unicode/ures.h>
 #include <unicode/udata.h>
 #include <unicode/putil.h>
-#include <stdio.h>
+#include <cstdio>
 
 const char* PROG = "iculslocs";
 const char* NAME = U_ICUDATA_NAME;  // assume ICU data


### PR DESCRIPTION
The rule link: https://clang.llvm.org/extra/clang-tidy/checks/modernize-deprecated-headers.html.
#### Summary
> Some headers from C library were deprecated in C++ and are no longer welcome in C++ codebases. Some have no effect in C++. For more details refer to the C++ 14 Standard [depr.c.headers] section.

> This check replaces C standard library headers with their C++ alternatives and removes redundant ones.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
