### PR TITLE
Revert "build: silence cpp lint by default"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1266,8 +1266,11 @@ else
 	@echo "To install (requires internet access) run: $ make format-cpp-build"
 endif
 
-CPPLINT_QUIET = --quiet
-
+ifeq ($(V),1)
+  CPPLINT_QUIET =
+else
+  CPPLINT_QUIET = --quiet
+endif
 .PHONY: lint-cpp
 # Lints the C++ code with cpplint.py and check-imports.py.
 lint-cpp: tools/.cpplintstamp


### PR DESCRIPTION
This reverts commit 0373836b390999644d116c96b41ba05a8a0f181a.

PR effect is semver major, and removes an escape hatch.
This landed without proper review from @nodejs/build-files 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
