### PR TITLE
fs: improve mode validation

### DIFF
--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -35,24 +35,17 @@ function validateMode(value, name, def) {
   }
 
   if (typeof value === 'number') {
-    if (!Number.isInteger(value)) {
-      throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
-    } else {
-      // 2 ** 32 === 4294967296
-      throw new ERR_OUT_OF_RANGE(name, '>= 0 && < 4294967296', value);
-    }
+    validateInt32(value, name, 0, 2 ** 32 - 1);
   }
 
   if (typeof value === 'string') {
     if (!octalReg.test(value)) {
       throw new ERR_INVALID_ARG_VALUE(name, value, modeDesc);
     }
-    const parsed = parseInt(value, 8);
-    return parsed;
+    return parseInt(value, 8);
   }
 
-  // TODO(BridgeAR): Only return `def` in case `value == null`
-  if (def !== undefined) {
+  if (def !== undefined && value == null) {
     return def;
   }
 

--- a/test/parallel/test-fs-fchmod.js
+++ b/test/parallel/test-fs-fchmod.js
@@ -46,8 +46,8 @@ const fs = require('fs');
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError [ERR_OUT_OF_RANGE]',
-    message: 'The value of "mode" is out of range. It must be >= 0 && < ' +
-             `4294967296. Received ${input}`
+    message: 'The value of "mode" is out of range. It must be >= 0 && <= ' +
+             `4294967295. Received ${input}`
   };
 
   assert.throws(() => fs.fchmod(1, input), errObj);

--- a/test/parallel/test-fs-lchmod.js
+++ b/test/parallel/test-fs-lchmod.js
@@ -56,8 +56,8 @@ assert.throws(() => fs.lchmod(f, {}), { code: 'ERR_INVALID_CALLBACK' });
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError [ERR_OUT_OF_RANGE]',
-    message: 'The value of "mode" is out of range. It must be >= 0 && < ' +
-             `4294967296. Received ${input}`
+    message: 'The value of "mode" is out of range. It must be >= 0 && <= ' +
+             `4294967295. Received ${input}`
   };
 
   promises.lchmod(f, input, () => {})

--- a/test/parallel/test-fs-lchmod.js
+++ b/test/parallel/test-fs-lchmod.js
@@ -46,9 +46,7 @@ assert.throws(() => fs.lchmod(f, {}), { code: 'ERR_INVALID_CALLBACK' });
              `octal string. Received ${util.inspect(input)}`
   };
 
-  promises.lchmod(f, input, () => {})
-    .then(common.mustNotCall())
-    .catch(common.expectsError(errObj));
+  assert.rejects(promises.lchmod(f, input, () => {}), errObj);
   assert.throws(() => fs.lchmodSync(f, input), errObj);
 });
 
@@ -60,8 +58,6 @@ assert.throws(() => fs.lchmod(f, {}), { code: 'ERR_INVALID_CALLBACK' });
              `4294967295. Received ${input}`
   };
 
-  promises.lchmod(f, input, () => {})
-    .then(common.mustNotCall())
-    .catch(common.expectsError(errObj));
+  assert.rejects(promises.lchmod(f, input, () => {}), errObj);
   assert.throws(() => fs.lchmodSync(f, input), errObj);
 });

--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -98,15 +98,36 @@ for (const extra of [[], ['r'], ['r', 0], ['r', 0, 'bad callback']]) {
       type: TypeError
     }
   );
-  fs.promises.open(i, 'r')
-    .then(common.mustNotCall())
-    .catch(common.mustCall((err) => {
-      common.expectsError(
-        () => { throw err; },
-        {
-          code: 'ERR_INVALID_ARG_TYPE',
-          type: TypeError
-        }
-      );
-    }));
+  assert.rejects(
+    fs.promises.open(i, 'r'),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+    }
+  );
+});
+
+// Check invalid modes.
+[false, [], {}].forEach((mode) => {
+  assert.throws(
+    () => fs.open(__filename, 'r', mode, common.mustNotCall()),
+    {
+      message: /'mode' must be a 32-bit/,
+      code: 'ERR_INVALID_ARG_VALUE'
+    }
+  );
+  assert.throws(
+    () => fs.openSync(__filename, 'r', mode, common.mustNotCall()),
+    {
+      message: /'mode' must be a 32-bit/,
+      code: 'ERR_INVALID_ARG_VALUE'
+    }
+  );
+  assert.rejects(
+    fs.promises.open(__filename, 'r', mode),
+    {
+      message: /'mode' must be a 32-bit/,
+      code: 'ERR_INVALID_ARG_VALUE'
+    }
+  );
 });


### PR DESCRIPTION
Do not return a default mode in case invalid mode values are provided.
This strictens and simplifies the function by reusing existing
functionality.

CI https://ci.nodejs.org/job/node-test-pull-request/21459/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
