### PR TITLE
http: use internal/debuglog directly in lib/_http_agent.js

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -22,9 +22,8 @@
 'use strict';
 
 const net = require('net');
-const util = require('util');
 const EventEmitter = require('events');
-const debug = util.debuglog('http');
+const debug = require('internal/util/debuglog').debuglog('http');
 const { async_id_symbol } = require('internal/async_hooks').symbols;
 
 // New Agent code.

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -22,8 +22,9 @@
 'use strict';
 
 const net = require('net');
+const util = require('util');
 const EventEmitter = require('events');
-const debug = require('internal/util/debuglog').debuglog('http');
+const debug = util.debuglog('http');
 const { async_id_symbol } = require('internal/async_hooks').symbols;
 
 // New Agent code.

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -36,7 +36,7 @@ const {
   readStop
 } = incoming;
 
-const debug = require('util').debuglog('http');
+const debug = require('internal/util/debuglog').debuglog('http');
 
 const kIncomingMessage = Symbol('IncomingMessage');
 const kOnHeaders = HTTPParser.kOnHeaders | 0;


### PR DESCRIPTION
This PR reduces internal usage of public require('util').
Single PR as asked here: https://github.com/nodejs/node/issues/26546#issuecomment-471240298

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
