### PR TITLE
tools: [wip] use worker_threads for lint-js.js

### DIFF
--- a/tools/lint-js.js
+++ b/tools/lint-js.js
@@ -1,44 +1,31 @@
 'use strict';
 
-const rulesDirs = ['tools/eslint-rules'];
-const extensions = ['.js', '.md'];
-// This is the maximum number of files to be linted per worker at any given time
-const maxWorkload = 40;
-
-const cluster = require('cluster');
-const path = require('path');
-const fs = require('fs');
-const totalCPUs = require('os').cpus().length;
+const worker_threads = require('worker_threads');
 
 const CLIEngine = require('eslint').CLIEngine;
-const glob = require('eslint/node_modules/glob');
-
 const cliOptions = {
-  rulePaths: rulesDirs,
-  extensions: extensions,
+  rulePaths: ['tools/eslint-rules'],
+  extensions: ['.js', '.md'],
 };
-
-// Check if we should fix errors that are fixable
-if (process.argv.indexOf('-F') !== -1)
-  cliOptions.fix = true;
-
 const cli = new CLIEngine(cliOptions);
 
-if (cluster.isMaster) {
+if (worker_threads.isMainThread) {
+
+  const path = require('path');
+  const fs = require('fs');
+  const glob = require('eslint/node_modules/glob');
+
+  // This is the maximum number of files to be linted at one time per worker.
+  const maxWorkload = 40;
+
   var numCPUs = 1;
   const paths = [];
   var files = null;
-  var totalPaths = 0;
   var failures = 0;
-  var successes = 0;
-  var lastLineLen = 0;
-  var curPath = 'Starting ...';
-  var showProgress = true;
   const globOptions = {
     nodir: true
   };
   const workerConfig = {};
-  var startTime;
   var formatter;
   var outFn;
   var fd;
@@ -46,7 +33,7 @@ if (cluster.isMaster) {
 
   // Check if spreading work among all cores/cpus
   if (process.argv.indexOf('-J') !== -1)
-    numCPUs = totalCPUs;
+    numCPUs = require('os').cpus().length;
 
   // Check if spreading work among an explicit number of cores/cpus
   i = process.argv.indexOf('-j');
@@ -67,8 +54,6 @@ if (cluster.isMaster) {
     formatter = cli.getFormatter(format);
     if (!formatter)
       throw new Error('Invalid format name');
-    // Automatically disable progress display
-    showProgress = false;
     // Tell worker to send all results, not just linter errors
     workerConfig.sendAll = true;
   } else {
@@ -113,35 +98,25 @@ if (cluster.isMaster) {
 
   if (paths.length === 0)
     return;
-  totalPaths = paths.length;
-
-  if (showProgress) {
-    // Start the progress display update timer when the first worker is ready
-    cluster.once('online', function() {
-      startTime = process.hrtime();
-      setInterval(printProgress, 1000).unref();
-      printProgress();
-    });
-  }
-
-  cluster.on('online', function(worker) {
-    // Configure worker and give it some initial work to do
-    worker.send(workerConfig);
-    sendWork(worker);
-  });
 
   process.on('exit', function(code) {
-    if (showProgress) {
-      curPath = 'Done';
-      printProgress();
-      outFn('\r\n');
-    }
     if (code === 0)
       process.exit(failures ? 1 : 0);
   });
 
-  for (i = 0; i < numCPUs; ++i)
-    cluster.fork().on('message', onWorkerMessage).on('exit', onWorkerExit);
+  function onOnline() {
+    // Configure worker and give it some initial work to do
+    this.postMessage(workerConfig);
+    sendWork(this);
+  }
+
+  const workerPool = [];
+  for (i = 0; i < numCPUs; ++i) {
+    workerPool[i] = new worker_threads.Worker(__filename);
+    workerPool[i].on('online', onOnline);
+    workerPool[i].on('message', onWorkerMessage);
+    workerPool[i].on('exit', onWorkerExit);
+  }
 
   function onWorkerMessage(results) {
     if (typeof results !== 'number') {
@@ -153,9 +128,6 @@ if (cluster.isMaster) {
         failures += results.length;
       }
       outFn(`${formatter(results)}\r\n`);
-      printProgress();
-    } else {
-      successes += results;
     }
     // Try to give the worker more work to do
     sendWork(this);
@@ -172,7 +144,6 @@ if (cluster.isMaster) {
       // path. Find the next path that has some files to be linted.
       while (paths.length) {
         var dir = paths.shift();
-        curPath = dir;
         const patterns = cli.resolveFileGlobPatterns([dir]);
         dir = path.resolve(patterns[0]);
         files = glob.sync(dir, globOptions);
@@ -182,7 +153,7 @@ if (cluster.isMaster) {
       if ((!files || !files.length) && !paths.length) {
         // We exhausted all input paths and thus have nothing left to do, so end
         // the worker
-        return worker.disconnect();
+        return worker.postMessage('disconnect');
       }
     }
     // Give the worker an equal portion of the work left for the current path,
@@ -198,48 +169,17 @@ if (cluster.isMaster) {
     } else {
       slice = files.splice(0, sliceLen);
     }
-    worker.send(slice);
-  }
-
-  function printProgress() {
-    if (!showProgress)
-      return;
-
-    // Clear line
-    outFn(`\r ${' '.repeat(lastLineLen)}\r`);
-
-    // Calculate and format the data for displaying
-    const elapsed = process.hrtime(startTime)[0];
-    const mins = `${Math.floor(elapsed / 60)}`.padStart(2, '0');
-    const secs = `${elapsed % 60}`.padStart(2, '0');
-    const passed = `${successes}`.padStart(6);
-    const failed = `${failures}`.padStart(6);
-    var pct = Math.ceil(((totalPaths - paths.length) / totalPaths) * 100);
-    pct = `${pct}`.padStart(3);
-
-    var line = `[${mins}:${secs}|%${pct}|+${passed}|-${failed}]: ${curPath}`;
-
-    // Truncate line like cpplint does in case it gets too long
-    if (line.length > 75)
-      line = `${line.slice(0, 75)}...`;
-
-    // Store the line length so we know how much to erase the next time around
-    lastLineLen = line.length;
-
-    outFn(line);
+    worker.postMessage(slice);
   }
 } else {
   // Worker
 
   var config = {};
-  process.on('message', function(files) {
+  const parentPort = worker_threads.parentPort;
+  parentPort.on('message', function(files) {
     if (files instanceof Array) {
       // Lint some files
       const report = cli.executeOnFiles(files);
-
-      // If we were asked to fix the fixable issues, do so.
-      if (cliOptions.fix)
-        CLIEngine.outputFixes(report);
 
       if (config.sendAll) {
         // Return both success and error results
@@ -256,18 +196,22 @@ if (cluster.isMaster) {
             }
           }
         }
-        process.send({ results: results, errorCount: report.errorCount });
+        parentPort.postMessage({ results, errorCount: report.errorCount });
       } else if (report.errorCount === 0) {
         // No errors, return number of successful lint operations
-        process.send(files.length);
+        parentPort.postMessage(files.length);
       } else {
         // One or more errors, return the error results only
-        process.send(CLIEngine.getErrorResults(report.results));
+        parentPort.postMessage(CLIEngine.getErrorResults(report.results));
       }
     } else if (typeof files === 'object') {
       // The master process is actually sending us our configuration and not a
       // list of files to lint
       config = files;
+    } else if (files === 'disconnect') {
+      process.exit(0);
+    } else {
+      require('assert').fail(`Unexpected value for 'files': ${files}`);
     }
   });
 }


### PR DESCRIPTION
Sometimes, you try something and it doesn't work out. I thought moving
to worker_threads from cluster in lint-js.js would show at least a
modest improvement. It seems about the same. Putting it up as a draft
pull request to see if anyone has any additional ideas. Feel free to
close if it seems stalled, or I'll get around to closing it.

The bottleneck seems to be [`CLIEngine#executeOnFiles()`](https://eslint.org/docs/developer-guide/nodejs-api#cliengineexecuteonfiles) and I don't think there's much to do about that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
