### PR TITLE
benchmark,lib: add process.hrtime.bigint benchmark

### DIFF
--- a/benchmark/process/bench-hrtime.js
+++ b/benchmark/process/bench-hrtime.js
@@ -5,27 +5,37 @@ const assert = require('assert');
 
 const bench = common.createBenchmark(main, {
   n: [1e6],
-  type: ['raw', 'diff']
+  type: ['raw', 'diff', 'bigint']
 });
 
 function main({ n, type }) {
   const hrtime = process.hrtime;
-  var noDead = hrtime();
+  var noDead = type === 'bigint' ? hrtime.bigint() : hrtime();
   var i;
 
-  if (type === 'raw') {
-    bench.start();
-    for (i = 0; i < n; i++) {
-      noDead = hrtime();
-    }
-    bench.end(n);
-  } else {
-    bench.start();
-    for (i = 0; i < n; i++) {
-      noDead = hrtime(noDead);
-    }
-    bench.end(n);
+  switch (type) {
+    case 'raw':
+      bench.start();
+      for (i = 0; i < n; i++) {
+        noDead = hrtime();
+      }
+      bench.end(n);
+      break;
+    case 'diff':
+      bench.start();
+      for (i = 0; i < n; i++) {
+        noDead = hrtime(noDead);
+      }
+      bench.end(n);
+      break;
+    case 'bigint':
+      bench.start();
+      for (i = 0; i < n; i++) {
+        noDead = hrtime.bigint();
+      }
+      bench.end(n);
+      break;
   }
 
-  assert.ok(Array.isArray(noDead));
+  assert.ok(Array.isArray(noDead) || typeof noDead === 'bigint');
 }

--- a/benchmark/process/bench-hrtime.js
+++ b/benchmark/process/bench-hrtime.js
@@ -37,5 +37,6 @@ function main({ n, type }) {
       break;
   }
 
+  // eslint-disable-next-line valid-typeof
   assert.ok(Array.isArray(noDead) || typeof noDead === 'bigint');
 }

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -122,8 +122,8 @@ function wrapProcessMethods(binding) {
     ];
   }
 
-  // Use a BigUint64Array in the closure because V8 does not have an API for
-  // creating a BigInt out of a uint64_t yet.
+  // Use a BigUint64Array in the closure because this is actually a bit
+  // faster than simply returning a BigInt from C++ in V8 7.1.
   const hrBigintValues = new BigUint64Array(1);
   function hrtimeBigInt() {
     _hrtimeBigInt(hrBigintValues);


### PR DESCRIPTION
Add a benchmark, and amend the relevant source code comment to state
that currently, switching to directly returning a BigInt is not
stopped by technical obstacles but rather the fact that using a typed
array is actually a bit faster (about 2.5 %, measured locally).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
