### PR TITLE
src: move AsyncResource impl out of public header

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -405,6 +405,7 @@
       'dependencies': [ 'deps/histogram/histogram.gyp:histogram' ],
 
       'sources': [
+        'src/api/async_resource.cc',
         'src/api/callback.cc',
         'src/api/encoding.cc',
         'src/api/environment.cc',

--- a/src/api/async_resource.cc
+++ b/src/api/async_resource.cc
@@ -1,0 +1,70 @@
+#include "node.h"
+
+namespace node {
+
+using v8::Function;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Local;
+using v8::MaybeLocal;
+using v8::Object;
+using v8::String;
+using v8::Value;
+
+AsyncResource::AsyncResource(Isolate* isolate,
+                             Local<Object> resource,
+                             const char* name,
+                             async_id trigger_async_id)
+    : isolate_(isolate),
+      resource_(isolate, resource) {
+  async_context_ = EmitAsyncInit(isolate, resource, name,
+                                 trigger_async_id);
+}
+
+AsyncResource::~AsyncResource() {
+  EmitAsyncDestroy(isolate_, async_context_);
+  resource_.Reset();
+}
+
+MaybeLocal<Value> AsyncResource::MakeCallback(Local<Function> callback,
+                                              int argc,
+                                              Local<Value>* argv) {
+  return node::MakeCallback(isolate_, get_resource(),
+                            callback, argc, argv,
+                            async_context_);
+}
+
+MaybeLocal<Value> AsyncResource::MakeCallback(const char* method,
+                                              int argc,
+                                              Local<Value>* argv) {
+  return node::MakeCallback(isolate_, get_resource(),
+                            method, argc, argv,
+                            async_context_);
+}
+
+MaybeLocal<Value> AsyncResource::MakeCallback(Local<String> symbol,
+                                              int argc,
+                                              Local<Value>* argv) {
+  return node::MakeCallback(isolate_, get_resource(),
+                            symbol, argc, argv,
+                            async_context_);
+}
+
+Local<Object> AsyncResource::get_resource() {
+  return resource_.Get(isolate_);
+}
+
+async_id AsyncResource::get_async_id() const {
+  return async_context_.async_id;
+}
+
+async_id AsyncResource::get_trigger_async_id() const {
+  return async_context_.trigger_async_id;
+}
+
+AsyncResource::CallbackScope::CallbackScope(AsyncResource* res)
+    : node::CallbackScope(res->isolate_,
+                          res->resource_.Get(res->isolate_),
+                          res->async_context_) {}
+
+}  // namespace node

--- a/src/node.h
+++ b/src/node.h
@@ -756,69 +756,41 @@ v8::MaybeLocal<v8::Value> MakeCallback(v8::Isolate* isolate,
 /* Helper class users can optionally inherit from. If
  * `AsyncResource::MakeCallback()` is used, then all four callbacks will be
  * called automatically. */
-class AsyncResource {
+class NODE_EXTERN AsyncResource {
  public:
   AsyncResource(v8::Isolate* isolate,
                 v8::Local<v8::Object> resource,
                 const char* name,
-                async_id trigger_async_id = -1)
-      : isolate_(isolate),
-        resource_(isolate, resource) {
-    async_context_ = EmitAsyncInit(isolate, resource, name,
-                                   trigger_async_id);
-  }
+                async_id trigger_async_id = -1);
 
-  virtual ~AsyncResource() {
-    EmitAsyncDestroy(isolate_, async_context_);
-    resource_.Reset();
-  }
+  virtual ~AsyncResource();
+
+  AsyncResource(const AsyncResource&) = delete;
+  void operator=(const AsyncResource&) = delete;
 
   v8::MaybeLocal<v8::Value> MakeCallback(
       v8::Local<v8::Function> callback,
       int argc,
-      v8::Local<v8::Value>* argv) {
-    return node::MakeCallback(isolate_, get_resource(),
-                              callback, argc, argv,
-                              async_context_);
-  }
+      v8::Local<v8::Value>* argv);
 
   v8::MaybeLocal<v8::Value> MakeCallback(
       const char* method,
       int argc,
-      v8::Local<v8::Value>* argv) {
-    return node::MakeCallback(isolate_, get_resource(),
-                              method, argc, argv,
-                              async_context_);
-  }
+      v8::Local<v8::Value>* argv);
 
   v8::MaybeLocal<v8::Value> MakeCallback(
       v8::Local<v8::String> symbol,
       int argc,
-      v8::Local<v8::Value>* argv) {
-    return node::MakeCallback(isolate_, get_resource(),
-                              symbol, argc, argv,
-                              async_context_);
-  }
+      v8::Local<v8::Value>* argv);
 
-  v8::Local<v8::Object> get_resource() {
-    return resource_.Get(isolate_);
-  }
-
-  async_id get_async_id() const {
-    return async_context_.async_id;
-  }
-
-  async_id get_trigger_async_id() const {
-    return async_context_.trigger_async_id;
-  }
+  v8::Local<v8::Object> get_resource();
+  async_id get_async_id() const;
+  async_id get_trigger_async_id() const;
 
  protected:
-  class CallbackScope : public node::CallbackScope {
+  class NODE_EXTERN CallbackScope : public node::CallbackScope {
    public:
-    explicit CallbackScope(AsyncResource* res)
-      : node::CallbackScope(res->isolate_,
-                            res->resource_.Get(res->isolate_),
-                            res->async_context_) {}
+    explicit CallbackScope(AsyncResource* res);
   };
 
  private:


### PR DESCRIPTION
Implementing the methods out-of-line (i.e., not inline) means we can fix
bugs and have already compiled add-ons pick up the fixes automatically,
something that doesn't work when the methods are inline because then
they get compiled into the add-on instead of the node binary.

CI: https://ci.nodejs.org/job/node-test-pull-request/21029/