### PR TITLE
buffer: improve performance of buffer indexof method

### DIFF
--- a/benchmark/buffers/buffer-indexof.js
+++ b/benchmark/buffers/buffer-indexof.js
@@ -23,9 +23,15 @@ const searchStrings = [
 
 const bench = common.createBenchmark(main, {
   search: searchStrings,
-  encoding: ['undefined', 'utf8', 'ucs2', 'binary'],
+  encoding: [
+    'utf8', 'utf-8', 'UTF8', 'UTF-8',
+    'ucs2', 'ucs-2', 'UCS2', 'UCS-2',
+    'utf16le', 'utf-16le', 'UTF16LE', 'UTF-16LE',
+    'latin1', 'LATIN1', 'binary', 'BINARY', 'base64', 'BASE64',
+    'ascii', 'ASCII', 'hex', 'HEX', 'undefined',
+  ],
   type: ['buffer', 'string'],
-  n: [100000]
+  n: [1000]
 });
 
 function main({ n, search, encoding, type }) {
@@ -37,7 +43,7 @@ function main({ n, search, encoding, type }) {
     encoding = undefined;
   }
 
-  if (encoding === 'ucs2') {
+  if (/^(ucs-?2|utf-?16le)$/i.test(encoding)) {
     aliceBuffer = Buffer.from(aliceBuffer.toString(), encoding);
   }
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -781,34 +781,53 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
 }
 
 function slowIndexOf(buffer, val, byteOffset, encoding, dir) {
-  let loweredCase = false;
-  for (;;) {
-    switch (encoding) {
-      case 'utf8':
-      case 'utf-8':
-      case 'ucs2':
-      case 'ucs-2':
-      case 'utf16le':
-      case 'utf-16le':
-      case 'latin1':
-      case 'binary':
+  encoding += '';
+  switch (encoding.length) {
+    case 4:
+      if (encoding === 'utf8' ||
+          encoding === 'UTF8' ||
+          encoding === 'ucs2' ||
+          encoding === 'UCS2')
         return indexOfString(buffer, val, byteOffset, encoding, dir);
-
-      case 'base64':
-      case 'ascii':
-      case 'hex':
+      break;
+    case 5:
+      if (encoding === 'utf-8' ||
+          encoding === 'UTF-8' ||
+          encoding === 'ucs-2' ||
+          encoding === 'UCS-2')
+        return indexOfString(buffer, val, byteOffset, encoding, dir);
+      if (encoding === 'ascii' || encoding === 'ASCII')
         return indexOfBuffer(
           buffer, Buffer.from(val, encoding), byteOffset, encoding, dir);
-
-      default:
-        if (loweredCase) {
-          throw new ERR_UNKNOWN_ENCODING(encoding);
-        }
-
-        encoding = ('' + encoding).toLowerCase();
-        loweredCase = true;
-    }
+      break;
+    case 7:
+      if (encoding === 'utf16le' || encoding === 'UTF16LE')
+        return indexOfString(buffer, val, byteOffset, encoding, dir);
+      break;
+    case 8:
+      if (encoding === 'utf-16le' || encoding === 'UTF-16LE')
+        return indexOfString(buffer, val, byteOffset, encoding, dir);
+      break;
+    case 6:
+      if (encoding === 'latin1' ||
+          encoding === 'LATIN1' ||
+          encoding === 'binary' ||
+          encoding === 'BINARY')
+        return indexOfString(buffer, val, byteOffset, encoding, dir);
+      if (encoding === 'base64' || encoding === 'BASE64')
+        return indexOfBuffer(
+          buffer, Buffer.from(val, encoding), byteOffset, encoding, dir);
+      break;
+    case 3:
+      if (encoding === 'hex' || encoding === 'HEX')
+        return indexOfBuffer(
+          buffer, Buffer.from(val, encoding), byteOffset, encoding, dir);
+      break;
   }
+  const lowerEnc = encoding.toLowerCase();
+  if (lowerEnc !== encoding)
+    return slowIndexOf(buffer, val, byteOffset, lowerEnc, dir);
+  throw new ERR_UNKNOWN_ENCODING(encoding);
 }
 
 Buffer.prototype.indexOf = function indexOf(val, byteOffset, encoding) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -765,7 +765,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   dir = !!dir;  // Cast to bool.
 
   if (typeof val === 'string') {
-    if (encoding === undefined) {
+    if (encoding === undefined || encoding === 'utf8') {
       return indexOfString(buffer, val, byteOffset, encoding, dir);
     }
     return slowIndexOf(buffer, val, byteOffset, encoding, dir);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Inspired by #12361, making buffer `indexof` method be consistent with [`byteLength`](https://github.com/nodejs/node/blob/2a5edafabd2cce9cff59321f0b492fa50af2e705/lib/buffer.js#L502), [`stringSlice`](https://github.com/nodejs/node/blob/2a5edafabd2cce9cff59321f0b492fa50af2e705/lib/buffer.js#L582), [`Buffer.prototype.write`](https://github.com/nodejs/node/blob/2a5edafabd2cce9cff59321f0b492fa50af2e705/lib/buffer.js#L937) , and IIUC this should have some performance improvement.

(I've run the buffer benchmark and seems a bit of improvement, but it took too long and my laptop has no power, so I canceled -:(

/cc @mscdex 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
