### PR TITLE
lib: explicitly initialize debuglog during bootstrap

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -27,8 +27,15 @@ Readable.ReadableState = ReadableState;
 const EE = require('events');
 const Stream = require('stream');
 const { Buffer } = require('buffer');
-const util = require('util');
-const debug = util.debuglog('stream');
+
+let debuglog;
+function debug(...args) {
+  if (!debuglog) {
+    debuglog = require('internal/util/debuglog').debuglog('stream');
+  }
+  debuglog(...args);
+}
+
 const BufferList = require('internal/streams/buffer_list');
 const destroyImpl = require('internal/streams/destroy');
 const { getHighWaterMark } = require('internal/streams/state');

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -8,6 +8,8 @@ let traceEventsAsyncHook;
 function prepareMainThreadExecution() {
   setupTraceCategoryState();
 
+  setupDebugEnv();
+
   // Only main thread receives signals.
   setupSignalHandlers();
 
@@ -50,6 +52,10 @@ function initializeReport() {
       return report;
     }
   });
+}
+
+function setupDebugEnv() {
+  require('internal/util/debuglog').initializeDebugEnv(process.env.NODE_DEBUG);
 }
 
 function setupSignalHandlers() {
@@ -231,6 +237,7 @@ function loadPreloadModules() {
 }
 
 module.exports = {
+  setupDebugEnv,
   prepareMainThreadExecution,
   initializeDeprecations,
   initializeESMLoader,

--- a/lib/internal/main/inspect.js
+++ b/lib/internal/main/inspect.js
@@ -2,6 +2,12 @@
 
 // `node inspect ...` or `node debug ...`
 
+const {
+  prepareMainThreadExecution
+} = require('internal/bootstrap/pre_execution');
+
+prepareMainThreadExecution();
+
 if (process.argv[1] === 'debug') {
   process.emitWarning(
     '`node debug` is deprecated. Please use `node inspect` instead.',

--- a/lib/internal/main/print_bash_completion.js
+++ b/lib/internal/main/print_bash_completion.js
@@ -1,6 +1,10 @@
 'use strict';
 const { options, aliases } = require('internal/options');
 
+const {
+  prepareMainThreadExecution
+} = require('internal/bootstrap/pre_execution');
+
 function print(stream) {
   const all_opts = [...options.keys(), ...aliases.keys()];
 
@@ -17,6 +21,8 @@ function print(stream) {
 }
 complete -F _node_complete node node_g`);
 }
+
+prepareMainThreadExecution();
 
 markBootstrapComplete();
 

--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -3,6 +3,10 @@
 const { types } = internalBinding('options');
 const hasCrypto = Boolean(process.versions.openssl);
 
+const {
+  prepareMainThreadExecution
+} = require('internal/bootstrap/pre_execution');
+
 const typeLookup = [];
 for (const key of Object.keys(types))
   typeLookup[types[key]] = key;
@@ -170,6 +174,8 @@ function print(stream) {
 
   stream.write('\nDocumentation can be found at https://nodejs.org/\n');
 }
+
+prepareMainThreadExecution();
 
 markBootstrapComplete();
 

--- a/lib/internal/main/prof_process.js
+++ b/lib/internal/main/prof_process.js
@@ -1,4 +1,9 @@
 'use strict';
 
+const {
+  prepareMainThreadExecution
+} = require('internal/bootstrap/pre_execution');
+
+prepareMainThreadExecution();
 markBootstrapComplete();
 require('internal/v8_prof_processor');

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -4,6 +4,7 @@
 // message port.
 
 const {
+  setupDebugEnv,
   initializeDeprecations,
   initializeESMLoader,
   initializeFrozenIntrinsics,
@@ -37,6 +38,9 @@ const {
 } = require('internal/process/execution');
 
 const publicWorker = require('worker_threads');
+
+setupDebugEnv();
+
 const debug = require('util').debuglog('worker');
 
 debug(`[${threadId}] is setting up worker child environment`);

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -174,7 +174,13 @@ Object.defineProperty(Module, 'wrapper', {
   }
 });
 
-const debug = util.debuglog('module');
+let debuglog;
+function debug(...args) {
+  if (!debuglog) {
+    debuglog = require('internal/util/debuglog').debuglog('module');
+  }
+  debuglog(...args);
+}
 
 Module._debug = util.deprecate(debug, 'Module._debug is deprecated.',
                                'DEP0077');

--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { format } = require('internal/util/inspect');
+
+// `debugs` is deliberately initialized to undefined so any call to
+// debuglog() before initializeDebugEnv() is called will throw.
+let debugs;
+
+let debugEnvRegex = /^$/;
+
+// `debugEnv` is initial value of process.env.NODE_DEBUG
+function initializeDebugEnv(debugEnv) {
+  debugs = {};
+  if (debugEnv) {
+    debugEnv = debugEnv.replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
+      .replace(/\*/g, '.*')
+      .replace(/,/g, '$|^')
+      .toUpperCase();
+    debugEnvRegex = new RegExp(`^${debugEnv}$`, 'i');
+  }
+}
+
+// Emits warning when user sets
+// NODE_DEBUG=http or NODE_DEBUG=http2.
+function emitWarningIfNeeded(set) {
+  if ('HTTP' === set || 'HTTP2' === set) {
+    process.emitWarning('Setting the NODE_DEBUG environment variable ' +
+      'to \'' + set.toLowerCase() + '\' can expose sensitive ' +
+      'data (such as passwords, tokens and authentication headers) ' +
+      'in the resulting log.');
+  }
+}
+
+function debuglog(set) {
+  set = set.toUpperCase();
+  if (!debugs[set]) {
+    if (debugEnvRegex.test(set)) {
+      const pid = process.pid;
+      emitWarningIfNeeded(set);
+      debugs[set] = function debug(...args) {
+        const msg = format(...args);
+        console.error('%s %d: %s', set, pid, msg);
+      };
+    } else {
+      debugs[set] = function debug() {};
+    }
+  }
+  return debugs[set];
+}
+
+module.exports = {
+  debuglog,
+  initializeDebugEnv
+};

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1363,8 +1363,139 @@ function reduceToSingleString(ctx, output, base, braces, combine = false) {
   return `${braces[0]}${ln}${join(output, `,\n${indentation}  `)} ${braces[1]}`;
 }
 
+const emptyOptions = {};
+function format(...args) {
+  return formatWithOptions(emptyOptions, ...args);
+}
+
+
+let CIRCULAR_ERROR_MESSAGE;
+function tryStringify(arg) {
+  try {
+    return JSON.stringify(arg);
+  } catch (err) {
+    // Populate the circular error message lazily
+    if (!CIRCULAR_ERROR_MESSAGE) {
+      try {
+        const a = {}; a.a = a; JSON.stringify(a);
+      } catch (err) {
+        CIRCULAR_ERROR_MESSAGE = err.message;
+      }
+    }
+    if (err.name === 'TypeError' && err.message === CIRCULAR_ERROR_MESSAGE)
+      return '[Circular]';
+    throw err;
+  }
+}
+
+function formatWithOptions(inspectOptions, ...args) {
+  const first = args[0];
+  let a = 0;
+  let str = '';
+  let join = '';
+
+  if (typeof first === 'string') {
+    if (args.length === 1) {
+      return first;
+    }
+    let tempStr;
+    let lastPos = 0;
+
+    for (var i = 0; i < first.length - 1; i++) {
+      if (first.charCodeAt(i) === 37) { // '%'
+        const nextChar = first.charCodeAt(++i);
+        if (a + 1 !== args.length) {
+          switch (nextChar) {
+            case 115: // 's'
+              tempStr = String(args[++a]);
+              break;
+            case 106: // 'j'
+              tempStr = tryStringify(args[++a]);
+              break;
+            case 100: // 'd'
+              const tempNum = args[++a];
+              // eslint-disable-next-line valid-typeof
+              if (typeof tempNum === 'bigint') {
+                tempStr = `${tempNum}n`;
+              } else if (typeof tempNum === 'symbol') {
+                tempStr = 'NaN';
+              } else {
+                tempStr = `${Number(tempNum)}`;
+              }
+              break;
+            case 79: // 'O'
+              tempStr = inspect(args[++a], inspectOptions);
+              break;
+            case 111: // 'o'
+            {
+              tempStr = inspect(args[++a], {
+                ...inspectOptions,
+                showHidden: true,
+                showProxy: true,
+                depth: 4
+              });
+              break;
+            }
+            case 105: // 'i'
+              const tempInteger = args[++a];
+              // eslint-disable-next-line valid-typeof
+              if (typeof tempInteger === 'bigint') {
+                tempStr = `${tempInteger}n`;
+              } else if (typeof tempInteger === 'symbol') {
+                tempStr = 'NaN';
+              } else {
+                tempStr = `${parseInt(tempInteger)}`;
+              }
+              break;
+            case 102: // 'f'
+              const tempFloat = args[++a];
+              if (typeof tempFloat === 'symbol') {
+                tempStr = 'NaN';
+              } else {
+                tempStr = `${parseFloat(tempFloat)}`;
+              }
+              break;
+            case 37: // '%'
+              str += first.slice(lastPos, i);
+              lastPos = i + 1;
+              continue;
+            default: // Any other character is not a correct placeholder
+              continue;
+          }
+          if (lastPos !== i - 1) {
+            str += first.slice(lastPos, i - 1);
+          }
+          str += tempStr;
+          lastPos = i + 1;
+        } else if (nextChar === 37) {
+          str += first.slice(lastPos, i);
+          lastPos = i + 1;
+        }
+      }
+    }
+    if (lastPos !== 0) {
+      a++;
+      join = ' ';
+      if (lastPos < first.length) {
+        str += first.slice(lastPos);
+      }
+    }
+  }
+
+  while (a < args.length) {
+    const value = args[a];
+    str += join;
+    str += typeof value !== 'string' ? inspect(value, inspectOptions) : value;
+    join = ' ';
+    a++;
+  }
+  return str;
+}
+
 module.exports = {
   inspect,
   formatProperty,
-  kObjectType
+  kObjectType,
+  format,
+  formatWithOptions
 };

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events');
 const assert = require('internal/assert');
 const path = require('path');
-const util = require('util');
+
 const {
   ERR_WORKER_PATH,
   ERR_WORKER_UNSERIALIZABLE_ERROR,
@@ -45,7 +45,13 @@ const kOnCouldNotSerializeErr = Symbol('kOnCouldNotSerializeErr');
 const kOnErrorMessage = Symbol('kOnErrorMessage');
 const kParentSideStdio = Symbol('kParentSideStdio');
 
-const debug = util.debuglog('worker');
+let debuglog;
+function debug(...args) {
+  if (!debuglog) {
+    debuglog = require('internal/util/debuglog').debuglog('worker');
+  }
+  debuglog(...args);
+}
 
 class Worker extends EventEmitter {
   constructor(filename, options = {}) {

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -15,7 +15,14 @@ const { threadId } = internalBinding('worker');
 const { Readable, Writable } = require('stream');
 const EventEmitter = require('events');
 const util = require('util');
-const debug = util.debuglog('worker');
+
+let debuglog;
+function debug(...args) {
+  if (!debuglog) {
+    debuglog = require('internal/util/debuglog').debuglog('worker');
+  }
+  debuglog(...args);
+}
 
 const kIncrementsPortRef = Symbol('kIncrementsPortRef');
 const kName = Symbol('kName');

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -42,7 +42,15 @@ const {
 const internalUtil = require('internal/util');
 const util = require('util');
 const { ERR_INVALID_CALLBACK } = require('internal/errors').codes;
-const debug = util.debuglog('timer');
+
+let debuglog;
+function debug(...args) {
+  if (!debuglog) {
+    debuglog = require('internal/util/debuglog').debuglog('timer');
+  }
+  debuglog(...args);
+}
+
 const {
   destroyHooksExist,
   // The needed emit*() functions.

--- a/lib/util.js
+++ b/lib/util.js
@@ -22,7 +22,11 @@
 'use strict';
 
 const errors = require('internal/errors');
-const { inspect } = require('internal/util/inspect');
+const {
+  format,
+  formatWithOptions,
+  inspect
+} = require('internal/util/inspect');
 const {
   ERR_FALSY_VALUE_REJECTION,
   ERR_INVALID_ARG_TYPE,
@@ -46,135 +50,7 @@ function uncurryThis(func) {
 }
 const objectToString = uncurryThis(Object.prototype.toString);
 
-let CIRCULAR_ERROR_MESSAGE;
 let internalDeepEqual;
-
-function tryStringify(arg) {
-  try {
-    return JSON.stringify(arg);
-  } catch (err) {
-    // Populate the circular error message lazily
-    if (!CIRCULAR_ERROR_MESSAGE) {
-      try {
-        const a = {}; a.a = a; JSON.stringify(a);
-      } catch (err) {
-        CIRCULAR_ERROR_MESSAGE = err.message;
-      }
-    }
-    if (err.name === 'TypeError' && err.message === CIRCULAR_ERROR_MESSAGE)
-      return '[Circular]';
-    throw err;
-  }
-}
-
-const emptyOptions = {};
-function format(...args) {
-  return formatWithOptions(emptyOptions, ...args);
-}
-
-function formatWithOptions(inspectOptions, ...args) {
-  const first = args[0];
-  let a = 0;
-  let str = '';
-  let join = '';
-
-  if (typeof first === 'string') {
-    if (args.length === 1) {
-      return first;
-    }
-    let tempStr;
-    let lastPos = 0;
-
-    for (var i = 0; i < first.length - 1; i++) {
-      if (first.charCodeAt(i) === 37) { // '%'
-        const nextChar = first.charCodeAt(++i);
-        if (a + 1 !== args.length) {
-          switch (nextChar) {
-            case 115: // 's'
-              tempStr = String(args[++a]);
-              break;
-            case 106: // 'j'
-              tempStr = tryStringify(args[++a]);
-              break;
-            case 100: // 'd'
-              const tempNum = args[++a];
-              // eslint-disable-next-line valid-typeof
-              if (typeof tempNum === 'bigint') {
-                tempStr = `${tempNum}n`;
-              } else if (typeof tempNum === 'symbol') {
-                tempStr = 'NaN';
-              } else {
-                tempStr = `${Number(tempNum)}`;
-              }
-              break;
-            case 79: // 'O'
-              tempStr = inspect(args[++a], inspectOptions);
-              break;
-            case 111: // 'o'
-            {
-              tempStr = inspect(args[++a], {
-                ...inspectOptions,
-                showHidden: true,
-                showProxy: true,
-                depth: 4
-              });
-              break;
-            }
-            case 105: // 'i'
-              const tempInteger = args[++a];
-              // eslint-disable-next-line valid-typeof
-              if (typeof tempInteger === 'bigint') {
-                tempStr = `${tempInteger}n`;
-              } else if (typeof tempInteger === 'symbol') {
-                tempStr = 'NaN';
-              } else {
-                tempStr = `${parseInt(tempInteger)}`;
-              }
-              break;
-            case 102: // 'f'
-              const tempFloat = args[++a];
-              if (typeof tempFloat === 'symbol') {
-                tempStr = 'NaN';
-              } else {
-                tempStr = `${parseFloat(tempFloat)}`;
-              }
-              break;
-            case 37: // '%'
-              str += first.slice(lastPos, i);
-              lastPos = i + 1;
-              continue;
-            default: // Any other character is not a correct placeholder
-              continue;
-          }
-          if (lastPos !== i - 1) {
-            str += first.slice(lastPos, i - 1);
-          }
-          str += tempStr;
-          lastPos = i + 1;
-        } else if (nextChar === 37) {
-          str += first.slice(lastPos, i);
-          lastPos = i + 1;
-        }
-      }
-    }
-    if (lastPos !== 0) {
-      a++;
-      join = ' ';
-      if (lastPos < first.length) {
-        str += first.slice(lastPos);
-      }
-    }
-  }
-
-  while (a < args.length) {
-    const value = args[a];
-    str += join;
-    str += typeof value !== 'string' ? inspect(value, inspectOptions) : value;
-    join = ' ';
-    a++;
-  }
-  return str;
-}
 
 const debugs = {};
 let debugEnvRegex = /^$/;

--- a/lib/util.js
+++ b/lib/util.js
@@ -27,6 +27,7 @@ const {
   formatWithOptions,
   inspect
 } = require('internal/util/inspect');
+const { debuglog } = require('internal/util/debuglog');
 const {
   ERR_FALSY_VALUE_REJECTION,
   ERR_INVALID_ARG_TYPE,
@@ -51,45 +52,6 @@ function uncurryThis(func) {
 const objectToString = uncurryThis(Object.prototype.toString);
 
 let internalDeepEqual;
-
-const debugs = {};
-let debugEnvRegex = /^$/;
-if (process.env.NODE_DEBUG) {
-  let debugEnv = process.env.NODE_DEBUG;
-  debugEnv = debugEnv.replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
-      .replace(/\*/g, '.*')
-      .replace(/,/g, '$|^')
-      .toUpperCase();
-  debugEnvRegex = new RegExp(`^${debugEnv}$`, 'i');
-}
-
-// Emits warning when user sets
-// NODE_DEBUG=http or NODE_DEBUG=http2.
-function emitWarningIfNeeded(set) {
-  if ('HTTP' === set || 'HTTP2' === set) {
-    process.emitWarning('Setting the NODE_DEBUG environment variable ' +
-      'to \'' + set.toLowerCase() + '\' can expose sensitive ' +
-      'data (such as passwords, tokens and authentication headers) ' +
-      'in the resulting log.');
-  }
-}
-
-function debuglog(set) {
-  set = set.toUpperCase();
-  if (!debugs[set]) {
-    if (debugEnvRegex.test(set)) {
-      const pid = process.pid;
-      emitWarningIfNeeded(set);
-      debugs[set] = function debug() {
-        const msg = exports.format.apply(exports, arguments);
-        console.error('%s %d: %s', set, pid, msg);
-      };
-    } else {
-      debugs[set] = function debug() {};
-    }
-  }
-  return debugs[set];
-}
 
 function isBoolean(arg) {
   return typeof arg === 'boolean';

--- a/node.gyp
+++ b/node.gyp
@@ -185,6 +185,7 @@
       'lib/internal/url.js',
       'lib/internal/util.js',
       'lib/internal/util/comparisons.js',
+      'lib/internal/util/debuglog.js',
       'lib/internal/util/inspect.js',
       'lib/internal/util/inspector.js',
       'lib/internal/util/types.js',


### PR DESCRIPTION
#### lib: move format and formatWithOptions into internal/util/inspect.js

So these can be required without requiring the whole `util.js`.

#### process: call prepareMainThreadExecution in all main thread scripts

#### lib: explicitly initialize debuglog during bootstrap

This patch splits the implementation of util.debuglog into a
separate file and explicitly initialize it during pre-execution
since the initialization depends on environment variables.
Also delays the call to `debuglog` in modules that are loaded during
bootstrap to make sure we only access the environment variable
during pre-execution.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
