### PR TITLE
report: use ru_stime for system CPU calculation

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -483,7 +483,7 @@ static void PrintResourceUsage(JSONWriter* writer) {
     double user_cpu =
         stats.ru_utime.tv_sec + SEC_PER_MICROS * stats.ru_utime.tv_usec;
     double kernel_cpu =
-        stats.ru_utime.tv_sec + SEC_PER_MICROS * stats.ru_utime.tv_usec;
+        stats.ru_stime.tv_sec + SEC_PER_MICROS * stats.ru_stime.tv_usec;
     writer->json_keyvalue("userCpuSeconds", user_cpu);
     writer->json_keyvalue("kernelCpuSeconds", kernel_cpu);
     double cpu_abs = user_cpu + kernel_cpu;
@@ -506,7 +506,7 @@ static void PrintResourceUsage(JSONWriter* writer) {
     double user_cpu =
         stats.ru_utime.tv_sec + SEC_PER_MICROS * stats.ru_utime.tv_usec;
     double kernel_cpu =
-        stats.ru_utime.tv_sec + SEC_PER_MICROS * stats.ru_utime.tv_usec;
+        stats.ru_stime.tv_sec + SEC_PER_MICROS * stats.ru_stime.tv_usec;
     writer->json_keyvalue("userCpuSeconds", user_cpu);
     writer->json_keyvalue("kernelCpuSeconds", kernel_cpu);
     double cpu_abs = user_cpu + kernel_cpu;


### PR DESCRIPTION
Prior to this change, user and system CPU were the same values.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
