### PR TITLE
lib: support dumb terminals

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -346,7 +346,7 @@ const consoleMethods = {
   clear() {
     // It only makes sense to clear if _stdout is a TTY.
     // Otherwise, do nothing.
-    if (this._stdout.isTTY) {
+    if (this._stdout.isTTY && process.env.TERM !== 'dumb') {
       // The require is here intentionally to avoid readline being
       // required too early when console is first loaded.
       const { cursorTo, clearScreenDown } = require('readline');

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -161,6 +161,10 @@ function Interface(input, output, completer, terminal) {
 
   this.terminal = !!terminal;
 
+  if (process.env.TERM === 'dumb') {
+    this._ttyWrite = _ttyWriteDumb.bind(this);
+  }
+
   function ondata(data) {
     self._normalWrite(data);
   }
@@ -181,11 +185,7 @@ function Interface(input, output, completer, terminal) {
   }
 
   function onkeypress(s, key) {
-    if (process.env.TERM === 'dumb') {
-      self._ttyWriteDumb(s, key);
-    } else {
-      self._ttyWrite(s, key);
-    }
+    self._ttyWrite(s, key);
     if (key && key.sequence) {
       // If the key.sequence is half of a surrogate pair
       // (>= 0xd800 and <= 0xdfff), refresh the line so
@@ -422,11 +422,7 @@ Interface.prototype.resume = function() {
 Interface.prototype.write = function(d, key) {
   if (this.paused) this.resume();
   if (this.terminal) {
-    if (process.env.TERM === 'dumb') {
-      this._ttyWriteDumb(d, key);
-    } else {
-      this._ttyWrite(d, key);
-    }
+    this._ttyWrite(d, key);
   } else {
     this._normalWrite(d);
   }
@@ -801,7 +797,7 @@ Interface.prototype._moveCursor = function(dx) {
   }
 };
 
-Interface.prototype._ttyWriteDumb = function(s, key) {
+function _ttyWriteDumb(s, key) {
   key = key || {};
 
   if (key.name === 'escape') return;
@@ -843,7 +839,7 @@ Interface.prototype._ttyWriteDumb = function(s, key) {
         this._writeToOutput(s);
       }
   }
-};
+}
 
 // handle a write from the tty
 Interface.prototype._ttyWrite = function(s, key) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -829,7 +829,7 @@ function _ttyWriteDumb(s, key) {
       break;
 
     default:
-      if (s) {
+      if (typeof s === 'string' && s) {
         this.line += s;
         this.cursor += s.length;
         this._writeToOutput(s);
@@ -1054,7 +1054,7 @@ Interface.prototype._ttyWrite = function(s, key) {
         // falls through
 
       default:
-        if (s) {
+        if (typeof s === 'string' && s) {
           var lines = s.split(/\r\n|\n|\r/);
           for (var i = 0, len = lines.length; i < len; i++) {
             if (i > 0) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -34,7 +34,6 @@ const {
 const { validateString } = require('internal/validators');
 const { debug } = require('util');
 const { emitExperimentalWarning } = require('internal/util');
-const { Buffer } = require('buffer');
 const EventEmitter = require('events');
 const {
   CSI,
@@ -830,9 +829,6 @@ function _ttyWriteDumb(s, key) {
       break;
 
     default:
-      if (s instanceof Buffer)
-        s = s.toString('utf-8');
-
       if (s) {
         this.line += s;
         this.cursor += s.length;
@@ -1058,9 +1054,6 @@ Interface.prototype._ttyWrite = function(s, key) {
         // falls through
 
       default:
-        if (s instanceof Buffer)
-          s = s.toString('utf-8');
-
         if (s) {
           var lines = s.split(/\r\n|\n|\r/);
           for (var i = 0, len = lines.length; i < len; i++) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -181,7 +181,11 @@ function Interface(input, output, completer, terminal) {
   }
 
   function onkeypress(s, key) {
-    self._ttyWrite(s, key);
+    if (process.env.TERM === 'dumb') {
+      self._ttyWriteDumb(s, key);
+    } else {
+      self._ttyWrite(s, key);
+    }
     if (key && key.sequence) {
       // If the key.sequence is half of a surrogate pair
       // (>= 0xd800 and <= 0xdfff), refresh the line so
@@ -276,7 +280,7 @@ Interface.prototype._setRawMode = function(mode) {
 
 Interface.prototype.prompt = function(preserveCursor) {
   if (this.paused) this.resume();
-  if (this.terminal) {
+  if (this.terminal && process.env.TERM !== 'dumb') {
     if (!preserveCursor) this.cursor = 0;
     this._refreshLine();
   } else {
@@ -417,7 +421,15 @@ Interface.prototype.resume = function() {
 
 Interface.prototype.write = function(d, key) {
   if (this.paused) this.resume();
-  this.terminal ? this._ttyWrite(d, key) : this._normalWrite(d);
+  if (this.terminal) {
+    if (process.env.TERM === 'dumb') {
+      this._ttyWriteDumb(d, key);
+    } else {
+      this._ttyWrite(d, key);
+    }
+  } else {
+    this._normalWrite(d);
+  }
 };
 
 Interface.prototype._normalWrite = function(b) {
@@ -789,6 +801,49 @@ Interface.prototype._moveCursor = function(dx) {
   }
 };
 
+Interface.prototype._ttyWriteDumb = function(s, key) {
+  key = key || {};
+
+  if (key.name === 'escape') return;
+
+  if (this._sawReturnAt && key.name !== 'enter')
+    this._sawReturnAt = 0;
+
+  if (key.ctrl && key.name === 'c') {
+    if (this.listenerCount('SIGINT') > 0) {
+      this.emit('SIGINT');
+    } else {
+      // This readline instance is finished
+      this.close();
+    }
+  }
+
+  switch (key.name) {
+    case 'return':  // carriage return, i.e. \r
+      this._sawReturnAt = Date.now();
+      this._line();
+      break;
+
+    case 'enter':
+      // When key interval > crlfDelay
+      if (this._sawReturnAt === 0 ||
+          Date.now() - this._sawReturnAt > this.crlfDelay) {
+        this._line();
+      }
+      this._sawReturnAt = 0;
+      break;
+
+    default:
+      if (s instanceof Buffer)
+        s = s.toString('utf-8');
+
+      if (s) {
+        this.line += s;
+        this.cursor += s.length;
+        this._writeToOutput(s);
+      }
+  }
+};
 
 // handle a write from the tty
 Interface.prototype._ttyWrite = function(s, key) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -508,10 +508,7 @@ function REPLServer(prompt,
   if (self.useColors && self.writer === writer) {
     // Turn on ANSI coloring.
     self.writer = (obj) => util.inspect(obj, self.writer.options);
-    self.writer.options = {
-      ...writer.options,
-      colors: self.useColors
-    };
+    self.writer.options = { ...writer.options, colors: true };
   }
 
   function filterInternalStackFrames(structuredStack) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -501,14 +501,17 @@ function REPLServer(prompt,
   self.writer = options.writer || exports.writer;
 
   if (options.useColors === undefined) {
-    options.useColors = self.terminal;
+    options.useColors = self.terminal && process.env.TERM !== 'dumb';
   }
   self.useColors = !!options.useColors;
 
   if (self.useColors && self.writer === writer) {
     // Turn on ANSI coloring.
     self.writer = (obj) => util.inspect(obj, self.writer.options);
-    self.writer.options = { ...writer.options, colors: true };
+    self.writer.options = {
+      ...writer.options,
+      colors: self.useColors
+    };
   }
 
   function filterInternalStackFrames(structuredStack) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -501,7 +501,9 @@ function REPLServer(prompt,
   self.writer = options.writer || exports.writer;
 
   if (options.useColors === undefined) {
-    options.useColors = self.terminal && process.env.TERM !== 'dumb';
+    options.useColors = self.terminal && (
+      typeof self.outputStream.getColorDepth === 'function' ?
+        self.outputStream.getColorDepth() > 2 : true);
   }
   self.useColors = !!options.useColors;
 

--- a/test/pseudo-tty/console-dumb-tty.js
+++ b/test/pseudo-tty/console-dumb-tty.js
@@ -1,0 +1,9 @@
+'use strict';
+require('../common');
+
+process.env.TERM = 'dumb';
+
+console.log({ foo: 'bar' });
+console.dir({ foo: 'bar' });
+console.log('%s q', 'string');
+console.log('%o with object format param', { foo: 'bar' });

--- a/test/pseudo-tty/console-dumb-tty.out
+++ b/test/pseudo-tty/console-dumb-tty.out
@@ -1,0 +1,4 @@
+{ foo: 'bar' }
+{ foo: 'bar' }
+string q
+{ foo: 'bar' } with object format param

--- a/test/pseudo-tty/readline-dumb-tty.js
+++ b/test/pseudo-tty/readline-dumb-tty.js
@@ -1,0 +1,21 @@
+'use strict';
+require('../common');
+
+process.env.TERM = 'dumb';
+
+const readline = require('readline');
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+rl.write('text');
+rl.write(null, { ctrl: true, name: 'u' });
+rl.write(null, { name: 'return' });
+rl.write('text');
+rl.write(null, { name: 'backspace' });
+rl.write(null, { name: 'escape' });
+rl.write(null, { name: 'enter' });
+rl.write('text');
+rl.write(null, { ctrl: true, name: 'c' });

--- a/test/pseudo-tty/readline-dumb-tty.out
+++ b/test/pseudo-tty/readline-dumb-tty.out
@@ -1,0 +1,3 @@
+text
+text
+text

--- a/test/pseudo-tty/repl-dumb-tty.js
+++ b/test/pseudo-tty/repl-dumb-tty.js
@@ -1,0 +1,15 @@
+'use strict';
+require('../common');
+
+process.env.TERM = 'dumb';
+
+const repl = require('repl');
+
+repl.start('> ');
+process.stdin.push('console.log("foo")\n');
+process.stdin.push('1 + 2\n');
+process.stdin.push('"str"\n');
+process.stdin.push('console.dir({ a: 1 })\n');
+process.stdin.push('{ a: 1 }\n');
+process.stdin.push('\n');
+process.stdin.push('.exit\n');

--- a/test/pseudo-tty/repl-dumb-tty.out
+++ b/test/pseudo-tty/repl-dumb-tty.out
@@ -1,0 +1,14 @@
+> console.log("foo")
+foo
+undefined
+> 1 + 2
+3
+> "str"
+'str'
+> console.dir({ a: 1 })
+{ a: 1 }
+undefined
+> { a: 1 }
+{ a: 1 }
+>
+> .exit


### PR DESCRIPTION
Add checks for `TERM='dumb'` in `console` and `repl`.

Add support for dumb terminals in `readline`. When `TERM='dumb'`:
- it doesn't use any ANSI escape codes for movement and output
- it doesn't use color
- it ignores all special keys except: `escape`, `return` and `ctrl-c`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests  are included
- [x] commit message follows commit guidelines