### PR TITLE
tools: add and apply eslint rule no-regex-spaces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -137,6 +137,7 @@ module.exports = {
     'no-path-concat': 'error',
     'no-proto': 'error',
     'no-redeclare': 'error',
+    'no-regex-spaces': 'error',
     'no-restricted-modules': ['error', 'sys'],
     /* eslint-disable max-len */
     'no-restricted-properties': [

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -1064,7 +1064,7 @@ assert.throws(
     {
       code: 'ERR_ASSERTION',
       name: 'AssertionError [ERR_ASSERTION]',
-      message: /a: \[Getter: 5]\n-   a: \[Getter: 6]\n  /
+      message: /a: \[Getter: 5]\n- {3}a: \[Getter: 6]\n {2}/
     }
   );
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1144,7 +1144,7 @@ assert.throws(
     assert.deepStrictEqual(Array(100).fill(1), 'foobar');
   } catch (err) {
     threw = true;
-    assert(/actual: \[Array],\n  expected: 'foobar',/.test(inspect(err)));
+    assert(/actual: \[Array],\n {2}expected: 'foobar',/.test(inspect(err)));
   }
   assert(threw);
 }

--- a/test/parallel/test-debug-usage.js
+++ b/test/parallel/test-debug-usage.js
@@ -12,7 +12,7 @@ child.stderr.setEncoding('utf8');
 const expectedLines = [
   /^\(node:\d+\) \[DEP0068\] DeprecationWarning:/,
   /^Usage: .*node.* debug script\.js$/,
-  /^       .*node.* debug <host>:<port>$/
+  /^ {7}.*node.* debug <host>:<port>$/
 ];
 
 let actualUsageMessage = '';

--- a/test/parallel/test-events-uncaught-exception-stack.js
+++ b/test/parallel/test-events-uncaught-exception-stack.js
@@ -9,7 +9,7 @@ process.on('uncaughtException', common.mustCall((err) => {
   const lines = err.stack.split('\n');
   assert.strictEqual(lines[0], 'Error');
   lines.slice(1).forEach((line) => {
-    assert(/^    at/.test(line), `${line} has an unexpected format`);
+    assert(/^ {4}at/.test(line), `${line} has an unexpected format`);
   });
 }));
 

--- a/test/parallel/test-http2-stream-client.js
+++ b/test/parallel/test-http2-stream-client.js
@@ -12,9 +12,9 @@ server.on('stream', common.mustCall((stream) => {
   assert.strictEqual(stream.aborted, false);
   const insp = util.inspect(stream);
   assert.ok(/Http2Stream { id/.test(insp));
-  assert.ok(/  state:/.test(insp));
-  assert.ok(/  readableState:/.test(insp));
-  assert.ok(/  writableState:/.test(insp));
+  assert.ok(/ {2}state:/.test(insp));
+  assert.ok(/ {2}readableState:/.test(insp));
+  assert.ok(/ {2}writableState:/.test(insp));
   stream.end('ok');
 }));
 server.listen(0, common.mustCall(() => {

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -86,7 +86,7 @@ common.expectsError(() => {
   }, { code: 'TEST_ERROR_1', type: RangeError });
 }, {
   code: 'ERR_ASSERTION',
-  message: /\+   type: \[Function: TypeError]\n-   type: \[Function: RangeError]/
+  message: /\+ {3}type: \[Function: TypeError]\n- {3}type: \[Function: RangeError]/
 });
 
 common.expectsError(() => {
@@ -98,7 +98,7 @@ common.expectsError(() => {
 }, {
   code: 'ERR_ASSERTION',
   type: assert.AssertionError,
-  message: /\+   message: 'Error for testing purposes: a',\n-   message: \/\^Error/
+  message: /\+ {3}message: 'Error for testing purposes: a',\n- {3}message: \/\^Error/
 });
 
 // Test ERR_INVALID_FD_TYPE

--- a/test/parallel/test-repl-definecommand.js
+++ b/test/parallel/test-repl-definecommand.js
@@ -35,7 +35,7 @@ r.defineCommand('say2', function() {
 });
 
 inputStream.write('.help\n');
-assert(/\n\.say1     help for say1\n/.test(output),
+assert(/\n\.say1 {5}help for say1\n/.test(output),
        'help for say1 not present');
 assert(/\n\.say2\n/.test(output), 'help for say2 not present');
 inputStream.write('.say1 node developer\n');

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -181,7 +181,7 @@ function testError() {
       'Thrown:',
       /^{ Error: ENOENT: no such file or directory, scandir '.*nonexistent.*'/,
       /Object\.readdirSync/,
-      /^  errno: -(2|4058),$/,
+      /^ {2}errno: -(2|4058),$/,
       "  syscall: 'scandir',",
       "  code: 'ENOENT',",
       "  path: '/nonexistent?' }",
@@ -196,8 +196,8 @@ function testError() {
       'Thrown:',
       'Error: baz',
       /setImmediate/,
-      /^    at/,
-      /^    at/,
+      /^ {4}at/,
+      /^ {4}at/,
     ];
     for (const line of lines) {
       const expected = expectedLines.shift();

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -537,10 +537,10 @@ const errorTests = [
       /^{ Error: Cannot find module 'internal\/repl'/,
       /^Require stack:/,
       /^- <repl>/,
-      /^    at .*/,
-      /^    at .*/,
-      /^    at .*/,
-      /^    at .*/
+      /^ {4}at .*/,
+      /^ {4}at .*/,
+      /^ {4}at .*/,
+      /^ {4}at .*/
     ]
   },
   // REPL should handle quotes within regexp literal in multiline mode

--- a/test/parallel/test-v8-untrusted-code-mitigations.js
+++ b/test/parallel/test-v8-untrusted-code-mitigations.js
@@ -15,4 +15,4 @@ assert.notStrictEqual(untrustedFlag, -1);
 const nextFlag = v8Options.indexOf('--', untrustedFlag + 2);
 const slice = v8Options.substring(untrustedFlag, nextFlag);
 
-assert(slice.match(/type: bool  default: false/));
+assert(slice.match(/type: bool {2}default: false/));

--- a/test/tick-processor/test-tick-processor-unknown.js
+++ b/test/tick-processor/test-tick-processor-unknown.js
@@ -17,7 +17,7 @@ const base = require('./tick-processor-base.js');
 // Unknown checked for to prevent flakiness, if pattern is not found,
 // then a large number of unknown ticks should be present
 base.runTest({
-  pattern: /LazyCompile.*\[eval]:1|.*%  UNKNOWN/,
+  pattern: /LazyCompile.*\[eval]:1|.*% {2}UNKNOWN/,
   code: `function f() {
            for (var i = 0; i < 1000000; i++) {
              i++;


### PR DESCRIPTION
Expert from https://eslint.org/docs/rules/no-regex-spaces: 

> Regular expressions can be very complex and difficult to understand, which is why it’s important to keep them as simple as possible in order to avoid mistakes. One of the more error-prone things you can do with a regular expression is to use more than one space, such as:
> ```js
> var re = /foo   bar/;
> ```
> In this regular expression, it’s very hard to tell how many spaces are intended to be matched. It’s better to use only one space and then specify how many spaces are expected, such as:
> ```js
> var re = /foo {3}bar/;
> ```
> Now it is very clear that three spaces are expected to be matched.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
