### PR TITLE
process: delay signal handler setup to pre-execution and skip them in workers

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -282,36 +282,15 @@ if (process.env.NODE_V8_COVERAGE) {
   };
 }
 
-// Worker threads don't receive signals.
-if (isMainThread) {
-  const {
-    isSignal,
-    startListeningIfSignal,
-    stopListeningIfSignal
-  } = mainThreadSetup.createSignalHandlers();
-  process.on('newListener', startListeningIfSignal);
-  process.on('removeListener', stopListeningIfSignal);
-  // re-arm pre-existing signal event registrations
-  // with this signal wrap capabilities.
-  const signalEvents = process.eventNames().filter(isSignal);
-  for (const ev of signalEvents) {
-    process.emit('newListener', ev);
-  }
-}
-
 if (getOptionValue('--experimental-report')) {
   const {
     config,
-    handleSignal,
     report,
     syncConfig
   } = NativeModule.require('internal/process/report');
   process.report = report;
   // Download the CLI / ENV config into JS land.
   syncConfig(config, false);
-  if (config.events.includes('signal')) {
-    process.on(config.signal, handleSignal);
-  }
 }
 
 function setupProcessObject() {

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -38,7 +38,6 @@
 
 const { internalBinding, NativeModule } = loaderExports;
 const { Object, Symbol } = primordials;
-const { getOptionValue } = NativeModule.require('internal/options');
 const config = internalBinding('config');
 const { deprecate } = NativeModule.require('internal/util');
 
@@ -280,17 +279,6 @@ if (process.env.NODE_V8_COVERAGE) {
     writeCoverage();
     originalReallyExit(code);
   };
-}
-
-if (getOptionValue('--experimental-report')) {
-  const {
-    config,
-    report,
-    syncConfig
-  } = NativeModule.require('internal/process/report');
-  process.report = report;
-  // Download the CLI / ENV config into JS land.
-  syncConfig(config, false);
 }
 
 function setupProcessObject() {

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -11,6 +11,10 @@ function prepareMainThreadExecution() {
   // Only main thread receives signals.
   setupSignalHandlers();
 
+  // Process initial configurations of node-report, if any.
+  initializeReport();
+  initializeReportSignalHandlers();  // Main-thread-only.
+
   // If the process is spawned with env NODE_CHANNEL_FD, it's probably
   // spawned by our child_process module, then initialize IPC.
   // This attaches some internal event listeners and creates:
@@ -31,6 +35,20 @@ function prepareMainThreadExecution() {
   loadPreloadModules();
 }
 
+function initializeReport() {
+  if (!getOptionValue('--experimental-report')) {
+    return;
+  }
+  const {
+    config,
+    report,
+    syncConfig
+  } = require('internal/process/report');
+  process.report = report;
+  // Download the CLI / ENV config into JS land.
+  syncConfig(config, false);
+}
+
 function setupSignalHandlers() {
   const {
     createSignalHandlers
@@ -41,15 +59,20 @@ function setupSignalHandlers() {
   } = createSignalHandlers();
   process.on('newListener', startListeningIfSignal);
   process.on('removeListener', stopListeningIfSignal);
+}
 
-  if (getOptionValue('--experimental-report')) {
-    const {
-      config,
-      handleSignal
-    } = require('internal/process/report');
-    if (config.events.includes('signal')) {
-      process.on(config.signal, handleSignal);
-    }
+// This has to be called after both initializeReport() and
+// setupSignalHandlers() are called
+function initializeReportSignalHandlers() {
+  if (!getOptionValue('--experimental-report')) {
+    return;
+  }
+  const {
+    config,
+    handleSignal
+  } = require('internal/process/report');
+  if (config.events.includes('signal')) {
+    process.on(config.signal, handleSignal);
   }
 }
 
@@ -204,5 +227,6 @@ module.exports = {
   initializeDeprecations,
   initializeESMLoader,
   loadPreloadModules,
-  setupTraceCategoryState
+  setupTraceCategoryState,
+  initializeReport
 };

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -8,6 +8,9 @@ let traceEventsAsyncHook;
 function prepareMainThreadExecution() {
   setupTraceCategoryState();
 
+  // Only main thread receives signals.
+  setupSignalHandlers();
+
   // If the process is spawned with env NODE_CHANNEL_FD, it's probably
   // spawned by our child_process module, then initialize IPC.
   // This attaches some internal event listeners and creates:
@@ -26,6 +29,28 @@ function prepareMainThreadExecution() {
   initializeDeprecations();
   initializeESMLoader();
   loadPreloadModules();
+}
+
+function setupSignalHandlers() {
+  const {
+    createSignalHandlers
+  } = require('internal/process/main_thread_only');
+  const {
+    startListeningIfSignal,
+    stopListeningIfSignal
+  } = createSignalHandlers();
+  process.on('newListener', startListeningIfSignal);
+  process.on('removeListener', stopListeningIfSignal);
+
+  if (getOptionValue('--experimental-report')) {
+    const {
+      config,
+      handleSignal
+    } = require('internal/process/report');
+    if (config.events.includes('signal')) {
+      process.on(config.signal, handleSignal);
+    }
+  }
 }
 
 function setupTraceCategoryState() {

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -6,6 +6,7 @@
 const {
   initializeDeprecations,
   initializeESMLoader,
+  initializeReport,
   loadPreloadModules,
   setupTraceCategoryState
 } = require('internal/bootstrap/pre_execution');
@@ -75,6 +76,7 @@ port.on('message', (message) => {
     } = message;
 
     setupTraceCategoryState();
+    initializeReport();
     if (manifestSrc) {
       require('internal/process/policy').setup(manifestSrc, manifestURL);
     }

--- a/lib/internal/process/main_thread_only.js
+++ b/lib/internal/process/main_thread_only.js
@@ -144,7 +144,6 @@ function createSignalHandlers() {
   }
 
   return {
-    isSignal,
     startListeningIfSignal,
     stopListeningIfSignal
   };


### PR DESCRIPTION
#### process: setup signal handler in prepareMainThreadExecution

Because this is only necessary in the main thread.
Also removes the rearming of signal events since no
signal event handlers should be created during the execution
of node.js now that we've made the creation of stdout and stderr
streams lazy - this has been demonstrated in the test coverage.

#### process: move initialization of node-report into pre_execution.js

- Splits signal handler setup code into two functions: one sets up
  `process.on('SIGNAL_NAME')`, another takes care of the signal
  triggers of node-report. Both should only happen on the main thread.
  The latter needs to happen after the node-report configurations
  are read into the process.
- Move the initialization of node-report into pre_execution.js
  because it depends on CLI/environment settings.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
