### PR TITLE
process: add --pending-deprecation to `process.binding()`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2136,7 +2136,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Documentation-only (supports [`--pending-deprecation`][])
 
 `process.binding()` is for use by Node.js internal code only.
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2134,6 +2134,9 @@ changes:
   - version: v10.9.0
     pr-url: https://github.com/nodejs/node/pull/22004
     description: Documentation-only deprecation.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26500
+    description: Added support for `--pending-deprecation`.
 -->
 
 Type: Documentation-only (supports [`--pending-deprecation`][])

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -153,7 +153,7 @@ function initializeDeprecations() {
 
   if (pendingDeprecation) {
     process.binding = deprecate(process.binding,
-                                '`process.binding()` is deprecated. ' +
+                                'process.binding() is deprecated. ' +
                                 'Please use public APIs instead.', 'DEP0111');
   }
 }

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -150,6 +150,12 @@ function initializeDeprecations() {
       value: noBrowserGlobals
     });
   }
+
+  if (pendingDeprecation) {
+    process.binding = deprecate(process.binding,
+                                '`process.binding()` is deprecated. ' +
+                                'Please use public APIs instead.', 'DEP0111');
+  }
 }
 
 function setupChildProcessIpcChannel() {

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -10,7 +10,7 @@ const assert = require('assert');
 
 const isMainThread = common.isMainThread;
 const kCoverageModuleCount = process.env.NODE_V8_COVERAGE ? 1 : 0;
-const kMaxModuleCount = (isMainThread ? 64 : 86) + kCoverageModuleCount;
+const kMaxModuleCount = (isMainThread ? 65 : 87) + kCoverageModuleCount;
 
 assert(list.length <= kMaxModuleCount,
        `Total length: ${list.length}\n` + list.join('\n')

--- a/test/parallel/test-err-name-deprecation.js
+++ b/test/parallel/test-err-name-deprecation.js
@@ -5,7 +5,7 @@ const common = require('../common');
 
 common.expectWarning({
   DeprecationWarning: [
-    ['`process.binding()` is deprecated. Please use public APIs instead.',
+    ['process.binding() is deprecated. Please use public APIs instead.',
      'DEP0111'],
     ['Directly calling process.binding(\'uv\').errname(<val>) is being ' +
      'deprecated. Please make sure to use util.getSystemErrorName() instead.',

--- a/test/parallel/test-err-name-deprecation.js
+++ b/test/parallel/test-err-name-deprecation.js
@@ -3,11 +3,14 @@ const common = require('../common');
 
 // Flags: --pending-deprecation
 
-common.expectWarning(
-  'DeprecationWarning',
-  'Directly calling process.binding(\'uv\').errname(<val>) is being ' +
-  'deprecated. Please make sure to use util.getSystemErrorName() instead.',
-  'DEP0119'
-);
+common.expectWarning({
+  DeprecationWarning: [
+    ['`process.binding()` is deprecated. Please use public APIs instead.',
+     'DEP0111'],
+    ['Directly calling process.binding(\'uv\').errname(<val>) is being ' +
+     'deprecated. Please make sure to use util.getSystemErrorName() instead.',
+     'DEP0119']
+  ]
+});
 
 process.binding('uv').errname(-1);


### PR DESCRIPTION
Print a deprecation warning for `process.binding()` when using
`--pending-deprecation`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
