### PR TITLE
src: simplify native immediate by using v8::Global

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -617,8 +617,8 @@ void Environment::CreateImmediate(native_immediate_callback cb,
   native_immediate_callbacks_.push_back({
     cb,
     data,
-    std::unique_ptr<Persistent<v8::Object>>(obj.IsEmpty() ?
-        nullptr : new Persistent<v8::Object>(isolate_, obj)),
+    obj.IsEmpty() ? v8::Global<v8::Object>() :
+        v8::Global<v8::Object>(isolate_, obj),
     ref
   });
   immediate_info()->count_inc(1);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -617,8 +617,7 @@ void Environment::CreateImmediate(native_immediate_callback cb,
   native_immediate_callbacks_.push_back({
     cb,
     data,
-    obj.IsEmpty() ? v8::Global<v8::Object>() :
-        v8::Global<v8::Object>(isolate_, obj),
+    v8::Global<v8::Object>(isolate_, obj),
     ref
   });
   immediate_info()->count_inc(1);

--- a/src/env.h
+++ b/src/env.h
@@ -1092,7 +1092,7 @@ class Environment {
   struct NativeImmediateCallback {
     native_immediate_callback cb_;
     void* data_;
-    std::unique_ptr<Persistent<v8::Object>> keep_alive_;
+    v8::Global<v8::Object> keep_alive_;
     bool refed_;
   };
   std::vector<NativeImmediateCallback> native_immediate_callbacks_;


### PR DESCRIPTION
Unlike `node::Persistent`, `v8::Global` has move semantics and
can be used directly in STL containers.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
