### PR TITLE
report: refactor getReport() argument validation and increase test coverage

### DIFF
--- a/lib/internal/process/report.js
+++ b/lib/internal/process/report.js
@@ -91,13 +91,13 @@ const report = {
   },
   getReport(err) {
     emitExperimentalWarning('report');
-    if (err == null) {
-      return nr.getReport(new ERR_SYNTHETIC().stack);
-    } else if (typeof err !== 'object') {
+
+    if (err === undefined)
+      err = new ERR_SYNTHETIC();
+    else if (err === null || typeof err !== 'object')
       throw new ERR_INVALID_ARG_TYPE('err', 'Object', err);
-    } else {
-      return nr.getReport(err.stack);
-    }
+
+    return nr.getReport(err.stack);
   }
 };
 

--- a/test/node-report/test-api-getreport.js
+++ b/test/node-report/test-api-getreport.js
@@ -8,5 +8,22 @@ const helper = require('../common/report');
 common.expectWarning('ExperimentalWarning',
                      'report is an experimental feature. This feature could ' +
                      'change at any time');
-helper.validateContent(process.report.getReport());
-assert.deepStrictEqual(helper.findReports(process.pid, process.cwd()), []);
+
+{
+  // Test with no arguments.
+  helper.validateContent(process.report.getReport());
+  assert.deepStrictEqual(helper.findReports(process.pid, process.cwd()), []);
+}
+
+{
+  // Test with an error argument.
+  helper.validateContent(process.report.getReport(new Error('test error')));
+  assert.deepStrictEqual(helper.findReports(process.pid, process.cwd()), []);
+}
+
+// Test with an invalid error argument.
+[null, 1, Symbol(), function() {}, 'foo'].forEach((error) => {
+  common.expectsError(() => {
+    process.report.getReport(error);
+  }, { code: 'ERR_INVALID_ARG_TYPE' });
+});


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
