### PR TITLE
build,test: guard eslint with crypto check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1184,8 +1184,12 @@ lint-js-fix:
 # Note that on the CI `lint-js-ci` is run instead.
 # Lints the JavaScript code with eslint.
 lint-js:
-	@echo "Running JS linter..."
-	@$(call available-node,$(run-lint-js))
+	@if [ "$(shell $(node_use_openssl))" != "true" ]; then \
+		echo "Skipping $@ (no crypto)"; \
+	else \
+		echo "Running JS linter..."; \
+		$(call available-node,$(run-lint-js)) \
+	fi
 
 jslint: lint-js
 	@echo "Please use lint-js instead of jslint"

--- a/test/parallel/test-eslint-alphabetize-errors.js
+++ b/test/parallel/test-eslint-alphabetize-errors.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;

--- a/test/parallel/test-eslint-crypto-check.js
+++ b/test/parallel/test-eslint-crypto-check.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-documented-errors.js
+++ b/test/parallel/test-eslint-documented-errors.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;

--- a/test/parallel/test-eslint-duplicate-requires.js
+++ b/test/parallel/test-eslint-duplicate-requires.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-eslint-check.js
+++ b/test/parallel/test-eslint-eslint-check.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-inspector-check.js
+++ b/test/parallel/test-eslint-inspector-check.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;

--- a/test/parallel/test-eslint-lowercase-name-for-primitive.js
+++ b/test/parallel/test-eslint-lowercase-name-for-primitive.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-no-let-in-for-declaration.js
+++ b/test/parallel/test-eslint-no-let-in-for-declaration.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-no-unescaped-regexp-dot.js
+++ b/test/parallel/test-eslint-no-unescaped-regexp-dot.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-number-isnan.js
+++ b/test/parallel/test-eslint-number-isnan.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-prefer-assert-iferror.js
+++ b/test/parallel/test-eslint-prefer-assert-iferror.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-prefer-assert-methods.js
+++ b/test/parallel/test-eslint-prefer-assert-methods.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-prefer-common-expectserror.js
+++ b/test/parallel/test-eslint-prefer-common-expectserror.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-prefer-common-mustnotcall.js
+++ b/test/parallel/test-eslint-prefer-common-mustnotcall.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-prefer-util-format-errors.js
+++ b/test/parallel/test-eslint-prefer-util-format-errors.js
@@ -3,6 +3,8 @@
 /* eslint-disable no-template-curly-in-string */
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-require-buffer.js
+++ b/test/parallel/test-eslint-require-buffer.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-required-modules.js
+++ b/test/parallel/test-eslint-required-modules.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 common.skipIfEslintMissing();
 


### PR DESCRIPTION
Currently, configuring `--without-ssl` will cause the lint-js target to
fail with the following error:
```console
$ make lint-js
Running JS linter...
internal/util.js:101
    throw new ERR_NO_CRYPTO();
    ^

Error [ERR_NO_CRYPTO]:
Node.js is not compiled with OpenSSL crypto support
at assertCrypto (internal/util.js:101:11)
at crypto.js:31:1
...
(/node/tools/node_modules/eslint/node_modules/file-entry-cache/cache.js:2:14)
at Module._compile (internal/modules/cjs/loader.js:746:30)
at Object.Module._extensions..js (internal/modules/cjs/loader.js:757:10)
make: *** [lint-js] Error 1
```
There are also a number of tests that are affected in a similar way.

This commit adds crypto checks to allow for lint-js and the affected
tests to be skipped when configured `--without-ssl`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
