### PR TITLE
doc: add note about showProxy and custom inspect

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -446,10 +446,12 @@ changes:
     codes. Colors are customizable. See [Customizing `util.inspect` colors][].
     **Default:** `false`.
   * `customInspect` {boolean} If `false`,
-    `[util.inspect.custom](depth, opts)` functions are not invoked.
-    **Default:** `true`.
+    [`[util.inspect.custom](depth, opts)`][util.inspect.custom] functions are
+    not invoked. **Default:** `true`.
   * `showProxy` {boolean} If `true`, `Proxy` inspection includes
-    the [`target` and `handler`][] objects. **Default:** `false`.
+    the [`target` and `handler`][] objects and
+    [custom inspect function][util.inspect.custom] on the target will not be
+    triggered. **Default:** `false`.
   * `maxArrayLength` {integer} Specifies the maximum number of `Array`,
     [`TypedArray`][], [`WeakMap`][] and [`WeakSet`][] elements to include when
     formatting. Set to `null` or `Infinity` to show all elements. Set to `0` or

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -449,7 +449,7 @@ changes:
     [`[util.inspect.custom](depth, opts)`][util.inspect.custom] functions are
     not invoked. **Default:** `true`.
   * `showProxy` {boolean} If `true`, `Proxy` inspection includes
-    the [`target` and `handler`][] objects and
+    the [`target` and `handler`][] objects, and
     [custom inspect function][util.inspect.custom] on the target will not be
     triggered. **Default:** `false`.
   * `maxArrayLength` {integer} Specifies the maximum number of `Array`,

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -450,7 +450,7 @@ changes:
     not invoked. **Default:** `true`.
   * `showProxy` {boolean} If `true`, `Proxy` inspection includes
     the [`target` and `handler`][] objects, and
-    [custom inspect function][util.inspect.custom] on the target will not be
+    [custom inspect functions][util.inspect.custom] on the target will not be
     triggered. **Default:** `false`.
   * `maxArrayLength` {integer} Specifies the maximum number of `Array`,
     [`TypedArray`][], [`WeakMap`][] and [`WeakSet`][] elements to include when


### PR DESCRIPTION
While using the `showProxy` option in `util.inspect()` it's not
possible to also trigger a custom inspect function. This documents
that behavior.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
