### PR TITLE
src: deprecate AddPromiseHook()

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -585,9 +585,10 @@ struct async_context {
 
 /* Registers an additional v8::PromiseHook wrapper. This API exists because V8
  * itself supports only a single PromiseHook. */
-NODE_EXTERN void AddPromiseHook(v8::Isolate* isolate,
-                                promise_hook_func fn,
-                                void* arg);
+NODE_DEPRECATED("Use async_hooks directly instead",
+                NODE_EXTERN void AddPromiseHook(v8::Isolate* isolate,
+                                                promise_hook_func fn,
+                                                void* arg));
 
 /* This is a lot like node::AtExit, except that the hooks added via this
  * function are run before the AtExit ones and will always be registered


### PR DESCRIPTION
This API was added to fill an use case that is served by `async_hooks`,
since that has `Promise` support.

Deprecate this, as the underlying `Isolate::SetPromiseHook()` may be
removed in its current form in the future.

Refs: https://docs.google.com/document/d/1g8OrG5lMIUhRn1zbkutgY83MiTSMx-0NHDs8Bf-nXxM/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
