### PR TITLE
inspector: return Error objects on error

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1159,6 +1159,11 @@ inspector was already connected.
 While using the `inspector` module, an attempt was made to use the inspector
 after the session had already closed.
 
+<a id="ERR_INSPECTOR_COMMAND"></a>
+### ERR_INSPECTOR_COMMAND
+
+An error occurred while issuing a command via the `inspector` module.
+
 <a id="ERR_INSPECTOR_NOT_AVAILABLE"></a>
 ### ERR_INSPECTOR_NOT_AVAILABLE
 

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -3,6 +3,7 @@
 const {
   ERR_INSPECTOR_ALREADY_CONNECTED,
   ERR_INSPECTOR_CLOSED,
+  ERR_INSPECTOR_COMMAND,
   ERR_INSPECTOR_NOT_AVAILABLE,
   ERR_INSPECTOR_NOT_CONNECTED,
   ERR_INVALID_ARG_TYPE,
@@ -48,8 +49,14 @@ class Session extends EventEmitter {
       if (parsed.id) {
         const callback = this[messageCallbacksSymbol].get(parsed.id);
         this[messageCallbacksSymbol].delete(parsed.id);
-        if (callback)
-          callback(parsed.error || null, parsed.result || null);
+        if (callback) {
+          if (parsed.error) {
+            return callback(new ERR_INSPECTOR_COMMAND(parsed.error.code,
+                                                      parsed.error.message));
+          }
+
+          callback(null, parsed.result);
+        }
       } else {
         this.emit(parsed.method, parsed);
         this.emit('inspectorNotification', parsed);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -706,6 +706,7 @@ E('ERR_INCOMPATIBLE_OPTION_PAIR',
   'Option "%s" can not be used in combination with option "%s"', TypeError);
 E('ERR_INSPECTOR_ALREADY_CONNECTED', '%s is already connected', Error);
 E('ERR_INSPECTOR_CLOSED', 'Session was closed', Error);
+E('ERR_INSPECTOR_COMMAND', 'Inspector error %d: %s', Error);
 E('ERR_INSPECTOR_NOT_AVAILABLE', 'Inspector is not available', Error);
 E('ERR_INSPECTOR_NOT_CONNECTED', 'Session is not connected', Error);
 E('ERR_INVALID_ADDRESS_FAMILY', 'Invalid address family: %s', RangeError);

--- a/test/sequential/test-inspector-runtime-evaluate-with-timeout.js
+++ b/test/sequential/test-inspector-runtime-evaluate-with-timeout.js
@@ -5,17 +5,22 @@ const common = require('../common');
 common.skipIfInspectorDisabled();
 
 (async function test() {
-  const { strictEqual } = require('assert');
+  const assert = require('assert');
   const { Session } = require('inspector');
   const { promisify } = require('util');
 
   const session = new Session();
   session.connect();
   session.post = promisify(session.post);
-  const result = await session.post('Runtime.evaluate', {
-    expression: 'for(;;);',
-    timeout: 0
-  }).catch((e) => e);
-  strictEqual(result.message, 'Execution was terminated');
+  await assert.rejects(
+    session.post('Runtime.evaluate', {
+      expression: 'for(;;);',
+      timeout: 0
+    }),
+    {
+      code: 'ERR_INSPECTOR_COMMAND',
+      message: 'Inspector error -32000: Execution was terminated'
+    }
+  );
   session.disconnect();
 })();


### PR DESCRIPTION
The inspector communicates errors via POJOs. This PR wraps the error information in an actual Error object.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
