### PR TITLE
Upgrade acorn from 6.1.1 to 6.3.1

### DIFF
--- a/deps/acorn/acorn-walk/package.json
+++ b/deps/acorn/acorn-walk/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/acornjs/acorn",
   "main": "dist/walk.js",
   "module": "dist/walk.mjs",
-  "version": "6.1.1",
+  "version": "6.3.1",
   "engines": {"node": ">=0.4.0"},
   "maintainers": [
     {

--- a/deps/acorn/acorn/package.json
+++ b/deps/acorn/acorn/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/acornjs/acorn",
   "main": "dist/acorn.js",
   "module": "dist/acorn.mjs",
-  "version": "6.1.0",
+  "version": "6.3.0",
   "engines": {"node": ">=0.4.0"},
   "maintainers": [
     {


### PR DESCRIPTION
This will just upgrade acorn to 6.3.1.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ x] tests and/or benchmarks are included
- [x ] documentation is changed or added
- [ x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
