### PR TITLE
src: use the config binding to carry --no-browser-globals

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -180,8 +180,7 @@ if (config.hasInspector) {
   internalBinding('inspector').registerAsyncHook(enable, disable);
 }
 
-const browserGlobals = !process._noBrowserGlobals;
-if (browserGlobals) {
+if (!config.noBrowserGlobals) {
   // Override global console from the one provided by the VM
   // to the one implemented by Node.js
   // https://console.spec.whatwg.org/#console-namespace

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -136,6 +136,20 @@ function initializeDeprecations() {
                 'DEP0103') :
       types[name];
   }
+
+  // TODO(joyeecheung): this is a legacy property exposed to process.
+  // Now that we use the config binding to carry this information, remove
+  // it from the process. We may consider exposing it properly in
+  // process.features.
+  const { noBrowserGlobals } = internalBinding('config');
+  if (noBrowserGlobals) {
+    Object.defineProperty(process, '_noBrowserGlobals', {
+      writable: false,
+      enumerable: true,
+      configurable: true,
+      value: noBrowserGlobals
+    });
+  }
 }
 
 function setupChildProcessIpcChannel() {

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -64,6 +64,13 @@ static void Initialize(Local<Object> target,
   READONLY_FALSE_PROPERTY(target, "hasInspector");
 #endif
 
+// configure --no-browser-globals
+#ifdef NODE_NO_BROWSER_GLOBALS
+  READONLY_TRUE_PROPERTY(target, "noBrowserGlobals");
+#else
+  READONLY_FALSE_PROPERTY(target, "noBrowserGlobals");
+#endif  // NODE_NO_BROWSER_GLOBALS
+
   READONLY_PROPERTY(target,
                     "bits",
                     Number::New(env->isolate(), 8 * sizeof(intptr_t)));

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -233,11 +233,6 @@ MaybeLocal<Object> CreateProcessObject(
     READONLY_PROPERTY(process, "throwDeprecation", True(env->isolate()));
   }
 
-#ifdef NODE_NO_BROWSER_GLOBALS
-  // configure --no-browser-globals
-  READONLY_PROPERTY(process, "_noBrowserGlobals", True(env->isolate()));
-#endif  // NODE_NO_BROWSER_GLOBALS
-
   // --prof-process
   // TODO(addaleax): Remove this.
   if (env->options()->prof_process) {


### PR DESCRIPTION
Instead of setting it in the process object, since this is
a configure-time option. Also added a shim that can be
deprecated and removed some time later.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
