### PR TITLE
test: relax timer check in test-report-uv-handles.js

### DIFF
--- a/test/report/test-report-uv-handles.js
+++ b/test/report/test-report-uv-handles.js
@@ -133,7 +133,7 @@ if (process.argv[2] === 'child') {
         }
         assert(handle.is_referenced);
       }, 3),
-      timer: common.mustCall(function timer_validator(handle) {
+      timer: common.mustCallAtLeast(function timer_validator(handle) {
         assert(!handle.is_referenced);
         assert.strictEqual(handle.repeat, 0);
       }),
@@ -143,6 +143,7 @@ if (process.argv[2] === 'child') {
         assert(handle.is_referenced);
       }),
     };
+    console.log(report.libuv);
     for (const entry of report.libuv) {
       if (validators[entry.type]) validators[entry.type](entry);
     }


### PR DESCRIPTION
The underlying JavaScript runtime may schedule tasks at its discretion
so there may be more timer handles than the one created by the test.

Refs: https://github.com/nodejs/node/pull/25852#issuecomment-469305602

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
