### PR TITLE
buffer: harden SlowBuffer creation

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -297,8 +297,6 @@ Buffer.allocUnsafeSlow = function allocUnsafeSlow(size) {
 // If --zero-fill-buffers command line argument is set, a zero-filled
 // buffer is returned.
 function SlowBuffer(length) {
-  if (typeof length !== 'number')
-    length = +length;
   assertSize(length);
   return createUnsafeBuffer(length);
 }

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const buffer = require('buffer');
 const SlowBuffer = buffer.SlowBuffer;
@@ -40,22 +40,22 @@ try {
 }
 
 // Should throw with invalid length type
-const bufferInvalidTypeMsg = common.expectsError({
+const bufferInvalidTypeMsg = {
   code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
+  name: 'TypeError [ERR_INVALID_ARG_TYPE]',
   message: /^The "size" argument must be of type number/,
-}, 4);
+};
 assert.throws(() => SlowBuffer(), bufferInvalidTypeMsg);
 assert.throws(() => SlowBuffer({}), bufferInvalidTypeMsg);
 assert.throws(() => SlowBuffer('6'), bufferInvalidTypeMsg);
 assert.throws(() => SlowBuffer(true), bufferInvalidTypeMsg);
 
 // Should throw with invalid length value
-const bufferMaxSizeMsg = common.expectsError({
+const bufferMaxSizeMsg = {
   code: 'ERR_INVALID_OPT_VALUE',
-  type: RangeError,
+  name: 'RangeError [ERR_INVALID_OPT_VALUE]',
   message: /^The value "[^"]*" is invalid for option "size"$/
-}, 4);
+};
 assert.throws(() => SlowBuffer(NaN), bufferMaxSizeMsg);
 assert.throws(() => SlowBuffer(Infinity), bufferMaxSizeMsg);
 assert.throws(() => SlowBuffer(-1), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -39,21 +39,24 @@ try {
   assert.strictEqual(e.name, 'RangeError');
 }
 
-// Should work with number-coercible values
-assert.strictEqual(SlowBuffer('6').length, 6);
-assert.strictEqual(SlowBuffer(true).length, 1);
+// Should throw with invalid length type
+const bufferInvalidTypeMsg = common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: /^The "size" argument must be of type number/,
+}, 4);
+assert.throws(() => SlowBuffer(), bufferInvalidTypeMsg);
+assert.throws(() => SlowBuffer({}), bufferInvalidTypeMsg);
+assert.throws(() => SlowBuffer('6'), bufferInvalidTypeMsg);
+assert.throws(() => SlowBuffer(true), bufferInvalidTypeMsg);
 
-// Should throw with invalid length
+// Should throw with invalid length value
 const bufferMaxSizeMsg = common.expectsError({
   code: 'ERR_INVALID_OPT_VALUE',
   type: RangeError,
   message: /^The value "[^"]*" is invalid for option "size"$/
-}, 7);
-
-assert.throws(() => SlowBuffer(), bufferMaxSizeMsg);
+}, 4);
 assert.throws(() => SlowBuffer(NaN), bufferMaxSizeMsg);
-assert.throws(() => SlowBuffer({}), bufferMaxSizeMsg);
-assert.throws(() => SlowBuffer('string'), bufferMaxSizeMsg);
 assert.throws(() => SlowBuffer(Infinity), bufferMaxSizeMsg);
 assert.throws(() => SlowBuffer(-1), bufferMaxSizeMsg);
 assert.throws(() => SlowBuffer(buffer.kMaxLength + 1), bufferMaxSizeMsg);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Now `SlowBuffer` creation throw misleading `Error`(which should be `ERR_INVALID_ARG_TYPE` IMHO) in our newest master since #26162 landed.

![screen shot 2019-02-23 at 5 25 41 pm](https://user-images.githubusercontent.com/23313266/53284474-11811000-3790-11e9-8e6d-ea4f291c620f.png)


So harden SlowBuffer creation again, make `SlowBuffer` function be consistent with the comment of `Buffer.allocUnsafeSlow` at the same time:

https://github.com/nodejs/node/blob/8ebd339031cf9826629ad780dd35fee130e95985/lib/buffer.js#L291-L299

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
