### PR TITLE
doc: fix nits in report docs

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1669,7 +1669,7 @@ added: v11.8.0
 reports for the current process. Additional documentation is available in the
 [report documentation][].
 
-## process.report.directory
+### process.report.directory
 <!-- YAML
 added: REPLACEME
 -->
@@ -1682,6 +1682,21 @@ Node.js process.
 
 ```js
 console.log(`Report directory is ${process.report.directory}`);
+```
+
+### process.report.filename
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string}
+
+Filename where the report is written. If set to the empty string, the output
+filename will be comprised of a timestamp, PID, and sequence number. The default
+value is the empty string.
+
+```js
+console.log(`Report filename is ${process.report.filename}`);
 ```
 
 ### process.report.getReport([err])
@@ -1702,22 +1717,7 @@ console.log(data);
 
 Additional documentation is available in the [report documentation][].
 
-## process.report.filename
-<!-- YAML
-added: REPLACEME
--->
-
-* {string}
-
-Filename where the report is written. If set to the empty string, the output
-filename will be comprised of a timestamp, PID, and sequence number. The default
-value is the empty string.
-
-```js
-console.log(`Report filename is ${process.report.filename}`);
-```
-
-## process.report.reportOnFatalError
+### process.report.reportOnFatalError
 <!-- YAML
 added: REPLACEME
 -->
@@ -1731,7 +1731,7 @@ memory errors or failed C++ assertions.
 console.log(`Report on fatal error: ${process.report.reportOnFatalError}`);
 ```
 
-## process.report.reportOnSignal
+### process.report.reportOnSignal
 <!-- YAML
 added: REPLACEME
 -->
@@ -1745,7 +1745,7 @@ signal specified by `process.report.signal`.
 console.log(`Report on signal: ${process.report.reportOnSignal}`);
 ```
 
-## process.report.reportOnUncaughtException
+### process.report.reportOnUncaughtException
 <!-- YAML
 added: REPLACEME
 -->
@@ -1758,7 +1758,7 @@ If `true`, a diagnostic report is generated on uncaught exception.
 console.log(`Report on exception: ${process.report.reportOnUncaughtException}`);
 ```
 
-## process.report.signal
+### process.report.signal
 <!-- YAML
 added: REPLACEME
 -->
@@ -1766,7 +1766,7 @@ added: REPLACEME
 * {string}
 
 The signal used to trigger the creation of a diagnostic report. Defaults to
-`SIGUSR2`.
+`'SIGUSR2'`.
 
 ```js
 console.log(`Report signal: ${process.report.signal}`);

--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -503,7 +503,7 @@ to intercept external triggers for report generation. Defaults to
 `filename` specifies the name of the output file in the file system.
 Special meaning is attached to `stdout` and `stderr`. Usage of these
 will result in report being written to the associated standard streams.
-In cases where standard streams are used, the value in `'directory'` is ignored.
+In cases where standard streams are used, the value in `directory` is ignored.
 URLs are not supported. Defaults to a composite filename that contains
 timestamp, PID and sequence number.
 
@@ -522,7 +522,7 @@ process.report.reportOnFatalError = true;
 process.report.reportOnSignal = true;
 process.report.reportOnUncaughtException = false;
 
-// Change the default signal to `SIGQUIT` and enable it.
+// Change the default signal to 'SIGQUIT' and enable it.
 process.report.reportOnFatalError = false;
 process.report.reportOnUncaughtException = false;
 process.report.reportOnSignal = true;


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

* Fix heading levels.
* Fix section sorting.
* Add quotes around string values.
* Remove quotes around property names.
