### PR TITLE
url: handle quasi-WHATWG URLs in urlToOptions()

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1257,13 +1257,13 @@ function domainToUnicode(domain) {
 function urlToOptions(url) {
   var options = {
     protocol: url.protocol,
-    hostname: url.hostname.startsWith('[') ?
+    hostname: typeof url.hostname === 'string' && url.hostname.startsWith('[') ?
       url.hostname.slice(1, -1) :
       url.hostname,
     hash: url.hash,
     search: url.search,
     pathname: url.pathname,
-    path: `${url.pathname}${url.search}`,
+    path: `${url.pathname || ''}${url.search || ''}`,
     href: url.href
   };
   if (url.port !== '') {

--- a/test/parallel/test-whatwg-url-custom-properties.js
+++ b/test/parallel/test-whatwg-url-custom-properties.js
@@ -133,8 +133,8 @@ assert.strictEqual(url.searchParams, oldParams);
 
 // Test urlToOptions
 {
-  const opts =
-    urlToOptions(new URL('http://user:pass@foo.bar.com:21/aaa/zzz?l=24#test'));
+  const urlObj = new URL('http://user:pass@foo.bar.com:21/aaa/zzz?l=24#test');
+  const opts = urlToOptions(urlObj);
   assert.strictEqual(opts instanceof URL, false);
   assert.strictEqual(opts.protocol, 'http:');
   assert.strictEqual(opts.auth, 'user:pass');
@@ -147,6 +147,23 @@ assert.strictEqual(url.searchParams, oldParams);
 
   const { hostname } = urlToOptions(new URL('http://[::1]:21'));
   assert.strictEqual(hostname, '::1');
+
+  // If a WHATWG URL object is copied, it is possible that the resulting copy
+  // contains the Symbols that Node uses for brand checking, but not the data
+  // properties, which are getters. Verify that urlToOptions() can handle such
+  // a case.
+  const copiedUrlObj = Object.assign({}, urlObj);
+  const copiedOpts = urlToOptions(copiedUrlObj);
+  assert.strictEqual(copiedOpts instanceof URL, false);
+  assert.strictEqual(copiedOpts.protocol, undefined);
+  assert.strictEqual(copiedOpts.auth, undefined);
+  assert.strictEqual(copiedOpts.hostname, undefined);
+  assert.strictEqual(copiedOpts.port, NaN);
+  assert.strictEqual(copiedOpts.path, '');
+  assert.strictEqual(copiedOpts.pathname, undefined);
+  assert.strictEqual(copiedOpts.search, undefined);
+  assert.strictEqual(copiedOpts.hash, undefined);
+  assert.strictEqual(copiedOpts.href, undefined);
 }
 
 // Test special origins


### PR DESCRIPTION
This commit prevents the internal `urlToOptions()` from throwing when a malformed WHATWG URL is encountered. This is more of a bandaid fix, as the return value will still be pretty useless, but garbage in, garbage out I guess.

I don't think we want to slow this specific function down with a lot of extra validation code, but maybe others feel differently.

Refs: https://github.com/nodejs/node/issues/26198

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
