### PR TITLE
process: delay creation of process.env until after bootstrap/node.js

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -340,6 +340,16 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
   MaybeLocal<Value> result = ExecuteBootstrapper(
       env, "internal/bootstrap/node", &node_params, &node_args);
 
+  Local<Object> env_var_proxy;
+  if (!CreateEnvVarProxy(context, isolate, env->as_callback_data())
+           .ToLocal(&env_var_proxy) ||
+      process
+          ->Set(env->context(),
+                FIXED_ONE_BYTE_STRING(env->isolate(), "env"),
+                env_var_proxy)
+          .IsNothing())
+    return MaybeLocal<Value>();
+
   env->set_has_run_bootstrapping_code(true);
 
   return scope.EscapeMaybe(result);

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -151,18 +151,6 @@ MaybeLocal<Object> CreateProcessObject(
                ToV8Value(env->context(), exec_args)
                    .ToLocalChecked()).FromJust();
 
-  Local<Object> env_var_proxy;
-  if (!CreateEnvVarProxy(context, isolate, env->as_callback_data())
-           .ToLocal(&env_var_proxy))
-    return MaybeLocal<Object>();
-
-  // process.env
-  process
-      ->Set(env->context(),
-            FIXED_ONE_BYTE_STRING(env->isolate(), "env"),
-            env_var_proxy)
-      .FromJust();
-
   READONLY_PROPERTY(process, "pid",
                     Integer::New(env->isolate(), uv_os_getpid()));
 


### PR DESCRIPTION
Make sure that no code is allowed to access process.env during
the execution of bootstrap/node.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
