### PR TITLE
timers: remove dead code and simplify args check

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -102,34 +102,13 @@ Timeout.prototype.refresh = function() {
   return this;
 };
 
-function setUnrefTimeout(callback, after, arg1, arg2, arg3) {
+function setUnrefTimeout(callback, after) {
   // Type checking identical to setTimeout()
   if (typeof callback !== 'function') {
     throw new ERR_INVALID_CALLBACK();
   }
 
-  let i, args;
-  switch (arguments.length) {
-    // fast cases
-    case 1:
-    case 2:
-      break;
-    case 3:
-      args = [arg1];
-      break;
-    case 4:
-      args = [arg1, arg2];
-      break;
-    default:
-      args = [arg1, arg2, arg3];
-      for (i = 5; i < arguments.length; i++) {
-        // Extend array dynamically, makes .apply run much faster in v6.0.0
-        args[i - 2] = arguments[i];
-      }
-      break;
-  }
-
-  const timer = new Timeout(callback, after, args, false);
+  const timer = new Timeout(callback, after, undefined, false);
   getTimers()._unrefActive(timer);
 
   return timer;

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -331,7 +331,7 @@ function listOnTimeout(list, now) {
 
     try {
       const args = timer._timerArgs;
-      if (!args)
+      if (args === undefined)
         timer._onTimeout();
       else
         Reflect.apply(timer._onTimeout, timer, args);
@@ -470,8 +470,9 @@ function setTimeout(callback, after, arg1, arg2, arg3) {
 }
 
 setTimeout[internalUtil.promisify.custom] = function(after, value) {
+  const args = value !== undefined ? [value] : value;
   return new Promise((resolve) => {
-    active(new Timeout(resolve, after, [value], false));
+    active(new Timeout(resolve, after, args, false));
   });
 };
 


### PR DESCRIPTION
The `setUnrefTimeout` function is never called with more arguments
than two. So quite some code was dead and never used. This removes
that code and simplifies the args check not to coerce objects to
booleans.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
