### PR TITLE
doc: correct typos in various docs

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2107,7 +2107,7 @@ otherwise `err` will be `null`. By default, the successfully generated
 thrown if any of the input arguments specify invalid values or types.
 
 If `digest` is `null`, `'sha1'` will be used. This behavior is deprecated,
-please specify a `digest` explicitely.
+please specify a `digest` explicitly.
 
 The `iterations` argument must be a number set as high as possible. The
 higher the number of iterations, the more secure the derived key will be,
@@ -2173,7 +2173,7 @@ If an error occurs an `Error` will be thrown, otherwise the derived key will be
 returned as a [`Buffer`][].
 
 If `digest` is `null`, `'sha1'` will be used. This behavior is deprecated,
-please specify a `digest` explicitely.
+please specify a `digest` explicitly.
 
 The `iterations` argument must be a number set as high as possible. The
 higher the number of iterations, the more secure the derived key will be,

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -377,7 +377,7 @@ typedef void (*napi_finalize)(napi_env env,
 
 #### napi_async_execute_callback
 Function pointer used with functions that support asynchronous
-operations. Callback functions must statisfy the following signature:
+operations. Callback functions must satisfy the following signature:
 
 ```C
 typedef void (*napi_async_execute_callback)(napi_env env, void* data);
@@ -390,7 +390,7 @@ calls should be made in `napi_async_complete_callback` instead.
 
 #### napi_async_complete_callback
 Function pointer used with functions that support asynchronous
-operations. Callback functions must statisfy the following signature:
+operations. Callback functions must satisfy the following signature:
 
 ```C
 typedef void (*napi_async_complete_callback)(napi_env env,

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1674,7 +1674,7 @@ reports for the current process. Additional documentation is available in the
 added: v11.8.0
 -->
 
-* `err` {Error} A custom error used for reporting the JavsScript stack.
+* `err` {Error} A custom error used for reporting the JavaScript stack.
 * Returns: {string}
 
 Returns a JSON-formatted diagnostic report for the running process. The report's
@@ -1734,7 +1734,7 @@ added: v11.8.0
   should be a relative path, that will be appended to the directory specified in
   `process.report.setOptions`, or the current working directory of the Node.js
   process, if unspecified.
-* `err` {Error} A custom error used for reporting the JavsScript stack.
+* `err` {Error} A custom error used for reporting the JavaScript stack.
 
 * Returns: {string} Returns the filename of the generated report.
 

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -224,7 +224,7 @@ if a previous write has failed.
 * `id` {integer} A 32-bit unsigned integer.
 * `arrayBuffer` {ArrayBuffer} An `ArrayBuffer` instance.
 
-Marks an `ArrayBuffer` as havings its contents transferred out of band.
+Marks an `ArrayBuffer` as having its contents transferred out of band.
 Pass the corresponding `ArrayBuffer` in the deserializing context to
 [`deserializer.transferArrayBuffer()`][].
 
@@ -328,7 +328,7 @@ Deserializes a JavaScript value from the buffer and returns it.
 * `id` {integer} A 32-bit unsigned integer.
 * `arrayBuffer` {ArrayBuffer|SharedArrayBuffer} An `ArrayBuffer` instance.
 
-Marks an `ArrayBuffer` as havings its contents transferred out of band.
+Marks an `ArrayBuffer` as having its contents transferred out of band.
 Pass the corresponding `ArrayBuffer` in the serializing context to
 [`serializer.transferArrayBuffer()`][] (or return the `id` from
 [`serializer._getSharedArrayBufferId()`][] in the case of `SharedArrayBuffer`s).

--- a/doc/guides/using-internal-errors.md
+++ b/doc/guides/using-internal-errors.md
@@ -107,7 +107,7 @@ message string. A simple example is:
 // Test ERR_TLS_CERT_ALTNAME_INVALID
 assert.strictEqual(
   errors.message('ERR_TLS_CERT_ALTNAME_INVALID', ['altname']),
-  'Hostname/IP does not match certificate\'s altname: altname');
+  'Hostname/IP does not match certificate\'s altnames: altname');
 ```
 
 In addition, there should also be tests which validate the use of the

--- a/doc/guides/using-internal-errors.md
+++ b/doc/guides/using-internal-errors.md
@@ -107,7 +107,7 @@ message string. A simple example is:
 // Test ERR_TLS_CERT_ALTNAME_INVALID
 assert.strictEqual(
   errors.message('ERR_TLS_CERT_ALTNAME_INVALID', ['altname']),
-  'Hostname/IP does not match certificate\'s altnames: altname');
+  'Hostname/IP does not match certificate\'s altname: altname');
 ```
 
 In addition, there should also be tests which validate the use of the


### PR DESCRIPTION
Noticed a few typos while reading docs. Tried out corrections in this PR.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
