### PR TITLE
src: apply clang-tidy rule modernize-make-unique

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -30,6 +30,7 @@
 
 #include <cerrno>
 #include <cstring>
+#include <memory>
 #include <vector>
 #include <unordered_set>
 
@@ -663,7 +664,7 @@ class QueryWrap : public AsyncWrap {
       memcpy(buf_copy, answer_buf, answer_len);
     }
 
-    wrap->response_data_.reset(new ResponseData());
+    wrap->response_data_ = std::make_unique<ResponseData>();
     ResponseData* data = wrap->response_data_.get();
     data->status = status;
     data->is_host = false;
@@ -683,7 +684,7 @@ class QueryWrap : public AsyncWrap {
       cares_wrap_hostent_cpy(host_copy, host);
     }
 
-    wrap->response_data_.reset(new ResponseData());
+    wrap->response_data_ = std::make_unique<ResponseData>();
     ResponseData* data = wrap->response_data_.get();
     data->status = status;
     data->host.reset(host_copy);

--- a/src/env.cc
+++ b/src/env.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdio>
+#include <memory>
 
 namespace node {
 
@@ -217,8 +218,7 @@ Environment::Environment(IsolateData* isolate_data,
 
 #if HAVE_INSPECTOR
   // We can only create the inspector agent after having cloned the options.
-  inspector_agent_ =
-      std::unique_ptr<inspector::Agent>(new inspector::Agent(this));
+  inspector_agent_ = std::make_unique<inspector::Agent>(this);
 #endif
 
   AssignToContext(context, ContextInfo(""));
@@ -238,7 +238,8 @@ Environment::Environment(IsolateData* isolate_data,
       },
       this);
 
-  performance_state_.reset(new performance::performance_state(isolate()));
+  performance_state_ =
+      std::make_unique<performance::performance_state>(isolate());
   performance_state_->Mark(
       performance::NODE_PERFORMANCE_MILESTONE_ENVIRONMENT);
   performance_state_->Mark(performance::NODE_PERFORMANCE_MILESTONE_NODE_START,

--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -7,6 +7,7 @@
 #include <unicode/unistr.h>
 
 #include <functional>
+#include <memory>
 
 namespace node {
 namespace inspector {
@@ -114,8 +115,7 @@ class AnotherThreadObjectReference {
 
   ~AnotherThreadObjectReference() {
     // Disappearing thread may cause a memory leak
-    thread_->Post(
-        std::unique_ptr<DeleteRequest>(new DeleteRequest(object_id_)));
+    thread_->Post(std::make_unique<DeleteRequest>(object_id_));
   }
 
   template <typename Fn>
@@ -151,8 +151,7 @@ class MainThreadSessionState {
 
   static std::unique_ptr<MainThreadSessionState> Create(
       MainThreadInterface* thread, bool prevent_shutdown) {
-    return std::unique_ptr<MainThreadSessionState>(
-        new MainThreadSessionState(thread, prevent_shutdown));
+    return std::make_unique<MainThreadSessionState>(thread, prevent_shutdown);
   }
 
   void Connect(std::unique_ptr<InspectorSessionDelegate> delegate) {

--- a/src/inspector/worker_inspector.cc
+++ b/src/inspector/worker_inspector.cc
@@ -1,6 +1,7 @@
 #include "worker_inspector.h"
-
 #include "main_thread_interface.h"
+
+#include <memory>
 
 namespace node {
 namespace inspector {
@@ -88,8 +89,7 @@ void WorkerManager::WorkerStarted(int session_id,
 std::unique_ptr<ParentInspectorHandle>
 WorkerManager::NewParentHandle(int thread_id, const std::string& url) {
   bool wait = !delegates_waiting_on_start_.empty();
-  return std::unique_ptr<ParentInspectorHandle>(
-      new ParentInspectorHandle(thread_id, url, thread_, wait));
+  return std::make_unique<ParentInspectorHandle>(thread_id, url, thread_, wait);
 }
 
 void WorkerManager::RemoveAttachDelegate(int id) {
@@ -106,8 +106,7 @@ std::unique_ptr<WorkerManagerEventHandle> WorkerManager::SetAutoAttach(
     // Waiting is only reported when a worker is started, same as browser
     Report(delegate, worker.second, false);
   }
-  return std::unique_ptr<WorkerManagerEventHandle>(
-      new WorkerManagerEventHandle(shared_from_this(), id));
+  return std::make_unique<WorkerManagerEventHandle>(shared_from_this(), id);
 }
 
 void WorkerManager::SetWaitOnStartForDelegate(int id, bool wait) {

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -4,6 +4,8 @@
 #include "v8.h"
 #include "v8-inspector.h"
 
+#include <memory>
+
 namespace node {
 namespace inspector {
 namespace {
@@ -65,8 +67,8 @@ class JSBindingsConnection : public AsyncWrap {
                        : AsyncWrap(env, wrap, PROVIDER_INSPECTORJSBINDING),
                          callback_(env->isolate(), callback) {
     Agent* inspector = env->inspector_agent();
-    session_ = inspector->Connect(std::unique_ptr<JSBindingsSessionDelegate>(
-        new JSBindingsSessionDelegate(env, this)), false);
+    session_ = inspector->Connect(std::make_unique<JSBindingsSessionDelegate>(
+        env, this), false);
   }
 
   void OnMessage(Local<Value> value) {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -341,7 +341,7 @@ int FileHandle::ReadStart() {
                .ToLocal(&wrap_obj)) {
         return UV_EBUSY;
       }
-      read_wrap.reset(new FileHandleReadWrap(this, wrap_obj));
+      read_wrap = std::make_unique<FileHandleReadWrap>(this, wrap_obj);
     }
   }
   int64_t recommended_read = 65536;
@@ -1285,8 +1285,8 @@ int MKDirpAsync(uv_loop_t* loop,
   FSReqBase* req_wrap = FSReqBase::from_req(req);
   // on the first iteration of algorithm, stash state information.
   if (req_wrap->continuation_data == nullptr) {
-    req_wrap->continuation_data = std::unique_ptr<FSContinuationData>{
-      new FSContinuationData(req, mode, cb)};
+    req_wrap->continuation_data =
+        std::make_unique<FSContinuationData>(req, mode, cb);
     req_wrap->continuation_data->PushPath(std::move(path));
   }
 

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -5,6 +5,7 @@
 #include "debug_utils.h"
 #include "util.h"
 #include <algorithm>
+#include <memory>
 
 namespace node {
 
@@ -172,8 +173,8 @@ WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int thread_pool_size) {
   Mutex::ScopedLock lock(platform_workers_mutex);
   int pending_platform_workers = thread_pool_size;
 
-  delayed_task_scheduler_.reset(
-      new DelayedTaskScheduler(&pending_worker_tasks_));
+  delayed_task_scheduler_ = std::make_unique<DelayedTaskScheduler>(
+      &pending_worker_tasks_);
   threads_.push_back(delayed_task_scheduler_->Start());
 
   for (int i = 0; i < thread_pool_size; i++) {

--- a/src/node_v8_platform-inl.h
+++ b/src/node_v8_platform-inl.h
@@ -3,6 +3,8 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include <memory>
+
 #include "env-inl.h"
 #include "node.h"
 #include "node_metadata.h"
@@ -79,11 +81,12 @@ class NodeTraceStateObserver
 struct V8Platform {
 #if NODE_USE_V8_PLATFORM
   inline void Initialize(int thread_pool_size) {
-    tracing_agent_.reset(new tracing::Agent());
+    tracing_agent_ = std::make_unique<tracing::Agent>();
     node::tracing::TraceEventHelper::SetAgent(tracing_agent_.get());
     node::tracing::TracingController* controller =
         tracing_agent_->GetTracingController();
-    trace_state_observer_.reset(new NodeTraceStateObserver(controller));
+    trace_state_observer_ =
+        std::make_unique<NodeTraceStateObserver>(controller);
     controller->AddTraceStateObserver(trace_state_observer_.get());
     tracing_file_writer_ = tracing_agent_->DefaultHandle();
     // Only start the tracing agent if we enabled any tracing categories.

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -10,6 +10,7 @@
 #include "inspector/worker_inspector.h"  // ParentInspectorHandle
 #endif
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -117,7 +118,7 @@ Worker::Worker(Environment* env,
     return;
   }
 
-  child_port_data_.reset(new MessagePortData(nullptr));
+  child_port_data_ = std::make_unique<MessagePortData>(nullptr);
   MessagePort::Entangle(parent_port_, child_port_data_.get());
 
   object()->Set(env->context(),

--- a/src/tracing/node_trace_buffer.cc
+++ b/src/tracing/node_trace_buffer.cc
@@ -1,4 +1,6 @@
 #include "tracing/node_trace_buffer.h"
+
+#include <memory>
 #include "util-inl.h"
 
 namespace node {
@@ -19,7 +21,7 @@ TraceObject* InternalTraceBuffer::AddTraceEvent(uint64_t* handle) {
     if (chunk) {
       chunk->Reset(current_chunk_seq_++);
     } else {
-      chunk.reset(new TraceBufferChunk(current_chunk_seq_++));
+      chunk = std::make_unique<TraceBufferChunk>(current_chunk_seq_++);
     }
   }
   auto& chunk = chunks_[total_chunks_ - 1];

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -2,6 +2,7 @@
 #define TEST_CCTEST_NODE_TEST_FIXTURE_H_
 
 #include <cstdlib>
+#include <memory>
 #include "gtest/gtest.h"
 #include "node.h"
 #include "node_platform.h"
@@ -77,7 +78,7 @@ class NodeTestFixture : public ::testing::Test {
       node::Init(&argc, &argv0, &exec_argc, &exec_argv);
     }
 
-    tracing_agent.reset(new node::tracing::Agent());
+    tracing_agent = std::make_unique<node::tracing::Agent>();
     node::tracing::TraceEventHelper::SetAgent(tracing_agent.get());
     CHECK_EQ(0, uv_loop_init(&current_loop));
     platform.reset(static_cast<node::NodePlatform*>(

--- a/test/cctest/test_inspector_socket_server.cc
+++ b/test/cctest/test_inspector_socket_server.cc
@@ -4,6 +4,7 @@
 #include "gtest/gtest.h"
 
 #include <algorithm>
+#include <memory>
 #include <sstream>
 
 static uv_loop_t loop;
@@ -356,8 +357,8 @@ ServerHolder::ServerHolder(bool has_targets, uv_loop_t* loop,
     targets = { MAIN_TARGET_ID };
   std::unique_ptr<TestSocketServerDelegate> delegate(
       new TestSocketServerDelegate(this, targets));
-  server_.reset(
-      new InspectorSocketServer(std::move(delegate), loop, host, port, out));
+  server_ = std::make_unique<InspectorSocketServer>(
+      std::move(delegate), loop, host, port, out);
 }
 
 static void TestHttpRequest(int port, const std::string& path,


### PR DESCRIPTION
Apply clang-tidy rule https://clang.llvm.org/extra/clang-tidy/checks/modernize-make-unique.html

And also in `Item 21: Prefer std::make_unique and std::make_shared to direct use of new.`

> * Compared to direct use of new, make functions eliminate source code duplication, improve exception safety, and, for std::make_shared and std::allocate_shared, generate code that’s smaller and faster.
> * Situations where use of make functions is inappropriate include the need to specify custom deleters and a desire to pass braced initializers.

cc @addaleax @refack @bnoordhuis 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
