### PR TITLE
src: add fast path for equal size to `Reallocate()`

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -923,6 +923,7 @@ void Environment::BuildEmbedderGraph(Isolate* isolate,
 }
 
 char* Environment::Reallocate(char* data, size_t old_size, size_t size) {
+  if (old_size == size) return data;
   // If we know that the allocator is our ArrayBufferAllocator, we can let
   // if reallocate directly.
   if (isolate_data()->uses_node_allocator()) {


### PR DESCRIPTION
When old and new size match, we can skip the rest of the function,
which makes sense in the case of embedders who do not use Node's
allocator, as that would lead to needlessly allocating and freeing
buffers of identical sizes.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
