### PR TITLE
doc: remove tsc-review

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -305,7 +305,6 @@ in the placeholder's `README`.
 For pull requests introducing new core modules:
 
 * Allow at least one week for review.
-* Label with the `tsc-review` label.
 * Land only after sign-off from at least two TSC members.
 * Land with a [Stability Index][] of Experimental. The module must remain
   Experimental until a semver-major release.
@@ -382,9 +381,8 @@ This should be done where a pull request:
 - has failed to reach consensus amongst the Collaborators who are
   actively participating in the discussion.
 
-Assign the `tsc-review` label or @-mention the
-`@nodejs/tsc` GitHub team if you want to elevate an issue to the [TSC][].
-Do not use the GitHub UI on the right-hand side to assign to
+@-mention the `@nodejs/tsc` GitHub team if you want to elevate an issue to the
+[TSC][]. Do not use the GitHub UI on the right-hand side to assign to
 `@nodejs/tsc` or request a review from `@nodejs/tsc`.
 
 The TSC should serve as the final arbiter where required.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -50,10 +50,6 @@ be accepted unless:
   This should only happen if disagreements between Collaborators cannot be
   resolved through discussion.
 
-Collaborators may opt to elevate significant or controversial modifications to
-the TSC by assigning the `tsc-review` label to a pull request or issue. The
-TSC should serve as the final arbiter where required.
-
 See:
 
 * [Current list of Collaborators](./README.md#current-project-team-members)
@@ -105,11 +101,9 @@ The intention of the agenda is not to approve or review all patches.
 That should happen continuously on GitHub and be handled by the larger
 group of Collaborators.
 
-Any community member or contributor can ask that something be reviewed
-by the TSC by logging a GitHub issue. Any Collaborator, TSC member, or the
-meeting chair can bring the issue to the TSC's attention by applying the
-`tsc-review` label. If consensus-seeking among TSC members fails for a
-particular issue, it may be added to the TSC meeting agenda by adding the
+Any community member or contributor can ask that something be reviewed by the
+TSC by logging a GitHub issue. If consensus-seeking among TSC members fails for
+a particular issue, it may be added to the TSC meeting agenda by adding the
 `tsc-agenda` label.
 
 Prior to each TSC meeting, the meeting chair will share the agenda with

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -89,8 +89,6 @@ onboarding session.
     so that we know what parts of the code base the pull request modifies. It is
     not perfect, of course. Feel free to apply relevant labels and remove
     irrelevant labels from pull requests and issues.
-  * Use the `tsc-review` label if a topic is controversial or isn't coming to a
-    conclusion after an extended time.
   * `semver-{minor,major}`:
     * If a change has the remote *chance* of breaking something, use the
       `semver-major` label


### PR DESCRIPTION
The tsc-review label is ineffective. It almost always gets ignored.
Remove it. When requiring TSC attention, people should @-mention the
TSC GitHub team.

I removed the adjacent "The TSC should serve as the final arbiter where required." text in one case because it literally repeats what is in the immediately-preceding bullet point now that the `tsc-review` sentence is removed. The immediately-preceding sentence is: "The change is escalated to the TSC and the TSC votes to approve the change.  This should only happen if disagreements between Collaborators cannot be  resolved through discussion."


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
