### PR TITLE
http: send connection: close on client error

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -507,10 +507,12 @@ function onParserExecute(server, socket, parser, state, ret) {
 
 const noop = () => {};
 const badRequestResponse = Buffer.from(
-  `HTTP/1.1 400 ${STATUS_CODES[400]}${CRLF}${CRLF}`, 'ascii'
+  `HTTP/1.1 400 ${STATUS_CODES[400]}${CRLF}` +
+  `Connection: close${CRLF}${CRLF}`, 'ascii'
 );
 const requestHeaderFieldsTooLargeResponse = Buffer.from(
-  `HTTP/1.1 431 ${STATUS_CODES[431]}${CRLF}${CRLF}`, 'ascii'
+  `HTTP/1.1 431 ${STATUS_CODES[431]}${CRLF}` +
+  `Connection: close${CRLF}${CRLF}`, 'ascii'
 );
 function socketOnError(e) {
   // Ignore further errors

--- a/test/parallel/test-http-blank-header.js
+++ b/test/parallel/test-http-blank-header.js
@@ -52,7 +52,9 @@ server.listen(0, common.mustCall(() => {
     received += data.toString();
   }));
   c.on('end', common.mustCall(() => {
-    assert.strictEqual(received, 'HTTP/1.1 400 Bad Request\r\n\r\n');
+    assert.strictEqual(received,
+                       'HTTP/1.1 400 Bad Request\r\n' +
+                       'Connection: close\r\n\r\n');
     c.end();
   }));
   c.on('close', common.mustCall(() => server.close()));

--- a/test/parallel/test-http-header-overflow.js
+++ b/test/parallel/test-http-header-overflow.js
@@ -39,7 +39,8 @@ server.listen(0, mustCall(() => {
   c.on('end', mustCall(() => {
     assert.strictEqual(
       received,
-      'HTTP/1.1 431 Request Header Fields Too Large\r\n\r\n'
+      'HTTP/1.1 431 Request Header Fields Too Large\r\n' +
+      'Connection: close\r\n\r\n'
     );
     c.end();
   }));

--- a/test/parallel/test-http-server-destroy-socket-on-client-error.js
+++ b/test/parallel/test-http-server-destroy-socket-on-client-error.js
@@ -37,7 +37,9 @@ server.listen(0, () => {
   });
 
   socket.on('end', mustCall(() => {
-    const expected = Buffer.from('HTTP/1.1 400 Bad Request\r\n\r\n');
+    const expected = Buffer.from(
+      'HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n'
+    );
     assert(Buffer.concat(chunks).equals(expected));
 
     server.close();


### PR DESCRIPTION
HTTP/1.1 mandates connections which do not support keep-alive and
close the connection send the connection: close header, see
https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.10

This page also provides more information:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection

I understand that HTTP/1.1 defaults to keep-alive - and that the
Connection: close header is required when closing a connection.

This adds the Connection: close header in the 400 and 414
responses sent on client errors.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
