### PR TITLE
src: fix StreamPipe cleanup & interaction with env handles

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -394,7 +394,11 @@ void Environment::RegisterHandleCleanups() {
                                         void* arg) {
     handle->data = env;
 
-    env->CloseHandle(handle, [](uv_handle_t* handle) {});
+    env->CloseHandle(handle, [](uv_handle_t* handle) {
+#ifdef DEBUG
+      memset(handle, 0xab, uv_handle_size(handle->type));
+#endif
+    });
   };
 
   RegisterHandleCleanup(
@@ -508,6 +512,7 @@ void Environment::PrintSyncTrace() const {
 }
 
 void Environment::RunCleanup() {
+  started_cleanup_ = true;
   TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
                               "RunCleanup", this);
   CleanupHandles();
@@ -656,10 +661,13 @@ void Environment::RunAndClearNativeImmediates() {
 
 
 void Environment::ScheduleTimer(int64_t duration_ms) {
+  if (started_cleanup_) return;
   uv_timer_start(timer_handle(), RunTimers, duration_ms, 0);
 }
 
 void Environment::ToggleTimerRef(bool ref) {
+  if (started_cleanup_) return;
+
   if (ref) {
     uv_ref(reinterpret_cast<uv_handle_t*>(timer_handle()));
   } else {
@@ -759,6 +767,8 @@ void Environment::CheckImmediate(uv_check_t* handle) {
 }
 
 void Environment::ToggleImmediateRef(bool ref) {
+  if (started_cleanup_) return;
+
   if (ref) {
     // Idle handle is needed only to stop the event loop from blocking in poll.
     uv_idle_start(immediate_idle_handle(), [](uv_idle_t*){ });

--- a/src/env.h
+++ b/src/env.h
@@ -1126,6 +1126,7 @@ class Environment {
                      CleanupHookCallback::Hash,
                      CleanupHookCallback::Equal> cleanup_hooks_;
   uint64_t cleanup_hook_counter_ = 0;
+  bool started_cleanup_ = false;
 
   static void EnvPromiseHook(v8::PromiseHookType type,
                              v8::Local<v8::Promise> promise,

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -42,7 +42,7 @@ StreamPipe::StreamPipe(StreamBase* source,
 }
 
 StreamPipe::~StreamPipe() {
-  CHECK(is_closed_);
+  Unpipe();
 }
 
 StreamBase* StreamPipe::source() {

--- a/test/parallel/test-worker-terminate-http2-respond-with-file.js
+++ b/test/parallel/test-worker-terminate-http2-respond-with-file.js
@@ -1,0 +1,39 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+const makeDuplexPair = require('../common/duplexpair');
+const { Worker, isMainThread } = require('worker_threads');
+
+// This is a variant of test-http2-generic-streams-sendfile for checking
+// that Workers can be terminated during a .respondWithFile() operation.
+
+if (isMainThread) {
+  return new Worker(__filename);
+}
+
+{
+  const server = http2.createServer();
+  server.on('stream', common.mustCall((stream, headers) => {
+    stream.respondWithFile(process.execPath);  // Use a large-ish file.
+  }));
+
+  const { clientSide, serverSide } = makeDuplexPair();
+  server.emit('connection', serverSide);
+
+  const client = http2.connect('http://localhost:80', {
+    createConnection: common.mustCall(() => clientSide)
+  });
+
+  const req = client.request();
+
+  req.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[':status'], 200);
+  }));
+
+  req.on('data', common.mustCall(process.exit));
+  req.on('end', common.mustNotCall());
+  req.end();
+}


### PR DESCRIPTION
##### src: do not access Environment-owned handles after cleanup

Do not access handles that have already begun to be closed
or are closed.

##### src: clean up `StreamPipe` in destructor

In the presence of Workers, it is not safe to assume that
`StreamPipe::Unpipe()` has been called at the time when the object
is destroyed.

Instead, clean up when the destructor is called.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
