### PR TITLE
http: convert var to let or const for http

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -61,7 +61,7 @@ function Agent(options) {
   this.maxFreeSockets = this.options.maxFreeSockets || 256;
 
   this.on('free', (socket, options) => {
-    var name = this.getName(options);
+    const name = this.getName(options);
     debug('agent.on(free)', name);
 
     if (socket.writable &&
@@ -75,14 +75,14 @@ function Agent(options) {
     } else {
       // If there are no pending requests, then put it in
       // the freeSockets pool, but only if we're allowed to do so.
-      var req = socket._httpMessage;
+      const req = socket._httpMessage;
       if (req &&
           req.shouldKeepAlive &&
           socket.writable &&
           this.keepAlive) {
-        var freeSockets = this.freeSockets[name];
-        var freeLen = freeSockets ? freeSockets.length : 0;
-        var count = freeLen;
+        let freeSockets = this.freeSockets[name];
+        const freeLen = freeSockets ? freeSockets.length : 0;
+        let count = freeLen;
         if (this.sockets[name])
           count += this.sockets[name].length;
 
@@ -114,7 +114,7 @@ Agent.prototype.createConnection = net.createConnection;
 
 // Get the key for a given set of request options
 Agent.prototype.getName = function getName(options) {
-  var name = options.host || 'localhost';
+  let name = options.host || 'localhost';
 
   name += ':';
   if (options.port)
@@ -153,17 +153,17 @@ Agent.prototype.addRequest = function addRequest(req, options, port/* legacy */,
   if (!options.servername)
     options.servername = calculateServerName(options, req);
 
-  var name = this.getName(options);
+  const name = this.getName(options);
   if (!this.sockets[name]) {
     this.sockets[name] = [];
   }
 
-  var freeLen = this.freeSockets[name] ? this.freeSockets[name].length : 0;
-  var sockLen = freeLen + this.sockets[name].length;
+  const freeLen = this.freeSockets[name] ? this.freeSockets[name].length : 0;
+  const sockLen = freeLen + this.sockets[name].length;
 
   if (freeLen) {
     // we have a free socket, so use that.
-    var socket = this.freeSockets[name].shift();
+    const socket = this.freeSockets[name].shift();
     // Guard against an uninitialized or user supplied Socket.
     if (socket._handle && typeof socket._handle.asyncReset === 'function') {
       // Assign the handle a new asyncId and run any destroy()/init() hooks.
@@ -200,12 +200,12 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
   if (!options.servername)
     options.servername = calculateServerName(options, req);
 
-  var name = this.getName(options);
+  const name = this.getName(options);
   options._agentKey = name;
 
   debug('createConnection', name, options);
   options.encoding = null;
-  var called = false;
+  let called = false;
 
   const oncreate = (err, s) => {
     if (called)
@@ -280,19 +280,19 @@ function installListeners(agent, s, options) {
 }
 
 Agent.prototype.removeSocket = function removeSocket(s, options) {
-  var name = this.getName(options);
+  const name = this.getName(options);
   debug('removeSocket', name, 'writable:', s.writable);
-  var sets = [this.sockets];
+  const sets = [this.sockets];
 
   // If the socket was destroyed, remove it from the free buffers too.
   if (!s.writable)
     sets.push(this.freeSockets);
 
   for (var sk = 0; sk < sets.length; sk++) {
-    var sockets = sets[sk];
+    const sockets = sets[sk];
 
     if (sockets[name]) {
-      var index = sockets[name].indexOf(s);
+      const index = sockets[name].indexOf(s);
       if (index !== -1) {
         sockets[name].splice(index, 1);
         // Don't leak
@@ -324,12 +324,12 @@ Agent.prototype.reuseSocket = function reuseSocket(socket, req) {
 };
 
 Agent.prototype.destroy = function destroy() {
-  var sets = [this.freeSockets, this.sockets];
+  const sets = [this.freeSockets, this.sockets];
   for (var s = 0; s < sets.length; s++) {
-    var set = sets[s];
-    var keys = Object.keys(set);
+    const set = sets[s];
+    const keys = Object.keys(set);
     for (var v = 0; v < keys.length; v++) {
-      var setName = set[keys[v]];
+      const setName = set[keys[v]];
       for (var n = 0; n < setName.length; n++) {
         setName[n].destroy();
       }

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -97,8 +97,8 @@ function ClientRequest(input, options, cb) {
     options = Object.assign(input || {}, options);
   }
 
-  var agent = options.agent;
-  var defaultAgent = options._defaultAgent || Agent.globalAgent;
+  let agent = options.agent;
+  const defaultAgent = options._defaultAgent || Agent.globalAgent;
   if (agent === false) {
     agent = new defaultAgent.constructor();
   } else if (agent === null || agent === undefined) {
@@ -114,12 +114,12 @@ function ClientRequest(input, options, cb) {
   }
   this.agent = agent;
 
-  var protocol = options.protocol || defaultAgent.protocol;
-  var expectedProtocol = defaultAgent.protocol;
+  const protocol = options.protocol || defaultAgent.protocol;
+  let expectedProtocol = defaultAgent.protocol;
   if (this.agent && this.agent.protocol)
     expectedProtocol = this.agent.protocol;
 
-  var path;
+  let path;
   if (options.path) {
     path = String(options.path);
     if (INVALID_PATH_REGEX.test(path))
@@ -130,22 +130,22 @@ function ClientRequest(input, options, cb) {
     throw new ERR_INVALID_PROTOCOL(protocol, expectedProtocol);
   }
 
-  var defaultPort = options.defaultPort ||
+  const defaultPort = options.defaultPort ||
                     this.agent && this.agent.defaultPort;
 
-  var port = options.port = options.port || defaultPort || 80;
-  var host = options.host = validateHost(options.hostname, 'hostname') ||
+  const port = options.port = options.port || defaultPort || 80;
+  const host = options.host = validateHost(options.hostname, 'hostname') ||
                             validateHost(options.host, 'host') || 'localhost';
 
-  var setHost = (options.setHost === undefined || Boolean(options.setHost));
+  const setHost = (options.setHost === undefined || Boolean(options.setHost));
 
   this.socketPath = options.socketPath;
 
   if (options.timeout !== undefined)
     this.timeout = validateTimerDuration(options.timeout, 'timeout');
 
-  var method = options.method;
-  var methodIsString = (typeof method === 'string');
+  let method = options.method;
+  const methodIsString = (typeof method === 'string');
   if (method !== null && method !== undefined && !methodIsString) {
     throw new ERR_INVALID_ARG_TYPE('method', 'string', method);
   }
@@ -182,7 +182,7 @@ function ClientRequest(input, options, cb) {
   this.parser = null;
   this.maxHeadersCount = null;
 
-  var called = false;
+  let called = false;
 
   if (this.agent) {
     // If there is an agent we should default to Connection:keep-alive,
@@ -198,23 +198,23 @@ function ClientRequest(input, options, cb) {
     }
   }
 
-  var headersArray = Array.isArray(options.headers);
+  const headersArray = Array.isArray(options.headers);
   if (!headersArray) {
     if (options.headers) {
-      var keys = Object.keys(options.headers);
+      const keys = Object.keys(options.headers);
       for (var i = 0; i < keys.length; i++) {
-        var key = keys[i];
+        const key = keys[i];
         this.setHeader(key, options.headers[key]);
       }
     }
 
     if (host && !this.getHeader('host') && setHost) {
-      var hostHeader = host;
+      let hostHeader = host;
 
       // For the Host header, ensure that IPv6 addresses are enclosed
       // in square brackets, as defined by URI formatting
       // https://tools.ietf.org/html/rfc3986#section-3.2.2
-      var posColon = hostHeader.indexOf(':');
+      const posColon = hostHeader.indexOf(':');
       if (posColon !== -1 &&
           hostHeader.indexOf(':', posColon + 1) !== -1 &&
           hostHeader.charCodeAt(0) !== 91/* '[' */) {
@@ -245,7 +245,7 @@ function ClientRequest(input, options, cb) {
                       options.headers);
   }
 
-  var oncreate = (err, socket) => {
+  const oncreate = (err, socket) => {
     if (called)
       return;
     called = true;
@@ -327,15 +327,15 @@ function emitAbortNT() {
 
 function createHangUpError() {
   // eslint-disable-next-line no-restricted-syntax
-  var error = new Error('socket hang up');
+  const error = new Error('socket hang up');
   error.code = 'ECONNRESET';
   return error;
 }
 
 
 function socketCloseListener() {
-  var socket = this;
-  var req = socket._httpMessage;
+  const socket = this;
+  const req = socket._httpMessage;
   debug('HTTP socket close');
 
   // Pull through final chunk, if anything is buffered.
@@ -386,8 +386,8 @@ function socketCloseListener() {
 }
 
 function socketErrorListener(err) {
-  var socket = this;
-  var req = socket._httpMessage;
+  const socket = this;
+  const req = socket._httpMessage;
   debug('SOCKET ERROR:', err.message, err.stack);
 
   if (req) {
@@ -400,7 +400,7 @@ function socketErrorListener(err) {
   // Handle any pending data
   socket.read();
 
-  var parser = socket.parser;
+  const parser = socket.parser;
   if (parser) {
     parser.finish();
     freeParser(parser, req, socket);
@@ -413,16 +413,16 @@ function socketErrorListener(err) {
 }
 
 function freeSocketErrorListener(err) {
-  var socket = this;
+  const socket = this;
   debug('SOCKET ERROR on FREE socket:', err.message, err.stack);
   socket.destroy();
   socket.emit('agentRemove');
 }
 
 function socketOnEnd() {
-  var socket = this;
-  var req = this._httpMessage;
-  var parser = this.parser;
+  const socket = this;
+  const req = this._httpMessage;
+  const parser = this.parser;
 
   if (!req.res && !req.socket._hadError) {
     // If we don't have a response then we know that the socket
@@ -438,13 +438,13 @@ function socketOnEnd() {
 }
 
 function socketOnData(d) {
-  var socket = this;
-  var req = this._httpMessage;
-  var parser = this.parser;
+  const socket = this;
+  const req = this._httpMessage;
+  const parser = this.parser;
 
   assert(parser && parser.socket === socket);
 
-  var ret = parser.execute(d);
+  const ret = parser.execute(d);
   if (ret instanceof Error) {
     debug('parse error', ret);
     freeParser(parser, req, socket);
@@ -453,8 +453,8 @@ function socketOnData(d) {
     req.emit('error', ret);
   } else if (parser.incoming && parser.incoming.upgrade) {
     // Upgrade (if status code 101) or CONNECT
-    var bytesParsed = ret;
-    var res = parser.incoming;
+    const bytesParsed = ret;
+    const res = parser.incoming;
     req.res = res;
 
     socket.removeListener('data', socketOnData);
@@ -463,9 +463,9 @@ function socketOnData(d) {
     parser.finish();
     freeParser(parser, req, socket);
 
-    var bodyHead = d.slice(bytesParsed, d.length);
+    const bodyHead = d.slice(bytesParsed, d.length);
 
-    var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
+    const eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
     if (req.listenerCount(eventName) > 0) {
       req.upgradeOrConnect = true;
 
@@ -506,8 +506,8 @@ function statusIsInformational(status) {
 
 // client
 function parserOnIncomingClient(res, shouldKeepAlive) {
-  var socket = this.socket;
-  var req = socket._httpMessage;
+  const socket = this.socket;
+  const req = socket._httpMessage;
 
   debug('AGENT incoming response!');
 
@@ -557,7 +557,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
   // Add our listener first, so that we guarantee socket cleanup
   res.on('end', responseOnEnd);
   req.on('prefinish', requestOnPrefinish);
-  var handled = req.emit('response', res);
+  const handled = req.emit('response', res);
 
   // If the user did not listen for the 'response' event, then they
   // can't possibly read the data, so we ._dump() it into the void
@@ -573,7 +573,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
 
 // client
 function responseKeepAlive(res, req) {
-  var socket = req.socket;
+  const socket = req.socket;
 
   if (!req.shouldKeepAlive) {
     if (socket.writable) {
@@ -627,7 +627,7 @@ function emitFreeNT(socket) {
 }
 
 function tickOnSocket(req, socket) {
-  var parser = parsers.alloc();
+  const parser = parsers.alloc();
   req.socket = socket;
   req.connection = socket;
   parser.reinitialize(HTTPParser.RESPONSE, parser[is_reused_symbol]);

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -93,7 +93,7 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
   incoming.url = url;
   incoming.upgrade = upgrade;
 
-  var n = headers.length;
+  let n = headers.length;
 
   // If parser.maxHeaderPairs <= 0 assume that there's no limit.
   if (parser.maxHeaderPairs > 0)
@@ -122,8 +122,8 @@ function parserOnBody(b, start, len) {
 
   // Pretend this was the result of a stream._read call.
   if (len > 0 && !stream._dumped) {
-    var slice = b.slice(start, start + len);
-    var ret = stream.push(slice);
+    const slice = b.slice(start, start + len);
+    const ret = stream.push(slice);
     if (!ret)
       readStop(this.socket);
   }

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -108,7 +108,7 @@ IncomingMessage.prototype.destroy = function destroy(error) {
 IncomingMessage.prototype._addHeaderLines = _addHeaderLines;
 function _addHeaderLines(headers, n) {
   if (headers && headers.length) {
-    var dest;
+    let dest;
     if (this.complete) {
       this.rawTrailers = headers;
       dest = this.trailers;
@@ -243,7 +243,7 @@ function matchKnownFields(field, lowercased) {
 IncomingMessage.prototype._addHeaderLine = _addHeaderLine;
 function _addHeaderLine(field, value, dest) {
   field = matchKnownFields(field);
-  var flag = field.charCodeAt(0);
+  const flag = field.charCodeAt(0);
   if (flag === 0 || flag === 2) {
     field = field.slice(1);
     // Make a delimited list

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -53,8 +53,8 @@ const kIsCorked = Symbol('isCorked');
 
 const hasOwnProperty = Function.call.bind(Object.prototype.hasOwnProperty);
 
-var RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
-var RE_TE_CHUNKED = common.chunkExpression;
+const RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
+const RE_TE_CHUNKED = common.chunkExpression;
 
 // isCookieField performs a case-insensitive comparison of a provided string
 // against the word "cookie." As of V8 6.6 this is faster than handrolling or
@@ -162,7 +162,7 @@ OutgoingMessage.prototype._renderHeaders = function _renderHeaders() {
     throw new ERR_HTTP_HEADERS_SENT('render');
   }
 
-  var headersMap = this[outHeadersKey];
+  const headersMap = this[outHeadersKey];
   const headers = {};
 
   if (headersMap !== null) {
@@ -217,7 +217,7 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback) {
         (encoding === 'utf8' || encoding === 'latin1' || !encoding)) {
       data = this._header + data;
     } else {
-      var header = this._header;
+      const header = this._header;
       if (this.outputData.length === 0) {
         this.outputData = [{
           data: header,
@@ -296,7 +296,7 @@ function _storeHeader(firstLine, headers) {
     header: firstLine
   };
 
-  var key;
+  let key;
   if (headers === this[outHeadersKey]) {
     for (key in headers) {
       const entry = headers[key];
@@ -541,7 +541,7 @@ OutgoingMessage.prototype.removeHeader = function removeHeader(name) {
     throw new ERR_HTTP_HEADERS_SENT('remove');
   }
 
-  var key = name.toLowerCase();
+  const key = name.toLowerCase();
 
   switch (key) {
     case 'connection':
@@ -623,7 +623,7 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
     process.nextTick(connectionCorkNT, msg, msg.connection);
   }
 
-  var len, ret;
+  let len, ret;
   if (msg.chunkedEncoding) {
     if (typeof chunk === 'string')
       len = Buffer.byteLength(chunk, encoding);
@@ -657,11 +657,11 @@ function connectionCorkNT(msg, conn) {
 
 OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
   this._trailer = '';
-  var keys = Object.keys(headers);
-  var isArray = Array.isArray(headers);
-  var field, value;
+  const keys = Object.keys(headers);
+  const isArray = Array.isArray(headers);
+  let field, value;
   for (var i = 0, l = keys.length; i < l; i++) {
-    var key = keys[i];
+    const key = keys[i];
     if (isArray) {
       field = headers[key][0];
       value = headers[key][1];
@@ -697,7 +697,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     return this;
   }
 
-  var uncork;
+  let uncork;
   if (chunk) {
     if (typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
       throw new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
@@ -721,7 +721,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
   if (typeof callback === 'function')
     this.once('finish', callback);
 
-  var finish = onFinish.bind(undefined, this);
+  const finish = onFinish.bind(undefined, this);
 
   if (this._hasBody && this.chunkedEncoding) {
     this._send('0\r\n' + this._trailer + '\r\n', 'latin1', finish);
@@ -774,8 +774,8 @@ OutgoingMessage.prototype._finish = function _finish() {
 // This function, outgoingFlush(), is called by both the Server and Client
 // to attempt to flush any pending messages out to the socket.
 OutgoingMessage.prototype._flush = function _flush() {
-  var socket = this.socket;
-  var ret;
+  const socket = this.socket;
+  let ret;
 
   if (socket && socket.writable) {
     // There might be remaining data in this.output; write it out
@@ -792,12 +792,12 @@ OutgoingMessage.prototype._flush = function _flush() {
 };
 
 OutgoingMessage.prototype._flushOutput = function _flushOutput(socket) {
-  var ret;
-  var outputLength = this.outputData.length;
+  let ret;
+  const outputLength = this.outputData.length;
   if (outputLength <= 0)
     return ret;
 
-  var outputData = this.outputData;
+  const outputData = this.outputData;
   socket.cork();
   for (var i = 0; i < outputLength; i++) {
     const { data, encoding, callback } = outputData[i];

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -203,7 +203,7 @@ ServerResponse.prototype._implicitHeader = function _implicitHeader() {
 
 ServerResponse.prototype.writeHead = writeHead;
 function writeHead(statusCode, reason, obj) {
-  var originalStatusCode = statusCode;
+  const originalStatusCode = statusCode;
 
   statusCode |= 0;
   if (statusCode < 100 || statusCode > 999) {
@@ -222,12 +222,12 @@ function writeHead(statusCode, reason, obj) {
   }
   this.statusCode = statusCode;
 
-  var headers;
+  let headers;
   if (this[outHeadersKey]) {
     // Slow-case: when progressive API and header fields are passed.
-    var k;
+    let k;
     if (obj) {
-      var keys = Object.keys(obj);
+      const keys = Object.keys(obj);
       for (var i = 0; i < keys.length; i++) {
         k = keys[i];
         if (k) this.setHeader(k, obj[k]);
@@ -246,7 +246,7 @@ function writeHead(statusCode, reason, obj) {
   if (checkInvalidHeaderChar(this.statusMessage))
     throw new ERR_INVALID_CHAR('statusMessage');
 
-  var statusLine = `HTTP/1.1 ${statusCode} ${this.statusMessage}${CRLF}`;
+  const statusLine = `HTTP/1.1 ${statusCode} ${this.statusMessage}${CRLF}`;
 
   if (statusCode === 204 || statusCode === 304 ||
       (statusCode >= 100 && statusCode <= 199)) {
@@ -344,7 +344,7 @@ function connectionListenerInternal(server, socket) {
     socket.setTimeout(server.timeout);
   socket.on('timeout', socketOnTimeout);
 
-  var parser = parsers.alloc();
+  const parser = parsers.alloc();
   parser.reinitialize(HTTPParser.REQUEST, parser[is_reused_symbol]);
   parser.socket = socket;
 
@@ -357,7 +357,7 @@ function connectionListenerInternal(server, socket) {
     parser.maxHeaderPairs = server.maxHeadersCount << 1;
   }
 
-  var state = {
+  const state = {
     onData: null,
     onEnd: null,
     onClose: null,
@@ -391,7 +391,7 @@ function connectionListenerInternal(server, socket) {
 
   // We only consume the socket if it has never been consumed before.
   if (socket._handle) {
-    var external = socket._handle._externalStream;
+    const external = socket._handle._externalStream;
     if (!socket._handle._consumed && external) {
       parser._consumed = true;
       socket._handle._consumed = true;
@@ -414,7 +414,7 @@ function updateOutgoingData(socket, state, delta) {
 }
 
 function socketOnDrain(socket, state) {
-  var needPause = state.outgoingData > socket.writableHighWaterMark;
+  const needPause = state.outgoingData > socket.writableHighWaterMark;
 
   // If we previously paused, then start reading again.
   if (socket._paused && !needPause) {
@@ -426,11 +426,11 @@ function socketOnDrain(socket, state) {
 }
 
 function socketOnTimeout() {
-  var req = this.parser && this.parser.incoming;
-  var reqTimeout = req && !req.complete && req.emit('timeout', this);
-  var res = this._httpMessage;
-  var resTimeout = res && res.emit('timeout', this);
-  var serverTimeout = this.server.emit('timeout', this);
+  const req = this.parser && this.parser.incoming;
+  const reqTimeout = req && !req.complete && req.emit('timeout', this);
+  const res = this._httpMessage;
+  const resTimeout = res && res.emit('timeout', this);
+  const serverTimeout = this.server.emit('timeout', this);
 
   if (!reqTimeout && !resTimeout && !serverTimeout)
     this.destroy();
@@ -448,7 +448,7 @@ function socketOnClose(socket, state) {
 
 function abortIncoming(incoming) {
   while (incoming.length) {
-    var req = incoming.shift();
+    const req = incoming.shift();
     req.aborted = true;
     req.emit('aborted');
     req.emit('close');
@@ -457,7 +457,7 @@ function abortIncoming(incoming) {
 }
 
 function socketOnEnd(server, socket, parser, state) {
-  var ret = parser.finish();
+  const ret = parser.finish();
 
   if (ret instanceof Error) {
     debug('parse error');
@@ -481,7 +481,7 @@ function socketOnData(server, socket, parser, state, d) {
   assert(!socket._paused);
   debug('SERVER socketOnData %d', d.length);
 
-  var ret = parser.execute(d);
+  const ret = parser.execute(d);
   onParserExecuteCommon(server, socket, parser, state, ret, d);
 }
 
@@ -535,8 +535,8 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
     socketOnError.call(socket, ret);
   } else if (parser.incoming && parser.incoming.upgrade) {
     // Upgrade or CONNECT
-    var bytesParsed = ret;
-    var req = parser.incoming;
+    const bytesParsed = ret;
+    const req = parser.incoming;
     debug('SERVER upgrade or connect', req.method);
 
     if (!d)
@@ -553,10 +553,10 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
     freeParser(parser, req, socket);
     parser = null;
 
-    var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
+    const eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
     if (eventName === 'upgrade' || server.listenerCount(eventName) > 0) {
       debug('SERVER have listener for %s', eventName);
-      var bodyHead = d.slice(bytesParsed, d.length);
+      const bodyHead = d.slice(bytesParsed, d.length);
 
       socket.readableFlowing = null;
       server.emit(eventName, req, socket, bodyHead);
@@ -604,7 +604,7 @@ function resOnFinish(req, res, socket, state, server) {
     }
   } else {
     // start sending the next message
-    var m = state.outgoing.shift();
+    const m = state.outgoing.shift();
     if (m) {
       m.assignSocket(socket);
     }
@@ -641,7 +641,7 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
   // so that we don't become overwhelmed by a flood of
   // pipelined requests that may never be resolved.
   if (!socket._paused) {
-    var ws = socket._writableState;
+    const ws = socket._writableState;
     if (ws.needDrain || state.outgoingData >= socket.writableHighWaterMark) {
       socket._paused = true;
       // We also need to pause the parser, but don't do that until after
@@ -651,7 +651,7 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
     }
   }
 
-  var res = new server[kServerResponse](req);
+  const res = new server[kServerResponse](req);
   res._onPendingData = updateOutgoingData.bind(undefined, socket, state);
 
   res.shouldKeepAlive = keepAlive;
@@ -736,7 +736,7 @@ function unconsume(parser, socket) {
 }
 
 function socketOnWrap(ev, fn) {
-  var res = net.Socket.prototype.on.call(this, ev, fn);
+  const res = net.Socket.prototype.on.call(this, ev, fn);
   if (!this.parser) {
     this.on = net.Socket.prototype.on;
     return res;

--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -2,8 +2,8 @@
 
 const { setUnrefTimeout } = require('internal/timers');
 
-var nowCache;
-var utcCache;
+let nowCache;
+let utcCache;
 
 function nowDate() {
   if (!nowCache) cache();


### PR DESCRIPTION
Refs #26486

> @ BeniCheni Can you put the var -> let/const stuff in a separate commit? (Separate PR would be even better!)

Per [this comment in #26486](https://github.com/nodejs/node/pull/26486#issuecomment-470663793) ☝️ , this PR follows up to convert `var` variables to `let` or `const`, in the scope of http source in `lib/` path.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
