### PR TITLE
crypto: fix error handling in KeyObject.export

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -172,6 +172,9 @@ function isStringOrBuffer(val) {
 }
 
 function parseKeyEncoding(enc, keyType, isPublic, objName) {
+  if (enc === null || typeof enc !== 'object')
+    throw new ERR_INVALID_ARG_TYPE('options', 'object', enc);
+
   const isInput = keyType === undefined;
 
   const {

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -104,6 +104,16 @@ const privatePem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
   assert.strictEqual(derivedPublicKey.asymmetricKeyType, 'rsa');
   assert.strictEqual(derivedPublicKey.symmetricKeySize, undefined);
 
+  // Test exporting with an invalid options object, this should throw.
+  for (const opt of [undefined, null, 'foo', 0, NaN]) {
+    common.expectsError(() => publicKey.export(opt), {
+      type: TypeError,
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "options" argument must be of type object. Received type ' +
+               typeof opt
+    });
+  }
+
   const publicDER = publicKey.export({
     format: 'der',
     type: 'pkcs1'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This change only affects `KeyObject.export()`:

```js
crypto.generateKeyPairSync('rsa', { modulusLength: 1024 }).publicKey.export()
```

Old error message:

```
TypeError: Cannot destructure property `format` of 'undefined' or 'null'.
    at parseKeyFormatAndType (internal/crypto/keys.js:154:48)
    at parseKeyEncoding (internal/crypto/keys.js:180:7)
    at parsePublicKeyEncoding (internal/crypto/keys.js:212:10)
    at PublicKeyObject.export (internal/crypto/keys.js:94:9)
```

New error message:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "options" argument must be of type object. Received type undefined
    at parseKeyEncoding (internal/crypto/keys.js:176:11)
    at parsePublicKeyEncoding (internal/crypto/keys.js:215:10)
    at PublicKeyObject.export (internal/crypto/keys.js:94:9)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
