### PR TITLE
process: patch more process properties during pre-execution

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -210,13 +210,6 @@ if (!config.noBrowserGlobals) {
 
 setupDOMException();
 
-Object.defineProperty(process, 'argv0', {
-  enumerable: true,
-  configurable: false,
-  value: process.argv[0]
-});
-process.argv[0] = process.execPath;
-
 // process.allowedNodeEnvironmentFlags
 Object.defineProperty(process, 'allowedNodeEnvironmentFlags', {
   get() {

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -60,22 +60,22 @@ function patchProcessObject() {
 
   // TODO(joyeecheung): most of these should be deprecated and removed,
   // execpt some that we need to be able to mutate during run time.
-  defineReadOnlyAlias('_eval', '--eval');
-  defineReadOnlyAlias('_print_eval', '--print');
-  defineReadOnlyAlias('_syntax_check_only', '--check');
-  defineReadOnlyAlias('_forceRepl', '--interactive');
-  defineReadOnlyAlias('_preload_modules', '--require');
-  defineReadOnlyAlias('noDeprecation', '--no-deprecation');
-  defineReadOnlyAlias('noProcessWarnings', '--no-warnings');
-  defineReadOnlyAlias('traceProcessWarnings', '--trace-warnings');
-  defineReadOnlyAlias('throwDeprecation', '--throw-deprecation');
-  defineReadOnlyAlias('profProcess', '--prof-process');
-  defineReadOnlyAlias('traceDeprecation', '--trace-deprecation');
-  defineReadOnlyAlias('_breakFirstLine', '--inspect-brk', false);
-  defineReadOnlyAlias('_breakNodeFirstLine', '--inspect-brk-node', false);
+  addReadOnlyProcessAlias('_eval', '--eval');
+  addReadOnlyProcessAlias('_print_eval', '--print');
+  addReadOnlyProcessAlias('_syntax_check_only', '--check');
+  addReadOnlyProcessAlias('_forceRepl', '--interactive');
+  addReadOnlyProcessAlias('_preload_modules', '--require');
+  addReadOnlyProcessAlias('noDeprecation', '--no-deprecation');
+  addReadOnlyProcessAlias('noProcessWarnings', '--no-warnings');
+  addReadOnlyProcessAlias('traceProcessWarnings', '--trace-warnings');
+  addReadOnlyProcessAlias('throwDeprecation', '--throw-deprecation');
+  addReadOnlyProcessAlias('profProcess', '--prof-process');
+  addReadOnlyProcessAlias('traceDeprecation', '--trace-deprecation');
+  addReadOnlyProcessAlias('_breakFirstLine', '--inspect-brk', false);
+  addReadOnlyProcessAlias('_breakNodeFirstLine', '--inspect-brk-node', false);
 }
 
-function defineReadOnlyAlias(name, option, enumerable = true) {
+function addReadOnlyProcessAlias(name, option, enumerable = true) {
   const value = getOptionValue(option);
   if (value) {
     Object.defineProperty(process, name, {

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -6,6 +6,8 @@ const { getOptionValue } = require('internal/options');
 let traceEventsAsyncHook;
 
 function prepareMainThreadExecution() {
+  // Patch the process object with legacy properties and normalizations
+  patchProcessObject();
   setupTraceCategoryState();
 
   setupWarningHandler();
@@ -46,6 +48,15 @@ function prepareMainThreadExecution() {
   initializeFrozenIntrinsics();
   initializeESMLoader();
   loadPreloadModules();
+}
+
+function patchProcessObject() {
+  Object.defineProperty(process, 'argv0', {
+    enumerable: true,
+    configurable: false,
+    value: process.argv[0]
+  });
+  process.argv[0] = process.execPath;
 }
 
 function setupWarningHandler() {
@@ -290,6 +301,7 @@ function loadPreloadModules() {
 }
 
 module.exports = {
+  patchProcessObject,
   setupCoverageHooks,
   setupWarningHandler,
   setupDebugEnv,

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -57,13 +57,42 @@ function patchProcessObject() {
     value: process.argv[0]
   });
   process.argv[0] = process.execPath;
+
+  // TODO(joyeecheung): most of these should be deprecated and removed,
+  // execpt some that we need to be able to mutate during run time.
+  defineReadOnlyAlias('_eval', '--eval');
+  defineReadOnlyAlias('_print_eval', '--print');
+  defineReadOnlyAlias('_syntax_check_only', '--check');
+  defineReadOnlyAlias('_forceRepl', '--interactive');
+  defineReadOnlyAlias('_preload_modules', '--require');
+  defineReadOnlyAlias('noDeprecation', '--no-deprecation');
+  defineReadOnlyAlias('noProcessWarnings', '--no-warnings');
+  defineReadOnlyAlias('traceProcessWarnings', '--trace-warnings');
+  defineReadOnlyAlias('throwDeprecation', '--throw-deprecation');
+  defineReadOnlyAlias('profProcess', '--prof-process');
+  defineReadOnlyAlias('traceDeprecation', '--trace-deprecation');
+  defineReadOnlyAlias('_breakFirstLine', '--inspect-brk', false);
+  defineReadOnlyAlias('_breakNodeFirstLine', '--inspect-brk-node', false);
+}
+
+function defineReadOnlyAlias(name, option, enumerable = true) {
+  const value = getOptionValue(option);
+  if (value) {
+    Object.defineProperty(process, name, {
+      writable: false,
+      configurable: true,
+      enumerable,
+      value
+    });
+  }
 }
 
 function setupWarningHandler() {
   const {
     onWarning
   } = require('internal/process/warning');
-  if (!process.noProcessWarnings && process.env.NODE_NO_WARNINGS !== '1') {
+  if (!getOptionValue('--no-warnings') &&
+    process.env.NODE_NO_WARNINGS !== '1') {
     process.on('warning', onWarning);
   }
 }

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -4,6 +4,7 @@
 // message port.
 
 const {
+  patchProcessObject,
   setupCoverageHooks,
   setupWarningHandler,
   setupDebugEnv,
@@ -41,6 +42,7 @@ const {
 
 const publicWorker = require('worker_threads');
 
+patchProcessObject();
 setupDebugEnv();
 
 const debug = require('util').debuglog('worker');

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -170,91 +170,10 @@ MaybeLocal<Object> CreateProcessObject(
                              FIXED_ONE_BYTE_STRING(env->isolate(), "ppid"),
                              GetParentProcessId).FromJust());
 
-  // TODO(joyeecheung): the following process properties that are set using
-  // parsed CLI flags should be migrated to `internal/options` in JS land.
-
-  // -e, --eval
-  // TODO(addaleax): Remove this.
-  if (env->options()->has_eval_string) {
-    READONLY_PROPERTY(process,
-                      "_eval",
-                      String::NewFromUtf8(
-                          env->isolate(),
-                          env->options()->eval_string.c_str(),
-                          NewStringType::kNormal).ToLocalChecked());
-  }
-
-  // -p, --print
-  // TODO(addaleax): Remove this.
-  if (env->options()->print_eval) {
-    READONLY_PROPERTY(process, "_print_eval", True(env->isolate()));
-  }
-
-  // -c, --check
-  // TODO(addaleax): Remove this.
-  if (env->options()->syntax_check_only) {
-    READONLY_PROPERTY(process, "_syntax_check_only", True(env->isolate()));
-  }
-
-  // -i, --interactive
-  // TODO(addaleax): Remove this.
-  if (env->options()->force_repl) {
-    READONLY_PROPERTY(process, "_forceRepl", True(env->isolate()));
-  }
-
-  // -r, --require
-  // TODO(addaleax): Remove this.
-  const std::vector<std::string>& preload_modules =
-      env->options()->preload_modules;
-  if (!preload_modules.empty()) {
-    READONLY_PROPERTY(process,
-                      "_preload_modules",
-                      ToV8Value(env->context(), preload_modules)
-                          .ToLocalChecked());
-  }
-
-  // --no-deprecation
-  if (env->options()->no_deprecation) {
-    READONLY_PROPERTY(process, "noDeprecation", True(env->isolate()));
-  }
-
-  // --no-warnings
-  if (env->options()->no_warnings) {
-    READONLY_PROPERTY(process, "noProcessWarnings", True(env->isolate()));
-  }
-
-  // --trace-warnings
-  if (env->options()->trace_warnings) {
-    READONLY_PROPERTY(process, "traceProcessWarnings", True(env->isolate()));
-  }
-
-  // --throw-deprecation
-  if (env->options()->throw_deprecation) {
-    READONLY_PROPERTY(process, "throwDeprecation", True(env->isolate()));
-  }
-
-  // --prof-process
-  // TODO(addaleax): Remove this.
-  if (env->options()->prof_process) {
-    READONLY_PROPERTY(process, "profProcess", True(env->isolate()));
-  }
-
-  // --trace-deprecation
-  if (env->options()->trace_deprecation) {
-    READONLY_PROPERTY(process, "traceDeprecation", True(env->isolate()));
-  }
-
-  // --inspect-brk
-  if (env->options()->debug_options().wait_for_connect()) {
-    READONLY_DONT_ENUM_PROPERTY(process,
-                                "_breakFirstLine", True(env->isolate()));
-  }
-
-  // --inspect-brk-node
-  if (env->options()->debug_options().break_node_first_line) {
-    READONLY_DONT_ENUM_PROPERTY(process,
-                                "_breakNodeFirstLine", True(env->isolate()));
-  }
+  // TODO(joyeecheung): make this available in JS during pre-execution.
+  // Note that to use this in releases the code doing the revert need to be
+  // careful to delay the check until after the bootstrap but that may not
+  // be possible depending on the feature being reverted.
 
   // --security-revert flags
 #define V(code, _, __)                                                        \


### PR DESCRIPTION
#### process: delay process.argv[0] and process.argv0 handling

Since these depends on process runtime states, delay them until
pre-execution.

#### process: create legacy process properties during pre-execution

Shim legacy process object properties of CLI options during
pre-execution instead of serializing them during bootstrap.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
