### PR TITLE
http: check "parser" existence in various conditions for http client

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -48,7 +48,7 @@ const {
 const { validateTimerDuration } = require('internal/timers');
 const is_reused_symbol = require('internal/freelist').symbols.is_reused_symbol;
 
-var INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
+const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 
 function validateHost(host, name) {
   if (host !== null && host !== undefined && typeof host !== 'string') {

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -97,8 +97,8 @@ function ClientRequest(input, options, cb) {
     options = Object.assign(input || {}, options);
   }
 
-  var agent = options.agent;
-  var defaultAgent = options._defaultAgent || Agent.globalAgent;
+  let agent = options.agent;
+  const defaultAgent = options._defaultAgent || Agent.globalAgent;
   if (agent === false) {
     agent = new defaultAgent.constructor();
   } else if (agent === null || agent === undefined) {
@@ -114,12 +114,12 @@ function ClientRequest(input, options, cb) {
   }
   this.agent = agent;
 
-  var protocol = options.protocol || defaultAgent.protocol;
-  var expectedProtocol = defaultAgent.protocol;
+  const protocol = options.protocol || defaultAgent.protocol;
+  let expectedProtocol = defaultAgent.protocol;
   if (this.agent && this.agent.protocol)
     expectedProtocol = this.agent.protocol;
 
-  var path;
+  let path;
   if (options.path) {
     path = String(options.path);
     if (INVALID_PATH_REGEX.test(path))
@@ -130,22 +130,22 @@ function ClientRequest(input, options, cb) {
     throw new ERR_INVALID_PROTOCOL(protocol, expectedProtocol);
   }
 
-  var defaultPort = options.defaultPort ||
+  const defaultPort = options.defaultPort ||
                     this.agent && this.agent.defaultPort;
 
-  var port = options.port = options.port || defaultPort || 80;
-  var host = options.host = validateHost(options.hostname, 'hostname') ||
+  const port = options.port = options.port || defaultPort || 80;
+  const host = options.host = validateHost(options.hostname, 'hostname') ||
                             validateHost(options.host, 'host') || 'localhost';
 
-  var setHost = (options.setHost === undefined || Boolean(options.setHost));
+  const setHost = (options.setHost === undefined || Boolean(options.setHost));
 
   this.socketPath = options.socketPath;
 
   if (options.timeout !== undefined)
     this.timeout = validateTimerDuration(options.timeout, 'timeout');
 
-  var method = options.method;
-  var methodIsString = (typeof method === 'string');
+  let method = options.method;
+  const methodIsString = (typeof method === 'string');
   if (method !== null && method !== undefined && !methodIsString) {
     throw new ERR_INVALID_ARG_TYPE('method', 'string', method);
   }
@@ -182,7 +182,7 @@ function ClientRequest(input, options, cb) {
   this.parser = null;
   this.maxHeadersCount = null;
 
-  var called = false;
+  let called = false;
 
   if (this.agent) {
     // If there is an agent we should default to Connection:keep-alive,
@@ -198,23 +198,23 @@ function ClientRequest(input, options, cb) {
     }
   }
 
-  var headersArray = Array.isArray(options.headers);
+  const headersArray = Array.isArray(options.headers);
   if (!headersArray) {
     if (options.headers) {
-      var keys = Object.keys(options.headers);
+      const keys = Object.keys(options.headers);
       for (var i = 0; i < keys.length; i++) {
-        var key = keys[i];
+        const key = keys[i];
         this.setHeader(key, options.headers[key]);
       }
     }
 
     if (host && !this.getHeader('host') && setHost) {
-      var hostHeader = host;
+      let hostHeader = host;
 
       // For the Host header, ensure that IPv6 addresses are enclosed
       // in square brackets, as defined by URI formatting
       // https://tools.ietf.org/html/rfc3986#section-3.2.2
-      var posColon = hostHeader.indexOf(':');
+      const posColon = hostHeader.indexOf(':');
       if (posColon !== -1 &&
           hostHeader.indexOf(':', posColon + 1) !== -1 &&
           hostHeader.charCodeAt(0) !== 91/* '[' */) {
@@ -245,7 +245,7 @@ function ClientRequest(input, options, cb) {
                       options.headers);
   }
 
-  var oncreate = (err, socket) => {
+  const oncreate = (err, socket) => {
     if (called)
       return;
     called = true;
@@ -327,15 +327,15 @@ function emitAbortNT() {
 
 function createHangUpError() {
   // eslint-disable-next-line no-restricted-syntax
-  var error = new Error('socket hang up');
+  const error = new Error('socket hang up');
   error.code = 'ECONNRESET';
   return error;
 }
 
 
 function socketCloseListener() {
-  var socket = this;
-  var req = socket._httpMessage;
+  const socket = this;
+  const req = socket._httpMessage;
   debug('HTTP socket close');
 
   // Pull through final chunk, if anything is buffered.
@@ -363,7 +363,7 @@ function socketCloseListener() {
       res.emit('close');
     }
   } else {
-    if (!req.socket._hadError) {
+    if (parser && !req.socket._hadError) {
       // This socket error fired before we started to
       // receive a response. The error needs to
       // fire on the request.
@@ -386,8 +386,8 @@ function socketCloseListener() {
 }
 
 function socketErrorListener(err) {
-  var socket = this;
-  var req = socket._httpMessage;
+  const socket = this;
+  const req = socket._httpMessage;
   debug('SOCKET ERROR:', err.message, err.stack);
 
   if (req) {
@@ -400,7 +400,7 @@ function socketErrorListener(err) {
   // Handle any pending data
   socket.read();
 
-  var parser = socket.parser;
+  const parser = socket.parser;
   if (parser) {
     parser.finish();
     freeParser(parser, req, socket);
@@ -413,18 +413,18 @@ function socketErrorListener(err) {
 }
 
 function freeSocketErrorListener(err) {
-  var socket = this;
+  const socket = this;
   debug('SOCKET ERROR on FREE socket:', err.message, err.stack);
   socket.destroy();
   socket.emit('agentRemove');
 }
 
 function socketOnEnd() {
-  var socket = this;
-  var req = this._httpMessage;
-  var parser = this.parser;
+  const socket = this;
+  const req = this._httpMessage;
+  const parser = this.parser;
 
-  if (!req.res && !req.socket._hadError) {
+  if (parser && !req.res && !req.socket._hadError) {
     // If we don't have a response then we know that the socket
     // ended prematurely and we need to emit an error on the request.
     req.socket._hadError = true;
@@ -438,61 +438,63 @@ function socketOnEnd() {
 }
 
 function socketOnData(d) {
-  var socket = this;
-  var req = this._httpMessage;
-  var parser = this.parser;
+  const socket = this;
+  const req = this._httpMessage;
+  const parser = this.parser;
 
-  assert(parser && parser.socket === socket);
+  if (parser) {
+    assert(parser.socket === socket);
 
-  var ret = parser.execute(d);
-  if (ret instanceof Error) {
-    debug('parse error', ret);
-    freeParser(parser, req, socket);
-    socket.destroy();
-    req.socket._hadError = true;
-    req.emit('error', ret);
-  } else if (parser.incoming && parser.incoming.upgrade) {
-    // Upgrade (if status code 101) or CONNECT
-    var bytesParsed = ret;
-    var res = parser.incoming;
-    req.res = res;
-
-    socket.removeListener('data', socketOnData);
-    socket.removeListener('end', socketOnEnd);
-    socket.removeListener('drain', ondrain);
-    parser.finish();
-    freeParser(parser, req, socket);
-
-    var bodyHead = d.slice(bytesParsed, d.length);
-
-    var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
-    if (req.listenerCount(eventName) > 0) {
-      req.upgradeOrConnect = true;
-
-      // detach the socket
-      socket.emit('agentRemove');
-      socket.removeListener('close', socketCloseListener);
-      socket.removeListener('error', socketErrorListener);
-
-      socket._httpMessage = null;
-      socket.readableFlowing = null;
-
-      req.emit(eventName, res, socket, bodyHead);
-      req.emit('close');
-    } else {
-      // Requested Upgrade or used CONNECT method, but have no handler.
+    const ret = parser.execute(d);
+    if (ret instanceof Error) {
+      debug('parse error', ret);
+      freeParser(parser, req, socket);
       socket.destroy();
+      req.socket._hadError = true;
+      req.emit('error', ret);
+    } else if (parser.incoming && parser.incoming.upgrade) {
+      // Upgrade (if status code 101) or CONNECT
+      const bytesParsed = ret;
+      const res = parser.incoming;
+      req.res = res;
+
+      socket.removeListener('data', socketOnData);
+      socket.removeListener('end', socketOnEnd);
+      socket.removeListener('drain', ondrain);
+      parser.finish();
+      freeParser(parser, req, socket);
+
+      const bodyHead = d.slice(bytesParsed, d.length);
+
+      const eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
+      if (req.listenerCount(eventName) > 0) {
+        req.upgradeOrConnect = true;
+
+        // detach the socket
+        socket.emit('agentRemove');
+        socket.removeListener('close', socketCloseListener);
+        socket.removeListener('error', socketErrorListener);
+
+        socket._httpMessage = null;
+        socket.readableFlowing = null;
+
+        req.emit(eventName, res, socket, bodyHead);
+        req.emit('close');
+      } else {
+        // Requested Upgrade or used CONNECT method, but have no handler.
+        socket.destroy();
+      }
+    } else if (parser.incoming && parser.incoming.complete &&
+      // When the status code is informational (100, 102-199),
+      // the server will send a final response after this client
+      // sends a request body, so we must not free the parser.
+      // 101 (Switching Protocols) and all other status codes
+      // should be processed normally.
+      !statusIsInformational(parser.incoming.statusCode)) {
+      socket.removeListener('data', socketOnData);
+      socket.removeListener('end', socketOnEnd);
+      freeParser(parser, req, socket);
     }
-  } else if (parser.incoming && parser.incoming.complete &&
-             // When the status code is informational (100, 102-199),
-             // the server will send a final response after this client
-             // sends a request body, so we must not free the parser.
-             // 101 (Switching Protocols) and all other status codes
-             // should be processed normally.
-             !statusIsInformational(parser.incoming.statusCode)) {
-    socket.removeListener('data', socketOnData);
-    socket.removeListener('end', socketOnEnd);
-    freeParser(parser, req, socket);
   }
 }
 
@@ -506,8 +508,8 @@ function statusIsInformational(status) {
 
 // client
 function parserOnIncomingClient(res, shouldKeepAlive) {
-  var socket = this.socket;
-  var req = socket._httpMessage;
+  const socket = this.socket;
+  const req = socket._httpMessage;
 
   debug('AGENT incoming response!');
 
@@ -557,7 +559,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
   // Add our listener first, so that we guarantee socket cleanup
   res.on('end', responseOnEnd);
   req.on('prefinish', requestOnPrefinish);
-  var handled = req.emit('response', res);
+  const handled = req.emit('response', res);
 
   // If the user did not listen for the 'response' event, then they
   // can't possibly read the data, so we ._dump() it into the void
@@ -573,7 +575,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
 
 // client
 function responseKeepAlive(res, req) {
-  var socket = req.socket;
+  const socket = req.socket;
 
   if (!req.shouldKeepAlive) {
     if (socket.writable) {
@@ -627,39 +629,42 @@ function emitFreeNT(socket) {
 }
 
 function tickOnSocket(req, socket) {
-  var parser = parsers.alloc();
-  req.socket = socket;
-  req.connection = socket;
-  parser.reinitialize(HTTPParser.RESPONSE, parser[is_reused_symbol]);
-  parser.socket = socket;
-  parser.outgoing = req;
-  req.parser = parser;
+  const parser = parsers.alloc();
+  if (parser) {
+    req.socket = socket;
+    req.connection = socket;
+    parser.reinitialize(HTTPParser.RESPONSE, parser[is_reused_symbol]);
+    parser.socket = socket;
+    parser.outgoing = req;
 
-  socket.parser = parser;
-  socket._httpMessage = req;
+    req.parser = parser;
 
-  // Setup "drain" propagation.
-  httpSocketSetup(socket);
+    socket.parser = parser;
+    socket._httpMessage = req;
 
-  // Propagate headers limit from request object to parser
-  if (typeof req.maxHeadersCount === 'number') {
-    parser.maxHeaderPairs = req.maxHeadersCount << 1;
+    // Setup "drain" propagation.
+    httpSocketSetup(socket);
+
+    // Propagate headers limit from request object to parser
+    if (typeof req.maxHeadersCount === 'number') {
+      parser.maxHeaderPairs = req.maxHeadersCount << 1;
+    }
+
+    parser.onIncoming = parserOnIncomingClient;
+    socket.removeListener('error', freeSocketErrorListener);
+    socket.on('error', socketErrorListener);
+    socket.on('data', socketOnData);
+    socket.on('end', socketOnEnd);
+    socket.on('close', socketCloseListener);
+
+    if (
+      req.timeout !== undefined ||
+      (req.agent && req.agent.options && req.agent.options.timeout)
+    ) {
+      listenSocketTimeout(req);
+    }
+    req.emit('socket', socket);
   }
-
-  parser.onIncoming = parserOnIncomingClient;
-  socket.removeListener('error', freeSocketErrorListener);
-  socket.on('error', socketErrorListener);
-  socket.on('data', socketOnData);
-  socket.on('end', socketOnEnd);
-  socket.on('close', socketCloseListener);
-
-  if (
-    req.timeout !== undefined ||
-    (req.agent && req.agent.options && req.agent.options.timeout)
-  ) {
-    listenSocketTimeout(req);
-  }
-  req.emit('socket', socket);
 }
 
 function listenSocketTimeout(req) {

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -485,11 +485,11 @@ function socketOnData(d) {
         socket.destroy();
       }
     } else if (parser.incoming && parser.incoming.complete &&
-      // When the status code is informational (100, 102-199),
-      // the server will send a final response after this client
-      // sends a request body, so we must not free the parser.
-      // 101 (Switching Protocols) and all other status codes
-      // should be processed normally.
+               // When the status code is informational (100, 102-199),
+               // the server will send a final response after this client
+               // sends a request body, so we must not free the parser.
+               // 101 (Switching Protocols) and all other status codes
+               // should be processed normally.
       !statusIsInformational(parser.incoming.statusCode)) {
       socket.removeListener('data', socketOnData);
       socket.removeListener('end', socketOnEnd);

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -21,10 +21,10 @@
 
 'use strict';
 
-const net = require('net');
-const url = require('url');
-const assert = require('internal/assert');
-const {
+var net = require('net');
+var url = require('url');
+var assert = require('internal/assert');
+var {
   _checkIsHttpToken: checkIsHttpToken,
   debug,
   freeParser,
@@ -32,23 +32,23 @@ const {
   parsers,
   HTTPParser,
 } = require('_http_common');
-const { OutgoingMessage } = require('_http_outgoing');
-const Agent = require('_http_agent');
-const { Buffer } = require('buffer');
-const { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
-const { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
-const { outHeadersKey, ondrain } = require('internal/http');
-const {
+var { OutgoingMessage } = require('_http_outgoing');
+var Agent = require('_http_agent');
+var { Buffer } = require('buffer');
+var { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
+var { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
+var { outHeadersKey, ondrain } = require('internal/http');
+var {
   ERR_HTTP_HEADERS_SENT,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_HTTP_TOKEN,
   ERR_INVALID_PROTOCOL,
   ERR_UNESCAPED_CHARACTERS
 } = require('internal/errors').codes;
-const { validateTimerDuration } = require('internal/timers');
-const is_reused_symbol = require('internal/freelist').symbols.is_reused_symbol;
+var { validateTimerDuration } = require('internal/timers');
+var is_reused_symbol = require('internal/freelist').symbols.is_reused_symbol;
 
-const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
+var INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 
 function validateHost(host, name) {
   if (host !== null && host !== undefined && typeof host !== 'string') {
@@ -59,12 +59,12 @@ function validateHost(host, name) {
   return host;
 }
 
-let urlWarningEmitted = false;
+var urlWarningEmitted = false;
 function ClientRequest(input, options, cb) {
   OutgoingMessage.call(this);
 
   if (typeof input === 'string') {
-    const urlStr = input;
+    var urlStr = input;
     try {
       input = urlToOptions(new URL(urlStr));
     } catch (err) {
@@ -97,8 +97,8 @@ function ClientRequest(input, options, cb) {
     options = Object.assign(input || {}, options);
   }
 
-  let agent = options.agent;
-  const defaultAgent = options._defaultAgent || Agent.globalAgent;
+  var agent = options.agent;
+  var defaultAgent = options._defaultAgent || Agent.globalAgent;
   if (agent === false) {
     agent = new defaultAgent.constructor();
   } else if (agent === null || agent === undefined) {
@@ -114,12 +114,12 @@ function ClientRequest(input, options, cb) {
   }
   this.agent = agent;
 
-  const protocol = options.protocol || defaultAgent.protocol;
-  let expectedProtocol = defaultAgent.protocol;
+  var protocol = options.protocol || defaultAgent.protocol;
+  var expectedProtocol = defaultAgent.protocol;
   if (this.agent && this.agent.protocol)
     expectedProtocol = this.agent.protocol;
 
-  let path;
+  var path;
   if (options.path) {
     path = String(options.path);
     if (INVALID_PATH_REGEX.test(path))
@@ -130,22 +130,22 @@ function ClientRequest(input, options, cb) {
     throw new ERR_INVALID_PROTOCOL(protocol, expectedProtocol);
   }
 
-  const defaultPort = options.defaultPort ||
+  var defaultPort = options.defaultPort ||
                     this.agent && this.agent.defaultPort;
 
-  const port = options.port = options.port || defaultPort || 80;
-  const host = options.host = validateHost(options.hostname, 'hostname') ||
+  var port = options.port = options.port || defaultPort || 80;
+  var host = options.host = validateHost(options.hostname, 'hostname') ||
                             validateHost(options.host, 'host') || 'localhost';
 
-  const setHost = (options.setHost === undefined || Boolean(options.setHost));
+  var setHost = (options.setHost === undefined || Boolean(options.setHost));
 
   this.socketPath = options.socketPath;
 
   if (options.timeout !== undefined)
     this.timeout = validateTimerDuration(options.timeout, 'timeout');
 
-  let method = options.method;
-  const methodIsString = (typeof method === 'string');
+  var method = options.method;
+  var methodIsString = (typeof method === 'string');
   if (method !== null && method !== undefined && !methodIsString) {
     throw new ERR_INVALID_ARG_TYPE('method', 'string', method);
   }
@@ -182,7 +182,7 @@ function ClientRequest(input, options, cb) {
   this.parser = null;
   this.maxHeadersCount = null;
 
-  let called = false;
+  var called = false;
 
   if (this.agent) {
     // If there is an agent we should default to Connection:keep-alive,
@@ -198,23 +198,23 @@ function ClientRequest(input, options, cb) {
     }
   }
 
-  const headersArray = Array.isArray(options.headers);
+  var headersArray = Array.isArray(options.headers);
   if (!headersArray) {
     if (options.headers) {
-      const keys = Object.keys(options.headers);
+      var keys = Object.keys(options.headers);
       for (var i = 0; i < keys.length; i++) {
-        const key = keys[i];
+        var key = keys[i];
         this.setHeader(key, options.headers[key]);
       }
     }
 
     if (host && !this.getHeader('host') && setHost) {
-      let hostHeader = host;
+      var hostHeader = host;
 
       // For the Host header, ensure that IPv6 addresses are enclosed
       // in square brackets, as defined by URI formatting
       // https://tools.ietf.org/html/rfc3986#section-3.2.2
-      const posColon = hostHeader.indexOf(':');
+      var posColon = hostHeader.indexOf(':');
       if (posColon !== -1 &&
           hostHeader.indexOf(':', posColon + 1) !== -1 &&
           hostHeader.charCodeAt(0) !== 91/* '[' */) {
@@ -245,7 +245,7 @@ function ClientRequest(input, options, cb) {
                       options.headers);
   }
 
-  const oncreate = (err, socket) => {
+  var oncreate = (err, socket) => {
     if (called)
       return;
     called = true;
@@ -265,7 +265,7 @@ function ClientRequest(input, options, cb) {
     this._last = true;
     this.shouldKeepAlive = false;
     if (typeof options.createConnection === 'function') {
-      const newSocket = options.createConnection(options, oncreate);
+      var newSocket = options.createConnection(options, oncreate);
       if (newSocket && !called) {
         called = true;
         this.onSocket(newSocket);
@@ -327,15 +327,15 @@ function emitAbortNT() {
 
 function createHangUpError() {
   // eslint-disable-next-line no-restricted-syntax
-  const error = new Error('socket hang up');
+  var error = new Error('socket hang up');
   error.code = 'ECONNRESET';
   return error;
 }
 
 
 function socketCloseListener() {
-  const socket = this;
-  const req = socket._httpMessage;
+  var socket = this;
+  var req = socket._httpMessage;
   debug('HTTP socket close');
 
   // Pull through final chunk, if anything is buffered.
@@ -345,8 +345,8 @@ function socketCloseListener() {
 
   // NOTE: It's important to get parser here, because it could be freed by
   // the `socketOnData`.
-  const parser = socket.parser;
-  const res = req.res;
+  var parser = socket.parser;
+  var res = req.res;
   if (res) {
     // Socket closed before we emitted 'end' below.
     if (!res.complete) {
@@ -386,8 +386,8 @@ function socketCloseListener() {
 }
 
 function socketErrorListener(err) {
-  const socket = this;
-  const req = socket._httpMessage;
+  var socket = this;
+  var req = socket._httpMessage;
   debug('SOCKET ERROR:', err.message, err.stack);
 
   if (req) {
@@ -400,7 +400,7 @@ function socketErrorListener(err) {
   // Handle any pending data
   socket.read();
 
-  const parser = socket.parser;
+  var parser = socket.parser;
   if (parser) {
     parser.finish();
     freeParser(parser, req, socket);
@@ -413,16 +413,16 @@ function socketErrorListener(err) {
 }
 
 function freeSocketErrorListener(err) {
-  const socket = this;
+  var socket = this;
   debug('SOCKET ERROR on FREE socket:', err.message, err.stack);
   socket.destroy();
   socket.emit('agentRemove');
 }
 
 function socketOnEnd() {
-  const socket = this;
-  const req = this._httpMessage;
-  const parser = this.parser;
+  var socket = this;
+  var req = this._httpMessage;
+  var parser = this.parser;
 
   if (parser && !req.res && !req.socket._hadError) {
     // If we don't have a response then we know that the socket
@@ -438,14 +438,14 @@ function socketOnEnd() {
 }
 
 function socketOnData(d) {
-  const socket = this;
-  const req = this._httpMessage;
-  const parser = this.parser;
+  var socket = this;
+  var req = this._httpMessage;
+  var parser = this.parser;
 
   if (parser) {
     assert(parser.socket === socket);
 
-    const ret = parser.execute(d);
+    var ret = parser.execute(d);
     if (ret instanceof Error) {
       debug('parse error', ret);
       freeParser(parser, req, socket);
@@ -454,8 +454,8 @@ function socketOnData(d) {
       req.emit('error', ret);
     } else if (parser.incoming && parser.incoming.upgrade) {
       // Upgrade (if status code 101) or CONNECT
-      const bytesParsed = ret;
-      const res = parser.incoming;
+      var bytesParsed = ret;
+      var res = parser.incoming;
       req.res = res;
 
       socket.removeListener('data', socketOnData);
@@ -464,9 +464,9 @@ function socketOnData(d) {
       parser.finish();
       freeParser(parser, req, socket);
 
-      const bodyHead = d.slice(bytesParsed, d.length);
+      var bodyHead = d.slice(bytesParsed, d.length);
 
-      const eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
+      var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
       if (req.listenerCount(eventName) > 0) {
         req.upgradeOrConnect = true;
 
@@ -508,8 +508,8 @@ function statusIsInformational(status) {
 
 // client
 function parserOnIncomingClient(res, shouldKeepAlive) {
-  const socket = this.socket;
-  const req = socket._httpMessage;
+  var socket = this.socket;
+  var req = socket._httpMessage;
 
   debug('AGENT incoming response!');
 
@@ -526,7 +526,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
     return 2;
 
   // Responses to CONNECT request is handled as Upgrade.
-  const method = req.method;
+  var method = req.method;
   if (method === 'CONNECT') {
     res.upgrade = true;
     return 2;  // Skip body and treat as Upgrade.
@@ -559,7 +559,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
   // Add our listener first, so that we guarantee socket cleanup
   res.on('end', responseOnEnd);
   req.on('prefinish', requestOnPrefinish);
-  const handled = req.emit('response', res);
+  var handled = req.emit('response', res);
 
   // If the user did not listen for the 'response' event, then they
   // can't possibly read the data, so we ._dump() it into the void
@@ -575,7 +575,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
 
 // client
 function responseKeepAlive(res, req) {
-  const socket = req.socket;
+  var socket = req.socket;
 
   if (!req.shouldKeepAlive) {
     if (socket.writable) {
@@ -597,7 +597,7 @@ function responseKeepAlive(res, req) {
     socket.once('error', freeSocketErrorListener);
     // There are cases where _handle === null. Avoid those. Passing null to
     // nextTick() will call getDefaultTriggerAsyncId() to retrieve the id.
-    const asyncId = socket._handle ? socket._handle.getAsyncId() : undefined;
+    var asyncId = socket._handle ? socket._handle.getAsyncId() : undefined;
     // Mark this socket as available, AFTER user-added end
     // handlers have a chance to run.
     defaultTriggerAsyncIdScope(asyncId, process.nextTick, emitFreeNT, socket);
@@ -605,8 +605,8 @@ function responseKeepAlive(res, req) {
 }
 
 function responseOnEnd() {
-  const res = this;
-  const req = this.req;
+  var res = this;
+  var req = this.req;
 
   req._ended = true;
   if (!req.shouldKeepAlive || req.finished)
@@ -614,8 +614,8 @@ function responseOnEnd() {
 }
 
 function requestOnPrefinish() {
-  const req = this;
-  const res = this.res;
+  var req = this;
+  var res = this.res;
 
   if (!req.shouldKeepAlive)
     return;
@@ -629,7 +629,7 @@ function emitFreeNT(socket) {
 }
 
 function tickOnSocket(req, socket) {
-  const parser = parsers.alloc();
+  var parser = parsers.alloc();
   if (parser) {
     req.socket = socket;
     req.connection = socket;
@@ -671,7 +671,7 @@ function listenSocketTimeout(req) {
   if (req.timeoutCb) {
     return;
   }
-  const emitRequestTimeout = () => req.emit('timeout');
+  var emitRequestTimeout = () => req.emit('timeout');
   // Set timeoutCb so it will get cleaned up on request end.
   req.timeoutCb = emitRequestTimeout;
   // Delegate socket timeout event.
@@ -715,7 +715,7 @@ function _deferToConnect(method, arguments_, cb) {
   // in the future (when a socket gets assigned out of the pool and is
   // eventually writable).
 
-  const callSocketMethod = () => {
+  var callSocketMethod = () => {
     if (method)
       this.socket[method].apply(this.socket, arguments_);
 
@@ -723,7 +723,7 @@ function _deferToConnect(method, arguments_, cb) {
       cb();
   };
 
-  const onSocket = () => {
+  var onSocket = () => {
     if (this.socket.writable) {
       callSocketMethod();
     } else {

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -485,11 +485,11 @@ function socketOnData(d) {
         socket.destroy();
       }
     } else if (parser.incoming && parser.incoming.complete &&
-               // When the status code is informational (100, 102-199),
-               // the server will send a final response after this client
-               // sends a request body, so we must not free the parser.
-               // 101 (Switching Protocols) and all other status codes
-               // should be processed normally.
+      // When the status code is informational (100, 102-199),
+      // the server will send a final response after this client
+      // sends a request body, so we must not free the parser.
+      // 101 (Switching Protocols) and all other status codes
+      // should be processed normally.
       !statusIsInformational(parser.incoming.statusCode)) {
       socket.removeListener('data', socketOnData);
       socket.removeListener('end', socketOnEnd);

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -21,10 +21,10 @@
 
 'use strict';
 
-var net = require('net');
-var url = require('url');
-var assert = require('internal/assert');
-var {
+const net = require('net');
+const url = require('url');
+const assert = require('internal/assert');
+const {
   _checkIsHttpToken: checkIsHttpToken,
   debug,
   freeParser,
@@ -32,21 +32,21 @@ var {
   parsers,
   HTTPParser,
 } = require('_http_common');
-var { OutgoingMessage } = require('_http_outgoing');
-var Agent = require('_http_agent');
-var { Buffer } = require('buffer');
-var { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
-var { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
-var { outHeadersKey, ondrain } = require('internal/http');
-var {
+const { OutgoingMessage } = require('_http_outgoing');
+const Agent = require('_http_agent');
+const { Buffer } = require('buffer');
+const { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
+const { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
+const { outHeadersKey, ondrain } = require('internal/http');
+const {
   ERR_HTTP_HEADERS_SENT,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_HTTP_TOKEN,
   ERR_INVALID_PROTOCOL,
   ERR_UNESCAPED_CHARACTERS
 } = require('internal/errors').codes;
-var { validateTimerDuration } = require('internal/timers');
-var is_reused_symbol = require('internal/freelist').symbols.is_reused_symbol;
+const { validateTimerDuration } = require('internal/timers');
+const is_reused_symbol = require('internal/freelist').symbols.is_reused_symbol;
 
 var INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 
@@ -59,12 +59,12 @@ function validateHost(host, name) {
   return host;
 }
 
-var urlWarningEmitted = false;
+let urlWarningEmitted = false;
 function ClientRequest(input, options, cb) {
   OutgoingMessage.call(this);
 
   if (typeof input === 'string') {
-    var urlStr = input;
+    const urlStr = input;
     try {
       input = urlToOptions(new URL(urlStr));
     } catch (err) {
@@ -265,7 +265,7 @@ function ClientRequest(input, options, cb) {
     this._last = true;
     this.shouldKeepAlive = false;
     if (typeof options.createConnection === 'function') {
-      var newSocket = options.createConnection(options, oncreate);
+      const newSocket = options.createConnection(options, oncreate);
       if (newSocket && !called) {
         called = true;
         this.onSocket(newSocket);
@@ -345,8 +345,8 @@ function socketCloseListener() {
 
   // NOTE: It's important to get parser here, because it could be freed by
   // the `socketOnData`.
-  var parser = socket.parser;
-  var res = req.res;
+  const parser = socket.parser;
+  const res = req.res;
   if (res) {
     // Socket closed before we emitted 'end' below.
     if (!res.complete) {
@@ -526,7 +526,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
     return 2;
 
   // Responses to CONNECT request is handled as Upgrade.
-  var method = req.method;
+  const method = req.method;
   if (method === 'CONNECT') {
     res.upgrade = true;
     return 2;  // Skip body and treat as Upgrade.
@@ -597,7 +597,7 @@ function responseKeepAlive(res, req) {
     socket.once('error', freeSocketErrorListener);
     // There are cases where _handle === null. Avoid those. Passing null to
     // nextTick() will call getDefaultTriggerAsyncId() to retrieve the id.
-    var asyncId = socket._handle ? socket._handle.getAsyncId() : undefined;
+    const asyncId = socket._handle ? socket._handle.getAsyncId() : undefined;
     // Mark this socket as available, AFTER user-added end
     // handlers have a chance to run.
     defaultTriggerAsyncIdScope(asyncId, process.nextTick, emitFreeNT, socket);
@@ -605,8 +605,8 @@ function responseKeepAlive(res, req) {
 }
 
 function responseOnEnd() {
-  var res = this;
-  var req = this.req;
+  const res = this;
+  const req = this.req;
 
   req._ended = true;
   if (!req.shouldKeepAlive || req.finished)
@@ -614,8 +614,8 @@ function responseOnEnd() {
 }
 
 function requestOnPrefinish() {
-  var req = this;
-  var res = this.res;
+  const req = this;
+  const res = this.res;
 
   if (!req.shouldKeepAlive)
     return;
@@ -671,7 +671,7 @@ function listenSocketTimeout(req) {
   if (req.timeoutCb) {
     return;
   }
-  var emitRequestTimeout = () => req.emit('timeout');
+  const emitRequestTimeout = () => req.emit('timeout');
   // Set timeoutCb so it will get cleaned up on request end.
   req.timeoutCb = emitRequestTimeout;
   // Delegate socket timeout event.
@@ -715,7 +715,7 @@ function _deferToConnect(method, arguments_, cb) {
   // in the future (when a socket gets assigned out of the pool and is
   // eventually writable).
 
-  var callSocketMethod = () => {
+  const callSocketMethod = () => {
     if (method)
       this.socket[method].apply(this.socket, arguments_);
 
@@ -723,7 +723,7 @@ function _deferToConnect(method, arguments_, cb) {
       cb();
   };
 
-  var onSocket = () => {
+  const onSocket = () => {
     if (this.socket.writable) {
       callSocketMethod();
     } else {

--- a/test/parallel/test-http-client-delete-parser.js
+++ b/test/parallel/test-http-client-delete-parser.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+
+const http = require('http');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.write('okay', common.mustCall(() => {
+    delete req.socket.parser;
+  }));
+  res.end();
+}));
+
+server.listen(1337, '127.0.0.1');
+server.unref();
+
+const req = http.request({
+  port: 1337,
+  host: '127.0.0.1',
+  method: 'GET',
+});
+
+req.end();


### PR DESCRIPTION
Fixes: #26404 and Refs: #26351

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

After analyzing the comments, the fix and the test in #26402 for http server, got inspired to try out a similar fix and a test as to check for the `parser`existence in various conditions for http client.

My local test passed in repl with similar script from #26404:

```js
'use strict';

const http = require('http');

const server = http.createServer((req, res) => {
  res.writeHead(200, { 'Content-Type': 'text/plain' });
  res.end('okay');
});

server.listen(1337, '127.0.0.1');

const req = http.request({
  port: 1337,
  host: '127.0.0.1',
  method: 'GET',
});

req.write('');
req.end(() => { delete req.socket.parser; });
```
