### PR TITLE
src: remove cast for unsupported openssl

### DIFF
--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -39,9 +39,7 @@ namespace crypto {
 
 
 BIOPointer NodeBIO::New(Environment* env) {
-  // The const_cast doesn't violate const correctness.  OpenSSL's usage of
-  // BIO_METHOD is effectively const but BIO_new() takes a non-const argument.
-  BIOPointer bio(BIO_new(const_cast<BIO_METHOD*>(GetMethod())));
+  BIOPointer bio(BIO_new(GetMethod()));
   if (bio && env != nullptr)
     NodeBIO::FromBIO(bio.get())->env_ = env;
   return bio;


### PR DESCRIPTION
The cast is needed to build against OpenSSL 1.0.2, which master, 11.x,
and 10.x no longer support.

To be clear, I mean don't support even when configured against an external openssl.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
