### PR TITLE
process: fix calculation in process.uptime()

### DIFF
--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -57,10 +57,8 @@ Mutex umask_mutex;
 
 // Microseconds in a second, as a float, used in CPUUsage() below
 #define MICROS_PER_SEC 1e6
-// used in Hrtime() below
+// used in Hrtime() and Uptime() below
 #define NANOS_PER_SEC 1000000000
-// Used in Uptime()
-#define NANOS_PER_MICROS 1e3
 
 #ifdef _WIN32
 /* MAX_PATH is in characters, not bytes. Make sure we have enough headroom. */
@@ -246,7 +244,7 @@ static void Uptime(const FunctionCallbackInfo<Value>& args) {
   uv_update_time(env->event_loop());
   double uptime =
       static_cast<double>(uv_hrtime() - per_process::node_start_time);
-  Local<Number> result = Number::New(env->isolate(), uptime / NANOS_PER_MICROS);
+  Local<Number> result = Number::New(env->isolate(), uptime / NANOS_PER_SEC);
   args.GetReturnValue().Set(result);
 }
 

--- a/test/parallel/test-process-uptime.js
+++ b/test/parallel/test-process-uptime.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 console.error(process.uptime());

--- a/test/parallel/test-process-uptime.js
+++ b/test/parallel/test-process-uptime.js
@@ -20,18 +20,18 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 console.error(process.uptime());
-assert.ok(process.uptime() <= 2);
+// Add some wiggle room for different platforms.
+// Verify that the returned value is in seconds -
+// 15 seconds should be a good estimate.
+assert.ok(process.uptime() <= 15);
 
 const original = process.uptime();
 
 setTimeout(function() {
   const uptime = process.uptime();
-  // some wiggle room to account for timer
-  // granularity, processor speed, and scheduling
-  assert.ok(uptime >= original + 2);
-  assert.ok(uptime <= original + 3);
-}, 2000);
+  assert.ok(original < uptime);
+}, 10);


### PR DESCRIPTION
#### process: fix calculation in process.uptime()

In https://github.com/nodejs/node/pull/26016 the result returned
by process.uptime() was mistakenly set to be based in the wrong
unit. This patch fixes the calculation and makes sure the returned
value is in seconds.

Refs: https://github.com/nodejs/node/pull/26016
Fixes: https://github.com/nodejs/node/issues/26205

#### process: move test-process-uptime to parallel

In addition, do not make too many assumptions about the startup
time and timer latency in test-process-uptime. Instead only test
that the value is likely in the correct unit (seconds) and it should
be increasing in subsequent calls.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
