### PR TITLE
worker: provide process.execArgv

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -429,7 +429,8 @@ if (isMainThread) {
   * `execArgv` {string[]} List of node CLI options passed to the worker.
     V8 options (such as `--max-old-space-size`) and options that affect the
     process (such as `--title`) are not supported. If set, this will be provided
-    as [`process.execArgv`][] inside the worker.
+    as [`process.execArgv`][] inside the worker. By default, options will be
+    inherited from the parent thread.
 
 ### Event: 'error'
 <!-- YAML

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -428,7 +428,8 @@ if (isMainThread) {
     not automatically be piped through to `process.stderr` in the parent.
   * `execArgv` {string[]} List of node CLI options passed to the worker.
     V8 options (such as `--max-old-space-size`) and options that affect the
-    process (such as `--title`) are not supported.
+    process (such as `--title`) are not supported. If set, this will be provided
+    as [`process.execArgv`][] inside the worker.
 
 ### Event: 'error'
 <!-- YAML
@@ -582,6 +583,7 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [`process.abort()`]: process.html#process_process_abort
 [`process.chdir()`]: process.html#process_process_chdir_directory
 [`process.env`]: process.html#process_process_env
+[`process.execArgv`]: process.html#process_process_execargv
 [`process.exit()`]: process.html#process_process_exit_code
 [`process.stderr`]: process.html#process_process_stderr
 [`process.stdin`]: process.html#process_process_stdin

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -605,6 +605,10 @@ inline std::shared_ptr<EnvironmentOptions> Environment::options() {
   return options_;
 }
 
+inline const std::vector<std::string>& Environment::exec_argv() {
+  return exec_argv_;
+}
+
 inline std::shared_ptr<HostPort> Environment::inspector_host_port() {
   return inspector_host_port_;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -386,6 +386,7 @@ MaybeLocal<Object> Environment::ProcessCliArgs(
                                       std::move(traced_value));
   }
 
+  exec_argv_ = exec_args;
   Local<Object> process_object =
       node::CreateProcessObject(this, args, exec_args)
           .FromMaybe(Local<Object>());

--- a/src/env.h
+++ b/src/env.h
@@ -676,6 +676,7 @@ class Environment {
   v8::MaybeLocal<v8::Object> ProcessCliArgs(
       const std::vector<std::string>& args,
       const std::vector<std::string>& exec_args);
+  inline const std::vector<std::string>& exec_argv();
 
   typedef void (*HandleCleanupCb)(Environment* env,
                                   uv_handle_t* handle,
@@ -1060,6 +1061,7 @@ class Environment {
   // the inspector_host_port_->port() will be the actual port being
   // used.
   std::shared_ptr<HostPort> inspector_host_port_;
+  std::vector<std::string> exec_argv_;
 
   uint32_t module_id_counter_ = 0;
   uint32_t script_id_counter_ = 0;

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -38,7 +38,8 @@ class Worker : public AsyncWrap {
   Worker(Environment* env,
          v8::Local<v8::Object> wrap,
          const std::string& url,
-         std::shared_ptr<PerIsolateOptions> per_isolate_opts);
+         std::shared_ptr<PerIsolateOptions> per_isolate_opts,
+         std::vector<std::string>&& exec_argv);
   ~Worker() override;
 
   // Run the worker. This is only called from the worker thread.
@@ -74,6 +75,7 @@ class Worker : public AsyncWrap {
   const std::string url_;
 
   std::shared_ptr<PerIsolateOptions> per_isolate_opts_;
+  std::vector<std::string> exec_argv_;
   MultiIsolatePlatform* platform_;
   v8::Isolate* isolate_ = nullptr;
   bool profiler_idle_notifier_started_;

--- a/test/parallel/test-worker-execargv.js
+++ b/test/parallel/test-worker-execargv.js
@@ -19,4 +19,5 @@ if (isMainThread) {
   }));
 } else {
   process.emitWarning('some warning');
+  assert.deepStrictEqual(process.execArgv, ['--trace-warnings']);
 }

--- a/test/parallel/test-worker-execargv.js
+++ b/test/parallel/test-worker-execargv.js
@@ -5,11 +5,13 @@ const assert = require('assert');
 // This test ensures that Workers have the ability to get
 // their own command line flags.
 
-const { Worker, isMainThread } = require('worker_threads');
+const { Worker } = require('worker_threads');
 const { StringDecoder } = require('string_decoder');
 const decoder = new StringDecoder('utf8');
 
-if (isMainThread) {
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
   const w = new Worker(__filename, { execArgv: ['--trace-warnings'] });
   w.stderr.on('data', common.mustCall((chunk) => {
     const error = decoder.write(chunk);


### PR DESCRIPTION
Provide `process.execArgv`. If an `execArgv` option is passed to the
`Worker` constructor, that option is used as its value; if not,
the parent’s `process.execArgv` is inherited (since that also goes
for the actual options in that case).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
