### PR TITLE
build: silence cpp lint by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1266,11 +1266,8 @@ else
 	@echo "To install (requires internet access) run: $ make format-cpp-build"
 endif
 
-ifeq ($(V),1)
-  CPPLINT_QUIET =
-else
-  CPPLINT_QUIET = --quiet
-endif
+CPPLINT_QUIET = --quiet
+
 .PHONY: lint-cpp
 # Lints the C++ code with cpplint.py and check-imports.py.
 lint-cpp: tools/.cpplintstamp


### PR DESCRIPTION
The cpp linter is very noisy at the moment. So use the --quiet flag
by default instead of being verbose in this case.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
