### PR TITLE
worker: improve integration with native addons (take II)

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -251,6 +251,11 @@ down. If necessary, such hooks can be removed using
 `RemoveEnvironmentCleanupHook()` before they are run, which has the same
 signature.
 
+In order to be loaded from multiple Node.js environments,
+such as a main thread and a Worker thread, an add-on needs to either:
+- Be an N-API addon, or
+- Be declared as context-aware using `NODE_MODULE_INIT()` as described above
+
 ### Building
 
 Once the source code has been written, it must be compiled into the binary

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -363,10 +363,6 @@ Notable differences inside a Worker environment are:
 - Native add-ons can only be loaded from multiple threads if they fulfill
   [certain conditions][Addons worker support].
 
-Currently, the following differences also exist until they are addressed:
-
-- The [`inspector`][] module is not available yet.
-
 Creating `Worker` instances inside of other `Worker`s is possible.
 
 Like [Web Workers][] and the [`cluster` module][], two-way communication can be

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -360,11 +360,12 @@ Notable differences inside a Worker environment are:
   being invoked.
 - IPC channels from parent processes are not accessible.
 - The [`trace_events`][] module is not supported.
+- Native add-ons can only be loaded from multiple threads if they fulfill
+  [certain conditions][Addons worker support].
 
 Currently, the following differences also exist until they are addressed:
 
 - The [`inspector`][] module is not available yet.
-- Native addons are not supported yet.
 
 Creating `Worker` instances inside of other `Worker`s is possible.
 
@@ -602,6 +603,7 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [`worker.postMessage()`]: #worker_threads_worker_postmessage_value_transferlist
 [`worker.terminate()`]: #worker_threads_worker_terminate_callback
 [`worker.threadId`]: #worker_threads_worker_threadid_1
+[Addons worker support]: addons.html#addons_worker_support
 [HTML structured clone algorithm]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 [Signals events]: process.html#process_signal_events
 [Web Workers]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -577,7 +577,6 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [`WebAssembly.Module`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
 [`Worker`]: #worker_threads_class_worker
 [`cluster` module]: cluster.html
-[`inspector`]: inspector.html
 [`port.on('message')`]: #worker_threads_event_message
 [`port.postMessage()`]: #worker_threads_port_postmessage_value_transferlist
 [`process.abort()`]: process.html#process_process_abort

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -484,7 +484,7 @@ void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
 void napi_module_register(napi_module* mod) {
   node::node_module* nm = new node::node_module {
     -1,
-    mod->nm_flags,
+    mod->nm_flags | NM_F_DELETEME,
     nullptr,
     mod->nm_filename,
     nullptr,

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -18,6 +18,7 @@ enum {
   NM_F_BUILTIN = 1 << 0,  // Unused.
   NM_F_LINKED = 1 << 1,
   NM_F_INTERNAL = 1 << 2,
+  NM_F_DELETEME = 1 << 3,
 };
 
 #define NODE_MODULE_CONTEXT_AWARE_CPP(modname, regfunc, priv, flags)           \

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -63,6 +63,8 @@ class DLib {
   bool Open();
   void Close();
   void* GetSymbolAddress(const char* name);
+  void SaveInGlobalHandleMap(node_module* mp);
+  node_module* GetSavedModuleFromGlobalHandleMap();
 
   const std::string filename_;
   const int flags_;
@@ -71,6 +73,7 @@ class DLib {
 #ifndef __POSIX__
   uv_lib_t lib_;
 #endif
+  bool has_entry_in_global_handle_map_ = false;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(DLib);

--- a/test/addons/dlopen-ping-pong/test-worker.js
+++ b/test/addons/dlopen-ping-pong/test-worker.js
@@ -1,5 +1,9 @@
 'use strict';
 const common = require('../../common');
+
+if (common.isWindows)
+  common.skip('dlopen global symbol loading is not supported on this os.');
+
 const assert = require('assert');
 const { Worker } = require('worker_threads');
 

--- a/test/addons/dlopen-ping-pong/test-worker.js
+++ b/test/addons/dlopen-ping-pong/test-worker.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Check that modules that are not declared as context-aware cannot be re-loaded
+// from workers.
+
+const bindingPath = require.resolve(`./build/${common.buildType}/binding`);
+require(bindingPath);
+
+new Worker(`require(${JSON.stringify(bindingPath)})`, { eval: true })
+  .on('error', common.mustCall((err) => {
+    assert.strictEqual(err.constructor, Error);
+    assert.strictEqual(err.message, 'Module did not self-register.');
+  }));

--- a/test/addons/worker-addon/binding.cc
+++ b/test/addons/worker-addon/binding.cc
@@ -21,7 +21,7 @@ struct statically_allocated {
   }
   ~statically_allocated() {
     assert(count == 0);
-    printf("dtor");
+    printf("dtor ");
   }
 } var;
 

--- a/test/addons/worker-addon/test.js
+++ b/test/addons/worker-addon/test.js
@@ -6,21 +6,30 @@ const path = require('path');
 const { Worker } = require('worker_threads');
 const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
 
-if (process.argv[2] === 'worker') {
-  new Worker(`require(${JSON.stringify(binding)});`, { eval: true });
-  return;
-} else if (process.argv[2] === 'main-thread') {
-  process.env.addExtraItemToEventLoop = 'yes';
-  require(binding);
-  return;
+switch (process.argv[2]) {
+  case 'both':
+    require(binding);
+    // fallthrough
+  case 'worker':
+    new Worker(`require(${JSON.stringify(binding)});`, { eval: true });
+    return;
+  case 'main-thread':
+    process.env.addExtraItemToEventLoop = 'yes';
+    require(binding);
+    return;
 }
 
-for (const test of ['worker', 'main-thread']) {
+for (const test of ['worker', 'main-thread', 'both']) {
   const proc = child_process.spawnSync(process.execPath, [
     __filename,
     test
   ]);
   assert.strictEqual(proc.stderr.toString(), '');
-  assert.strictEqual(proc.stdout.toString(), 'ctor cleanup dtor');
+  // We always only have 1 instance of the shared object in memory, so
+  // 1 ctor and 1 dtor call. If we attach the module to 2 Environments,
+  // we expect 2 cleanup calls, otherwise one.
+  assert.strictEqual(
+    proc.stdout.toString(),
+    test === 'both' ? 'ctor cleanup cleanup dtor' : 'ctor cleanup dtor');
   assert.strictEqual(proc.status, 0);
 }

--- a/test/addons/worker-addon/test.js
+++ b/test/addons/worker-addon/test.js
@@ -20,10 +20,12 @@ switch (process.argv[2]) {
 }
 
 for (const test of ['worker', 'main-thread', 'both']) {
+  console.log('spawning test', test);
   const proc = child_process.spawnSync(process.execPath, [
     __filename,
     test
   ]);
+  process.stderr.write(proc.stderr.toString());
   assert.strictEqual(proc.stderr.toString(), '');
   // We always only have 1 instance of the shared object in memory, so
   // 1 ctor and 1 dtor call. If we attach the module to 2 Environments,

--- a/test/node-api/1_hello_world/test.js
+++ b/test/node-api/1_hello_world/test.js
@@ -1,6 +1,8 @@
 'use strict';
 const common = require('../../common');
 const assert = require('assert');
+const { Worker } = require('worker_threads');
+
 const bindingPath = require.resolve(`./build/${common.buildType}/binding`);
 const binding = require(bindingPath);
 assert.strictEqual(binding.hello(), 'world');
@@ -11,3 +13,10 @@ delete require.cache[bindingPath];
 const rebinding = require(bindingPath);
 assert.strictEqual(rebinding.hello(), 'world');
 assert.notStrictEqual(binding.hello, rebinding.hello);
+
+// Test that workers can load addons declared using NAPI_MODULE_INIT().
+new Worker(`
+const { parentPort } = require('worker_threads');
+const msg = require(${JSON.stringify(bindingPath)}).hello();
+parentPort.postMessage(msg)`, { eval: true })
+  .on('message', common.mustCall((msg) => assert.strictEqual(msg, 'world')));

--- a/test/node-api/test_worker_terminate/test.js
+++ b/test/node-api/test_worker_terminate/test.js
@@ -4,6 +4,11 @@ const assert = require('assert');
 const { Worker, isMainThread, workerData } = require('worker_threads');
 
 if (isMainThread) {
+  // Load the addon in the main thread first.
+  // This checks that N-API addons can be loaded from multiple contexts
+  // when they are not loaded through NAPI_MODULE().
+  require(`./build/${common.buildType}/test_worker_terminate`);
+
   const counter = new Int32Array(new SharedArrayBuffer(4));
   const worker = new Worker(__filename, { workerData: { counter } });
   worker.on('exit', common.mustCall(() => {

--- a/test/node-api/test_worker_terminate/test_worker_terminate.c
+++ b/test/node-api/test_worker_terminate/test_worker_terminate.c
@@ -36,4 +36,6 @@ napi_value Init(napi_env env, napi_value exports) {
   return exports;
 }
 
+// Do not start using NAPI_MODULE_INIT() here, so that we can test
+// compatibility of Workers with NAPI_MODULE().
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
Allow loading add-ons from multiple Node.js instances if they are
declared context-aware; in particular, this applies to N-API addons.

Also, plug a memory leak that occurred when registering N-API addons.

Refs: https://github.com/nodejs/node/pull/23319
Fixes: https://github.com/nodejs/node/issues/21481
Fixes: https://github.com/nodejs/node/issues/21783
Fixes: https://github.com/nodejs/node/issues/25662
Fixes: https://github.com/nodejs/node/issues/20239

/cc @nodejs/workers @nodejs/n-api  

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
