### PR TITLE
src: reduce to simple `const char*` in OptionsParser

### DIFF
--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -28,8 +28,8 @@ EnvironmentOptions* PerIsolateOptions::get_per_env_options() {
 namespace options_parser {
 
 template <typename Options>
-void OptionsParser<Options>::AddOption(const std::string& name,
-                                       const std::string& help_text,
+void OptionsParser<Options>::AddOption(const char* name,
+                                       const char* help_text,
                                        bool Options::* field,
                                        OptionEnvvarSettings env_setting) {
   options_.emplace(name,
@@ -40,8 +40,8 @@ void OptionsParser<Options>::AddOption(const std::string& name,
 }
 
 template <typename Options>
-void OptionsParser<Options>::AddOption(const std::string& name,
-                                       const std::string& help_text,
+void OptionsParser<Options>::AddOption(const char* name,
+                                       const char* help_text,
                                        uint64_t Options::* field,
                                        OptionEnvvarSettings env_setting) {
   options_.emplace(
@@ -53,8 +53,8 @@ void OptionsParser<Options>::AddOption(const std::string& name,
 }
 
 template <typename Options>
-void OptionsParser<Options>::AddOption(const std::string& name,
-                                       const std::string& help_text,
+void OptionsParser<Options>::AddOption(const char* name,
+                                       const char* help_text,
                                        int64_t Options::* field,
                                        OptionEnvvarSettings env_setting) {
   options_.emplace(
@@ -66,8 +66,8 @@ void OptionsParser<Options>::AddOption(const std::string& name,
 }
 
 template <typename Options>
-void OptionsParser<Options>::AddOption(const std::string& name,
-                                       const std::string& help_text,
+void OptionsParser<Options>::AddOption(const char* name,
+                                       const char* help_text,
                                        std::string Options::* field,
                                        OptionEnvvarSettings env_setting) {
   options_.emplace(
@@ -80,8 +80,8 @@ void OptionsParser<Options>::AddOption(const std::string& name,
 
 template <typename Options>
 void OptionsParser<Options>::AddOption(
-    const std::string& name,
-    const std::string& help_text,
+    const char* name,
+    const char* help_text,
     std::vector<std::string> Options::* field,
     OptionEnvvarSettings env_setting) {
   options_.emplace(name, OptionInfo {
@@ -93,8 +93,8 @@ void OptionsParser<Options>::AddOption(
 }
 
 template <typename Options>
-void OptionsParser<Options>::AddOption(const std::string& name,
-                                       const std::string& help_text,
+void OptionsParser<Options>::AddOption(const char* name,
+                                       const char* help_text,
                                        HostPort Options::* field,
                                        OptionEnvvarSettings env_setting) {
   options_.emplace(
@@ -106,16 +106,16 @@ void OptionsParser<Options>::AddOption(const std::string& name,
 }
 
 template <typename Options>
-void OptionsParser<Options>::AddOption(const std::string& name,
-                                       const std::string& help_text,
+void OptionsParser<Options>::AddOption(const char* name,
+                                       const char* help_text,
                                        NoOp no_op_tag,
                                        OptionEnvvarSettings env_setting) {
   options_.emplace(name, OptionInfo{kNoOp, nullptr, env_setting, help_text});
 }
 
 template <typename Options>
-void OptionsParser<Options>::AddOption(const std::string& name,
-                                       const std::string& help_text,
+void OptionsParser<Options>::AddOption(const char* name,
+                                       const char* help_text,
                                        V8Option v8_option_tag,
                                        OptionEnvvarSettings env_setting) {
   options_.emplace(name,
@@ -123,27 +123,27 @@ void OptionsParser<Options>::AddOption(const std::string& name,
 }
 
 template <typename Options>
-void OptionsParser<Options>::AddAlias(const std::string& from,
-                                      const std::string& to) {
+void OptionsParser<Options>::AddAlias(const char* from,
+                                      const char* to) {
   aliases_[from] = { to };
 }
 
 template <typename Options>
-void OptionsParser<Options>::AddAlias(const std::string& from,
+void OptionsParser<Options>::AddAlias(const char* from,
                                       const std::vector<std::string>& to) {
   aliases_[from] = to;
 }
 
 template <typename Options>
 void OptionsParser<Options>::AddAlias(
-    const std::string& from,
+    const char* from,
     const std::initializer_list<std::string>& to) {
   AddAlias(from, std::vector<std::string>(to));
 }
 
 template <typename Options>
-void OptionsParser<Options>::Implies(const std::string& from,
-                                     const std::string& to) {
+void OptionsParser<Options>::Implies(const char* from,
+                                     const char* to) {
   auto it = options_.find(to);
   CHECK_NE(it, options_.end());
   CHECK_EQ(it->second.type, kBoolean);
@@ -153,8 +153,8 @@ void OptionsParser<Options>::Implies(const std::string& from,
 }
 
 template <typename Options>
-void OptionsParser<Options>::ImpliesNot(const std::string& from,
-                                        const std::string& to) {
+void OptionsParser<Options>::ImpliesNot(const char* from,
+                                        const char* to) {
   auto it = options_.find(to);
   CHECK_NE(it, options_.end());
   CHECK_EQ(it->second.type, kBoolean);

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -229,43 +229,39 @@ class OptionsParser {
   struct NoOp {};
   struct V8Option {};
 
-  // TODO(addaleax): A lot of the `std::string` usage here could be reduced
-  // to simple `const char*`s if it's reasonable to expect the values to be
-  // known at compile-time.
-
   // These methods add a single option to the parser. Optionally, it can be
   // specified whether the option should be allowed from environment variable
   // sources (i.e. NODE_OPTIONS).
-  void AddOption(const std::string& name,
-                 const std::string& help_text,
+  void AddOption(const char* name,
+                 const char* help_text,
                  bool Options::* field,
                  OptionEnvvarSettings env_setting = kDisallowedInEnvironment);
-  void AddOption(const std::string& name,
-                 const std::string& help_text,
+  void AddOption(const char* name,
+                 const char* help_text,
                  uint64_t Options::* field,
                  OptionEnvvarSettings env_setting = kDisallowedInEnvironment);
-  void AddOption(const std::string& name,
-                 const std::string& help_text,
+  void AddOption(const char* name,
+                 const char* help_text,
                  int64_t Options::* field,
                  OptionEnvvarSettings env_setting = kDisallowedInEnvironment);
-  void AddOption(const std::string& name,
-                 const std::string& help_text,
+  void AddOption(const char* name,
+                 const char* help_text,
                  std::string Options::* field,
                  OptionEnvvarSettings env_setting = kDisallowedInEnvironment);
-  void AddOption(const std::string& name,
-                 const std::string& help_text,
+  void AddOption(const char* name,
+                 const char* help_text,
                  std::vector<std::string> Options::* field,
                  OptionEnvvarSettings env_setting = kDisallowedInEnvironment);
-  void AddOption(const std::string& name,
-                 const std::string& help_text,
+  void AddOption(const char* name,
+                 const char* help_text,
                  HostPort Options::* field,
                  OptionEnvvarSettings env_setting = kDisallowedInEnvironment);
-  void AddOption(const std::string& name,
-                 const std::string& help_text,
+  void AddOption(const char* name,
+                 const char* help_text,
                  NoOp no_op_tag,
                  OptionEnvvarSettings env_setting = kDisallowedInEnvironment);
-  void AddOption(const std::string& name,
-                 const std::string& help_text,
+  void AddOption(const char* name,
+                 const char* help_text,
                  V8Option v8_option_tag,
                  OptionEnvvarSettings env_setting = kDisallowedInEnvironment);
 
@@ -276,15 +272,15 @@ class OptionsParser {
   // the option is presented in that form (i.e. with a '=').
   // If `from` has the form "--option-a <arg>", the alias will only be expanded
   // if the option has a non-option argument (not starting with -) following it.
-  void AddAlias(const std::string& from, const std::string& to);
-  void AddAlias(const std::string& from, const std::vector<std::string>& to);
-  void AddAlias(const std::string& from,
+  void AddAlias(const char* from, const char* to);
+  void AddAlias(const char* from, const std::vector<std::string>& to);
+  void AddAlias(const char* from,
                 const std::initializer_list<std::string>& to);
 
   // Add implications from some arbitrary option to a boolean one, either
   // in a way that makes `from` set `to` to true or to false.
-  void Implies(const std::string& from, const std::string& to);
-  void ImpliesNot(const std::string& from, const std::string& to);
+  void Implies(const char* from, const char* to);
+  void ImpliesNot(const char* from, const char* to);
 
   // Insert options from another options parser into this one, along with
   // a method that yields the target options type from this parser's options


### PR DESCRIPTION
As the comment said:
> TODO(addaleax): A lot of the `std::string` usage here could be reduced
  to simple `const char*`s if it's reasonable to expect the values to be
  known at compile-time.

So this commit uses `const char*` to replace most of `std::string` in
`OptionsParser` and remove the `TODO`.

/cc @addaleax 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
