### PR TITLE
src,buffer: allow heap-allocated typed arrays 

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1123,10 +1123,6 @@ def configure_v8(o):
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)
   o['variables']['force_dynamic_crt'] = 1 if options.shared else 0
   o['variables']['node_enable_d8'] = b(options.enable_d8)
-  # Unconditionally force typed arrays to allocate outside the v8 heap. This
-  # is to prevent memory pointers from being moved around that are returned by
-  # Buffer::Data().
-  o['variables']['v8_typed_array_max_size_in_heap'] = 0
   if options.enable_d8:
     o['variables']['test_isolation_mode'] = 'noop'  # Needed by d8.gyp.
   if options.without_bundled_v8 and options.enable_d8:

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -105,13 +105,9 @@ let poolSize, poolOffset, allocPool;
 const zeroFill = bindingZeroFill || [0];
 
 function createUnsafeBuffer(size) {
-  return new FastBuffer(createUnsafeArrayBuffer(size));
-}
-
-function createUnsafeArrayBuffer(size) {
   zeroFill[0] = 0;
   try {
-    return new ArrayBuffer(size);
+    return new FastBuffer(size);
   } finally {
     zeroFill[0] = 1;
   }
@@ -119,7 +115,7 @@ function createUnsafeArrayBuffer(size) {
 
 function createPool() {
   poolSize = Buffer.poolSize;
-  allocPool = createUnsafeArrayBuffer(poolSize);
+  allocPool = createUnsafeBuffer(poolSize).buffer;
   poolOffset = 0;
 }
 createPool();

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -335,7 +335,7 @@ class SSLWrap {
 
   ClientHelloParser hello_parser_;
 
-  Persistent<v8::Object> ocsp_response_;
+  Persistent<v8::ArrayBufferView> ocsp_response_;
   Persistent<v8::Value> sni_context_;
 
   friend class SecureContext;
@@ -464,7 +464,7 @@ class KeyObject : public BaseObject {
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static void Init(const v8::FunctionCallbackInfo<v8::Value>& args);
-  void InitSecret(const char* key, size_t key_len);
+  void InitSecret(v8::Local<v8::ArrayBufferView> abv);
   void InitPublic(const ManagedEVPPKey& pkey);
   void InitPrivate(const ManagedEVPPKey& pkey);
 
@@ -805,8 +805,7 @@ class ECDH : public BaseObject {
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
   static ECPointPointer BufferToPoint(Environment* env,
                                       const EC_GROUP* group,
-                                      char* data,
-                                      size_t len);
+                                      v8::Local<v8::Value> buf);
 
   // TODO(joyeecheung): track the memory used by OpenSSL types
   SET_NO_MEMORY_INFO()

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -699,7 +699,8 @@ class Http2Session : public AsyncWrap, public StreamListener {
   void Close(uint32_t code = NGHTTP2_NO_ERROR,
              bool socket_closed = false);
   void Consume(Local<External> external);
-  void Goaway(uint32_t code, int32_t lastStreamID, uint8_t* data, size_t len);
+  void Goaway(uint32_t code, int32_t lastStreamID,
+              const uint8_t* data, size_t len);
   void AltSvc(int32_t id,
               uint8_t* origin,
               size_t origin_len,
@@ -1089,7 +1090,7 @@ class Http2Session::Http2Ping : public AsyncWrap {
   SET_MEMORY_INFO_NAME(Http2Ping)
   SET_SELF_SIZE(Http2Ping)
 
-  void Send(uint8_t* payload);
+  void Send(const uint8_t* payload);
   void Done(bool ack, const uint8_t* payload = nullptr);
 
  private:

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -8,6 +8,7 @@ namespace util {
 
 using v8::ALL_PROPERTIES;
 using v8::Array;
+using v8::ArrayBufferView;
 using v8::Boolean;
 using v8::Context;
 using v8::Function;
@@ -174,6 +175,11 @@ void WatchdogHasPendingSigint(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(ret);
 }
 
+void ArrayBufferViewHasBuffer(const FunctionCallbackInfo<Value>& args) {
+  CHECK(args[0]->IsArrayBufferView());
+  args.GetReturnValue().Set(args[0].As<ArrayBufferView>()->HasBuffer());
+}
+
 void EnqueueMicrotask(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Isolate* isolate = env->isolate();
@@ -254,6 +260,7 @@ void Initialize(Local<Object> target,
   env->SetMethodNoSideEffect(target, "watchdogHasPendingSigint",
                              WatchdogHasPendingSigint);
 
+  env->SetMethod(target, "arrayBufferViewHasBuffer", ArrayBufferViewHasBuffer);
   env->SetMethod(target, "enqueueMicrotask", EnqueueMicrotask);
   env->SetMethod(target, "triggerFatalException", FatalException);
   Local<Object> constants = Object::New(env->isolate());

--- a/src/string_decoder.cc
+++ b/src/string_decoder.cc
@@ -4,6 +4,7 @@
 #include "string_decoder-inl.h"
 
 using v8::Array;
+using v8::ArrayBufferView;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Integer;
@@ -252,9 +253,13 @@ void DecodeData(const FunctionCallbackInfo<Value>& args) {
   StringDecoder* decoder =
       reinterpret_cast<StringDecoder*>(Buffer::Data(args[0]));
   CHECK_NOT_NULL(decoder);
-  size_t nread = Buffer::Length(args[1]);
+
+  CHECK(args[1]->IsArrayBufferView());
+  ArrayBufferViewContents<char> content(args[1].As<ArrayBufferView>());
+  size_t length = content.length();
+
   MaybeLocal<String> ret =
-      decoder->DecodeData(args.GetIsolate(), Buffer::Data(args[1]), &nread);
+      decoder->DecodeData(args.GetIsolate(), content.data(), &length);
   if (!ret.IsEmpty())
     args.GetReturnValue().Set(ret.ToLocalChecked());
 }

--- a/src/util.cc
+++ b/src/util.cc
@@ -29,6 +29,7 @@
 
 namespace node {
 
+using v8::ArrayBufferView;
 using v8::Isolate;
 using v8::Local;
 using v8::String;
@@ -89,11 +90,11 @@ BufferValue::BufferValue(Isolate* isolate, Local<Value> value) {
 
   if (value->IsString()) {
     MakeUtf8String(isolate, value, this);
-  } else if (Buffer::HasInstance(value)) {
-    const size_t len = Buffer::Length(value);
+  } else if (value->IsArrayBufferView()) {
+    const size_t len = value.As<ArrayBufferView>()->ByteLength();
     // Leave place for the terminating '\0' byte.
     AllocateSufficientStorage(len + 1);
-    memcpy(out(), Buffer::Data(value), len);
+    value.As<ArrayBufferView>()->CopyContents(out(), len);
     SetLengthAndZeroTerminate(len);
   } else {
     Invalidate();

--- a/src/util.h
+++ b/src/util.h
@@ -417,6 +417,27 @@ class MaybeStackBuffer {
   T buf_st_[kStackStorageSize];
 };
 
+// Provides access to an ArrayBufferView's storage, either the original,
+// or for small data, a copy of it. This object's lifetime is bound to the
+// original ArrayBufferView's lifetime.
+template <typename T, size_t kStackStorageSize = 64>
+class ArrayBufferViewContents {
+ public:
+  ArrayBufferViewContents() {}
+
+  explicit inline ArrayBufferViewContents(v8::Local<v8::Value> value);
+  explicit inline ArrayBufferViewContents(v8::Local<v8::ArrayBufferView> abv);
+  inline void Read(v8::Local<v8::ArrayBufferView> abv);
+
+  inline const T* data() const { return data_; }
+  inline size_t length() const { return length_; }
+
+ private:
+  T stack_storage_[kStackStorageSize];
+  T* data_ = nullptr;
+  size_t length_ = 0;
+};
+
 class Utf8Value : public MaybeStackBuffer<char> {
  public:
   explicit Utf8Value(v8::Isolate* isolate, v8::Local<v8::Value> value);

--- a/test/parallel/test-buffer-backing-arraybuffer.js
+++ b/test/parallel/test-buffer-backing-arraybuffer.js
@@ -1,0 +1,37 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('assert');
+const { internalBinding } = require('internal/test/binding');
+const { arrayBufferViewHasBuffer } = internalBinding('util');
+
+const tests = [
+  { length: 0, expectOnHeap: true },
+  { length: 48, expectOnHeap: true },
+  { length: 96, expectOnHeap: false },
+  { length: 1024, expectOnHeap: false },
+];
+
+for (const { length, expectOnHeap } of tests) {
+  const arrays = [
+    new Uint8Array(length),
+    new Uint16Array(length / 2),
+    new Uint32Array(length / 4),
+    new Float32Array(length / 4),
+    new Float64Array(length / 8),
+    Buffer.alloc(length),
+    Buffer.allocUnsafeSlow(length)
+    // Buffer.allocUnsafe() is missing because it may use pooled allocations.
+  ];
+
+  for (const array of arrays) {
+    const isOnHeap = !arrayBufferViewHasBuffer(array);
+    assert.strictEqual(isOnHeap, expectOnHeap,
+                       `mismatch: ${isOnHeap} vs ${expectOnHeap} ` +
+                       `for ${array.constructor.name}, length = ${length}`);
+
+    // Consistency check: Accessing .buffer should create it.
+    array.buffer;
+    assert(arrayBufferViewHasBuffer(array));
+  }
+}


### PR DESCRIPTION
I noticed that the reason we’ve been disabling this has not actually been true, so it seems to make sense to let the engine use its default values. /cc @nodejs/buffer @nodejs/v8

---

##### build: remove v8_typed_array_max_size_in_heap option

This was added in 16f86d6c578ff7aec708c7d736558a199d290e9c, based on
the assumption that otherwise, the memory behind `ArrayBuffer`
instances could be moved around on the heap while native code
holds references to it.

This does not match what V8 actually does (and also did at the time):

- The option/build variable was about always only about TypedArrays,
  not ArrayBuffers. Calls like `new ArrayBuffer(4)` call into C++
  regardless of the option value, but calls like `new Uint8Array(4)`
  would not call into C++ under V8 defaults.
- When first accessing a heap-allocated TypedArray’s `ArrayBuffer`,
  whether that is through the JS `.buffer` getter or the C++
  `ArrayBufferView::Buffer()` function, a copy of the contents is
  created using the ArrayBuffer allocator and stored as the
  (permanent, unmovable) backing store.

As a consequence, the memory returned by `ArrayBuffer::GetContents()`
is not moved around, because it is fixed once the `ArrayBuffer`
object itself first comes into explicit existence in any way.

Removing this build option significantly speeds up creation of typed
arrays from JS:

    $ ./node benchmark/compare.js --new ./node --old ./node-master --runs 10 --filter buffer-creation.js buffers | Rscript benchmark/compare.R
                                                                         confidence improvement accuracy (*)     (**)    (***)
     buffers/buffer-creation.js n=1024 len=10 type='buffer()'                  ***    593.66 %      ±28.64%  ±41.10%  ±60.36%
     buffers/buffer-creation.js n=1024 len=10 type='fast-alloc-fill'           ***    675.42 %      ±90.67% ±130.24% ±191.54%
     buffers/buffer-creation.js n=1024 len=10 type='fast-alloc'                ***    663.55 %      ±58.41%  ±83.87% ±123.29%
     [... see commit log for more, statistically insignificant results ...]

The performance gains effect are undone once native code accesses
the underlying ArrayBuffer, but then again that a) does not happen for
all TypedArrays, and b) it should also make sense to look into using
`ArrayBufferView::CopyContents()` in some places, which is made
specifically to avoid such a performance impact and allows us to
use the benefits of heap-allocated typed arrays.

Refs: https://github.com/nodejs/node/commit/16f86d6c578ff7aec708c7d736558a199d290e9c
Refs: https://github.com/nodejs/node/pull/2893
Refs: https://github.com/nodejs/node/commit/74178a5682958d499896e0fa1af6bc0321ec1935#commitcomment-13250880
Refs: http://logs.libuv.org/node-dev/2015-09-15

##### src: allow not materializing ArrayBuffers from C++

Where appropriate, use a helper that wraps around
`ArrayBufferView::Buffer()` or `ArrayBufferView::CopyContents()`
rather than `Buffer::Data()`, as that may help to avoid materializing
the underlying `ArrayBuffer` when reading small typed arrays from C++.
This allows keeping the performance benefits of the faster creation of
heap-allocated small typed arrays in many cases.

##### buffer: avoid materializing ArrayBuffer for creation

Do not create an `ArrayBuffer` if the engine’s settings avoid it
and we don’t need it.

##### test: verify heap buffer allocations occur

Check that small typed arrays, including `Buffer`s (unless allocated
by `Buffer.allocUnsafe()`), are indeed heap-allocated.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
