### PR TITLE
TLS1.3 support

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -443,21 +443,43 @@ added: v4.0.0
 Specify an alternative default TLS cipher list. Requires Node.js to be built
 with crypto support (default).
 
-### `--tls-v1.0`
+### `--tls-max-v1.2`
 <!-- YAML
 added: REPLACEME
 -->
 
-Enable TLSv1.0 and greater in default [secureProtocol][]. Use for compatibility
-with old TLS clients or servers.
+Set default [`maxVersion`][] to `'TLSv1.2'`. Use to disable support for TLSv1.3.
 
-### `--tls-v1.1`
+### `--tls-max-v1.3`
 <!-- YAML
 added: REPLACEME
 -->
 
-Enable TLSv1.1 and greater in default [secureProtocol][]. Use for compatibility
-with old TLS clients or servers.
+Set default [`maxVersion`][] to `'TLSv1.3'`. Use to enable support for TLSv1.3.
+
+### `--tls-min-v1.0`
+<!-- YAML
+added: REPLACEME
+-->
+
+Set default [`minVersion`][] to `'TLSv1'`. Use for compatibility with old TLS
+clients or servers.
+
+### `--tls-min-v1.1`
+<!-- YAML
+added: REPLACEME
+-->
+
+Set default [`minVersion`][] to `'TLSv1.1'`. Use for compatibility with old TLS
+clients or servers.
+
+### `--tls-min-v1.3`
+<!-- YAML
+added: REPLACEME
+-->
+
+Set default [`minVersion`][] to `'TLSv1.3'`. Use to disable support for TLSv1.2
+in favour of TLSv1.3, which is more secure.
 
 ### `--trace-deprecation`
 <!-- YAML
@@ -896,6 +918,8 @@ greater than `4` (its current default value). For more information, see the
 [`--openssl-config`]: #cli_openssl_config_file
 [`Buffer`]: buffer.html#buffer_class_buffer
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
+[`maxVersion`]: tls.html#tls_tls_createsecurecontext_options
+[`minVersion`]: tls.html#tls_tls_createsecurecontext_options
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
 [REPL]: repl.html
@@ -907,4 +931,3 @@ greater than `4` (its current default value). For more information, see the
 [experimental ECMAScript Module]: esm.html#esm_loader_hooks
 [libuv threadpool documentation]: http://docs.libuv.org/en/latest/threadpool.html
 [remote code execution]: https://www.owasp.org/index.php/Code_Injection
-[secureProtocol]: tls.html#tls_tls_createsecurecontext_options

--- a/doc/node.1
+++ b/doc/node.1
@@ -236,13 +236,23 @@ Specify process.title on startup.
 Specify an alternative default TLS cipher list.
 Requires Node.js to be built with crypto support. (Default)
 .
-.It Fl -tls-v1.0
-Enable TLSv1.0 and greater in default secureProtocol. Use for compatibility
-with old TLS clients or servers.
+.It Fl -tls-max-v1.2
+Set default  maxVersion to 'TLSv1.2'. Use to disable support for TLSv1.3.
 .
-.It Fl -tls-v1.1
-Enable TLSv1.1 and greater in default secureProtocol. Use for compatibility
-with old TLS clients or servers.
+.It Fl -tls-max-v1.3
+Set default  maxVersion to 'TLSv1.3'. Use to enable support for TLSv1.3.
+.
+.It Fl -tls-min-v1.0
+Set default minVersion to 'TLSv1'. Use for compatibility with old TLS clients
+or servers.
+.
+.It Fl -tls-min-v1.1
+Set default minVersion to 'TLSv1.1'. Use for compatibility with old TLS clients
+or servers.
+.
+.It Fl -tls-min-v1.3
+Set default minVersion to 'TLSv1.3'. Use to disable support for TLSv1.2 in
+favour of TLSv1.3, which is more secure.
 .
 .It Fl -trace-deprecation
 Print stack traces for deprecations.

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -27,6 +27,7 @@ const tls = require('tls');
 const {
   ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED,
   ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_OPT_VALUE,
   ERR_TLS_INVALID_PROTOCOL_VERSION,
   ERR_TLS_PROTOCOL_VERSION_CONFLICT,
 } = require('internal/errors').codes;
@@ -35,6 +36,7 @@ const {
   TLS1_VERSION,
   TLS1_1_VERSION,
   TLS1_2_VERSION,
+  TLS1_3_VERSION,
 } = internalBinding('constants').crypto;
 
 // Lazily loaded from internal/crypto/util.
@@ -45,6 +47,7 @@ function toV(which, v, def) {
   if (v === 'TLSv1') return TLS1_VERSION;
   if (v === 'TLSv1.1') return TLS1_1_VERSION;
   if (v === 'TLSv1.2') return TLS1_2_VERSION;
+  if (v === 'TLSv1.3') return TLS1_3_VERSION;
   throw new ERR_TLS_INVALID_PROTOCOL_VERSION(v, which);
 }
 
@@ -148,10 +151,35 @@ exports.createSecureContext = function createSecureContext(options) {
     }
   }
 
-  if (options.ciphers)
-    c.context.setCiphers(options.ciphers);
-  else
-    c.context.setCiphers(tls.DEFAULT_CIPHERS);
+  if (options.ciphers && typeof options.ciphers !== 'string') {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.ciphers', 'string', options.ciphers);
+  }
+
+  // Work around an OpenSSL API quirk. cipherList is for TLSv1.2 and below,
+  // cipherSuites is for TLSv1.3 (and presumably any later versions). TLSv1.3
+  // cipher suites all have a standard name format beginning with TLS_, so split
+  // the ciphers and pass them to the appropriate API.
+  const ciphers = (options.ciphers || tls.DEFAULT_CIPHERS).split(':');
+  const cipherList = ciphers.filter((_) => !_.match(/^TLS_/)).join(':');
+  const cipherSuites = ciphers.filter((_) => _.match(/^TLS_/)).join(':');
+
+  if (cipherSuites === '' && cipherList === '') {
+    // Specifying empty cipher suites for both TLS1.2 and TLS1.3 is invalid, its
+    // not possible to handshake with no suites.
+    throw ERR_INVALID_OPT_VALUE('ciphers', ciphers);
+  }
+
+  c.context.setCipherSuites(cipherSuites);
+  c.context.setCiphers(cipherList);
+
+  if (cipherSuites === '' && c.context.getMaxProto() > TLS1_2_VERSION &&
+      c.context.getMinProto() < TLS1_3_VERSION)
+    c.context.setMaxProto(TLS1_2_VERSION);
+
+  if (cipherList === '' && c.context.getMinProto() < TLS1_3_VERSION &&
+      c.context.getMaxProto() > TLS1_2_VERSION)
+    c.context.setMinProto(TLS1_3_VERSION);
 
   if (options.ecdhCurve === undefined)
     c.context.setECDHCurve(tls.DEFAULT_ECDH_CURVE);

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -65,7 +65,7 @@ let ipServernameWarned = false;
 // Server side times how long a handshake is taking to protect against slow
 // handshakes being used for DoS.
 function onhandshakestart(now) {
-  debug('onhandshakestart');
+  debug('server onhandshakestart');
 
   const { lastHandshakeTime } = this;
   assert(now >= lastHandshakeTime,
@@ -83,6 +83,9 @@ function onhandshakestart(now) {
     this.handshakes++;
 
   const owner = this[owner_symbol];
+
+  assert(owner._tlsOptions.isServer);
+
   if (this.handshakes > tls.CLIENT_RENEG_LIMIT) {
     owner._emitTLSError(new ERR_TLS_SESSION_ATTACK());
     return;
@@ -93,9 +96,10 @@ function onhandshakestart(now) {
 }
 
 function onhandshakedone() {
-  debug('onhandshakedone');
+  debug('server onhandshakedone');
 
   const owner = this[owner_symbol];
+  assert(owner._tlsOptions.isServer);
 
   // `newSession` callback wasn't called yet
   if (owner._newSessionPending) {
@@ -108,10 +112,15 @@ function onhandshakedone() {
 
 
 function loadSession(hello) {
+  debug('server onclienthello',
+        'sessionid.len', hello.sessionId.length,
+        'ticket?', hello.tlsTicket
+  );
   const owner = this[owner_symbol];
 
   var once = false;
   function onSession(err, session) {
+    debug('server resumeSession callback(err %j, sess? %s)', err, !!session);
     if (once)
       return owner.destroy(new ERR_MULTIPLE_CALLBACK());
     once = true;
@@ -193,6 +202,8 @@ function requestOCSP(socket, info) {
 
   let once = false;
   const onOCSP = (err, response) => {
+    debug('server OCSPRequest done', 'handle?', !!socket._handle, 'once?', once,
+          'response?', !!response, 'err?', err);
     if (once)
       return socket.destroy(new ERR_MULTIPLE_CALLBACK());
     once = true;
@@ -208,6 +219,7 @@ function requestOCSP(socket, info) {
     requestOCSPDone(socket);
   };
 
+  debug('server oncertcb emit OCSPRequest');
   socket.server.emit('OCSPRequest',
                      ctx.getCertificate(),
                      ctx.getIssuer(),
@@ -215,16 +227,17 @@ function requestOCSP(socket, info) {
 }
 
 function requestOCSPDone(socket) {
+  debug('server certcb done');
   try {
     socket._handle.certCbDone();
   } catch (e) {
+    debug('server certcb done errored', e);
     socket.destroy(e);
   }
 }
 
-
 function onnewsessionclient(sessionId, session) {
-  debug('client onnewsessionclient', sessionId, session);
+  debug('client emit session');
   const owner = this[owner_symbol];
   owner.emit('session', session);
 }
@@ -233,8 +246,9 @@ function onnewsession(sessionId, session) {
   debug('onnewsession');
   const owner = this[owner_symbol];
 
-  // XXX(sam) no server to emit the event on, but handshake won't continue
-  // unless newSessionDone() is called, should it be?
+  // TODO(@sam-github) no server to emit the event on, but handshake won't
+  // continue unless newSessionDone() is called, should it be, or is that
+  // situation unreachable, or only occurring during shutdown?
   if (!owner.server)
     return;
 
@@ -263,11 +277,15 @@ function onnewsession(sessionId, session) {
 
 
 function onocspresponse(resp) {
+  debug('client onocspresponse');
   this[owner_symbol].emit('OCSPResponse', resp);
 }
 
 function onerror(err) {
   const owner = this[owner_symbol];
+  debug('%s onerror %s had? %j',
+        owner._tlsOptions.isServer ? 'server' : 'client', err,
+        owner._hadError);
 
   if (owner._hadError)
     return;
@@ -285,7 +303,7 @@ function onerror(err) {
     // Ignore server's authorization errors
     owner.destroy();
   } else {
-    // Throw error
+    // Emit error
     owner._emitTLSError(err);
   }
 }
@@ -293,6 +311,11 @@ function onerror(err) {
 // Used by both client and server TLSSockets to start data flowing from _handle,
 // read(0) causes a StreamBase::ReadStart, via Socket._read.
 function initRead(tlsSocket, socket) {
+  debug('%s initRead',
+        tlsSocket._tlsOptions.isServer ? 'server' : 'client',
+        'handle?', !!tlsSocket._handle,
+        'buffered?', !!socket && socket.readableLength
+  );
   // If we were destroyed already don't bother reading
   if (!tlsSocket._handle)
     return;
@@ -493,11 +516,16 @@ TLSSocket.prototype._destroySSL = function _destroySSL() {
   this.ssl = null;
 };
 
+// Constructor guts, arbitrarily factored out.
 TLSSocket.prototype._init = function(socket, wrap) {
   var options = this._tlsOptions;
   var ssl = this._handle;
-
   this.server = options.server;
+
+  debug('%s _init',
+        options.isServer ? 'server' : 'client',
+        'handle?', !!ssl
+  );
 
   // Clients (!isServer) always request a cert, servers request a client cert
   // only on explicit configuration.
@@ -529,7 +557,10 @@ TLSSocket.prototype._init = function(socket, wrap) {
     }
   } else {
     ssl.onhandshakestart = noop;
-    ssl.onhandshakedone = this._finishInit.bind(this);
+    ssl.onhandshakedone = () => {
+      debug('client onhandshakedone');
+      this._finishInit();
+    };
     ssl.onocspresponse = onocspresponse;
 
     if (options.session)
@@ -600,6 +631,11 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
   if (callback !== undefined && typeof callback !== 'function')
     throw new ERR_INVALID_CALLBACK();
 
+  debug('%s renegotiate()',
+        this._tlsOptions.isServer ? 'server' : 'client',
+        'destroyed?', this.destroyed
+  );
+
   if (this.destroyed)
     return;
 
@@ -667,9 +703,25 @@ TLSSocket.prototype._releaseControl = function() {
 };
 
 TLSSocket.prototype._finishInit = function() {
-  debug('secure established');
+  // Guard against getting onhandshakedone() after .destroy().
+  // * 1.2: If destroy() during onocspresponse(), then write of next handshake
+  // record fails, the handshake done info callbacks does not occur, and the
+  // socket closes.
+  // * 1.3: The OCSP response comes in the same record that finishes handshake,
+  // so even after .destroy(), the handshake done info callback occurs
+  // immediately after onocspresponse(). Ignore it.
+  if (!this._handle)
+    return;
+
   this.alpnProtocol = this._handle.getALPNNegotiatedProtocol();
   this.servername = this._handle.getServername();
+
+  debug('%s _finishInit',
+        this._tlsOptions.isServer ? 'server' : 'client',
+        'handle?', !!this._handle,
+        'alpn', this.alpnProtocol,
+        'servername', this.servername);
+
   this._secureEstablished = true;
   if (this._tlsOptions.handshakeTimeout > 0)
     this.setTimeout(0, this._handleTimeout);
@@ -677,6 +729,12 @@ TLSSocket.prototype._finishInit = function() {
 };
 
 TLSSocket.prototype._start = function() {
+  debug('%s _start',
+        this._tlsOptions.isServer ? 'server' : 'client',
+        'handle?', !!this._handle,
+        'connecting?', this.connecting,
+        'requestOCSP?', !!this._tlsOptions.requestOCSP,
+  );
   if (this.connecting) {
     this.once('connect', this._start);
     return;
@@ -686,7 +744,6 @@ TLSSocket.prototype._start = function() {
   if (!this._handle)
     return;
 
-  debug('start');
   if (this._tlsOptions.requestOCSP)
     this._handle.requestOCSP();
   this._handle.start();
@@ -765,13 +822,16 @@ function onServerSocketSecure() {
     }
   }
 
-  if (!this.destroyed && this._releaseControl())
+  if (!this.destroyed && this._releaseControl()) {
+    debug('server emit secureConnection');
     this._tlsOptions.server.emit('secureConnection', this);
+  }
 }
 
 function onSocketTLSError(err) {
   if (!this._controlReleased && !this[kErrorEmitted]) {
     this[kErrorEmitted] = true;
+    debug('server emit tlsClientError:', err);
     this._tlsOptions.server.emit('tlsClientError', err, this);
   }
 }
@@ -792,6 +852,7 @@ function onSocketClose(err) {
 }
 
 function tlsConnectionListener(rawSocket) {
+  debug('net.Server.on(connection): new TLSSocket');
   const socket = new TLSSocket(rawSocket, {
     secureContext: this._sharedCreds,
     isServer: true,
@@ -1180,6 +1241,7 @@ function onConnectSecure() {
   const ekeyinfo = this.getEphemeralKeyInfo();
   if (ekeyinfo.type === 'DH' && ekeyinfo.size < options.minDHSize) {
     const err = new ERR_TLS_DH_PARAM_SIZE(ekeyinfo.size);
+    debug('client emit:', err);
     this.emit('error', err);
     this.destroy();
     return;
@@ -1206,10 +1268,12 @@ function onConnectSecure() {
       this.destroy(verifyError);
       return;
     } else {
+      debug('client emit secureConnect');
       this.emit('secureConnect');
     }
   } else {
     this.authorized = true;
+    debug('client emit secureConnect');
     this.emit('secureConnect');
   }
 

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -30,6 +30,8 @@ const kAfterAsyncWrite = Symbol('kAfterAsyncWrite');
 const kHandle = Symbol('kHandle');
 const kSession = Symbol('kSession');
 
+const debug = require('util').debuglog('stream');
+
 function handleWriteReq(req, data, encoding) {
   const { handle } = req;
 
@@ -66,6 +68,8 @@ function handleWriteReq(req, data, encoding) {
 }
 
 function onWriteComplete(status) {
+  debug('onWriteComplete', status, this.error);
+
   const stream = this.handle[owner_symbol];
 
   if (stream.destroyed) {

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -54,14 +54,24 @@ exports.DEFAULT_CIPHERS =
 
 exports.DEFAULT_ECDH_CURVE = 'auto';
 
-exports.DEFAULT_MAX_VERSION = 'TLSv1.2';
+exports.DEFAULT_MAX_VERSION = 'TLSv1.3';
 
-if (getOptionValue('--tls-v1.0'))
+if (getOptionValue('--tls-min-v1.0'))
   exports.DEFAULT_MIN_VERSION = 'TLSv1';
-else if (getOptionValue('--tls-v1.1'))
+else if (getOptionValue('--tls-min-v1.1'))
   exports.DEFAULT_MIN_VERSION = 'TLSv1.1';
+else if (getOptionValue('--tls-min-v1.3'))
+  exports.DEFAULT_MIN_VERSION = 'TLSv1.3';
 else
   exports.DEFAULT_MIN_VERSION = 'TLSv1.2';
+
+if (getOptionValue('--tls-max-v1.3'))
+  exports.DEFAULT_MAX_VERSION = 'TLSv1.3';
+else if (getOptionValue('--tls-max-v1.2'))
+  exports.DEFAULT_MAX_VERSION = 'TLSv1.2';
+else
+  exports.DEFAULT_MAX_VERSION = 'TLSv1.3'; // Will depend on node version.
+
 
 exports.getCiphers = internalUtil.cachedResult(
   () => internalUtil.filterDuplicateStrings(binding.getSSLCiphers(), true)

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1245,6 +1245,7 @@ void DefineCryptoConstants(Local<Object> target) {
   NODE_DEFINE_CONSTANT(target, TLS1_VERSION);
   NODE_DEFINE_CONSTANT(target, TLS1_1_VERSION);
   NODE_DEFINE_CONSTANT(target, TLS1_2_VERSION);
+  NODE_DEFINE_CONSTANT(target, TLS1_3_VERSION);
 #endif
   NODE_DEFINE_CONSTANT(target, INT_MAX);
 }

--- a/src/node_constants.h
+++ b/src/node_constants.h
@@ -41,7 +41,13 @@
 #define RSA_PSS_SALTLEN_AUTO -2
 #endif
 
-#define DEFAULT_CIPHER_LIST_CORE "ECDHE-RSA-AES128-GCM-SHA256:"     \
+// TLSv1.3 suites start with TLS_, and are the OpenSSL defaults, see:
+//   https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_ciphersuites.html
+#define DEFAULT_CIPHER_LIST_CORE \
+                                 "TLS_AES_256_GCM_SHA384:"          \
+                                 "TLS_CHACHA20_POLY1305_SHA256:"    \
+                                 "TLS_AES_128_GCM_SHA256:"          \
+                                 "ECDHE-RSA-AES128-GCM-SHA256:"     \
                                  "ECDHE-ECDSA-AES128-GCM-SHA256:"   \
                                  "ECDHE-RSA-AES256-GCM-SHA384:"     \
                                  "ECDHE-ECDSA-AES256-GCM-SHA384:"   \

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -147,6 +147,7 @@ class SecureContext : public BaseObject {
   static void AddCACert(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddCRL(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddRootCerts(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetCipherSuites(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetCiphers(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetECDHCurve(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetDHParam(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -155,6 +156,10 @@ class SecureContext : public BaseObject {
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetSessionTimeout(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetMinProto(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetMaxProto(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetMinProto(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetMaxProto(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Close(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void LoadPKCS12(const v8::FunctionCallbackInfo<v8::Value>& args);
 #ifndef OPENSSL_NO_ENGINE

--- a/src/node_crypto_clienthello.cc
+++ b/src/node_crypto_clienthello.cc
@@ -86,6 +86,8 @@ void ClientHelloParser::ParseHeader(const uint8_t* data, size_t avail) {
   // (3,2) TLS v1.1
   // (3,3) TLS v1.2
   //
+  // Note that TLS v1.3 uses a TLS v1.2 handshake so requires no specific
+  // support here.
   if (data[body_offset_ + 4] != 0x03 ||
       data[body_offset_ + 5] < 0x01 ||
       data[body_offset_ + 5] > 0x03) {

--- a/src/node_crypto_clienthello.h
+++ b/src/node_crypto_clienthello.h
@@ -33,6 +33,12 @@ namespace crypto {
 // Parse the client hello so we can do async session resumption. OpenSSL's
 // session resumption uses synchronous callbacks, see SSL_CTX_sess_set_get_cb
 // and get_session_cb.
+//
+// TLS1.3 handshakes masquerade as TLS1.2 session resumption, and to do this,
+// they always include a session_id in the ClientHello, making up a bogus value
+// if necessary. The parser can't know if its a bogus id, and will cause a
+// 'newSession' event to be emitted. This should do no harm, the id won't be
+// found, and the handshake will continue.
 class ClientHelloParser {
  public:
   inline ClientHelloParser();

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -335,16 +335,30 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
 
   AddOption("--napi-modules", "", NoOp{}, kAllowedInEnvironment);
 
-#if HAVE_OPENSSL
-  AddOption("--tls-v1.0",
-            "enable TLSv1.0 and greater by default",
-            &EnvironmentOptions::tls_v1_0,
+  AddOption("--tls-min-v1.0",
+            "set default TLS minimum to TLSv1.0 (default: TLSv1.2)",
+            &EnvironmentOptions::tls_min_v1_0,
             kAllowedInEnvironment);
-  AddOption("--tls-v1.1",
-            "enable TLSv1.1 and greater by default",
-            &EnvironmentOptions::tls_v1_1,
+  AddOption("--tls-min-v1.1",
+            "set default TLS minimum to TLSv1.1 (default: TLSv1.2)",
+            &EnvironmentOptions::tls_min_v1_1,
             kAllowedInEnvironment);
-#endif
+  AddOption("--tls-min-v1.3",
+            "set default TLS minimum to TLSv1.3 (default: TLSv1.2)",
+            &EnvironmentOptions::tls_min_v1_3,
+            kAllowedInEnvironment);
+  AddOption("--tls-max-v1.2",
+            "set default TLS maximum to TLSv1.2 (default: TLSv1.3)",
+            &EnvironmentOptions::tls_max_v1_2,
+            kAllowedInEnvironment);
+  // Current plan is:
+  // - 11.x and below: TLS1.3 is opt-in with --tls-max-v1.3
+  // - 12.x: TLS1.3 is opt-out with --tls-max-v1.2
+  // In either case, support both options they are uniformly available.
+  AddOption("--tls-max-v1.3",
+            "set default TLS maximum to TLSv1.3 (default: TLSv1.3)",
+            &EnvironmentOptions::tls_max_v1_3,
+            kAllowedInEnvironment);
 }
 
 PerIsolateOptionsParser::PerIsolateOptionsParser(

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -121,10 +121,11 @@ class EnvironmentOptions : public Options {
   bool print_eval = false;
   bool force_repl = false;
 
-#if HAVE_OPENSSL
-  bool tls_v1_0 = false;
-  bool tls_v1_1 = false;
-#endif
+  bool tls_min_v1_0 = false;
+  bool tls_min_v1_1 = false;
+  bool tls_min_v1_3 = false;
+  bool tls_max_v1_2 = false;
+  bool tls_max_v1_3 = false;
 
   std::vector<std::string> preload_modules;
 

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -173,6 +173,7 @@ class TLSWrap : public AsyncWrap,
   std::vector<uv_buf_t> pending_cleartext_input_;
   size_t write_size_ = 0;
   WriteWrap* current_write_ = nullptr;
+  bool in_dowrite_ = false;
   WriteWrap* current_empty_write_ = nullptr;
   bool write_callback_scheduled_ = false;
   bool started_ = false;

--- a/test/async-hooks/test-graph.tls-write-12.js
+++ b/test/async-hooks/test-graph.tls-write-12.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const tls = require('tls');
+
+tls.DEFAULT_MAX_VERSION = 'TLSv1.2';
+
+require('./test-graph.tls-write.js');

--- a/test/async-hooks/test-graph.tls-write.js
+++ b/test/async-hooks/test-graph.tls-write.js
@@ -39,8 +39,10 @@ function onlistening() {
 function onsecureConnection() {}
 
 function onsecureConnect() {
-  // Destroying client socket
-  this.destroy();
+  // end() client socket, which causes slightly different hook events than
+  // destroy(), but with TLS1.3 destroy() rips the connection down before the
+  // server completes the handshake.
+  this.end();
 
   // Closing server
   server.close(common.mustCall(onserverClosed));
@@ -68,7 +70,8 @@ function onexit() {
       { type: 'WRITEWRAP', id: 'write:2', triggerAsyncId: null },
       { type: 'WRITEWRAP', id: 'write:3', triggerAsyncId: null },
       { type: 'WRITEWRAP', id: 'write:4', triggerAsyncId: null },
-      { type: 'Immediate', id: 'immediate:1', triggerAsyncId: 'tcp:1' },
-      { type: 'Immediate', id: 'immediate:2', triggerAsyncId: 'tcp:2' } ]
+      { type: 'Immediate', id: 'immediate:1', triggerAsyncId: 'tcp:2' },
+      { type: 'Immediate', id: 'immediate:2', triggerAsyncId: 'tcp:1' },
+    ]
   );
 }

--- a/test/async-hooks/test-tlswrap.js
+++ b/test/async-hooks/test-tlswrap.js
@@ -15,6 +15,10 @@ const { checkInvocations } = require('./hook-checks');
 const hooks = initHooks();
 hooks.enable();
 
+// TODO(@sam-github) assumes server handshake completes before client, true for
+// 1.2, not for 1.3. Might need a rewrite for TLS1.3.
+tls.DEFAULT_MAX_VERSION = 'TLSv1.2';
+
 //
 // Creating server and listening on port
 //
@@ -52,6 +56,7 @@ function onsecureConnection() {
   //
   const as = hooks.activitiesOfTypes('TLSWRAP');
   assert.strictEqual(as.length, 2);
+  // TODO(@sam-github) This happens after onsecureConnect, with TLS1.3.
   client = as[1];
   assert.strictEqual(client.type, 'TLSWRAP');
   assert.strictEqual(typeof client.uid, 'number');
@@ -78,7 +83,7 @@ function onsecureConnect() {
   //
   // Destroying client socket
   //
-  this.destroy();
+  this.destroy();  // This destroys client before server handshakes, with TLS1.3
   checkInvocations(svr, { init: 1, before: 2, after: 1 },
                    'server: when destroying client');
   checkInvocations(client, { init: 1, before: 2, after: 2 },

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -129,6 +129,7 @@ validateList(cryptoCiphers);
 // Assume that we have at least AES256-SHA.
 const tlsCiphers = tls.getCiphers();
 assert(tls.getCiphers().includes('aes256-sha'));
+assert(tls.getCiphers().includes('tls_aes_128_ccm_8_sha256'));
 // There should be no capital letters in any element.
 const noCapitals = /^[^A-Z]+$/;
 assert(tlsCiphers.every((value) => noCapitals.test(value)));

--- a/test/parallel/test-https-agent-additional-options.js
+++ b/test/parallel/test-https-agent-additional-options.js
@@ -1,4 +1,4 @@
-// Flags: --tls-v1.1
+// Flags: --tls-min-v1.1
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto)

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -1,4 +1,4 @@
-// Flags: --tls-v1.0
+// Flags: --tls-min-v1.0
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-https-client-renegotiation-limit.js
+++ b/test/parallel/test-https-client-renegotiation-limit.js
@@ -32,6 +32,9 @@ const tls = require('tls');
 const https = require('https');
 const fixtures = require('../common/fixtures');
 
+// Renegotiation as a protocol feature was dropped after TLS1.2.
+tls.DEFAULT_MAX_VERSION = 'TLSv1.2';
+
 // renegotiation limits to test
 const LIMITS = [0, 1, 2, 3, 5, 10, 16];
 

--- a/test/parallel/test-https-client-resume.js
+++ b/test/parallel/test-https-client-resume.js
@@ -55,7 +55,8 @@ server.listen(0, common.mustCall(function() {
                   '\r\n');
   }));
 
-  client1.on('session', common.mustCall((session) => {
+  // TLS1.2 servers issue 1 ticket, TLS1.3 issues more, but only use the first.
+  client1.once('session', common.mustCall((session) => {
     console.log('session');
 
     const opts = {

--- a/test/parallel/test-tls-alert-handling.js
+++ b/test/parallel/test-tls-alert-handling.js
@@ -64,7 +64,7 @@ function sendClient() {
     }
     client.end();
   }, max_iter));
-  client.write('a');
+  client.write('a', common.mustCall());
   client.on('error', common.mustNotCall());
   client.on('close', common.mustCall(function() {
     clientClosed = true;

--- a/test/parallel/test-tls-async-cb-after-socket-end.js
+++ b/test/parallel/test-tls-async-cb-after-socket-end.js
@@ -14,7 +14,6 @@ const tls = require('tls');
 // new and resume session events will never be emitted on the server.
 
 const options = {
-  maxVersion: 'TLSv1.2',
   secureOptions: SSL_OP_NO_TICKET,
   key: fixtures.readSync('test_key.pem'),
   cert: fixtures.readSync('test_cert.pem')
@@ -38,6 +37,10 @@ server.on('resumeSession', common.mustCall((id, cb) => {
 
 server.listen(0, common.mustCall(() => {
   const clientOpts = {
+    // Don't send a TLS1.3/1.2 ClientHello, they contain a fake session_id,
+    // which triggers a 'resumeSession' event for client1. TLS1.2 ClientHello
+    // won't have a session_id until client2, which will have a valid session.
+    maxVersion: 'TLSv1.2',
     port: server.address().port,
     rejectUnauthorized: false,
     session: false

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -12,7 +12,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'Ciphers must be a string'
+    message: 'The "options.ciphers" property must be of type string.' +
+      ' Received type number'
   });
 
 common.expectsError(
@@ -20,7 +21,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'Ciphers must be a string'
+    message: 'The "options.ciphers" property must be of type string.' +
+      ' Received type number'
   });
 
 common.expectsError(

--- a/test/parallel/test-tls-cli-max-version-1.2.js
+++ b/test/parallel/test-tls-cli-max-version-1.2.js
@@ -1,15 +1,15 @@
-// Flags: --tls-min-v1.1
+// Flags: --tls-max-v1.2
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto) common.skip('missing crypto');
 
-// Check that node `--tls-v1.1` is supported.
+// Check that node `--tls-max-v1.2` is supported.
 
 const assert = require('assert');
 const tls = require('tls');
 
-assert.strictEqual(tls.DEFAULT_MAX_VERSION, 'TLSv1.3');
-assert.strictEqual(tls.DEFAULT_MIN_VERSION, 'TLSv1.1');
+assert.strictEqual(tls.DEFAULT_MAX_VERSION, 'TLSv1.2');
+assert.strictEqual(tls.DEFAULT_MIN_VERSION, 'TLSv1.2');
 
 // Check the min-max version protocol versions against these CLI settings.
 require('./test-tls-min-max-version.js');

--- a/test/parallel/test-tls-cli-max-version-1.3.js
+++ b/test/parallel/test-tls-cli-max-version-1.3.js
@@ -1,15 +1,15 @@
-// Flags: --tls-min-v1.1
+// Flags: --tls-max-v1.3
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto) common.skip('missing crypto');
 
-// Check that node `--tls-v1.1` is supported.
+// Check that node `--tls-max-v1.3` is supported.
 
 const assert = require('assert');
 const tls = require('tls');
 
 assert.strictEqual(tls.DEFAULT_MAX_VERSION, 'TLSv1.3');
-assert.strictEqual(tls.DEFAULT_MIN_VERSION, 'TLSv1.1');
+assert.strictEqual(tls.DEFAULT_MIN_VERSION, 'TLSv1.2');
 
 // Check the min-max version protocol versions against these CLI settings.
 require('./test-tls-min-max-version.js');

--- a/test/parallel/test-tls-cli-min-version-1.0.js
+++ b/test/parallel/test-tls-cli-min-version-1.0.js
@@ -1,4 +1,4 @@
-// Flags: --tls-v1.0 --tls-v1.1
+// Flags: --tls-min-v1.0 --tls-min-v1.1
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto) common.skip('missing crypto');
@@ -8,7 +8,7 @@ if (!common.hasCrypto) common.skip('missing crypto');
 const assert = require('assert');
 const tls = require('tls');
 
-assert.strictEqual(tls.DEFAULT_MAX_VERSION, 'TLSv1.2');
+assert.strictEqual(tls.DEFAULT_MAX_VERSION, 'TLSv1.3');
 assert.strictEqual(tls.DEFAULT_MIN_VERSION, 'TLSv1');
 
 // Check the min-max version protocol versions against these CLI settings.

--- a/test/parallel/test-tls-cli-min-version-1.3.js
+++ b/test/parallel/test-tls-cli-min-version-1.3.js
@@ -1,15 +1,15 @@
-// Flags: --tls-min-v1.1
+// Flags: --tls-min-v1.3
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto) common.skip('missing crypto');
 
-// Check that node `--tls-v1.1` is supported.
+// Check that node `--tls-min-v1.3` is supported.
 
 const assert = require('assert');
 const tls = require('tls');
 
 assert.strictEqual(tls.DEFAULT_MAX_VERSION, 'TLSv1.3');
-assert.strictEqual(tls.DEFAULT_MIN_VERSION, 'TLSv1.1');
+assert.strictEqual(tls.DEFAULT_MIN_VERSION, 'TLSv1.3');
 
 // Check the min-max version protocol versions against these CLI settings.
 require('./test-tls-min-max-version.js');

--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -10,6 +10,9 @@ const tls = require('tls');
 const key = fixtures.readKey('agent2-key.pem');
 const cert = fixtures.readKey('agent2-cert.pem');
 
+// TODO(@sam-github) test works with TLS1.3, rework test to add
+//   'ECDH' with 'TLS_AES_128_GCM_SHA256',
+
 function loadDHParam(n) {
   return fixtures.readKey(`dh${n}.pem`);
 }

--- a/test/parallel/test-tls-client-reject-12.js
+++ b/test/parallel/test-tls-client-reject-12.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// test-tls-client-reject specifically for TLS1.2.
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const tls = require('tls');
+
+tls.DEFAULT_MAX_VERSION = 'TLSv1.2';
+
+require('./test-tls-client-reject.js');

--- a/test/parallel/test-tls-client-renegotiation-13.js
+++ b/test/parallel/test-tls-client-renegotiation-13.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+// Confirm that for TLSv1.3, renegotiate() is disallowed.
+
+const {
+  assert, connect, keys
+} = require(fixtures.path('tls-connect'));
+
+const server = keys.agent10;
+
+connect({
+  client: {
+    ca: server.ca,
+    checkServerIdentity: common.mustCall(),
+  },
+  server: {
+    key: server.key,
+    cert: server.cert,
+  },
+}, function(err, pair, cleanup) {
+  assert.ifError(err);
+
+  const client = pair.client.conn;
+
+  assert.strictEqual(client.getProtocol(), 'TLSv1.3');
+
+  const ok = client.renegotiate({}, common.mustCall((err) => {
+    assert(err.code, 'ERR_TLS_RENEGOTIATE');
+    assert(err.message, 'Attempt to renegotiate TLS session failed');
+    cleanup();
+  }));
+
+  assert.strictEqual(ok, false);
+});

--- a/test/parallel/test-tls-client-renegotiation-limit.js
+++ b/test/parallel/test-tls-client-renegotiation-limit.js
@@ -31,6 +31,9 @@ const assert = require('assert');
 const tls = require('tls');
 const fixtures = require('../common/fixtures');
 
+// Renegotiation as a protocol feature was dropped after TLS1.2.
+tls.DEFAULT_MAX_VERSION = 'TLSv1.2';
+
 // renegotiation limits to test
 const LIMITS = [0, 1, 2, 3, 5, 10, 16];
 

--- a/test/parallel/test-tls-client-resume-12.js
+++ b/test/parallel/test-tls-client-resume-12.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// test-tls-client-resume specifically for TLS1.2.
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const tls = require('tls');
+
+tls.DEFAULT_MAX_VERSION = 'TLSv1.2';
+
+require('./test-tls-client-resume.js');

--- a/test/parallel/test-tls-client-resume.js
+++ b/test/parallel/test-tls-client-resume.js
@@ -44,32 +44,59 @@ const server = tls.Server(options, common.mustCall((socket) => {
 
 // start listening
 server.listen(0, common.mustCall(function() {
-
-  let sessionx = null;
-  let session1 = null;
+  let sessionx = null; // From right after connect, invalid for TLS1.3
+  let session1 = null; // Delivered by the session event, always valid.
+  let sessions = 0;
+  let tls13;
   const client1 = tls.connect({
     port: this.address().port,
     rejectUnauthorized: false
   }, common.mustCall(() => {
-    console.log('connect1');
+    tls13 = client1.getProtocol() === 'TLSv1.3';
     assert.strictEqual(client1.isSessionReused(), false);
     sessionx = client1.getSession();
+    assert(sessionx);
+
+    if (session1)
+      reconnect();
+  }));
+
+  client1.on('data', common.mustCall((d) => {
   }));
 
   client1.once('session', common.mustCall((session) => {
     console.log('session1');
     session1 = session;
+    assert(session1);
+    if (sessionx)
+      reconnect();
   }));
 
-  client1.on('close', common.mustCall(() => {
+  client1.on('session', () => {
+    console.log('client1 session#', ++sessions);
+  });
+
+  client1.on('close', () => {
+    console.log('client1 close');
+    assert.strictEqual(sessions, tls13 ? 2 : 1);
+  });
+
+  function reconnect() {
     assert(sessionx);
     assert(session1);
-    assert.strictEqual(sessionx.compare(session1), 0);
+    if (tls13)
+      // For TLS1.3, the session immediately after handshake is a dummy,
+      // unresumable session. The one delivered later in session event is
+      // resumable.
+      assert.notStrictEqual(sessionx.compare(session1), 0);
+    else
+      // For TLS1.2, they are identical.
+      assert.strictEqual(sessionx.compare(session1), 0);
 
     const opts = {
       port: server.address().port,
       rejectUnauthorized: false,
-      session: session1
+      session: session1,
     };
 
     const client2 = tls.connect(opts, common.mustCall(() => {
@@ -83,7 +110,7 @@ server.listen(0, common.mustCall(function() {
     }));
 
     client2.resume();
-  }));
+  }
 
   client1.resume();
 }));

--- a/test/parallel/test-tls-destroy-stream-12.js
+++ b/test/parallel/test-tls-destroy-stream-12.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// test-tls-destroy-stream specifically for TLS1.2.
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const tls = require('tls');
+
+tls.DEFAULT_MAX_VERSION = 'TLSv1.2';
+
+require('./test-tls-destroy-stream.js');

--- a/test/parallel/test-tls-disable-renegotiation.js
+++ b/test/parallel/test-tls-disable-renegotiation.js
@@ -10,6 +10,9 @@ if (!common.hasCrypto)
 
 const tls = require('tls');
 
+// Renegotiation as a protocol feature was dropped after TLS1.2.
+tls.DEFAULT_MAX_VERSION = 'TLSv1.2';
+
 const options = {
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem'),
@@ -86,5 +89,9 @@ server.listen(0, common.mustCall(() => {
       }));
     }));
     assert.strictEqual(ok, true);
+    client.on('secureConnect', common.mustCall(() => {
+    }));
+    client.on('secure', common.mustCall(() => {
+    }));
   }));
 }));

--- a/test/parallel/test-tls-getcipher.js
+++ b/test/parallel/test-tls-getcipher.js
@@ -60,12 +60,33 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
   tls.connect({
     host: '127.0.0.1',
     port: this.address().port,
-    cipher: 'ECDHE-RSA-AES128-GCM-SHA256',
+    ciphers: 'ECDHE-RSA-AES128-GCM-SHA256',
     rejectUnauthorized: false
   }, common.mustCall(function() {
     const cipher = this.getCipher();
     assert.strictEqual(cipher.name, 'ECDHE-RSA-AES128-GCM-SHA256');
     assert.strictEqual(cipher.version, 'TLSv1.2');
     this.end();
+  }));
+}));
+
+tls.createServer({
+  key: fixtures.readKey('agent2-key.pem'),
+  cert: fixtures.readKey('agent2-cert.pem'),
+  ciphers: 'TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_CCM_8_SHA256',
+  maxVersion: 'TLSv1.3',
+}, common.mustCall(function() {
+  this.close();
+})).listen(0, common.mustCall(function() {
+  const client = tls.connect({
+    port: this.address().port,
+    ciphers: 'TLS_AES_128_CCM_8_SHA256',
+    maxVersion: 'TLSv1.3',
+    rejectUnauthorized: false
+  }, common.mustCall(() => {
+    const cipher = client.getCipher();
+    assert.strictEqual(cipher.name, 'TLS_AES_128_CCM_8_SHA256');
+    assert.strictEqual(cipher.version, 'TLSv1.3');
+    client.end();
   }));
 }));

--- a/test/parallel/test-tls-min-max-version.js
+++ b/test/parallel/test-tls-min-max-version.js
@@ -13,6 +13,10 @@ const DEFAULT_MAX_VERSION = tls.DEFAULT_MAX_VERSION;
 
 function test(cmin, cmax, cprot, smin, smax, sprot, proto, cerr, serr) {
   assert(proto || cerr || serr, 'test missing any expectations');
+  // Report where test was called from. Strip leading garbage from
+  //     at Object.<anonymous> (file:line)
+  // from the stack location, we only want the file:line part.
+  const where = (new Error()).stack.split('\n')[2].replace(/[^(]*/, '');
   connect({
     client: {
       checkServerIdentity: (servername, cert) => { },
@@ -32,6 +36,7 @@ function test(cmin, cmax, cprot, smin, smax, sprot, proto, cerr, serr) {
     function u(_) { return _ === undefined ? 'U' : _; }
     console.log('test:', u(cmin), u(cmax), u(cprot), u(smin), u(smax), u(sprot),
                 'expect', u(proto), u(cerr), u(serr));
+    console.log('  ', where);
     if (!proto) {
       console.log('client', pair.client.err ? pair.client.err.code : undefined);
       console.log('server', pair.server.err ? pair.server.err.code : undefined);
@@ -64,8 +69,8 @@ function test(cmin, cmax, cprot, smin, smax, sprot, proto, cerr, serr) {
 
 const U = undefined;
 
-// Default protocol is TLSv1.2.
-test(U, U, U, U, U, U, 'TLSv1.2');
+// Default protocol is the max version.
+test(U, U, U, U, U, U, DEFAULT_MAX_VERSION);
 
 // Insecure or invalid protocols cannot be enabled.
 test(U, U, U, U, U, 'SSLv2_method',
@@ -101,7 +106,23 @@ test(U, U, 'TLS_method', U, U, 'TLSv1_method', 'TLSv1');
 
 // SSLv23 also means "any supported protocol" greater than the default
 // minimum (which is configurable via command line).
-test(U, U, 'TLSv1_2_method', U, U, 'SSLv23_method', 'TLSv1.2');
+if (DEFAULT_MIN_VERSION === 'TLSv1.3') {
+  test(U, U, 'TLSv1_2_method', U, U, 'SSLv23_method',
+       U, 'ECONNRESET', 'ERR_SSL_INTERNAL_ERROR');
+} else {
+  test(U, U, 'TLSv1_2_method', U, U, 'SSLv23_method', 'TLSv1.2');
+}
+
+if (DEFAULT_MIN_VERSION === 'TLSv1.3') {
+  test(U, U, 'TLSv1_1_method', U, U, 'SSLv23_method',
+       U, 'ECONNRESET', 'ERR_SSL_INTERNAL_ERROR');
+  test(U, U, 'TLSv1_method', U, U, 'SSLv23_method',
+       U, 'ECONNRESET', 'ERR_SSL_INTERNAL_ERROR');
+  test(U, U, 'SSLv23_method', U, U, 'TLSv1_1_method',
+       U, 'ERR_SSL_NO_PROTOCOLS_AVAILABLE', 'ERR_SSL_UNEXPECTED_MESSAGE');
+  test(U, U, 'SSLv23_method', U, U, 'TLSv1_method',
+       U, 'ERR_SSL_NO_PROTOCOLS_AVAILABLE', 'ERR_SSL_UNEXPECTED_MESSAGE');
+}
 
 if (DEFAULT_MIN_VERSION === 'TLSv1.2') {
   test(U, U, 'TLSv1_1_method', U, U, 'SSLv23_method',
@@ -149,7 +170,11 @@ if (DEFAULT_MIN_VERSION === 'TLSv1.2') {
     test(U, U, U, U, U, 'TLSv1_method',
          U, 'ERR_SSL_UNSUPPORTED_PROTOCOL', 'ERR_SSL_WRONG_VERSION_NUMBER');
   } else {
-    assert(false, 'unreachable');
+    // TLS1.3 client hellos are are not understood by TLS1.1 or below.
+    test(U, U, U, U, U, 'TLSv1_1_method',
+         U, 'ECONNRESET', 'ERR_SSL_UNSUPPORTED_PROTOCOL');
+    test(U, U, U, U, U, 'TLSv1_method',
+         U, 'ECONNRESET', 'ERR_SSL_UNSUPPORTED_PROTOCOL');
   }
 }
 
@@ -164,7 +189,9 @@ if (DEFAULT_MIN_VERSION === 'TLSv1.1') {
     test(U, U, U, U, U, 'TLSv1_method',
          U, 'ERR_SSL_UNSUPPORTED_PROTOCOL', 'ERR_SSL_WRONG_VERSION_NUMBER');
   } else {
-    assert(false, 'unreachable');
+    // TLS1.3 client hellos are are not understood by TLS1.1 or below.
+    test(U, U, U, U, U, 'TLSv1_method',
+         U, 'ECONNRESET', 'ERR_SSL_UNSUPPORTED_PROTOCOL');
   }
 }
 
@@ -180,14 +207,32 @@ if (DEFAULT_MIN_VERSION === 'TLSv1') {
 test('TLSv1', 'TLSv1.2', U, U, U, 'TLSv1_method', 'TLSv1');
 test('TLSv1', 'TLSv1.2', U, U, U, 'TLSv1_1_method', 'TLSv1.1');
 test('TLSv1', 'TLSv1.2', U, U, U, 'TLSv1_2_method', 'TLSv1.2');
+test('TLSv1', 'TLSv1.2', U, U, U, 'TLS_method', 'TLSv1.2');
 
 test(U, U, 'TLSv1_method', 'TLSv1', 'TLSv1.2', U, 'TLSv1');
 test(U, U, 'TLSv1_1_method', 'TLSv1', 'TLSv1.2', U, 'TLSv1.1');
 test(U, U, 'TLSv1_2_method', 'TLSv1', 'TLSv1.2', U, 'TLSv1.2');
 
+test('TLSv1', 'TLSv1.1', U, 'TLSv1', 'TLSv1.3', U, 'TLSv1.1');
 test('TLSv1', 'TLSv1.1', U, 'TLSv1', 'TLSv1.2', U, 'TLSv1.1');
 test('TLSv1', 'TLSv1.2', U, 'TLSv1', 'TLSv1.1', U, 'TLSv1.1');
+test('TLSv1', 'TLSv1.3', U, 'TLSv1', 'TLSv1.1', U, 'TLSv1.1');
 test('TLSv1', 'TLSv1', U, 'TLSv1', 'TLSv1.1', U, 'TLSv1');
 test('TLSv1', 'TLSv1.2', U, 'TLSv1', 'TLSv1', U, 'TLSv1');
+test('TLSv1', 'TLSv1.3', U, 'TLSv1', 'TLSv1', U, 'TLSv1');
 test('TLSv1.1', 'TLSv1.1', U, 'TLSv1', 'TLSv1.2', U, 'TLSv1.1');
 test('TLSv1', 'TLSv1.2', U, 'TLSv1.1', 'TLSv1.1', U, 'TLSv1.1');
+test('TLSv1', 'TLSv1.2', U, 'TLSv1', 'TLSv1.3', U, 'TLSv1.2');
+
+// v-any client can connect to v-specific server
+test('TLSv1', 'TLSv1.3', U, 'TLSv1.3', 'TLSv1.3', U, 'TLSv1.3');
+test('TLSv1', 'TLSv1.3', U, 'TLSv1.2', 'TLSv1.3', U, 'TLSv1.3');
+test('TLSv1', 'TLSv1.3', U, 'TLSv1.2', 'TLSv1.2', U, 'TLSv1.2');
+test('TLSv1', 'TLSv1.3', U, 'TLSv1.1', 'TLSv1.1', U, 'TLSv1.1');
+test('TLSv1', 'TLSv1.3', U, 'TLSv1', 'TLSv1', U, 'TLSv1');
+
+// v-specific client can connect to v-any server
+test('TLSv1.3', 'TLSv1.3', U, 'TLSv1', 'TLSv1.3', U, 'TLSv1.3');
+test('TLSv1.2', 'TLSv1.2', U, 'TLSv1', 'TLSv1.3', U, 'TLSv1.2');
+test('TLSv1.1', 'TLSv1.1', U, 'TLSv1', 'TLSv1.3', U, 'TLSv1.1');
+test('TLSv1', 'TLSv1', U, 'TLSv1', 'TLSv1.3', U, 'TLSv1');

--- a/test/parallel/test-tls-net-socket-keepalive-12.js
+++ b/test/parallel/test-tls-net-socket-keepalive-12.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// test-tls-net-socket-keepalive specifically for TLS1.2.
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const tls = require('tls');
+
+tls.DEFAULT_MAX_VERSION = 'TLSv1.2';
+
+require('./test-tls-net-socket-keepalive.js');

--- a/test/parallel/test-tls-net-socket-keepalive.js
+++ b/test/parallel/test-tls-net-socket-keepalive.js
@@ -20,8 +20,11 @@ const options = {
 };
 
 const server = tls.createServer(options, common.mustCall((conn) => {
-  conn.write('hello');
+  conn.write('hello', common.mustCall());
   conn.on('data', common.mustCall());
+  conn.on('end', common.mustCall());
+  conn.on('data', common.mustCall());
+  conn.on('close', common.mustCall());
   conn.end();
 })).listen(0, common.mustCall(() => {
   const netSocket = new net.Socket({
@@ -42,6 +45,7 @@ const server = tls.createServer(options, common.mustCall((conn) => {
     address,
   });
 
+  socket.on('secureConnect', common.mustCall());
   socket.on('end', common.mustCall());
   socket.on('data', common.mustCall());
   socket.on('close', common.mustCall(() => {

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -272,6 +272,8 @@ function runTest(port, testIndex) {
   if (tcase.renegotiate) {
     serverOptions.secureOptions =
         SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
+    // Renegotiation as a protocol feature was dropped after TLS1.2.
+    serverOptions.maxVersion = 'TLSv1.2';
   }
 
   let renegotiated = false;

--- a/test/parallel/test-tls-set-ciphers-error.js
+++ b/test/parallel/test-tls-set-ciphers-error.js
@@ -19,4 +19,7 @@ const fixtures = require('../common/fixtures');
   options.ciphers = 'FOOBARBAZ';
   assert.throws(() => tls.createServer(options, common.mustNotCall()),
                 /no cipher match/i);
+  options.ciphers = 'TLS_not_a_cipher';
+  assert.throws(() => tls.createServer(options, common.mustNotCall()),
+                /no cipher match/i);
 }

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -1,62 +1,93 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 'use strict';
 const common = require('../common');
-
-if (!common.opensslCli)
-  common.skip('node compiled without OpenSSL CLI.');
-
-if (!common.hasCrypto)
-  common.skip('missing crypto');
-
-const assert = require('assert');
-const exec = require('child_process').exec;
-const tls = require('tls');
+if (!common.hasCrypto) common.skip('missing crypto');
 const fixtures = require('../common/fixtures');
 
-const options = {
-  key: fixtures.readKey('agent2-key.pem'),
-  cert: fixtures.readKey('agent2-cert.pem'),
-  ciphers: 'AES256-SHA'
-};
+// Test cipher: option for TLS.
 
-const reply = 'I AM THE WALRUS'; // something recognizable
-let response = '';
+const {
+  assert, connect, keys
+} = require(fixtures.path('tls-connect'));
 
-process.on('exit', function() {
-  assert.ok(response.includes(reply));
-});
 
-const server = tls.createServer(options, common.mustCall(function(conn) {
-  conn.end(reply);
-}));
+function test(cciphers, sciphers, cipher, cerr, serr) {
+  assert(cipher || cerr || serr, 'test missing any expectations');
+  const where = (new Error()).stack.split('\n')[2].replace(/[^(]*/, '');
+  connect({
+    client: {
+      checkServerIdentity: (servername, cert) => { },
+      ca: `${keys.agent1.cert}\n${keys.agent6.ca}`,
+      ciphers: cciphers,
+    },
+    server: {
+      cert: keys.agent6.cert,
+      key: keys.agent6.key,
+      ciphers: sciphers,
+    },
+  }, common.mustCall((err, pair, cleanup) => {
+    function u(_) { return _ === undefined ? 'U' : _; }
+    console.log('test:', u(cciphers), u(sciphers),
+                'expect', u(cipher), u(cerr), u(serr));
+    console.log('  ', where);
+    if (!cipher) {
+      console.log('client', pair.client.err ? pair.client.err.code : undefined);
+      console.log('server', pair.server.err ? pair.server.err.code : undefined);
+      if (cerr) {
+        assert(pair.client.err);
+        assert.strictEqual(pair.client.err.code, cerr);
+      }
+      if (serr) {
+        assert(pair.server.err);
+        assert.strictEqual(pair.server.err.code, serr);
+      }
+      return cleanup();
+    }
 
-server.listen(0, '127.0.0.1', function() {
-  const cmd = `"${common.opensslCli}" s_client -cipher ${
-    options.ciphers} -connect 127.0.0.1:${this.address().port}`;
+    const reply = 'So long and thanks for all the fish.';
 
-  exec(cmd, function(err, stdout, stderr) {
     assert.ifError(err);
-    response = stdout;
-    server.close();
-  });
-});
+    assert.ifError(pair.server.err);
+    assert.ifError(pair.client.err);
+    assert(pair.server.conn);
+    assert(pair.client.conn);
+    assert.strictEqual(pair.client.conn.getCipher().name, cipher);
+    assert.strictEqual(pair.server.conn.getCipher().name, cipher);
+
+    pair.server.conn.write(reply);
+
+    pair.client.conn.on('data', common.mustCall((data) => {
+      assert.strictEqual(data.toString(), reply);
+      return cleanup();
+    }));
+  }));
+}
+
+const U = undefined;
+
+// Have shared ciphers.
+test(U, 'AES256-SHA', 'AES256-SHA');
+test('AES256-SHA', U, 'AES256-SHA');
+
+test(U, 'TLS_AES_256_GCM_SHA384', 'TLS_AES_256_GCM_SHA384');
+test('TLS_AES_256_GCM_SHA384', U, 'TLS_AES_256_GCM_SHA384');
+
+// Do not have shared ciphers.
+test('TLS_AES_256_GCM_SHA384', 'TLS_CHACHA20_POLY1305_SHA256',
+     U, 'ECONNRESET', 'ERR_SSL_NO_SHARED_CIPHER');
+
+test('AES128-SHA', 'AES256-SHA', U, 'ECONNRESET', 'ERR_SSL_NO_SHARED_CIPHER');
+test('AES128-SHA:TLS_AES_256_GCM_SHA384',
+     'TLS_CHACHA20_POLY1305_SHA256:AES256-SHA',
+     U, 'ECONNRESET', 'ERR_SSL_NO_SHARED_CIPHER');
+
+// Cipher order ignored, TLS1.3 chosen before TLS1.2.
+test('AES256-SHA:TLS_AES_256_GCM_SHA384', U, 'TLS_AES_256_GCM_SHA384');
+test(U, 'AES256-SHA:TLS_AES_256_GCM_SHA384', 'TLS_AES_256_GCM_SHA384');
+
+// TLS_AES_128_CCM_8_SHA256 & TLS_AES_128_CCM_SHA256 are not enabled by
+// default, but work.
+test('TLS_AES_128_CCM_8_SHA256', U,
+     U, 'ECONNRESET', 'ERR_SSL_NO_SHARED_CIPHER');
+
+test('TLS_AES_128_CCM_8_SHA256', 'TLS_AES_128_CCM_8_SHA256',
+     'TLS_AES_128_CCM_8_SHA256');

--- a/test/parallel/test-tls-ticket-12.js
+++ b/test/parallel/test-tls-ticket-12.js
@@ -1,0 +1,12 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// Run test-tls-ticket.js with TLS1.2
+
+const tls = require('tls');
+
+tls.DEFAULT_MAX_VERSION = 'TLSv1.2';
+
+require('./test-tls-ticket.js');

--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -40,13 +40,17 @@ if (cluster.isMaster) {
   let workerPort = null;
 
   function shoot() {
-    console.error('[master] connecting', workerPort);
+    console.error('[master] connecting', workerPort, 'session?', !!lastSession);
     const c = tls.connect(workerPort, {
       session: lastSession,
       rejectUnauthorized: false
     }, () => {
       c.end();
-
+    }).on('close', () => {
+      // Wait for close to shoot off another connection. We don't want to shoot
+      // until a new session is allocated, if one will be. The new session is
+      // not guaranteed on secureConnect (it depends on TLS1.2 vs TLS1.3), but
+      // it is guaranteed to happen before the connection is closed.
       if (++reqCount === expectedReqCount) {
         Object.keys(cluster.workers).forEach(function(id) {
           cluster.workers[id].send('die');
@@ -55,8 +59,11 @@ if (cluster.isMaster) {
         shoot();
       }
     }).once('session', (session) => {
+      assert(!lastSession);
       lastSession = session;
     });
+
+    c.resume(); // See close_notify comment in server
   }
 
   function fork() {
@@ -93,12 +100,15 @@ const cert = fixtures.readSync('agent.crt');
 const options = { key, cert };
 
 const server = tls.createServer(options, (c) => {
+  console.error('[worker] connection reused?', c.isSessionReused());
   if (c.isSessionReused()) {
     process.send({ msg: 'reused' });
   } else {
     process.send({ msg: 'not-reused' });
   }
-  c.end();
+  // Used to just .end(), but that means client gets close_notify before
+  // NewSessionTicket. Send data until that problem is solved.
+  c.end('x');
 });
 
 server.listen(0, () => {


### PR DESCRIPTION


    This introduces TLS1.3 support and makes it the default max protocol,
    but also supports CLI/NODE_OPTIONS switches to disable it if necessary.
    
    TLS1.3 is a major update to the TLS protocol, with many security
    enhancements. It should be preferred over TLS1.2 whenever possible.
    
    TLS1.3 is different enough that even though the OpenSSL APIs are
    technically API/ABI compatible, that when TLS1.3 is negotiated, the
    timing of protocol records and of callbacks broke assumptions hard-coded
    into the 'tls' module.
    
    This change introduces no API incompatibilities when TLS1.2 is
    negotiated. It is the intention that it be backported to current and LTS
    release lines with the default maximum TLS protocol reset to 'TLSv1.2'.
    This will allow users of those lines to explicitly enable TLS1.3 if they
    want.
    
    API incompatibilities between TLS1.2 and TLS1.3 are:
    
    - Variations of `conn.write('data'); conn.destroy()` have undefined
    behaviour according to the streams API. They may or may not send the
    'data', and may or may not cause a ERR_STREAM_DESTROYED error to be
    emitted. This has always been true, but conditions under which the write
    suceeds is slightly but observably different when TLS1.3 is negotiated
    vs when TLS1.2 or below is negotiated.
    
    - If TLS1.3 is negotiated, and a server calls `conn.end()` in its
    'secureConnection' listener without any data being written, the client
    will not receive session tickets (no 'session' events will be emitted,
    and `conn.getSession()` will never return a resumable session).
    
    - The return value of `conn.getSession()` API may not return a resumable
    session if called right after the handshake. The effect will be that
    clients using the legacy `getSession()` API will resume sessions if
    TLS1.2 is negotiated, but will do full handshakes if TLS1.3 is
    negotiated.  See https://github.com/nodejs/node/pull/25831 for more
    information.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
