### PR TITLE
fs: allow int64 offset in fs.read/readSync/write/writeSync

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -85,7 +85,7 @@ const {
   isUint32,
   parseMode,
   validateBuffer,
-  validateInteger,
+  validateSafeInteger,
   validateInt32,
   validateUint32
 } = require('internal/validators');
@@ -621,7 +621,7 @@ function truncate(path, len, callback) {
     len = 0;
   }
 
-  validateInteger(len, 'len');
+  validateSafeInteger(len, 'len');
   callback = maybeCallback(callback);
   fs.open(path, 'r+', (er, fd) => {
     if (er) return callback(er);
@@ -662,7 +662,7 @@ function ftruncate(fd, len = 0, callback) {
     len = 0;
   }
   validateInt32(fd, 'fd', 0);
-  validateInteger(len, 'len');
+  validateSafeInteger(len, 'len');
   len = Math.max(0, len);
   const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
@@ -671,7 +671,7 @@ function ftruncate(fd, len = 0, callback) {
 
 function ftruncateSync(fd, len = 0) {
   validateInt32(fd, 'fd', 0);
-  validateInteger(len, 'len');
+  validateSafeInteger(len, 'len');
   len = Math.max(0, len);
   const ctx = {};
   binding.ftruncate(fd, len, undefined, ctx);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -541,8 +541,11 @@ function write(fd, buffer, offset, length, position, callback) {
 
   if (isArrayBufferView(buffer)) {
     callback = maybeCallback(callback || position || length || offset);
-    if (typeof offset !== 'number')
+    if (offset == null || typeof offset === 'function') {
       offset = 0;
+    } else {
+      validateSafeInteger(offset, 'offset');
+    }
     if (typeof length !== 'number')
       length = buffer.length - offset;
     if (typeof position !== 'number')
@@ -580,8 +583,11 @@ function writeSync(fd, buffer, offset, length, position) {
   if (isArrayBufferView(buffer)) {
     if (position === undefined)
       position = null;
-    if (typeof offset !== 'number')
+    if (offset == null) {
       offset = 0;
+    } else {
+      validateSafeInteger(offset, 'offset');
+    }
     if (typeof length !== 'number')
       length = buffer.byteLength - offset;
     validateOffsetLengthWrite(offset, length, buffer.byteLength);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -453,7 +453,12 @@ function read(fd, buffer, offset, length, position, callback) {
   validateBuffer(buffer);
   callback = maybeCallback(callback);
 
-  offset |= 0;
+  if (offset == null) {
+    offset = 0;
+  } else {
+    validateSafeInteger(offset, 'offset');
+  }
+
   length |= 0;
 
   if (length === 0) {
@@ -490,7 +495,12 @@ function readSync(fd, buffer, offset, length, position) {
   validateInt32(fd, 'fd', 0);
   validateBuffer(buffer);
 
-  offset |= 0;
+  if (offset == null) {
+    offset = 0;
+  } else {
+    validateSafeInteger(offset, 'offset');
+  }
+
   length |= 0;
 
   if (length === 0) {

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -3,7 +3,7 @@
 const { AsyncWrap, Providers } = internalBinding('async_wrap');
 const { Buffer } = require('buffer');
 const { scrypt: _scrypt } = internalBinding('crypto');
-const { validateInteger, validateUint32 } = require('internal/validators');
+const { validateSafeInteger, validateUint32 } = require('internal/validators');
 const {
   ERR_CRYPTO_SCRYPT_INVALID_PARAMETER,
   ERR_CRYPTO_SCRYPT_NOT_SUPPORTED,
@@ -108,7 +108,7 @@ function check(password, salt, keylen, options) {
     }
     if (options.maxmem !== undefined) {
       maxmem = options.maxmem;
-      validateInteger(maxmem, 'maxmem', 0);
+      validateSafeInteger(maxmem, 'maxmem', 0);
     }
     if (N === 0) N = defaults.N;
     if (r === 0) r = defaults.r;

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -206,7 +206,12 @@ async function read(handle, buffer, offset, length, position) {
   validateFileHandle(handle);
   validateBuffer(buffer);
 
-  offset |= 0;
+  if (offset == null) {
+    offset = 0;
+  } else {
+    validateSafeInteger(offset, 'offset');
+  }
+
   length |= 0;
 
   if (length === 0)

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -36,7 +36,7 @@ const {
 const {
   parseMode,
   validateBuffer,
-  validateInteger,
+  validateSafeInteger,
   validateUint32
 } = require('internal/validators');
 const pathModule = require('path');
@@ -270,7 +270,7 @@ async function truncate(path, len = 0) {
 
 async function ftruncate(handle, len = 0) {
   validateFileHandle(handle);
-  validateInteger(len, 'len');
+  validateSafeInteger(len, 'len');
   len = Math.max(0, len);
   return binding.ftruncate(handle.fd, len, kUsePromises);
 }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -240,8 +240,11 @@ async function write(handle, buffer, offset, length, position) {
     return { bytesWritten: 0, buffer };
 
   if (isUint8Array(buffer)) {
-    if (typeof offset !== 'number')
+    if (offset == null) {
       offset = 0;
+    } else {
+      validateSafeInteger(offset, 'offset');
+    }
     if (typeof length !== 'number')
       length = buffer.length - offset;
     if (typeof position !== 'number')

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -2,7 +2,7 @@
 
 const { Object, Reflect } = primordials;
 
-const { Buffer, kMaxLength } = require('buffer');
+const { Buffer } = require('buffer');
 const {
   codes: {
     ERR_FS_INVALID_SYMLINK_TYPE,
@@ -476,9 +476,8 @@ const validateOffsetLengthWrite = hideStackFrames(
       throw new ERR_OUT_OF_RANGE('offset', `<= ${byteLength}`, offset);
     }
 
-    const max = byteLength > kMaxLength ? kMaxLength : byteLength;
-    if (length > max - offset) {
-      throw new ERR_OUT_OF_RANGE('length', `<= ${max - offset}`, length);
+    if (length > byteLength - offset) {
+      throw new ERR_OUT_OF_RANGE('length', `<= ${byteLength - offset}`, length);
     }
   }
 );

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -62,7 +62,7 @@ function parseMode(value, name, def) {
   throw new ERR_INVALID_ARG_VALUE(name, value, modeDesc);
 }
 
-const validateInteger = hideStackFrames(
+const validateSafeInteger = hideStackFrames(
   (value, name, min = MIN_SAFE_INTEGER, max = MAX_SAFE_INTEGER) => {
     if (typeof value !== 'number')
       throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
@@ -161,7 +161,7 @@ module.exports = {
   parseMode,
   validateBuffer,
   validateEncoding,
-  validateInteger,
+  validateSafeInteger,
   validateInt32,
   validateUint32,
   validateString,

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1130,7 +1130,7 @@ static void FTruncate(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsInt32());
   const int fd = args[0].As<Int32>()->Value();
 
-  CHECK(args[1]->IsNumber());
+  CHECK(IsSafeJsInt(args[1]));
   const int64_t len = args[1].As<Integer>()->Value();
 
   FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -88,7 +88,7 @@ constexpr char kPathSeparator = '/';
 const char* const kPathSeparator = "\\/";
 #endif
 
-#define GET_OFFSET(a) ((a)->IsNumber() ? (a).As<Integer>()->Value() : -1)
+#define GET_OFFSET(a) (IsSafeJsInt(a) ? (a).As<Integer>()->Value() : -1)
 #define TRACE_NAME(name) "fs.sync." #name
 #define GET_TRACE_ENABLED                                                  \
   (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED                             \
@@ -1669,9 +1669,11 @@ static void WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   char* buffer_data = Buffer::Data(buffer_obj);
   size_t buffer_length = Buffer::Length(buffer_obj);
 
-  CHECK(args[2]->IsInt32());
-  const size_t off = static_cast<size_t>(args[2].As<Int32>()->Value());
-  CHECK_LE(off, buffer_length);
+  CHECK(IsSafeJsInt(args[2]));
+  const int64_t off_64 = args[2].As<Integer>()->Value();
+  CHECK_GE(off_64, 0);
+  CHECK_LE(static_cast<uint64_t>(off_64), buffer_length);
+  const size_t off = static_cast<size_t>(off_64);
 
   CHECK(args[3]->IsInt32());
   const size_t len = static_cast<size_t>(args[3].As<Int32>()->Value());

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -24,6 +24,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include <cmath>
 #include <cstring>
 #include "util.h"
 
@@ -519,6 +520,17 @@ void ArrayBufferViewContents<T, S>::Read(v8::Local<v8::ArrayBufferView> abv) {
     abv->CopyContents(stack_storage_, sizeof(stack_storage_));
     data_ = stack_storage_;
   }
+}
+
+// ECMA262 20.1.2.5
+inline bool IsSafeJsInt(v8::Local<v8::Value> v) {
+  if (!v->IsNumber()) return false;
+  double v_d = v.As<v8::Number>()->Value();
+  if (std::isnan(v_d)) return false;
+  if (std::isinf(v_d)) return false;
+  if (std::trunc(v_d) != v_d) return false;  // not int
+  if (std::abs(v_d) <= static_cast<double>(kMaxSafeJsInteger)) return true;
+  return false;
 }
 
 }  // namespace node

--- a/src/util.h
+++ b/src/util.h
@@ -184,6 +184,11 @@ void DumpBacktrace(FILE* fp);
 #define UNREACHABLE(...)                                                      \
   ERROR_AND_ABORT("Unreachable code reached" __VA_OPT__(": ") __VA_ARGS__)
 
+// ECMA262 20.1.2.6 Number.MAX_SAFE_INTEGER (2^53-1)
+constexpr int64_t kMaxSafeJsInteger = 9007199254740991;
+
+inline bool IsSafeJsInt(v8::Local<v8::Value> v);
+
 // TAILQ-style intrusive list node.
 template <typename T>
 class ListNode;

--- a/test/parallel/test-fs-read-type.js
+++ b/test/parallel/test-fs-read-type.js
@@ -53,6 +53,20 @@ assert.throws(() => {
 assert.throws(() => {
   fs.read(fd,
           Buffer.allocUnsafe(expected.length),
+          NaN,
+          expected.length,
+          0,
+          common.mustNotCall());
+}, {
+  code: 'ERR_OUT_OF_RANGE',
+  name: 'RangeError',
+  message: 'The value of "offset" is out of range. It must be an integer. ' +
+           'Received NaN'
+});
+
+assert.throws(() => {
+  fs.read(fd,
+          Buffer.allocUnsafe(expected.length),
           0,
           -1,
           0,
@@ -101,6 +115,19 @@ assert.throws(() => {
   name: 'RangeError',
   message: 'The value of "offset" is out of range. ' +
            'It must be >= 0 && <= 4. Received -1'
+});
+
+assert.throws(() => {
+  fs.readSync(fd,
+              Buffer.allocUnsafe(expected.length),
+              NaN,
+              expected.length,
+              0);
+}, {
+  code: 'ERR_OUT_OF_RANGE',
+  name: 'RangeError',
+  message: 'The value of "offset" is out of range. It must be an integer. ' +
+           'Received NaN'
 });
 
 assert.throws(() => {

--- a/test/parallel/test-fs-util-validateoffsetlengthwrite.js
+++ b/test/parallel/test-fs-util-validateoffsetlengthwrite.js
@@ -22,22 +22,6 @@ const { kMaxLength } = require('buffer');
   );
 }
 
-// RangeError when byteLength > kMaxLength, and length > kMaxLength - offset .
-{
-  const offset = kMaxLength;
-  const length = 100;
-  const byteLength = kMaxLength + 1;
-  common.expectsError(
-    () => validateOffsetLengthWrite(offset, length, byteLength),
-    {
-      code: 'ERR_OUT_OF_RANGE',
-      type: RangeError,
-      message: 'The value of "length" is out of range. ' +
-               `It must be <= ${kMaxLength - offset}. Received ${length}`
-    }
-  );
-}
-
 // RangeError when byteLength < kMaxLength, and length > byteLength - offset .
 {
   const offset = kMaxLength - 150;

--- a/test/parallel/test-fs-write-buffer.js
+++ b/test/parallel/test-fs-write-buffer.js
@@ -148,3 +148,27 @@ tmpdir.refresh();
     fs.write(fd, Uint8Array.from(expected), cb);
   }));
 }
+
+// fs.write with invalid offset type
+{
+  const filename = path.join(tmpdir.path, 'write7.txt');
+  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
+    assert.ifError(err);
+
+    assert.throws(() => {
+      fs.write(fd,
+               Buffer.from('abcd'),
+               NaN,
+               expected.length,
+               0,
+               common.mustNotCall());
+    }, {
+      code: 'ERR_OUT_OF_RANGE',
+      name: 'RangeError',
+      message: 'The value of "offset" is out of range. ' +
+               'It must be an integer. Received NaN'
+    });
+
+    fs.closeSync(fd);
+  }));
+}


### PR DESCRIPTION
Since v10.10.0, 'buf' can be any DataView, meaning the largest byteLength can be Float64Array.BYTES_PER_ELEMENT * kMaxLength = 17,179,869,176.

Fixes #26563

~~Eventually, the same change applies to fs.write*. If this current change is acceptable, I'll make the corresponding change there.~~ Done

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included - No. I can add a test but I don't see a way to do it without requiring a large amount of disk space and memory. benchmark N/A.
- [ ] documentation is changed or added - No. If this is significant enough to note in the history section, let me know.
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

