### PR TITLE
process: use common operations to define browser globals

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -183,11 +183,34 @@ if (config.hasInspector) {
 
 const browserGlobals = !process._noBrowserGlobals;
 if (browserGlobals) {
-  setupGlobalTimeouts();
-  setupGlobalConsole();
-  setupGlobalURL();
-  setupGlobalEncoding();
+  // Override global console from the one provided by the VM
+  // to the one implemented by Node.js
+  // https://console.spec.whatwg.org/#console-namespace
+  exposeNamespace(global, 'console', createGlobalConsole(global.console));
+
+  const { URL, URLSearchParams } = NativeModule.require('internal/url');
+  // https://url.spec.whatwg.org/#url
+  exposeInterface(global, 'URL', URL);
+  // https://url.spec.whatwg.org/#urlsearchparams
+  exposeInterface(global, 'URLSearchParams', URLSearchParams);
+
+  const { TextEncoder, TextDecoder } = NativeModule.require('util');
+  // https://encoding.spec.whatwg.org/#textencoder
+  exposeInterface(global, 'TextEncoder', TextEncoder);
+  // https://encoding.spec.whatwg.org/#textdecoder
+  exposeInterface(global, 'TextDecoder', TextDecoder);
+
+  // https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope
+  const timers = NativeModule.require('timers');
+  defineOperation(global, 'clearInterval', timers.clearInterval);
+  defineOperation(global, 'clearTimeout', timers.clearTimeout);
+  defineOperation(global, 'setInterval', timers.setInterval);
+  defineOperation(global, 'setTimeout', timers.setTimeout);
   setupQueueMicrotask();
+
+  // Non-standard extensions:
+  defineOperation(global, 'clearImmediate', timers.clearImmediate);
+  defineOperation(global, 'setImmediate', timers.setImmediate);
 }
 
 setupDOMException();
@@ -409,29 +432,9 @@ function setupBuffer() {
   });
 }
 
-function setupGlobalTimeouts() {
-  const timers = NativeModule.require('timers');
-  global.clearImmediate = timers.clearImmediate;
-  global.clearInterval = timers.clearInterval;
-  global.clearTimeout = timers.clearTimeout;
-  global.setImmediate = timers.setImmediate;
-  global.setInterval = timers.setInterval;
-  global.setTimeout = timers.setTimeout;
-}
-
-function setupGlobalConsole() {
-  const consoleFromVM = global.console;
+function createGlobalConsole(consoleFromVM) {
   const consoleFromNode =
     NativeModule.require('internal/console/global');
-  // Override global console from the one provided by the VM
-  // to the one implemented by Node.js
-  Object.defineProperty(global, 'console', {
-    configurable: true,
-    enumerable: false,
-    value: consoleFromNode,
-    writable: true
-  });
-
   if (config.hasInspector) {
     const inspector = NativeModule.require('internal/util/inspector');
     // This will be exposed by `require('inspector').console` later.
@@ -443,42 +446,7 @@ function setupGlobalConsole() {
     // Setup inspector command line API.
     setConsoleExtensionInstaller(inspector.installConsoleExtensions);
   }
-}
-
-function setupGlobalURL() {
-  const { URL, URLSearchParams } = NativeModule.require('internal/url');
-  Object.defineProperties(global, {
-    URL: {
-      value: URL,
-      writable: true,
-      configurable: true,
-      enumerable: false
-    },
-    URLSearchParams: {
-      value: URLSearchParams,
-      writable: true,
-      configurable: true,
-      enumerable: false
-    }
-  });
-}
-
-function setupGlobalEncoding() {
-  const { TextEncoder, TextDecoder } = NativeModule.require('util');
-  Object.defineProperties(global, {
-    TextEncoder: {
-      value: TextEncoder,
-      writable: true,
-      configurable: true,
-      enumerable: false
-    },
-    TextDecoder: {
-      value: TextDecoder,
-      writable: true,
-      configurable: true,
-      enumerable: false
-    }
-  });
+  return consoleFromNode;
 }
 
 function setupQueueMicrotask() {
@@ -515,4 +483,34 @@ function setupDOMException() {
   const DOMException = NativeModule.require('internal/domexception');
   const { registerDOMException } = internalBinding('messaging');
   registerDOMException(DOMException);
+}
+
+// https://heycam.github.io/webidl/#es-namespaces
+function exposeNamespace(target, name, namespaceObject) {
+  Object.defineProperty(target, name, {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+    value: namespaceObject
+  });
+}
+
+// https://heycam.github.io/webidl/#es-interfaces
+function exposeInterface(target, name, interfaceObject) {
+  Object.defineProperty(target, name, {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+    value: interfaceObject
+  });
+}
+
+// https://heycam.github.io/webidl/#define-the-operations
+function defineOperation(target, name, method) {
+  Object.defineProperty(target, name, {
+    writable: true,
+    enumerable: true,
+    configurable: true,
+    value: method
+  });
 }


### PR DESCRIPTION
Extracts:

- `exposeNamespace`: https://heycam.github.io/webidl/#es-namespaces
- `exposeInterface`: https://heycam.github.io/webidl/#es-interfaces
- `defineOperation`: https://heycam.github.io/webidl/#define-the-operations

into functions to define browser globals.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
