### PR TITLE
doc: fix deprecation "End-of-Life" capitalization

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1284,7 +1284,7 @@ changes:
     description: End-of-Life.
 -->
 
-Type: End-Of-Life
+Type: End-of-Life
 
 `--debug` activates the legacy V8 debugger interface, which was removed as
 of V8 5.8. It is replaced by Inspector which is activated with `--inspect`
@@ -2186,7 +2186,7 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: End-Of-Life
+Type: End-of-Life
 
 The `crypto._toBuf()` function was not designed to be used by modules outside
 of Node.js core and was removed.


### PR DESCRIPTION
There are 78 occurrences of `End-of-Life` and two occurrences of `End-Of-Life`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
