### PR TITLE
src: remove `process.binding('config').fipsForced`

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -37,10 +37,8 @@ const {
 const constants = internalBinding('constants').crypto;
 const { getOptionValue } = require('internal/options');
 const pendingDeprecation = getOptionValue('--pending-deprecation');
-const {
-  fipsMode,
-  fipsForced
-} = internalBinding('config');
+const { fipsMode } = internalBinding('config');
+const fipsForced = getOptionValue('--force-fips');
 const { getFipsCrypto, setFipsCrypto } = internalBinding('crypto');
 const {
   randomBytes,

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -40,9 +40,6 @@ static void Initialize(Local<Object> target,
 
 #ifdef NODE_FIPS_MODE
   READONLY_TRUE_PROPERTY(target, "fipsMode");
-  // TODO(addaleax): Use options parser variable instead.
-  if (per_process::cli_options->force_fips_crypto)
-    READONLY_TRUE_PROPERTY(target, "fipsForced");
 #endif
 
 #ifdef NODE_HAVE_I18N_SUPPORT


### PR DESCRIPTION
Instead use `require('internal/options').getOptionValue` to
query to value of `--force-fips`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
