### PR TITLE
report: reuse triggerReport() for exceptions and signals

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -23,7 +23,7 @@ is provided below for reference.
 {
   "header": {
     "event": "exception",
-    "location": "OnUncaughtException",
+    "trigger": "Exception",
     "filename": "report.20181221.005011.8974.001.json",
     "dumpEventTime": "2018-12-21T00:50:11Z",
     "dumpEventTimeStamp": "1545371411331",

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -116,7 +116,10 @@ function createFatalException() {
           report.syncConfig(config, false);
           if (Array.isArray(config.events) &&
               config.events.includes('exception')) {
-            report.onUnCaughtException(er ? er.stack : undefined);
+            report.triggerReport(er ? er.message : 'Exception',
+                                 'Exception',
+                                 null,
+                                 er ? er.stack : undefined);
           }
         }
       } catch {}  // Ignore the exception. Diagnostic reporting is unavailable.

--- a/lib/internal/process/report.js
+++ b/lib/internal/process/report.js
@@ -104,7 +104,7 @@ const report = {
 function handleSignal(signo) {
   if (typeof signo !== 'string')
     signo = config.signal;
-  nr.onUserSignal(signo);
+  nr.triggerReport(signo, 'Signal', null, '');
 }
 
 module.exports = {

--- a/lib/internal/process/report.js
+++ b/lib/internal/process/report.js
@@ -87,7 +87,7 @@ const report = {
       throw new ERR_INVALID_ARG_TYPE('err', 'Object', err);
     }
 
-    return nr.triggerReport(file, err.stack);
+    return nr.triggerReport('JavaScript API', 'API', file, err.stack);
   },
   getReport(err) {
     emitExperimentalWarning('report');

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -318,7 +318,7 @@ void OnFatalError(const char* location, const char* message) {
   Environment* env = Environment::GetCurrent(isolate);
   if (env == nullptr || env->isolate_data()->options()->report_on_fatalerror) {
     report::TriggerNodeReport(
-        isolate, env, message, __func__, "", Local<String>());
+        isolate, env, message, "FatalError", "", Local<String>());
   }
 #endif  // NODE_REPORT
   fflush(stderr);

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -377,7 +377,7 @@ static void PrintJavaScriptStack(JSONWriter* writer,
 
   std::string ss;
   if ((!strcmp(location, "OnFatalError")) ||
-      (!strcmp(location, "OnUserSignal"))) {
+      (!strcmp(location, "Signal"))) {
     ss = "No stack.\nUnavailable.\n";
   } else {
     String::Utf8Value sv(isolate, stackstr);

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -43,13 +43,13 @@ typedef struct tm TIME_TYPE;
 std::string TriggerNodeReport(v8::Isolate* isolate,
                               node::Environment* env,
                               const char* message,
-                              const char* location,
+                              const char* trigger,
                               std::string name,
                               v8::Local<v8::String> stackstr);
 void GetNodeReport(v8::Isolate* isolate,
                    node::Environment* env,
                    const char* message,
-                   const char* location,
+                   const char* trigger,
                    v8::Local<v8::String> stackstr,
                    std::ostream& out);
 

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -34,11 +34,6 @@ using v8::String;
 using v8::V8;
 using v8::Value;
 
-// Internal/static function declarations
-static void Initialize(Local<Object> exports,
-                       Local<Value> unused,
-                       Local<Context> context);
-
 // External JavaScript API for triggering a report
 void TriggerReport(const FunctionCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -75,18 +75,6 @@ void GetReport(const FunctionCallbackInfo<Value>& info) {
                                 .ToLocalChecked());
 }
 
-// Signal handler for report action, called from JS land (util.js)
-void OnUserSignal(const FunctionCallbackInfo<Value>& info) {
-  Environment* env = Environment::GetCurrent(info);
-  Isolate* isolate = env->isolate();
-  CHECK(info[0]->IsString());
-  Local<String> str = info[0].As<String>();
-  String::Utf8Value value(isolate, str);
-  std::string filename;
-  TriggerNodeReport(
-      isolate, env, *value, __func__, filename, info[0].As<String>());
-}
-
 // A method to sync up data elements in the JS land with its
 // corresponding elements in the C++ world. Required because
 // (i) the tunables are first intercepted through the CLI but
@@ -219,7 +207,6 @@ static void Initialize(Local<Object> exports,
   std::shared_ptr<PerIsolateOptions> options = env->isolate_data()->options();
   env->SetMethod(exports, "triggerReport", TriggerReport);
   env->SetMethod(exports, "getReport", GetReport);
-  env->SetMethod(exports, "onUserSignal", OnUserSignal);
   env->SetMethod(exports, "syncConfig", SyncConfig);
 }
 

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -204,7 +204,7 @@ static void Initialize(Local<Object> exports,
                        Local<Value> unused,
                        Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
-  std::shared_ptr<PerIsolateOptions> options = env->isolate_data()->options();
+
   env->SetMethod(exports, "triggerReport", TriggerReport);
   env->SetMethod(exports, "getReport", GetReport);
   env->SetMethod(exports, "syncConfig", SyncConfig);

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -58,7 +58,7 @@ function _validateContent(data) {
 
   // Verify the format of the header section.
   const header = report.header;
-  const headerFields = ['event', 'location', 'filename', 'dumpEventTime',
+  const headerFields = ['event', 'trigger', 'filename', 'dumpEventTime',
                         'dumpEventTimeStamp', 'processId', 'commandLine',
                         'nodejsVersion', 'wordSize', 'arch', 'platform',
                         'componentVersions', 'release', 'osName', 'osRelease',
@@ -66,7 +66,7 @@ function _validateContent(data) {
                         'glibcVersionCompiler'];
   checkForUnknownFields(header, headerFields);
   assert.strictEqual(typeof header.event, 'string');
-  assert.strictEqual(typeof header.location, 'string');
+  assert.strictEqual(typeof header.trigger, 'string');
   assert(typeof header.filename === 'string' || header.filename === null);
   assert.notStrictEqual(new Date(header.dumpEventTime).toString(),
                         'Invalid Date');


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
