### PR TITLE
tools: update markdown linter

### DIFF
--- a/tools/lint-md.js
+++ b/tools/lint-md.js
@@ -3897,7 +3897,7 @@ function resolvePlugin(name, options) {
 
 module.exports = function (args, opts) {
     if (!opts) opts = {};
-
+    
     var flags = { bools : {}, strings : {}, unknownFn: null };
 
     if (typeof opts['unknown'] === 'function') {
@@ -3911,7 +3911,7 @@ module.exports = function (args, opts) {
           flags.bools[key] = true;
       });
     }
-
+    
     var aliases = {};
     Object.keys(opts.alias || {}).forEach(function (key) {
         aliases[key] = [].concat(opts.alias[key]);
@@ -3930,12 +3930,12 @@ module.exports = function (args, opts) {
      });
 
     var defaults = opts['default'] || {};
-
+    
     var argv = { _ : [] };
     Object.keys(flags.bools).forEach(function (key) {
         setArg(key, defaults[key] === undefined ? false : defaults[key]);
     });
-
+    
     var notFlags = [];
 
     if (args.indexOf('--') !== -1) {
@@ -3957,7 +3957,7 @@ module.exports = function (args, opts) {
             ? Number(val) : val
         ;
         setKey(argv, key.split('.'), value);
-
+        
         (aliases[key] || []).forEach(function (x) {
             setKey(argv, x.split('.'), value);
         });
@@ -3981,7 +3981,7 @@ module.exports = function (args, opts) {
             o[key] = [ o[key], value ];
         }
     }
-
+    
     function aliasIsBoolean(key) {
       return aliases[key].some(function (x) {
           return flags.bools[x];
@@ -3990,7 +3990,7 @@ module.exports = function (args, opts) {
 
     for (var i = 0; i < args.length; i++) {
         var arg = args[i];
-
+        
         if (/^--.+=/.test(arg)) {
             // Using [\s\S] instead of . because js doesn't support the
             // 'dotall' regex modifier. See:
@@ -4027,29 +4027,29 @@ module.exports = function (args, opts) {
         }
         else if (/^-[^-]+/.test(arg)) {
             var letters = arg.slice(1,-1).split('');
-
+            
             var broken = false;
             for (var j = 0; j < letters.length; j++) {
                 var next = arg.slice(j+2);
-
+                
                 if (next === '-') {
                     setArg(letters[j], next, arg)
                     continue;
                 }
-
+                
                 if (/[A-Za-z]/.test(letters[j]) && /=/.test(next)) {
                     setArg(letters[j], next.split('=')[1], arg);
                     broken = true;
                     break;
                 }
-
+                
                 if (/[A-Za-z]/.test(letters[j])
                 && /-?\d+(\.\d*)?(e-?\d+)?$/.test(next)) {
                     setArg(letters[j], next, arg);
                     broken = true;
                     break;
                 }
-
+                
                 if (letters[j+1] && letters[j+1].match(/\W/)) {
                     setArg(letters[j], arg.slice(j+2), arg);
                     broken = true;
@@ -4059,7 +4059,7 @@ module.exports = function (args, opts) {
                     setArg(letters[j], flags.strings[letters[j]] ? '' : true, arg);
                 }
             }
-
+            
             var key = arg.slice(-1)[0];
             if (!broken && key !== '-') {
                 if (args[i+1] && !/^(-|--)[^-]/.test(args[i+1])
@@ -4089,17 +4089,17 @@ module.exports = function (args, opts) {
             }
         }
     }
-
+    
     Object.keys(defaults).forEach(function (key) {
         if (!hasKey(argv, key.split('.'))) {
             setKey(argv, key.split('.'), defaults[key]);
-
+            
             (aliases[key] || []).forEach(function (x) {
                 setKey(argv, x.split('.'), defaults[key]);
             });
         }
     });
-
+    
     if (opts['--']) {
         argv['--'] = new Array();
         notFlags.forEach(function(key) {
@@ -26609,7 +26609,7 @@ module.exports = function (rows_, opts) {
     var stringLength = opts.stringLength
         || function (s) { return String(s).length; }
     ;
-
+    
     var dotsizes = reduce(rows_, function (acc, row) {
         forEach(row, function (c, ix) {
             var n = dotindex(c);
@@ -26617,7 +26617,7 @@ module.exports = function (rows_, opts) {
         });
         return acc;
     }, []);
-
+    
     var rows = map(rows_, function (row) {
         return map(row, function (c_, ix) {
             var c = String(c_);
@@ -26631,7 +26631,7 @@ module.exports = function (rows_, opts) {
             else return c;
         });
     });
-
+    
     var sizes = reduce(rows, function (acc, row) {
         forEach(row, function (c, ix) {
             var n = stringLength(c);
@@ -26639,7 +26639,7 @@ module.exports = function (rows_, opts) {
         });
         return acc;
     }, []);
-
+    
     return map(rows, function (row) {
         return map(row, function (c, ix) {
             var n = (sizes[ix] - stringLength(c)) || 0;
@@ -26652,7 +26652,7 @@ module.exports = function (rows_, opts) {
                     + c + Array(Math.floor(n / 2 + 1)).join(' ')
                 ;
             }
-
+            
             return c + s;
         }).join(hsep).replace(/\s+$/, '');
     }).join('\n');
@@ -35184,13 +35184,13 @@ function tableCell(node) {
 /* 302 */
 /***/ (function(module) {
 
-module.exports = {"name":"remark","version":"10.0.0","description":"Markdown processor powered by plugins","license":"MIT","keywords":["markdown","abstract","syntax","tree","ast","parse","stringify","process"],"homepage":"http://remark.js.org","repository":"https://github.com/remarkjs/remark/tree/master/packages/remark","bugs":"https://github.com/remarkjs/remark/issues","author":"Titus Wormer <tituswormer@gmail.com> (http://wooorm.com)","contributors":["Titus Wormer <tituswormer@gmail.com> (http://wooorm.com)"],"files":["index.js"],"dependencies":{"remark-parse":"^6.0.0","remark-stringify":"^6.0.0","unified":"^7.0.0"},"devDependencies":{"tape":"^4.9.1"},"scripts":{"test":"tape test.js"},"xo":false,"_resolved":"https://registry.npmjs.org/remark/-/remark-10.0.0.tgz","_integrity":"sha512-0fZvVmd9CgDi1qHGsRTyhpJShw60r3/4OSdRpAx+I7CmE8/Jmt829T9KWHpw2Ygw3chRZ26sMorqb8aIolU9tQ==","_from":"remark@10.0.0"};
+module.exports = {"_args":[["remark@10.0.0","/Users/trott/io.js/tools/node-lint-md-cli-rollup"]],"_from":"remark@10.0.0","_id":"remark@10.0.0","_inBundle":false,"_integrity":"sha512-0fZvVmd9CgDi1qHGsRTyhpJShw60r3/4OSdRpAx+I7CmE8/Jmt829T9KWHpw2Ygw3chRZ26sMorqb8aIolU9tQ==","_location":"/remark","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"remark@10.0.0","name":"remark","escapedName":"remark","rawSpec":"10.0.0","saveSpec":null,"fetchSpec":"10.0.0"},"_requiredBy":["/"],"_resolved":"https://registry.npmjs.org/remark/-/remark-10.0.0.tgz","_spec":"10.0.0","_where":"/Users/trott/io.js/tools/node-lint-md-cli-rollup","author":{"name":"Titus Wormer","email":"tituswormer@gmail.com","url":"http://wooorm.com"},"bugs":{"url":"https://github.com/remarkjs/remark/issues"},"contributors":[{"name":"Titus Wormer","email":"tituswormer@gmail.com","url":"http://wooorm.com"}],"dependencies":{"remark-parse":"^6.0.0","remark-stringify":"^6.0.0","unified":"^7.0.0"},"description":"Markdown processor powered by plugins","devDependencies":{"tape":"^4.9.1"},"files":["index.js"],"homepage":"http://remark.js.org","keywords":["markdown","abstract","syntax","tree","ast","parse","stringify","process"],"license":"MIT","name":"remark","repository":{"type":"git","url":"https://github.com/remarkjs/remark/tree/master/packages/remark"},"scripts":{"test":"tape test.js"},"version":"10.0.0","xo":false};
 
 /***/ }),
 /* 303 */
 /***/ (function(module) {
 
-module.exports = {"name":"node-lint-md-cli-rollup","description":"remark packaged for node markdown linting","version":"1.0.0","devDependencies":{"@zeit/ncc":"^0.2.0"},"dependencies":{"markdown-extensions":"^1.1.0","remark":"^10.0.0","remark-lint":"^6.0.3","remark-preset-lint-node":"^1.3.1","unified-args":"^6.0.0","unified-engine":"^5.1.0"},"main":"src/cli-entry.js","scripts":{"build":"ncc build","build-node":"npm run build && cp dist/index.js ../lint-md.js"}};
+module.exports = {"name":"node-lint-md-cli-rollup","description":"remark packaged for node markdown linting","version":"1.0.0","devDependencies":{"@zeit/ncc":"^0.2.0"},"dependencies":{"markdown-extensions":"^1.1.0","remark":"^10.0.0","remark-lint":"^6.0.3","remark-preset-lint-node":"^1.4.0","unified-args":"^6.0.0","unified-engine":"^5.1.0"},"main":"src/cli-entry.js","scripts":{"build":"ncc build","build-node":"npm run build && cp dist/index.js ../lint-md.js"}};
 
 /***/ }),
 /* 304 */
@@ -35210,10 +35210,7 @@ module.exports.plugins = [
   __webpack_require__(316),
   __webpack_require__(93),
   __webpack_require__(93),
-  [
-    __webpack_require__(317),
-    'space'
-  ],
+  [__webpack_require__(317), "space"],
   __webpack_require__(320),
   __webpack_require__(321),
   __webpack_require__(322),
@@ -35237,25 +35234,27 @@ module.exports.plugins = [
   [
     __webpack_require__(340),
     {
-      'checked': 'x', 'unchecked': ' '
+      checked: "x",
+      unchecked: " "
     }
   ],
-  [__webpack_require__(341), 'fenced'],
-  [__webpack_require__(342), '`'],
-  [__webpack_require__(343), 'md'],
+  [__webpack_require__(341), "fenced"],
+  [__webpack_require__(342), "`"],
+  [__webpack_require__(343), "md"],
   [__webpack_require__(344), 1],
-  [__webpack_require__(345), 'atx'],
+  [__webpack_require__(345), "atx"],
   [
     __webpack_require__(346),
     [
-      { no: 'Github', yes: 'GitHub' },
-      { no: 'Javascript', yes: 'JavaScript' },
-      { no: 'Node.JS', yes: 'Node.js' },
-      { no: 'v8', yes: 'V8' }
+      { no: "End-Of-Life", yes: "End-of-Life" },
+      { no: "Github", yes: "GitHub" },
+      { no: "Javascript", yes: "JavaScript" },
+      { no: "Node.JS", yes: "Node.js" },
+      { no: "v8", yes: "V8" }
     ]
   ],
-  [__webpack_require__(347), '*'],
-  [__webpack_require__(348), 'padded']
+  [__webpack_require__(347), "*"],
+  [__webpack_require__(348), "padded"]
 ];
 
 
@@ -36842,7 +36841,7 @@ module.exports = {"addendum":"addenda","aircraft":"aircraft","alga":"algae","alu
  *   Options: `number`, default: `80`.
  *
  *   Ignores nodes that cannot be wrapped, such as headings, tables,
- *   code, and definitions.
+ *   code, definitions, HTML, and JSX.
  *
  *   Ignores images, links, and inline code if they start before the wrap, end
  *   after the wrap, and there’s no white-space after them.
@@ -36867,6 +36866,8 @@ module.exports = {"addendum":"addenda","aircraft":"aircraft","alga":"algae","alu
  *   | An | exception | is | line | length | in | long | tables | because | those | can’t | just |
  *   | -- | --------- | -- | ---- | ------ | -- | ---- | ------ | ------- | ----- | ----- | ---- |
  *   | be | helped    |    |      |        |    |      |        |         |       |       | .    |
+ *
+ *   <a><b><i><p><q><s><u>alpha bravo charlie delta echo foxtrot golf</u></s></q></p></i></b></a>
  *
  *   The following is also fine, because there is no white-space.
  *
@@ -36941,10 +36942,11 @@ function maximumLineLength(tree, file, pref) {
   var index = -1
   var lineLength
 
-  visit(tree, ['heading', 'table', 'code', 'definition'], ignore)
+  // Note: JSX is from MDX: <https://github.com/mdx-js/specification>.
+  visit(tree, ['heading', 'table', 'code', 'definition', 'html', 'jsx'], ignore)
   visit(tree, ['link', 'image', 'inlineCode'], inline)
 
-  /* Iterate over every line, and warn for violating lines. */
+  // Iterate over every line, and warn for violating lines.
   while (++index < length) {
     lineLength = lines[index].length
 
@@ -36956,9 +36958,9 @@ function maximumLineLength(tree, file, pref) {
     }
   }
 
-  /* Finally, whitelist some inline spans, but only if they occur at or after
-   * the wrap.  However, when they do, and there’s white-space after it, they
-   * are not whitelisted. */
+  // Finally, whitelist some inline spans, but only if they occur at or after
+  // the wrap.  However, when they do, and there’s white-space after it, they
+  // are not whitelisted.
   function inline(node, pos, parent) {
     var next = parent.children[pos + 1]
     var initial
@@ -36972,13 +36974,12 @@ function maximumLineLength(tree, file, pref) {
     initial = start(node)
     final = end(node)
 
-    /* No whitelisting when starting after the border, or ending before it. */
+    // No whitelisting when starting after the border, or ending before it.
     if (initial.column > style || final.column < style) {
       return
     }
 
-    /* No whitelisting when there’s white-space after
-     * the link. */
+    // No whitelisting when there’s white-space after the link.
     if (
       next &&
       start(next).line === initial.line &&
@@ -36997,7 +36998,7 @@ function maximumLineLength(tree, file, pref) {
     }
   }
 
-  /* Whitelist from `initial` to `final`, zero-based. */
+  // Whitelist from `initial` to `final`, zero-based.
   function whitelist(initial, final) {
     while (initial < final) {
       lines[initial++] = ''
@@ -39599,16 +39600,16 @@ function tableCellPadding(tree, file, pref) {
     var entry
     var final
 
-    /* Check rows. */
+    // Check rows.
     while (++index < length) {
       row = rows[index]
       cells = row.children
       cellCount = cells.length
-      column = -2 /* Start without a first cell */
+      column = -2 // Start without a first cell.
       next = null
       final = undefined
 
-      /* Check fences (before, between, and after cells) */
+      // Check fences (before, between, and after cells).
       while (++column < cellCount) {
         cell = next
         next = cells[column + 1]
@@ -39623,7 +39624,7 @@ function tableCellPadding(tree, file, pref) {
         if (cell && cell.children.length !== 0 && final !== undefined) {
           entries.push({node: cell, start: final, end: pos, index: column})
 
-          /* Detect max space per column. */
+          // Detect max space per column.
           sizes[column] = Math.max(sizes[column] || 0, size(cell))
         } else {
           final = undefined
@@ -39670,7 +39671,7 @@ function tableCellPadding(tree, file, pref) {
     if (style === 0) {
       reason += 'compact'
 
-      /* Ignore every cell except the biggest in the column. */
+      // Ignore every cell except the biggest in the column.
       if (size(cell) < sizes[index]) {
         return
       }
@@ -39680,7 +39681,7 @@ function tableCellPadding(tree, file, pref) {
       if (spacing > style) {
         reason += ' with 1 space, not ' + spacing
 
-        /* May be right or center aligned. */
+        // May be right or center aligned.
         if (size(cell) < sizes[index]) {
           return
         }

--- a/tools/node-lint-md-cli-rollup/package-lock.json
+++ b/tools/node-lint-md-cli-rollup/package-lock.json
@@ -608,7 +608,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -626,11 +627,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -643,15 +646,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -754,7 +760,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -764,6 +771,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -776,17 +784,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -803,6 +814,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -875,7 +887,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -885,6 +898,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -960,7 +974,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -990,6 +1005,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1007,6 +1023,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1045,11 +1062,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -1776,14 +1795,14 @@
       }
     },
     "remark-lint-definition-spacing": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remark-lint-definition-spacing/-/remark-lint-definition-spacing-1.0.2.tgz",
-      "integrity": "sha512-Yg1BcI/nydXii1B6kiqKIBsqDW7KlOCBMpJO2jMGmNuEuZe8sv1AWNmaCtiSCdPuDiX0CZRidklrkrZwAthPdw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-definition-spacing/-/remark-lint-definition-spacing-1.0.3.tgz",
+      "integrity": "sha512-8lFBtgSE3xbvvSuO95B6lUiD6Ph1wZr5xevKokwwfKoyfOkXDpN85wh7JepIZnUj1OnTXvupCwr7yYUEji/Rrw==",
       "requires": {
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
         "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1"
+        "unist-util-visit": "^1.4.0"
       }
     },
     "remark-lint-fenced-code-flag": {
@@ -1836,13 +1855,13 @@
       }
     },
     "remark-lint-first-heading-level": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/remark-lint-first-heading-level/-/remark-lint-first-heading-level-1.1.2.tgz",
-      "integrity": "sha512-4LXZmaeQwlkOoK7PVGoI53ohwdaSB54MgQ+FZ353oVxRO1fY+nbNu70/qxvnyu8/23NK4GkCgHvDVb3+unRJNQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-first-heading-level/-/remark-lint-first-heading-level-1.1.3.tgz",
+      "integrity": "sha512-7dKkiVrzlMoeZJX/TwKIrqaBLYIwGUG5a8sS8dxlGG00LnL2S8koAFL8t/U+dZsfDdF7p0kf4jhcwJWB4U26rA==",
       "requires": {
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^1.1.1"
+        "unist-util-visit": "^1.4.0"
       }
     },
     "remark-lint-hard-break-spaces": {
@@ -1880,14 +1899,14 @@
       }
     },
     "remark-lint-maximum-line-length": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remark-lint-maximum-line-length/-/remark-lint-maximum-line-length-1.1.0.tgz",
-      "integrity": "sha512-L+jI6+DReoxHyAWRIxABjX8hPDgxB8B5Lzp0/nDYjWbjl7I4vTsdEvejpmP1K8LVvZ7Ew0XcVHd1zt+p2O8tDg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-maximum-line-length/-/remark-lint-maximum-line-length-1.2.0.tgz",
+      "integrity": "sha512-tqqZ8YCvfz9ZvKN2vRA12qgNKM+DKb73rJMMb6zq9yd2Nt32n7S+1nobSpKQqAR7/bn2ysUGu/NNA7FjlRXt6g==",
       "requires": {
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
         "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1"
+        "unist-util-visit": "^1.4.0"
       }
     },
     "remark-lint-no-auto-link-without-protocol": {
@@ -1915,15 +1934,15 @@
       }
     },
     "remark-lint-no-duplicate-definitions": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-duplicate-definitions/-/remark-lint-no-duplicate-definitions-1.0.2.tgz",
-      "integrity": "sha512-e5tSoIBChG3UCz4eJ+JPKV915iNeIeT7uKBKzXBPxnMcEgQaT3V7DBDdN8Wn1oPw9fLp/5AjDN5l9x7iddLsRw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-duplicate-definitions/-/remark-lint-no-duplicate-definitions-1.0.3.tgz",
+      "integrity": "sha512-8iQhawbIMwQILRpCsoYCVYrSF2rrWEfF7KPvIIJavp0TA02Wv+SX7b3hQslNtvso0Ka2VX+kI1+x+QzG16Duqg==",
       "requires": {
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
         "unist-util-position": "^3.0.0",
         "unist-util-stringify-position": "^1.1.2",
-        "unist-util-visit": "^1.1.1"
+        "unist-util-visit": "^1.4.0"
       }
     },
     "remark-lint-no-file-name-articles": {
@@ -1976,14 +1995,14 @@
       }
     },
     "remark-lint-no-inline-padding": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-inline-padding/-/remark-lint-no-inline-padding-1.0.2.tgz",
-      "integrity": "sha512-SHYqEH27yxzgcXSyaIzvqImvktDhXGltRSOEhAHiL2nJktuPt3nosFfGy4/oKAJMWJ2N3aMudXq/zuw1dAkQSg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-inline-padding/-/remark-lint-no-inline-padding-1.0.3.tgz",
+      "integrity": "sha512-zEe7LjM13kQshdBtPnSzzCUNzGIX/XiGspMb7HZBCDWYsPJ73s01X+m+YI99Dz7wKvB3EUTZ7/MFhTUIvqcGRw==",
       "requires": {
         "mdast-util-to-string": "^1.0.2",
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^1.1.1"
+        "unist-util-visit": "^1.4.0"
       }
     },
     "remark-lint-no-multiple-toplevel-headings": {
@@ -2019,14 +2038,14 @@
       }
     },
     "remark-lint-no-table-indentation": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-table-indentation/-/remark-lint-no-table-indentation-1.0.2.tgz",
-      "integrity": "sha512-wH0lMGV3DGf7WeDLYGle7SODkXNKqmFtGuh6sG5oa0XgA17rI/L35Vq5tal4DE/5gQG+l4+/0Iy9FPKdBODSDA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-table-indentation/-/remark-lint-no-table-indentation-1.0.3.tgz",
+      "integrity": "sha512-argI2JADlVrlwsdORdbmE89QXB9XtBtAy2YBHZv/q/d247CyL+h+hw9wpg06P1lLQwbllxYJD5u1bNtfgv3XVg==",
       "requires": {
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
         "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1"
+        "unist-util-visit": "^1.4.0"
       }
     },
     "remark-lint-no-tabs": {
@@ -2047,13 +2066,13 @@
       }
     },
     "remark-lint-no-unused-definitions": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-unused-definitions/-/remark-lint-no-unused-definitions-1.0.2.tgz",
-      "integrity": "sha512-Qv4J2hI2S0NJdrlFuQhBVOlGNUSBLpe+2VBm/hSJAnBE7FW2ZGkVwwrs9h7HdZ/vW3LqfBrNcTKTVw+5ZzWTiA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-unused-definitions/-/remark-lint-no-unused-definitions-1.0.4.tgz",
+      "integrity": "sha512-wKh10+2hiVKEkVXfW5zC8lyDCJQM6lpyRsyIVxq0ROHkrAjsO+seljEQCOsIJ55nZHbdCOCFDQosA0/5wgryRw==",
       "requires": {
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^1.1.1"
+        "unist-util-visit": "^1.4.0"
       }
     },
     "remark-lint-prohibited-strings": {
@@ -2088,14 +2107,14 @@
       }
     },
     "remark-lint-table-cell-padding": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remark-lint-table-cell-padding/-/remark-lint-table-cell-padding-1.0.2.tgz",
-      "integrity": "sha512-uYm8ia0joAFeK0XLpxVtGW37Ry1XRBDmWH1gDiO2MXWcUip1w1Brvyue4H8JfXB4IM+S5eI/zPR5zN5Wpj9kfA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-table-cell-padding/-/remark-lint-table-cell-padding-1.0.3.tgz",
+      "integrity": "sha512-beXwMK8KAGIDQWixf7wzte4GhyB9w33DxTGgmP4HWOWMVXHvBnufJvnIozBBOH9nOsi1fP8NYRb/01hrgjNnmw==",
       "requires": {
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
         "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1"
+        "unist-util-visit": "^1.4.0"
       }
     },
     "remark-lint-table-pipes": {
@@ -2142,9 +2161,9 @@
       }
     },
     "remark-preset-lint-node": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/remark-preset-lint-node/-/remark-preset-lint-node-1.3.1.tgz",
-      "integrity": "sha512-Mh9eX1ovpnKQiTy9R/BR8ZKkPJrMOHrLn+vRw7SRs1UooiKwIm1KRp1UaDLO6Z3pCCizhH4Bqln5XZTGnMkNaA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/remark-preset-lint-node/-/remark-preset-lint-node-1.4.0.tgz",
+      "integrity": "sha512-opl2LaTkuSK8DWZXurjl4k9i891rwN/o6IvrZmzyIrWj7p8oL1JrdUo6NBxAr5cKmWokFhEBex5U2DIsQBsiAQ==",
       "requires": {
         "remark-lint": "^6.0.0",
         "remark-lint-blockquote-indentation": "^1.0.0",

--- a/tools/node-lint-md-cli-rollup/package.json
+++ b/tools/node-lint-md-cli-rollup/package.json
@@ -9,7 +9,7 @@
     "markdown-extensions": "^1.1.0",
     "remark": "^10.0.0",
     "remark-lint": "^6.0.3",
-    "remark-preset-lint-node": "^1.3.1",
+    "remark-preset-lint-node": "^1.4.0",
     "unified-args": "^6.0.0",
     "unified-engine": "^5.1.0"
   },


### PR DESCRIPTION
Update remark-preset-lint-node to 1.4.0. This adds `End-Of-Life` as a
prohibited string, favoring `End-of-Life` for consistency.

Fair amount of diff-noise in this one because the big change is in an auto-generated file. Suppressing whitespace-only changes will probably help.

Refs: https://github.com/nodejs/node/pull/26251

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
