### PR TITLE
build: make 'floating patch' message informational

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -585,6 +585,10 @@ def warn(msg):
 # track if warnings occurred
 warn.warned = False
 
+def info(msg):
+  prefix = '\033[1m\033[32mINFO\033[0m' if os.isatty(1) else 'INFO'
+  print('%s: %s' % (prefix, msg))
+
 def print_verbose(x):
   if not options.verbose:
     return
@@ -1236,7 +1240,7 @@ def glob_to_var(dir_base, dir_sub, patch_dir):
           patchfile = '%s/%s/%s' % (dir_base, patch_dir, file)
           if os.path.isfile(patchfile):
             srcfile = '%s/%s' % (patch_dir, file)
-            warn('Using floating patch "%s" from "%s"' % (patchfile, dir_base))
+            info('Using floating patch "%s" from "%s"' % (patchfile, dir_base))
         list.append(srcfile)
     break
   return list


### PR DESCRIPTION
Downgrade the 'Using floating patch' message that is emitted
when a local patch is applied to the bundled ICU from a warning
to a notice. There isn't anything the user can or should do so
warning isn't appropriate. Instead of angry yellow use soothing green.

Fixes: https://github.com/nodejs/node/issues/26346
CI: https://ci.nodejs.org/job/node-test-pull-request/21030/