### PR TITLE
[v11.x] src: allocate Buffer memory using ArrayBuffer allocator 

### DIFF
--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -7717,6 +7717,9 @@ class V8_EXPORT Isolate {
    */
   void SetIdle(bool is_idle);
 
+  /** Returns the ArrayBuffer::Allocator used in this isolate. */
+  ArrayBuffer::Allocator* GetArrayBufferAllocator();
+
   /** Returns true if this isolate has a current context. */
   bool InContext();
 

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -8084,6 +8084,11 @@ void Isolate::SetIdle(bool is_idle) {
   isolate->SetIdle(is_idle);
 }
 
+ArrayBuffer::Allocator* Isolate::GetArrayBufferAllocator() {
+  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(this);
+  return isolate->array_buffer_allocator();
+}
+
 bool Isolate::InContext() {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(this);
   return isolate->context() != nullptr;

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -20773,6 +20773,7 @@ TEST(IsolateNewDispose) {
   CHECK_NOT_NULL(isolate);
   CHECK(current_isolate != isolate);
   CHECK(current_isolate == CcTest::isolate());
+  CHECK(isolate->GetArrayBufferAllocator() == CcTest::array_buffer_allocator());
 
   isolate->SetFatalErrorHandler(StoringErrorCallback);
   last_location = last_message = nullptr;

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -115,11 +115,7 @@ IsolateData* CreateIsolateData(Isolate* isolate,
                                uv_loop_t* loop,
                                MultiIsolatePlatform* platform,
                                ArrayBufferAllocator* allocator) {
-  return new IsolateData(
-      isolate,
-      loop,
-      platform,
-      allocator != nullptr ? allocator->zero_fill_field() : nullptr);
+  return new IsolateData(isolate, loop, platform, allocator);
 }
 
 void FreeIsolateData(IsolateData* isolate_data) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -49,8 +49,16 @@ inline uv_loop_t* IsolateData::event_loop() const {
   return event_loop_;
 }
 
-inline uint32_t* IsolateData::zero_fill_field() const {
-  return zero_fill_field_;
+inline bool IsolateData::uses_node_allocator() const {
+  return uses_node_allocator_;
+}
+
+inline v8::ArrayBuffer::Allocator* IsolateData::allocator() const {
+  return allocator_;
+}
+
+inline ArrayBufferAllocator* IsolateData::node_allocator() const {
+  return node_allocator_;
 }
 
 inline MultiIsolatePlatform* IsolateData::platform() const {

--- a/src/env.cc
+++ b/src/env.cc
@@ -74,11 +74,14 @@ void* const Environment::kNodeContextTagPtr = const_cast<void*>(
 IsolateData::IsolateData(Isolate* isolate,
                          uv_loop_t* event_loop,
                          MultiIsolatePlatform* platform,
-                         uint32_t* zero_fill_field) :
-    isolate_(isolate),
-    event_loop_(event_loop),
-    zero_fill_field_(zero_fill_field),
-    platform_(platform) {
+                         ArrayBufferAllocator* node_allocator)
+    : isolate_(isolate),
+      event_loop_(event_loop),
+      allocator_(isolate->GetArrayBufferAllocator()),
+      node_allocator_(node_allocator),
+      uses_node_allocator_(allocator_ == node_allocator_),
+      platform_(platform) {
+  CHECK_NOT_NULL(allocator_);
   if (platform_ != nullptr)
     platform_->RegisterIsolate(isolate_, event_loop);
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -21,6 +21,7 @@
 namespace node {
 
 using errors::TryCatchScope;
+using v8::ArrayBuffer;
 using v8::Boolean;
 using v8::Context;
 using v8::EmbedderGraph;
@@ -924,6 +925,23 @@ void Environment::BuildEmbedderGraph(Isolate* isolate,
   });
 }
 
+char* Environment::Reallocate(char* data, size_t old_size, size_t size) {
+  // If we know that the allocator is our ArrayBufferAllocator, we can let
+  // if reallocate directly.
+  if (isolate_data()->uses_node_allocator()) {
+    return static_cast<char*>(
+        isolate_data()->node_allocator()->Reallocate(data, old_size, size));
+  }
+  // Generic allocators do not provide a reallocation method; we need to
+  // allocate a new chunk of memory and copy the data over.
+  char* new_data = AllocateUnchecked(size);
+  if (new_data == nullptr) return nullptr;
+  memcpy(new_data, data, std::min(size, old_size));
+  if (size > old_size)
+    memset(new_data + old_size, 0, size - old_size);
+  Free(data, old_size);
+  return new_data;
+}
 
 // Not really any better place than env.cc at this moment.
 void BaseObject::DeleteMe(void* data) {

--- a/src/env.h
+++ b/src/env.h
@@ -474,6 +474,38 @@ enum class DebugCategory {
   CATEGORY_COUNT
 };
 
+// A unique-pointer-ish object that is compatible with the JS engine's
+// ArrayBuffer::Allocator.
+struct AllocatedBuffer {
+ public:
+  explicit inline AllocatedBuffer(Environment* env = nullptr);
+  inline AllocatedBuffer(Environment* env, uv_buf_t buf);
+  inline ~AllocatedBuffer();
+  inline void Resize(size_t len);
+
+  inline uv_buf_t release();
+  inline char* data();
+  inline const char* data() const;
+  inline size_t size() const;
+  inline void clear();
+
+  inline v8::MaybeLocal<v8::Object> ToBuffer();
+  inline v8::Local<v8::ArrayBuffer> ToArrayBuffer();
+
+  inline AllocatedBuffer(AllocatedBuffer&& other);
+  inline AllocatedBuffer& operator=(AllocatedBuffer&& other);
+  AllocatedBuffer(const AllocatedBuffer& other) = delete;
+  AllocatedBuffer& operator=(const AllocatedBuffer& other) = delete;
+
+ private:
+  Environment* env_;
+  // We do not pass this to libuv directly, but uv_buf_t is a convenient way
+  // to represent a chunk of memory, and plays nicely with other parts of core.
+  uv_buf_t buffer_;
+
+  friend class Environment;
+};
+
 class Environment {
  public:
   class AsyncHooks {
@@ -694,6 +726,15 @@ class Environment {
   inline uint64_t timer_base() const;
 
   inline IsolateData* isolate_data() const;
+
+  // Utilites that allocate memory using the Isolate's ArrayBuffer::Allocator.
+  // In particular, using AllocateManaged() will provide a RAII-style object
+  // with easy conversion to `Buffer` and `ArrayBuffer` objects.
+  inline AllocatedBuffer AllocateManaged(size_t size, bool checked = true);
+  inline char* Allocate(size_t size);
+  inline char* AllocateUnchecked(size_t size);
+  char* Reallocate(char* data, size_t old_size, size_t size);
+  inline void Free(char* data, size_t size);
 
   inline bool printed_error() const;
   inline void set_printed_error(bool value);

--- a/src/env.h
+++ b/src/env.h
@@ -392,15 +392,19 @@ class Environment;
 
 class IsolateData {
  public:
-  IsolateData(v8::Isolate* isolate, uv_loop_t* event_loop,
+  IsolateData(v8::Isolate* isolate,
+              uv_loop_t* event_loop,
               MultiIsolatePlatform* platform = nullptr,
-              uint32_t* zero_fill_field = nullptr);
+              ArrayBufferAllocator* node_allocator = nullptr);
   ~IsolateData();
   inline uv_loop_t* event_loop() const;
-  inline uint32_t* zero_fill_field() const;
   inline MultiIsolatePlatform* platform() const;
   inline std::shared_ptr<PerIsolateOptions> options();
   inline void set_options(std::shared_ptr<PerIsolateOptions> options);
+
+  inline bool uses_node_allocator() const;
+  inline v8::ArrayBuffer::Allocator* allocator() const;
+  inline ArrayBufferAllocator* node_allocator() const;
 
 #define VP(PropertyName, StringValue) V(v8::Private, PropertyName)
 #define VY(PropertyName, StringValue) V(v8::Symbol, PropertyName)
@@ -434,7 +438,9 @@ class IsolateData {
 
   v8::Isolate* const isolate_;
   uv_loop_t* const event_loop_;
-  uint32_t* const zero_fill_field_;
+  v8::ArrayBuffer::Allocator* const allocator_;
+  ArrayBufferAllocator* const node_allocator_;
+  const bool uses_node_allocator_;
   MultiIsolatePlatform* platform_;
   std::shared_ptr<PerIsolateOptions> options_;
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -54,17 +54,6 @@
   size_t length = end - start;
 
 namespace node {
-
-namespace {
-
-inline void* BufferMalloc(size_t length) {
-  return per_process::cli_options->zero_fill_all_buffers ?
-             node::UncheckedCalloc(length) :
-             node::UncheckedMalloc(length);
-}
-
-}  // namespace
-
 namespace Buffer {
 
 using v8::ArrayBuffer;
@@ -260,7 +249,7 @@ MaybeLocal<Object> New(Isolate* isolate,
   char* data = nullptr;
 
   if (length > 0) {
-    data = static_cast<char*>(BufferMalloc(length));
+    data = UncheckedMalloc(length);
 
     if (data == nullptr)
       return Local<Object>();
@@ -276,13 +265,7 @@ MaybeLocal<Object> New(Isolate* isolate,
     }
   }
 
-  Local<Object> buf;
-  if (New(isolate, data, actual).ToLocal(&buf))
-    return scope.Escape(buf);
-
-  // Object failed to be created. Clean up resources.
-  free(data);
-  return Local<Object>();
+  return scope.EscapeMaybe(New(isolate, data, actual));
 }
 
 
@@ -308,28 +291,15 @@ MaybeLocal<Object> New(Environment* env, size_t length) {
     return Local<Object>();
   }
 
-  void* data;
+  AllocatedBuffer ret(env);
   if (length > 0) {
-    data = BufferMalloc(length);
-    if (data == nullptr)
+    ret = env->AllocateManaged(length, false);
+    if (ret.data() == nullptr) {
       return Local<Object>();
-  } else {
-    data = nullptr;
+    }
   }
 
-  Local<ArrayBuffer> ab =
-    ArrayBuffer::New(env->isolate(),
-        data,
-        length,
-        ArrayBufferCreationMode::kInternalized);
-  MaybeLocal<Uint8Array> ui = Buffer::New(env, ab, 0, length);
-
-  if (ui.IsEmpty()) {
-    // Object failed to be created. Clean up resources.
-    free(data);
-  }
-
-  return scope.Escape(ui.FromMaybe(Local<Uint8Array>()));
+  return scope.EscapeMaybe(ret.ToBuffer());
 }
 
 
@@ -355,30 +325,17 @@ MaybeLocal<Object> Copy(Environment* env, const char* data, size_t length) {
     return Local<Object>();
   }
 
-  void* new_data;
+  AllocatedBuffer ret(env);
   if (length > 0) {
     CHECK_NOT_NULL(data);
-    new_data = node::UncheckedMalloc(length);
-    if (new_data == nullptr)
+    ret = env->AllocateManaged(length, false);
+    if (ret.data() == nullptr) {
       return Local<Object>();
-    memcpy(new_data, data, length);
-  } else {
-    new_data = nullptr;
+    }
+    memcpy(ret.data(), data, length);
   }
 
-  Local<ArrayBuffer> ab =
-    ArrayBuffer::New(env->isolate(),
-        new_data,
-        length,
-        ArrayBufferCreationMode::kInternalized);
-  MaybeLocal<Uint8Array> ui = Buffer::New(env, ab, 0, length);
-
-  if (ui.IsEmpty()) {
-    // Object failed to be created. Clean up resources.
-    free(new_data);
-  }
-
-  return scope.Escape(ui.FromMaybe(Local<Uint8Array>()));
+  return scope.EscapeMaybe(ret.ToBuffer());
 }
 
 
@@ -423,7 +380,8 @@ MaybeLocal<Object> New(Environment* env,
   return scope.Escape(ui.ToLocalChecked());
 }
 
-
+// Warning: This function needs `data` to be allocated with malloc() and not
+// necessarily isolate's ArrayBuffer::Allocator.
 MaybeLocal<Object> New(Isolate* isolate, char* data, size_t length) {
   EscapableHandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
@@ -433,16 +391,35 @@ MaybeLocal<Object> New(Isolate* isolate, char* data, size_t length) {
     return MaybeLocal<Object>();
   }
   Local<Object> obj;
-  if (Buffer::New(env, data, length).ToLocal(&obj))
+  if (Buffer::New(env, data, length, true).ToLocal(&obj))
     return handle_scope.Escape(obj);
   return Local<Object>();
 }
 
-
-MaybeLocal<Object> New(Environment* env, char* data, size_t length) {
+// Warning: If this call comes through the public node_buffer.h API,
+// the contract for this function is that `data` is allocated with malloc()
+// and not necessarily isolate's ArrayBuffer::Allocator.
+MaybeLocal<Object> New(Environment* env,
+                       char* data,
+                       size_t length,
+                       bool uses_malloc) {
   if (length > 0) {
     CHECK_NOT_NULL(data);
     CHECK(length <= kMaxLength);
+  }
+
+  if (uses_malloc) {
+    if (env->isolate_data()->uses_node_allocator()) {
+      // We don't know for sure that the allocator is malloc()-based, so we need
+      // to fall back to the FreeCallback variant.
+      auto free_callback = [](char* data, void* hint) { free(data); };
+      return New(env, data, length, free_callback, nullptr);
+    } else {
+      // This is malloc()-based, so we can acquire it into our own
+      // ArrayBufferAllocator.
+      CHECK_NOT_NULL(env->isolate_data()->node_allocator());
+      env->isolate_data()->node_allocator()->RegisterPointer(data, length);
+    }
   }
 
   Local<ArrayBuffer> ab =
@@ -1051,15 +1028,13 @@ static void EncodeUtf8String(const FunctionCallbackInfo<Value>& args) {
 
   Local<String> str = args[0].As<String>();
   size_t length = str->Utf8Length(isolate);
-  char* data = node::UncheckedMalloc(length);
+  AllocatedBuffer buf = env->AllocateManaged(length);
   str->WriteUtf8(isolate,
-                 data,
+                 buf.data(),
                  -1,  // We are certain that `data` is sufficiently large
                  nullptr,
                  String::NO_NULL_TERMINATION | String::REPLACE_INVALID_UTF8);
-  auto array_buf = ArrayBuffer::New(
-      isolate, data, length, ArrayBufferCreationMode::kInternalized);
-  auto array = Uint8Array::New(array_buf, 0, length);
+  auto array = Uint8Array::New(buf.ToArrayBuffer(), 0, length);
   args.GetReturnValue().Set(array);
 }
 
@@ -1121,7 +1096,8 @@ void Initialize(Local<Object> target,
 
   // It can be a nullptr when running inside an isolate where we
   // do not own the ArrayBuffer allocator.
-  if (uint32_t* zero_fill_field = env->isolate_data()->zero_fill_field()) {
+  if (ArrayBufferAllocator* allocator = env->isolate_data()->node_allocator()) {
+    uint32_t* zero_fill_field = allocator->zero_fill_field();
     Local<ArrayBuffer> array_buffer = ArrayBuffer::New(
         env->isolate(), zero_fill_field, sizeof(*zero_fill_field));
     CHECK(target

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -52,15 +52,6 @@ static const int X509_NAME_FLAGS = ASN1_STRFLGS_ESC_CTRL
                                  | XN_FLAG_FN_SN;
 
 namespace node {
-namespace Buffer {
-// OpenSSL uses `unsigned char*` for raw data, make this easier for us.
-v8::MaybeLocal<v8::Object> New(Environment* env, unsigned char* udata,
-                               size_t length) {
-  char* data = reinterpret_cast<char*>(udata);
-  return Buffer::New(env, data, length);
-}
-}  // namespace Buffer
-
 namespace crypto {
 
 using v8::Array;
@@ -1624,13 +1615,18 @@ static MaybeLocal<Object> ECPointToBuffer(Environment* env,
     if (error != nullptr) *error = "Failed to get public key length";
     return MaybeLocal<Object>();
   }
-  MallocedBuffer<unsigned char> buf(len);
-  len = EC_POINT_point2oct(group, point, form, buf.data, buf.size, nullptr);
+  AllocatedBuffer buf = env->AllocateManaged(len);
+  len = EC_POINT_point2oct(group,
+                           point,
+                           form,
+                           reinterpret_cast<unsigned char*>(buf.data()),
+                           buf.size(),
+                           nullptr);
   if (len == 0) {
     if (error != nullptr) *error = "Failed to get public key";
     return MaybeLocal<Object>();
   }
-  return Buffer::New(env, buf.release(), len);
+  return buf.ToBuffer();
 }
 
 
@@ -2009,9 +2005,9 @@ void SSLWrap<Base>::GetFinished(const FunctionCallbackInfo<Value>& args) {
   if (len == 0)
     return;
 
-  char* buf = Malloc(len);
-  CHECK_EQ(len, SSL_get_finished(w->ssl_.get(), buf, len));
-  args.GetReturnValue().Set(Buffer::New(env, buf, len).ToLocalChecked());
+  AllocatedBuffer buf = env->AllocateManaged(len);
+  CHECK_EQ(len, SSL_get_finished(w->ssl_.get(), buf.data(), len));
+  args.GetReturnValue().Set(buf.ToBuffer().ToLocalChecked());
 }
 
 
@@ -2032,9 +2028,9 @@ void SSLWrap<Base>::GetPeerFinished(const FunctionCallbackInfo<Value>& args) {
   if (len == 0)
     return;
 
-  char* buf = Malloc(len);
-  CHECK_EQ(len, SSL_get_peer_finished(w->ssl_.get(), buf, len));
-  args.GetReturnValue().Set(Buffer::New(env, buf, len).ToLocalChecked());
+  AllocatedBuffer buf = env->AllocateManaged(len);
+  CHECK_EQ(len, SSL_get_peer_finished(w->ssl_.get(), buf.data(), len));
+  args.GetReturnValue().Set(buf.ToBuffer().ToLocalChecked());
 }
 
 
@@ -2052,10 +2048,10 @@ void SSLWrap<Base>::GetSession(const FunctionCallbackInfo<Value>& args) {
   int slen = i2d_SSL_SESSION(sess, nullptr);
   CHECK_GT(slen, 0);
 
-  char* sbuf = Malloc(slen);
-  unsigned char* p = reinterpret_cast<unsigned char*>(sbuf);
+  AllocatedBuffer sbuf = env->AllocateManaged(slen);
+  unsigned char* p = reinterpret_cast<unsigned char*>(sbuf.data());
   i2d_SSL_SESSION(sess, &p);
-  args.GetReturnValue().Set(Buffer::New(env, sbuf, slen).ToLocalChecked());
+  args.GetReturnValue().Set(sbuf.ToBuffer().ToLocalChecked());
 }
 
 
@@ -3936,11 +3932,9 @@ void CipherBase::SetAAD(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(b);  // Possibly report invalid state failure
 }
 
-
 CipherBase::UpdateResult CipherBase::Update(const char* data,
                                             int len,
-                                            unsigned char** out,
-                                            int* out_len) {
+                                            AllocatedBuffer* out) {
   if (!ctx_)
     return kErrorState;
   MarkPopErrorOnReturn mark_pop_error_on_return;
@@ -3958,27 +3952,27 @@ CipherBase::UpdateResult CipherBase::Update(const char* data,
     CHECK(MaybePassAuthTagToOpenSSL());
   }
 
-  *out_len = 0;
-  int buff_len = len + EVP_CIPHER_CTX_block_size(ctx_.get());
+  int buf_len = len + EVP_CIPHER_CTX_block_size(ctx_.get());
   // For key wrapping algorithms, get output size by calling
   // EVP_CipherUpdate() with null output.
   if (kind_ == kCipher && mode == EVP_CIPH_WRAP_MODE &&
       EVP_CipherUpdate(ctx_.get(),
                        nullptr,
-                       &buff_len,
+                       &buf_len,
                        reinterpret_cast<const unsigned char*>(data),
                        len) != 1) {
     return kErrorState;
   }
 
-  *out = Malloc<unsigned char>(buff_len);
+  *out = env()->AllocateManaged(buf_len);
   int r = EVP_CipherUpdate(ctx_.get(),
-                           *out,
-                           out_len,
+                           reinterpret_cast<unsigned char*>(out->data()),
+                           &buf_len,
                            reinterpret_cast<const unsigned char*>(data),
                            len);
 
-  CHECK_LE(*out_len, buff_len);
+  CHECK_LE(static_cast<size_t>(buf_len), out->size());
+  out->Resize(buf_len);
 
   // When in CCM mode, EVP_CipherUpdate will fail if the authentication tag is
   // invalid. In that case, remember the error and throw in final().
@@ -3996,9 +3990,8 @@ void CipherBase::Update(const FunctionCallbackInfo<Value>& args) {
   CipherBase* cipher;
   ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
 
-  unsigned char* out = nullptr;
+  AllocatedBuffer out;
   UpdateResult r;
-  int out_len = 0;
 
   // Only copy the data if we have to, because it's a string
   if (args[0]->IsString()) {
@@ -4006,15 +3999,14 @@ void CipherBase::Update(const FunctionCallbackInfo<Value>& args) {
     if (!decoder.Decode(env, args[0].As<String>(), args[1], UTF8)
              .FromMaybe(false))
       return;
-    r = cipher->Update(decoder.out(), decoder.size(), &out, &out_len);
+    r = cipher->Update(decoder.out(), decoder.size(), &out);
   } else {
     char* buf = Buffer::Data(args[0]);
     size_t buflen = Buffer::Length(args[0]);
-    r = cipher->Update(buf, buflen, &out, &out_len);
+    r = cipher->Update(buf, buflen, &out);
   }
 
   if (r != kSuccess) {
-    free(out);
     if (r == kErrorState) {
       ThrowCryptoError(env, ERR_get_error(),
                        "Trying to add data in unsupported state");
@@ -4022,11 +4014,9 @@ void CipherBase::Update(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  CHECK(out != nullptr || out_len == 0);
-  Local<Object> buf =
-      Buffer::New(env, reinterpret_cast<char*>(out), out_len).ToLocalChecked();
+  CHECK(out.data() != nullptr || out.size() == 0);
 
-  args.GetReturnValue().Set(buf);
+  args.GetReturnValue().Set(out.ToBuffer().ToLocalChecked());
 }
 
 
@@ -4046,14 +4036,13 @@ void CipherBase::SetAutoPadding(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(b);  // Possibly report invalid state failure
 }
 
-
-bool CipherBase::Final(unsigned char** out, int* out_len) {
+bool CipherBase::Final(AllocatedBuffer* out) {
   if (!ctx_)
     return false;
 
   const int mode = EVP_CIPHER_CTX_mode(ctx_.get());
 
-  *out = Malloc<unsigned char>(
+  *out = env()->AllocateManaged(
       static_cast<size_t>(EVP_CIPHER_CTX_block_size(ctx_.get())));
 
   if (kind_ == kDecipher && IsSupportedAuthenticatedMode(ctx_.get())) {
@@ -4065,8 +4054,17 @@ bool CipherBase::Final(unsigned char** out, int* out_len) {
   bool ok;
   if (kind_ == kDecipher && mode == EVP_CIPH_CCM_MODE) {
     ok = !pending_auth_failed_;
+    *out = AllocatedBuffer(env());  // Empty buffer.
   } else {
-    ok = EVP_CipherFinal_ex(ctx_.get(), *out, out_len) == 1;
+    int out_len = out->size();
+    ok = EVP_CipherFinal_ex(ctx_.get(),
+                            reinterpret_cast<unsigned char*>(out->data()),
+                            &out_len) == 1;
+
+    if (out_len >= 0)
+      out->Resize(out_len);
+    else
+      *out = AllocatedBuffer();  // *out will not be used.
 
     if (ok && kind_ == kCipher && IsAuthenticatedMode()) {
       // In GCM mode, the authentication tag length can be specified in advance,
@@ -4095,33 +4093,21 @@ void CipherBase::Final(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
   if (cipher->ctx_ == nullptr) return env->ThrowError("Unsupported state");
 
-  unsigned char* out_value = nullptr;
-  int out_len = -1;
+  AllocatedBuffer out;
 
   // Check IsAuthenticatedMode() first, Final() destroys the EVP_CIPHER_CTX.
   const bool is_auth_mode = cipher->IsAuthenticatedMode();
-  bool r = cipher->Final(&out_value, &out_len);
+  bool r = cipher->Final(&out);
 
-  if (out_len <= 0 || !r) {
-    free(out_value);
-    out_value = nullptr;
-    out_len = 0;
-    if (!r) {
-      const char* msg = is_auth_mode ?
-          "Unsupported state or unable to authenticate data" :
-          "Unsupported state";
+  if (!r) {
+    const char* msg = is_auth_mode
+                          ? "Unsupported state or unable to authenticate data"
+                          : "Unsupported state";
 
-      return ThrowCryptoError(env,
-                              ERR_get_error(),
-                              msg);
-    }
+    return ThrowCryptoError(env, ERR_get_error(), msg);
   }
 
-  Local<Object> buf = Buffer::New(
-      env,
-      reinterpret_cast<char*>(out_value),
-      out_len).ToLocalChecked();
-  args.GetReturnValue().Set(buf);
+  args.GetReturnValue().Set(out.ToBuffer().ToLocalChecked());
 }
 
 
@@ -4481,20 +4467,21 @@ void Sign::SignUpdate(const FunctionCallbackInfo<Value>& args) {
   sign->CheckThrow(err);
 }
 
-static MallocedBuffer<unsigned char> Node_SignFinal(EVPMDPointer&& mdctx,
-                                                    const ManagedEVPPKey& pkey,
-                                                    int padding,
-                                                    int pss_salt_len) {
+static AllocatedBuffer Node_SignFinal(Environment* env,
+                                      EVPMDPointer&& mdctx,
+                                      const ManagedEVPPKey& pkey,
+                                      int padding,
+                                      int pss_salt_len) {
   unsigned char m[EVP_MAX_MD_SIZE];
   unsigned int m_len;
 
   if (!EVP_DigestFinal_ex(mdctx.get(), m, &m_len))
-    return MallocedBuffer<unsigned char>();
+    return AllocatedBuffer();
 
   int signed_sig_len = EVP_PKEY_size(pkey.get());
   CHECK_GE(signed_sig_len, 0);
   size_t sig_len = static_cast<size_t>(signed_sig_len);
-  MallocedBuffer<unsigned char> sig(sig_len);
+  AllocatedBuffer sig = env->AllocateManaged(sig_len);
 
   EVPKeyCtxPointer pkctx(EVP_PKEY_CTX_new(pkey.get(), nullptr));
   if (pkctx &&
@@ -4502,12 +4489,16 @@ static MallocedBuffer<unsigned char> Node_SignFinal(EVPMDPointer&& mdctx,
       ApplyRSAOptions(pkey, pkctx.get(), padding, pss_salt_len) &&
       EVP_PKEY_CTX_set_signature_md(pkctx.get(),
                                     EVP_MD_CTX_md(mdctx.get())) > 0 &&
-      EVP_PKEY_sign(pkctx.get(), sig.data, &sig_len, m, m_len) > 0) {
-    sig.Truncate(sig_len);
+      EVP_PKEY_sign(pkctx.get(),
+                    reinterpret_cast<unsigned char*>(sig.data()),
+                    &sig_len,
+                    m,
+                    m_len) > 0) {
+    sig.Resize(sig_len);
     return sig;
   }
 
-  return MallocedBuffer<unsigned char>();
+  return AllocatedBuffer();
 }
 
 Sign::SignResult Sign::SignFinal(
@@ -4546,16 +4537,14 @@ Sign::SignResult Sign::SignFinal(
   }
 #endif  // NODE_FIPS_MODE
 
-  MallocedBuffer<unsigned char> buffer =
-      Node_SignFinal(std::move(mdctx), pkey, padding, salt_len);
-  Error error = buffer.is_empty() ? kSignPrivateKey : kSignOk;
+  AllocatedBuffer buffer =
+      Node_SignFinal(env(), std::move(mdctx), pkey, padding, salt_len);
+  Error error = buffer.data() == nullptr ? kSignPrivateKey : kSignOk;
   return SignResult(error, std::move(buffer));
 }
 
 
 void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
   Sign* sign;
   ASSIGN_OR_RETURN_UNWRAP(&sign, args.Holder());
 
@@ -4580,13 +4569,7 @@ void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
   if (ret.error != kSignOk)
     return sign->CheckThrow(ret.error);
 
-  MallocedBuffer<unsigned char> sig =
-      std::move(ret.signature);
-
-  Local<Object> rc =
-      Buffer::New(env, reinterpret_cast<char*>(sig.release()), sig.size)
-      .ToLocalChecked();
-  args.GetReturnValue().Set(rc);
+  args.GetReturnValue().Set(ret.signature.ToBuffer().ToLocalChecked());
 }
 
 void Verify::Initialize(Environment* env, Local<Object> target) {
@@ -4695,16 +4678,15 @@ void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(verify_result);
 }
 
-
 template <PublicKeyCipher::Operation operation,
           PublicKeyCipher::EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init,
           PublicKeyCipher::EVP_PKEY_cipher_t EVP_PKEY_cipher>
-bool PublicKeyCipher::Cipher(const ManagedEVPPKey& pkey,
+bool PublicKeyCipher::Cipher(Environment* env,
+                             const ManagedEVPPKey& pkey,
                              int padding,
                              const unsigned char* data,
                              int len,
-                             unsigned char** out,
-                             size_t* out_len) {
+                             AllocatedBuffer* out) {
   EVPKeyCtxPointer ctx(EVP_PKEY_CTX_new(pkey.get(), nullptr));
   if (!ctx)
     return false;
@@ -4713,14 +4695,21 @@ bool PublicKeyCipher::Cipher(const ManagedEVPPKey& pkey,
   if (EVP_PKEY_CTX_set_rsa_padding(ctx.get(), padding) <= 0)
     return false;
 
-  if (EVP_PKEY_cipher(ctx.get(), nullptr, out_len, data, len) <= 0)
+  size_t out_len = 0;
+  if (EVP_PKEY_cipher(ctx.get(), nullptr, &out_len, data, len) <= 0)
     return false;
 
-  *out = Malloc<unsigned char>(*out_len);
+  *out = env->AllocateManaged(out_len);
 
-  if (EVP_PKEY_cipher(ctx.get(), *out, out_len, data, len) <= 0)
+  if (EVP_PKEY_cipher(ctx.get(),
+                      reinterpret_cast<unsigned char*>(out->data()),
+                      &out_len,
+                      data,
+                      len) <= 0) {
     return false;
+  }
 
+  out->Resize(out_len);
   return true;
 }
 
@@ -4743,33 +4732,22 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
   uint32_t padding;
   if (!args[offset + 1]->Uint32Value(env->context()).To(&padding)) return;
 
-  unsigned char* out_value = nullptr;
-  size_t out_len = 0;
+  AllocatedBuffer out;
 
   ClearErrorOnReturn clear_error_on_return;
 
   bool r = Cipher<operation, EVP_PKEY_cipher_init, EVP_PKEY_cipher>(
+      env,
       pkey,
       padding,
       reinterpret_cast<const unsigned char*>(buf),
       len,
-      &out_value,
-      &out_len);
+      &out);
 
-  if (out_len == 0 || !r) {
-    free(out_value);
-    out_value = nullptr;
-    out_len = 0;
-    if (!r) {
-      return ThrowCryptoError(env,
-        ERR_get_error());
-    }
-  }
+  if (!r)
+    return ThrowCryptoError(env, ERR_get_error());
 
-  Local<Object> vbuf =
-      Buffer::New(env, reinterpret_cast<char*>(out_value), out_len)
-      .ToLocalChecked();
-  args.GetReturnValue().Set(vbuf);
+  args.GetReturnValue().Set(out.ToBuffer().ToLocalChecked());
 }
 
 
@@ -4934,10 +4912,11 @@ void DiffieHellman::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
   DH_get0_key(diffieHellman->dh_.get(), &pub_key, nullptr);
   const int size = BN_num_bytes(pub_key);
   CHECK_GE(size, 0);
-  char* data = Malloc(size);
+  AllocatedBuffer data = env->AllocateManaged(size);
   CHECK_EQ(size,
-           BN_bn2binpad(pub_key, reinterpret_cast<unsigned char*>(data), size));
-  args.GetReturnValue().Set(Buffer::New(env, data, size).ToLocalChecked());
+           BN_bn2binpad(
+               pub_key, reinterpret_cast<unsigned char*>(data.data()), size));
+  args.GetReturnValue().Set(data.ToBuffer().ToLocalChecked());
 }
 
 
@@ -4954,10 +4933,11 @@ void DiffieHellman::GetField(const FunctionCallbackInfo<Value>& args,
 
   const int size = BN_num_bytes(num);
   CHECK_GE(size, 0);
-  char* data = Malloc(size);
-  CHECK_EQ(size,
-           BN_bn2binpad(num, reinterpret_cast<unsigned char*>(data), size));
-  args.GetReturnValue().Set(Buffer::New(env, data, size).ToLocalChecked());
+  AllocatedBuffer data = env->AllocateManaged(size);
+  CHECK_EQ(
+      size,
+      BN_bn2binpad(num, reinterpret_cast<unsigned char*>(data.data()), size));
+  args.GetReturnValue().Set(data.ToBuffer().ToLocalChecked());
 }
 
 void DiffieHellman::GetPrime(const FunctionCallbackInfo<Value>& args) {
@@ -5015,9 +4995,9 @@ void DiffieHellman::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
       Buffer::Length(args[0]),
       nullptr));
 
-  MallocedBuffer<char> data(DH_size(diffieHellman->dh_.get()));
+  AllocatedBuffer ret = env->AllocateManaged(DH_size(diffieHellman->dh_.get()));
 
-  int size = DH_compute_key(reinterpret_cast<unsigned char*>(data.data),
+  int size = DH_compute_key(reinterpret_cast<unsigned char*>(ret.data()),
                             key.get(),
                             diffieHellman->dh_.get());
 
@@ -5052,14 +5032,13 @@ void DiffieHellman::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   // DH_compute_key returns number of bytes in a remainder of exponent, which
   // may have less bytes than a prime number. Therefore add 0-padding to the
   // allocated buffer.
-  if (static_cast<size_t>(size) != data.size) {
-    CHECK_GT(data.size, static_cast<size_t>(size));
-    memmove(data.data + data.size - size, data.data, size);
-    memset(data.data, 0, data.size - size);
+  if (static_cast<size_t>(size) != ret.size()) {
+    CHECK_GT(ret.size(), static_cast<size_t>(size));
+    memmove(ret.data() + ret.size() - size, ret.data(), size);
+    memset(ret.data(), 0, ret.size() - size);
   }
 
-  args.GetReturnValue().Set(
-      Buffer::New(env->isolate(), data.release(), data.size).ToLocalChecked());
+  args.GetReturnValue().Set(ret.ToBuffer().ToLocalChecked());
 }
 
 void DiffieHellman::SetKey(const FunctionCallbackInfo<Value>& args,
@@ -5233,15 +5212,14 @@ void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   // NOTE: field_size is in bits
   int field_size = EC_GROUP_get_degree(ecdh->group_);
   size_t out_len = (field_size + 7) / 8;
-  char* out = node::Malloc(out_len);
+  AllocatedBuffer out = env->AllocateManaged(out_len);
 
-  int r = ECDH_compute_key(out, out_len, pub.get(), ecdh->key_.get(), nullptr);
-  if (!r) {
-    free(out);
+  int r = ECDH_compute_key(
+      out.data(), out_len, pub.get(), ecdh->key_.get(), nullptr);
+  if (!r)
     return env->ThrowError("Failed to compute ECDH key");
-  }
 
-  Local<Object> buf = Buffer::New(env, out, out_len).ToLocalChecked();
+  Local<Object> buf = out.ToBuffer().ToLocalChecked();
   args.GetReturnValue().Set(buf);
 }
 
@@ -5283,11 +5261,12 @@ void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("Failed to get ECDH private key");
 
   const int size = BN_num_bytes(b);
-  unsigned char* out = node::Malloc<unsigned char>(size);
-  CHECK_EQ(size, BN_bn2binpad(b, out, size));
+  AllocatedBuffer out = env->AllocateManaged(size);
+  CHECK_EQ(size, BN_bn2binpad(b,
+                              reinterpret_cast<unsigned char*>(out.data()),
+                              size));
 
-  Local<Object> buf =
-      Buffer::New(env, reinterpret_cast<char*>(out), size).ToLocalChecked();
+  Local<Object> buf = out.ToBuffer().ToLocalChecked();
   args.GetReturnValue().Set(buf);
 }
 
@@ -6039,31 +6018,28 @@ void VerifySpkac(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(verify_result);
 }
 
-
-char* ExportPublicKey(const char* data, int len, size_t* size) {
-  char* buf = nullptr;
-
+AllocatedBuffer ExportPublicKey(Environment* env,
+                                const char* data,
+                                int len,
+                                size_t* size) {
   BIOPointer bio(BIO_new(BIO_s_mem()));
-  if (!bio)
-    return nullptr;
+  if (!bio) return AllocatedBuffer();
 
   NetscapeSPKIPointer spki(NETSCAPE_SPKI_b64_decode(data, len));
-  if (!spki)
-    return nullptr;
+  if (!spki) return AllocatedBuffer();
 
   EVPKeyPointer pkey(NETSCAPE_SPKI_get_pubkey(spki.get()));
-  if (!pkey)
-    return nullptr;
+  if (!pkey) return AllocatedBuffer();
 
   if (PEM_write_bio_PUBKEY(bio.get(), pkey.get()) <= 0)
-    return nullptr;
+    return AllocatedBuffer();
 
   BUF_MEM* ptr;
   BIO_get_mem_ptr(bio.get(), &ptr);
 
   *size = ptr->length;
-  buf = Malloc(*size);
-  memcpy(buf, ptr->data, *size);
+  AllocatedBuffer buf = env->AllocateManaged(*size);
+  memcpy(buf.data(), ptr->data, *size);
 
   return buf;
 }
@@ -6080,12 +6056,11 @@ void ExportPublicKey(const FunctionCallbackInfo<Value>& args) {
   CHECK_NOT_NULL(data);
 
   size_t pkey_size;
-  char* pkey = ExportPublicKey(data, length, &pkey_size);
-  if (pkey == nullptr)
+  AllocatedBuffer pkey = ExportPublicKey(env, data, length, &pkey_size);
+  if (pkey.data() == nullptr)
     return args.GetReturnValue().SetEmptyString();
 
-  Local<Value> out = Buffer::New(env, pkey, pkey_size).ToLocalChecked();
-  args.GetReturnValue().Set(out);
+  args.GetReturnValue().Set(pkey.ToBuffer().ToLocalChecked());
 }
 
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -544,9 +544,8 @@ class CipherBase : public BaseObject {
   bool InitAuthenticated(const char* cipher_type, int iv_len,
                          unsigned int auth_tag_len);
   bool CheckCCMMessageLength(int message_len);
-  UpdateResult Update(const char* data, int len, unsigned char** out,
-                      int* out_len);
-  bool Final(unsigned char** out, int* out_len);
+  UpdateResult Update(const char* data, int len, AllocatedBuffer* out);
+  bool Final(AllocatedBuffer* out);
   bool SetAutoPadding(bool auto_padding);
 
   bool IsAuthenticatedMode() const;
@@ -677,11 +676,11 @@ class Sign : public SignBase {
 
   struct SignResult {
     Error error;
-    MallocedBuffer<unsigned char> signature;
+    AllocatedBuffer signature;
 
     explicit SignResult(
         Error err,
-        MallocedBuffer<unsigned char>&& sig = MallocedBuffer<unsigned char>())
+        AllocatedBuffer&& sig = AllocatedBuffer())
       : error(err), signature(std::move(sig)) {}
   };
 
@@ -738,12 +737,12 @@ class PublicKeyCipher {
   template <Operation operation,
             EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init,
             EVP_PKEY_cipher_t EVP_PKEY_cipher>
-  static bool Cipher(const ManagedEVPPKey& pkey,
+  static bool Cipher(Environment* env,
+                     const ManagedEVPPKey& pkey,
                      int padding,
                      const unsigned char* data,
                      int len,
-                     unsigned char** out,
-                     size_t* out_len);
+                     AllocatedBuffer* out);
 
   template <Operation operation,
             EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init,

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -783,6 +783,7 @@ class Http2Session : public AsyncWrap, public StreamListener {
   }
 
   // Handle reads/writes from the underlying network transport.
+  uv_buf_t OnStreamAlloc(size_t suggested_size) override;
   void OnStreamRead(ssize_t nread, const uv_buf_t& buf) override;
   void OnStreamAfterWrite(WriteWrap* w, int status) override;
 

--- a/src/node_http_parser_impl.h
+++ b/src/node_http_parser_impl.h
@@ -594,10 +594,9 @@ class Parser : public AsyncWrap, public StreamListener {
   uv_buf_t OnStreamAlloc(size_t suggested_size) override {
     // For most types of streams, OnStreamRead will be immediately after
     // OnStreamAlloc, and will consume all data, so using a static buffer for
-    // reading is more efficient. For other streams, just use the default
-    // allocator, which uses Malloc().
+    // reading is more efficient. For other streams, just use Malloc() directly.
     if (env()->http_parser_buffer_in_use())
-      return StreamListener::OnStreamAlloc(suggested_size);
+      return uv_buf_init(Malloc(suggested_size), suggested_size);
     env()->set_http_parser_buffer_in_use(true);
 
     if (env()->http_parser_buffer() == nullptr)

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -146,10 +146,12 @@ v8::MaybeLocal<v8::Object> New(Environment* env,
                                size_t length,
                                void (*callback)(char* data, void* hint),
                                void* hint);
-// Takes ownership of |data|.  Must allocate |data| with malloc() or realloc()
-// because ArrayBufferAllocator::Free() deallocates it again with free().
-// Mixing operator new and free() is undefined behavior so don't do that.
-v8::MaybeLocal<v8::Object> New(Environment* env, char* data, size_t length);
+// Takes ownership of |data|.  Must allocate |data| with the current Isolate's
+// ArrayBuffer::Allocator().
+v8::MaybeLocal<v8::Object> New(Environment* env,
+                               char* data,
+                               size_t length,
+                               bool uses_malloc);
 
 // Construct a Buffer from a MaybeStackBuffer (and also its subclasses like
 // Utf8Value and TwoByteValue).
@@ -167,7 +169,7 @@ static v8::MaybeLocal<v8::Object> New(Environment* env,
   const size_t len_in_bytes = buf->length() * sizeof(buf->out()[0]);
 
   if (buf->IsAllocated())
-    ret = New(env, src, len_in_bytes);
+    ret = New(env, src, len_in_bytes, true);
   else if (!buf->IsInvalidated())
     ret = Copy(env, src, len_in_bytes);
 

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -11,7 +11,6 @@ namespace native_module {
 
 using v8::Array;
 using v8::ArrayBuffer;
-using v8::ArrayBufferCreationMode;
 using v8::Context;
 using v8::DEFAULT;
 using v8::EscapableHandleScope;
@@ -153,13 +152,8 @@ MaybeLocal<Uint8Array> NativeModuleLoader::GetCodeCache(Isolate* isolate,
 
   cached_data = it->second.get();
 
-  MallocedBuffer<uint8_t> copied(cached_data->length);
-  memcpy(copied.data, cached_data->data, cached_data->length);
-  Local<ArrayBuffer> buf =
-      ArrayBuffer::New(isolate,
-                       copied.release(),
-                       cached_data->length,
-                       ArrayBufferCreationMode::kInternalized);
+  Local<ArrayBuffer> buf = ArrayBuffer::New(isolate, cached_data->length);
+  memcpy(buf->GetContents().Data(), cached_data->data, cached_data->length);
   return scope.Escape(Uint8Array::New(buf, 0, cached_data->length));
 }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -369,6 +369,10 @@ PerProcessOptionsParser::PerProcessOptionsParser() {
             "SlowBuffer instances",
             &PerProcessOptions::zero_fill_all_buffers,
             kAllowedInEnvironment);
+  AddOption("--debug-arraybuffer-allocations",
+            "", /* undocumented, only for debugging */
+            &PerProcessOptions::debug_arraybuffer_allocations,
+            kAllowedInEnvironment);
 
   AddOption("--security-reverts", "", &PerProcessOptions::security_reverts);
   AddOption("--completion-bash",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -168,6 +168,7 @@ class PerProcessOptions : public Options {
   uint64_t max_http_header_size = 8 * 1024;
   int64_t v8_thread_pool_size = 4;
   bool zero_fill_all_buffers = false;
+  bool debug_arraybuffer_allocations = false;
 
   std::vector<std::string> security_reverts;
   bool print_bash_completion = false;

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -201,10 +201,13 @@ void SerializerContext::ReleaseBuffer(const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
   ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
 
+  // Note: Both ValueSerializer and this Buffer::New() variant use malloc()
+  // as the underlying allocator.
   std::pair<uint8_t*, size_t> ret = ctx->serializer_.Release();
   auto buf = Buffer::New(ctx->env(),
                          reinterpret_cast<char*>(ret.first),
-                         ret.second);
+                         ret.second,
+                         true /* uses_malloc */);
 
   if (!buf.IsEmpty()) {
     args.GetReturnValue().Set(buf.ToLocalChecked());

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -419,18 +419,9 @@ inline void ShutdownWrap::OnDone(int status) {
   Dispose();
 }
 
-inline void WriteWrap::SetAllocatedStorage(char* data, size_t size) {
-  CHECK_NULL(storage_);
-  storage_ = data;
-  storage_size_ = size;
-}
-
-inline char* WriteWrap::Storage() {
-  return storage_;
-}
-
-inline size_t WriteWrap::StorageSize() const {
-  return storage_size_;
+inline void WriteWrap::SetAllocatedStorage(AllocatedBuffer&& storage) {
+  CHECK_NULL(storage_.data());
+  storage_ = std::move(storage);
 }
 
 inline void WriteWrap::OnDone(int status) {

--- a/src/stream_pipe.h
+++ b/src/stream_pipe.h
@@ -41,7 +41,7 @@ class StreamPipe : public AsyncWrap {
   // `OnStreamWantsWrite()` support.
   size_t wanted_data_ = 0;
 
-  void ProcessData(size_t nread, const uv_buf_t& buf);
+  void ProcessData(size_t nread, AllocatedBuffer&& buf);
 
   class ReadableListener : public StreamListener {
    public:

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -461,24 +461,22 @@ void UDPWrap::OnSend(uv_udp_send_t* req, int status) {
 void UDPWrap::OnAlloc(uv_handle_t* handle,
                       size_t suggested_size,
                       uv_buf_t* buf) {
-  buf->base = node::Malloc(suggested_size);
-  buf->len = suggested_size;
+  UDPWrap* wrap = static_cast<UDPWrap*>(handle->data);
+  *buf = wrap->env()->AllocateManaged(suggested_size).release();
 }
-
 
 void UDPWrap::OnRecv(uv_udp_t* handle,
                      ssize_t nread,
-                     const uv_buf_t* buf,
+                     const uv_buf_t* buf_,
                      const struct sockaddr* addr,
                      unsigned int flags) {
-  if (nread == 0 && addr == nullptr) {
-    if (buf->base != nullptr)
-      free(buf->base);
-    return;
-  }
-
   UDPWrap* wrap = static_cast<UDPWrap*>(handle->data);
   Environment* env = wrap->env();
+
+  AllocatedBuffer buf(env, *buf_);
+  if (nread == 0 && addr == nullptr) {
+    return;
+  }
 
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
@@ -492,14 +490,12 @@ void UDPWrap::OnRecv(uv_udp_t* handle,
   };
 
   if (nread < 0) {
-    if (buf->base != nullptr)
-      free(buf->base);
     wrap->MakeCallback(env->onmessage_string(), arraysize(argv), argv);
     return;
   }
 
-  char* base = node::UncheckedRealloc(buf->base, nread);
-  argv[2] = Buffer::New(env, base, nread).ToLocalChecked();
+  buf.Resize(nread);
+  argv[2] = buf.ToBuffer().ToLocalChecked();
   argv[3] = AddressToJS(env, addr);
   wrap->MakeCallback(env->onmessage_string(), arraysize(argv), argv);
 }


### PR DESCRIPTION
Backport of #26207. Conflicts were only in the last commit in `node_buffer.cc`, the rest applied cleanly.