### PR TITLE
doc: added example for setting Vary: Accept-Encoding header in zlib.md

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -107,6 +107,8 @@ const http = require('http');
 const fs = require('fs');
 http.createServer((request, response) => {
   const raw = fs.createReadStream('index.html');
+  // instruct the proxy to store both a compressed and uncompressed version of the resource
+  response.setHeader('Vary: Accept-Encoding');
   let acceptEncoding = request.headers['accept-encoding'];
   if (!acceptEncoding) {
     acceptEncoding = '';

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -107,7 +107,7 @@ const http = require('http');
 const fs = require('fs');
 http.createServer((request, response) => {
   const raw = fs.createReadStream('index.html');
-  // To store both, a compressed and an uncompressed version of the resource.
+  // Store both a compressed and an uncompressed version of the resource.
   response.setHeader('Vary: Accept-Encoding');
   let acceptEncoding = request.headers['accept-encoding'];
   if (!acceptEncoding) {

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -107,7 +107,7 @@ const http = require('http');
 const fs = require('fs');
 http.createServer((request, response) => {
   const raw = fs.createReadStream('index.html');
-  // instruct the proxy to store both a compressed and uncompressed version of the resource
+  // To store both, a compressed and an uncompressed version of the resource.
   response.setHeader('Vary: Accept-Encoding');
   let acceptEncoding = request.headers['accept-encoding'];
   if (!acceptEncoding) {


### PR DESCRIPTION
Resolving issue #25495.
Added example to set `Vary: Accept-Encoding` header with explanatory comment to doc/api/zlib.md
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
