### PR TITLE
repl: use object writer for thrown errors

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -415,7 +415,7 @@ function REPLServer(prompt,
                                       (_, pre, line) => pre + (line - 1));
           }
         }
-        errStack = util.inspect(e);
+        errStack = self.writer(e);
 
         // Remove one line error braces to keep the old style in place.
         if (errStack[errStack.length - 1] === ']') {
@@ -425,7 +425,7 @@ function REPLServer(prompt,
     }
 
     if (errStack === '') {
-      errStack = `Thrown: ${util.inspect(e)}\n`;
+      errStack = `Thrown: ${self.writer(e)}\n`;
     } else {
       const ln = errStack.endsWith('\n') ? '' : '\n';
       errStack = `Thrown:\n${errStack}${ln}`;

--- a/test/parallel/test-repl-pretty-stack.js
+++ b/test/parallel/test-repl-pretty-stack.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const repl = require('repl');
 
 
-function run({ command, expected }) {
+function run({ command, expected, ...extraREPLOptions }) {
   let accum = '';
 
   const inputStream = new ArrayStream();
@@ -19,7 +19,8 @@ function run({ command, expected }) {
     input: inputStream,
     output: outputStream,
     terminal: false,
-    useColors: false
+    useColors: false,
+    ...extraREPLOptions
   });
 
   r.write(`${command}\n`);
@@ -43,6 +44,18 @@ const tests = [
   {
     command: 'throw new Error(\'Whoops!\')',
     expected: 'Thrown:\nError: Whoops!\n'
+  },
+  {
+    command: '(() => { const err = Error(\'Whoops!\'); ' +
+             'err.foo = \'bar\'; throw err; })()',
+    expected: 'Thrown:\n{ Error: Whoops!\n    at repl:1:22 foo: \'bar\' }\n',
+  },
+  {
+    command: '(() => { const err = Error(\'Whoops!\'); ' +
+             'err.foo = \'bar\'; throw err; })()',
+    expected: 'Thrown:\n{ Error: Whoops!\n    at repl:1:22 foo: ' +
+              "\u001b[32m'bar'\u001b[39m }\n",
+    useColors: true
   },
   {
     command: 'foo = bar;',


### PR DESCRIPTION
This makes us use the defaults that were set for the REPL, i.e.
aligns with the printing of expression completion values, and in
particular enables color support.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
