### PR TITLE
util: mark iterator entries as such

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -540,6 +540,15 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
   return formatRaw(ctx, value, recurseTimes, typedArray);
 }
 
+function setIteratorBraces(type, tag) {
+  if (tag !== `${type} Iterator`) {
+    if (tag !== '')
+      tag += '] [';
+    tag += `${type} Iterator`;
+  }
+  return [`[${tag}] {`, '}'];
+}
+
 function formatRaw(ctx, value, recurseTimes, typedArray) {
   let keys;
 
@@ -594,11 +603,11 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
       extrasType = kArrayExtrasType;
     } else if (isMapIterator(value)) {
       keys = getKeys(value, ctx.showHidden);
-      braces = [`[${tag}] {`, '}'];
+      braces = setIteratorBraces('Map', tag);
       formatter = formatIterator;
     } else if (isSetIterator(value)) {
       keys = getKeys(value, ctx.showHidden);
-      braces = [`[${tag}] {`, '}'];
+      braces = setIteratorBraces('Set', tag);
       formatter = formatIterator;
     } else {
       noIterator = true;
@@ -730,10 +739,10 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
         }
       }
       if (isMapIterator(value)) {
-        braces = [`[${tag || 'Map Iterator'}] {`, '}'];
+        braces = setIteratorBraces('Map', tag);
         formatter = formatIterator;
       } else if (isSetIterator(value)) {
-        braces = [`[${tag || 'Set Iterator'}] {`, '}'];
+        braces = setIteratorBraces('Set', tag);
         formatter = formatIterator;
       // Handle other regular objects again.
       } else if (keys.length === 0) {
@@ -755,7 +764,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
   let output;
   const indentationLvl = ctx.indentationLvl;
   try {
-    output = formatter(ctx, value, recurseTimes, keys);
+    output = formatter(ctx, value, recurseTimes, keys, braces);
     for (i = 0; i < keys.length; i++) {
       output.push(
         formatProperty(ctx, value, recurseTimes, keys[i], extrasType));
@@ -1091,9 +1100,11 @@ function formatWeakMap(ctx, value, recurseTimes) {
   return formatMapIterInner(ctx, recurseTimes, entries, kWeak);
 }
 
-function formatIterator(ctx, value, recurseTimes) {
+function formatIterator(ctx, value, recurseTimes, keys, braces) {
   const [entries, isKeyValue] = previewEntries(value, true);
   if (isKeyValue) {
+    // Mark entry iterators as such.
+    braces[0] = braces[0].replace(/ Iterator] {$/, ' Entries] {');
     return formatMapIterInner(ctx, recurseTimes, entries, kMapEntries);
   }
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -976,10 +976,15 @@ if (typeof Symbol !== 'undefined') {
 {
   const map = new Map([['foo', 'bar']]);
   assert.strictEqual(util.inspect(map.keys()), '[Map Iterator] { \'foo\' }');
-  assert.strictEqual(util.inspect(map.values()), '[Map Iterator] { \'bar\' }');
+  const mapValues = map.values();
+  Object.defineProperty(mapValues, Symbol.toStringTag, { value: 'Foo' });
+  assert.strictEqual(
+    util.inspect(mapValues),
+    '[Foo] [Map Iterator] { \'bar\' }'
+  );
   map.set('A', 'B!');
   assert.strictEqual(util.inspect(map.entries(), { maxArrayLength: 1 }),
-                     "[Map Iterator] { [ 'foo', 'bar' ], ... 1 more item }");
+                     "[Map Entries] { [ 'foo', 'bar' ], ... 1 more item }");
   // Make sure the iterator doesn't get consumed.
   const keys = map.keys();
   assert.strictEqual(util.inspect(keys), "[Map Iterator] { 'foo', 'A' }");
@@ -995,10 +1000,13 @@ if (typeof Symbol !== 'undefined') {
   const aSet = new Set([1, 3]);
   assert.strictEqual(util.inspect(aSet.keys()), '[Set Iterator] { 1, 3 }');
   assert.strictEqual(util.inspect(aSet.values()), '[Set Iterator] { 1, 3 }');
-  assert.strictEqual(util.inspect(aSet.entries()),
-                     '[Set Iterator] { [ 1, 1 ], [ 3, 3 ] }');
+  const setEntries = aSet.entries();
+  Object.defineProperty(setEntries, Symbol.toStringTag, { value: 'Foo' });
+  assert.strictEqual(util.inspect(setEntries),
+                     '[Foo] [Set Entries] { [ 1, 1 ], [ 3, 3 ] }');
   // Make sure the iterator doesn't get consumed.
   const keys = aSet.keys();
+  Object.defineProperty(keys, Symbol.toStringTag, { value: null });
   assert.strictEqual(util.inspect(keys), '[Set Iterator] { 1, 3 }');
   assert.strictEqual(util.inspect(keys), '[Set Iterator] { 1, 3 }');
   keys.extra = true;
@@ -1610,7 +1618,7 @@ assert.strictEqual(util.inspect('"\'${a}'), "'\"\\'${a}'");
   [{ a: 5 }, '{ a: 5 }'],
   [new Set([1, 2]), 'Set { 1, 2 }'],
   [new Map([[1, 2]]), 'Map { 1 => 2 }'],
-  [new Set([1, 2]).entries(), '[Set Iterator] { [ 1, 1 ], [ 2, 2 ] }'],
+  [new Set([1, 2]).entries(), '[Set Entries] { [ 1, 1 ], [ 2, 2 ] }'],
   [new Map([[1, 2]]).keys(), '[Map Iterator] { 1 }'],
   [new Date(2000), '1970-01-01T00:00:02.000Z'],
   [new Uint8Array(2), 'Uint8Array [ 0, 0 ]'],


### PR DESCRIPTION
It is possible to distinguish the entries iterator from others.
Expose that information to the users as well and improve the
Symbol.toStringTag handling by adding a special tag instead of
replacing the existent information.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
