### PR TITLE
doc: add examples for tty.getColorDepth() env

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -165,7 +165,7 @@ to pass in an object with different settings.
 Use the `NODE_DISABLE_COLORS` environment variable to enforce this function to
 always return 1.
 
-To enforce a specific color support it's possible to set either one of the
+To enforce a specific color support, it's possible to set either one of the
 following environment settings.
 This rule does not apply to Windows OS, CI environments, and some other rare
 cases.

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -165,8 +165,7 @@ to pass in an object with different settings.
 Use the `NODE_DISABLE_COLORS` environment variable to enforce this function to
 always return 1.
 
-To enforce a specific color support, it's possible to set either one of the
-following environment settings.
+To enforce a specific color support, use one of the below environment settings.
 This rule does not apply to Windows OS, CI environments, and some other rare
 cases.
 

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -162,12 +162,9 @@ may lie about what terminal is used.
 To enforce a specific behavior without relying on `process.env` it is possible
 to pass in an object with different settings.
 
-Use the `NODE_DISABLE_COLORS` environment variable to enforce this function to
-always return 1.
-
 To enforce a specific color support, use one of the below environment settings.
 This rule does not apply to Windows OS, CI environments, and some other rare
-cases.
+cases. Only disabling color support with `NODE_DISABLE_COLORS` will always work.
 
 * 2 colors: `NODE_DISABLE_COLORS = 1`
 * 16 colors: `TERM = 'console'`

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -167,7 +167,7 @@ always return 1.
 
 To enforce a specific color support it's possible to set either one of the
 following environment settings.
-This rule does not apply to Windows OS, CI environments and some other rare
+This rule does not apply to Windows OS, CI environments, and some other rare
 cases.
 
 * 2 colors: `NODE_DISABLE_COLORS = 1`

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -165,6 +165,16 @@ to pass in an object with different settings.
 Use the `NODE_DISABLE_COLORS` environment variable to enforce this function to
 always return 1.
 
+To enforce a specific color support it's possible to set either one of the
+following environment settings.
+This rule does not apply to Windows OS, CI environments and some other rare
+cases.
+
+* 2 colors: `NODE_DISABLE_COLORS = 1`
+* 16 colors: `TERM = 'console'`
+* 256 colors: `TMUX = 1`
+* 16,777,216 colors: `TERM_PROGRAM = 'Hyper'`
+
 ### writeStream.getWindowSize()
 <!-- YAML
 added: v0.7.7


### PR DESCRIPTION
This adds some examples what values can be used to enforce a specific
color support in Node.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
