### PR TITLE
src: cleanup in all return paths in node::Start

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -760,6 +760,7 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   HandleScope handle_scope(isolate);
   Local<Context> context = NewContext(isolate);
   Context::Scope context_scope(context);
+  int exit_code = 0;
   Environment env(
       isolate_data,
       context,
@@ -780,7 +781,8 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
                                true);
   if (env.options()->debug_options().inspector_enabled &&
       !env.inspector_agent()->IsListening()) {
-    return 12;  // Signal internal error.
+    exit_code = 12;  // Signal internal error.
+    goto exit;
   }
 #else
   // inspector_enabled can't be true if !HAVE_INSPECTOR or !NODE_USE_V8_PLATFORM
@@ -821,10 +823,11 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
 
   env.set_trace_sync_io(false);
 
-  const int exit_code = EmitExit(&env);
+  exit_code = EmitExit(&env);
 
   WaitForInspectorDisconnect(&env);
 
+exit:
   env.set_can_call_into_js(false);
   env.stop_sub_worker_contexts();
   uv_tty_reset_mode();


### PR DESCRIPTION
`node::Start` creates a number of artifacts in its scope which are
cleaned up in the exit path, but there is at least one path where the
cleanups are bypassed. Force all paths follow the exit sequence.

Refs: https://github.com/nodejs/node/pull/21283

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
