### PR TITLE
src: merge debug-only `SealHandleScope`s

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -23,7 +23,6 @@ using v8::MaybeLocal;
 using v8::Message;
 using v8::MicrotasksPolicy;
 using v8::ObjectTemplate;
-using v8::SealHandleScope;
 using v8::String;
 using v8::Value;
 
@@ -35,9 +34,7 @@ static bool AllowWasmCodeGenerationCallback(Local<Context> context,
 }
 
 static bool ShouldAbortOnUncaughtException(Isolate* isolate) {
-#ifdef DEBUG
-  SealHandleScope scope(isolate);
-#endif
+  DebugSealHandleScope scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
   return env != nullptr &&
          (env->is_main_thread() || !env->is_stopping_worker()) &&

--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -1,5 +1,5 @@
 #include "env-inl.h"
-#include "node.h"
+#include "node_internals.h"
 #include "node_process.h"
 #include "async_wrap.h"
 
@@ -11,7 +11,6 @@ using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
-using v8::SealHandleScope;
 using v8::String;
 using v8::Value;
 using v8::NewStringType;
@@ -116,9 +115,7 @@ async_context EmitAsyncInit(Isolate* isolate,
                             Local<Object> resource,
                             Local<String> name,
                             async_id trigger_async_id) {
-#ifdef DEBUG
-  SealHandleScope handle_scope(isolate);
-#endif
+  DebugSealHandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
   CHECK_NOT_NULL(env);
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -644,9 +644,7 @@ void Environment::RunAndClearNativeImmediates() {
     auto drain_list = [&]() {
       TryCatchScope try_catch(this);
       for (auto it = list.begin(); it != list.end(); ++it) {
-#ifdef DEBUG
-        v8::SealHandleScope seal_handle_scope(isolate());
-#endif
+        DebugSealHandleScope seal_handle_scope(isolate());
         it->cb_(this, it->data_);
         if (it->refed_)
           ref_count++;

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -217,6 +217,20 @@ class InternalCallbackScope {
   bool closed_ = false;
 };
 
+class DebugSealHandleScope {
+ public:
+  explicit inline DebugSealHandleScope(v8::Isolate* isolate)
+#ifdef DEBUG
+    : actual_scope_(isolate)
+#endif
+  {}
+
+ private:
+#ifdef DEBUG
+  v8::SealHandleScope actual_scope_;
+#endif
+};
+
 class ThreadPoolWork {
  public:
   explicit inline ThreadPoolWork(Environment* env) : env_(env) {

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -12,7 +12,6 @@ using v8::Isolate;
 using v8::Local;
 using v8::Object;
 using v8::Platform;
-using v8::SealHandleScope;
 using v8::Task;
 using node::tracing::TracingController;
 
@@ -332,9 +331,7 @@ int NodePlatform::NumberOfWorkerThreads() {
 
 void PerIsolatePlatformData::RunForegroundTask(std::unique_ptr<Task> task) {
   Isolate* isolate = Isolate::GetCurrent();
-#ifdef DEBUG
-  SealHandleScope scope(isolate);
-#endif
+  DebugSealHandleScope scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
   if (env != nullptr) {
     InternalCallbackScope cb_scope(env, Local<Object>(), { 0, 0 },

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -113,39 +113,29 @@ inline void StreamResource::RemoveStreamListener(StreamListener* listener) {
 }
 
 inline uv_buf_t StreamResource::EmitAlloc(size_t suggested_size) {
-#ifdef DEBUG
-  v8::SealHandleScope handle_scope(v8::Isolate::GetCurrent());
-#endif
+  DebugSealHandleScope handle_scope(v8::Isolate::GetCurrent());
   return listener_->OnStreamAlloc(suggested_size);
 }
 
 inline void StreamResource::EmitRead(ssize_t nread, const uv_buf_t& buf) {
-#ifdef DEBUG
-  v8::SealHandleScope handle_scope(v8::Isolate::GetCurrent());
-#endif
+  DebugSealHandleScope handle_scope(v8::Isolate::GetCurrent());
   if (nread > 0)
     bytes_read_ += static_cast<uint64_t>(nread);
   listener_->OnStreamRead(nread, buf);
 }
 
 inline void StreamResource::EmitAfterWrite(WriteWrap* w, int status) {
-#ifdef DEBUG
-  v8::SealHandleScope handle_scope(v8::Isolate::GetCurrent());
-#endif
+  DebugSealHandleScope handle_scope(v8::Isolate::GetCurrent());
   listener_->OnStreamAfterWrite(w, status);
 }
 
 inline void StreamResource::EmitAfterShutdown(ShutdownWrap* w, int status) {
-#ifdef DEBUG
-  v8::SealHandleScope handle_scope(v8::Isolate::GetCurrent());
-#endif
+  DebugSealHandleScope handle_scope(v8::Isolate::GetCurrent());
   listener_->OnStreamAfterShutdown(w, status);
 }
 
 inline void StreamResource::EmitWantsWrite(size_t suggested_size) {
-#ifdef DEBUG
-  v8::SealHandleScope handle_scope(v8::Isolate::GetCurrent());
-#endif
+  DebugSealHandleScope handle_scope(v8::Isolate::GetCurrent());
   listener_->OnStreamWantsWrite(suggested_size);
 }
 


### PR DESCRIPTION
Instead of repeating the same `#ifdef DEBUG` + `SealHandleScope`
pattern over and over, create an utility that does this for us.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

![A debugging seal](https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/Seehund.jpg/320px-Seehund.jpg)