### PR TITLE
dns: refactor QueryWrap lifetime management

### DIFF
--- a/test/parallel/test-worker-dns-terminate-during-query.js
+++ b/test/parallel/test-worker-dns-terminate-during-query.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const { Resolver } = require('dns');
+const dgram = require('dgram');
+const { Worker, isMainThread } = require('worker_threads');
+
+// Test that Workers can terminate while DNS queries are outstanding.
+
+if (isMainThread) {
+  return new Worker(__filename);
+}
+
+const socket = dgram.createSocket('udp4');
+
+socket.bind(0, common.mustCall(() => {
+  const resolver = new Resolver();
+  resolver.setServers([`127.0.0.1:${socket.address().port}`]);
+  resolver.resolve4('example.org', common.mustNotCall());
+}));
+
+socket.on('message', common.mustCall(() => {
+  process.exit();
+}));


### PR DESCRIPTION
- Prefer RAII-style management over manual resource management.
- Prefer `env->SetImmediate()` over a separate `uv_async_t`.
- Perform `ares_destroy()` before possibly tearing down c-ares state.
- Verify that the number of active queries is non-negative.
- Let pending callbacks know when their underlying `QueryWrap` object
  has been destroyed.

The last item has been a real bug, in that when Workers shut down
during currently running DNS queries, they may run into use-after-free
situations because:

1. Shutting the `Worker` down leads to the cleanup code deleting
   the `QueryWrap` objects first; then
2. deleting the `ChannelWrap` object (as it has been created before
   the `QueryWrap`s), whose destructor runs `ares_destroy()`, which
   in turn invokes all pending query callbacks with `ARES_ECANCELLED`,
3. which lead to use-after-free, as the callback tried to access the
   deleted `QueryWrap` object.

The added test verifies that this is no longer an issue.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
