### PR TITLE
doc: add guidance on console output in tests

### DIFF
--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -281,6 +281,32 @@ assert.throws(
 );
 ```
 
+### Console output
+
+Output written by tests to stdout or stderr, such as with `console.log()` or
+`console.error()`, can be useful when writing tests, as well as for debugging
+them during later maintenance.  The output will be supressed by the test runner
+(`./tools/test.py`) unless the test fails, but will always be displayed when
+running tests directly with `node`. For failing tests, the test runner will
+include the output along with the failed test assertion in the test report.
+
+Some output can help debugging by giving context to test failures. For example,
+when troubleshooting tests that timeout in CI. With no log statements, we have
+no idea where the test got hung up. There have been cases where tests fail
+without `console.log()`, and then pass when its added, so be cautious about its
+use, particularly in tests of the I/O and streaming APIs.
+
+Excessive use of console output is discouraged as it can overwhelm the display,
+including the Jenkins console and test report displays.  Be particularly
+cautious of output in loops, or other contexts where output may be repeated many
+times in the case of failure.
+
+In some tests, it can be unclear whether a `console.log()` statement is required
+as part of the test (message tests, tests that check output from child
+processes, etc.), or is there as a debug aide. If there is any chance of
+confusion, use comments to make the purpose clear.
+
+
 ### ES.Next features
 
 For performance considerations, we only use a selected subset of ES.Next


### PR DESCRIPTION
I'd like the test writing guide to include some information on expected usage of console.log/error, to avoid having to discuss it (as much) in individual PRs.

As long as I've been writing node.js unit tests (since 0.10), I've written my tests with console.log statements (or added them while debugging), then removed them before PRing the changes. I'm not entirely sure why this is the node.js convention, or even if it is widely agreed that its the convention (I count over 200 tests with 2 or more calls to `console.log()` or `console.error()`).

Output is surpressed by the test runner if the test passes, so it does not increase the noise/verbosity of most test runs, but it will be included as context if a test fails.

Since its going to be in the tap output and show up in jenkins, as well as the local display, the output should not be so excessive as to overwhelm the display, but other than that, I can't see why anyone other than a test author/maintainer should have concerns over what the test outputs.

What do other @nodejs/collaborators think?

If the consensus is that console output should be avoided, I'll modify the text. No matter what the text ends up being, by documenting it, it should make PR review clearer since there will be agreement on the general policy.

cf. discussion with @jasnell and @addaleax preceeding
https://github.com/nodejs/node/pull/26209#discussion_r262605089 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
