### PR TITLE
tools: ignore clion ide files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ ipch/
 .vs/
 .vscode/
 /*.exe
+cmake-build-*/
+CMakeLists.txt
 
 /config.mk
 /config.gypi


### PR DESCRIPTION
ignore all configuration files of  CLion  IDE JetBrains.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
