### PR TITLE
worker: use copy of process.env

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -954,6 +954,11 @@ emitMyWarning();
 <!-- YAML
 added: v0.1.27
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26544
+    description: Worker threads will now use a copy of the parent thread’s
+                 `process.env` by default, configurable through the `env`
+                 option of the `Worker` constructor.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18990
     description: Implicit conversion of variable value to string is deprecated.
@@ -983,8 +988,9 @@ An example of this object looks like:
 ```
 
 It is possible to modify this object, but such modifications will not be
-reflected outside the Node.js process. In other words, the following example
-would not work:
+reflected outside the Node.js process, or (unless explicitly requested)
+to other [`Worker`][] threads.
+In other words, the following example would not work:
 
 ```console
 $ node -e 'process.env.foo = "bar"' && echo $foo
@@ -1027,7 +1033,12 @@ console.log(process.env.test);
 // => 1
 ```
 
-`process.env` is read-only in [`Worker`][] threads.
+Unless explicitly specified when creating a [`Worker`][] instance,
+each [`Worker`][] thread has its own copy of `process.env`, based on its
+parent thread’s `process.env`, or whatever was specified as the `env` option
+to the [`Worker`][] constructor. Changes to `process.env` will not be visible
+across [`Worker`][] threads, and only the main thread can make changes that
+are visible to the operating system or to native add-ons.
 
 ## process.execArgv
 <!-- YAML

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -45,6 +45,8 @@ const kOnCouldNotSerializeErr = Symbol('kOnCouldNotSerializeErr');
 const kOnErrorMessage = Symbol('kOnErrorMessage');
 const kParentSideStdio = Symbol('kParentSideStdio');
 
+const SHARE_ENV = Symbol.for('nodejs.worker_threads.SHARE_ENV');
+
 let debuglog;
 function debug(...args) {
   if (!debuglog) {
@@ -79,11 +81,32 @@ class Worker extends EventEmitter {
       }
     }
 
+    let env;
+    if (typeof options.env === 'object' && options.env !== null) {
+      env = Object.create(null);
+      for (const [ key, value ] of Object.entries(options.env))
+        env[key] = `${value}`;
+    } else if (options.env == null) {
+      env = process.env;
+    } else if (options.env !== SHARE_ENV) {
+      throw new ERR_INVALID_ARG_TYPE(
+        'options.env',
+        ['object', 'undefined', 'null', 'worker_threads.SHARE_ENV'],
+        options.env);
+    }
+
     const url = options.eval ? null : pathToFileURL(filename);
     // Set up the C++ handle for the worker, as well as some internal wiring.
     this[kHandle] = new WorkerImpl(url, options.execArgv);
     if (this[kHandle].invalidExecArgv) {
       throw new ERR_WORKER_INVALID_EXEC_ARGV(this[kHandle].invalidExecArgv);
+    }
+    if (env === process.env) {
+      // This may be faster than manually cloning the object in C++, especially
+      // when recursively spawning Workers.
+      this[kHandle].cloneParentEnvVars();
+    } else if (env !== undefined) {
+      this[kHandle].setEnvVars(env);
     }
     this[kHandle].onexit = (code) => this[kOnExit](code);
     this[kPort] = this[kHandle].messagePort;
@@ -253,6 +276,7 @@ function pipeWithoutWarning(source, dest) {
 module.exports = {
   ownsProcessState,
   isMainThread,
+  SHARE_ENV,
   threadId,
   Worker,
 };

--- a/lib/worker_threads.js
+++ b/lib/worker_threads.js
@@ -2,6 +2,7 @@
 
 const {
   isMainThread,
+  SHARE_ENV,
   threadId,
   Worker
 } = require('internal/worker');
@@ -18,6 +19,7 @@ module.exports = {
   MessageChannel,
   moveMessagePortToContext,
   threadId,
+  SHARE_ENV,
   Worker,
   parentPort: null,
   workerData: null,

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -447,6 +447,14 @@ inline uint64_t Environment::timer_base() const {
   return timer_base_;
 }
 
+inline std::shared_ptr<KVStore> Environment::envvars() {
+  return envvars_;
+}
+
+inline void Environment::set_envvars(std::shared_ptr<KVStore> envvars) {
+  envvars_ = envvars;
+}
+
 inline bool Environment::printed_error() const {
   return printed_error_;
 }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -447,12 +447,12 @@ inline uint64_t Environment::timer_base() const {
   return timer_base_;
 }
 
-inline std::shared_ptr<KVStore> Environment::envvars() {
-  return envvars_;
+inline std::shared_ptr<KVStore> Environment::env_vars() {
+  return env_vars_;
 }
 
-inline void Environment::set_envvars(std::shared_ptr<KVStore> envvars) {
-  envvars_ = envvars;
+inline void Environment::set_env_vars(std::shared_ptr<KVStore> env_vars) {
+  env_vars_ = env_vars;
 }
 
 inline bool Environment::printed_error() const {

--- a/src/env.cc
+++ b/src/env.cc
@@ -178,6 +178,8 @@ Environment::Environment(IsolateData* isolate_data,
     set_as_callback_data_template(templ);
   }
 
+  set_envvars(per_process::real_environment);
+
   // We create new copies of the per-Environment option sets, so that it is
   // easier to modify them after Environment creation. The defaults are
   // part of the per-Isolate option set, for which in turn the defaults are
@@ -221,7 +223,7 @@ Environment::Environment(IsolateData* isolate_data,
   should_abort_on_uncaught_toggle_[0] = 1;
 
   std::string debug_cats;
-  credentials::SafeGetenv("NODE_DEBUG_NATIVE", &debug_cats);
+  credentials::SafeGetenv("NODE_DEBUG_NATIVE", &debug_cats, this);
   set_debug_categories(debug_cats, true);
 
   isolate()->GetHeapProfiler()->AddBuildEmbedderGraphCallback(

--- a/src/env.cc
+++ b/src/env.cc
@@ -178,7 +178,7 @@ Environment::Environment(IsolateData* isolate_data,
     set_as_callback_data_template(templ);
   }
 
-  set_envvars(per_process::real_environment);
+  set_env_vars(per_process::system_environment);
 
   // We create new copies of the per-Environment option sets, so that it is
   // easier to modify them after Environment creation. The defaults are

--- a/src/env.h
+++ b/src/env.h
@@ -556,11 +556,11 @@ class KVStore {
   virtual v8::Maybe<bool> AssignFromObject(v8::Local<v8::Context> context,
                                            v8::Local<v8::Object> entries);
 
-  static std::shared_ptr<KVStore> CreateGenericKVStore();
+  static std::shared_ptr<KVStore> CreateMapKVStore();
 };
 
 namespace per_process {
-extern std::shared_ptr<KVStore> real_environment;
+extern std::shared_ptr<KVStore> system_environment;
 }
 
 class AsyncHooks {
@@ -812,8 +812,8 @@ class Environment {
   inline ImmediateInfo* immediate_info();
   inline TickInfo* tick_info();
   inline uint64_t timer_base() const;
-  inline std::shared_ptr<KVStore> envvars();
-  inline void set_envvars(std::shared_ptr<KVStore> envvars);
+  inline std::shared_ptr<KVStore> env_vars();
+  inline void set_env_vars(std::shared_ptr<KVStore> env_vars);
 
   inline IsolateData* isolate_data() const;
 
@@ -1100,7 +1100,7 @@ class Environment {
   ImmediateInfo immediate_info_;
   TickInfo tick_info_;
   const uint64_t timer_base_;
-  std::shared_ptr<KVStore> envvars_;
+  std::shared_ptr<KVStore> env_vars_;
   bool printed_error_ = false;
   bool emit_env_nonstring_warning_ = true;
   bool emit_err_name_warning_ = true;

--- a/src/env.h
+++ b/src/env.h
@@ -551,6 +551,12 @@ class KVStore {
                         v8::Local<v8::String> key) const = 0;
   virtual void Delete(v8::Isolate* isolate, v8::Local<v8::String> key) = 0;
   virtual v8::Local<v8::Array> Enumerate(v8::Isolate* isolate) const = 0;
+
+  virtual std::shared_ptr<KVStore> Clone(v8::Isolate* isolate) const;
+  virtual v8::Maybe<bool> AssignFromObject(v8::Local<v8::Context> context,
+                                           v8::Local<v8::Object> entries);
+
+  static std::shared_ptr<KVStore> CreateGenericKVStore();
 };
 
 namespace per_process {

--- a/src/env.h
+++ b/src/env.h
@@ -540,6 +540,23 @@ class AsyncRequest : public MemoryRetainer {
   std::atomic_bool stopped_ {true};
 };
 
+class KVStore {
+ public:
+  virtual v8::Local<v8::String> Get(v8::Isolate* isolate,
+                                    v8::Local<v8::String> key) const = 0;
+  virtual void Set(v8::Isolate* isolate,
+                   v8::Local<v8::String> key,
+                   v8::Local<v8::String> value) = 0;
+  virtual int32_t Query(v8::Isolate* isolate,
+                        v8::Local<v8::String> key) const = 0;
+  virtual void Delete(v8::Isolate* isolate, v8::Local<v8::String> key) = 0;
+  virtual v8::Local<v8::Array> Enumerate(v8::Isolate* isolate) const = 0;
+};
+
+namespace per_process {
+extern std::shared_ptr<KVStore> real_environment;
+}
+
 class AsyncHooks {
  public:
   // Reason for both UidFields and Fields are that one is stored as a double*
@@ -789,6 +806,8 @@ class Environment {
   inline ImmediateInfo* immediate_info();
   inline TickInfo* tick_info();
   inline uint64_t timer_base() const;
+  inline std::shared_ptr<KVStore> envvars();
+  inline void set_envvars(std::shared_ptr<KVStore> envvars);
 
   inline IsolateData* isolate_data() const;
 
@@ -1075,6 +1094,7 @@ class Environment {
   ImmediateInfo immediate_info_;
   TickInfo tick_info_;
   const uint64_t timer_base_;
+  std::shared_ptr<KVStore> envvars_;
   bool printed_error_ = false;
   bool emit_env_nonstring_warning_ = true;
   bool emit_err_name_warning_ = true;

--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -43,7 +43,7 @@ bool SafeGetenv(const char* key, std::string* text, Environment* env) {
   if (env != nullptr) {
     HandleScope handle_scope(env->isolate());
     TryCatch ignore_errors(env->isolate());
-    MaybeLocal<String> value = env->envvars()->Get(
+    MaybeLocal<String> value = env->env_vars()->Get(
         env->isolate(),
         String::NewFromUtf8(env->isolate(), key, NewStringType::kNormal)
             .ToLocalChecked());

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -293,7 +293,7 @@ int ThreadPoolWork::CancelWork() {
 #endif  // __POSIX__ && !defined(__ANDROID__) && !defined(__CloudABI__)
 
 namespace credentials {
-bool SafeGetenv(const char* key, std::string* text);
+bool SafeGetenv(const char* key, std::string* text, Environment* env = nullptr);
 }  // namespace credentials
 
 void DefineZlibConstants(v8::Local<v8::Object> target);

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -68,7 +68,8 @@ Worker::Worker(Environment* env,
       exec_argv_(exec_argv),
       platform_(env->isolate_data()->platform()),
       profiler_idle_notifier_started_(env->profiler_idle_notifier_started()),
-      thread_id_(Environment::AllocateThreadId()) {
+      thread_id_(Environment::AllocateThreadId()),
+      env_vars_(env->env_vars()) {
   Debug(this, "Creating new worker instance with thread id %llu", thread_id_);
 
   // Set up everything that needs to be set up in the parent environment.
@@ -254,6 +255,7 @@ void Worker::Run() {
                                    Environment::kNoFlags,
                                    thread_id_));
         CHECK_NOT_NULL(env_);
+        env_->set_env_vars(std::move(env_vars_));
         env_->set_abort_on_uncaught_exception(false);
         env_->set_worker_context(this);
 
@@ -469,6 +471,25 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
   new Worker(env, args.This(), url, per_isolate_opts, std::move(exec_argv_out));
 }
 
+void Worker::CloneParentEnvVars(const FunctionCallbackInfo<Value>& args) {
+  Worker* w;
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
+  CHECK(w->thread_joined_);  // The Worker has not started yet.
+
+  w->env_vars_ = w->env()->env_vars()->Clone(args.GetIsolate());
+}
+
+void Worker::SetEnvVars(const FunctionCallbackInfo<Value>& args) {
+  Worker* w;
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
+  CHECK(w->thread_joined_);  // The Worker has not started yet.
+
+  CHECK(args[0]->IsObject());
+  w->env_vars_ = KVStore::CreateMapKVStore();
+  w->env_vars_->AssignFromObject(args.GetIsolate()->GetCurrentContext(),
+                                args[0].As<Object>());
+}
+
 void Worker::StartThread(const FunctionCallbackInfo<Value>& args) {
   Worker* w;
   ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
@@ -566,6 +587,8 @@ void InitWorker(Local<Object> target,
     w->InstanceTemplate()->SetInternalFieldCount(1);
     w->Inherit(AsyncWrap::GetConstructorTemplate(env));
 
+    env->SetProtoMethod(w, "setEnvVars", Worker::SetEnvVars);
+    env->SetProtoMethod(w, "cloneParentEnvVars", Worker::CloneParentEnvVars);
     env->SetProtoMethod(w, "startThread", Worker::StartThread);
     env->SetProtoMethod(w, "stopThread", Worker::StopThread);
     env->SetProtoMethod(w, "ref", Worker::Ref);

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -43,6 +43,9 @@ class Worker : public AsyncWrap {
   bool is_stopped() const;
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void CloneParentEnvVars(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetEnvVars(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void StartThread(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void StopThread(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Ref(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -78,6 +81,7 @@ class Worker : public AsyncWrap {
   static constexpr size_t kStackBufferSize = 192 * 1024;
 
   std::unique_ptr<MessagePortData> child_port_data_;
+  std::shared_ptr<KVStore> env_vars_;
 
   // The child port is kept alive by the child Environment's persistent
   // handle to it, as long as that child Environment exists.

--- a/test/parallel/test-worker-process-env-shared.js
+++ b/test/parallel/test-worker-process-env-shared.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker, parentPort, SHARE_ENV, workerData } = require('worker_threads');
+
+if (!workerData) {
+  process.env.SET_IN_PARENT = 'set';
+  assert.strictEqual(process.env.SET_IN_PARENT, 'set');
+
+  const w = new Worker(__filename, {
+    workerData: 'runInWorker',
+    env: SHARE_ENV
+  }).on('exit', common.mustCall(() => {
+    // Env vars from the child thread are not set globally.
+    assert.strictEqual(process.env.SET_IN_WORKER, 'set');
+  }));
+
+  process.env.SET_IN_PARENT_AFTER_CREATION = 'set';
+  w.postMessage({});
+} else {
+  assert.strictEqual(workerData, 'runInWorker');
+
+  // Env vars from the parent thread are inherited.
+  assert.strictEqual(process.env.SET_IN_PARENT, 'set');
+
+  process.env.SET_IN_WORKER = 'set';
+  assert.strictEqual(process.env.SET_IN_WORKER, 'set');
+
+  parentPort.once('message', common.mustCall(() => {
+    assert.strictEqual(process.env.SET_IN_PARENT_AFTER_CREATION, 'set');
+  }));
+}

--- a/test/parallel/test-worker-process-env.js
+++ b/test/parallel/test-worker-process-env.js
@@ -1,0 +1,54 @@
+'use strict';
+const common = require('../common');
+const child_process = require('child_process');
+const assert = require('assert');
+const { Worker, workerData } = require('worker_threads');
+
+// Test for https://github.com/nodejs/node/issues/24947.
+
+if (!workerData && process.argv[2] !== 'child') {
+  process.env.SET_IN_PARENT = 'set';
+  assert.strictEqual(process.env.SET_IN_PARENT, 'set');
+
+  new Worker(__filename, { workerData: 'runInWorker' })
+    .on('exit', common.mustCall(() => {
+      // Env vars from the child thread are not set globally.
+      assert.strictEqual(process.env.SET_IN_WORKER, undefined);
+    }));
+
+  process.env.SET_IN_PARENT_AFTER_CREATION = 'set';
+
+  new Worker(__filename, {
+    workerData: 'resetEnv',
+    env: { 'MANUALLY_SET': true }
+  });
+
+  common.expectsError(() => {
+    new Worker(__filename, { env: 42 });
+  }, {
+    type: TypeError,
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "options.env" property must be one of type object, ' +
+      'undefined, null, or worker_threads.SHARE_ENV. Received type number'
+  });
+} else if (workerData === 'runInWorker') {
+  // Env vars from the parent thread are inherited.
+  assert.strictEqual(process.env.SET_IN_PARENT, 'set');
+  assert.strictEqual(process.env.SET_IN_PARENT_AFTER_CREATION, undefined);
+  process.env.SET_IN_WORKER = 'set';
+  assert.strictEqual(process.env.SET_IN_WORKER, 'set');
+
+  Object.defineProperty(process.env, 'DEFINED_IN_WORKER', { value: 42 });
+  assert.strictEqual(process.env.DEFINED_IN_WORKER, '42');
+
+  const { stderr } =
+    child_process.spawnSync(process.execPath, [__filename, 'child']);
+  assert.strictEqual(stderr.toString(), '', stderr.toString());
+} else if (workerData === 'resetEnv') {
+  assert.deepStrictEqual(Object.keys(process.env), ['MANUALLY_SET']);
+  assert.strictEqual(process.env.MANUALLY_SET, 'true');
+} else {
+  // Child processes inherit the parent's env, even from Workers.
+  assert.strictEqual(process.env.SET_IN_PARENT, 'set');
+  assert.strictEqual(process.env.SET_IN_WORKER, 'set');
+}


### PR DESCRIPTION
Instead of sharing the OS-backed store for all `process.env` instances,
create a copy of `process.env` for every worker that is created.

The copies do not interact. Native-addons do not see modifications to
`process.env` from Worker threads, but child processes started from
Workers do default to the Worker’s copy of `process.env`.

This makes Workers behave like child processes as far as `process.env`
is concerned, and an option corresponding to the `child_process`
module’s `env` option is added to the constructor.

Fixes: https://github.com/nodejs/node/issues/24947

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

/cc @nodejs/workers 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
