### PR TITLE
src: use CHECK(false) in switch default case

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3456,7 +3456,7 @@ static ManagedEVPPKey GetPublicOrPrivateKeyFromJs(
           is_public = false;
           break;
         default:
-          CHECK(!"Invalid key encoding type");
+          UNREACHABLE("Invalid key encoding type");
       }
 
       if (is_public) {

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -162,7 +162,7 @@ template <typename NativeT,
 constexpr NativeT ToNative(uv_timespec_t ts) {
   // This template has exactly two specializations below.
   static_assert(std::is_arithmetic<NativeT>::value == false, "Not implemented");
-  UNREACHABLE();
+  return NativeT();
 }
 
 template <>

--- a/src/util.h
+++ b/src/util.h
@@ -120,7 +120,7 @@ void DumpBacktrace(FILE* fp);
   do {                                                                        \
     /* Make sure that this struct does not end up in inline code, but      */ \
     /* rather in a read-only data section when modifying this code.        */ \
-    constexpr node::AssertionInfo args = {                                    \
+    const node::AssertionInfo args = {                                        \
       __FILE__ ":" STRINGIFY(__LINE__), #expr, PRETTY_FUNCTION_NAME           \
     };                                                                        \
     node::Assert(args);                                                       \

--- a/src/util.h
+++ b/src/util.h
@@ -181,7 +181,8 @@ void DumpBacktrace(FILE* fp);
 #endif
 
 
-#define UNREACHABLE(expr) ASSERT(expr)
+#define UNREACHABLE(expr)                                                     \
+  ASSERT("Unreachable code reached:" expr)
 
 // TAILQ-style intrusive list node.
 template <typename T>

--- a/src/util.h
+++ b/src/util.h
@@ -116,6 +116,16 @@ void DumpBacktrace(FILE* fp);
 
 #define ABORT() node::Abort()
 
+#define ASSERT(expr)                                                          \
+  do {                                                                        \
+    /* Make sure that this struct does not end up in inline code, but      */ \
+    /* rather in a read-only data section when modifying this code.        */ \
+    constexpr node::AssertionInfo args = {                                    \
+      __FILE__ ":" STRINGIFY(__LINE__), #expr, PRETTY_FUNCTION_NAME           \
+    };                                                                        \
+    node::Assert(args);                                                       \
+  } while (0)
+
 #ifdef __GNUC__
 #define LIKELY(expr) __builtin_expect(!!(expr), 1)
 #define UNLIKELY(expr) __builtin_expect(!!(expr), 0)
@@ -132,12 +142,7 @@ void DumpBacktrace(FILE* fp);
 #define CHECK(expr)                                                           \
   do {                                                                        \
     if (UNLIKELY(!(expr))) {                                                  \
-      /* Make sure that this struct does not end up in inline code, but    */ \
-      /* rather in a read-only data section when modifying this code.      */ \
-      static const node::AssertionInfo args = {                               \
-        __FILE__ ":" STRINGIFY(__LINE__), #expr, PRETTY_FUNCTION_NAME         \
-      };                                                                      \
-      node::Assert(args);                                                     \
+      ASSERT(expr);                                                           \
     }                                                                         \
   } while (0)
 
@@ -176,7 +181,7 @@ void DumpBacktrace(FILE* fp);
 #endif
 
 
-#define UNREACHABLE() ABORT()
+#define UNREACHABLE(expr) ASSERT(expr)
 
 // TAILQ-style intrusive list node.
 template <typename T>

--- a/src/util.h
+++ b/src/util.h
@@ -182,7 +182,7 @@ void DumpBacktrace(FILE* fp);
 
 
 #define UNREACHABLE(expr)                                                     \
-  ERROR_AND_ABORT("Unreachable code reached:" expr)
+  ERROR_AND_ABORT("Unreachable code reached: " expr)
 
 // TAILQ-style intrusive list node.
 template <typename T>

--- a/src/util.h
+++ b/src/util.h
@@ -116,7 +116,7 @@ void DumpBacktrace(FILE* fp);
 
 #define ABORT() node::Abort()
 
-#define ASSERT(expr)                                                          \
+#define ERROR_AND_ABORT(expr)                                                 \
   do {                                                                        \
     /* Make sure that this struct does not end up in inline code, but      */ \
     /* rather in a read-only data section when modifying this code.        */ \
@@ -142,7 +142,7 @@ void DumpBacktrace(FILE* fp);
 #define CHECK(expr)                                                           \
   do {                                                                        \
     if (UNLIKELY(!(expr))) {                                                  \
-      ASSERT(expr);                                                           \
+      ERROR_AND_ABORT(expr);                                                  \
     }                                                                         \
   } while (0)
 
@@ -182,7 +182,7 @@ void DumpBacktrace(FILE* fp);
 
 
 #define UNREACHABLE(expr)                                                     \
-  ASSERT("Unreachable code reached:" expr)
+  ERROR_AND_ABORT("Unreachable code reached:" expr)
 
 // TAILQ-style intrusive list node.
 template <typename T>

--- a/src/util.h
+++ b/src/util.h
@@ -120,7 +120,7 @@ void DumpBacktrace(FILE* fp);
   do {                                                                        \
     /* Make sure that this struct does not end up in inline code, but      */ \
     /* rather in a read-only data section when modifying this code.        */ \
-    const node::AssertionInfo args = {                                        \
+    static const node::AssertionInfo args = {                                 \
       __FILE__ ":" STRINGIFY(__LINE__), #expr, PRETTY_FUNCTION_NAME           \
     };                                                                        \
     node::Assert(args);                                                       \


### PR DESCRIPTION
Passing a !string to `CHECK` will trigger a string conversion warning and it's also inconsistent with the usage in other places. Hence, this changes it to `CHECK(false)` making it consistent.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
