### PR TITLE
crypto: expose KeyObject class

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1109,14 +1109,18 @@ This can be called many times with new data as it is streamed.
 ## Class: KeyObject
 <!-- YAML
 added: v11.6.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26438
+    description: This class is now exported.
 -->
 
-Node.js uses an internal `KeyObject` class which should not be accessed
-directly. Instead, factory functions exist to create instances of this class
-in a secure manner, see [`crypto.createSecretKey()`][],
-[`crypto.createPublicKey()`][] and [`crypto.createPrivateKey()`][]. A
-`KeyObject` can represent a symmetric or asymmetric key, and each kind of key
-exposes different functions.
+Node.js uses a `KeyObject` class to represent a symmetric or asymmetric key,
+and each kind of key exposes different functions. The
+[`crypto.createSecretKey()`][], [`crypto.createPublicKey()`][] and
+[`crypto.createPrivateKey()`][] methods are used to create `KeyObject`
+instances. `KeyObject` objects are not to be created directly using the `new`
+keyword.
 
 Most applications should consider using the new `KeyObject` API instead of
 passing keys as strings or `Buffer`s due to improved security features.

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -60,7 +60,8 @@ const {
 const {
   createSecretKey,
   createPublicKey,
-  createPrivateKey
+  createPrivateKey,
+  KeyObject,
 } = require('internal/crypto/keys');
 const {
   DiffieHellman,
@@ -191,6 +192,7 @@ module.exports = exports = {
   ECDH,
   Hash,
   Hmac,
+  KeyObject,
   Sign,
   Verify
 };

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -318,6 +318,7 @@ module.exports = {
   createSecretKey,
   createPublicKey,
   createPrivateKey,
+  KeyObject,
 
   // These are designed for internal use only and should not be exposed.
   parsePublicKeyEncoding,


### PR DESCRIPTION
This PR exposes the KeyObject class as per #26200 discussion.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @sam-github @tniessen 

Closes #26200 