### PR TITLE
perf_hooks: add heap statistics monitoring

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -530,6 +530,161 @@ added: v11.10.0
 
 The standard deviation of the recorded event loop delays.
 
+## perf_hooks.monitorHeapStatistics([options])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {Object}
+  * `resolution` {number} The sample rate in milliseconds. Must be greater
+    than zero. **Default** `10`.
+* Returns {HeapHistograms}
+
+Creates an object that samples and reports heap use statistics as a set
+of histograms.
+
+```js
+const { monitorHeapStatistics } = require('perf_hooks');
+const h = monitorHeapStatistics({ resolution: 20 });
+h.enable();
+// Do something.
+h.disable();
+console.log(h.heapTotal.min);
+console.log(h.heapTotal.max);
+console.log(h.heapTotal.mean);
+console.log(h.heapTotal.stddev);
+console.log(h.heapTotal.percentiles);
+console.log(h.heapTotal.percentile(50));
+console.log(h.heapTotal.percentile(99));
+```
+
+### Class: HeapHistograms
+
+#### heaphistograms.disable()
+<!--YAML
+added: REPLACEME
+-->
+* Returns: {boolean}
+
+Disables the heap statistics sample timer. Returns `true` if the timer was
+stopped, `false` if it was already stopped.
+
+
+#### heaphistograms.enable()
+<!--YAML
+added: REPLACEME
+-->
+* Returns: {boolean}
+
+Enables the heap statistics sample timer. Returns `true` if the timer was
+started, `false` if it was already started.
+
+
+#### heaphistograms.external
+<!--YAML
+added: REPLACEME
+-->
+* Returns: {HeapHistogram}
+
+A histogram object that tracks external memory.
+
+#### heaphistograms.heapTotal
+<!--YAML
+added: REPLACEME
+-->
+* Returns: {HeapHistogram}
+
+A histogram object that tracks total heap memory size.
+
+#### heaphistograms.heapUsed
+<!--YAML
+added: REPLACEME
+-->
+* Returns: {HeapHistogram}
+
+A histogram object that tracks used heap memory size.
+
+#### heaphistograms.reset()
+<!--YAML
+added: REPLACEME
+-->
+
+Resets the collected histogram data.
+
+#### heaphistograms.rss
+<!--YAML
+added: REPLACEME
+-->
+* Returns: {HeapHistogram}
+
+A histogram object that tracks RSS memory size.
+
+### HeapHistogram
+
+#### heaphistogram.exceeds
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+The number of times the sample value exceeded the maximum.
+
+#### heaphistogram.max
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+The maximum recorded sample value.
+
+#### heaphistogram.mean
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+The mean of the recorded samples.
+
+#### heaphistogram.min
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+The minimum recorded sample value.
+
+#### heaphistogram.percentile(percentile)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `percentile` {number} A percentile value between 1 and 100.
+* Returns: {number}
+
+Returns the value at the given percentile.
+
+#### heaphistogram.percentiles
+<!-- YAML
+added: REPLACEME
+-->
+
+* {Map}
+
+Returns a `Map` object detailing the accumulated percentile distribution.
+
+#### heaphistogram.stddev
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+The standard deviation of the recorded samples.
+
 ## Examples
 
 ### Measuring the duration of async operations

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -2,6 +2,7 @@
 
 const {
   ELDHistogram: _ELDHistogram,
+  HeapHistograms: _HeapHistograms,
   PerformanceEntry,
   mark: _mark,
   clearMark: _clearMark,
@@ -548,15 +549,11 @@ function sortedInsert(list, entry) {
   list.splice(location, 0, entry);
 }
 
-class ELDHistogram {
+class Histogram {
   constructor(handle) {
     this[kHandle] = handle;
     this[kMap] = new Map();
   }
-
-  reset() { this[kHandle].reset(); }
-  enable() { return this[kHandle].enable(); }
-  disable() { return this[kHandle].disable(); }
 
   get exceeds() { return this[kHandle].exceeds(); }
   get min() { return this[kHandle].min(); }
@@ -593,6 +590,39 @@ class ELDHistogram {
   }
 }
 
+class ELDHistogram extends Histogram {
+  constructor(handle) {
+    super(handle);
+  }
+
+  reset() { this[kHandle].reset(); }
+  enable() { return this[kHandle].enable(); }
+  disable() { return this[kHandle].disable(); }
+}
+
+class HeapHistograms {
+ constructor(handle) {
+   this[kHandle] = handle;
+   this.rss = new Histogram(handle.rss);
+   this.heapTotal = new Histogram(handle.heapTotal);
+   this.heapUsed = new Histogram(handle.heapUsed);
+   this.external = new Histogram(handle.external);
+ }
+
+ reset() { this[kHandle].reset(); }
+ enable() { return this[kHandle].enable(); }
+ disable() { return this[kHandle].disable(); }
+
+ [kInspect]() {
+   return {
+     rss: this.rss,
+     heapTotal: this.heapTotal,
+     heapUed: this.heapUsed,
+     external: this.external
+   }
+ }
+}
+
 function monitorEventLoopDelay(options = {}) {
   if (typeof options !== 'object' || options === null) {
     const errors = lazyErrors();
@@ -611,10 +641,29 @@ function monitorEventLoopDelay(options = {}) {
   return new ELDHistogram(new _ELDHistogram(resolution));
 }
 
+function monitorHeapStatistics(options = {}) {
+  if (typeof options !== 'object' || options === null) {
+    const errors = lazyErrors();
+    throw new errors.ERR_INVALID_ARG_TYPE('options', 'Object', options);
+  }
+  const { resolution = 10 } = options;
+  if (typeof resolution !== 'number') {
+    const errors = lazyErrors();
+    throw new errors.ERR_INVALID_ARG_TYPE('options.resolution',
+                                          'number', resolution);
+  }
+  if (resolution <= 0 || !Number.isSafeInteger(resolution)) {
+    const errors = lazyErrors();
+    throw new errors.ERR_INVALID_OPT_VALUE.RangeError('resolution', resolution);
+  }
+  return new HeapHistograms(new _HeapHistograms(resolution));
+}
+
 module.exports = {
   performance,
   PerformanceObserver,
-  monitorEventLoopDelay
+  monitorEventLoopDelay,
+  monitorHeapStatistics
 };
 
 Object.defineProperty(module.exports, 'constants', {

--- a/src/env.h
+++ b/src/env.h
@@ -175,6 +175,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(exponent_string, "exponent")                                               \
   V(exports_string, "exports")                                                 \
   V(ext_key_usage_string, "ext_key_usage")                                     \
+  V(external_string, "external")                                               \
   V(external_stream_string, "_externalStream")                                 \
   V(family_string, "family")                                                   \
   V(fatal_exception_string, "_fatalException")                                 \
@@ -189,6 +190,8 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(get_shared_array_buffer_id_string, "_getSharedArrayBufferId")              \
   V(gid_string, "gid")                                                         \
   V(handle_string, "handle")                                                   \
+  V(heap_total_string, "heapTotal")                                            \
+  V(heap_used_string, "heapUsed")                                              \
   V(help_text_string, "helpText")                                              \
   V(homedir_string, "homedir")                                                 \
   V(host_string, "host")                                                       \
@@ -273,6 +276,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(replacement_string, "replacement")                                         \
   V(require_string, "require")                                                 \
   V(retry_string, "retry")                                                     \
+  V(rss_string, "rss")                                                         \
   V(scheme_string, "scheme")                                                   \
   V(scopeid_string, "scopeid")                                                 \
   V(serial_number_string, "serialNumber")                                      \
@@ -343,6 +347,8 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(fs_use_promises_symbol, v8::Symbol)                                        \
   V(fsreqpromise_constructor_template, v8::ObjectTemplate)                     \
   V(handle_wrap_ctor_template, v8::FunctionTemplate)                           \
+  V(heap_histograms_constructor_template, v8::ObjectTemplate)                  \
+  V(histogram_constructor_template, v8::ObjectTemplate)                        \
   V(host_import_module_dynamically_callback, v8::Function)                     \
   V(host_initialize_import_meta_object_callback, v8::Function)                 \
   V(http2ping_constructor_template, v8::ObjectTemplate)                        \

--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -6,6 +6,7 @@
 #include "node.h"
 #include "uv.h"
 #include "v8.h"
+#include "histogram-inl.h"
 
 #include <algorithm>
 #include <map>
@@ -66,7 +67,16 @@ class performance_state {
       isolate,
       offsetof(performance_state_internal, observers),
       NODE_PERFORMANCE_ENTRY_TYPE_INVALID,
-      root) {
+      root),
+    total_memory_(uv_get_total_memory()),
+    rss_histogram_(1, total_memory_),
+    total_heap_size_histogram_(1, total_memory_),
+    used_heap_size_histogram_(1, total_memory_),
+    external_memory_histogram_(1, total_memory_),
+    rss_exceeds_(0),
+    total_heap_size_exceeds_(0),
+    used_heap_size_exceeds_(0),
+    external_memory_exceeds_(0) {
     for (size_t i = 0; i < milestones.Length(); i++)
       milestones[i] = -1.;
   }
@@ -80,12 +90,75 @@ class performance_state {
   void Mark(enum PerformanceMilestone milestone,
             uint64_t ts = PERFORMANCE_NOW());
 
+  void RecordHeapStatistics(v8::Isolate* isolate) {
+    size_t rss;
+    int err = uv_resident_set_memory(&rss);
+    if (!err) {
+      if (!rss_histogram_.Record(rss) && rss_exceeds_ < 0xFFFFFFFF)
+        rss_exceeds_++;
+    }
+
+    v8::HeapStatistics v8_heap_stats;
+    isolate->GetHeapStatistics(&v8_heap_stats);
+
+    if (!total_heap_size_histogram_.Record(v8_heap_stats.total_heap_size()) &&
+        total_heap_size_exceeds_ < 0xFFFFFFFF) {
+      total_heap_size_exceeds_++;
+    }
+    if (!used_heap_size_histogram_.Record(v8_heap_stats.used_heap_size()) &&
+        used_heap_size_exceeds_ < 0xFFFFFFFF) {
+      used_heap_size_exceeds_++;
+    }
+    if (!external_memory_histogram_.Record(v8_heap_stats.external_memory()) &&
+        external_memory_exceeds_ < 0xFFFFFFFF) {
+      external_memory_exceeds_++;
+    }
+  }
+
+  void ResetHeapStatistics() {
+    rss_histogram_.Reset();
+    total_heap_size_histogram_.Reset();
+    used_heap_size_histogram_.Reset();
+    external_memory_histogram_.Reset();
+    rss_exceeds_ = 0;
+    total_heap_size_exceeds_ = 0;
+    used_heap_size_exceeds_ = 0;
+    external_memory_exceeds_ = 0;
+  }
+
+  Histogram* rss_histogram() {
+    return &rss_histogram_;
+  }
+  Histogram* total_heap_size_histogram() {
+    return &total_heap_size_histogram_;
+  }
+  Histogram* used_heap_size_histogram() {
+    return &used_heap_size_histogram_;
+  }
+  Histogram* external_memory_histogram() {
+    return &external_memory_histogram_;
+  }
+
+  int64_t rss_exceeds() { return rss_exceeds_; }
+  int64_t total_heap_size_exceeds() { return total_heap_size_exceeds_; }
+  int64_t used_heap_size_exceeds() { return used_heap_size_exceeds_; }
+  int64_t external_memory_exceeds() { return external_memory_exceeds_; }
+
  private:
   struct performance_state_internal {
     // doubles first so that they are always sizeof(double)-aligned
     double milestones[NODE_PERFORMANCE_MILESTONE_INVALID];
     uint32_t observers[NODE_PERFORMANCE_ENTRY_TYPE_INVALID];
   };
+  int64_t total_memory_;
+  Histogram rss_histogram_;
+  Histogram total_heap_size_histogram_;
+  Histogram used_heap_size_histogram_;
+  Histogram external_memory_histogram_;
+  int64_t rss_exceeds_;
+  int64_t total_heap_size_exceeds_;
+  int64_t used_heap_size_exceeds_;
+  int64_t external_memory_exceeds_;
 };
 
 }  // namespace performance

--- a/test/sequential/test-performance-heapstatistics.js
+++ b/test/sequential/test-performance-heapstatistics.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const {
+  monitorHeapStatistics
+} = require('perf_hooks');
+
+{
+  const histograms = monitorHeapStatistics();
+  assert(histograms);
+  assert(histograms.enable());
+  assert(!histograms.enable());
+  histograms.reset();
+  assert(histograms.disable());
+  assert(!histograms.disable());
+}
+
+
+{
+  [null, 'a', 1, false, Infinity].forEach((i) => {
+    common.expectsError(
+      () => monitorHeapStatistics(i),
+      {
+        type: TypeError,
+        code: 'ERR_INVALID_ARG_TYPE'
+      }
+    );
+  });
+
+  [null, 'a', false, {}, []].forEach((i) => {
+    common.expectsError(
+      () => monitorHeapStatistics({ resolution: i }),
+      {
+        type: TypeError,
+        code: 'ERR_INVALID_ARG_TYPE'
+      }
+    );
+  });
+
+  [-1, 0, Infinity].forEach((i) => {
+    common.expectsError(
+      () => monitorHeapStatistics({ resolution: i }),
+      {
+        type: RangeError,
+        code: 'ERR_INVALID_OPT_VALUE'
+      }
+    );
+  });
+}
+
+{
+  const histograms = monitorHeapStatistics({ resolution: 1 });
+  const intentionalMemoryLeak = new Set();
+  histograms.enable();
+  let m = 5;
+  function checkHistogram(histogram) {
+    assert(histogram.min > 0);
+    assert(histogram.max > 0);
+    assert(histogram.stddev >= 0);
+    assert(histogram.mean > 0);
+    assert(histogram.percentiles.size > 0);
+    for (let n = 1; n < 100; n = n + 0.1) {
+      assert(histogram.percentile(n) >= 0);
+    }
+    ['a', false, {}, []].forEach((i) => {
+      common.expectsError(
+        () => histogram.percentile(i),
+        {
+          type: TypeError,
+          code: 'ERR_INVALID_ARG_TYPE'
+        }
+      );
+    });
+    [-1, 0, 101].forEach((i) => {
+      common.expectsError(
+        () => histogram.percentile(i),
+        {
+          type: RangeError,
+          code: 'ERR_INVALID_ARG_VALUE'
+        }
+      );
+    });
+  }
+  function spinAWhile() {
+    for (let n = 0; n < 100; n++)
+      intentionalMemoryLeak.add(new Object());
+    common.busyLoop();
+    if (--m > 0) {
+      setTimeout(spinAWhile, common.platformTimeout(500));
+    } else {
+      histograms.disable();
+      checkHistogram(histograms.heapUsed);
+      checkHistogram(histograms.heapTotal);
+      checkHistogram(histograms.rss);
+      checkHistogram(histograms.external);
+    }
+  }
+  spinAWhile();
+}


### PR DESCRIPTION
Adds a sampling heap statistics monitor that yields histograms
for rss, heap used, heap total, and external. Implemented in
a way that is API consistent with the recently added event
loop monitoring.

```js
const { monitorHeapStatistics } = require('perf_hooks');

const h = monitorHeapStatistics({ resolution: 10 });
h.enable();
// Do stuff
h.disable();

console.log(h.heapUsed.min, h.heapUsed.max, h.heapUsed.percentiles)
console.log(h.heapTotal.min, h.heapTotal.min, h.heapTotal.percentiles)
h.reset();
```
```js
{ rss:
   { min: 26624000,
     max: 26640383,
     mean: 26632192,
     stddev: 0,
     percentiles: Map { 0 => 26624000, 100 => 26624000 },
     exceeds: 0 },
  heapTotal:
   { min: 6918144,
     max: 6922239,
     mean: 6920192,
     stddev: 0,
     percentiles: Map { 0 => 6918144, 100 => 6918144 },
     exceeds: 0 },
  heapUed:
   { min: 4259840,
     max: 4333567,
     mean: 4304379.697478992,
     stddev: 24541.15138640944,
     percentiles:
      Map {
        0 => 4259840,
        50 => 4317184,
        75 => 4321280,
        87.5 => 4329472,
        100 => 4329472 },
     exceeds: 0 },
  external:
   { min: 11648,
     max: 11663,
     mean: 11656.773109243697,
     stddev: 3.924576677465929,
     percentiles: Map { 0 => 11648, 50 => 11656, 100 => 11656 },
     exceeds: 0 } }
```
/cc @mcollina 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
