### PR TITLE
Fixes: #26546

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -22,9 +22,8 @@
 'use strict';
 
 const net = require('net');
-const util = require('util');
 const EventEmitter = require('events');
-const debug = util.debuglog('http');
+const debug = require('internal/util/debuglog').debuglog('http');
 const { async_id_symbol } = require('internal/async_hooks').symbols;
 
 // New Agent code.

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -36,7 +36,7 @@ const {
   readStop
 } = incoming;
 
-const debug = require('util').debuglog('http');
+const debug = require('internal/util/debuglog').debuglog('http');
 
 const kIncomingMessage = Symbol('IncomingMessage');
 const kOnHeaders = HTTPParser.kOnHeaders | 0;

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -23,8 +23,7 @@
 
 const assert = require('internal/assert');
 const Stream = require('stream');
-const util = require('util');
-const internalUtil = require('internal/util');
+const deprecate = require('internal/util').deprecate
 const { outHeadersKey, utcDate } = require('internal/http');
 const { Buffer } = require('buffer');
 const common = require('_http_common');
@@ -109,10 +108,10 @@ Object.setPrototypeOf(OutgoingMessage, Stream);
 
 
 Object.defineProperty(OutgoingMessage.prototype, '_headers', {
-  get: util.deprecate(function() {
+  get: deprecate(function() {
     return this.getHeaders();
   }, 'OutgoingMessage.prototype._headers is deprecated', 'DEP0066'),
-  set: util.deprecate(function(val) {
+  set: deprecate(function(val) {
     if (val == null) {
       this[outHeadersKey] = null;
     } else if (typeof val === 'object') {
@@ -127,7 +126,7 @@ Object.defineProperty(OutgoingMessage.prototype, '_headers', {
 });
 
 Object.defineProperty(OutgoingMessage.prototype, '_headerNames', {
-  get: util.deprecate(function() {
+  get: deprecate(function() {
     const headers = this[outHeadersKey];
     if (headers !== null) {
       const out = Object.create(null);
@@ -141,7 +140,7 @@ Object.defineProperty(OutgoingMessage.prototype, '_headerNames', {
     }
     return null;
   }, 'OutgoingMessage.prototype._headerNames is deprecated', 'DEP0066'),
-  set: util.deprecate(function(val) {
+  set: deprecate(function(val) {
     if (typeof val === 'object' && val !== null) {
       const headers = this[outHeadersKey];
       if (!headers)
@@ -822,7 +821,7 @@ OutgoingMessage.prototype.flushHeaders = function flushHeaders() {
   this._send('');
 };
 
-OutgoingMessage.prototype.flush = internalUtil.deprecate(function() {
+OutgoingMessage.prototype.flush = deprecate(function() {
   this.flushHeaders();
 }, 'OutgoingMessage.flush is deprecated. Use flushHeaders instead.', 'DEP0001');
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -310,7 +310,7 @@ function Server(options, requestListener) {
   this.maxHeadersCount = null;
   this.headersTimeout = 40 * 1000; // 40 seconds
 }
-util.inherits(Server, net.Server);
+Object.setPrototypeOf(Server, net.Server);
 
 
 Server.prototype.setTimeout = function setTimeout(msecs, callback) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -29,7 +29,7 @@ const { codes: {
 } } = require('internal/errors');
 const AssertionError = require('internal/assert/assertion_error');
 const { openSync, closeSync, readSync } = require('fs');
-const { inspect, types: { isPromise, isRegExp } } = require('util');
+const { inspect, types: { isPromise, isRegExp } } = require('internal/util/inspect').inspect;
 const { EOL } = require('internal/constants');
 const { NativeModule } = require('internal/bootstrap/loaders');
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -21,10 +21,10 @@
 
 'use strict';
 
-const util = require('util');
+const promisify = require('internal/util').promisify;
 const { convertToValidSignal, getSystemErrorName } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
-const debug = util.debuglog('child_process');
+const debug = require('intern/util/debuglog').debuglog('child_process');
 const { Buffer } = require('buffer');
 const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');
 const {
@@ -168,7 +168,7 @@ const customPromiseExecFunction = (orig) => {
   };
 };
 
-Object.defineProperty(exports.exec, util.promisify.custom, {
+Object.defineProperty(exports.exec, promisify.custom, {
   enumerable: false,
   value: customPromiseExecFunction(exports.exec)
 });
@@ -389,7 +389,7 @@ exports.execFile = function execFile(file /* , args, options, callback */) {
   return child;
 };
 
-Object.defineProperty(exports.execFile, util.promisify.custom, {
+Object.defineProperty(exports.execFile, promisify.custom, {
   enumerable: false,
   value: customPromiseExecFunction(exports.execFile)
 });

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -45,7 +45,7 @@ const {
   validateNumber
 } = require('internal/validators');
 const { Buffer } = require('buffer');
-const util = require('util');
+const deprecate = require('internal/util').deprecate;
 const { isUint8Array } = require('internal/util/types');
 const EventEmitter = require('events');
 const {
@@ -729,61 +729,61 @@ Socket.prototype.getSendBufferSize = function() {
 
 // Deprecated private APIs.
 Object.defineProperty(Socket.prototype, '_handle', {
-  get: util.deprecate(function() {
+  get: deprecate(function() {
     return this[kStateSymbol].handle;
   }, 'Socket.prototype._handle is deprecated', 'DEP0112'),
-  set: util.deprecate(function(val) {
+  set: deprecate(function(val) {
     this[kStateSymbol].handle = val;
   }, 'Socket.prototype._handle is deprecated', 'DEP0112')
 });
 
 
 Object.defineProperty(Socket.prototype, '_receiving', {
-  get: util.deprecate(function() {
+  get: deprecate(function() {
     return this[kStateSymbol].receiving;
   }, 'Socket.prototype._receiving is deprecated', 'DEP0112'),
-  set: util.deprecate(function(val) {
+  set: deprecate(function(val) {
     this[kStateSymbol].receiving = val;
   }, 'Socket.prototype._receiving is deprecated', 'DEP0112')
 });
 
 
 Object.defineProperty(Socket.prototype, '_bindState', {
-  get: util.deprecate(function() {
+  get: deprecate(function() {
     return this[kStateSymbol].bindState;
   }, 'Socket.prototype._bindState is deprecated', 'DEP0112'),
-  set: util.deprecate(function(val) {
+  set: deprecate(function(val) {
     this[kStateSymbol].bindState = val;
   }, 'Socket.prototype._bindState is deprecated', 'DEP0112')
 });
 
 
 Object.defineProperty(Socket.prototype, '_queue', {
-  get: util.deprecate(function() {
+  get: deprecate(function() {
     return this[kStateSymbol].queue;
   }, 'Socket.prototype._queue is deprecated', 'DEP0112'),
-  set: util.deprecate(function(val) {
+  set: deprecate(function(val) {
     this[kStateSymbol].queue = val;
   }, 'Socket.prototype._queue is deprecated', 'DEP0112')
 });
 
 
 Object.defineProperty(Socket.prototype, '_reuseAddr', {
-  get: util.deprecate(function() {
+  get: deprecate(function() {
     return this[kStateSymbol].reuseAddr;
   }, 'Socket.prototype._reuseAddr is deprecated', 'DEP0112'),
-  set: util.deprecate(function(val) {
+  set: deprecate(function(val) {
     this[kStateSymbol].reuseAddr = val;
   }, 'Socket.prototype._reuseAddr is deprecated', 'DEP0112')
 });
 
 
-Socket.prototype._healthCheck = util.deprecate(function() {
+Socket.prototype._healthCheck = deprecate(function() {
   healthCheck(this);
 }, 'Socket.prototype._healthCheck() is deprecated', 'DEP0112');
 
 
-Socket.prototype._stopReceiving = util.deprecate(function() {
+Socket.prototype._stopReceiving = deprecate(function() {
   stopReceiving(this);
 }, 'Socket.prototype._stopReceiving() is deprecated', 'DEP0112');
 
@@ -797,7 +797,7 @@ Object.defineProperty(UDP.prototype, 'owner', {
 
 
 module.exports = {
-  _createSocketHandle: util.deprecate(
+  _createSocketHandle: deprecate(
     _createSocketHandle,
     'dgram._createSocketHandle() is deprecated',
     'DEP0112'

--- a/lib/https.js
+++ b/lib/https.js
@@ -25,7 +25,6 @@ require('internal/util').assertCrypto();
 
 const tls = require('tls');
 const url = require('url');
-const util = require('util');
 const { Agent: HttpAgent } = require('_http_agent');
 const {
   Server: HttpServer,
@@ -33,8 +32,7 @@ const {
   kServerResponse
 } = require('_http_server');
 const { ClientRequest } = require('_http_client');
-const { inherits } = util;
-const debug = util.debuglog('https');
+const debug = require('internal/util/debuglog').debuglog('https');
 const { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
 const { IncomingMessage, ServerResponse } = require('http');
 const { kIncomingMessage } = require('_http_common');
@@ -76,7 +74,7 @@ function Server(opts, requestListener) {
   this.maxHeadersCount = null;
   this.headersTimeout = 40 * 1000; // 40 seconds
 }
-inherits(Server, tls.Server);
+Object.setPrototypeOf(Server, tls.Server);
 
 Server.prototype.setTimeout = HttpServer.prototype.setTimeout;
 

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { inspect } = require('util');
+const inspect = require('internal/util/inspect').inspect;
 const { codes: {
   ERR_INVALID_ARG_TYPE
 } } = require('internal/errors');

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -18,7 +18,7 @@ const { validateString } = require('internal/validators');
 const EventEmitter = require('events');
 const net = require('net');
 const dgram = require('dgram');
-const util = require('util');
+const inspect = require('internal/util/inspect').inspect;
 const assert = require('internal/assert');
 
 const { Process } = internalBinding('process_wrap');
@@ -875,7 +875,7 @@ function _validateStdio(stdio, sync) {
         throw new ERR_INVALID_OPT_VALUE('stdio', stdio);
     }
   } else if (!Array.isArray(stdio)) {
-    throw new ERR_INVALID_OPT_VALUE('stdio', util.inspect(stdio));
+    throw new ERR_INVALID_OPT_VALUE('stdio', inspect(stdio));
   }
 
   // At least 3 stdio will be created
@@ -955,12 +955,12 @@ function _validateStdio(stdio, sync) {
     } else if (isArrayBufferView(stdio) || typeof stdio === 'string') {
       if (!sync) {
         cleanup();
-        throw new ERR_INVALID_SYNC_FORK_INPUT(util.inspect(stdio));
+        throw new ERR_INVALID_SYNC_FORK_INPUT(inspect(stdio));
       }
     } else {
       // Cleanup
       cleanup();
-      throw new ERR_INVALID_OPT_VALUE('stdio', util.inspect(stdio));
+      throw new ERR_INVALID_OPT_VALUE('stdio', inspect(stdio));
     }
 
     return acc;

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -16,6 +16,7 @@ const {
 const { previewEntries } = internalBinding('util');
 const { Buffer: { isBuffer } } = require('buffer');
 const util = require('util');
+const inspect = require('internal/util/inspect').inspect;
 const {
   isTypedArray, isSet, isMap, isSetIterator, isMapIterator,
 } = util.types;
@@ -291,7 +292,7 @@ const consoleMethods = {
 
 
   dir(object, options) {
-    this[kWriteToConsole](kUseStdout, util.inspect(object, {
+    this[kWriteToConsole](kUseStdout, inspect(object, {
       customInspect: false,
       ...this[kGetInspectOptions](this._stdout),
       ...options
@@ -415,7 +416,7 @@ const consoleMethods = {
         maxArrayLength: 3,
         ...this[kGetInspectOptions](this._stdout)
       };
-      return util.inspect(v, opt);
+      return inspect(v, opt);
     };
     const getIndexArray = (length) => ArrayFrom(
       { length }, (_, i) => inspect(i));

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -327,7 +327,7 @@ class TextEncoder {
     });
     obj.encoding = this.encoding;
     // Lazy to avoid circular dependency
-    return require('util').inspect(obj, opts);
+    return require('internal/util/inspect').inspect(obj, opts);
   }
 }
 


### PR DESCRIPTION
Fixes:

- [x] lib/_http_agent.js#L25
- [x] lib/_http_common.js#L39
- [x] lib/_http_outgoing.js#L26
- [x] lib/_http_server.js#L24
- [ ] lib/_tls_wrap.js#L30 *
- [x] lib/assert.js#L32
- [x] lib/child_process.js#L24
- [x] lib/dgram.js#L48
- [ ] lib/domain.js#L29 *
- [x] lib/https.js#L28
- [x] lib/inspector.js#L19
- [x] lib/internal/assert/assertion_error.js#L3
- [ ] lib/internal/bootstrap/node.js#L192 *
- [x] lib/internal/child_process.js#L21
- [x] lib/internal/console/constructor.js#L18 *
- [x] lib/internal/encoding.js#L330

* not clear what to do

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
