### PR TITLE
src: track memory retainer fields

### DIFF
--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -241,6 +241,13 @@ void MemoryTracker::Track(const MemoryRetainer* retainer,
   PopNode();
 }
 
+void MemoryTracker::TrackInlineField(const MemoryRetainer* retainer,
+                                     const char* edge_name) {
+  Track(retainer, edge_name);
+  CHECK(CurrentNode());
+  CurrentNode()->size_ -= retainer->SelfSize();
+}
+
 MemoryRetainerNode* MemoryTracker::CurrentNode() const {
   if (node_stack_.empty()) return nullptr;
   return node_stack_.top();

--- a/src/memory_tracker.h
+++ b/src/memory_tracker.h
@@ -197,6 +197,17 @@ class MemoryTracker {
   inline void Track(const MemoryRetainer* retainer,
                     const char* edge_name = nullptr);
 
+  // Useful for parents that do not wish to perform manual
+  // adjustments to its `SelfSize()` when embedding retainer
+  // objects inline.
+  // Put a memory container into the graph, create an edge from
+  // the current node if there is one on the stack - there should
+  // be one, of the container object which the current field is part of.
+  // Reduce the size of memory from the container so as to avoid
+  // duplication in accounting.
+  inline void TrackInlineField(const MemoryRetainer* retainer,
+                               const char* edge_name = nullptr);
+
   inline v8::EmbedderGraph* graph() { return graph_; }
   inline v8::Isolate* isolate() { return isolate_; }
 


### PR DESCRIPTION
If retainers are embedded in retainers, direct tracking
those lead to double tracking. Instead, use the base tracker
to track the field objects.

cc @addaleax [ I should admit that I don't have full understanding of this feature, so let me know if this needs rewrite ]
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
