### PR TITLE
test: eliminate port collision in test-cluster-net-listen-ipv6only-rr

### DIFF
--- a/test/sequential/test-cluster-net-listen-ipv6only-rr.js
+++ b/test/sequential/test-cluster-net-listen-ipv6only-rr.js
@@ -48,9 +48,14 @@ if (cluster.isMaster) {
     workers.set(i, worker);
   }
 } else {
+  // As the cluster member has the potential to grab any port
+  // from the environment, this can cause collision when master
+  // obtains the port from cluster member and tries to listen on.
+  // So move this to sequential, and provide a static port.
+  // Refs: https://github.com/nodejs/node/issues/25813
   net.createServer().listen({
-    host,
-    port: 0,
+    host: host,
+    port: common.PORT,
     ipv6Only: true,
   }, common.mustCall());
 }


### PR DESCRIPTION
In test test-cluster-net-listen-ipv6only-rr, the cluster member that
listens to `any` port actually has the potential to `grab` any port
from the environment which when passed onto the master causes
collision when it tries to listen on.

Moving the test to sequential alone is not sufficient as the cluster
member can in theory catch on to the admin ports on the host.

Assigning static port alone is also not sufficient, as it can interfere
with other running tests in the parallel category which would be mostly
running with `port: any` fashion.

So move to sequential, and use a static port.

Fixes: https://github.com/nodejs/node/issues/25813

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
