### PR TITLE
src: fix node_report maybe-uninitialized warning

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -146,7 +146,7 @@ std::string TriggerNodeReport(Isolate* isolate,
   // Open the report file stream for writing. Supports stdout/err,
   // user-specified or (default) generated name
   std::ofstream outfile;
-  std::ostream* outstream;
+  std::ostream* outstream = nullptr;
   if (filename == "stdout") {
     outstream = &std::cout;
   } else if (filename == "stderr") {


### PR DESCRIPTION
g++ 8.2 reports warning:

  outstream may be used uninitialized in this function [-Wmaybe-uninitialized]

It's wrong, but initialize the variable anyhow to silence the warning.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
