### PR TITLE
crypto: move DEP0113 to End-of-Life

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2163,7 +2163,7 @@ accessed outside of Node.js core: `Socket.prototype._handle`,
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/???
+    pr-url: https://github.com/nodejs/node/pull/26249
     description: End-of-Life.
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/22126

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2172,8 +2172,8 @@ changes:
 
 Type: End-of-Life
 
-The functions `Cipher.setAuthTag()` and `Decipher.getAuthTag()` have been
-removed. They had never been documented would throw when called.
+`Cipher.setAuthTag()` and `Decipher.getAuthTag()` are no longer available. They
+were never documented and would throw when called.
 
 <a id="DEP0114"></a>
 ### DEP0114: crypto._toBuf()

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2162,17 +2162,18 @@ accessed outside of Node.js core: `Socket.prototype._handle`,
 ### DEP0113: Cipher.setAuthTag(), Decipher.getAuthTag()
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/???
+    description: End-of-Life.
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/22126
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-With the current crypto API, having `Cipher.setAuthTag()` and
-`Decipher.getAuthTag()` is not helpful and both functions will throw an error
-when called. They have never been documented and will be removed in a future
-release.
+The functions `Cipher.setAuthTag()` and `Decipher.getAuthTag()` have been
+removed. They had never been documented would throw when called.
 
 <a id="DEP0114"></a>
 ### DEP0114: crypto._toBuf()

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -37,7 +37,7 @@ const {
 const assert = require('internal/assert');
 const LazyTransform = require('internal/streams/lazy_transform');
 
-const { deprecate, normalizeEncoding } = require('internal/util');
+const { normalizeEncoding } = require('internal/util');
 
 // Lazy loaded for startup performance.
 let StringDecoder;
@@ -206,13 +206,6 @@ function setAuthTag(tagbuf) {
   return this;
 }
 
-Object.defineProperty(Cipher.prototype, 'setAuthTag', {
-  get: deprecate(() => setAuthTag,
-                 'Cipher.setAuthTag is deprecated and will be removed in a ' +
-                 'future version of Node.js.',
-                 'DEP0113')
-});
-
 Cipher.prototype.setAAD = function setAAD(aadbuf, options) {
   if (!isArrayBufferView(aadbuf)) {
     throw new ERR_INVALID_ARG_TYPE('buffer',
@@ -243,20 +236,8 @@ function addCipherPrototypeFunctions(constructor) {
   constructor.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
   if (constructor === Cipheriv) {
     constructor.prototype.getAuthTag = Cipher.prototype.getAuthTag;
-    Object.defineProperty(constructor.prototype, 'setAuthTag', {
-      get: deprecate(() => setAuthTag,
-                     'Cipher.setAuthTag is deprecated and will be removed in ' +
-                     'a future version of Node.js.',
-                     'DEP0113')
-    });
   } else {
     constructor.prototype.setAuthTag = setAuthTag;
-    Object.defineProperty(constructor.prototype, 'getAuthTag', {
-      get: deprecate(() => constructor.prototype.getAuthTag,
-                     'Decipher.getAuthTag is deprecated and will be removed ' +
-                     'in a future version of Node.js.',
-                     'DEP0113')
-    });
   }
   constructor.prototype.setAAD = Cipher.prototype.setAAD;
 }


### PR DESCRIPTION
`Cipher.setAuthTag` and `Decipher.getAuthTag` have been runtime deprecated in node 11 and their existence still does not make sense. It is not urgent to remove them, but it also should do no harm. (Calling them will always throw anyway, and that behavior will still be the same after removal, except that the reason will be different.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
