### PR TITLE
process: move more dependency of environment variables to pre-execution

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -115,12 +115,9 @@ if (isMainThread) {
 }
 
 const {
-  onWarning,
   emitWarning
 } = NativeModule.require('internal/process/warning');
-if (!process.noProcessWarnings && process.env.NODE_NO_WARNINGS !== '1') {
-  process.on('warning', onWarning);
-}
+
 process.emitWarning = emitWarning;
 
 const {

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -278,29 +278,6 @@ Object.defineProperty(process, 'features', {
     hasUncaughtExceptionCaptureCallback;
 }
 
-// User-facing NODE_V8_COVERAGE environment variable that writes
-// ScriptCoverage to a specified file.
-if (process.env.NODE_V8_COVERAGE) {
-  const originalReallyExit = process.reallyExit;
-  const cwd = NativeModule.require('internal/process/execution').tryGetCwd();
-  const { resolve } = NativeModule.require('path');
-  // Resolve the coverage directory to an absolute path, and
-  // overwrite process.env so that the original path gets passed
-  // to child processes even when they switch cwd.
-  const coverageDirectory = resolve(cwd, process.env.NODE_V8_COVERAGE);
-  process.env.NODE_V8_COVERAGE = coverageDirectory;
-  const {
-    writeCoverage,
-    setCoverageDirectory
-  } = NativeModule.require('internal/coverage-gen/with_profiler');
-  setCoverageDirectory(coverageDirectory);
-  process.on('exit', writeCoverage);
-  process.reallyExit = (code) => {
-    writeCoverage();
-    originalReallyExit(code);
-  };
-}
-
 function setupProcessObject() {
   const EventEmitter = NativeModule.require('events');
   const origProcProto = Object.getPrototypeOf(process);

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -10,6 +10,14 @@ function prepareMainThreadExecution() {
 
   setupWarningHandler();
 
+  // Resolve the coverage directory to an absolute path, and
+  // overwrite process.env so that the original path gets passed
+  // to child processes even when they switch cwd.
+  if (process.env.NODE_V8_COVERAGE) {
+    process.env.NODE_V8_COVERAGE =
+      setupCoverageHooks(process.env.NODE_V8_COVERAGE);
+  }
+
   // Only main thread receives signals.
   setupSignalHandlers();
 
@@ -45,6 +53,26 @@ function setupWarningHandler() {
   if (!process.noProcessWarnings && process.env.NODE_NO_WARNINGS !== '1') {
     process.on('warning', onWarning);
   }
+}
+
+// Setup User-facing NODE_V8_COVERAGE environment variable that writes
+// ScriptCoverage to a specified file.
+function setupCoverageHooks(dir) {
+  const originalReallyExit = process.reallyExit;
+  const cwd = require('internal/process/execution').tryGetCwd();
+  const { resolve } = require('path');
+  const coverageDirectory = resolve(cwd, dir);
+  const {
+    writeCoverage,
+    setCoverageDirectory
+  } = require('internal/coverage-gen/with_profiler');
+  setCoverageDirectory(coverageDirectory);
+  process.on('exit', writeCoverage);
+  process.reallyExit = (code) => {
+    writeCoverage();
+    originalReallyExit(code);
+  };
+  return coverageDirectory;
 }
 
 function initializeReport() {
@@ -242,6 +270,7 @@ function loadPreloadModules() {
 }
 
 module.exports = {
+  setupCoverageHooks,
   setupWarningHandler,
   prepareMainThreadExecution,
   initializeDeprecations,

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -8,6 +8,8 @@ let traceEventsAsyncHook;
 function prepareMainThreadExecution() {
   setupTraceCategoryState();
 
+  setupWarningHandler();
+
   // Only main thread receives signals.
   setupSignalHandlers();
 
@@ -34,6 +36,15 @@ function prepareMainThreadExecution() {
   initializeFrozenIntrinsics();
   initializeESMLoader();
   loadPreloadModules();
+}
+
+function setupWarningHandler() {
+  const {
+    onWarning
+  } = require('internal/process/warning');
+  if (!process.noProcessWarnings && process.env.NODE_NO_WARNINGS !== '1') {
+    process.on('warning', onWarning);
+  }
 }
 
 function initializeReport() {
@@ -231,6 +242,7 @@ function loadPreloadModules() {
 }
 
 module.exports = {
+  setupWarningHandler,
   prepareMainThreadExecution,
   initializeDeprecations,
   initializeESMLoader,

--- a/lib/internal/main/inspect.js
+++ b/lib/internal/main/inspect.js
@@ -2,6 +2,12 @@
 
 // `node inspect ...` or `node debug ...`
 
+const {
+  prepareMainThreadExecution
+} = require('internal/bootstrap/pre_execution');
+
+prepareMainThreadExecution();
+
 if (process.argv[1] === 'debug') {
   process.emitWarning(
     '`node debug` is deprecated. Please use `node inspect` instead.',

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -4,6 +4,7 @@
 // message port.
 
 const {
+  setupWarningHandler,
   initializeDeprecations,
   initializeESMLoader,
   initializeFrozenIntrinsics,
@@ -38,6 +39,8 @@ const {
 
 const publicWorker = require('worker_threads');
 const debug = require('util').debuglog('worker');
+
+setupWarningHandler();
 
 debug(`[${threadId}] is setting up worker child environment`);
 

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -4,6 +4,7 @@
 // message port.
 
 const {
+  setupCoverageHooks,
   setupWarningHandler,
   initializeDeprecations,
   initializeESMLoader,
@@ -41,6 +42,12 @@ const publicWorker = require('worker_threads');
 const debug = require('util').debuglog('worker');
 
 setupWarningHandler();
+
+// Since worker threads cannot switch cwd, we do not need to
+// overwrite the process.env.NODE_V8_COVERAGE variable.
+if (process.env.NODE_V8_COVERAGE) {
+  setupCoverageHooks(process.env.NODE_V8_COVERAGE);
+}
 
 debug(`[${threadId}] is setting up worker child environment`);
 


### PR DESCRIPTION
#### process: call `prepareMainThreadExecution` in `node inspect`

Since we should treat the node-inspect as third-party
user code.

#### process: set up process warning handler in pre-execution

Since it depends on environment variables.

#### process: handle process.env.NODE_V8_COVERAGE in pre-execution

Since this depends on environment variable, and the worker threads
do not need to persist the variable value because they cannot
switch cwd.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
