### PR TITLE
util: prevent tampering with internals in `inspect()`

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -206,7 +206,7 @@ function inspect(value, opts) {
         // TODO(BridgeAR): Find a solution what to do about stylize. Either make
         // this function public or add a new API with a similar or better
         // functionality.
-        if (hasOwnProperty(inspectDefaultOptions, key) && key !== 'stylize') {
+        if (hasOwnProperty(inspectDefaultOptions, key) || key === 'stylize') {
           ctx[key] = opts[key];
         } else if (ctx.userOptions === undefined) {
           // This is required to pass through the actual user input.

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -150,6 +150,16 @@ const meta = [
   '', '', '', '', '', '', '', '\\\\'
 ];
 
+function getUserOptions(ctx) {
+  const obj = { stylize: ctx.stylize };
+  for (const key of Object.keys(inspectDefaultOptions)) {
+    obj[key] = ctx[key];
+  }
+  if (ctx.userOptions === undefined)
+    return obj;
+  return { ...obj, ...ctx.userOptions };
+}
+
 /**
  * Echos the value of any input. Tries to print the value out
  * in the best way possible given the different types.
@@ -192,8 +202,16 @@ function inspect(value, opts) {
       ctx.showHidden = opts;
     } else if (opts) {
       const optKeys = Object.keys(opts);
-      for (var i = 0; i < optKeys.length; i++) {
-        ctx[optKeys[i]] = opts[optKeys[i]];
+      for (const key of optKeys) {
+        // TODO(BridgeAR): Find a solution what to do about stylize. Either make
+        // this function public or add a new API with a similar or better
+        // functionality.
+        if (hasOwnProperty(inspectDefaultOptions, key) && key !== 'stylize') {
+          ctx[key] = opts[key];
+        } else if (ctx.userOptions === undefined) {
+          // This is required to pass through the actual user input.
+          ctx.userOptions = opts;
+        }
       }
     }
   }
@@ -522,14 +540,10 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
         maybeCustom !== inspect &&
         // Also filter out any prototype objects using the circular check.
         !(value.constructor && value.constructor.prototype === value)) {
-      // Remove some internal properties from the options before passing it
-      // through to the user function. This also prevents option manipulation.
-      // eslint-disable-next-line no-unused-vars
-      const { budget, seen, indentationLvl, ...plainCtx } = ctx;
       // This makes sure the recurseTimes are reported as before while using
       // a counter internally.
       const depth = ctx.depth === null ? null : ctx.depth - recurseTimes;
-      const ret = maybeCustom.call(context, depth, plainCtx);
+      const ret = maybeCustom.call(context, depth, getUserOptions(ctx));
       // If the custom inspection method returned `this`, don't go into
       // infinite recursion.
       if (ret !== context) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -820,7 +820,7 @@ util.inspect({ hasOwnProperty: null });
 
 // Verify that it's possible to use the stylize function to manipulate input.
 assert.strictEqual(
-  util.inspect([1, 2, 3], { stylize() { return ''; } }),
+  util.inspect([1, 2, 3], { stylize() { return 'x'; } }),
   '[ x, x, x ]'
 );
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -818,6 +818,12 @@ util.inspect({ hasOwnProperty: null });
                      `{ a: 123,\n  [Symbol(${UIC})]: [Function: [${UIC}]] }`);
 }
 
+// Verify that it's possible to use the stylize function to manipulate input.
+assert.strictEqual(
+  util.inspect([1, 2, 3], { stylize() { return ''; } }),
+  '[ x, x, x ]'
+);
+
 // Using `util.inspect` with "colors" option should produce as many lines as
 // without it.
 {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -791,7 +791,7 @@ util.inspect({ hasOwnProperty: null });
     }) };
   });
 
-  util.inspect(subject, { customInspectOptions: true });
+  util.inspect(subject);
 
   // util.inspect.custom is a shared symbol which can be accessed as
   // Symbol.for("nodejs.util.inspect.custom").
@@ -803,9 +803,11 @@ util.inspect({ hasOwnProperty: null });
 
   subject[inspect] = (depth, opts) => {
     assert.strictEqual(opts.customInspectOptions, true);
+    assert.strictEqual(opts.seen, null);
+    return {};
   };
 
-  util.inspect(subject, { customInspectOptions: true });
+  util.inspect(subject, { customInspectOptions: true, seen: null });
 }
 
 {


### PR DESCRIPTION
This makes sure user options passed to `util.inspect()` will not
override any internal properties (besides `stylize`).

Fixes: https://github.com/nodejs/node/issues/24765

Defensively marked as semver-major. @nodejs/tsc PTAL.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
