### PR TITLE
src: fix more extra-semi warnings

### DIFF
--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -310,4 +310,4 @@ void Initialize(Local<Object> target, Local<Value> unused,
 }  // namespace node
 
 NODE_MODULE_CONTEXT_AWARE_INTERNAL(inspector,
-                                  node::inspector::Initialize);
+                                  node::inspector::Initialize)

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -35,7 +35,7 @@ using performance::PerformanceEntry;
 #define DEFAULT_MAX_SETTINGS 10
 
 // Default maximum total memory cap for Http2Session.
-#define DEFAULT_MAX_SESSION_MEMORY 1e7;
+#define DEFAULT_MAX_SESSION_MEMORY 1e7
 
 // These are the standard HTTP/2 defaults as specified by the RFC
 #define DEFAULT_SETTINGS_HEADER_TABLE_SIZE 4096

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -63,7 +63,7 @@ class DeserializerDelegate : public ValueDeserializer::Delegate {
       return MaybeLocal<Object>();
     CHECK_LE(id, message_ports_.size());
     return message_ports_[id]->object(isolate);
-  };
+  }
 
   MaybeLocal<SharedArrayBuffer> GetSharedArrayBufferFromId(
       Isolate* isolate, uint32_t clone_id) override {


### PR DESCRIPTION
Follow-up to #26330. Fixes warnings emitted by [`-Wc++98-compat-extra-semi`](https://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-compat-extra-semi).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
