### PR TITLE
test: fix compiler warning in test_string.c

### DIFF
--- a/test/js-native-api/test_string/test_string.c
+++ b/test/js-native-api/test_string/test_string.c
@@ -232,7 +232,9 @@ static napi_value TestLargeLatin1(napi_env env, napi_callback_info info) {
 static napi_value TestLargeUtf16(napi_env env, napi_callback_info info) {
   napi_value output;
   if (SIZE_MAX > INT_MAX) {
-    NAPI_CALL(env, napi_create_string_utf16(env, "", ((size_t)INT_MAX) + 1, &output));
+    NAPI_CALL(env, napi_create_string_utf16(env,
+                                            ((const char16_t*)""),
+                                            ((size_t)INT_MAX) + 1, &output));
   } else {
     // just throw the expected error as there is nothing to test
     // in this case since we can't overflow


### PR DESCRIPTION
Currently, the following compiler warnings is generated:
```console
../test_string.c:235:50: warning:
incompatible pointer types passing 'char [1]' to parameter of type
'const char16_t *' (aka 'const unsigned short *')
[-Wincompatible-pointer-types]
NAPI_CALL(env, napi_create_string_utf16(env,
    "", ((size_t)INT_MAX) + 1, &output));
    ^~
../../common.h:50:23: note: expanded from macro 'NAPI_CALL'
  NAPI_CALL_BASE(env, the_call, NULL)
                      ^~~~~~~~
../../common.h:42:10: note: expanded from macro 'NAPI_CALL_BASE'
    if ((the_call) != napi_ok) {                               \
         ^~~~~~~~
/node/src/js_native_api.h:80:66: note:
passing argument to parameter 'str' here const char16_t* str,
                                                         ^
1 warning generated.
```
This commit adds a cast to silence this warning.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
