### PR TITLE
tools: fix a typo error

### DIFF
--- a/tools/license2rtf.js
+++ b/tools/license2rtf.js
@@ -239,7 +239,8 @@ function rtfEscape(string) {
 }
 
 /*
- * This filter generates an rtf document from a stream of paragraph objects.
+ * This filter generates a document in RTF format
+ * from a stream of paragraph objects.
  */
 class RtfGenerator extends Stream {
   constructor() {


### PR DESCRIPTION
'an rtf document' => 'a document in RTF format' to avoid confusion.

---

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
