### PR TITLE
[WIP] lib: tweak buffer.indexOf

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -104,6 +104,11 @@ let poolSize, poolOffset, allocPool;
 // do not own the ArrayBuffer allocator.  Zero fill is always on in that case.
 const zeroFill = bindingZeroFill || [0];
 
+const KnownBinaryEncoding = {
+  'base64': true, 'ascii': true, 'hex': true,
+  'BASE64': true, 'ASCII': true, 'HEX': true,
+}
+
 function createUnsafeBuffer(size) {
   zeroFill[0] = 0;
   try {
@@ -764,11 +769,11 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   }
   dir = !!dir;  // Cast to bool.
 
+  if (encoding in KnownBinaryEncoding && typeof val === 'string') {
+    val = Buffer.from(val, encoding)
+  }
   if (typeof val === 'string') {
-    if (encoding === undefined) {
-      return indexOfString(buffer, val, byteOffset, encoding, dir);
-    }
-    return slowIndexOf(buffer, val, byteOffset, encoding, dir);
+    return indexOfString(buffer, val, byteOffset, encoding, dir);
   } else if (isUint8Array(val)) {
     return indexOfBuffer(buffer, val, byteOffset, encoding, dir);
   } else if (typeof val === 'number') {
@@ -778,37 +783,6 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   throw new ERR_INVALID_ARG_TYPE(
     'value', ['string', 'Buffer', 'Uint8Array'], val
   );
-}
-
-function slowIndexOf(buffer, val, byteOffset, encoding, dir) {
-  let loweredCase = false;
-  for (;;) {
-    switch (encoding) {
-      case 'utf8':
-      case 'utf-8':
-      case 'ucs2':
-      case 'ucs-2':
-      case 'utf16le':
-      case 'utf-16le':
-      case 'latin1':
-      case 'binary':
-        return indexOfString(buffer, val, byteOffset, encoding, dir);
-
-      case 'base64':
-      case 'ascii':
-      case 'hex':
-        return indexOfBuffer(
-          buffer, Buffer.from(val, encoding), byteOffset, encoding, dir);
-
-      default:
-        if (loweredCase) {
-          throw new ERR_UNKNOWN_ENCODING(encoding);
-        }
-
-        encoding = ('' + encoding).toLowerCase();
-        loweredCase = true;
-    }
-  }
 }
 
 Buffer.prototype.indexOf = function indexOf(val, byteOffset, encoding) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -107,7 +107,7 @@ const zeroFill = bindingZeroFill || [0];
 const KnownBinaryEncoding = {
   'base64': true, 'ascii': true, 'hex': true,
   'BASE64': true, 'ASCII': true, 'HEX': true,
-}
+};
 
 function createUnsafeBuffer(size) {
   zeroFill[0] = 0;

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -104,7 +104,7 @@ let poolSize, poolOffset, allocPool;
 // do not own the ArrayBuffer allocator.  Zero fill is always on in that case.
 const zeroFill = bindingZeroFill || [0];
 
-const KnownBinaryEncoding = {
+const EncodingsToUseWithBufferValues = {
   'base64': true, 'ascii': true, 'hex': true,
   'BASE64': true, 'ASCII': true, 'HEX': true,
 };
@@ -770,7 +770,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   encoding = encoding || 'utf8';
   dir = !!dir;  // Cast to bool.
 
-  if (encoding in KnownBinaryEncoding && typeof val === 'string') {
+  if (encoding in EncodingsToUseWithBufferValues && typeof val === 'string') {
     val = Buffer.from(val, encoding);
   }
   if (typeof val === 'string') {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -767,13 +767,18 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   if (Number.isNaN(byteOffset)) {
     byteOffset = dir ? 0 : buffer.length;
   }
+  encoding = encoding || 'utf8';
   dir = !!dir;  // Cast to bool.
 
   if (encoding in KnownBinaryEncoding && typeof val === 'string') {
-    val = Buffer.from(val, encoding)
+    val = Buffer.from(val, encoding);
   }
   if (typeof val === 'string') {
-    return indexOfString(buffer, val, byteOffset, encoding, dir);
+    const ret = indexOfString(buffer, val, byteOffset, encoding, dir);
+    if (ret === -2) {
+      throw new ERR_UNKNOWN_ENCODING(encoding);
+    }
+    return ret;
   } else if (isUint8Array(val)) {
     return indexOfBuffer(buffer, val, byteOffset, encoding, dir);
   } else if (typeof val === 'number') {

--- a/src/node.h
+++ b/src/node.h
@@ -391,7 +391,8 @@ inline void NODE_SET_PROTOTYPE_METHOD(v8::Local<v8::FunctionTemplate> recv,
 #define NODE_SET_PROTOTYPE_METHOD node::NODE_SET_PROTOTYPE_METHOD
 
 // BINARY is a deprecated alias of LATIN1.
-enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER, LATIN1 = BINARY};
+enum encoding {ASCII, UTF8, BASE64, UCS2,
+               BINARY, HEX, BUFFER, LATIN1 = BINARY, PARSE_ERROR};
 
 NODE_EXTERN enum encoding ParseEncoding(
     v8::Isolate* isolate,

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -785,7 +785,11 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsNumber());
   CHECK(args[4]->IsBoolean());
 
-  enum encoding enc = ParseEncoding(isolate, args[3], UTF8);
+  enum encoding enc = ParseEncoding(isolate, args[3], PARSE_ERROR);
+  if (enc == PARSE_ERROR) {
+    return args.GetReturnValue().Set(-2);
+  }
+
 
   THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
   SPREAD_BUFFER_ARG(args[0], ts_obj);


### PR DESCRIPTION
`ParseEncoding` is case insensitive, no benefit in manipulation in JS.
https://github.com/nodejs/node/blob/3ad8f6123640ae82b1c4840e7184c36650a7b64d/src/api/encoding.cc#L59-L85

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
