### PR TITLE
test: remove flaky designation for test_threadsafe_function

### DIFF
--- a/test/node-api/node-api.status
+++ b/test/node-api/node-api.status
@@ -7,5 +7,3 @@ prefix node-api
 [true] # This section applies to all platforms
 
 [$system==win32]
-# https://github.com/nodejs/node/issues/23621
-test_threadsafe_function/test: PASS,FLAKY


### PR DESCRIPTION
The test_threadsafe_function doesn't seem to be flaky anymore on
Windows. Optimistically removing the flaky designation in the relevant
status file.

Refs: https://github.com/nodejs/node/issues/23621#issuecomment-468938980

Will close https://github.com/nodejs/node/issues/23621 before landing this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
