### PR TITLE
worker: make MessagePort `uv_async_t` inline field

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -494,10 +494,6 @@ MessagePort::MessagePort(Environment* env,
   Debug(this, "Created message port");
 }
 
-void MessagePort::AddToIncomingQueue(Message&& message) {
-  data_->AddToIncomingQueue(std::move(message));
-}
-
 uv_async_t* MessagePort::async() {
   return reinterpret_cast<uv_async_t*>(GetHandle());
 }

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -152,8 +152,6 @@ class MessagePort : public HandleWrap {
   v8::Maybe<bool> PostMessage(Environment* env,
                               v8::Local<v8::Value> message,
                               v8::Local<v8::Value> transfer);
-  // Deliver a single message into this port's incoming queue.
-  void AddToIncomingQueue(Message&& message);
 
   // Start processing messages on this port as a receiving end.
   void Start();

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -198,9 +198,9 @@ class MessagePort : public HandleWrap {
   void OnClose() override;
   void OnMessage();
   void TriggerAsync();
-  inline uv_async_t* async();
 
   std::unique_ptr<MessagePortData> data_ = nullptr;
+  uv_async_t async_;
 
   friend class MessagePortData;
 };


### PR DESCRIPTION
It’s not obvious why this was a heap allocation in the first place,
but it’s unneccessary. Most other `HandleWrap`s also store the
libuv handle directly.

(This is going to have a minor merge conflict with https://github.com/nodejs/node/pull/26099 so I’d wait until after that one lands before merging this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
