### PR TITLE
crypto: expose crypto.isKeyObject() helper

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1121,6 +1121,9 @@ exposes different functions.
 Most applications should consider using the new `KeyObject` API instead of
 passing keys as strings or `Buffer`s due to improved security features.
 
+See [`crypto.isKeyObject()`][] for checking whether a given input is
+a `KeyObject` instance.
+
 ### keyObject.asymmetricKeyType
 <!-- YAML
 added: v11.6.0
@@ -2068,6 +2071,23 @@ added: v0.9.3
 ```js
 const hashes = crypto.getHashes();
 console.log(hashes); // ['DSA', 'DSA-SHA', 'DSA-SHA1', ...]
+```
+
+### crypto.isKeyObject(value)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `value` {any}
+* Returns: {boolean}
+
+Returns `true` if the value is a [`KeyObject`] instance.
+
+```js
+const crypto = require('crypto');
+const keypair = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+
+crypto.isKeyObject(keypair.privateKey);  // Returns true
 ```
 
 ### crypto.pbkdf2(password, salt, iterations, keylen, digest, callback)

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1913,7 +1913,7 @@ are currently supported.
 
 If a `publicKeyEncoding` or `privateKeyEncoding` was specified, this function
 behaves as if [`keyObject.export()`][] had been called on its result. Otherwise,
-the respective part of the key is returned as a [`KeyObject`].
+the respective part of the key is returned as a [`KeyObject`][].
 
 It is recommended to encode public keys as `'spki'` and private keys as
 `'pkcs8'` with encryption for long-term storage:
@@ -1969,7 +1969,7 @@ are currently supported.
 
 If a `publicKeyEncoding` or `privateKeyEncoding` was specified, this function
 behaves as if [`keyObject.export()`][] had been called on its result. Otherwise,
-the respective part of the key is returned as a [`KeyObject`].
+the respective part of the key is returned as a [`KeyObject`][].
 
 When encoding public keys, it is recommended to use `'spki'`. When encoding
 private keys, it is recommended to use `'pks8'` with a strong passphrase, and to
@@ -2081,7 +2081,7 @@ added: REPLACEME
 * `value` {any}
 * Returns: {boolean}
 
-Returns `true` if the value is a [`KeyObject`] instance.
+Returns `true` if the value is a [`KeyObject`][] instance.
 
 ```js
 const crypto = require('crypto');

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -60,6 +60,7 @@ const {
   generateKeyPairSync
 } = require('internal/crypto/keygen');
 const {
+  isKeyObject,
   createSecretKey,
   createPublicKey,
   createPrivateKey
@@ -164,6 +165,7 @@ module.exports = exports = {
   getHashes,
   pbkdf2,
   pbkdf2Sync,
+  isKeyObject,
   generateKeyPair,
   generateKeyPairSync,
   privateDecrypt,

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -318,6 +318,7 @@ module.exports = {
   createSecretKey,
   createPublicKey,
   createPrivateKey,
+  isKeyObject,
 
   // These are designed for internal use only and should not be exposed.
   parsePublicKeyEncoding,
@@ -327,6 +328,5 @@ module.exports = {
   prepareSecretKey,
   SecretKeyObject,
   PublicKeyObject,
-  PrivateKeyObject,
-  isKeyObject
+  PrivateKeyObject
 };

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -300,3 +300,12 @@ testEncoding({
 testEncoding({
   defaultEncoding: 'latin1'
 }, assertionHashLatin1);
+
+// isKeyObject checks
+assert(crypto.isKeyObject(crypto.createSecretKey(Buffer.from('foo'))));
+const keypair = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+assert(crypto.isKeyObject(keypair.privateKey));
+assert(crypto.isKeyObject(keypair.publicKey));
+[null, undefined, false, 5, 'foo', {}, Buffer].forEach((value) => {
+  assert(!crypto.isKeyObject(value));
+});


### PR DESCRIPTION
Exposes `crypto.isKeyObject` to be able to check that a provided input is a prepared crypto key object from the crypto module add in v11.6.0 (#24234)

This is to get around a dirty practice we have to use now (example below) that allows to use `instanceof`.

```js
const { generateKeyPairSync, createSecretKey } = require('crypto')

const { publicKey, privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' })

const PrivateKeyObject = privateKey.constructor
const PublicKeyObject = publicKey.constructor
const SecretKeyObject = createSecretKey(Buffer.allocUnsafe(1)).constructor

module.exports = { PrivateKeyObject, PublicKeyObject, SecretKeyObject }
```

With this check in place this can be replaced with

```js
const { isKeyObject } = require('crypto')

module.exports.isPrivateKey = (value) => {
  return isKeyObject(value) && value.type === 'private'
}
module.exports.isPublicKey = (value) => {
  return isKeyObject(value) && value.type === 'public'
}
module.exports.isSecretKey = (value) => {
  return isKeyObject(value) && value.type === 'secret'
}
```

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
