### PR TITLE
http: check for existance in resetHeadersTimeoutOnReqEnd

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -755,7 +755,7 @@ function resetHeadersTimeoutOnReqEnd() {
   const parser = this.socket.parser;
   // Parser can be null if the socket was destroyed
   // in that case, there is nothing to do.
-  if (parser !== null) {
+  if (parser) {
     parser.parsingHeadersStart = nowDate();
   }
 }

--- a/test/parallel/test-http-server-delete-parser.js
+++ b/test/parallel/test-http-server-delete-parser.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+
+const http = require('http');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.write('okay', common.mustCall(() => {
+    delete res.socket.parser;
+  }));
+  res.end();
+}));
+
+server.listen(1337, '127.0.0.1');
+server.unref();
+
+const req = http.request({
+  port: 1337,
+  host: '127.0.0.1',
+  method: 'GET',
+});
+
+req.end();


### PR DESCRIPTION
socket.parser can be undefined under unknown circumstances.
This is a fix for a bug I cannot reproduce but it is affecting
people.

Fixes: https://github.com/nodejs/node/issues/26366

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
