### PR TITLE
net: use kHandle symbol for accessing native handle

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -106,13 +106,13 @@ const {
   updateSettingsBuffer
 } = require('internal/http2/util');
 const {
-  createWriteWrap,
   writeGeneric,
   writevGeneric,
   onStreamRead,
   kAfterAsyncWrite,
   kMaybeDestroy,
   kUpdateTimer,
+  kHandle,
   kSession,
   setStreamTimeout
 } = require('internal/stream_base_commons');
@@ -149,7 +149,6 @@ const TLSServer = tls.Server;
 const kAlpnProtocol = Symbol('alpnProtocol');
 const kAuthority = Symbol('authority');
 const kEncrypted = Symbol('encrypted');
-const kHandle = Symbol('handle');
 const kID = Symbol('id');
 const kInit = Symbol('init');
 const kInfoHeaders = Symbol('sent-info-headers');
@@ -1795,13 +1794,12 @@ class Http2Stream extends Duplex {
     if (!this.headersSent)
       this[kProceed]();
 
-    const req = createWriteWrap(this[kHandle]);
-    req.stream = this[kID];
+    let req;
 
     if (writev)
-      writevGeneric(this, req, data, cb);
+      req = writevGeneric(this, data, cb);
     else
-      writeGeneric(this, req, data, encoding, cb);
+      req = writeGeneric(this, data, encoding, cb);
 
     trackWriteState(this, req.bytes);
   }

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -27,7 +27,8 @@ const {
 const kMaybeDestroy = Symbol('kMaybeDestroy');
 const kUpdateTimer = Symbol('kUpdateTimer');
 const kAfterAsyncWrite = Symbol('kAfterAsyncWrite');
-const kSession = Symbol('session');
+const kHandle = Symbol('kHandle');
+const kSession = Symbol('kSession');
 
 function handleWriteReq(req, data, encoding) {
   const { handle } = req;
@@ -98,7 +99,8 @@ function createWriteWrap(handle) {
   return req;
 }
 
-function writevGeneric(self, req, data, cb) {
+function writevGeneric(self, data, cb) {
+  const req = createWriteWrap(self[kHandle]);
   var allBuffers = data.allBuffers;
   var chunks;
   var i;
@@ -120,12 +122,15 @@ function writevGeneric(self, req, data, cb) {
   if (err === 0) req._chunks = chunks;
 
   afterWriteDispatched(self, req, err, cb);
+  return req;
 }
 
-function writeGeneric(self, req, data, encoding, cb) {
+function writeGeneric(self, data, encoding, cb) {
+  const req = createWriteWrap(self[kHandle]);
   var err = handleWriteReq(req, data, encoding);
 
   afterWriteDispatched(self, req, err, cb);
+  return req;
 }
 
 function afterWriteDispatched(self, req, err, cb) {
@@ -229,6 +234,7 @@ module.exports = {
   kAfterAsyncWrite,
   kMaybeDestroy,
   kUpdateTimer,
+  kHandle,
   kSession,
   setStreamTimeout
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -58,11 +58,11 @@ const {
   symbols: { async_id_symbol, owner_symbol }
 } = require('internal/async_hooks');
 const {
-  createWriteWrap,
   writevGeneric,
   writeGeneric,
   onStreamRead,
   kAfterAsyncWrite,
+  kHandle,
   kUpdateTimer,
   setStreamTimeout
 } = require('internal/stream_base_commons');
@@ -233,7 +233,7 @@ function Socket(options) {
   // probably be supplied by async_hooks.
   this[async_id_symbol] = -1;
   this._hadError = false;
-  this._handle = null;
+  this[kHandle] = null;
   this._parent = null;
   this._host = null;
   this[kLastWriteQueueSize] = 0;
@@ -689,11 +689,11 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
 
   this._unrefTimer();
 
-  var req = createWriteWrap(this._handle);
+  let req;
   if (writev)
-    writevGeneric(this, req, data, cb);
+    req = writevGeneric(this, data, cb);
   else
-    writeGeneric(this, req, data, encoding, cb);
+    req = writeGeneric(this, data, encoding, cb);
   if (req.async)
     this[kLastWriteQueueSize] = req.bytes;
 };
@@ -1582,6 +1582,11 @@ function emitCloseNT(self) {
 Object.defineProperty(TCP.prototype, 'owner', {
   get() { return this[owner_symbol]; },
   set(v) { return this[owner_symbol] = v; }
+});
+
+Object.defineProperty(Socket.prototype, '_handle', {
+  get() { return this[kHandle]; },
+  set(v) { return this[kHandle] = v; }
 });
 
 


### PR DESCRIPTION
Use a common `kHandle` for all `StreamBase`-based streams.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
