### PR TITLE
repl: deprecate REPLServer.rli

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2336,7 +2336,7 @@ Setting the TLS ServerName to an IP address is not permitted by
 [RFC 6066][]. This will be ignored in a future version.
 
 <a id="DEP0XXX"></a>
-### DEP0XXX: using REPLServer#rli
+### DEP0XXX: using REPLServer.rli
 <!-- YAML
 changes:
   - version: REPLACEME
@@ -2346,7 +2346,7 @@ changes:
 
 Type: Runtime
 
-This property is just a reference to the instance itself.
+This property is a reference to the instance itself.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2321,7 +2321,6 @@ Type: Runtime
 
 Please use `Server.prototype.setSecureContext()` instead.
 
-
 <a id="DEP0123"></a>
 ### DEP0123: setting the TLS ServerName to an IP address
 <!-- YAML
@@ -2335,6 +2334,19 @@ Type: Runtime
 
 Setting the TLS ServerName to an IP address is not permitted by
 [RFC 6066][]. This will be ignored in a future version.
+
+<a id="DEP0XXX"></a>
+### DEP0XXX: using REPLServer#rli
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+This property is just a reference to the instance itself.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -176,8 +176,15 @@ function REPLServer(prompt,
   // Context id for use with the inspector protocol.
   self[kContextId] = undefined;
 
-  // Just for backwards compat, see github.com/joyent/node/pull/7127
-  self.rli = this;
+  let rli = self;
+  Object.defineProperty(self, 'rli', {
+    get: util.deprecate(() => rli,
+                        'REPLServer.rli is deprecated', 'DEP0XXX'),
+    set: util.deprecate((val) => rli = val,
+                        'REPLServer.rli is deprecated', 'DEP0XXX'),
+    enumerable: true,
+    configurable: true
+  });
 
   const savedRegExMatches = ['', '', '', '', '', '', '', '', '', ''];
   const sep = '\u0000\u0000\u0000';

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -25,6 +25,12 @@ const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
 
+common.expectWarning({
+  DeprecationWarning: {
+    DEP0XXX: 'REPLServer.rli is deprecated'
+  }
+});
+
 // Create a dummy stream that does nothing
 const stream = new ArrayStream();
 


### PR DESCRIPTION
This is only a reference to the instance and should not be used.

It was originally meant to be removed years ago but then forgotten.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
