### PR TITLE
crypto: fix error condition in Verify::VerifyFinal

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4675,6 +4675,8 @@ void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
 
   unsigned int offset = 0;
   ManagedEVPPKey pkey = GetPublicOrPrivateKeyFromJs(args, &offset, true);
+  if (!pkey)
+    return;
 
   char* hbuf = Buffer::Data(args[offset]);
   ssize_t hlen = Buffer::Length(args[offset]);


### PR DESCRIPTION
Fail early if key parsing failed, don't try to construct a context out of it. Luckily, OpenSSL makes sure that we do not pass in a `nullptr`, so this is not a security issue. The observable behavior is still the same under certain assumptions about the error queue at the time, so it is difficult to add a test for this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
