### PR TITLE
http: validate timeout in ClientRequest()

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -140,7 +140,9 @@ function ClientRequest(input, options, cb) {
   var setHost = (options.setHost === undefined || Boolean(options.setHost));
 
   this.socketPath = options.socketPath;
-  this.timeout = options.timeout;
+
+  if (options.timeout !== undefined)
+    this.timeout = validateTimerDuration(options.timeout, 'timeout');
 
   var method = options.method;
   var methodIsString = (typeof method === 'string');

--- a/test/parallel/test-http-client-timeout-option.js
+++ b/test/parallel/test-http-client-timeout-option.js
@@ -3,6 +3,10 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
+assert.throws(() => {
+  http.request({ timeout: null });
+}, /The "timeout" argument must be of type number/);
+
 const options = {
   method: 'GET',
   port: undefined,


### PR DESCRIPTION
Validate the `timeout` option in the `ClientRequest()` constructor to prevent asynchronously thrown validation errors.

Fixes: https://github.com/nodejs/node/issues/26143

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
