### PR TITLE
url: require encodeStr from internal/querystring

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -22,7 +22,7 @@
 'use strict';
 
 const { toASCII } = require('internal/idna');
-const { hexTable } = require('internal/querystring');
+const { encodeStr, hexTable } = require('internal/querystring');
 const { SafeSet } = primordials;
 
 const {
@@ -41,7 +41,6 @@ const {
   domainToASCII,
   domainToUnicode,
   formatSymbol,
-  encodeStr,
   pathToFileURL,
   fileURLToPath
 } = require('internal/url');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

`encodeStr` function is exported from `internal/querystring.js` originally.

https://github.com/nodejs/node/blob/1acf3b155f6345c6d3ad24f90cd49ec9d83424f5/lib/internal/querystring.js#L92-L96

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
