### PR TITLE
src: clean up MultiIsolatePlatform interface

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -81,8 +81,6 @@ IsolateData::IsolateData(Isolate* isolate,
       uses_node_allocator_(allocator_ == node_allocator_),
       platform_(platform) {
   CHECK_NOT_NULL(allocator_);
-  if (platform_ != nullptr)
-    platform_->RegisterIsolate(isolate_, event_loop);
 
   options_.reset(
       new PerIsolateOptions(*(per_process::cli_options->per_isolate)));
@@ -133,12 +131,6 @@ IsolateData::IsolateData(Isolate* isolate,
   PER_ISOLATE_STRING_PROPERTIES(V)
 #undef V
 }
-
-IsolateData::~IsolateData() {
-  if (platform_ != nullptr)
-    platform_->UnregisterIsolate(isolate_);
-}
-
 
 void InitThreadLocalOnce() {
   CHECK_EQ(0, uv_key_create(&Environment::thread_local_env));

--- a/src/env.h
+++ b/src/env.h
@@ -399,7 +399,6 @@ class IsolateData {
               uv_loop_t* event_loop,
               MultiIsolatePlatform* platform = nullptr,
               ArrayBufferAllocator* node_allocator = nullptr);
-  ~IsolateData();
   inline uv_loop_t* event_loop() const;
   inline MultiIsolatePlatform* platform() const;
   inline std::shared_ptr<PerIsolateOptions> options();

--- a/src/node.h
+++ b/src/node.h
@@ -228,10 +228,22 @@ class NODE_EXTERN MultiIsolatePlatform : public v8::Platform {
   virtual void DrainTasks(v8::Isolate* isolate) = 0;
   virtual void CancelPendingDelayedTasks(v8::Isolate* isolate) = 0;
 
-  // These will be called by the `IsolateData` creation/destruction functions.
+  // This needs to be called between the calls to `Isolate::Allocate()` and
+  // `Isolate::Initialize()`, so that initialization can already start
+  // using the platform.
+  // When using `NewIsolate()`, this is taken care of by that function.
+  // This function may only be called once per `Isolate`.
   virtual void RegisterIsolate(v8::Isolate* isolate,
                                struct uv_loop_s* loop) = 0;
+  // This needs to be called right before calling `Isolate::Dispose()`.
+  // This function may only be called once per `Isolate`.
   virtual void UnregisterIsolate(v8::Isolate* isolate) = 0;
+  // The platform should call the passed function once all state associated
+  // with the given isolate has been cleaned up. This can, but does not have to,
+  // happen asynchronously.
+  virtual void AddIsolateFinishedCallback(v8::Isolate* isolate,
+                                          void (*callback)(void*),
+                                          void* data) = 0;
 };
 
 // Creates a new isolate with Node.js-specific settings.

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -260,6 +260,11 @@ PerIsolatePlatformData::~PerIsolatePlatformData() {
   Shutdown();
 }
 
+void PerIsolatePlatformData::AddShutdownCallback(void (*callback)(void*),
+                                                 void* data) {
+  shutdown_callbacks_.emplace_back(ShutdownCallback { callback, data });
+}
+
 void PerIsolatePlatformData::Shutdown() {
   if (flush_tasks_ == nullptr)
     return;
@@ -268,19 +273,17 @@ void PerIsolatePlatformData::Shutdown() {
   CHECK_NULL(foreground_tasks_.Pop());
   CancelPendingDelayedTasks();
 
+  ShutdownCbList* copy = new ShutdownCbList(std::move(shutdown_callbacks_));
+  flush_tasks_->data = copy;
   uv_close(reinterpret_cast<uv_handle_t*>(flush_tasks_),
            [](uv_handle_t* handle) {
+    std::unique_ptr<ShutdownCbList> callbacks(
+        static_cast<ShutdownCbList*>(handle->data));
+    for (const auto& callback : *callbacks)
+      callback.cb(callback.data);
     delete reinterpret_cast<uv_async_t*>(handle);
   });
   flush_tasks_ = nullptr;
-}
-
-void PerIsolatePlatformData::ref() {
-  ref_count_++;
-}
-
-int PerIsolatePlatformData::unref() {
-  return --ref_count_;
 }
 
 NodePlatform::NodePlatform(int thread_pool_size,
@@ -297,23 +300,29 @@ NodePlatform::NodePlatform(int thread_pool_size,
 void NodePlatform::RegisterIsolate(Isolate* isolate, uv_loop_t* loop) {
   Mutex::ScopedLock lock(per_isolate_mutex_);
   std::shared_ptr<PerIsolatePlatformData> existing = per_isolate_[isolate];
-  if (existing) {
-    CHECK_EQ(loop, existing->event_loop());
-    existing->ref();
-  } else {
-    per_isolate_[isolate] =
-        std::make_shared<PerIsolatePlatformData>(isolate, loop);
-  }
+  CHECK(!existing);
+  per_isolate_[isolate] =
+      std::make_shared<PerIsolatePlatformData>(isolate, loop);
 }
 
 void NodePlatform::UnregisterIsolate(Isolate* isolate) {
   Mutex::ScopedLock lock(per_isolate_mutex_);
   std::shared_ptr<PerIsolatePlatformData> existing = per_isolate_[isolate];
   CHECK(existing);
-  if (existing->unref() == 0) {
-    existing->Shutdown();
-    per_isolate_.erase(isolate);
+  existing->Shutdown();
+  per_isolate_.erase(isolate);
+}
+
+void NodePlatform::AddIsolateFinishedCallback(Isolate* isolate,
+                                              void (*cb)(void*), void* data) {
+  Mutex::ScopedLock lock(per_isolate_mutex_);
+  auto it = per_isolate_.find(isolate);
+  if (it == per_isolate_.end()) {
+    CHECK(it->second);
+    cb(data);
+    return;
   }
+  it->second->AddShutdownCallback(cb, data);
 }
 
 void NodePlatform::Shutdown() {

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -186,16 +186,20 @@ class WorkerThreadData {
 
     w_->platform_->CancelPendingDelayedTasks(isolate);
 
+    bool platform_finished = false;
+
     isolate_data_.reset();
+
+    w_->platform_->AddIsolateFinishedCallback(isolate, [](void* data) {
+      *static_cast<bool*>(data) = true;
+    }, &platform_finished);
     w_->platform_->UnregisterIsolate(isolate);
 
     isolate->Dispose();
 
-    // Need to run the loop twice more to close the platform's uv_async_t
-    // TODO(addaleax): It would be better for the platform itself to provide
-    // some kind of notification when it has fully cleaned up.
-    uv_run(&loop_, UV_RUN_ONCE);
-    uv_run(&loop_, UV_RUN_ONCE);
+    // Wait until the platform has cleaned up all relevant resources.
+    while (!platform_finished)
+      uv_run(&loop_, UV_RUN_ONCE);
 
     CheckedUvLoopClose(&loop_);
   }


### PR DESCRIPTION
- Since this was introduced, V8 has effectively started requiring
  that the platform knows of the `Isolate*` before we (or an embedder)
  create our `IsolateData` structure; therefore, (un)registering it
  from the `IsolateData` constructor/destructor doesn’t make much
  sense anymore.
- Instead, we can require that the register/unregister functions
  are only called once, simplifying the implementation a bit.
- Add a callback that we can use to know when the platform has
  cleaned up its resources associated with a given `Isolate`.
  In particular, this means that in the Worker code, we don’t need
  to rely on what are essentially guesses about the number of event
  loop turns that we need in order to have everything cleaned up.

(Semver-major because of the ABI/API changes.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
