### PR TITLE
timers: support name in validateTimerDuration()

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -737,7 +737,7 @@ ClientRequest.prototype.setTimeout = function setTimeout(msecs, callback) {
   }
 
   listenSocketTimeout(this);
-  msecs = validateTimerDuration(msecs);
+  msecs = validateTimerDuration(msecs, 'msecs');
   if (callback) this.once('timeout', callback);
 
   if (this.socket) {

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -196,7 +196,7 @@ function setStreamTimeout(msecs, callback) {
   this.timeout = msecs;
 
   // Type checking identical to timers.enroll()
-  msecs = validateTimerDuration(msecs);
+  msecs = validateTimerDuration(msecs, 'msecs');
 
   // Attempt to clear an existing timer in both cases -
   //  even if it will be rescheduled we don't want to leak an existing timer.

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -136,10 +136,10 @@ function setUnrefTimeout(callback, after, arg1, arg2, arg3) {
 }
 
 // Type checking used by timers.enroll() and Socket#setTimeout()
-function validateTimerDuration(msecs) {
-  validateNumber(msecs, 'msecs');
+function validateTimerDuration(msecs, name) {
+  validateNumber(msecs, name);
   if (msecs < 0 || !isFinite(msecs)) {
-    throw new ERR_OUT_OF_RANGE('msecs', 'a non-negative finite number', msecs);
+    throw new ERR_OUT_OF_RANGE(name, 'a non-negative finite number', msecs);
   }
 
   // Ensure that msecs fits into signed int32

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -408,7 +408,7 @@ exports.unenroll = util.deprecate(unenroll,
 // This function does not start the timer, see `active()`.
 // Using existing objects as timers slightly reduces object overhead.
 function enroll(item, msecs) {
-  msecs = validateTimerDuration(msecs);
+  msecs = validateTimerDuration(msecs, 'msecs');
 
   // if this item was already in a list somewhere
   // then we should unenroll it from that


### PR DESCRIPTION
As requested in https://github.com/nodejs/node/pull/26214#pullrequestreview-205818789

Allow passing a name to `validateTimerDuration()` so that error messages can reflect the name of the thing being validated.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
