### PR TITLE
src: move function from header to source file

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -234,6 +234,20 @@ size_t Length(Local<Object> obj) {
 }
 
 
+inline MaybeLocal<Uint8Array> New(Environment* env,
+                                  Local<ArrayBuffer> ab,
+                                  size_t byte_offset,
+                                  size_t length) {
+  CHECK(!env->buffer_prototype_object().IsEmpty());
+  Local<Uint8Array> ui = Uint8Array::New(ab, byte_offset, length);
+  Maybe<bool> mb =
+      ui->SetPrototype(env->context(), env->buffer_prototype_object());
+  if (mb.IsNothing())
+    return MaybeLocal<Uint8Array>();
+  return ui;
+}
+
+
 MaybeLocal<Object> New(Isolate* isolate,
                        Local<String> string,
                        enum encoding enc) {

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -128,20 +128,6 @@ v8::MaybeLocal<v8::Object> New(Environment* env,
 // Mixing operator new and free() is undefined behavior so don't do that.
 v8::MaybeLocal<v8::Object> New(Environment* env, char* data, size_t length);
 
-inline
-v8::MaybeLocal<v8::Uint8Array> New(Environment* env,
-                                   v8::Local<v8::ArrayBuffer> ab,
-                                   size_t byte_offset,
-                                   size_t length) {
-  v8::Local<v8::Uint8Array> ui = v8::Uint8Array::New(ab, byte_offset, length);
-  CHECK(!env->buffer_prototype_object().IsEmpty());
-  v8::Maybe<bool> mb =
-      ui->SetPrototype(env->context(), env->buffer_prototype_object());
-  if (mb.IsNothing())
-    return v8::MaybeLocal<v8::Uint8Array>();
-  return ui;
-}
-
 // Construct a Buffer from a MaybeStackBuffer (and also its subclasses like
 // Utf8Value and TwoByteValue).
 // If |buf| is invalidated, an empty MaybeLocal is returned, and nothing is


### PR DESCRIPTION
This particular Buffer::New() overload used to live in node_internals.h
to work around a cyclic header dependency (IIRC) but that is no longer
necessary.