### PR TITLE
benchmark: refactor path benchmarks

### DIFF
--- a/benchmark/path/basename-posix.js
+++ b/benchmark/path/basename-posix.js
@@ -15,7 +15,7 @@ const bench = common.createBenchmark(main, {
     '/foo/bar/baz/asdf/quux.html',
     ['/foo/bar/baz/asdf/quux.html', '.html'].join('|'),
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, pathext }) {
@@ -28,7 +28,7 @@ function main({ n, pathext }) {
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    posix.basename(pathext, ext);
+    posix.basename(i % 3 === 0 ? `${pathext}${i}` : pathext, ext);
   }
   bench.end(n);
 }

--- a/benchmark/path/basename-win32.js
+++ b/benchmark/path/basename-win32.js
@@ -15,7 +15,7 @@ const bench = common.createBenchmark(main, {
     '\\foo\\bar\\baz\\asdf\\quux.html',
     ['\\foo\\bar\\baz\\asdf\\quux.html', '.html'].join('|'),
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, pathext }) {
@@ -28,7 +28,7 @@ function main({ n, pathext }) {
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    win32.basename(pathext, ext);
+    win32.basename(i % 3 === 0 ? `${pathext}${i}` : pathext, ext);
   }
   bench.end(n);
 }

--- a/benchmark/path/dirname-posix.js
+++ b/benchmark/path/dirname-posix.js
@@ -12,13 +12,13 @@ const bench = common.createBenchmark(main, {
     'foo/bar',
     '/foo/bar/baz/asdf/quux',
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    posix.dirname(path);
+    posix.dirname(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);
 }

--- a/benchmark/path/dirname-win32.js
+++ b/benchmark/path/dirname-win32.js
@@ -12,13 +12,13 @@ const bench = common.createBenchmark(main, {
     'foo\\bar',
     'D:\\foo\\bar\\baz\\asdf\\quux',
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    win32.dirname(path);
+    win32.dirname(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);
 }

--- a/benchmark/path/extname-posix.js
+++ b/benchmark/path/extname-posix.js
@@ -15,13 +15,13 @@ const bench = common.createBenchmark(main, {
     '/foo/bar/baz/asdf/quux',
     '/foo/bar/baz/asdf/quux.foobarbazasdfquux',
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    posix.extname(path);
+    posix.extname(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);
 }

--- a/benchmark/path/extname-win32.js
+++ b/benchmark/path/extname-win32.js
@@ -15,13 +15,13 @@ const bench = common.createBenchmark(main, {
     'D:\\foo\\bar\\baz\\asdf\\quux',
     '\\foo\\bar\\baz\\asdf\\quux.foobarbazasdfquux',
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    win32.extname(path);
+    win32.extname(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);
 }

--- a/benchmark/path/format-posix.js
+++ b/benchmark/path/format-posix.js
@@ -6,7 +6,7 @@ const bench = common.createBenchmark(main, {
   props: [
     ['/', '/home/user/dir', 'index.html', '.html', 'index'].join('|'),
   ],
-  n: [1e7]
+  n: [1e6]
 });
 
 function main({ n, props }) {
@@ -14,13 +14,15 @@ function main({ n, props }) {
   const obj = {
     root: props[0] || '',
     dir: props[1] || '',
-    base: props[2] || '',
+    base: '',
     ext: props[3] || '',
-    name: props[4] || '',
+    name: '',
   };
 
   bench.start();
   for (var i = 0; i < n; i++) {
+    obj.base = `a${i}${props[2] || ''}`;
+    obj.name = `a${i}${props[4] || ''}`;
     posix.format(obj);
   }
   bench.end(n);

--- a/benchmark/path/format-win32.js
+++ b/benchmark/path/format-win32.js
@@ -6,7 +6,7 @@ const bench = common.createBenchmark(main, {
   props: [
     ['C:\\', 'C:\\path\\dir', 'index.html', '.html', 'index'].join('|'),
   ],
-  n: [1e7]
+  n: [1e6]
 });
 
 function main({ n, props }) {
@@ -14,13 +14,15 @@ function main({ n, props }) {
   const obj = {
     root: props[0] || '',
     dir: props[1] || '',
-    base: props[2] || '',
+    base: '',
     ext: props[3] || '',
-    name: props[4] || '',
+    name: '',
   };
 
   bench.start();
   for (var i = 0; i < n; i++) {
+    obj.base = `a${i}${props[2] || ''}`;
+    obj.name = `a${i}${props[4] || ''}`;
     win32.format(obj);
   }
   bench.end(n);

--- a/benchmark/path/isAbsolute-posix.js
+++ b/benchmark/path/isAbsolute-posix.js
@@ -10,13 +10,13 @@ const bench = common.createBenchmark(main, {
     '/baz/..',
     'bar/baz',
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    posix.isAbsolute(path);
+    posix.isAbsolute(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);
 }

--- a/benchmark/path/isAbsolute-win32.js
+++ b/benchmark/path/isAbsolute-win32.js
@@ -11,13 +11,13 @@ const bench = common.createBenchmark(main, {
     'C:baz\\..',
     'bar\\baz',
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    win32.isAbsolute(path);
+    win32.isAbsolute(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);
 }

--- a/benchmark/path/join-posix.js
+++ b/benchmark/path/join-posix.js
@@ -6,15 +6,22 @@ const bench = common.createBenchmark(main, {
   paths: [
     ['/foo', 'bar', '', 'baz/asdf', 'quux', '..'].join('|'),
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, paths }) {
   const args = paths.split('|');
+  const copy = [...args];
+  const orig = copy[1];
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    posix.join.apply(null, args);
+    if (i % 3 === 0) {
+      copy[1] = `${orig}${i}`;
+      posix.join(...copy);
+    } else {
+      posix.join(...args);
+    }
   }
   bench.end(n);
 }

--- a/benchmark/path/join-win32.js
+++ b/benchmark/path/join-win32.js
@@ -6,15 +6,22 @@ const bench = common.createBenchmark(main, {
   paths: [
     ['C:\\foo', 'bar', '', 'baz\\asdf', 'quux', '..'].join('|'),
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, paths }) {
   const args = paths.split('|');
+  const copy = [...args];
+  const orig = copy[1];
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    win32.join.apply(null, args);
+    if (i % 3 === 0) {
+      copy[1] = `${orig}${i}`;
+      win32.join(...copy);
+    } else {
+      win32.join(...args);
+    }
   }
   bench.end(n);
 }

--- a/benchmark/path/makeLong-win32.js
+++ b/benchmark/path/makeLong-win32.js
@@ -9,13 +9,13 @@ const bench = common.createBenchmark(main, {
     '\\\\foo\\bar',
     '\\\\?\\foo',
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    win32._makeLong(path);
+    win32._makeLong(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);
 }

--- a/benchmark/path/normalize-posix.js
+++ b/benchmark/path/normalize-posix.js
@@ -11,13 +11,13 @@ const bench = common.createBenchmark(main, {
     '/foo/bar',
     '/foo/bar//baz/asdf/quux/..',
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    posix.normalize(path);
+    posix.normalize(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);
 }

--- a/benchmark/path/normalize-win32.js
+++ b/benchmark/path/normalize-win32.js
@@ -11,13 +11,13 @@ const bench = common.createBenchmark(main, {
     'C:\\foo\\bar',
     'C:\\foo\\bar\\\\baz\\asdf\\quux\\..',
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    win32.normalize(path);
+    win32.normalize(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);
 }

--- a/benchmark/path/parse-posix.js
+++ b/benchmark/path/parse-posix.js
@@ -12,16 +12,13 @@ const bench = common.createBenchmark(main, {
     'foo/bar',
     '/foo/bar/baz/asdf/.quux',
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, path }) {
-  for (var i = 0; i < n; i++) {
-    posix.parse(path);
-  }
   bench.start();
-  for (i = 0; i < n; i++) {
-    posix.parse(path);
+  for (let i = 0; i < n; i++) {
+    posix.parse(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);
 }

--- a/benchmark/path/parse-win32.js
+++ b/benchmark/path/parse-win32.js
@@ -13,16 +13,13 @@ const bench = common.createBenchmark(main, {
     'foo\\bar',
     '\\foo\\bar\\baz\\asdf\\.quux',
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, path }) {
-  for (var i = 0; i < n; i++) {
-    win32.parse(path);
-  }
   bench.start();
-  for (i = 0; i < n; i++) {
-    win32.parse(path);
+  for (let i = 0; i < n; i++) {
+    win32.parse(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);
 }

--- a/benchmark/path/relative-posix.js
+++ b/benchmark/path/relative-posix.js
@@ -12,7 +12,7 @@ const bench = common.createBenchmark(main, {
     ['/foo/bar/baz/quux', '/foo/bar/baz/quux'].join('|'),
     ['/foo/bar/baz/quux', '/var/log'].join('|'),
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, paths }) {
@@ -22,13 +22,13 @@ function main({ n, paths }) {
     to = paths.slice(delimIdx + 1);
     paths = paths.slice(0, delimIdx);
   }
-  for (var i = 0; i < n; i++) {
-    posix.relative(paths, to);
-  }
 
   bench.start();
-  for (i = 0; i < n; i++) {
-    posix.relative(paths, to);
+  for (let i = 0; i < n; i++) {
+    if (i % 3 === 0)
+      posix.relative(`${paths}${i}`, `${to}${i}`);
+    else
+      posix.relative(paths, to);
   }
   bench.end(n);
 }

--- a/benchmark/path/relative-win32.js
+++ b/benchmark/path/relative-win32.js
@@ -10,7 +10,7 @@ const bench = common.createBenchmark(main, {
     ['C:\\foo\\BAR\\BAZ', 'C:\\foo\\bar\\baz'].join('|'),
     ['C:\\foo\\bar\\baz\\quux', 'C:\\'].join('|'),
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, paths }) {
@@ -21,14 +21,12 @@ function main({ n, paths }) {
     paths = paths.slice(0, delimIdx);
   }
 
-  // Warmup
-  for (var i = 0; i < n; i++) {
-    win32.relative(paths, to);
-  }
-
   bench.start();
-  for (i = 0; i < n; i++) {
-    win32.relative(paths, to);
+  for (let i = 0; i < n; i++) {
+    if (i % 3 === 0)
+      win32.relative(`${paths}${i}`, `${to}${i}`);
+    else
+      win32.relative(paths, to);
   }
   bench.end(n);
 }

--- a/benchmark/path/resolve-posix.js
+++ b/benchmark/path/resolve-posix.js
@@ -9,15 +9,22 @@ const bench = common.createBenchmark(main, {
     ['foo/bar', '/tmp/file/', '..', 'a/../subfile'].join('|'),
     ['a/b/c/', '../../..'].join('|'),
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, paths }) {
   const args = paths.split('|');
+  const copy = [...args];
+  const orig = copy[0];
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    posix.resolve.apply(null, args);
+    if (i % 3 === 0) {
+      copy[0] = `${orig}${i}`;
+      posix.resolve(...copy);
+    } else {
+      posix.resolve(...args);
+    }
   }
   bench.end(n);
 }

--- a/benchmark/path/resolve-win32.js
+++ b/benchmark/path/resolve-win32.js
@@ -9,15 +9,22 @@ const bench = common.createBenchmark(main, {
     ['c:/ignore', 'd:\\a/b\\c/d', '\\e.exe'].join('|'),
     ['c:/blah\\blah', 'd:/games', 'c:../a'].join('|'),
   ],
-  n: [1e6]
+  n: [1e5]
 });
 
 function main({ n, paths }) {
   const args = paths.split('|');
+  const copy = [...args];
+  const orig = copy[0];
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    win32.resolve.apply(null, args);
+    if (i % 3 === 0) {
+      copy[0] = `${orig}${i}`;
+      win32.resolve(...copy);
+    } else {
+      win32.resolve(...args);
+    }
   }
   bench.end(n);
 }


### PR DESCRIPTION
So far the benchmarks created a highly specialized function which
would inline exactly to the input. This changes it to provide a
more realistic view to actual input by changing the input on each
iteration. That prevents the function to be to specific.

It also reduces the number of iterations the benchmarks are run to
reduce the overall runtime. A microbenchmark should already show a
significant difference with lower iterations, otherwise the
significance for real world applications is only limited.

This is pulled out from #25278.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
