### PR TITLE
async_hooks: remove deprecated emitBefore and emitAfter

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -659,41 +659,6 @@ of the async resource. This will establish the context, trigger the AsyncHooks
 before callbacks, call the function, trigger the AsyncHooks after callbacks, and
 then restore the original execution context.
 
-#### asyncResource.emitBefore()
-<!-- YAML
-deprecated: v9.6.0
--->
-> Stability: 0 - Deprecated: Use [`asyncResource.runInAsyncScope()`][] instead.
-
-Call all `before` callbacks to notify that a new asynchronous execution context
-is being entered. If nested calls to `emitBefore()` are made, the stack of
-`asyncId`s will be tracked and properly unwound.
-
-`before` and `after` calls must be unwound in the same order that they
-are called. Otherwise, an unrecoverable exception will occur and the process
-will abort. For this reason, the `emitBefore` and `emitAfter` APIs are
-considered deprecated. Please use `runInAsyncScope`, as it provides a much safer
-alternative.
-
-#### asyncResource.emitAfter()
-<!-- YAML
-deprecated: v9.6.0
--->
-> Stability: 0 - Deprecated: Use [`asyncResource.runInAsyncScope()`][] instead.
-
-Call all `after` callbacks. If nested calls to `emitBefore()` were made, then
-make sure the stack is unwound properly. Otherwise an error will be thrown.
-
-If the user's callback throws an exception, `emitAfter()` will automatically be
-called for all `asyncId`s on the stack if the error is handled by a domain or
-`'uncaughtException'` handler.
-
-`before` and `after` calls must be unwound in the same order that they
-are called. Otherwise, an unrecoverable exception will occur and the process
-will abort. For this reason, the `emitBefore` and `emitAfter` APIs are
-considered deprecated. Please use `runInAsyncScope`, as it provides a much safer
-alternative.
-
 #### asyncResource.emitDestroy()
 
 * Returns: {AsyncResource} A reference to `asyncResource`.
@@ -713,7 +678,6 @@ never be called.
 `AsyncResource` constructor.
 
 [`after` callback]: #async_hooks_after_asyncid
-[`asyncResource.runInAsyncScope()`]: #async_hooks_asyncresource_runinasyncscope_fn_thisarg_args
 [`before` callback]: #async_hooks_before_asyncid
 [`destroy` callback]: #async_hooks_destroy_asyncid
 [`init` callback]: #async_hooks_init_asyncid_type_triggerasyncid_resource

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1905,6 +1905,9 @@ should start using the `async_context` variant of `MakeCallback` or
 ### DEP0098: AsyncHooks Embedder AsyncResource.emitBefore and AsyncResource.emitAfter APIs
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url:
+    description: End-of-Life
   - version:
     - v8.12.0
     - v9.6.0
@@ -1913,7 +1916,7 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
 The embedded API provided by AsyncHooks exposes `.emitBefore()` and
 `.emitAfter()` methods which are very easy to use incorrectly which can lead

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -127,17 +127,6 @@ function createHook(fns) {
 
 const destroyedSymbol = Symbol('destroyed');
 
-let emitBeforeAfterWarning = true;
-function showEmitBeforeAfterWarning() {
-  if (emitBeforeAfterWarning) {
-    process.emitWarning(
-      'asyncResource.emitBefore and emitAfter are deprecated. Please use ' +
-      'asyncResource.runInAsyncScope instead',
-      'DeprecationWarning', 'DEP0098');
-    emitBeforeAfterWarning = false;
-  }
-}
-
 class AsyncResource {
   constructor(type, opts = {}) {
     validateString(type, 'type');
@@ -167,18 +156,6 @@ class AsyncResource {
     if (!opts.requireManualDestroy) {
       registerDestroyHook(this, this[async_id_symbol], this[destroyedSymbol]);
     }
-  }
-
-  emitBefore() {
-    showEmitBeforeAfterWarning();
-    emitBefore(this[async_id_symbol], this[trigger_async_id_symbol]);
-    return this;
-  }
-
-  emitAfter() {
-    showEmitBeforeAfterWarning();
-    emitAfter(this[async_id_symbol]);
-    return this;
   }
 
   runInAsyncScope(fn, thisArg, ...args) {

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -19,7 +19,7 @@ switch (arg) {
       onbefore: common.mustCall(() => { throw new Error(arg); })
     }).enable();
     const resource = new async_hooks.AsyncResource(`${arg}_type`);
-    resource.emitBefore();
+    resource.runInAsyncScope(() => {});
     return;
 
   case 'test_callback_abort':

--- a/test/async-hooks/test-embedder.api.async-resource.js
+++ b/test/async-hooks/test-embedder.api.async-resource.js
@@ -47,16 +47,16 @@ assert.strictEqual(typeof alcaEvent.asyncId(), 'number');
 assert.notStrictEqual(alcaEvent.asyncId(), alcaTriggerId);
 assert.strictEqual(alcaEvent.triggerAsyncId(), alcaTriggerId);
 
-alcaEvent.emitBefore();
-checkInvocations(alcazares, { init: 1, before: 1 },
-                 'alcazares emitted before');
-alcaEvent.emitAfter();
+alcaEvent.runInAsyncScope(() => {
+  checkInvocations(alcazares, { init: 1, before: 1 },
+                   'alcazares emitted before');
+});
 checkInvocations(alcazares, { init: 1, before: 1, after: 1 },
                  'alcazares emitted after');
-alcaEvent.emitBefore();
-checkInvocations(alcazares, { init: 1, before: 2, after: 1 },
-                 'alcazares emitted before again');
-alcaEvent.emitAfter();
+alcaEvent.runInAsyncScope(() => {
+  checkInvocations(alcazares, { init: 1, before: 2, after: 1 },
+                   'alcazares emitted before again');
+});
 checkInvocations(alcazares, { init: 1, before: 2, after: 2 },
                  'alcazares emitted after again');
 alcaEvent.emitDestroy();
@@ -75,11 +75,11 @@ function tick1() {
   assert.strictEqual(typeof poblado.uid, 'number');
   assert.strictEqual(poblado.triggerAsyncId, pobTriggerId);
   checkInvocations(poblado, { init: 1 }, 'poblado constructed');
-  pobEvent.emitBefore();
-  checkInvocations(poblado, { init: 1, before: 1 },
-                   'poblado emitted before');
+  pobEvent.runInAsyncScope(() => {
+    checkInvocations(poblado, { init: 1, before: 1 },
+                     'poblado emitted before');
+  });
 
-  pobEvent.emitAfter();
   checkInvocations(poblado, { init: 1, before: 1, after: 1 },
                    'poblado emitted after');
 

--- a/test/async-hooks/test-emit-before-on-destroyed.js
+++ b/test/async-hooks/test-emit-before-on-destroyed.js
@@ -1,12 +1,17 @@
+// Flags: --expose-internals
 'use strict';
 
 const common = require('../common');
 const assert = require('assert');
-const async_hooks = require('async_hooks');
-const { AsyncResource } = async_hooks;
+const internal_async_hooks = require('internal/async_hooks');
 const { spawn } = require('child_process');
 const corruptedMsg = /async hook stack has become corrupted/;
 const heartbeatMsg = /heartbeat: still alive/;
+
+const {
+  newAsyncId, getDefaultTriggerAsyncId,
+  emitInit, emitBefore, emitAfter, emitDestroy
+} = internal_async_hooks;
 
 const initHooks = require('./init-hooks');
 
@@ -14,21 +19,32 @@ if (process.argv[2] === 'child') {
   const hooks = initHooks();
   hooks.enable();
 
-  // Async hooks enforce proper order of 'before' and 'after' invocations
+  // Once 'destroy' has been emitted, we can no longer emit 'before'
 
-  // Proper ordering
-  const event1 = new AsyncResource('event1', async_hooks.executionAsyncId());
-  event1.emitBefore();
-  event1.emitAfter();
+  // Emitting 'before', 'after' and then 'destroy'
+  {
+    const asyncId = newAsyncId();
+    const triggerId = getDefaultTriggerAsyncId();
+    emitInit(asyncId, 'event1', triggerId, {});
+    emitBefore(asyncId, triggerId);
+    emitAfter(asyncId);
+    emitDestroy(asyncId);
+  }
 
-  // Improper ordering
-  // Emitting 'after' without 'before' which is illegal
-  const event2 = new AsyncResource('event2', async_hooks.executionAsyncId());
+  // Emitting 'before' after 'destroy'
+  {
+    const asyncId = newAsyncId();
+    const triggerId = getDefaultTriggerAsyncId();
+    emitInit(asyncId, 'event2', triggerId, {});
+    emitDestroy(asyncId);
 
-  console.log('heartbeat: still alive');
-  event2.emitAfter();
+    console.log('heartbeat: still alive');
+    emitBefore(asyncId, triggerId);
+  }
 } else {
-  const args = process.argv.slice(1).concat('child');
+  const args = ['--expose-internals']
+    .concat(process.argv.slice(1))
+    .concat('child');
   let errData = Buffer.from('');
   let outData = Buffer.from('');
 

--- a/test/parallel/test-async-hooks-recursive-stack.js
+++ b/test/parallel/test-async-hooks-recursive-stack.js
@@ -7,14 +7,14 @@ const async_hooks = require('async_hooks');
 
 function recurse(n) {
   const a = new async_hooks.AsyncResource('foobar');
-  a.emitBefore();
-  assert.strictEqual(a.asyncId(), async_hooks.executionAsyncId());
-  assert.strictEqual(a.triggerAsyncId(), async_hooks.triggerAsyncId());
-  if (n >= 0)
-    recurse(n - 1);
-  assert.strictEqual(a.asyncId(), async_hooks.executionAsyncId());
-  assert.strictEqual(a.triggerAsyncId(), async_hooks.triggerAsyncId());
-  a.emitAfter();
+  a.runInAsyncScope(() => {
+    assert.strictEqual(a.asyncId(), async_hooks.executionAsyncId());
+    assert.strictEqual(a.triggerAsyncId(), async_hooks.triggerAsyncId());
+    if (n >= 0)
+      recurse(n - 1);
+    assert.strictEqual(a.asyncId(), async_hooks.executionAsyncId());
+    assert.strictEqual(a.triggerAsyncId(), async_hooks.triggerAsyncId());
+  });
 }
 
 recurse(1000);

--- a/test/parallel/test-emit-after-uncaught-exception.js
+++ b/test/parallel/test-emit-after-uncaught-exception.js
@@ -26,12 +26,12 @@ setImmediate(common.mustCall(() => {
   // Create a stack of async ids that will need to be emitted in the case of
   // an uncaught exception.
   const ar1 = new async_hooks.AsyncResource('Mine');
-  ar1.emitBefore();
-
-  const ar2 = new async_hooks.AsyncResource('Mine');
-  ar2.emitBefore();
-
-  throw new Error('bye');
+  ar1.runInAsyncScope(() => {
+    const ar2 = new async_hooks.AsyncResource('Mine');
+    ar2.runInAsyncScope(() => {
+      throw new Error('bye');
+    });
+  });
 
   // TODO(trevnorris): This test shows that the after() hooks are always called
   // correctly, but it doesn't solve where the emitDestroy() is missed because


### PR DESCRIPTION
AsyncResource.emitBefore and AsyncResource.emitAfter have been
deprecated in https://github.com/nodejs/node/pull/18632. This PR removes
it all.
This commit also removes some embedder tests for conditions that are not
possible anymore.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
