### PR TITLE
src: fix build when NODE_USE_V8_PLATFORM is not defined

### DIFF
--- a/src/node_v8_platform-inl.h
+++ b/src/node_v8_platform-inl.h
@@ -149,7 +149,7 @@ struct V8Platform {
   inline void DrainVMTasks(v8::Isolate* isolate) {}
   inline void CancelVMTasks(v8::Isolate* isolate) {}
   inline void StartTracingAgent() {
-    if (!trace_enabled_categories.empty()) {
+    if (!per_process::cli_options->trace_event_categories.empty()) {
       fprintf(stderr,
               "Node compiled with NODE_USE_V8_PLATFORM=0, "
               "so event tracing is not available.\n");


### PR DESCRIPTION
`trace_enabled_categories` is not defined, so the build fails when `NODE_USE_V8_PLATFORM` is false.
This change fixes that with the appropriate value.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
