### PR TITLE
src: refactor node options parsers to mitigate MSVC bug

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -546,7 +546,7 @@ int ProcessGlobalArgs(std::vector<std::string>* args,
   std::vector<std::string> v8_args;
 
   Mutex::ScopedLock lock(per_process::cli_options_mutex);
-  options_parser::PerProcessOptionsParser::instance.Parse(
+  options_parser::Parse(
       args,
       exec_args,
       &v8_args,

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -1,7 +1,7 @@
 #include "env-inl.h"
 #include "node.h"
 #include "node_i18n.h"
-#include "node_options-inl.h"
+#include "node_options.h"
 #include "util-inl.h"
 
 namespace node {

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -213,15 +213,15 @@ auto OptionsParser<Options>::Convert(
 template <typename Options>
 template <typename ChildOptions>
 void OptionsParser<Options>::Insert(
-    const OptionsParser<ChildOptions>* child_options_parser,
+    const OptionsParser<ChildOptions>& child_options_parser,
     ChildOptions* (Options::* get_child)()) {
-  aliases_.insert(child_options_parser->aliases_.begin(),
-                  child_options_parser->aliases_.end());
+  aliases_.insert(std::begin(child_options_parser.aliases_),
+                  std::end(child_options_parser.aliases_));
 
-  for (const auto& pair : child_options_parser->options_)
+  for (const auto& pair : child_options_parser.options_)
     options_.emplace(pair.first, Convert(pair.second, get_child));
 
-  for (const auto& pair : child_options_parser->implications_)
+  for (const auto& pair : child_options_parser.implications_)
     implications_.emplace(pair.first, Convert(pair.second, get_child));
 }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1,7 +1,8 @@
-#include <cerrno>
 #include "env-inl.h"
 #include "node_binding.h"
 #include "node_options-inl.h"
+
+#include <cstdlib>  // strtoul, errno
 
 using v8::Boolean;
 using v8::Context;
@@ -123,7 +124,7 @@ class EnvironmentOptionsParser : public OptionsParser<EnvironmentOptions> {
   EnvironmentOptionsParser();
   explicit EnvironmentOptionsParser(const DebugOptionsParser& dop)
     : EnvironmentOptionsParser() {
-    Insert(&dop, &EnvironmentOptions::get_debug_options);
+    Insert(dop, &EnvironmentOptions::get_debug_options);
   }
 };
 
@@ -391,7 +392,7 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
             kAllowedInEnvironment);
 #endif  // NODE_REPORT
 
-  Insert(&eop, &PerIsolateOptions::get_per_env_options);
+  Insert(eop, &PerIsolateOptions::get_per_env_options);
 }
 
 PerProcessOptionsParser::PerProcessOptionsParser(
@@ -501,7 +502,7 @@ PerProcessOptionsParser::PerProcessOptionsParser(
 #endif
 #endif
 
-  Insert(&iop, &PerProcessOptions::get_per_isolate_options);
+  Insert(iop, &PerProcessOptions::get_per_isolate_options);
 }
 
 inline std::string RemoveBrackets(const std::string& host) {
@@ -515,7 +516,8 @@ inline int ParseAndValidatePort(const std::string& port,
                                 std::vector<std::string>* errors) {
   char* endptr;
   errno = 0;
-  const long result = strtol(port.c_str(), &endptr, 10);  // NOLINT(runtime/int)
+  const unsigned long result =                 // NOLINT(runtime/int)
+    strtoul(port.c_str(), &endptr, 10);
   if (errno != 0 || *endptr != '\0'||
       (result != 0 && result < 1024) || result > 65535) {
     errors->push_back(" must be 0 or in range 1024 to 65535.");

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -310,12 +310,12 @@ class OptionsParser {
   //
   // If `*error` is set, the result of the parsing should be discarded and the
   // contents of any of the argument vectors should be considered undefined.
-  virtual void Parse(std::vector<std::string>* const args,
-                     std::vector<std::string>* const exec_args,
-                     std::vector<std::string>* const v8_args,
-                     Options* const options,
-                     OptionEnvvarSettings required_env_settings,
-                     std::vector<std::string>* const errors) const;
+  void Parse(std::vector<std::string>* const args,
+             std::vector<std::string>* const exec_args,
+             std::vector<std::string>* const v8_args,
+             Options* const options,
+             OptionEnvvarSettings required_env_settings,
+             std::vector<std::string>* const errors) const;
 
  private:
   // We support the wide variety of different option types by remembering
@@ -396,33 +396,12 @@ class OptionsParser {
   friend void GetOptions(const v8::FunctionCallbackInfo<v8::Value>& args);
 };
 
-class DebugOptionsParser : public OptionsParser<DebugOptions> {
- public:
-  DebugOptionsParser();
-
-  static const DebugOptionsParser instance;
-};
-
-class EnvironmentOptionsParser : public OptionsParser<EnvironmentOptions> {
- public:
-  EnvironmentOptionsParser();
-
-  static const EnvironmentOptionsParser instance;
-};
-
-class PerIsolateOptionsParser : public OptionsParser<PerIsolateOptions> {
- public:
-  PerIsolateOptionsParser();
-
-  static const PerIsolateOptionsParser instance;
-};
-
-class PerProcessOptionsParser : public OptionsParser<PerProcessOptions> {
- public:
-  PerProcessOptionsParser();
-
-  static const PerProcessOptionsParser instance;
-};
+using StringVector = std::vector<std::string>;
+template <class OptionsType, class = Options>
+void Parse(
+  StringVector* const args, StringVector* const exec_args,
+  StringVector* const v8_args, OptionsType* const options,
+  OptionEnvvarSettings required_env_settings, StringVector* const errors);
 
 }  // namespace options_parser
 

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -290,7 +290,7 @@ class OptionsParser {
   // a method that yields the target options type from this parser's options
   // type.
   template <typename ChildOptions>
-  void Insert(const OptionsParser<ChildOptions>* child_options_parser,
+  void Insert(const OptionsParser<ChildOptions>& child_options_parser,
               ChildOptions* (Options::* get_child)());
 
   // Parse a sequence of options into an options struct, a list of

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -1,5 +1,3 @@
-#include <climits>  // PATH_MAX
-
 #include "env-inl.h"
 #include "node_internals.h"
 #include "node_options-inl.h"
@@ -7,6 +5,8 @@
 #include "node_process.h"
 #include "node_revert.h"
 #include "util-inl.h"
+
+#include <climits>  // PATH_MAX
 
 namespace node {
 using v8::Context;

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -487,13 +487,13 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
       // The first argument is program name.
       invalid_args.erase(invalid_args.begin());
       if (errors.size() > 0 || invalid_args.size() > 0) {
-        v8::Local<v8::Value> value =
+        v8::Local<v8::Value> error =
             ToV8Value(env->context(),
                       errors.size() > 0 ? errors : invalid_args)
                 .ToLocalChecked();
         Local<String> key =
             FIXED_ONE_BYTE_STRING(env->isolate(), "invalidExecArgv");
-        args.This()->Set(env->context(), key, value).FromJust();
+        USE(args.This()->Set(env->context(), key, error).FromJust());
         return;
       }
     }

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -476,7 +476,7 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
 
       // Using invalid_args as the v8_args argument as it stores unknown
       // options for the per isolate parser.
-      options_parser::PerIsolateOptionsParser::instance.Parse(
+      options_parser::Parse(
           &exec_argv,
           &exec_argv_out,
           &invalid_args,


### PR DESCRIPTION
Simplify `node_options` API, so the compiler bug should not manifest.
Should fix current `master`
Fixes: https://github.com/nodejs/node/issues/25593

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
