### PR TITLE
http: only destroy socket once error is sent

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -521,9 +521,12 @@ function socketOnError(e) {
     if (this.writable) {
       const response = e.code === 'HPE_HEADER_OVERFLOW' ?
         requestHeaderFieldsTooLargeResponse : badRequestResponse;
-      this.write(response);
+      this.write(response, () => {
+        this.destroy(e);
+      });
+    } else {
+      this.destroy(e);
     }
-    this.destroy(e);
   }
 }
 


### PR DESCRIPTION
This patch fixes the race condition: sometimes the socket is
destroyed before the data is sent. If node is proxied by, for
example, an AWS ELB, a 504 error would be returned instead
of the expected 400.


##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
