### PR TITLE
process: make Symbol.toStringTag writable

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -310,7 +310,7 @@ function setupProcessObject() {
   EventEmitter.call(process);
   Object.defineProperty(process, Symbol.toStringTag, {
     enumerable: false,
-    writable: false,
+    writable: true,
     configurable: false,
     value: 'process'
   });

--- a/test/es-module/test-esm-process.mjs
+++ b/test/es-module/test-esm-process.mjs
@@ -4,3 +4,4 @@ import assert from 'assert';
 import process from 'process';
 
 assert.strictEqual(Object.prototype.toString.call(process), '[object process]');
+assert(Object.getOwnPropertyDescriptor(process, Symbol.toStringTag).writable);


### PR DESCRIPTION
The ecosystem broke by making it non-writable, so this is a good
intermediate fix.

Refs: https://github.com/nodejs/node/pull/25963#issuecomment-470456374

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
