### PR TITLE
build: enable v8's SipHash for hash seed creation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -774,6 +774,17 @@ The externally maintained libraries used by Node.js are:
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   """
 
+- SipHash, located at deps/v8/src/third_party/siphash, is licensed as follows:
+  """
+    SipHash reference C implementation
+
+    Copyright (c) 2016 Jean-Philippe Aumasson <jeanphilippe.aumasson@gmail.com>
+
+    To the extent possible under law, the author(s) have dedicated all
+    copyright and related and neighboring rights to this software to the public
+    domain worldwide. This software is distributed without any warranty.
+  """
+
 - zlib, located at deps/zlib, is licensed as follows:
   """
     zlib.h -- interface of the 'zlib' general purpose compression library

--- a/common.gypi
+++ b/common.gypi
@@ -44,6 +44,9 @@
     # Old time default, now explicitly stated.
     'v8_use_snapshot': 'true',
 
+    # Turn on SipHash for hash seed generation, addresses HashWick
+    'v8_use_siphash': 'true',
+
     # These are more relevant for V8 internal development.
     # Refs: https://github.com/nodejs/node/issues/23122
     # Refs: https://github.com/nodejs/node/issues/23167

--- a/configure.py
+++ b/configure.py
@@ -477,6 +477,11 @@ parser.add_option('--without-snapshot',
     dest='without_snapshot',
     help=optparse.SUPPRESS_HELP)
 
+parser.add_option('--without-siphash',
+    action='store_true',
+    dest='without_siphash',
+    help=optparse.SUPPRESS_HELP)
+
 parser.add_option('--code-cache-path',
     action='store',
     dest='code_cache_path',
@@ -1122,6 +1127,7 @@ def configure_v8(o):
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
   o['variables']['v8_promise_internal_field_count'] = 1 # Add internal field to promises for async hooks.
   o['variables']['v8_use_snapshot'] = 'false' if options.without_snapshot else 'true'
+  o['variables']['v8_use_siphash'] = 'false' if options.without_siphash else 'true'
   o['variables']['v8_trace_maps'] = 1 if options.trace_maps else 0
   o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)

--- a/deps/v8/gypfiles/features.gypi
+++ b/deps/v8/gypfiles/features.gypi
@@ -178,6 +178,9 @@
       ['v8_use_snapshot=="true" and v8_use_external_startup_data==1', {
         'defines': ['V8_USE_EXTERNAL_STARTUP_DATA',],
       }],
+      ['v8_use_siphash=="true"', {
+        'defines': ['V8_USE_SIPHASH',],
+      }],
       ['dcheck_always_on!=0', {
         'defines': ['DEBUG',],
       }],

--- a/deps/v8/gypfiles/v8.gyp
+++ b/deps/v8/gypfiles/v8.gyp
@@ -130,6 +130,7 @@
               'v8_enable_verify_predictable=<(v8_enable_verify_predictable)',
               'v8_target_cpu=<(v8_target_arch)',
               'v8_use_snapshot=<(v8_use_snapshot)',
+              'v8_use_siphash=<(v8_use_siphash)',
             ]
           },
           'conditions': [
@@ -1528,6 +1529,8 @@
         '../src/string-stream.h',
         '../src/strtod.cc',
         '../src/strtod.h',
+        '../src/third_party/siphash/halfsiphash.cc',
+        '../src/third_party/siphash/halfsiphash.h',
         '../src/third_party/utf8-decoder/utf8-decoder.h',
         '../src/torque-assembler.h',
         '../src/tracing/trace-event.cc',

--- a/node.gyp
+++ b/node.gyp
@@ -1,6 +1,7 @@
 {
   'variables': {
     'v8_use_snapshot%': 'false',
+    'v8_use_siphash%': 'true',
     'v8_trace_maps%': 0,
     'node_use_dtrace%': 'false',
     'node_use_etw%': 'false',

--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -64,6 +64,8 @@ addlicense "OpenSSL" "deps/openssl" \
 addlicense "Punycode.js" "lib/punycode.js" \
            "$(curl -sL https://raw.githubusercontent.com/bestiejs/punycode.js/master/LICENSE-MIT.txt)"
 addlicense "V8" "deps/v8" "$(cat ${rootdir}/deps/v8/LICENSE)"
+addlicense "SipHash" "deps/v8/src/third_party/siphash" \
+           "$(sed -e '/You should have received a copy of the CC0/,$d' -e 's/^\/\* *//' -e 's/^ \* *//' deps/v8/src/third_party/siphash/halfsiphash.cc)"
 addlicense "zlib" "deps/zlib" \
            "$(sed -e '/The data format used by the zlib library/,$d' -e 's/^\/\* *//' -e 's/^ *//' ${rootdir}/deps/zlib/zlib.h)"
 


### PR DESCRIPTION
Triggers the V8_USE_SIPHASH to switch from the internal custom V8 hash seed generation function to an implementation of SipHash. Final step needed to clear up HashWick.

Ref: https://github.com/nodejs/node/issues/23259
Ref: https://darksi.de/12.hashwick-v8-vulnerability/

This could arguably be semver-minor because it introduces a configure flag, but that doesn't show in `--help`. I'm also unsure if this has any impact on snapshots, could it be breaking for people using snapshots for fast startup? (Electron projects do, don't they?).