### PR TITLE
src: forbid access to CLI options before bootstrapping is done

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -5,10 +5,6 @@ const {
   ERR_INVALID_ASYNC_ID
 } = require('internal/errors').codes;
 
-const { getOptionValue } = require('internal/options');
-const shouldAbortOnUncaughtException =
-  getOptionValue('--abort-on-uncaught-exception');
-
 const async_wrap = internalBinding('async_wrap');
 /* async_hook_fields is a Uint32Array wrapping the uint32_t array of
  * Environment::AsyncHooks::fields_[]. Each index tracks the number of active
@@ -112,7 +108,9 @@ function fatalError(e) {
     Error.captureStackTrace(o, fatalError);
     process._rawDebug(o.stack);
   }
-  if (shouldAbortOnUncaughtException) {
+
+  const { getOptionValue } = require('internal/options');
+  if (getOptionValue('--abort-on-uncaught-exception')) {
     process.abort();
   }
   process.exit(1);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -564,6 +564,12 @@ HostPort SplitHostPort(const std::string& arg,
 void GetOptions(const FunctionCallbackInfo<Value>& args) {
   Mutex::ScopedLock lock(per_process::cli_options_mutex);
   Environment* env = Environment::GetCurrent(args);
+  if (!env->has_run_bootstrapping_code()) {
+    // No code because this is an assertion.
+    return env->ThrowError(
+        "Should not query options before bootstrapping is done");
+  }
+
   Isolate* isolate = env->isolate();
   Local<Context> context = env->context();
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
