### PR TITLE
src: rename Init and Start overloads to something more distinctive

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -225,7 +225,7 @@ Environment* CreateEnvironment(IsolateData* isolate_data,
       static_cast<Environment::Flags>(Environment::kIsMainThread |
                                       Environment::kOwnsProcessState |
                                       Environment::kOwnsInspector));
-  env->Start(per_process::v8_is_profiling);
+  env->InitializeLibuv(per_process::v8_is_profiling);
   env->ProcessCliArgs(args, exec_args);
   return env;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -320,7 +320,7 @@ Environment::~Environment() {
   }
 }
 
-void Environment::Start(bool start_profiler_idle_notifier) {
+void Environment::InitializeLibuv(bool start_profiler_idle_notifier) {
   HandleScope handle_scope(isolate());
   Context::Scope context_scope(context());
 

--- a/src/env.h
+++ b/src/env.h
@@ -675,7 +675,7 @@ class Environment {
               uint64_t thread_id = kNoThreadId);
   ~Environment();
 
-  void Start(bool start_profiler_idle_notifier);
+  void InitializeLibuv(bool start_profiler_idle_notifier);
   v8::MaybeLocal<v8::Object> ProcessCliArgs(
       const std::vector<std::string>& args,
       const std::vector<std::string>& exec_args);

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -284,7 +284,7 @@ void Worker::Run() {
         env_->set_abort_on_uncaught_exception(false);
         env_->set_worker_context(this);
 
-        env_->Start(profiler_idle_notifier_started_);
+        env_->InitializeLibuv(profiler_idle_notifier_started_);
         env_->ProcessCliArgs(std::vector<std::string>{},
                              std::move(exec_argv_));
       }


### PR DESCRIPTION
In addition, move the `--help` and `--v8-help` processing out of
`StartNodeWithLoopAndArgs()` and process them earlier - right after
`InitializeNodeWithArgs()`, similar to how they are handled in
the legacy `Init()`.

Note: this is more of a personal reference but I find the overloads getting in the way of understanding what is being done in each layer of the bootstrap.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
