### PR TITLE
build: indicate that configure has done something

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1640,3 +1640,4 @@ if warn.warned and not options.verbose:
 
 print_verbose("running: \n    " + " ".join(['python', 'tools/gyp_node.py'] + gyp_args))
 run_gyp(gyp_args)
+info('configure completed successfully')


### PR DESCRIPTION
Print a message on completion to indicate that the `configure` script has worked.

Currently running `configure` without `--verbose` prints:
```bash
-bash-4.2$ ./configure
INFO: Using floating patch "tools/icu/patches/63/source/tools/toolutil/pkg_genc.cpp" from "tools/icu"
-bash-4.2$
```
but that info message will disappear with the next ICU update so what will happen is that `configure` will exit without indicating that anything has happened:
```bash
-bash-4.2$ ./configure
-bash-4.2$
```

This PR changes the output to:
```bash
-bash-4.2$ ./configure
INFO: configure completed successfully
-bash-4.2$
```
Refs: https://github.com/nodejs/node/issues/23111

cc @nodejs/build-files 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
