### PR TITLE
doc: edit "Involving the TSC"

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -374,13 +374,12 @@ deprecation level of an API.
 ### Involving the TSC
 
 Collaborators may opt to elevate pull requests or issues to the [TSC][].
-This should be done where a pull request:
+Do this if a pull request or issue:
 
 - is labeled `semver-major`, or
 - has a significant impact on the codebase, or
-- is inherently controversial, or
-- has failed to reach consensus amongst the Collaborators who are
-  actively participating in the discussion.
+- is controversial, or
+- is at an impasse among Collaborators who are  participating in the discussion.
 
 Assign the `tsc-review` label or @-mention the
 `@nodejs/tsc` GitHub team if you want to elevate an issue to the [TSC][].

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -379,7 +379,7 @@ Do this if a pull request or issue:
 - is labeled `semver-major`, or
 - has a significant impact on the codebase, or
 - is controversial, or
-- is at an impasse among Collaborators who are  participating in the discussion.
+- is at an impasse among Collaborators who are participating in the discussion.
 
 Assign the `tsc-review` label or @-mention the
 `@nodejs/tsc` GitHub team if you want to elevate an issue to the [TSC][].


### PR DESCRIPTION
Edit the "Involving the TSC" section of the Collaborator Guide to reduce
passive voice, make things concise, etc.

One thing I didn't do here but that I would definitely do if there is consensus: Remove mention of the `tsc-review` label and just tell people to @-mention the TSC. Sure, notification overload is a problem, but the `tsc-review` label always gets ignored. It's not even a placebo. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
