### PR TITLE
crypto: add support for EdDSA key pair generation

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1908,6 +1908,9 @@ algorithm names.
 <!-- YAML
 added: v10.12.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26554
+    description: Ed25519 and Ed448 key pairs can now be generated.
   - version: v11.6.0
     pr-url: https://github.com/nodejs/node/pull/24234
     description: The `generateKeyPair` and `generateKeyPairSync` functions now
@@ -1926,8 +1929,8 @@ changes:
   - `publicKey`: {string | Buffer | KeyObject}
   - `privateKey`: {string | Buffer | KeyObject}
 
-Generates a new asymmetric key pair of the given `type`. Only RSA, DSA and EC
-are currently supported.
+Generates a new asymmetric key pair of the given `type`. RSA, DSA, EC, Ed25519
+and Ed448 are currently supported.
 
 If a `publicKeyEncoding` or `privateKeyEncoding` was specified, this function
 behaves as if [`keyObject.export()`][] had been called on its result. Otherwise,
@@ -1965,6 +1968,9 @@ a `Promise` for an `Object` with `publicKey` and `privateKey` properties.
 <!-- YAML
 added: v10.12.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26554
+    description: Ed25519 and Ed448 key pairs can now be generated.
   - version: v11.6.0
     pr-url: https://github.com/nodejs/node/pull/24234
     description: The `generateKeyPair` and `generateKeyPairSync` functions now
@@ -1982,8 +1988,8 @@ changes:
   - `publicKey`: {string | Buffer | KeyObject}
   - `privateKey`: {string | Buffer | KeyObject}
 
-Generates a new asymmetric key pair of the given `type`. Only RSA, DSA and EC
-are currently supported.
+Generates a new asymmetric key pair of the given `type`. RSA, DSA, EC, Ed25519
+and Ed448 are currently supported.
 
 If a `publicKeyEncoding` or `privateKeyEncoding` was specified, this function
 behaves as if [`keyObject.export()`][] had been called on its result. Otherwise,

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1910,13 +1910,13 @@ added: v10.12.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/26554
-    description: Ed25519 and Ed448 key pairs can now be generated.
+    description: Add ability to generate Ed25519 and Ed448 key pairs.
   - version: v11.6.0
     pr-url: https://github.com/nodejs/node/pull/24234
     description: The `generateKeyPair` and `generateKeyPairSync` functions now
                  produce key objects if no encoding was specified.
 -->
-* `type`: {string} Must be `'rsa'`, `'dsa'` or `'ec'`.
+* `type`: {string} Must be `'rsa'`, `'dsa'`, `'ec'`, `'ed25519'`, or `'ed448'`.
 * `options`: {Object}
   - `modulusLength`: {number} Key size in bits (RSA, DSA).
   - `publicExponent`: {number} Public exponent (RSA). **Default:** `0x10001`.
@@ -1970,13 +1970,13 @@ added: v10.12.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/26554
-    description: Ed25519 and Ed448 key pairs can now be generated.
+    description: Add ability to generate Ed25519 and Ed448 key pairs.
   - version: v11.6.0
     pr-url: https://github.com/nodejs/node/pull/24234
     description: The `generateKeyPair` and `generateKeyPairSync` functions now
                  produce key objects if no encoding was specified.
 -->
-* `type`: {string} Must be `'rsa'`, `'dsa'` or `'ec'`.
+* `type`: {string} Must be `'rsa'`, `'dsa'`, `'ec'`, `'ed25519'`, or `'ed448'`.
 * `options`: {Object}
   - `modulusLength`: {number} Key size in bits (RSA, DSA).
   - `publicExponent`: {number} Public exponent (RSA). **Default:** `0x10001`.

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -5,6 +5,7 @@ const {
   generateKeyPairRSA,
   generateKeyPairDSA,
   generateKeyPairEC,
+  generateKeyPairEdDSA,
   OPENSSL_EC_NAMED_CURVE,
   OPENSSL_EC_EXPLICIT_CURVE
 } = internalBinding('crypto');
@@ -119,18 +120,25 @@ function parseKeyEncoding(keyType, options) {
 
 function check(type, options, callback) {
   validateString(type, 'type');
-  if (options == null || typeof options !== 'object')
-    throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
 
   // These will be set after parsing the type and type-specific options to make
   // the order a bit more intuitive.
   let cipher, passphrase, publicType, publicFormat, privateType, privateFormat;
 
+  if (options !== undefined && typeof options !== 'object')
+    throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
+
+  function needOptions() {
+    if (options == null)
+      throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
+    return options;
+  }
+
   let impl;
   switch (type) {
     case 'rsa':
       {
-        const { modulusLength } = options;
+        const { modulusLength } = needOptions();
         if (!isUint32(modulusLength))
           throw new ERR_INVALID_OPT_VALUE('modulusLength', modulusLength);
 
@@ -149,7 +157,7 @@ function check(type, options, callback) {
       break;
     case 'dsa':
       {
-        const { modulusLength } = options;
+        const { modulusLength } = needOptions();
         if (!isUint32(modulusLength))
           throw new ERR_INVALID_OPT_VALUE('modulusLength', modulusLength);
 
@@ -168,7 +176,7 @@ function check(type, options, callback) {
       break;
     case 'ec':
       {
-        const { namedCurve } = options;
+        const { namedCurve } = needOptions();
         if (typeof namedCurve !== 'string')
           throw new ERR_INVALID_OPT_VALUE('namedCurve', namedCurve);
         let { paramEncoding } = options;
@@ -185,19 +193,30 @@ function check(type, options, callback) {
                                            cipher, passphrase, wrap);
       }
       break;
+    case 'ed25519':
+    case 'ed448':
+      {
+        impl = (wrap) => generateKeyPairEdDSA(type,
+                                              publicFormat, publicType,
+                                              privateFormat, privateType,
+                                              cipher, passphrase, wrap);
+      }
+      break;
     default:
       throw new ERR_INVALID_ARG_VALUE('type', type,
                                       "must be one of 'rsa', 'dsa', 'ec'");
   }
 
-  ({
-    cipher,
-    passphrase,
-    publicType,
-    publicFormat,
-    privateType,
-    privateFormat
-  } = parseKeyEncoding(type, options));
+  if (options) {
+    ({
+      cipher,
+      passphrase,
+      publicType,
+      publicFormat,
+      privateType,
+      privateFormat
+    } = parseKeyEncoding(type, options));
+  }
 
   return impl;
 }

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -6,6 +6,8 @@ const {
   generateKeyPairDSA,
   generateKeyPairEC,
   generateKeyPairEdDSA,
+  EVP_PKEY_ED25519,
+  EVP_PKEY_ED448,
   OPENSSL_EC_NAMED_CURVE,
   OPENSSL_EC_EXPLICIT_CURVE
 } = internalBinding('crypto');
@@ -196,7 +198,8 @@ function check(type, options, callback) {
     case 'ed25519':
     case 'ed448':
       {
-        impl = (wrap) => generateKeyPairEdDSA(type === 'ed25519',
+        const id = type === 'ed25519' ? EVP_PKEY_ED25519 : EVP_PKEY_ED448;
+        impl = (wrap) => generateKeyPairEdDSA(id,
                                               publicFormat, publicType,
                                               privateFormat, privateType,
                                               cipher, passphrase, wrap);

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -196,7 +196,7 @@ function check(type, options, callback) {
     case 'ed25519':
     case 'ed448':
       {
-        impl = (wrap) => generateKeyPairEdDSA(type,
+        impl = (wrap) => generateKeyPairEdDSA(type === 'ed25519',
                                               publicFormat, publicType,
                                               privateFormat, privateType,
                                               cipher, passphrase, wrap);

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -204,7 +204,8 @@ function check(type, options, callback) {
       break;
     default:
       throw new ERR_INVALID_ARG_VALUE('type', type,
-                                      "must be one of 'rsa', 'dsa', 'ec'");
+                                      "must be one of 'rsa', 'dsa', 'ec', " +
+                                      "'ed25519', 'ed448'");
   }
 
   if (options) {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5952,8 +5952,8 @@ void GenerateKeyPairEC(const FunctionCallbackInfo<Value>& args) {
 }
 
 void GenerateKeyPairEdDSA(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args[0]->IsBoolean());
-  const int id = args[0]->IsTrue() ? EVP_PKEY_ED25519 : EVP_PKEY_ED448;
+  CHECK(args[0]->IsInt32());
+  const int id = args[0].As<Int32>()->Value();
   std::unique_ptr<KeyPairGenerationConfig> config(
       new EdDSAKeyPairGenerationConfig(id));
   GenerateKeyPair(args, 1, std::move(config));
@@ -6361,6 +6361,8 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "generateKeyPairDSA", GenerateKeyPairDSA);
   env->SetMethod(target, "generateKeyPairEC", GenerateKeyPairEC);
   env->SetMethod(target, "generateKeyPairEdDSA", GenerateKeyPairEdDSA);
+  NODE_DEFINE_CONSTANT(target, EVP_PKEY_ED25519);
+  NODE_DEFINE_CONSTANT(target, EVP_PKEY_ED448);
   NODE_DEFINE_CONSTANT(target, OPENSSL_EC_NAMED_CURVE);
   NODE_DEFINE_CONSTANT(target, OPENSSL_EC_EXPLICIT_CURVE);
   NODE_DEFINE_CONSTANT(target, kKeyEncodingPKCS1);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5952,16 +5952,8 @@ void GenerateKeyPairEC(const FunctionCallbackInfo<Value>& args) {
 }
 
 void GenerateKeyPairEdDSA(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args[0]->IsString());
-  String::Utf8Value curve_name(args.GetIsolate(), args[0].As<String>());
-  int id;
-  if (strcmp(*curve_name, "ed25519") == 0) {
-    id = EVP_PKEY_ED25519;
-  } else {
-    CHECK_EQ(strcmp(*curve_name, "ed448"), 0);
-    id = EVP_PKEY_ED448;
-  }
-
+  CHECK(args[0]->IsBoolean());
+  const int id = args[0]->IsTrue() ? EVP_PKEY_ED25519 : EVP_PKEY_ED448;
   std::unique_ptr<KeyPairGenerationConfig> config(
       new EdDSAKeyPairGenerationConfig(id));
   GenerateKeyPair(args, 1, std::move(config));

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -439,6 +439,15 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     message: 'The "options" argument must be of ' +
       'type object. Received type undefined'
   });
+
+  // Even if no options are required, it should be impossible to pass anything
+  // but an object (or undefined).
+  common.expectsError(() => generateKeyPair('ed448', 0, common.mustNotCall()), {
+    type: TypeError,
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "options" argument must be of ' +
+      'type object. Received type number'
+  });
 }
 
 {
@@ -776,6 +785,23 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }, common.mustCall((err, publicKey, privateKey) => {
     assert.ifError(err);
   }));
+}
+
+// Test EdDSA key generation.
+{
+  if (!/^1\.1\.0/.test(process.versions.openssl)) {
+    ['ed25519', 'ed448'].forEach((keyType) => {
+      generateKeyPair(keyType, common.mustCall((err, publicKey, privateKey) => {
+        assert.ifError(err);
+
+        assert.strictEqual(publicKey.type, 'public');
+        assert.strictEqual(publicKey.asymmetricKeyType, keyType);
+
+        assert.strictEqual(privateKey.type, 'private');
+        assert.strictEqual(privateKey.asymmetricKeyType, keyType);
+      }));
+    });
+  }
 }
 
 // Test invalid key encoding types.

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -427,7 +427,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     type: TypeError,
     code: 'ERR_INVALID_ARG_VALUE',
     message: "The argument 'type' must be one of " +
-             "'rsa', 'dsa', 'ec'. Received 'rsa2'"
+             "'rsa', 'dsa', 'ec', 'ed25519', 'ed448'. Received 'rsa2'"
   });
 }
 


### PR DESCRIPTION
This adds support for key pair generation for ed25519 and ed448.

Refs: https://github.com/nodejs/node/pull/26319

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
