### PR TITLE
test,console: add testing for monkeypatching of console stdio

### DIFF
--- a/test/parallel/test-console-stdio-setters.js
+++ b/test/parallel/test-console-stdio-setters.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// Test that monkeypatching console._stdout and console._stderr works.
+const common = require('../common');
+
+const { Writable } = require('stream');
+const { Console } = require('console');
+
+const streamToNowhere = new Writable({ write: common.mustCall() });
+const anotherStreamToNowhere = new Writable({ write: common.mustCall() });
+const myConsole = new Console(process.stdout);
+
+// Overriding the _stdout and _stderr properties this way is what we are
+// testing. Don't change this to be done via arguments passed to the constructor
+// above.
+myConsole._stdout = streamToNowhere;
+myConsole._stderr = anotherStreamToNowhere;
+
+myConsole.log('fhqwhgads');
+myConsole.error('fhqwhgads');


### PR DESCRIPTION
lib/internal/console/constructor.js contains setters for console._stdout
and console._stderr but these setters are not used in our tests or in
Node.js core. (This is confirmed by our nightly coverage reports.)

Add a test to check monkeypatching _stdout and _stderr on a console
object.

Version 2.6.9 of the very-popular npm module `debug` used this
monkeypatching in its code. No other version did and they are now at
version 4.something. It is not inconceivable that we would want to
change the setters to throw rather than work. Given that this has seen
use in the ecosystem, I'm inclined to leave the functionality in place.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
