### PR TITLE
worker: release native Worker object earlier

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -136,6 +136,9 @@ Worker::Worker(Environment* env,
       env->inspector_agent()->GetParentHandle(thread_id_, url);
 #endif
 
+  // Mark this Worker object as weak until we actually start the thread.
+  MakeWeak();
+
   Debug(this, "Preparation for worker %llu finished", thread_id_);
 }
 
@@ -412,13 +415,9 @@ void Worker::OnThreadStopped() {
 
 Worker::~Worker() {
   Mutex::ScopedLock lock(mutex_);
-  JoinThread();
 
   CHECK(thread_stopper_.IsStopped());
   CHECK(thread_joined_);
-
-  // This has most likely already happened within the worker thread -- this
-  // is just in case Worker creation failed early.
 
   Debug(this, "Worker %llu destroyed", thread_id_);
 }
@@ -508,6 +507,10 @@ void Worker::StartThread(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   Mutex::ScopedLock lock(w->mutex_);
 
+  // The object now owns the created thread and should not be garbage collected
+  // until that finishes.
+  w->ClearWeak();
+
   w->env()->add_sub_worker_context(w);
   w->thread_joined_ = false;
   w->thread_stopper_.SetStopped(false);
@@ -517,6 +520,7 @@ void Worker::StartThread(const FunctionCallbackInfo<Value>& args) {
     CHECK(w_->thread_stopper_.IsStopped());
     w_->parent_port_ = nullptr;
     w_->JoinThread();
+    delete w_;
   });
 
   uv_thread_options_t thread_options;
@@ -544,6 +548,7 @@ void Worker::StopThread(const FunctionCallbackInfo<Value>& args) {
   Debug(w, "Worker %llu is getting stopped by parent", w->thread_id_);
   w->Exit(1);
   w->JoinThread();
+  delete w;
 }
 
 void Worker::Ref(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
Destroy the `Worker` class earlier, because we don’t need access
to it once the thread has stopped and all resources have been
cleaned up.

Fixes: https://github.com/nodejs/node/issues/26535

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
