### PR TITLE
perf_hooks: add ReqWrap latency monitoring

### DIFF
--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -23,17 +23,19 @@ The available categories are:
 * `node.environment` - Enables capture of Node.js Environment milestones.
 * `node.fs.sync` - Enables capture of trace data for file system sync methods.
 * `node.perf` - Enables capture of [Performance API] measurements.
-  * `node.perf.usertiming` - Enables capture of only Performance API User Timing
-    measures and marks.
+  * `node.perf.event_loop` - Enables capture of event loop delay information
+    when the `perf_hooks.monitorEventLoopDelay()` API is used.
+  * `node.perf.reqwrap` - Enables capture of ReqWrap Latency information when
+    the `perf_hooks.monitorRequestWrapLatency()` API is used.
   * `node.perf.timerify` - Enables capture of only Performance API timerify
     measurements.
+  * `node.perf.usertiming` - Enables capture of only Performance API User Timing
+    measures and marks.
 * `node.promises.rejections` - Enables capture of trace data tracking the number
   of unhandled Promise rejections and handled-after-rejections.
 * `node.vm.script` - Enables capture of trace data for the `vm` module's
   `runInNewContext()`, `runInContext()`, and `runInThisContext()` methods.
 * `v8` - The [V8] events are GC, compiling, and execution related.
-
-By default the `node`, `node.async_hooks`, and `v8` categories are enabled.
 
 ```txt
 node --trace-event-categories v8,node,node.async_hooks server.js

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const {
-  ELDHistogram: _ELDHistogram,
+  ELDHistogram,
+  RWLHistogram,
   PerformanceEntry,
   mark: _mark,
   clearMark: _clearMark,
@@ -548,7 +549,7 @@ function sortedInsert(list, entry) {
   list.splice(location, 0, entry);
 }
 
-class ELDHistogram {
+class Histogram {
   constructor(handle) {
     this[kHandle] = handle;
     this[kMap] = new Map();
@@ -558,6 +559,7 @@ class ELDHistogram {
   enable() { return this[kHandle].enable(); }
   disable() { return this[kHandle].disable(); }
 
+  get count() { return this[kHandle].count(); }
   get exceeds() { return this[kHandle].exceeds(); }
   get min() { return this[kHandle].min(); }
   get max() { return this[kHandle].max(); }
@@ -588,7 +590,8 @@ class ELDHistogram {
       mean: this.mean,
       stddev: this.stddev,
       percentiles: this.percentiles,
-      exceeds: this.exceeds
+      exceeds: this.exceeds,
+      count: this.count
     };
   }
 }
@@ -608,13 +611,27 @@ function monitorEventLoopDelay(options = {}) {
     const errors = lazyErrors();
     throw new errors.ERR_INVALID_OPT_VALUE.RangeError('resolution', resolution);
   }
-  return new ELDHistogram(new _ELDHistogram(resolution));
+  return new Histogram(new ELDHistogram(resolution));
+}
+
+function monitorRequestWrapLatency(options = {}) {
+  if (typeof options !== 'object' || options === null) {
+    const errors = lazyErrors();
+    throw new errors.ERR_INVALID_ARG_TYPE('options', 'Object', options);
+  }
+  const { types } = options;
+  if (types === null || (types && !Array.isArray(types))) {
+    const errors = lazyErrors();
+    throw new errors.ERR_INVALID_ARG_TYPE('options.types', 'string[]', types);
+  }
+  return new Histogram(new RWLHistogram(types));
 }
 
 module.exports = {
   performance,
   PerformanceObserver,
-  monitorEventLoopDelay
+  monitorEventLoopDelay,
+  monitorRequestWrapLatency,
 };
 
 Object.defineProperty(module.exports, 'constants', {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -33,6 +33,7 @@
 #include "node_perf_common.h"
 #include "node_context_data.h"
 #include "node_worker.h"
+#include "histogram-inl.h"
 
 #include <cstddef>
 #include <cstdint>

--- a/src/env.cc
+++ b/src/env.cc
@@ -942,6 +942,26 @@ char* Environment::Reallocate(char* data, size_t old_size, size_t size) {
   return new_data;
 }
 
+void Environment::add_req_wrap_listener(ReqWrapHistogram* listener) {
+  req_wrap_listeners_.insert(listener);
+}
+
+void Environment::remove_req_wrap_listener(ReqWrapHistogram* listener) {
+  req_wrap_listeners_.erase(listener);
+}
+
+void Environment::record_req_wrap_latency(int type, uint64_t start_time) {
+  auto delta = uv_hrtime() - start_time;
+  for (auto listener : req_wrap_listeners_) {
+    listener->Record(type, delta);
+  }
+}
+
+bool Environment::req_wrap_latency_enabled() {
+  return !req_wrap_listeners_.empty();
+}
+
+
 // Not really any better place than env.cc at this moment.
 void BaseObject::DeleteMe(void* data) {
   BaseObject* self = static_cast<BaseObject*>(data);

--- a/src/env.h
+++ b/src/env.h
@@ -463,6 +463,11 @@ struct CompileFnEntry {
   CompileFnEntry(Environment* env, uint32_t id);
 };
 
+class ReqWrapHistogram {
+ public:
+  virtual void Record(int type, int64_t delta) = 0;
+};
+
 // Listing the AsyncWrap provider types first enables us to cast directly
 // from a provider type to a debug category.
 #define DEBUG_CATEGORY_NAMES(V)                                                \
@@ -814,6 +819,11 @@ class Environment {
   inline performance::performance_state* performance_state();
   inline std::unordered_map<std::string, uint64_t>* performance_marks();
 
+  void add_req_wrap_listener(ReqWrapHistogram* listener);
+  void remove_req_wrap_listener(ReqWrapHistogram* listener);
+  void record_req_wrap_latency(int type, uint64_t start_time);
+  bool req_wrap_latency_enabled();
+
   void CollectUVExceptionInfo(v8::Local<v8::Value> context,
                               int errorno,
                               const char* syscall = nullptr,
@@ -1123,6 +1133,8 @@ class Environment {
       file_handle_read_wrap_freelist_;
 
   worker::Worker* worker_context_ = nullptr;
+
+  std::unordered_set<ReqWrapHistogram*> req_wrap_listeners_;
 
   static void RunTimers(uv_timer_t* handle);
 

--- a/src/histogram-inl.h
+++ b/src/histogram-inl.h
@@ -5,10 +5,80 @@
 
 #include "histogram.h"
 #include "node_internals.h"
+#include "env-inl.h"
+#include "v8.h"
 
 namespace node {
 
-inline Histogram::Histogram(int64_t lowest, int64_t highest, int figures) {
+using v8::FunctionCallbackInfo;
+using v8::Local;
+using v8::Map;
+using v8::Number;
+using v8::Value;
+
+inline void Histogram::GetMin(
+    Histogram* histogram,
+    const FunctionCallbackInfo<Value>& args) {
+  double value = static_cast<double>(histogram->Min());
+  args.GetReturnValue().Set(value);
+}
+
+inline void Histogram::GetMax(
+    Histogram* histogram,
+    const FunctionCallbackInfo<Value>& args) {
+  double value = static_cast<double>(histogram->Max());
+  args.GetReturnValue().Set(value);
+}
+
+inline void Histogram::GetMean(
+    Histogram* histogram,
+    const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(histogram->Mean());
+}
+
+inline void Histogram::GetExceeds(
+    Histogram* histogram,
+    const FunctionCallbackInfo<Value>& args) {
+  double value = static_cast<double>(histogram->Exceeds());
+  args.GetReturnValue().Set(value);
+}
+
+inline void Histogram::GetCount(
+    Histogram* histogram,
+    const FunctionCallbackInfo<Value>& args) {
+  double value = static_cast<double>(histogram->Count());
+  args.GetReturnValue().Set(value);
+}
+
+inline void Histogram::GetStddev(
+    Histogram* histogram,
+    const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(histogram->Stddev());
+}
+
+inline void Histogram::GetPercentile(
+    Histogram* histogram,
+    const FunctionCallbackInfo<Value>& args) {
+  CHECK(args[0]->IsNumber());
+  double percentile = args[0].As<Number>()->Value();
+  args.GetReturnValue().Set(histogram->Percentile(percentile));
+}
+
+inline void Histogram::GetPercentiles(
+    Histogram* histogram,
+    const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(args[0]->IsMap());
+  Local<Map> map = args[0].As<Map>();
+  histogram->Percentiles([&](double key, double value) {
+    map->Set(env->context(),
+             Number::New(env->isolate(), key),
+             Number::New(env->isolate(), value)).IsEmpty();
+  });
+}
+
+inline Histogram::Histogram(int64_t lowest, int64_t highest, int figures) :
+    exceeds_(0), count_(0) {
   CHECK_EQ(0, hdr_init(lowest, highest, figures, &histogram_));
 }
 
@@ -18,10 +88,25 @@ inline Histogram::~Histogram() {
 
 inline void Histogram::Reset() {
   hdr_reset(histogram_);
+  exceeds_ = 0;
+  count_ = 0;
 }
 
 inline bool Histogram::Record(int64_t value) {
-  return hdr_record_value(histogram_, value);
+  bool ret = hdr_record_value(histogram_, value);
+  if (!ret && exceeds_ < 0xFFFFFFFF)
+    exceeds_++;
+  if (count_ < 0xFFFFFFFF)
+    count_++;
+  return ret;
+}
+
+inline int64_t Histogram::Exceeds() {
+  return exceeds_;
+}
+
+inline int64_t Histogram::Count() {
+  return count_;
 }
 
 inline int64_t Histogram::Min() {
@@ -54,6 +139,23 @@ inline void Histogram::Percentiles(std::function<void(double, double)> fn) {
     double value = iter.value;
     fn(key, value);
   }
+}
+
+inline void Histogram::DumpToTracedValue(tracing::TracedValue* value) {
+  value->SetDouble("min", static_cast<double>(Min()));
+  value->SetDouble("max", static_cast<double>(Max()));
+  value->SetDouble("mean", static_cast<double>(Mean()));
+  value->SetDouble("stddev", static_cast<double>(Stddev()));
+  value->SetDouble("exceeds", static_cast<double>(Exceeds()));
+  value->SetDouble("count", static_cast<double>(Count()));
+  value->BeginArray("percentiles");
+  Percentiles([&](double key, double val) {
+    value->BeginArray();
+    value->AppendDouble(key);
+    value->AppendDouble(val);
+    value->EndArray();
+  });
+  value->EndArray();
 }
 
 }  // namespace node

--- a/src/histogram.h
+++ b/src/histogram.h
@@ -3,7 +3,11 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include "env.h"
 #include "hdr_histogram.h"
+#include "tracing/traced_value.h"
+#include "v8.h"
+
 #include <functional>
 #include <map>
 
@@ -16,20 +20,71 @@ class Histogram {
 
   inline bool Record(int64_t value);
   inline void Reset();
+  inline int64_t Count();
   inline int64_t Min();
   inline int64_t Max();
   inline double Mean();
   inline double Stddev();
   inline double Percentile(double percentile);
   inline void Percentiles(std::function<void(double, double)> fn);
+  inline int64_t Exceeds();
 
   size_t GetMemorySize() const {
     return hdr_get_memory_size(histogram_);
   }
 
+  inline void DumpToTracedValue(tracing::TracedValue* value);
+
+  static inline void GetCount(
+      Histogram* histogram,
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void GetMin(
+      Histogram* histogram,
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void GetMax(
+      Histogram* histogram,
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void GetMean(
+      Histogram* histogram,
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void GetExceeds(
+      Histogram* histogram,
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void GetStddev(
+      Histogram* histogram,
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void GetPercentile(
+      Histogram* histogram,
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static inline void GetPercentiles(
+      Histogram* histogram,
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
  private:
   hdr_histogram* histogram_;
+  int64_t exceeds_;
+  int64_t count_;
 };
+
+#define HISTOGRAM_FNS(V)                                                       \
+  V(exceeds, Exceeds)                                                          \
+  V(count, Count)                                                              \
+  V(min, Min)                                                                  \
+  V(max, Max)                                                                  \
+  V(mean, Mean)                                                                \
+  V(stddev, Stddev)                                                            \
+  V(percentile, Percentile)                                                    \
+  V(percentiles, Percentiles)                                                  \
+  V(enable, Enable)                                                            \
+  V(disable, Disable)                                                          \
+  V(reset, Reset)
 
 }  // namespace node
 

--- a/src/req_wrap.h
+++ b/src/req_wrap.h
@@ -66,6 +66,7 @@ class ReqWrap : public AsyncWrap, public ReqWrapBase {
   // req_. For more information please refer to
   // `doc/guides/node-postmortem-support.md`
   T req_;
+  uint64_t start_timestamp_;
 };
 
 }  // namespace node


### PR DESCRIPTION
Similar to the recently added event loop relay, this adds a `perf_hooks.monitorRequestWrapLatency()` API that tracks the length of time between dispatching a ReqWrap and when the callback is invoked. This effectively tracks how long libuv is taking to perform requested actions. No differentiation is made between types of actions. The idea here is to provide a pulse on the general health of the application. If the histogram skews high, then it's taking libuv a longer time to process individual requests. 

```js
const { monitorRequestWrapLatency } = require('perf_hooks');
const m = monitorRequestWrapLatency();
m.enable();
// Do stuff
m.disable();

console.log(m.min);
console.log(m.max);
console.log(m.mean);
console.log(m.stddev);
console.log(m.percentile(50));
console.log(m.percentile(99));
console.log(m.percentiles);  // Map
```

Also outputs histogram data to the trace event log.

/cc @mcollina @mafintosh @nodejs/diagnostics 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
