### PR TITLE
napi: Improve performance creating strings

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1335,6 +1335,9 @@ napi_status napi_create_string_utf8(napi_env env,
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
+  RETURN_STATUS_IF_FALSE(env,
+      (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,
+      napi_invalid_arg);
   auto isolate = env->isolate;
   auto str_maybe =
       v8::String::NewFromUtf8(isolate,

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1320,7 +1320,7 @@ napi_status napi_create_string_latin1(napi_env env,
   auto str_maybe =
       v8::String::NewFromOneByte(isolate,
                                  reinterpret_cast<const uint8_t*>(str),
-                                 v8::NewStringType::kInternalized,
+                                 v8::NewStringType::kNormal,
                                  length);
   CHECK_MAYBE_EMPTY(env, str_maybe, napi_generic_failure);
 
@@ -1335,10 +1335,14 @@ napi_status napi_create_string_utf8(napi_env env,
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
-  v8::Local<v8::String> s;
-  CHECK_NEW_FROM_UTF8_LEN(env, s, str, length);
-
-  *result = v8impl::JsValueFromV8LocalValue(s);
+  auto isolate = env->isolate;
+  auto str_maybe =
+      v8::String::NewFromUtf8(isolate,
+                              str,
+                              v8::NewStringType::kNormal,
+                              static_cast<int>(length));
+  CHECK_MAYBE_EMPTY(env, str_maybe, napi_generic_failure);
+  *result = v8impl::JsValueFromV8LocalValue(str_maybe.ToLocalChecked());
   return napi_clear_last_error(env);
 }
 
@@ -1353,7 +1357,7 @@ napi_status napi_create_string_utf16(napi_env env,
   auto str_maybe =
       v8::String::NewFromTwoByte(isolate,
                                  reinterpret_cast<const uint16_t*>(str),
-                                 v8::NewStringType::kInternalized,
+                                 v8::NewStringType::kNormal,
                                  length);
   CHECK_MAYBE_EMPTY(env, str_maybe, napi_generic_failure);
 

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1315,6 +1315,9 @@ napi_status napi_create_string_latin1(napi_env env,
                                       napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
+  RETURN_STATUS_IF_FALSE(env,
+      (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,
+      napi_invalid_arg);
 
   auto isolate = env->isolate;
   auto str_maybe =
@@ -1334,10 +1337,10 @@ napi_status napi_create_string_utf8(napi_env env,
                                     napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
-
   RETURN_STATUS_IF_FALSE(env,
       (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,
       napi_invalid_arg);
+
   auto isolate = env->isolate;
   auto str_maybe =
       v8::String::NewFromUtf8(isolate,
@@ -1355,6 +1358,9 @@ napi_status napi_create_string_utf16(napi_env env,
                                      napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
+  RETURN_STATUS_IF_FALSE(env,
+      (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,
+      napi_invalid_arg);
 
   auto isolate = env->isolate;
   auto str_maybe =

--- a/test/js-native-api/test_string/test.js
+++ b/test/js-native-api/test_string/test.js
@@ -73,3 +73,11 @@ assert.strictEqual(test_string.Utf8Length(str6), 14);
 assert.throws(() => {
   test_string.TestLargeUtf8();
 }, /^Error: Invalid argument$/);
+
+assert.throws(() => {
+  test_string.TestLargeLatin1();
+}, /^Error: Invalid argument$/);
+
+assert.throws(() => {
+  test_string.TestLargeUtf16();
+}, /^Error: Invalid argument$/);

--- a/test/js-native-api/test_string/test_string.c
+++ b/test/js-native-api/test_string/test_string.c
@@ -216,6 +216,32 @@ static napi_value TestLargeUtf8(napi_env env, napi_callback_info info) {
   return output;
 }
 
+static napi_value TestLargeLatin1(napi_env env, napi_callback_info info) {
+  napi_value output;
+  if (SIZE_MAX > INT_MAX) {
+    NAPI_CALL(env, napi_create_string_latin1(env, "", ((size_t)INT_MAX) + 1, &output));
+  } else {
+    // just throw the expected error as there is nothing to test
+    // in this case since we can't overflow
+    NAPI_CALL(env, napi_throw_error(env, NULL, "Invalid argument"));
+  }
+
+  return output;
+}
+
+static napi_value TestLargeUtf16(napi_env env, napi_callback_info info) {
+  napi_value output;
+  if (SIZE_MAX > INT_MAX) {
+    NAPI_CALL(env, napi_create_string_utf16(env, "", ((size_t)INT_MAX) + 1, &output));
+  } else {
+    // just throw the expected error as there is nothing to test
+    // in this case since we can't overflow
+    NAPI_CALL(env, napi_throw_error(env, NULL, "Invalid argument"));
+  }
+
+  return output;
+}
+
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
@@ -228,6 +254,8 @@ napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NAPI_PROPERTY("Utf16Length", Utf16Length),
     DECLARE_NAPI_PROPERTY("Utf8Length", Utf8Length),
     DECLARE_NAPI_PROPERTY("TestLargeUtf8", TestLargeUtf8),
+    DECLARE_NAPI_PROPERTY("TestLargeLatin1", TestLargeLatin1),
+    DECLARE_NAPI_PROPERTY("TestLargeUtf16", TestLargeUtf16),
   };
 
   NAPI_CALL(env, napi_define_properties(


### PR DESCRIPTION
Improve performance creating strings using N-API by ensuring that the strings are not internalized (see Node issue #26437).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
