### PR TITLE
report: fix build warning in node_report.cc

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -172,16 +172,14 @@ std::string TriggerNodeReport(Isolate* isolate,
       std::cerr << " (errno: " << errno << ")" << std::endl;
       return "";
     }
+    outstream = &outfile;
 
     std::cerr << std::endl
               << "Writing Node.js report to file: " << filename << std::endl;
   }
 
-  // Pass our stream about by reference, not by copying it.
-  std::ostream& out = outfile.is_open() ? outfile : *outstream;
-
-  WriteNodeReport(
-      isolate, env, message, location, filename, out, stackstr, &tm_struct);
+  WriteNodeReport(isolate, env, message, location, filename, *outstream,
+                  stackstr, &tm_struct);
 
   // Do not close stdout/stderr, only close files we opened.
   if (outfile.is_open()) {


### PR DESCRIPTION
Fixes the following [build warning](https://travis-ci.com/nodejs/node/jobs/179891190#L8326-L8333):
```
CXX(target) /home/travis/build/nodejs/node/out/Release/obj.target/node_lib/src/node_report.o
../src/node_report.cc: In function ‘std::string report::TriggerNodeReport(v8::Isolate*, node::Environment*, const char*, const char*, std::string, v8::Local<v8::String>)’:
../src/node_report.cc:184:76: warning: ‘outstream’ may be used uninitialized in this function [-Wmaybe-uninitialized]
       isolate, env, message, location, filename, out, stackstr, &tm_struct);
                                                                            ^
../src/node_report.cc:149:17: note: ‘outstream’ was declared here
   std::ostream* outstream;
                 ^
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
