### PR TITLE
src: add public API for linked bindings

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -1037,6 +1037,7 @@
         'test/cctest/test_base64.cc',
         'test/cctest/test_node_postmortem_metadata.cc',
         'test/cctest/test_environment.cc',
+        'test/cctest/test_linked_binding.cc',
         'test/cctest/test_platform.cc',
         'test/cctest/test_report_util.cc',
         'test/cctest/test_traced_value.cc',

--- a/src/node.h
+++ b/src/node.h
@@ -445,6 +445,10 @@ typedef void (*addon_context_register_func)(
     v8::Local<v8::Context> context,
     void* priv);
 
+enum ModuleFlags {
+  kLinked = 0x02
+};
+
 struct node_module {
   int nm_version;
   unsigned int nm_flags;
@@ -531,6 +535,14 @@ extern "C" NODE_EXTERN void node_module_register(void* mod);
 #define NODE_MODULE_CONTEXT_AWARE(modname, regfunc)                   \
   /* NOLINTNEXTLINE (readability/null_usage) */                       \
   NODE_MODULE_CONTEXT_AWARE_X(modname, regfunc, NULL, 0)
+
+// Embedders can use this type of binding for statically linked native bindings.
+// It is used the same way addon bindings are used, except that linked bindings
+// can be accessed through `process._linkedBinding(modname)`.
+#define NODE_MODULE_LINKED(modname, regfunc)                               \
+  /* NOLINTNEXTLINE (readability/null_usage) */                            \
+  NODE_MODULE_CONTEXT_AWARE_X(modname, regfunc, NULL,                      \
+                              node::ModuleFlags::kLinked)
 
 /*
  * For backward compatibility in add-on modules.

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -23,7 +23,8 @@ enum {
 
 // Make sure our internal values match the public API's values.
 static_assert(static_cast<int>(NM_F_LINKED) ==
-              static_cast<int>(node::ModuleFlags::kLinked));
+              static_cast<int>(node::ModuleFlags::kLinked),
+              "NM_F_LINKED != node::ModuleFlags::kLinked");
 
 #define NODE_MODULE_CONTEXT_AWARE_CPP(modname, regfunc, priv, flags)           \
   static node::node_module _module = {                                         \

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -21,6 +21,10 @@ enum {
   NM_F_DELETEME = 1 << 3,
 };
 
+// Make sure our internal values match the public API's values.
+static_assert(static_cast<int>(NM_F_LINKED) ==
+              static_cast<int>(node::ModuleFlags::kLinked));
+
 #define NODE_MODULE_CONTEXT_AWARE_CPP(modname, regfunc, priv, flags)           \
   static node::node_module _module = {                                         \
       NODE_MODULE_VERSION,                                                     \

--- a/test/cctest/node_test_fixture.cc
+++ b/test/cctest/node_test_fixture.cc
@@ -4,3 +4,4 @@ ArrayBufferUniquePtr NodeTestFixture::allocator{nullptr, nullptr};
 uv_loop_t NodeTestFixture::current_loop;
 NodePlatformUniquePtr NodeTestFixture::platform;
 TracingAgentUniquePtr NodeTestFixture::tracing_agent;
+bool NodeTestFixture::node_initialized = false;

--- a/test/cctest/test_linked_binding.cc
+++ b/test/cctest/test_linked_binding.cc
@@ -1,0 +1,42 @@
+#include "node_test_fixture.h"
+#include "node_internals.h"  // RunBootstrapping()
+
+void InitializeBinding(v8::Local<v8::Object> exports,
+                       v8::Local<v8::Value> module,
+                       v8::Local<v8::Context> context) {
+  v8::Isolate* isolate = context->GetIsolate();
+  exports->Set(
+      context,
+      v8::String::NewFromOneByte(isolate,
+                                 reinterpret_cast<const uint8_t*>("key"),
+                                 v8::NewStringType::kNormal).ToLocalChecked(),
+      v8::String::NewFromOneByte(isolate,
+                                 reinterpret_cast<const uint8_t*>("value"),
+                                 v8::NewStringType::kNormal).ToLocalChecked())
+      .FromJust();
+}
+
+NODE_MODULE_LINKED(cctest_linkedbinding, InitializeBinding);
+
+class LinkedBindingTest : public EnvironmentTestFixture {};
+
+TEST_F(LinkedBindingTest, SimpleTest) {
+  const v8::HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env test_env {handle_scope, argv};
+
+  v8::Local<v8::Context> context = isolate_->GetCurrentContext();
+
+  const char* run_script =
+      "process._linkedBinding('cctest_linkedbinding').key";
+  v8::Local<v8::Script> script = v8::Script::Compile(
+      context,
+      v8::String::NewFromOneByte(isolate_,
+                                 reinterpret_cast<const uint8_t*>(run_script),
+                                 v8::NewStringType::kNormal).ToLocalChecked())
+      .ToLocalChecked();
+  v8::Local<v8::Value> completion_value = script->Run(context).ToLocalChecked();
+  v8::String::Utf8Value utf8val(isolate_, completion_value);
+  CHECK_NOT_NULL(*utf8val);
+  CHECK_EQ(strcmp(*utf8val, "value"), 0);
+}


### PR DESCRIPTION
##### test: make cctest full Node.js environment

Make sure `node::Init()` is called once, and execute
`RunBootstrapping()` so that Node’s internals are ready
when the cctests run.

##### src: add public API for linked bindings

(Re-?)add a public API for creating linked bindings (access to
`NM_F_LINKED` as a constant was previously removed in d6ac8a4db0c0a588258f594dc21fbd8018bef7c2),
and add a test for the functionality.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
