### PR TITLE
doc: napi_get_value_bigint_words argument order

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2255,8 +2255,8 @@ added: v10.7.0
 ```C
 napi_status napi_get_value_bigint_words(napi_env env,
                                         napi_value value,
-                                        size_t* word_count,
                                         int* sign_bit,
+                                        size_t* word_count,
                                         uint64_t* words);
 ```
 


### PR DESCRIPTION
The documentation for `napi_get_value_bigint_words` appears to have the arguments for word_count and sign_bit flipped. This PR changes the order in the documentation to match the correct order.

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
