### PR TITLE
Benchmark by group

### DIFF
--- a/benchmark/buffers/buffer-from-by-group.js
+++ b/benchmark/buffers/buffer-from-by-group.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const common = require('../common.js');
+const assert = require('assert');
+const bench = common.createBenchmark(main, {
+  groupA: {
+    source: [
+      'array',
+      'arraybuffer',
+      'arraybuffer-middle',
+      'buffer',
+      'uint8array',
+      'string',
+      'string-utf8',
+      'string-base64',
+      'object',
+    ],
+    len: [10, 2048],
+    n: [2048]
+  },
+  groupB: {
+    source: [
+      'buffer',
+      'string',
+    ],
+    len: [2048],
+    n: [2048]
+  }
+}, { byGroup: true });
+
+function main({ len, n, source }) {
+  const array = new Array(len).fill(42);
+  const arrayBuf = new ArrayBuffer(len);
+  const str = 'a'.repeat(len);
+  const buffer = Buffer.allocUnsafe(len);
+  const uint8array = new Uint8Array(len);
+  const obj = { length: null }; // Results in a new, empty Buffer
+
+  var i;
+
+  switch (source) {
+    case 'array':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(array);
+      }
+      bench.end(n);
+      break;
+    case 'arraybuffer':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(arrayBuf);
+      }
+      bench.end(n);
+      break;
+    case 'arraybuffer-middle':
+      const offset = ~~(len / 4);
+      const length = ~~(len / 2);
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(arrayBuf, offset, length);
+      }
+      bench.end(n);
+      break;
+    case 'buffer':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(buffer);
+      }
+      bench.end(n);
+      break;
+    case 'uint8array':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(uint8array);
+      }
+      bench.end(n);
+      break;
+    case 'string':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(str);
+      }
+      bench.end(n);
+      break;
+    case 'string-utf8':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(str, 'utf8');
+      }
+      bench.end(n);
+      break;
+    case 'string-base64':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(str, 'base64');
+      }
+      bench.end(n);
+      break;
+    case 'object':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(obj);
+      }
+      bench.end(n);
+      break;
+    default:
+      assert.fail(null, null, 'Should not get here');
+  }
+}

--- a/benchmark/buffers/buffer-from-by-group.js
+++ b/benchmark/buffers/buffer-from-by-group.js
@@ -36,7 +36,7 @@ function main({ len, n, source }) {
   const uint8array = new Uint8Array(len);
   const obj = { length: null }; // Results in a new, empty Buffer
 
-  var i;
+  let i;
 
   switch (source) {
     case 'array':

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -16,12 +16,13 @@ function Benchmark(fn, configs, options) {
   const byGroup = (options && options.byGroup) || false;
 
   if (byGroup) {
-    for (var groupKey of Object.keys(configs)) {
+    for (const groupKey of Object.keys(configs)) {
       const config = configs[groupKey];
       const parsed_args = this._parseArgs(process.argv.slice(2), config);
       this.options = parsed_args.cli;
       this.extra_options = parsed_args.extra;
-      // The configuration list as a queue of jobs
+      // The configuration list as a queue of jobs by merging the existing
+      // items with the new items to return a new array
       this.queue = [ ...this.queue, ...this._queue(this.options) ];
     }
   } else {

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -12,12 +12,27 @@ exports.createBenchmark = function(fn, configs, options) {
 function Benchmark(fn, configs, options) {
   // Use the file name as the name of the benchmark
   this.name = require.main.filename.slice(__dirname.length + 1);
-  // Parse job-specific configuration from the command line arguments
-  const parsed_args = this._parseArgs(process.argv.slice(2), configs);
-  this.options = parsed_args.cli;
-  this.extra_options = parsed_args.extra;
-  // The configuration list as a queue of jobs
-  this.queue = this._queue(this.options);
+  this.queue = [];
+  const byGroup = (options && options.byGroup) || false;
+
+  if (byGroup) {
+    for (var groupKey of Object.keys(configs)) {
+      const config = configs[groupKey];
+      const parsed_args = this._parseArgs(process.argv.slice(2), config);
+      this.options = parsed_args.cli;
+      this.extra_options = parsed_args.extra;
+      // The configuration list as a queue of jobs
+      this.queue = [ ...this.queue, ...this._queue(this.options) ];
+    }
+  } else {
+    // Parse job-specific configuration from the command line arguments
+    const parsed_args = this._parseArgs(process.argv.slice(2), configs);
+    this.options = parsed_args.cli;
+    this.extra_options = parsed_args.extra;
+    // The configuration list as a queue of jobs
+    this.queue = this._queue(this.options);
+  }
+
   // The configuration of the current job, head of the queue
   this.config = this.queue[0];
   // Execution arguments i.e. flags used to run the jobs

--- a/doc/guides/writing-and-running-benchmarks.md
+++ b/doc/guides/writing-and-running-benchmarks.md
@@ -353,8 +353,25 @@ The arguments of `createBenchmark` are:
   possible combinations of these parameters, unless specified otherwise.
   Each configuration is a property with an array of possible values.
   Note that the configuration values can only be strings or numbers.
-* `options` {Object} The benchmark options. At the moment only the `flags`
-  option for specifying command line flags is supported.
+* `options` {Object} The benchmark options are:
+
+  * `flags` option for specifying command line flags is supported
+  * `byGroup` option for processing `configs` by groups with this syntax:
+
+```js
+const bench = common.createBenchmark(main, {
+  groupA: {
+    source: ['array'],
+    len: [10, 2048],
+    n: [50]
+  },
+  groupB: {
+    source: ['buffer', 'string'],
+    len: [2048],
+    n: [50, 2048]
+  }
+}, { byGroup: true });
+```
 
 `createBenchmark` returns a `bench` object, which is used for timing
 the runtime of the benchmark. Run `bench.start()` after the initialization


### PR DESCRIPTION
Resolves #26425 

* Implement the `byGroup` benchmark config option
* Add an example with `buffer-from-by-group.js` benchmark
* Update `writing-and-running-benchmarks.md` to mention the `byGroup` option:

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<details open>
<summary>example in "buffer-from-by-group.js" benchmark</summary>
<br>

```js
const bench = common.createBenchmark(main, {
  groupA: {
    source: [
      'array',
      'arraybuffer',
      'arraybuffer-middle',
      'buffer',
      'uint8array',
      'string',
      'string-utf8',
      'string-base64',
      'object',
    ],
    len: [10, 2048],
    n: [2048]
  },
  groupB: {
    source: [
      'buffer',
      'string',
    ],
    len: [2048],
    n: [2048]
  }
}, { byGroup: true });
```
