### PR TITLE
test: only inspect on failure

### DIFF
--- a/test/parallel/test-path-join.js
+++ b/test/parallel/test-path-join.js
@@ -131,11 +131,12 @@ joinTests.forEach((test) => {
       } else {
         os = 'posix';
       }
-      const message =
-        `path.${os}.join(${test[0].map(JSON.stringify).join(',')})\n  expect=${
+      if (actual !== expected && actualAlt !== expected) {
+        const delimiter = test[0].map(JSON.stringify).join(',');
+        const message = `path.${os}.join(${delimiter})\n  expect=${
           JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
-      if (actual !== expected && actualAlt !== expected)
         failures.push(`\n${message}`);
+      }
     });
   });
 });

--- a/test/parallel/test-path-relative.js
+++ b/test/parallel/test-path-relative.js
@@ -56,12 +56,13 @@ relativeTests.forEach((test) => {
   test[1].forEach((test) => {
     const actual = relative(test[0], test[1]);
     const expected = test[2];
-    const os = relative === path.win32.relative ? 'win32' : 'posix';
-    const message = `path.${os}.relative(${
-      test.slice(0, 2).map(JSON.stringify).join(',')})\n  expect=${
-      JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
-    if (actual !== expected)
+    if (actual !== expected) {
+      const os = relative === path.win32.relative ? 'win32' : 'posix';
+      const message = `path.${os}.relative(${
+        test.slice(0, 2).map(JSON.stringify).join(',')})\n  expect=${
+        JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
       failures.push(`\n${message}`);
+    }
   });
 });
 assert.strictEqual(failures.length, 0, failures.join(''));


### PR DESCRIPTION
The inspection was done in all cases so far and that's not necessary.
Therefore this changed this behavior to only inspect the input on
failure cases.

I pulled this out from #25278.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
