### PR TITLE
lib: deprecate _stream_wrap

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2348,6 +2348,19 @@ Type: Runtime
 
 This property is a reference to the instance itself.
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: require('\_stream\_wrap')
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26245
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+The `_stream_wrap` module is deprecated.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/lib/_stream_wrap.js
+++ b/lib/_stream_wrap.js
@@ -1,3 +1,5 @@
 'use strict';
 
 module.exports = require('internal/js_stream_socket');
+process.emitWarning('The _stream_wrap module is deprecated.',
+                    'DeprecationWarning', 'DEP0XXX');

--- a/test/parallel/test-warn-stream-wrap.js
+++ b/test/parallel/test-warn-stream-wrap.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const common = require('../common');
+
+// _stream_wrap is deprecated.
+
+common.expectWarning('DeprecationWarning',
+                     'The _stream_wrap module is deprecated.', 'DEP0XXX');
+
+require('_stream_wrap');


### PR DESCRIPTION
Its unused by node, and doesn't have a reasonable use outside of node.

See: https://github.com/nodejs/node/pull/25153
See: https://github.com/nodejs/node/pull/16158

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
