### PR TITLE
test: fix tests so they work in worker threads

### DIFF
--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -34,9 +34,6 @@ const path = require('path');
 const fixtures = require('../common/fixtures');
 const nodejs = `"${process.execPath}"`;
 
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
-
 if (process.argv.length > 2) {
   console.log(process.argv.slice(2).join(' '));
   process.exit(0);
@@ -98,16 +95,14 @@ child.exec(`${nodejs} --print "os.platform()"`,
            }));
 
 // Module path resolve bug regression test.
-const cwd = process.cwd();
-process.chdir(path.resolve(__dirname, '../../'));
 child.exec(`${nodejs} --eval "require('./test/parallel/test-cli-eval.js')"`,
+           { cwd: path.resolve(__dirname, '../../') },
            common.mustCall((err, stdout, stderr) => {
              assert.strictEqual(err.code, 42);
              assert.strictEqual(
                stdout, 'Loaded as a module, exiting with status code 42.\n');
              assert.strictEqual(stderr, '');
            }));
-process.chdir(cwd);
 
 // Missing argument should not crash.
 child.exec(`${nodejs} -e`, common.mustCall((err, stdout, stderr) => {

--- a/test/parallel/test-cli-node-options-disallowed.js
+++ b/test/parallel/test-cli-node-options-disallowed.js
@@ -2,8 +2,6 @@
 const common = require('../common');
 if (process.config.variables.node_without_node_options)
   common.skip('missing NODE_OPTIONS support');
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
 
 // Test options specified by env variable.
 
@@ -12,7 +10,6 @@ const exec = require('child_process').execFile;
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
-process.chdir(tmpdir.path);
 
 disallow('--version');
 disallow('-v');
@@ -32,7 +29,7 @@ disallow('--');
 
 function disallow(opt) {
   const env = Object.assign({}, process.env, { NODE_OPTIONS: opt });
-  exec(process.execPath, { env }, common.mustCall(function(err) {
+  exec(process.execPath, { cwd: tmpdir.path, env }, common.mustCall((err) => {
     const message = err.message.split(/\r?\n/)[1];
     const expect = `${process.execPath}: ${opt} is not allowed in NODE_OPTIONS`;
 

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -2,8 +2,6 @@
 const common = require('../common');
 if (process.config.variables.node_without_node_options)
   common.skip('missing NODE_OPTIONS support');
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
 
 // Test options specified by env variable.
 
@@ -12,7 +10,6 @@ const exec = require('child_process').execFile;
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
-process.chdir(tmpdir.path);
 
 const printA = require.resolve('../fixtures/printA.js');
 expect(`-r ${printA}`, 'A\nB\n');
@@ -64,6 +61,7 @@ expect('--stack-trace-limit=100',
 function expect(opt, want, command = 'console.log("B")', wantsError = false) {
   const argv = ['-e', command];
   const opts = {
+    cwd: tmpdir.path,
     env: Object.assign({}, process.env, { NODE_OPTIONS: opt }),
     maxBuffer: 1e6,
   };

--- a/test/parallel/test-preload-print-process-argv.js
+++ b/test/parallel/test-preload-print-process-argv.js
@@ -3,31 +3,28 @@
 // This tests that process.argv is the same in the preloaded module
 // and the user module.
 
-const common = require('../common');
+require('../common');
 
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
+const { join } = require('path');
 const { spawnSync } = require('child_process');
 const fs = require('fs');
 
-if (!common.isMainThread) {
-  common.skip('Cannot chdir to the tmp directory in workers');
-}
-
 tmpdir.refresh();
 
-process.chdir(tmpdir.path);
 fs.writeFileSync(
-  'preload.js',
+  join(tmpdir.path, 'preload.js'),
   'console.log(JSON.stringify(process.argv));',
   'utf-8');
 
 fs.writeFileSync(
-  'main.js',
+  join(tmpdir.path, 'main.js'),
   'console.log(JSON.stringify(process.argv));',
   'utf-8');
 
-const child = spawnSync(process.execPath, ['-r', './preload.js', 'main.js']);
+const child = spawnSync(process.execPath, ['-r', './preload.js', 'main.js'],
+                        { cwd: tmpdir.path });
 
 if (child.status !== 0) {
   console.log(child.stderr.toString());

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -5,8 +5,6 @@ const fixtures = require('../common/fixtures');
 // Refs: https://github.com/nodejs/node/pull/2253
 if (common.isSunOS)
   common.skip('unreliable on SunOS');
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
 
 const assert = require('assert');
 const childProcess = require('child_process');
@@ -133,9 +131,9 @@ childProcess.exec(
 );
 
 // Test that preloading with a relative path works
-process.chdir(fixtures.fixturesDir);
 childProcess.exec(
   `"${nodeBinary}" ${preloadOption(['./printA.js'])} "${fixtureB}"`,
+  { cwd: fixtures.fixturesDir },
   common.mustCall(function(err, stdout, stderr) {
     assert.ifError(err);
     assert.strictEqual(stdout, 'A\nB\n');
@@ -145,6 +143,7 @@ if (common.isWindows) {
   // https://github.com/nodejs/node/issues/21918
   childProcess.exec(
     `"${nodeBinary}" ${preloadOption(['.\\printA.js'])} "${fixtureB}"`,
+    { cwd: fixtures.fixturesDir },
     common.mustCall(function(err, stdout, stderr) {
       assert.ifError(err);
       assert.strictEqual(stdout, 'A\nB\n');
@@ -153,10 +152,10 @@ if (common.isWindows) {
 }
 
 // https://github.com/nodejs/node/issues/1691
-process.chdir(fixtures.fixturesDir);
 childProcess.exec(
   `"${nodeBinary}" --require ` +
      `"${fixtures.path('cluster-preload.js')}" cluster-preload-test.js`,
+  { cwd: fixtures.fixturesDir },
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.ok(/worker terminated with code 43/.test(stdout));

--- a/test/parallel/test-tick-processor-arguments.js
+++ b/test/parallel/test-tick-processor-arguments.js
@@ -5,20 +5,18 @@ const fs = require('fs');
 const assert = require('assert');
 const { spawnSync } = require('child_process');
 
-if (!common.isMainThread)
-  common.skip('chdir not available in workers');
 if (!common.enoughTestMem)
   common.skip('skipped due to memory requirements');
 if (common.isAIX)
   common.skip('does not work on AIX');
 
 tmpdir.refresh();
-process.chdir(tmpdir.path);
 
 // Generate log file.
-spawnSync(process.execPath, [ '--prof', '-p', '42' ]);
+spawnSync(process.execPath, [ '--prof', '-p', '42' ], { cwd: tmpdir.path });
 
-const logfile = fs.readdirSync('.').filter((name) => name.endsWith('.log'))[0];
+const files = fs.readdirSync(tmpdir.path);
+const logfile = files.filter((name) => /\.log$/.test(name))[0];
 assert(logfile);
 
 // Make sure that the --preprocess argument is passed through correctly,
@@ -28,7 +26,7 @@ assert(logfile);
 const { stdout } = spawnSync(
   process.execPath,
   [ '--prof-process', '--preprocess', logfile ],
-  { encoding: 'utf8' });
+  { cwd: tmpdir.path, encoding: 'utf8' });
 
 // Make sure that the result is valid JSON.
 JSON.parse(stdout);

--- a/test/parallel/test-trace-events-environment.js
+++ b/test/parallel/test-trace-events-environment.js
@@ -10,9 +10,6 @@ const tmpdir = require('../common/tmpdir');
 
 // This tests the emission of node.environment trace events
 
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
-
 const names = new Set([
   'Environment',
   'RunAndClearNativeImmediates',
@@ -32,10 +29,10 @@ if (process.argv[2] === 'child') {
   setTimeout(() => { 1 + 1; }, 1);
 } else {
   tmpdir.refresh();
-  process.chdir(tmpdir.path);
 
   const proc = cp.fork(__filename,
                        [ 'child' ], {
+                         cwd: tmpdir.path,
                          execArgv: [
                            '--trace-event-categories',
                            'node.environment'


### PR DESCRIPTION
Use the `cwd` option for child_process instead of `process.chdir()` to
allow tests to work with worker threads.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
