### PR TITLE
report: fix formatting and add coverage for stdout/stderr

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -171,9 +171,7 @@ std::string TriggerNodeReport(Isolate* isolate,
       return "";
     }
     outstream = &outfile;
-
-    std::cerr << std::endl
-              << "Writing Node.js report to file: " << filename << std::endl;
+    std::cerr << std::endl << "Writing Node.js report to file: " << filename;
   }
 
   WriteNodeReport(isolate, env, message, trigger, filename, *outstream,
@@ -184,7 +182,7 @@ std::string TriggerNodeReport(Isolate* isolate,
     outfile.close();
   }
 
-  std::cerr << "Node.js report completed" << std::endl;
+  std::cerr << std::endl << "Node.js report completed" << std::endl;
   return filename;
 }
 


### PR DESCRIPTION
When `process.report.filename` is `'stdout'` or `'stderr'`, the output runs together. This PR fixes that, and also improves test coverage.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
