### PR TITLE
[RFC] crypto: replace createECDHKey with generate/importECDHKey

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -126,8 +126,12 @@ function createDiffieHellmanGroup(name) {
   return new DiffieHellmanGroup(name);
 }
 
-function createECDH(curve) {
+function generateECDHKey(curve) {
   return new ECDH(curve);
+}
+
+function importECDHKey(curve, key, encoding) {
+  return new ECDH(curve, key, encoding);
 }
 
 function createHmac(hmac, key, options) {
@@ -148,7 +152,8 @@ module.exports = exports = {
   createDecipheriv,
   createDiffieHellman,
   createDiffieHellmanGroup,
-  createECDH,
+  generateECDHKey,
+  importECDHKey,
   createHash,
   createHmac,
   createPrivateKey,

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -169,24 +169,21 @@ legacyNativeHandle(DiffieHellman);
 legacyNativeHandle(DiffieHellmanGroup);
 
 
-function ECDH(curve) {
+function ECDH(curve, key, encoding) {
   if (!(this instanceof ECDH))
-    return new ECDH(curve);
+    return new ECDH(...arguments);
 
   validateString(curve, 'curve');
-  this[kHandle] = new _ECDH(curve);
+  if (arguments.length >= 2) {
+    encoding = encoding || getDefaultEncoding();
+    this[kHandle] = new _ECDH(curve, toBuf(key, encoding))
+  } else {
+    this[kHandle] = new _ECDH(curve);
+  }
 }
 
 ECDH.prototype.computeSecret = DiffieHellman.prototype.computeSecret;
-ECDH.prototype.setPrivateKey = DiffieHellman.prototype.setPrivateKey;
-ECDH.prototype.setPublicKey = DiffieHellman.prototype.setPublicKey;
 ECDH.prototype.getPrivateKey = DiffieHellman.prototype.getPrivateKey;
-
-ECDH.prototype.generateKeys = function generateKeys(encoding, format) {
-  this[kHandle].generateKeys();
-
-  return this.getPublicKey(encoding, format);
-};
 
 ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
   const f = getFormat(format);

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -176,7 +176,7 @@ function ECDH(curve, key, encoding) {
   validateString(curve, 'curve');
   if (arguments.length >= 2) {
     encoding = encoding || getDefaultEncoding();
-    this[kHandle] = new _ECDH(curve, toBuf(key, encoding))
+    this[kHandle] = new _ECDH(curve, toBuf(key, encoding));
   } else {
     this[kHandle] = new _ECDH(curve);
   }

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -820,12 +820,9 @@ class ECDH : public BaseObject {
   }
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void GenerateKeys(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void ComputeSecret(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetPrivateKey(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void SetPrivateKey(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetPublicKey(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void SetPublicKey(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   bool IsKeyPairValid();
   bool IsKeyValidForCurve(const BignumPointer& private_key);

--- a/test/parallel/test-crypto-classes.js
+++ b/test/parallel/test-crypto-classes.js
@@ -18,7 +18,7 @@ const TEST_CASES = {
   'Verify': ['RSA-SHA1'],
   'DiffieHellman': [1024],
   'DiffieHellmanGroup': ['modp5'],
-  'ECDH': ['prime256v1'],
+  //'ECDH': ['prime256v1'],
 };
 
 if (!common.hasFipsCrypto) {

--- a/test/parallel/test-crypto-classes.js
+++ b/test/parallel/test-crypto-classes.js
@@ -18,7 +18,6 @@ const TEST_CASES = {
   'Verify': ['RSA-SHA1'],
   'DiffieHellman': [1024],
   'DiffieHellmanGroup': ['modp5'],
-  //'ECDH': ['prime256v1'],
 };
 
 if (!common.hasFipsCrypto) {

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -253,7 +253,7 @@ if (availableCurves.has('prime256v1') && availableCurves.has('secp256k1')) {
     });
 
   // ECDH should allow importing
-  const ecdh4 = crypto.importECDHKey('prime256v1', ecdh1.getPrivateKey());
+  crypto.importECDHKey('prime256v1', ecdh1.getPrivateKey());
 
   // Verify that we can use ECDH without having to use newly generated keys.
   // A valid private key for the secp256k1 curve.
@@ -264,13 +264,20 @@ if (availableCurves.has('prime256v1') && availableCurves.has('secp256k1')) {
   const cafebabePubPtUnComp =
   '04672a31bfc59d3f04548ec9b7daeeba2f61814e8ccc40448045007f5479f693a3' +
   '2e02c7f93d13dc2732b760ca377a5897b9dd41a1c1b29dc0442fdce6d0a04d1d';
-  const ecdh5 = crypto.importECDHKey('secp256k1', Buffer.from(cafebabeKey, 'hex'));
+  const ecdh5 = crypto.importECDHKey(
+    'secp256k1',
+    Buffer.from(cafebabeKey, 'hex')
+  );
 
   assert.strictEqual(ecdh5.getPrivateKey('hex'), cafebabeKey);
 
   // Show that the public point (key) is generated while setting the
   // private key.
   assert.strictEqual(ecdh5.getPublicKey('hex'), cafebabePubPtUnComp);
+  assert.strictEqual(
+    ecdh5.getPublicKey('hex', 'compressed'),
+    cafebabePubPtComp
+  );
 
   // Compressed and uncompressed public points/keys for other party's
   // private key.

--- a/test/parallel/test-crypto-ecdh-convert-key.js
+++ b/test/parallel/test-crypto-ecdh-convert-key.js
@@ -92,9 +92,7 @@ if (getCurves().includes('secp256k1')) {
   assert.strictEqual(compressed, cafebabePubPtComp);
 
   // Compare to getPublicKey.
-  const ecdh1 = ECDH('secp256k1');
-  ecdh1.generateKeys();
-  ecdh1.setPrivateKey(cafebabeKey, 'hex');
+  const ecdh1 = ECDH('secp256k1', cafebabeKey, 'hex');
   assert.strictEqual(ecdh1.getPublicKey('hex', 'uncompressed'), uncompressed);
   assert.strictEqual(ecdh1.getPublicKey('hex', 'compressed'), compressed);
   assert.strictEqual(ecdh1.getPublicKey('hex', 'hybrid'), hybrid);


### PR DESCRIPTION
The current crypto APIs make it possible to create a key object that is invalid or partly valid, by calling the `setPublicKey`/`setPrivateKey` methods incorrectly. This proposal would make it impossible to hold an invalid key object, eliminating a class of errors relating to key objects.

Before:

```js
const ecdh = crypto.createECDH('prime256v1')
ecdh.setPrivateKey('...', 'hex')
ecdh.setPublicKey('...', 'hex') // did it work? i hope so!

ecdh.generateKeys()
ecdh.setPublicKey(...) // what does this even mean?
```

After:

```js
const ecdh = crypto.importECDHKey('prime256v1', privateKey, 'hex')
const ecdh2 = crypto.generateECDHKey('prime256v1')
// the ECDH objects are immutable and valid by definition.
```

I understand that this would be a rather large change to the API, but if this is something worth doing, I'm happy to do the refactors in other crypto APIs and write the relevant documentation, deprecation warnings, etc. Just wanted to get this sketch & proof of concept up for discussion first.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
