### PR TITLE
test: increase run time in test-worker-prof

### DIFF
--- a/test/parallel/test-worker-prof.js
+++ b/test/parallel/test-worker-prof.js
@@ -37,6 +37,5 @@ for (const logfile of logfiles) {
   // have been recorded.
   // When running locally on x64 Linux, this number is usually at least 700
   // for both threads, so 15 seems like a very safe threshold.
-  console.log(ticks)
   assert(ticks >= 15, `${ticks} >= 15`);
 }

--- a/test/parallel/test-worker-prof.js
+++ b/test/parallel/test-worker-prof.js
@@ -15,7 +15,7 @@ if (!common.isMainThread)
 if (process.argv[2] === 'child') {
   const spin = `
   const start = Date.now();
-  while (Date.now() - start < 200);
+  while (Date.now() - start < 1000);
   `;
   new Worker(spin, { eval: true });
   eval(spin);
@@ -32,10 +32,11 @@ for (const logfile of logfiles) {
   const lines = fs.readFileSync(logfile, 'utf8').split('\n');
   const ticks = lines.filter((line) => /^tick,/.test(line)).length;
 
-  // Test that at least 20 ticks have been recorded for both parent and child
+  // Test that at least 15 ticks have been recorded for both parent and child
   // threads. When not tracking Worker threads, only 1 or 2 ticks would
   // have been recorded.
-  // When running locally on x64 Linux, this number is usually at least 150
+  // When running locally on x64 Linux, this number is usually at least 700
   // for both threads, so 15 seems like a very safe threshold.
+  console.log(ticks)
   assert(ticks >= 15, `${ticks} >= 15`);
 }


### PR DESCRIPTION
This test has occasionally been failing on Windows since it
was added, with 6 instead of 15 ticks being seen.

Increasing the duration of the test should make it more reliable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
