### PR TITLE
src: extra-semi warning in node_platform.h

### DIFF
--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -62,7 +62,7 @@ class PerIsolatePlatformData :
   void PostIdleTask(std::unique_ptr<v8::IdleTask> task) override;
   void PostDelayedTask(std::unique_ptr<v8::Task> task,
                        double delay_in_seconds) override;
-  bool IdleTasksEnabled() override { return false; };
+  bool IdleTasksEnabled() override { return false; }
 
   void Shutdown();
 


### PR DESCRIPTION
https://clang.llvm.org/docs/DiagnosticsReference.html#wextra-semi

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
