### PR TITLE
crypto: check for invalid chacha20-poly1305 IVs

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3701,6 +3701,16 @@ void CipherBase::InitIv(const char* cipher_type,
     return env()->ThrowError("Invalid IV length");
   }
 
+  if (EVP_CIPHER_nid(cipher) == NID_chacha20_poly1305) {
+    CHECK(has_iv);
+    // Check for invalid IV lengths, since OpenSSL does not under some
+    // conditions:
+    //   https://www.openssl.org/news/secadv/20190306.txt.
+    if (iv_len > 12) {
+      return env()->ThrowError("Invalid IV length");
+    }
+  }
+
   CommonInit(cipher_type, cipher, key, key_len, iv, iv_len, auth_tag_len);
 }
 


### PR DESCRIPTION
IV lengths of 13, 14, 15, and 16 are invalid, but are not checked by
OpenSSL. IV lengths of 17 or greater are also invalid, but they
were already checked by OpenSSL.

See:
- https://github.com/openssl/openssl/commit/f426625b6a
- https://www.openssl.org/news/secadv/20190306.txt

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
