### PR TITLE
src: apply clang-tidy rule modernize-use-emplace

### DIFF
--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -554,10 +554,11 @@ class HttpHandler : public ProtocolHandler {
   static int OnMessageComplete(parser_t* parser) {
     // Event needs to be fired after the parser is done.
     HttpHandler* handler = From(parser);
-    handler->events_.push_back(
-        HttpEvent(handler->path_, parser->upgrade, parser->method == HTTP_GET,
-                  handler->HeaderValue("Sec-WebSocket-Key"),
-                  handler->HeaderValue("Host")));
+    handler->events_.emplace_back(handler->path_,
+                                  parser->upgrade,
+                                  parser->method == HTTP_GET,
+                                  handler->HeaderValue("Sec-WebSocket-Key"),
+                                  handler->HeaderValue("Host"));
     handler->path_ = "";
     handler->parsing_value_ = false;
     handler->headers_.clear();

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -658,7 +658,7 @@ void AfterScanDirWithTypes(uv_fs_t* req) {
       return req_wrap->Reject(error);
 
     name_v.push_back(filename.ToLocalChecked());
-    type_v.push_back(Integer::New(isolate, ent.type));
+    type_v.emplace_back(Integer::New(isolate, ent.type));
   }
 
   Local<Array> result = Array::New(isolate, 2);
@@ -1505,7 +1505,7 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
       name_v.push_back(filename.ToLocalChecked());
 
       if (with_types) {
-        type_v.push_back(Integer::New(isolate, ent.type));
+        type_v.emplace_back(Integer::New(isolate, ent.type));
       }
     }
 

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -375,9 +375,8 @@ Maybe<bool> Message::Serialize(Environment* env,
     env->isolate_data()->node_allocator()->UnregisterPointer(
         contents.Data(), contents.ByteLength());
 
-    array_buffer_contents_.push_back(
-        MallocedBuffer<char> { static_cast<char*>(contents.Data()),
-                               contents.ByteLength() });
+    array_buffer_contents_.emplace_back(MallocedBuffer<char>{
+        static_cast<char*>(contents.Data()), contents.ByteLength()});
   }
 
   delegate.Finish();

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -92,7 +92,7 @@ void NativeModuleLoader::ModuleIdsGetter(
   ids.reserve(source_.size());
 
   for (auto const& x : source_) {
-    ids.push_back(OneByteString(isolate, x.first.c_str(), x.first.size()));
+    ids.emplace_back(OneByteString(isolate, x.first.c_str(), x.first.size()));
   }
 
   info.GetReturnValue().Set(Array::New(isolate, ids.data(), ids.size()));

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -256,7 +256,7 @@ static void GetActiveRequests(const FunctionCallbackInfo<Value>& args) {
     AsyncWrap* w = req_wrap->GetAsyncWrap();
     if (w->persistent().IsEmpty())
       continue;
-    request_v.push_back(w->GetOwner());
+    request_v.emplace_back(w->GetOwner());
   }
 
   args.GetReturnValue().Set(
@@ -272,7 +272,7 @@ void GetActiveHandles(const FunctionCallbackInfo<Value>& args) {
   for (auto w : *env->handle_wrap_queue()) {
     if (!HandleWrap::HasRef(w))
       continue;
-    handle_v.push_back(w->GetOwner());
+    handle_v.emplace_back(w->GetOwner());
   }
   args.GetReturnValue().Set(
       Array::New(env->isolate(), handle_v.data(), handle_v.size()));

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -2053,7 +2053,7 @@ void URL::Parse(const char* input,
             break;
           default:
             if (url->path.size() == 0)
-              url->path.push_back("");
+              url->path.emplace_back("");
             if (url->path.size() > 0 && ch != kEOL)
               AppendOrEscape(&url->path[0], ch, C0_CONTROL_ENCODE_SET);
         }


### PR DESCRIPTION
See https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
