### PR TITLE
test: fix flaky test-worker-ref-onexit

### DIFF
--- a/test/parallel/test-worker-ref-onexit.js
+++ b/test/parallel/test-worker-ref-onexit.js
@@ -5,6 +5,8 @@ const { Worker } = require('worker_threads');
 // Check that worker.unref() makes the 'exit' event not be emitted, if it is
 // the only thing we would otherwise be waiting for.
 
-const w = new Worker('', { eval: true });
+// Use `setInterval()` to make sure the worker is alive until the end of the
+// event loop turn.
+const w = new Worker('setInterval(() => {}, 100);', { eval: true });
 w.unref();
 w.on('exit', common.mustNotCall());


### PR DESCRIPTION
This was very flaky on AIX (over 10 % failure rate).

Stress test for this PR: https://ci.nodejs.org/job/node-stress-single-test/2158/ (0/359 failures – definitely better than 10 % :))
CI: https://ci.nodejs.org/job/node-test-commit/25940/

Please :+1: this comment to approve fast-tracking.

Fixes: https://github.com/nodejs/node/issues/26167

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
