### PR TITLE
src: guard against calling `Init()` multiple times

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -608,9 +608,14 @@ int ProcessGlobalArgs(std::vector<std::string>* args,
   return 0;
 }
 
+static std::atomic_bool init_called{false};
+
 int Init(std::vector<std::string>* argv,
          std::vector<std::string>* exec_argv,
          std::vector<std::string>* errors) {
+  // Make sure Init() is called only once.
+  CHECK(!init_called.exchange(true));
+
   // Register built-in modules
   binding::RegisterBuiltinModules();
 


### PR DESCRIPTION
This function should only be called once. Calling it multiple times
would currently break Node.js (e.g. re-registering builtin modules
would break the linked list for them).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
