### PR TITLE
crypto: simplify GetPublicOrPrivateKeyFromJs

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3150,8 +3150,7 @@ static ManagedEVPPKey GetPrivateKeyFromJs(
 
 static ManagedEVPPKey GetPublicOrPrivateKeyFromJs(
     const FunctionCallbackInfo<Value>& args,
-    unsigned int* offset,
-    bool allow_key_object) {
+    unsigned int* offset) {
   if (args[*offset]->IsString() || Buffer::HasInstance(args[*offset])) {
     Environment* env = Environment::GetCurrent(args);
     ByteSource data = ByteSource::FromStringOrBuffer(env, args[(*offset)++]);
@@ -3199,7 +3198,7 @@ static ManagedEVPPKey GetPublicOrPrivateKeyFromJs(
       ThrowCryptoError(env, ERR_get_error(), "Failed to read asymmetric key");
     return ManagedEVPPKey(pkey.release());
   } else {
-    CHECK(args[*offset]->IsObject() && allow_key_object);
+    CHECK(args[*offset]->IsObject());
     KeyObject* key = Unwrap<KeyObject>(args[*offset].As<Object>());
     CHECK(key);
     CHECK_NE(key->GetKeyType(), kKeyTypeSecret);
@@ -3409,7 +3408,7 @@ void KeyObject::Init(const FunctionCallbackInfo<Value>& args) {
     CHECK_EQ(args.Length(), 3);
 
     offset = 0;
-    pkey = GetPublicOrPrivateKeyFromJs(args, &offset, true);
+    pkey = GetPublicOrPrivateKeyFromJs(args, &offset);
     if (!pkey)
       return;
     key->InitPublic(pkey);
@@ -4676,7 +4675,7 @@ void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&verify, args.Holder());
 
   unsigned int offset = 0;
-  ManagedEVPPKey pkey = GetPublicOrPrivateKeyFromJs(args, &offset, true);
+  ManagedEVPPKey pkey = GetPublicOrPrivateKeyFromJs(args, &offset);
   if (!pkey)
     return;
 
@@ -4739,7 +4738,7 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   unsigned int offset = 0;
-  ManagedEVPPKey pkey = GetPublicOrPrivateKeyFromJs(args, &offset, true);
+  ManagedEVPPKey pkey = GetPublicOrPrivateKeyFromJs(args, &offset);
   if (!pkey)
     return;
 


### PR DESCRIPTION
The last argument is now always set to `true` due to #26278. This change removes said argument and its only usage in an assertion.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
