### PR TITLE
test: remove unnecessary default tmpdir value in test

### DIFF
--- a/test/parallel/test-pipe-file-to-http.js
+++ b/test/parallel/test-pipe-file-to-http.js
@@ -29,7 +29,7 @@ const path = require('path');
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-const filename = path.join(tmpdir.path || '/tmp', 'big');
+const filename = path.join(tmpdir.path, 'big');
 let count = 0;
 
 const server = http.createServer((req, res) => {


### PR DESCRIPTION
`tmpdir.path` will never be falsy so there is no need to guard against
that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
