### PR TITLE
src: fix SplitString to ignore white spaces

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -131,6 +131,7 @@ std::vector<std::string> SplitString(const std::string& in, char delim) {
   while (in_stream.good()) {
     std::string item;
     std::getline(in_stream, item, delim);
+    if (item.empty()) continue;
     out.emplace_back(std::move(item));
   }
   return out;

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -14,6 +14,8 @@ tmpdir.refresh();
 const printA = require.resolve('../fixtures/printA.js');
 expect(`-r ${printA}`, 'A\nB\n');
 expect(`-r ${printA} -r ${printA}`, 'A\nB\n');
+expect(`   -r ${printA}    -r ${printA}`, 'A\nB\n');
+expect(`   --require ${printA}    --require ${printA}`, 'A\nB\n');
 expect('--no-deprecation', 'B\n');
 expect('--no-warnings', 'B\n');
 expect('--no_warnings', 'B\n');


### PR DESCRIPTION

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
