### PR TITLE
src: simplify InspectorConsoleCall

### DIFF
--- a/lib/internal/util/inspector.js
+++ b/lib/internal/util/inspector.js
@@ -33,7 +33,6 @@ function installConsoleExtensions(commandLineApi) {
 
 // Wrap a console implemented by Node.js with features from the VM inspector
 function wrapConsole(consoleFromNode, consoleFromVM) {
-  const config = {};
   const { consoleCall } = internalBinding('inspector');
   for (const key of Object.keys(consoleFromVM)) {
     // If global console has the same method as inspector console,
@@ -42,8 +41,7 @@ function wrapConsole(consoleFromNode, consoleFromVM) {
     if (consoleFromNode.hasOwnProperty(key)) {
       consoleFromNode[key] = consoleCall.bind(consoleFromNode,
                                               consoleFromVM[key],
-                                              consoleFromNode[key],
-                                              config);
+                                              consoleFromNode[key]);
     } else {
       // Add additional console APIs from the inspector
       consoleFromNode[key] = consoleFromVM[key];

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -402,6 +402,16 @@ inline void Environment::TryLoadAddon(
   }
 }
 
+#if HAVE_INSPECTOR
+inline bool Environment::is_in_inspector_console_call() const {
+  return is_in_inspector_console_call_;
+}
+
+inline void Environment::set_is_in_inspector_console_call(bool value) {
+  is_in_inspector_console_call_ = value;
+}
+#endif
+
 inline Environment::AsyncHooks* Environment::async_hooks() {
   return &async_hooks_;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -857,6 +857,9 @@ class Environment {
   inline inspector::Agent* inspector_agent() const {
     return inspector_agent_.get();
   }
+
+  inline bool is_in_inspector_console_call() const;
+  inline void set_is_in_inspector_console_call(bool value);
 #endif
 
   typedef ListHead<HandleWrap, &HandleWrap::handle_wrap_queue_> HandleWrapQueue;
@@ -1026,6 +1029,7 @@ class Environment {
 
 #if HAVE_INSPECTOR
   std::unique_ptr<inspector::Agent> inspector_agent_;
+  bool is_in_inspector_console_call_ = false;
 #endif
 
   // handle_wrap_queue_ and req_wrap_queue_ needs to be at a fixed offset from

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -149,31 +149,22 @@ void InspectorConsoleCall(const FunctionCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
   Isolate* isolate = env->isolate();
   Local<Context> context = isolate->GetCurrentContext();
-  CHECK_LT(2, info.Length());
-  SlicedArguments call_args(info, /* start */ 3);
+  CHECK_GE(info.Length(), 2);
+  SlicedArguments call_args(info, /* start */ 2);
   if (InspectorEnabled(env)) {
     Local<Value> inspector_method = info[0];
     CHECK(inspector_method->IsFunction());
-    Local<Value> config_value = info[2];
-    CHECK(config_value->IsObject());
-    Local<Object> config_object = config_value.As<Object>();
-    Local<String> in_call_key = FIXED_ONE_BYTE_STRING(isolate, "in_call");
-    bool has_in_call;
-    if (!config_object->Has(context, in_call_key).To(&has_in_call))
-      return;
-    if (!has_in_call) {
-      if (config_object->Set(context,
-                             in_call_key,
-                             v8::True(isolate)).IsNothing() ||
+    if (!env->is_in_inspector_console_call()) {
+      env->set_is_in_inspector_console_call(true);
+      MaybeLocal<Value> ret =
           inspector_method.As<Function>()->Call(context,
                                                 info.Holder(),
                                                 call_args.length(),
-                                                call_args.out()).IsEmpty()) {
+                                                call_args.out());
+      env->set_is_in_inspector_console_call(false);
+      if (ret.IsEmpty())
         return;
-      }
     }
-    if (config_object->Delete(context, in_call_key).IsNothing())
-      return;
   }
 
   Local<Value> node_method = info[1];


### PR DESCRIPTION
Instead of a JS object, set the is-in-console-call flag as
a boolean in C++.

(Based on @joyeecheung’s suggestion in #26113)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
