### PR TITLE
[v10.x backport] deps: v8, backport coverage fixes

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -33,7 +33,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.51',
+    'v8_embedder_string': '-node.52',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -49,7 +49,7 @@ Andrew Paprocki <andrew@ishiboo.com>
 Andrei Kashcha <anvaka@gmail.com>
 Anna Henningsen <anna@addaleax.net>
 Bangfu Tao <bangfu.tao@samsung.com>
-Ben Coe <ben@npmjs.com>
+Ben Coe <bencoe@gmail.com>
 Ben Newman <ben@meteor.com>
 Ben Noordhuis <info@bnoordhuis.nl>
 Benjamin Tan <demoneaux@gmail.com>

--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -1496,6 +1496,8 @@ v8_source_set("v8_base") {
     "src/ast/prettyprinter.h",
     "src/ast/scopes.cc",
     "src/ast/scopes.h",
+    "src/ast/source-range-ast-visitor.cc",
+    "src/ast/source-range-ast-visitor.h",
     "src/ast/variables.cc",
     "src/ast/variables.h",
     "src/bailout-reason.cc",

--- a/deps/v8/gypfiles/v8.gyp
+++ b/deps/v8/gypfiles/v8.gyp
@@ -516,6 +516,8 @@
         '../src/ast/prettyprinter.h',
         '../src/ast/scopes.cc',
         '../src/ast/scopes.h',
+        "../src/ast/source-range-ast-visitor.cc",
+        "../src/ast/source-range-ast-visitor.h",
         '../src/ast/variables.cc',
         '../src/ast/variables.h',
         '../src/bailout-reason.cc',

--- a/deps/v8/src/ast/ast-source-ranges.h
+++ b/deps/v8/src/ast/ast-source-ranges.h
@@ -58,6 +58,8 @@ class AstNodeSourceRanges : public ZoneObject {
  public:
   virtual ~AstNodeSourceRanges() {}
   virtual SourceRange GetRange(SourceRangeKind kind) = 0;
+  virtual bool HasRange(SourceRangeKind kind) = 0;
+  virtual void RemoveContinuationRange() { UNREACHABLE(); }
 };
 
 class BinaryOperationSourceRanges final : public AstNodeSourceRanges {
@@ -65,9 +67,13 @@ class BinaryOperationSourceRanges final : public AstNodeSourceRanges {
   explicit BinaryOperationSourceRanges(const SourceRange& right_range)
       : right_range_(right_range) {}
 
-  SourceRange GetRange(SourceRangeKind kind) {
-    DCHECK_EQ(kind, SourceRangeKind::kRight);
+  SourceRange GetRange(SourceRangeKind kind) override {
+    DCHECK(HasRange(kind));
     return right_range_;
+  }
+
+  bool HasRange(SourceRangeKind kind) override {
+    return kind == SourceRangeKind::kRight;
   }
 
  private:
@@ -79,9 +85,18 @@ class ContinuationSourceRanges : public AstNodeSourceRanges {
   explicit ContinuationSourceRanges(int32_t continuation_position)
       : continuation_position_(continuation_position) {}
 
-  SourceRange GetRange(SourceRangeKind kind) {
-    DCHECK_EQ(kind, SourceRangeKind::kContinuation);
+  SourceRange GetRange(SourceRangeKind kind) override {
+    DCHECK(HasRange(kind));
     return SourceRange::OpenEnded(continuation_position_);
+  }
+
+  bool HasRange(SourceRangeKind kind) override {
+    return kind == SourceRangeKind::kContinuation;
+  }
+
+  void RemoveContinuationRange() override {
+    DCHECK(HasRange(SourceRangeKind::kContinuation));
+    continuation_position_ = kNoSourcePosition;
   }
 
  private:
@@ -99,9 +114,13 @@ class CaseClauseSourceRanges final : public AstNodeSourceRanges {
   explicit CaseClauseSourceRanges(const SourceRange& body_range)
       : body_range_(body_range) {}
 
-  SourceRange GetRange(SourceRangeKind kind) {
-    DCHECK_EQ(kind, SourceRangeKind::kBody);
+  SourceRange GetRange(SourceRangeKind kind) override {
+    DCHECK(HasRange(kind));
     return body_range_;
+  }
+
+  bool HasRange(SourceRangeKind kind) override {
+    return kind == SourceRangeKind::kBody;
   }
 
  private:
@@ -114,7 +133,8 @@ class ConditionalSourceRanges final : public AstNodeSourceRanges {
                                    const SourceRange& else_range)
       : then_range_(then_range), else_range_(else_range) {}
 
-  SourceRange GetRange(SourceRangeKind kind) {
+  SourceRange GetRange(SourceRangeKind kind) override {
+    DCHECK(HasRange(kind));
     switch (kind) {
       case SourceRangeKind::kThen:
         return then_range_;
@@ -123,6 +143,10 @@ class ConditionalSourceRanges final : public AstNodeSourceRanges {
       default:
         UNREACHABLE();
     }
+  }
+
+  bool HasRange(SourceRangeKind kind) override {
+    return kind == SourceRangeKind::kThen || kind == SourceRangeKind::kElse;
   }
 
  private:
@@ -136,13 +160,15 @@ class IfStatementSourceRanges final : public AstNodeSourceRanges {
                                    const SourceRange& else_range)
       : then_range_(then_range), else_range_(else_range) {}
 
-  SourceRange GetRange(SourceRangeKind kind) {
+  SourceRange GetRange(SourceRangeKind kind) override {
+    DCHECK(HasRange(kind));
     switch (kind) {
       case SourceRangeKind::kElse:
         return else_range_;
       case SourceRangeKind::kThen:
         return then_range_;
       case SourceRangeKind::kContinuation: {
+        if (!has_continuation_) return SourceRange::Empty();
         const SourceRange& trailing_range =
             else_range_.IsEmpty() ? then_range_ : else_range_;
         return SourceRange::ContinuationOf(trailing_range);
@@ -152,9 +178,20 @@ class IfStatementSourceRanges final : public AstNodeSourceRanges {
     }
   }
 
+  bool HasRange(SourceRangeKind kind) override {
+    return kind == SourceRangeKind::kThen || kind == SourceRangeKind::kElse ||
+           kind == SourceRangeKind::kContinuation;
+  }
+
+  void RemoveContinuationRange() override {
+    DCHECK(HasRange(SourceRangeKind::kContinuation));
+    has_continuation_ = false;
+  }
+
  private:
   SourceRange then_range_;
   SourceRange else_range_;
+  bool has_continuation_ = true;
 };
 
 class IterationStatementSourceRanges final : public AstNodeSourceRanges {
@@ -162,19 +199,32 @@ class IterationStatementSourceRanges final : public AstNodeSourceRanges {
   explicit IterationStatementSourceRanges(const SourceRange& body_range)
       : body_range_(body_range) {}
 
-  SourceRange GetRange(SourceRangeKind kind) {
+  SourceRange GetRange(SourceRangeKind kind) override {
+    DCHECK(HasRange(kind));
     switch (kind) {
       case SourceRangeKind::kBody:
         return body_range_;
       case SourceRangeKind::kContinuation:
+        if (!has_continuation_) return SourceRange::Empty();
         return SourceRange::ContinuationOf(body_range_);
       default:
         UNREACHABLE();
     }
   }
 
+  bool HasRange(SourceRangeKind kind) override {
+    return kind == SourceRangeKind::kBody ||
+           kind == SourceRangeKind::kContinuation;
+  }
+
+  void RemoveContinuationRange() override {
+    DCHECK(HasRange(SourceRangeKind::kContinuation));
+    has_continuation_ = false;
+  }
+
  private:
   SourceRange body_range_;
+  bool has_continuation_ = true;
 };
 
 class JumpStatementSourceRanges final : public ContinuationSourceRanges {
@@ -198,7 +248,8 @@ class NaryOperationSourceRanges final : public AstNodeSourceRanges {
   void AddRange(const SourceRange& range) { ranges_.push_back(range); }
   size_t RangeCount() const { return ranges_.size(); }
 
-  SourceRange GetRange(SourceRangeKind kind) { UNREACHABLE(); }
+  SourceRange GetRange(SourceRangeKind kind) override { UNREACHABLE(); }
+  bool HasRange(SourceRangeKind kind) override { return false; }
 
  private:
   ZoneVector<SourceRange> ranges_;
@@ -227,19 +278,32 @@ class TryCatchStatementSourceRanges final : public AstNodeSourceRanges {
   explicit TryCatchStatementSourceRanges(const SourceRange& catch_range)
       : catch_range_(catch_range) {}
 
-  SourceRange GetRange(SourceRangeKind kind) {
+  SourceRange GetRange(SourceRangeKind kind) override {
+    DCHECK(HasRange(kind));
     switch (kind) {
       case SourceRangeKind::kCatch:
         return catch_range_;
       case SourceRangeKind::kContinuation:
+        if (!has_continuation_) return SourceRange::Empty();
         return SourceRange::ContinuationOf(catch_range_);
       default:
         UNREACHABLE();
     }
   }
 
+  bool HasRange(SourceRangeKind kind) override {
+    return kind == SourceRangeKind::kCatch ||
+           kind == SourceRangeKind::kContinuation;
+  }
+
+  void RemoveContinuationRange() override {
+    DCHECK(HasRange(SourceRangeKind::kContinuation));
+    has_continuation_ = false;
+  }
+
  private:
   SourceRange catch_range_;
+  bool has_continuation_ = true;
 };
 
 class TryFinallyStatementSourceRanges final : public AstNodeSourceRanges {
@@ -247,19 +311,32 @@ class TryFinallyStatementSourceRanges final : public AstNodeSourceRanges {
   explicit TryFinallyStatementSourceRanges(const SourceRange& finally_range)
       : finally_range_(finally_range) {}
 
-  SourceRange GetRange(SourceRangeKind kind) {
+  SourceRange GetRange(SourceRangeKind kind) override {
+    DCHECK(HasRange(kind));
     switch (kind) {
       case SourceRangeKind::kFinally:
         return finally_range_;
       case SourceRangeKind::kContinuation:
+        if (!has_continuation_) return SourceRange::Empty();
         return SourceRange::ContinuationOf(finally_range_);
       default:
         UNREACHABLE();
     }
   }
 
+  bool HasRange(SourceRangeKind kind) override {
+    return kind == SourceRangeKind::kFinally ||
+           kind == SourceRangeKind::kContinuation;
+  }
+
+  void RemoveContinuationRange() override {
+    DCHECK(HasRange(SourceRangeKind::kContinuation));
+    has_continuation_ = false;
+  }
+
  private:
   SourceRange finally_range_;
+  bool has_continuation_ = true;
 };
 
 // Maps ast node pointers to associated source ranges. The parser creates these

--- a/deps/v8/src/ast/ast-traversal-visitor.h
+++ b/deps/v8/src/ast/ast-traversal-visitor.h
@@ -41,7 +41,7 @@ class AstTraversalVisitor : public AstVisitor<Subclass> {
 
   // Iteration left-to-right.
   void VisitDeclarations(Declaration::List* declarations);
-  void VisitStatements(ZoneList<Statement*>* statements);
+  void VisitStatements(ZonePtrList<Statement>* statements);
 
 // Individual nodes
 #define DECLARE_VISIT(type) void Visit##type(type* node);
@@ -112,7 +112,7 @@ void AstTraversalVisitor<Subclass>::VisitDeclarations(
 
 template <class Subclass>
 void AstTraversalVisitor<Subclass>::VisitStatements(
-    ZoneList<Statement*>* stmts) {
+    ZonePtrList<Statement>* stmts) {
   for (int i = 0; i < stmts->length(); ++i) {
     Statement* stmt = stmts->at(i);
     RECURSE(Visit(stmt));
@@ -198,14 +198,14 @@ void AstTraversalVisitor<Subclass>::VisitSwitchStatement(
   PROCESS_NODE(stmt);
   RECURSE(Visit(stmt->tag()));
 
-  ZoneList<CaseClause*>* clauses = stmt->cases();
+  ZonePtrList<CaseClause>* clauses = stmt->cases();
   for (int i = 0; i < clauses->length(); ++i) {
     CaseClause* clause = clauses->at(i);
     if (!clause->is_default()) {
       Expression* label = clause->label();
       RECURSE(Visit(label));
     }
-    ZoneList<Statement*>* stmts = clause->statements();
+    ZonePtrList<Statement>* stmts = clause->statements();
     RECURSE(VisitStatements(stmts));
   }
 }
@@ -330,7 +330,7 @@ void AstTraversalVisitor<Subclass>::VisitRegExpLiteral(RegExpLiteral* expr) {
 template <class Subclass>
 void AstTraversalVisitor<Subclass>::VisitObjectLiteral(ObjectLiteral* expr) {
   PROCESS_EXPRESSION(expr);
-  ZoneList<ObjectLiteralProperty*>* props = expr->properties();
+  ZonePtrList<ObjectLiteralProperty>* props = expr->properties();
   for (int i = 0; i < props->length(); ++i) {
     ObjectLiteralProperty* prop = props->at(i);
     RECURSE_EXPRESSION(Visit(prop->key()));
@@ -341,7 +341,7 @@ void AstTraversalVisitor<Subclass>::VisitObjectLiteral(ObjectLiteral* expr) {
 template <class Subclass>
 void AstTraversalVisitor<Subclass>::VisitArrayLiteral(ArrayLiteral* expr) {
   PROCESS_EXPRESSION(expr);
-  ZoneList<Expression*>* values = expr->values();
+  ZonePtrList<Expression>* values = expr->values();
   for (int i = 0; i < values->length(); ++i) {
     Expression* value = values->at(i);
     RECURSE_EXPRESSION(Visit(value));
@@ -404,7 +404,7 @@ template <class Subclass>
 void AstTraversalVisitor<Subclass>::VisitCall(Call* expr) {
   PROCESS_EXPRESSION(expr);
   RECURSE_EXPRESSION(Visit(expr->expression()));
-  ZoneList<Expression*>* args = expr->arguments();
+  ZonePtrList<Expression>* args = expr->arguments();
   for (int i = 0; i < args->length(); ++i) {
     Expression* arg = args->at(i);
     RECURSE_EXPRESSION(Visit(arg));
@@ -415,7 +415,7 @@ template <class Subclass>
 void AstTraversalVisitor<Subclass>::VisitCallNew(CallNew* expr) {
   PROCESS_EXPRESSION(expr);
   RECURSE_EXPRESSION(Visit(expr->expression()));
-  ZoneList<Expression*>* args = expr->arguments();
+  ZonePtrList<Expression>* args = expr->arguments();
   for (int i = 0; i < args->length(); ++i) {
     Expression* arg = args->at(i);
     RECURSE_EXPRESSION(Visit(arg));
@@ -425,7 +425,7 @@ void AstTraversalVisitor<Subclass>::VisitCallNew(CallNew* expr) {
 template <class Subclass>
 void AstTraversalVisitor<Subclass>::VisitCallRuntime(CallRuntime* expr) {
   PROCESS_EXPRESSION(expr);
-  ZoneList<Expression*>* args = expr->arguments();
+  ZonePtrList<Expression>* args = expr->arguments();
   for (int i = 0; i < args->length(); ++i) {
     Expression* arg = args->at(i);
     RECURSE_EXPRESSION(Visit(arg));
@@ -487,7 +487,7 @@ void AstTraversalVisitor<Subclass>::VisitClassLiteral(ClassLiteral* expr) {
   if (expr->instance_fields_initializer_function() != nullptr) {
     RECURSE_EXPRESSION(Visit(expr->instance_fields_initializer_function()));
   }
-  ZoneList<ClassLiteralProperty*>* props = expr->properties();
+  ZonePtrList<ClassLiteral::Property>* props = expr->properties();
   for (int i = 0; i < props->length(); ++i) {
     ClassLiteralProperty* prop = props->at(i);
     if (!prop->key()->IsLiteral()) {
@@ -501,7 +501,7 @@ template <class Subclass>
 void AstTraversalVisitor<Subclass>::VisitInitializeClassFieldsStatement(
     InitializeClassFieldsStatement* stmt) {
   PROCESS_NODE(stmt);
-  ZoneList<ClassLiteralProperty*>* props = stmt->fields();
+  ZonePtrList<ClassLiteral::Property>* props = stmt->fields();
   for (int i = 0; i < props->length(); ++i) {
     ClassLiteralProperty* prop = props->at(i);
     if (!prop->key()->IsLiteral()) {

--- a/deps/v8/src/ast/ast.cc
+++ b/deps/v8/src/ast/ast.cc
@@ -831,7 +831,7 @@ Call::CallType Call::GetCallType() const {
   return OTHER_CALL;
 }
 
-CaseClause::CaseClause(Expression* label, ZoneList<Statement*>* statements)
+CaseClause::CaseClause(Expression* label, ZonePtrList<Statement>* statements)
     : label_(label), statements_(statements) {}
 
 bool Literal::IsPropertyName() const {
@@ -954,7 +954,7 @@ const char* CallRuntime::debug_name() {
   case k##NodeType:             \
     return static_cast<const NodeType*>(this)->labels();
 
-ZoneList<const AstRawString*>* BreakableStatement::labels() const {
+ZonePtrList<const AstRawString>* BreakableStatement::labels() const {
   switch (node_type()) {
     BREAKABLE_NODE_LIST(RETURN_LABELS)
     ITERATION_NODE_LIST(RETURN_LABELS)

--- a/deps/v8/src/ast/ast.h
+++ b/deps/v8/src/ast/ast.h
@@ -255,7 +255,7 @@ class BreakableStatement : public Statement {
     TARGET_FOR_NAMED_ONLY
   };
 
-  ZoneList<const AstRawString*>* labels() const;
+  ZonePtrList<const AstRawString>* labels() const;
 
   // Testers.
   bool is_target_for_anonymous() const {
@@ -277,12 +277,12 @@ class BreakableStatement : public Statement {
 
 class Block : public BreakableStatement {
  public:
-  ZoneList<Statement*>* statements() { return &statements_; }
+  ZonePtrList<Statement>* statements() { return &statements_; }
   bool ignore_completion_value() const {
     return IgnoreCompletionField::decode(bit_field_);
   }
 
-  inline ZoneList<const AstRawString*>* labels() const;
+  inline ZonePtrList<const AstRawString>* labels() const;
 
   bool IsJump() const {
     return !statements_.is_empty() && statements_.last()->IsJump() &&
@@ -295,7 +295,7 @@ class Block : public BreakableStatement {
  private:
   friend class AstNodeFactory;
 
-  ZoneList<Statement*> statements_;
+  ZonePtrList<Statement> statements_;
   Scope* scope_;
 
   class IgnoreCompletionField
@@ -304,7 +304,7 @@ class Block : public BreakableStatement {
       : public BitField<bool, IgnoreCompletionField::kNext, 1> {};
 
  protected:
-  Block(Zone* zone, ZoneList<const AstRawString*>* labels, int capacity,
+  Block(Zone* zone, ZonePtrList<const AstRawString>* labels, int capacity,
         bool ignore_completion_value)
       : BreakableStatement(TARGET_FOR_NAMED_ONLY, kNoSourcePosition, kBlock),
         statements_(capacity, zone),
@@ -319,18 +319,18 @@ class LabeledBlock final : public Block {
   friend class AstNodeFactory;
   friend class Block;
 
-  LabeledBlock(Zone* zone, ZoneList<const AstRawString*>* labels, int capacity,
-               bool ignore_completion_value)
+  LabeledBlock(Zone* zone, ZonePtrList<const AstRawString>* labels,
+               int capacity, bool ignore_completion_value)
       : Block(zone, labels, capacity, ignore_completion_value),
         labels_(labels) {
     DCHECK_NOT_NULL(labels);
     DCHECK_GT(labels->length(), 0);
   }
 
-  ZoneList<const AstRawString*>* labels_;
+  ZonePtrList<const AstRawString>* labels_;
 };
 
-inline ZoneList<const AstRawString*>* Block::labels() const {
+inline ZonePtrList<const AstRawString>* Block::labels() const {
   if (IsLabeledField::decode(bit_field_)) {
     return static_cast<const LabeledBlock*>(this)->labels_;
   }
@@ -437,10 +437,10 @@ class IterationStatement : public BreakableStatement {
   Statement* body() const { return body_; }
   void set_body(Statement* s) { body_ = s; }
 
-  ZoneList<const AstRawString*>* labels() const { return labels_; }
+  ZonePtrList<const AstRawString>* labels() const { return labels_; }
 
  protected:
-  IterationStatement(ZoneList<const AstRawString*>* labels, int pos,
+  IterationStatement(ZonePtrList<const AstRawString>* labels, int pos,
                      NodeType type)
       : BreakableStatement(TARGET_FOR_ANONYMOUS, pos, type),
         labels_(labels),
@@ -451,7 +451,7 @@ class IterationStatement : public BreakableStatement {
       BreakableStatement::kNextBitFieldIndex;
 
  private:
-  ZoneList<const AstRawString*>* labels_;
+  ZonePtrList<const AstRawString>* labels_;
   Statement* body_;
 };
 
@@ -468,7 +468,7 @@ class DoWhileStatement final : public IterationStatement {
  private:
   friend class AstNodeFactory;
 
-  DoWhileStatement(ZoneList<const AstRawString*>* labels, int pos)
+  DoWhileStatement(ZonePtrList<const AstRawString>* labels, int pos)
       : IterationStatement(labels, pos, kDoWhileStatement), cond_(nullptr) {}
 
   Expression* cond_;
@@ -487,7 +487,7 @@ class WhileStatement final : public IterationStatement {
  private:
   friend class AstNodeFactory;
 
-  WhileStatement(ZoneList<const AstRawString*>* labels, int pos)
+  WhileStatement(ZonePtrList<const AstRawString>* labels, int pos)
       : IterationStatement(labels, pos, kWhileStatement), cond_(nullptr) {}
 
   Expression* cond_;
@@ -511,7 +511,7 @@ class ForStatement final : public IterationStatement {
  private:
   friend class AstNodeFactory;
 
-  ForStatement(ZoneList<const AstRawString*>* labels, int pos)
+  ForStatement(ZonePtrList<const AstRawString>* labels, int pos)
       : IterationStatement(labels, pos, kForStatement),
         init_(nullptr),
         cond_(nullptr),
@@ -537,7 +537,7 @@ class ForEachStatement : public IterationStatement {
   }
 
  protected:
-  ForEachStatement(ZoneList<const AstRawString*>* labels, int pos,
+  ForEachStatement(ZonePtrList<const AstRawString>* labels, int pos,
                    NodeType type)
       : IterationStatement(labels, pos, type) {}
 };
@@ -564,7 +564,7 @@ class ForInStatement final : public ForEachStatement {
  private:
   friend class AstNodeFactory;
 
-  ForInStatement(ZoneList<const AstRawString*>* labels, int pos)
+  ForInStatement(ZonePtrList<const AstRawString>* labels, int pos)
       : ForEachStatement(labels, pos, kForInStatement),
         each_(nullptr),
         subject_(nullptr) {
@@ -630,7 +630,7 @@ class ForOfStatement final : public ForEachStatement {
  private:
   friend class AstNodeFactory;
 
-  ForOfStatement(ZoneList<const AstRawString*>* labels, int pos)
+  ForOfStatement(ZonePtrList<const AstRawString>* labels, int pos)
       : ForEachStatement(labels, pos, kForOfStatement),
         iterator_(nullptr),
         assign_iterator_(nullptr),
@@ -757,40 +757,40 @@ class CaseClause final : public ZoneObject {
     DCHECK(!is_default());
     return label_;
   }
-  ZoneList<Statement*>* statements() const { return statements_; }
+  ZonePtrList<Statement>* statements() const { return statements_; }
 
  private:
   friend class AstNodeFactory;
 
-  CaseClause(Expression* label, ZoneList<Statement*>* statements);
+  CaseClause(Expression* label, ZonePtrList<Statement>* statements);
 
   Expression* label_;
-  ZoneList<Statement*>* statements_;
+  ZonePtrList<Statement>* statements_;
 };
 
 
 class SwitchStatement final : public BreakableStatement {
  public:
-  ZoneList<const AstRawString*>* labels() const { return labels_; }
+  ZonePtrList<const AstRawString>* labels() const { return labels_; }
 
   Expression* tag() const { return tag_; }
   void set_tag(Expression* t) { tag_ = t; }
 
-  ZoneList<CaseClause*>* cases() { return &cases_; }
+  ZonePtrList<CaseClause>* cases() { return &cases_; }
 
  private:
   friend class AstNodeFactory;
 
-  SwitchStatement(Zone* zone, ZoneList<const AstRawString*>* labels,
+  SwitchStatement(Zone* zone, ZonePtrList<const AstRawString>* labels,
                   Expression* tag, int pos)
       : BreakableStatement(TARGET_FOR_ANONYMOUS, pos, kSwitchStatement),
         labels_(labels),
         tag_(tag),
         cases_(4, zone) {}
 
-  ZoneList<const AstRawString*>* labels_;
+  ZonePtrList<const AstRawString>* labels_;
   Expression* tag_;
-  ZoneList<CaseClause*> cases_;
+  ZonePtrList<CaseClause> cases_;
 };
 
 
@@ -1280,7 +1280,7 @@ class ObjectLiteral final : public AggregateLiteral {
     return constant_properties_;
   }
   int properties_count() const { return boilerplate_properties_; }
-  ZoneList<Property*>* properties() const { return properties_; }
+  ZonePtrList<Property>* properties() const { return properties_; }
   bool has_elements() const { return HasElementsField::decode(bit_field_); }
   bool has_rest_property() const {
     return HasRestPropertyField::decode(bit_field_);
@@ -1355,7 +1355,7 @@ class ObjectLiteral final : public AggregateLiteral {
  private:
   friend class AstNodeFactory;
 
-  ObjectLiteral(ZoneList<Property*>* properties,
+  ObjectLiteral(ZonePtrList<Property>* properties,
                 uint32_t boilerplate_properties, int pos,
                 bool has_rest_property)
       : AggregateLiteral(pos, kObjectLiteral),
@@ -1381,7 +1381,7 @@ class ObjectLiteral final : public AggregateLiteral {
 
   uint32_t boilerplate_properties_;
   Handle<BoilerplateDescription> constant_properties_;
-  ZoneList<Property*>* properties_;
+  ZonePtrList<Property>* properties_;
 
   class HasElementsField
       : public BitField<bool, AggregateLiteral::kNextBitFieldIndex, 1> {};
@@ -1427,7 +1427,7 @@ class ArrayLiteral final : public AggregateLiteral {
     return constant_elements_;
   }
 
-  ZoneList<Expression*>* values() const { return values_; }
+  ZonePtrList<Expression>* values() const { return values_; }
 
   int first_spread_index() const { return first_spread_index_; }
 
@@ -1458,15 +1458,14 @@ class ArrayLiteral final : public AggregateLiteral {
  private:
   friend class AstNodeFactory;
 
-  ArrayLiteral(ZoneList<Expression*>* values, int first_spread_index, int pos)
+  ArrayLiteral(ZonePtrList<Expression>* values, int first_spread_index, int pos)
       : AggregateLiteral(pos, kArrayLiteral),
         first_spread_index_(first_spread_index),
-        values_(values) {
-  }
+        values_(values) {}
 
   int first_spread_index_;
   Handle<ConstantElementsPair> constant_elements_;
-  ZoneList<Expression*>* values_;
+  ZonePtrList<Expression>* values_;
 };
 
 enum class HoleCheckMode { kRequired, kElided };
@@ -1633,7 +1632,7 @@ class ResolvedProperty final : public Expression {
 class Call final : public Expression {
  public:
   Expression* expression() const { return expression_; }
-  ZoneList<Expression*>* arguments() const { return arguments_; }
+  ZonePtrList<Expression>* arguments() const { return arguments_; }
 
   bool is_possibly_eval() const {
     return IsPossiblyEvalField::decode(bit_field_);
@@ -1672,17 +1671,15 @@ class Call final : public Expression {
  private:
   friend class AstNodeFactory;
 
-  Call(Expression* expression, ZoneList<Expression*>* arguments, int pos,
+  Call(Expression* expression, ZonePtrList<Expression>* arguments, int pos,
        PossiblyEval possibly_eval)
-      : Expression(pos, kCall),
-        expression_(expression),
-        arguments_(arguments) {
+      : Expression(pos, kCall), expression_(expression), arguments_(arguments) {
     bit_field_ |=
         IsPossiblyEvalField::encode(possibly_eval == IS_POSSIBLY_EVAL) |
         IsTaggedTemplateField::encode(false);
   }
 
-  Call(Expression* expression, ZoneList<Expression*>* arguments, int pos,
+  Call(Expression* expression, ZonePtrList<Expression>* arguments, int pos,
        TaggedTemplateTag tag)
       : Expression(pos, kCall), expression_(expression), arguments_(arguments) {
     bit_field_ |= IsPossiblyEvalField::encode(false) |
@@ -1695,14 +1692,14 @@ class Call final : public Expression {
       : public BitField<bool, IsPossiblyEvalField::kNext, 1> {};
 
   Expression* expression_;
-  ZoneList<Expression*>* arguments_;
+  ZonePtrList<Expression>* arguments_;
 };
 
 
 class CallNew final : public Expression {
  public:
   Expression* expression() const { return expression_; }
-  ZoneList<Expression*>* arguments() const { return arguments_; }
+  ZonePtrList<Expression>* arguments() const { return arguments_; }
 
   bool only_last_arg_is_spread() {
     return !arguments_->is_empty() && arguments_->last()->IsSpread();
@@ -1711,14 +1708,13 @@ class CallNew final : public Expression {
  private:
   friend class AstNodeFactory;
 
-  CallNew(Expression* expression, ZoneList<Expression*>* arguments, int pos)
+  CallNew(Expression* expression, ZonePtrList<Expression>* arguments, int pos)
       : Expression(pos, kCallNew),
         expression_(expression),
-        arguments_(arguments) {
-  }
+        arguments_(arguments) {}
 
   Expression* expression_;
-  ZoneList<Expression*>* arguments_;
+  ZonePtrList<Expression>* arguments_;
 };
 
 // The CallRuntime class does not represent any official JavaScript
@@ -1727,7 +1723,7 @@ class CallNew final : public Expression {
 // implemented in JavaScript.
 class CallRuntime final : public Expression {
  public:
-  ZoneList<Expression*>* arguments() const { return arguments_; }
+  ZonePtrList<Expression>* arguments() const { return arguments_; }
   bool is_jsruntime() const { return function_ == nullptr; }
 
   int context_index() const {
@@ -1745,11 +1741,11 @@ class CallRuntime final : public Expression {
   friend class AstNodeFactory;
 
   CallRuntime(const Runtime::Function* function,
-              ZoneList<Expression*>* arguments, int pos)
+              ZonePtrList<Expression>* arguments, int pos)
       : Expression(pos, kCallRuntime),
         function_(function),
         arguments_(arguments) {}
-  CallRuntime(int context_index, ZoneList<Expression*>* arguments, int pos)
+  CallRuntime(int context_index, ZonePtrList<Expression>* arguments, int pos)
       : Expression(pos, kCallRuntime),
         context_index_(context_index),
         function_(nullptr),
@@ -1757,7 +1753,7 @@ class CallRuntime final : public Expression {
 
   int context_index_;
   const Runtime::Function* function_;
-  ZoneList<Expression*>* arguments_;
+  ZonePtrList<Expression>* arguments_;
 };
 
 
@@ -2190,7 +2186,7 @@ class FunctionLiteral final : public Expression {
   const AstConsString* raw_name() const { return raw_name_; }
   void set_raw_name(const AstConsString* name) { raw_name_ = name; }
   DeclarationScope* scope() const { return scope_; }
-  ZoneList<Statement*>* body() const { return body_; }
+  ZonePtrList<Statement>* body() const { return body_; }
   void set_function_token_position(int pos) { function_token_position_ = pos; }
   int function_token_position() const { return function_token_position_; }
   int start_position() const;
@@ -2310,7 +2306,7 @@ class FunctionLiteral final : public Expression {
 
   FunctionLiteral(
       Zone* zone, const AstRawString* name, AstValueFactory* ast_value_factory,
-      DeclarationScope* scope, ZoneList<Statement*>* body,
+      DeclarationScope* scope, ZonePtrList<Statement>* body,
       int expected_property_count, int parameter_count, int function_length,
       FunctionType function_type, ParameterFlag has_duplicate_parameters,
       EagerCompileHint eager_compile_hint, int position, bool has_braces,
@@ -2359,7 +2355,7 @@ class FunctionLiteral final : public Expression {
 
   const AstConsString* raw_name_;
   DeclarationScope* scope_;
-  ZoneList<Statement*>* body_;
+  ZonePtrList<Statement>* body_;
   const AstConsString* raw_inferred_name_;
   Handle<String> inferred_name_;
   ProducedPreParsedScopeData* produced_preparsed_scope_data_;
@@ -2407,15 +2403,16 @@ class ClassLiteralProperty final : public LiteralProperty {
 class InitializeClassFieldsStatement final : public Statement {
  public:
   typedef ClassLiteralProperty Property;
-  ZoneList<Property*>* fields() const { return fields_; }
+
+  ZonePtrList<Property>* fields() const { return fields_; }
 
  private:
   friend class AstNodeFactory;
 
-  InitializeClassFieldsStatement(ZoneList<Property*>* fields, int pos)
+  InitializeClassFieldsStatement(ZonePtrList<Property>* fields, int pos)
       : Statement(pos, kInitializeClassFieldsStatement), fields_(fields) {}
 
-  ZoneList<Property*>* fields_;
+  ZonePtrList<Property>* fields_;
 };
 
 class ClassLiteral final : public Expression {
@@ -2426,7 +2423,7 @@ class ClassLiteral final : public Expression {
   Variable* class_variable() const { return class_variable_; }
   Expression* extends() const { return extends_; }
   FunctionLiteral* constructor() const { return constructor_; }
-  ZoneList<Property*>* properties() const { return properties_; }
+  ZonePtrList<Property>* properties() const { return properties_; }
   int start_position() const { return position(); }
   int end_position() const { return end_position_; }
   bool has_name_static_property() const {
@@ -2455,7 +2452,7 @@ class ClassLiteral final : public Expression {
   friend class AstNodeFactory;
 
   ClassLiteral(Scope* scope, Variable* class_variable, Expression* extends,
-               FunctionLiteral* constructor, ZoneList<Property*>* properties,
+               FunctionLiteral* constructor, ZonePtrList<Property>* properties,
                FunctionLiteral* static_fields_initializer,
                FunctionLiteral* instance_fields_initializer_function,
                int start_position, int end_position,
@@ -2481,7 +2478,7 @@ class ClassLiteral final : public Expression {
   Variable* class_variable_;
   Expression* extends_;
   FunctionLiteral* constructor_;
-  ZoneList<Property*>* properties_;
+  ZonePtrList<Property>* properties_;
   FunctionLiteral* static_fields_initializer_;
   FunctionLiteral* instance_fields_initializer_function_;
   class HasNameStaticProperty
@@ -2636,10 +2633,10 @@ class GetIterator final : public Expression {
 // (defined at https://tc39.github.io/ecma262/#sec-gettemplateobject).
 class GetTemplateObject final : public Expression {
  public:
-  const ZoneList<const AstRawString*>* cooked_strings() const {
+  const ZonePtrList<const AstRawString>* cooked_strings() const {
     return cooked_strings_;
   }
-  const ZoneList<const AstRawString*>* raw_strings() const {
+  const ZonePtrList<const AstRawString>* raw_strings() const {
     return raw_strings_;
   }
 
@@ -2648,34 +2645,35 @@ class GetTemplateObject final : public Expression {
  private:
   friend class AstNodeFactory;
 
-  GetTemplateObject(const ZoneList<const AstRawString*>* cooked_strings,
-                    const ZoneList<const AstRawString*>* raw_strings, int pos)
+  GetTemplateObject(const ZonePtrList<const AstRawString>* cooked_strings,
+                    const ZonePtrList<const AstRawString>* raw_strings, int pos)
       : Expression(pos, kGetTemplateObject),
         cooked_strings_(cooked_strings),
         raw_strings_(raw_strings) {}
 
-  const ZoneList<const AstRawString*>* cooked_strings_;
-  const ZoneList<const AstRawString*>* raw_strings_;
+  const ZonePtrList<const AstRawString>* cooked_strings_;
+  const ZonePtrList<const AstRawString>* raw_strings_;
 };
 
 class TemplateLiteral final : public Expression {
  public:
-  using StringList = ZoneList<const AstRawString*>;
-  using ExpressionList = ZoneList<Expression*>;
-
-  const StringList* string_parts() const { return string_parts_; }
-  const ExpressionList* substitutions() const { return substitutions_; }
+  const ZonePtrList<const AstRawString>* string_parts() const {
+    return string_parts_;
+  }
+  const ZonePtrList<Expression>* substitutions() const {
+    return substitutions_;
+  }
 
  private:
   friend class AstNodeFactory;
-  TemplateLiteral(const StringList* parts, const ExpressionList* substitutions,
-                  int pos)
+  TemplateLiteral(const ZonePtrList<const AstRawString>* parts,
+                  const ZonePtrList<Expression>* substitutions, int pos)
       : Expression(pos, kTemplateLiteral),
         string_parts_(parts),
         substitutions_(substitutions) {}
 
-  const StringList* string_parts_;
-  const ExpressionList* substitutions_;
+  const ZonePtrList<const AstRawString>* string_parts_;
+  const ZonePtrList<Expression>* substitutions_;
 };
 
 // ----------------------------------------------------------------------------
@@ -2692,7 +2690,7 @@ class AstVisitor BASE_EMBEDDED {
     for (Declaration* decl : *declarations) Visit(decl);
   }
 
-  void VisitStatements(ZoneList<Statement*>* statements) {
+  void VisitStatements(ZonePtrList<Statement>* statements) {
     for (int i = 0; i < statements->length(); i++) {
       Statement* stmt = statements->at(i);
       Visit(stmt);
@@ -2700,7 +2698,7 @@ class AstVisitor BASE_EMBEDDED {
     }
   }
 
-  void VisitExpressions(ZoneList<Expression*>* expressions) {
+  void VisitExpressions(ZonePtrList<Expression>* expressions) {
     for (int i = 0; i < expressions->length(); i++) {
       // The variable statement visiting code may pass null expressions
       // to this code. Maybe this should be handled by introducing an
@@ -2794,7 +2792,7 @@ class AstNodeFactory final BASE_EMBEDDED {
   }
 
   Block* NewBlock(int capacity, bool ignore_completion_value,
-                  ZoneList<const AstRawString*>* labels = nullptr) {
+                  ZonePtrList<const AstRawString>* labels = nullptr) {
     return labels != nullptr
                ? new (zone_) LabeledBlock(zone_, labels, capacity,
                                           ignore_completion_value)
@@ -2802,22 +2800,22 @@ class AstNodeFactory final BASE_EMBEDDED {
                      Block(zone_, labels, capacity, ignore_completion_value);
   }
 
-#define STATEMENT_WITH_LABELS(NodeType)                                     \
-  NodeType* New##NodeType(ZoneList<const AstRawString*>* labels, int pos) { \
-    return new (zone_) NodeType(labels, pos);                               \
+#define STATEMENT_WITH_LABELS(NodeType)                                       \
+  NodeType* New##NodeType(ZonePtrList<const AstRawString>* labels, int pos) { \
+    return new (zone_) NodeType(labels, pos);                                 \
   }
   STATEMENT_WITH_LABELS(DoWhileStatement)
   STATEMENT_WITH_LABELS(WhileStatement)
   STATEMENT_WITH_LABELS(ForStatement)
 #undef STATEMENT_WITH_LABELS
 
-  SwitchStatement* NewSwitchStatement(ZoneList<const AstRawString*>* labels,
+  SwitchStatement* NewSwitchStatement(ZonePtrList<const AstRawString>* labels,
                                       Expression* tag, int pos) {
     return new (zone_) SwitchStatement(zone_, labels, tag, pos);
   }
 
   ForEachStatement* NewForEachStatement(ForEachStatement::VisitMode visit_mode,
-                                        ZoneList<const AstRawString*>* labels,
+                                        ZonePtrList<const AstRawString>* labels,
                                         int pos) {
     switch (visit_mode) {
       case ForEachStatement::ENUMERATE: {
@@ -2830,7 +2828,7 @@ class AstNodeFactory final BASE_EMBEDDED {
     UNREACHABLE();
   }
 
-  ForOfStatement* NewForOfStatement(ZoneList<const AstRawString*>* labels,
+  ForOfStatement* NewForOfStatement(ZonePtrList<const AstRawString>* labels,
                                     int pos) {
     return new (zone_) ForOfStatement(labels, pos);
   }
@@ -2921,7 +2919,7 @@ class AstNodeFactory final BASE_EMBEDDED {
   }
 
   CaseClause* NewCaseClause(Expression* label,
-                            ZoneList<Statement*>* statements) {
+                            ZonePtrList<Statement>* statements) {
     return new (zone_) CaseClause(label, statements);
   }
 
@@ -2961,7 +2959,7 @@ class AstNodeFactory final BASE_EMBEDDED {
   }
 
   ObjectLiteral* NewObjectLiteral(
-      ZoneList<ObjectLiteral::Property*>* properties,
+      ZonePtrList<ObjectLiteral::Property>* properties,
       uint32_t boilerplate_properties, int pos, bool has_rest_property) {
     return new (zone_) ObjectLiteral(properties, boilerplate_properties, pos,
                                      has_rest_property);
@@ -2986,12 +2984,11 @@ class AstNodeFactory final BASE_EMBEDDED {
     return new (zone_) RegExpLiteral(pattern, flags, pos);
   }
 
-  ArrayLiteral* NewArrayLiteral(ZoneList<Expression*>* values,
-                                int pos) {
+  ArrayLiteral* NewArrayLiteral(ZonePtrList<Expression>* values, int pos) {
     return new (zone_) ArrayLiteral(values, -1, pos);
   }
 
-  ArrayLiteral* NewArrayLiteral(ZoneList<Expression*>* values,
+  ArrayLiteral* NewArrayLiteral(ZonePtrList<Expression>* values,
                                 int first_spread_index, int pos) {
     return new (zone_) ArrayLiteral(values, first_spread_index, pos);
   }
@@ -3027,35 +3024,34 @@ class AstNodeFactory final BASE_EMBEDDED {
     return new (zone_) ResolvedProperty(obj, property, pos);
   }
 
-  Call* NewCall(Expression* expression, ZoneList<Expression*>* arguments,
+  Call* NewCall(Expression* expression, ZonePtrList<Expression>* arguments,
                 int pos, Call::PossiblyEval possibly_eval = Call::NOT_EVAL) {
     return new (zone_) Call(expression, arguments, pos, possibly_eval);
   }
 
   Call* NewTaggedTemplate(Expression* expression,
-                          ZoneList<Expression*>* arguments, int pos) {
+                          ZonePtrList<Expression>* arguments, int pos) {
     return new (zone_)
         Call(expression, arguments, pos, Call::TaggedTemplateTag::kTrue);
   }
 
   CallNew* NewCallNew(Expression* expression,
-                      ZoneList<Expression*>* arguments,
-                      int pos) {
+                      ZonePtrList<Expression>* arguments, int pos) {
     return new (zone_) CallNew(expression, arguments, pos);
   }
 
   CallRuntime* NewCallRuntime(Runtime::FunctionId id,
-                              ZoneList<Expression*>* arguments, int pos) {
+                              ZonePtrList<Expression>* arguments, int pos) {
     return new (zone_) CallRuntime(Runtime::FunctionForId(id), arguments, pos);
   }
 
   CallRuntime* NewCallRuntime(const Runtime::Function* function,
-                              ZoneList<Expression*>* arguments, int pos) {
+                              ZonePtrList<Expression>* arguments, int pos) {
     return new (zone_) CallRuntime(function, arguments, pos);
   }
 
   CallRuntime* NewCallRuntime(int context_index,
-                              ZoneList<Expression*>* arguments, int pos) {
+                              ZonePtrList<Expression>* arguments, int pos) {
     return new (zone_) CallRuntime(context_index, arguments, pos);
   }
 
@@ -3158,7 +3154,7 @@ class AstNodeFactory final BASE_EMBEDDED {
 
   FunctionLiteral* NewFunctionLiteral(
       const AstRawString* name, DeclarationScope* scope,
-      ZoneList<Statement*>* body, int expected_property_count,
+      ZonePtrList<Statement>* body, int expected_property_count,
       int parameter_count, int function_length,
       FunctionLiteral::ParameterFlag has_duplicate_parameters,
       FunctionLiteral::FunctionType function_type,
@@ -3176,7 +3172,7 @@ class AstNodeFactory final BASE_EMBEDDED {
   // result of an eval (top-level or otherwise), or the result of calling
   // the Function constructor.
   FunctionLiteral* NewScriptOrEvalFunctionLiteral(DeclarationScope* scope,
-                                                  ZoneList<Statement*>* body,
+                                                  ZonePtrList<Statement>* body,
                                                   int expected_property_count,
                                                   int parameter_count) {
     return new (zone_) FunctionLiteral(
@@ -3198,7 +3194,7 @@ class AstNodeFactory final BASE_EMBEDDED {
   ClassLiteral* NewClassLiteral(
       Scope* scope, Variable* variable, Expression* extends,
       FunctionLiteral* constructor,
-      ZoneList<ClassLiteral::Property*>* properties,
+      ZonePtrList<ClassLiteral::Property>* properties,
       FunctionLiteral* static_fields_initializer,
       FunctionLiteral* instance_fields_initializer_function, int start_position,
       int end_position, bool has_name_static_property,
@@ -3255,14 +3251,14 @@ class AstNodeFactory final BASE_EMBEDDED {
   }
 
   GetTemplateObject* NewGetTemplateObject(
-      const ZoneList<const AstRawString*>* cooked_strings,
-      const ZoneList<const AstRawString*>* raw_strings, int pos) {
+      const ZonePtrList<const AstRawString>* cooked_strings,
+      const ZonePtrList<const AstRawString>* raw_strings, int pos) {
     return new (zone_) GetTemplateObject(cooked_strings, raw_strings, pos);
   }
 
   TemplateLiteral* NewTemplateLiteral(
-      const ZoneList<const AstRawString*>* string_parts,
-      const ZoneList<Expression*>* substitutions, int pos) {
+      const ZonePtrList<const AstRawString>* string_parts,
+      const ZonePtrList<Expression>* substitutions, int pos) {
     return new (zone_) TemplateLiteral(string_parts, substitutions, pos);
   }
 
@@ -3271,7 +3267,7 @@ class AstNodeFactory final BASE_EMBEDDED {
   }
 
   InitializeClassFieldsStatement* NewInitializeClassFieldsStatement(
-      ZoneList<ClassLiteralProperty*>* args, int pos) {
+      ZonePtrList<ClassLiteral::Property>* args, int pos) {
     return new (zone_) InitializeClassFieldsStatement(args, pos);
   }
 

--- a/deps/v8/src/ast/prettyprinter.cc
+++ b/deps/v8/src/ast/prettyprinter.cc
@@ -498,16 +498,14 @@ void CallPrinter::VisitRewritableExpression(RewritableExpression* node) {
   Find(node->expression());
 }
 
-
-void CallPrinter::FindStatements(ZoneList<Statement*>* statements) {
+void CallPrinter::FindStatements(ZonePtrList<Statement>* statements) {
   if (statements == nullptr) return;
   for (int i = 0; i < statements->length(); i++) {
     Find(statements->at(i));
   }
 }
 
-
-void CallPrinter::FindArguments(ZoneList<Expression*>* arguments) {
+void CallPrinter::FindArguments(ZonePtrList<Expression>* arguments) {
   if (found_) return;
   for (int i = 0; i < arguments->length(); i++) {
     Find(arguments->at(i));
@@ -589,7 +587,7 @@ void AstPrinter::Print(const char* format, ...) {
   }
 }
 
-void AstPrinter::PrintLabels(ZoneList<const AstRawString*>* labels) {
+void AstPrinter::PrintLabels(ZonePtrList<const AstRawString>* labels) {
   if (labels != nullptr) {
     for (int i = 0; i < labels->length(); i++) {
       PrintLiteral(labels->at(i), false);
@@ -748,8 +746,7 @@ void AstPrinter::PrintLiteralWithModeIndented(const char* info, Variable* var,
   }
 }
 
-
-void AstPrinter::PrintLabelsIndented(ZoneList<const AstRawString*>* labels) {
+void AstPrinter::PrintLabelsIndented(ZonePtrList<const AstRawString>* labels) {
   if (labels == nullptr || labels->length() == 0) return;
   PrintIndented("LABELS ");
   PrintLabels(labels);
@@ -809,15 +806,13 @@ void AstPrinter::PrintParameters(DeclarationScope* scope) {
   }
 }
 
-
-void AstPrinter::PrintStatements(ZoneList<Statement*>* statements) {
+void AstPrinter::PrintStatements(ZonePtrList<Statement>* statements) {
   for (int i = 0; i < statements->length(); i++) {
     Visit(statements->at(i));
   }
 }
 
-
-void AstPrinter::PrintArguments(ZoneList<Expression*>* arguments) {
+void AstPrinter::PrintArguments(ZonePtrList<Expression>* arguments) {
   for (int i = 0; i < arguments->length(); i++) {
     Visit(arguments->at(i));
   }
@@ -1040,7 +1035,7 @@ void AstPrinter::VisitInitializeClassFieldsStatement(
 }
 
 void AstPrinter::PrintClassProperties(
-    ZoneList<ClassLiteral::Property*>* properties) {
+    ZonePtrList<ClassLiteral::Property>* properties) {
   for (int i = 0; i < properties->length(); i++) {
     ClassLiteral::Property* property = properties->at(i);
     const char* prop_kind = nullptr;
@@ -1119,7 +1114,7 @@ void AstPrinter::VisitObjectLiteral(ObjectLiteral* node) {
 }
 
 void AstPrinter::PrintObjectProperties(
-    ZoneList<ObjectLiteral::Property*>* properties) {
+    ZonePtrList<ObjectLiteral::Property>* properties) {
   for (int i = 0; i < properties->length(); i++) {
     ObjectLiteral::Property* property = properties->at(i);
     const char* prop_kind = nullptr;

--- a/deps/v8/src/ast/prettyprinter.h
+++ b/deps/v8/src/ast/prettyprinter.h
@@ -56,8 +56,8 @@ class CallPrinter final : public AstVisitor<CallPrinter> {
  protected:
   void PrintLiteral(Handle<Object> value, bool quote);
   void PrintLiteral(const AstRawString* value, bool quote);
-  void FindStatements(ZoneList<Statement*>* statements);
-  void FindArguments(ZoneList<Expression*>* arguments);
+  void FindStatements(ZonePtrList<Statement>* statements);
+  void FindArguments(ZonePtrList<Expression>* arguments);
 };
 
 
@@ -88,17 +88,17 @@ class AstPrinter final : public AstVisitor<AstPrinter> {
 
   void Init();
 
-  void PrintLabels(ZoneList<const AstRawString*>* labels);
+  void PrintLabels(ZonePtrList<const AstRawString>* labels);
   void PrintLiteral(const AstRawString* value, bool quote);
   void PrintLiteral(const AstConsString* value, bool quote);
   void PrintLiteral(Literal* literal, bool quote);
   void PrintIndented(const char* txt);
   void PrintIndentedVisit(const char* s, AstNode* node);
 
-  void PrintStatements(ZoneList<Statement*>* statements);
+  void PrintStatements(ZonePtrList<Statement>* statements);
   void PrintDeclarations(Declaration::List* declarations);
   void PrintParameters(DeclarationScope* scope);
-  void PrintArguments(ZoneList<Expression*>* arguments);
+  void PrintArguments(ZonePtrList<Expression>* arguments);
   void PrintCaseClause(CaseClause* clause);
   void PrintLiteralIndented(const char* info, Literal* literal, bool quote);
   void PrintLiteralIndented(const char* info, const AstRawString* value,
@@ -107,9 +107,9 @@ class AstPrinter final : public AstVisitor<AstPrinter> {
                             bool quote);
   void PrintLiteralWithModeIndented(const char* info, Variable* var,
                                     const AstRawString* value);
-  void PrintLabelsIndented(ZoneList<const AstRawString*>* labels);
-  void PrintObjectProperties(ZoneList<ObjectLiteral::Property*>* properties);
-  void PrintClassProperties(ZoneList<ClassLiteral::Property*>* properties);
+  void PrintLabelsIndented(ZonePtrList<const AstRawString>* labels);
+  void PrintObjectProperties(ZonePtrList<ObjectLiteral::Property>* properties);
+  void PrintClassProperties(ZonePtrList<ClassLiteral::Property>* properties);
 
   void inc_indent() { indent_++; }
   void dec_indent() { indent_--; }

--- a/deps/v8/src/ast/scopes.cc
+++ b/deps/v8/src/ast/scopes.cc
@@ -1327,7 +1327,7 @@ Declaration* Scope::CheckConflictingVarDeclarations() {
 }
 
 Declaration* Scope::CheckLexDeclarationsConflictingWith(
-    const ZoneList<const AstRawString*>& names) {
+    const ZonePtrList<const AstRawString>& names) {
   DCHECK(is_block_scope());
   for (int i = 0; i < names.length(); ++i) {
     Variable* var = LookupLocal(names.at(i));

--- a/deps/v8/src/ast/scopes.h
+++ b/deps/v8/src/ast/scopes.h
@@ -256,7 +256,7 @@ class V8_EXPORT_PRIVATE Scope : public NON_EXPORTED_BASE(ZoneObject) {
   // which is an error even though the two 'e's are declared in different
   // scopes.
   Declaration* CheckLexDeclarationsConflictingWith(
-      const ZoneList<const AstRawString*>& names);
+      const ZonePtrList<const AstRawString>& names);
 
   // ---------------------------------------------------------------------------
   // Scope-specific info.
@@ -964,7 +964,7 @@ class V8_EXPORT_PRIVATE DeclarationScope : public Scope {
   bool has_inferred_function_name_ : 1;
 
   // Parameter list in source order.
-  ZoneList<Variable*> params_;
+  ZonePtrList<Variable> params_;
   // Map of function names to lists of functions defined in sloppy blocks
   SloppyBlockFunctionMap* sloppy_block_function_map_;
   // Convenience variable.

--- a/deps/v8/src/ast/source-range-ast-visitor.cc
+++ b/deps/v8/src/ast/source-range-ast-visitor.cc
@@ -1,0 +1,79 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "src/ast/source-range-ast-visitor.h"
+
+#include "src/ast/ast-source-ranges.h"
+
+namespace v8 {
+namespace internal {
+
+SourceRangeAstVisitor::SourceRangeAstVisitor(uintptr_t stack_limit,
+                                             Expression* root,
+                                             SourceRangeMap* source_range_map)
+    : AstTraversalVisitor(stack_limit, root),
+      source_range_map_(source_range_map) {}
+
+void SourceRangeAstVisitor::VisitBlock(Block* stmt) {
+  AstTraversalVisitor::VisitBlock(stmt);
+  ZonePtrList<Statement>* stmts = stmt->statements();
+  AstNodeSourceRanges* enclosingSourceRanges = source_range_map_->Find(stmt);
+  if (enclosingSourceRanges != nullptr) {
+    CHECK(enclosingSourceRanges->HasRange(SourceRangeKind::kContinuation));
+    MaybeRemoveLastContinuationRange(stmts);
+  }
+}
+
+void SourceRangeAstVisitor::VisitFunctionLiteral(FunctionLiteral* expr) {
+  AstTraversalVisitor::VisitFunctionLiteral(expr);
+  ZonePtrList<Statement>* stmts = expr->body();
+  MaybeRemoveLastContinuationRange(stmts);
+}
+
+bool SourceRangeAstVisitor::VisitNode(AstNode* node) {
+  AstNodeSourceRanges* range = source_range_map_->Find(node);
+
+  if (range == nullptr) return true;
+  if (!range->HasRange(SourceRangeKind::kContinuation)) return true;
+
+  // Called in pre-order. In case of conflicting continuation ranges, only the
+  // outermost range may survive.
+
+  SourceRange continuation = range->GetRange(SourceRangeKind::kContinuation);
+  if (continuation_positions_.find(continuation.start) !=
+      continuation_positions_.end()) {
+    range->RemoveContinuationRange();
+  } else {
+    continuation_positions_.emplace(continuation.start);
+  }
+
+  return true;
+}
+
+void SourceRangeAstVisitor::MaybeRemoveLastContinuationRange(
+    ZonePtrList<Statement>* statements) {
+  if (statements == nullptr || statements->is_empty()) return;
+
+  Statement* last_statement = statements->last();
+  AstNodeSourceRanges* last_range = nullptr;
+
+  if (last_statement->IsExpressionStatement() &&
+      last_statement->AsExpressionStatement()->expression()->IsThrow()) {
+    // For ThrowStatement, source range is tied to Throw expression not
+    // ExpressionStatement.
+    last_range = source_range_map_->Find(
+        last_statement->AsExpressionStatement()->expression());
+  } else {
+    last_range = source_range_map_->Find(last_statement);
+  }
+
+  if (last_range == nullptr) return;
+
+  if (last_range->HasRange(SourceRangeKind::kContinuation)) {
+    last_range->RemoveContinuationRange();
+  }
+}
+
+}  // namespace internal
+}  // namespace v8

--- a/deps/v8/src/ast/source-range-ast-visitor.h
+++ b/deps/v8/src/ast/source-range-ast-visitor.h
@@ -1,0 +1,49 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_AST_SOURCE_RANGE_AST_VISITOR_H_
+#define V8_AST_SOURCE_RANGE_AST_VISITOR_H_
+
+#include <unordered_set>
+
+#include "src/ast/ast-traversal-visitor.h"
+
+namespace v8 {
+namespace internal {
+
+class SourceRangeMap;
+
+// Post-processes generated source ranges while the AST structure still exists.
+//
+// In particular, SourceRangeAstVisitor
+//
+// 1. deduplicates continuation source ranges, only keeping the outermost one.
+// See also: https://crbug.com/v8/8539.
+//
+// 2. removes the source range associated with the final statement in a block
+// or function body if the parent itself has a source range associated with it.
+// See also: https://crbug.com/v8/8381.
+class SourceRangeAstVisitor final
+    : public AstTraversalVisitor<SourceRangeAstVisitor> {
+ public:
+  SourceRangeAstVisitor(uintptr_t stack_limit, Expression* root,
+                        SourceRangeMap* source_range_map);
+
+ private:
+  friend class AstTraversalVisitor<SourceRangeAstVisitor>;
+
+  void VisitBlock(Block* stmt);
+  void VisitFunctionLiteral(FunctionLiteral* expr);
+  bool VisitNode(AstNode* node);
+
+  void MaybeRemoveLastContinuationRange(ZonePtrList<Statement>* stmts);
+
+  SourceRangeMap* source_range_map_ = nullptr;
+  std::unordered_set<int> continuation_positions_;
+};
+
+}  // namespace internal
+}  // namespace v8
+
+#endif  // V8_AST_SOURCE_RANGE_AST_VISITOR_H_

--- a/deps/v8/src/debug/debug-coverage.cc
+++ b/deps/v8/src/debug/debug-coverage.cc
@@ -172,6 +172,12 @@ class CoverageBlockIterator final {
     return function_->blocks[read_index_ + 1];
   }
 
+  CoverageBlock& GetPreviousBlock() {
+    DCHECK(IsActive());
+    DCHECK_GT(read_index_, 0);
+    return function_->blocks[read_index_ - 1];
+  }
+
   CoverageBlock& GetParent() {
     DCHECK(IsActive());
     return nesting_stack_.back();
@@ -226,25 +232,6 @@ class CoverageBlockIterator final {
 
 bool HaveSameSourceRange(const CoverageBlock& lhs, const CoverageBlock& rhs) {
   return lhs.start == rhs.start && lhs.end == rhs.end;
-}
-
-void MergeDuplicateSingletons(CoverageFunction* function) {
-  CoverageBlockIterator iter(function);
-
-  while (iter.Next() && iter.HasNext()) {
-    CoverageBlock& block = iter.GetBlock();
-    CoverageBlock& next_block = iter.GetNextBlock();
-
-    // Identical ranges should only occur through singleton ranges. Consider the
-    // ranges for `for (.) break;`: continuation ranges for both the `break` and
-    // `for` statements begin after the trailing semicolon.
-    // Such ranges are merged and keep the maximal execution count.
-    if (!HaveSameSourceRange(block, next_block)) continue;
-
-    DCHECK_EQ(kNoSourcePosition, block.end);  // Singleton range.
-    next_block.count = std::max(block.count, next_block.count);
-    iter.DeleteBlock();
-  }
 }
 
 void MergeDuplicateRanges(CoverageFunction* function) {
@@ -326,6 +313,30 @@ void MergeNestedRanges(CoverageFunction* function) {
   }
 }
 
+void FilterAliasedSingletons(CoverageFunction* function) {
+  CoverageBlockIterator iter(function);
+
+  iter.Next();  // Advance once since we reference the previous block later.
+
+  while (iter.Next()) {
+    CoverageBlock& previous_block = iter.GetPreviousBlock();
+    CoverageBlock& block = iter.GetBlock();
+
+    bool is_singleton = block.end == kNoSourcePosition;
+    bool aliases_start = block.start == previous_block.start;
+
+    if (is_singleton && aliases_start) {
+      // The previous block must have a full range since duplicate singletons
+      // have already been merged.
+      DCHECK_NE(previous_block.end, kNoSourcePosition);
+      // Likewise, the next block must have another start position since
+      // singletons are sorted to the end.
+      DCHECK_IMPLIES(iter.HasNext(), iter.GetNextBlock().start != block.start);
+      iter.DeleteBlock();
+    }
+  }
+}
+
 void FilterUncoveredRanges(CoverageFunction* function) {
   CoverageBlockIterator iter(function);
 
@@ -396,8 +407,14 @@ void CollectBlockCoverage(Isolate* isolate, CoverageFunction* function,
   // If in binary mode, only report counts of 0/1.
   if (mode == debug::Coverage::kBlockBinary) ClampToBinary(function);
 
-  // Remove duplicate singleton ranges, keeping the max count.
-  MergeDuplicateSingletons(function);
+  // Remove singleton ranges with the same start position as a full range and
+  // throw away their counts.
+  // Singleton ranges are only intended to split existing full ranges and should
+  // never expand into a full range. Consider 'if (cond) { ... } else { ... }'
+  // as a problematic example; if the then-block produces a continuation
+  // singleton, it would incorrectly expand into the else range.
+  // For more context, see https://crbug.com/v8/8237.
+  FilterAliasedSingletons(function);
 
   // Rewrite all singletons (created e.g. by continuations and unconditional
   // control flow) to ranges.

--- a/deps/v8/src/interpreter/bytecode-generator.h
+++ b/deps/v8/src/interpreter/bytecode-generator.h
@@ -43,7 +43,7 @@ class BytecodeGenerator final : public AstVisitor<BytecodeGenerator> {
 
   // Visiting function for declarations list and statements are overridden.
   void VisitDeclarations(Declaration::List* declarations);
-  void VisitStatements(ZoneList<Statement*>* statments);
+  void VisitStatements(ZonePtrList<Statement>* statments);
 
  private:
   class ContextScope;
@@ -100,7 +100,7 @@ class BytecodeGenerator final : public AstVisitor<BytecodeGenerator> {
 
   // Visit the arguments expressions in |args| and store them in |args_regs|,
   // growing |args_regs| for each argument visited.
-  void VisitArguments(ZoneList<Expression*>* args, RegisterList* arg_regs);
+  void VisitArguments(ZonePtrList<Expression>* args, RegisterList* arg_regs);
 
   // Visit a keyed super property load. The optional
   // |opt_receiver_out| register will have the receiver stored to it
@@ -179,7 +179,7 @@ class BytecodeGenerator final : public AstVisitor<BytecodeGenerator> {
                                FeedbackSlot element_slot);
   void BuildArrayLiteralElementsInsertion(Register array,
                                           int first_spread_index,
-                                          ZoneList<Expression*>* elements,
+                                          ZonePtrList<Expression>* elements,
                                           bool skip_constants);
 
   void AllocateTopLevelRegisters();

--- a/deps/v8/src/interpreter/control-flow-builders.cc
+++ b/deps/v8/src/interpreter/control-flow-builders.cc
@@ -13,7 +13,7 @@ namespace interpreter {
 BreakableControlFlowBuilder::~BreakableControlFlowBuilder() {
   BindBreakTarget();
   DCHECK(break_labels_.empty() || break_labels_.is_bound());
-  if (block_coverage_builder_ != nullptr && needs_continuation_counter()) {
+  if (block_coverage_builder_ != nullptr) {
     block_coverage_builder_->IncrementBlockCounter(
         node_, SourceRangeKind::kContinuation);
   }

--- a/deps/v8/src/interpreter/control-flow-builders.h
+++ b/deps/v8/src/interpreter/control-flow-builders.h
@@ -58,11 +58,6 @@ class V8_EXPORT_PRIVATE BreakableControlFlowBuilder
 
   BytecodeLabels* break_labels() { return &break_labels_; }
 
-  void set_needs_continuation_counter() { needs_continuation_counter_ = true; }
-  bool needs_continuation_counter() const {
-    return needs_continuation_counter_;
-  }
-
  protected:
   void EmitJump(BytecodeLabels* labels);
   void EmitJumpIfTrue(BytecodeArrayBuilder::ToBooleanMode mode,
@@ -81,7 +76,6 @@ class V8_EXPORT_PRIVATE BreakableControlFlowBuilder
   // A continuation counter (for block coverage) is needed e.g. when
   // encountering a break statement.
   AstNode* node_;
-  bool needs_continuation_counter_ = false;
   BlockCoverageBuilder* block_coverage_builder_;
 };
 
@@ -107,7 +101,6 @@ class V8_EXPORT_PRIVATE LoopBuilder final : public BreakableControlFlowBuilder {
       : BreakableControlFlowBuilder(builder, block_coverage_builder, node),
         continue_labels_(builder->zone()) {
     if (block_coverage_builder_ != nullptr) {
-      set_needs_continuation_counter();
       block_coverage_body_slot_ =
           block_coverage_builder_->AllocateBlockCoverageSlot(
               node, SourceRangeKind::kBody);

--- a/deps/v8/src/parsing/expression-scope-reparenter.cc
+++ b/deps/v8/src/parsing/expression-scope-reparenter.cc
@@ -55,7 +55,7 @@ void Reparenter::VisitClassLiteral(ClassLiteral* class_literal) {
 #if DEBUG
   // The same goes for the rest of the class, but we do some
   // sanity checking in debug mode.
-  ZoneList<ClassLiteralProperty*>* props = class_literal->properties();
+  ZonePtrList<ClassLiteralProperty>* props = class_literal->properties();
   for (int i = 0; i < props->length(); ++i) {
     ClassLiteralProperty* prop = props->at(i);
     // No need to visit the values, since all values are functions with

--- a/deps/v8/src/parsing/parse-info.cc
+++ b/deps/v8/src/parsing/parse-info.cc
@@ -59,7 +59,7 @@ ParseInfo::ParseInfo(Handle<SharedFunctionInfo> shared)
   set_language_mode(shared->language_mode());
   set_asm_wasm_broken(shared->is_asm_wasm_broken());
 
-  Handle<Script> script(Script::cast(shared->script()));
+  Handle<Script> script(Script::cast(shared->script()), isolate);
   set_script(script);
   set_native(script->type() == Script::TYPE_NATIVE);
   set_eval(script->compilation_type() == Script::COMPILATION_TYPE_EVAL);

--- a/deps/v8/src/parsing/parse-info.h
+++ b/deps/v8/src/parsing/parse-info.h
@@ -222,16 +222,6 @@ class V8_EXPORT_PRIVATE ParseInfo {
     set_strict_mode(is_strict(language_mode));
   }
 
-  void ReopenHandlesInNewHandleScope() {
-    if (!script_.is_null()) {
-      script_ = Handle<Script>(*script_);
-    }
-    Handle<ScopeInfo> outer_scope_info;
-    if (maybe_outer_scope_info_.ToHandle(&outer_scope_info)) {
-      maybe_outer_scope_info_ = Handle<ScopeInfo>(*outer_scope_info);
-    }
-  }
-
   void EmitBackgroundParseStatisticsOnBackgroundThread();
   void UpdateBackgroundParseStatisticsOnMainThread(Isolate* isolate);
 

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -554,7 +554,7 @@ class ParserBase {
     Scope* scope;
     BlockT init_block;
     BlockT inner_block;
-    ZoneList<const AstRawString*> bound_names;
+    ZonePtrList<const AstRawString> bound_names;
   };
 
   struct ForInfo {
@@ -564,7 +564,7 @@ class ParserBase {
           mode(ForEachStatement::ENUMERATE),
           position(kNoSourcePosition),
           parsing_result() {}
-    ZoneList<const AstRawString*> bound_names;
+    ZonePtrList<const AstRawString> bound_names;
     ForEachStatement::VisitMode mode;
     int position;
     DeclarationParsingResult parsing_result;
@@ -1192,17 +1192,17 @@ class ParserBase {
 
   BlockT ParseVariableDeclarations(VariableDeclarationContext var_context,
                                    DeclarationParsingResult* parsing_result,
-                                   ZoneList<const AstRawString*>* names,
+                                   ZonePtrList<const AstRawString>* names,
                                    bool* ok);
-  StatementT ParseAsyncFunctionDeclaration(ZoneList<const AstRawString*>* names,
-                                           bool default_export, bool* ok);
+  StatementT ParseAsyncFunctionDeclaration(
+      ZonePtrList<const AstRawString>* names, bool default_export, bool* ok);
   StatementT ParseFunctionDeclaration(bool* ok);
-  StatementT ParseHoistableDeclaration(ZoneList<const AstRawString*>* names,
+  StatementT ParseHoistableDeclaration(ZonePtrList<const AstRawString>* names,
                                        bool default_export, bool* ok);
   StatementT ParseHoistableDeclaration(int pos, ParseFunctionFlags flags,
-                                       ZoneList<const AstRawString*>* names,
+                                       ZonePtrList<const AstRawString>* names,
                                        bool default_export, bool* ok);
-  StatementT ParseClassDeclaration(ZoneList<const AstRawString*>* names,
+  StatementT ParseClassDeclaration(ZonePtrList<const AstRawString>* names,
                                    bool default_export, bool* ok);
   StatementT ParseNativeDeclaration(bool* ok);
 
@@ -1233,22 +1233,22 @@ class ParserBase {
                                        Token::Value end_token, bool may_abort,
                                        bool* ok);
   StatementT ParseStatementListItem(bool* ok);
-  StatementT ParseStatement(ZoneList<const AstRawString*>* labels, bool* ok) {
+  StatementT ParseStatement(ZonePtrList<const AstRawString>* labels, bool* ok) {
     return ParseStatement(labels, kDisallowLabelledFunctionStatement, ok);
   }
-  StatementT ParseStatement(ZoneList<const AstRawString*>* labels,
+  StatementT ParseStatement(ZonePtrList<const AstRawString>* labels,
                             AllowLabelledFunctionStatement allow_function,
                             bool* ok);
-  BlockT ParseBlock(ZoneList<const AstRawString*>* labels, bool* ok);
+  BlockT ParseBlock(ZonePtrList<const AstRawString>* labels, bool* ok);
 
   // Parse a SubStatement in strict mode, or with an extra block scope in
   // sloppy mode to handle
   // ES#sec-functiondeclarations-in-ifstatement-statement-clauses
-  StatementT ParseScopedStatement(ZoneList<const AstRawString*>* labels,
+  StatementT ParseScopedStatement(ZonePtrList<const AstRawString>* labels,
                                   bool* ok);
 
   StatementT ParseVariableStatement(VariableDeclarationContext var_context,
-                                    ZoneList<const AstRawString*>* names,
+                                    ZonePtrList<const AstRawString>* names,
                                     bool* ok);
 
   // Magical syntax support.
@@ -1259,43 +1259,45 @@ class ParserBase {
   StatementT ParseDebuggerStatement(bool* ok);
 
   StatementT ParseExpressionOrLabelledStatement(
-      ZoneList<const AstRawString*>* labels,
+      ZonePtrList<const AstRawString>* labels,
       AllowLabelledFunctionStatement allow_function, bool* ok);
-  StatementT ParseIfStatement(ZoneList<const AstRawString*>* labels, bool* ok);
+  StatementT ParseIfStatement(ZonePtrList<const AstRawString>* labels,
+                              bool* ok);
   StatementT ParseContinueStatement(bool* ok);
-  StatementT ParseBreakStatement(ZoneList<const AstRawString*>* labels,
+  StatementT ParseBreakStatement(ZonePtrList<const AstRawString>* labels,
                                  bool* ok);
   StatementT ParseReturnStatement(bool* ok);
-  StatementT ParseWithStatement(ZoneList<const AstRawString*>* labels,
+  StatementT ParseWithStatement(ZonePtrList<const AstRawString>* labels,
                                 bool* ok);
-  StatementT ParseDoWhileStatement(ZoneList<const AstRawString*>* labels,
+  StatementT ParseDoWhileStatement(ZonePtrList<const AstRawString>* labels,
                                    bool* ok);
-  StatementT ParseWhileStatement(ZoneList<const AstRawString*>* labels,
+  StatementT ParseWhileStatement(ZonePtrList<const AstRawString>* labels,
                                  bool* ok);
   StatementT ParseThrowStatement(bool* ok);
-  StatementT ParseSwitchStatement(ZoneList<const AstRawString*>* labels,
+  StatementT ParseSwitchStatement(ZonePtrList<const AstRawString>* labels,
                                   bool* ok);
   StatementT ParseTryStatement(bool* ok);
-  StatementT ParseForStatement(ZoneList<const AstRawString*>* labels, bool* ok);
+  StatementT ParseForStatement(ZonePtrList<const AstRawString>* labels,
+                               bool* ok);
   StatementT ParseForEachStatementWithDeclarations(
-      int stmt_pos, ForInfo* for_info, ZoneList<const AstRawString*>* labels,
+      int stmt_pos, ForInfo* for_info, ZonePtrList<const AstRawString>* labels,
       Scope* inner_block_scope, bool* ok);
   StatementT ParseForEachStatementWithoutDeclarations(
       int stmt_pos, ExpressionT expression, int lhs_beg_pos, int lhs_end_pos,
-      ForInfo* for_info, ZoneList<const AstRawString*>* labels, bool* ok);
+      ForInfo* for_info, ZonePtrList<const AstRawString>* labels, bool* ok);
 
   // Parse a C-style for loop: 'for (<init>; <cond>; <next>) { ... }'
   // "for (<init>;" is assumed to have been parser already.
   ForStatementT ParseStandardForLoop(int stmt_pos,
-                                     ZoneList<const AstRawString*>* labels,
+                                     ZonePtrList<const AstRawString>* labels,
                                      ExpressionT* cond, StatementT* next,
                                      StatementT* body, bool* ok);
   // Same as the above, but handles those cases where <init> is a
   // lexical variable declaration.
   StatementT ParseStandardForLoopWithLexicalDeclarations(
       int stmt_pos, StatementT init, ForInfo* for_info,
-      ZoneList<const AstRawString*>* labels, bool* ok);
-  StatementT ParseForAwaitStatement(ZoneList<const AstRawString*>* labels,
+      ZonePtrList<const AstRawString>* labels, bool* ok);
+  StatementT ParseForAwaitStatement(ZonePtrList<const AstRawString>* labels,
                                     bool* ok);
 
   bool IsNextLetKeyword();
@@ -3851,7 +3853,7 @@ template <typename Impl>
 typename ParserBase<Impl>::BlockT ParserBase<Impl>::ParseVariableDeclarations(
     VariableDeclarationContext var_context,
     DeclarationParsingResult* parsing_result,
-    ZoneList<const AstRawString*>* names, bool* ok) {
+    ZonePtrList<const AstRawString>* names, bool* ok) {
   // VariableDeclarations ::
   //   ('var' | 'const' | 'let') (Identifier ('=' AssignmentExpression)?)+[',']
   //
@@ -4009,7 +4011,7 @@ ParserBase<Impl>::ParseFunctionDeclaration(bool* ok) {
 template <typename Impl>
 typename ParserBase<Impl>::StatementT
 ParserBase<Impl>::ParseHoistableDeclaration(
-    ZoneList<const AstRawString*>* names, bool default_export, bool* ok) {
+    ZonePtrList<const AstRawString>* names, bool default_export, bool* ok) {
   Expect(Token::FUNCTION, CHECK_OK_CUSTOM(NullStatement));
   int pos = position();
   ParseFunctionFlags flags = ParseFunctionFlags::kIsNormal;
@@ -4022,7 +4024,7 @@ ParserBase<Impl>::ParseHoistableDeclaration(
 template <typename Impl>
 typename ParserBase<Impl>::StatementT
 ParserBase<Impl>::ParseHoistableDeclaration(
-    int pos, ParseFunctionFlags flags, ZoneList<const AstRawString*>* names,
+    int pos, ParseFunctionFlags flags, ZonePtrList<const AstRawString>* names,
     bool default_export, bool* ok) {
   // FunctionDeclaration ::
   //   'function' Identifier '(' FormalParameters ')' '{' FunctionBody '}'
@@ -4090,7 +4092,7 @@ ParserBase<Impl>::ParseHoistableDeclaration(
 
 template <typename Impl>
 typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseClassDeclaration(
-    ZoneList<const AstRawString*>* names, bool default_export, bool* ok) {
+    ZonePtrList<const AstRawString>* names, bool default_export, bool* ok) {
   // ClassDeclaration ::
   //   'class' Identifier ('extends' LeftHandExpression)? '{' ClassBody '}'
   //   'class' ('extends' LeftHandExpression)? '{' ClassBody '}'
@@ -4160,7 +4162,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseNativeDeclaration(
 template <typename Impl>
 typename ParserBase<Impl>::StatementT
 ParserBase<Impl>::ParseAsyncFunctionDeclaration(
-    ZoneList<const AstRawString*>* names, bool default_export, bool* ok) {
+    ZonePtrList<const AstRawString>* names, bool default_export, bool* ok) {
   // AsyncFunctionDeclaration ::
   //   async [no LineTerminator here] function BindingIdentifier[Await]
   //       ( FormalParameters[Await] ) { AsyncFunctionBody }
@@ -4983,7 +4985,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseStatementListItem(
 
 template <typename Impl>
 typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseStatement(
-    ZoneList<const AstRawString*>* labels,
+    ZonePtrList<const AstRawString>* labels,
     AllowLabelledFunctionStatement allow_function, bool* ok) {
   // Statement ::
   //   Block
@@ -5083,7 +5085,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseStatement(
 
 template <typename Impl>
 typename ParserBase<Impl>::BlockT ParserBase<Impl>::ParseBlock(
-    ZoneList<const AstRawString*>* labels, bool* ok) {
+    ZonePtrList<const AstRawString>* labels, bool* ok) {
   // Block ::
   //   '{' StatementList '}'
 
@@ -5115,7 +5117,7 @@ typename ParserBase<Impl>::BlockT ParserBase<Impl>::ParseBlock(
 
 template <typename Impl>
 typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseScopedStatement(
-    ZoneList<const AstRawString*>* labels, bool* ok) {
+    ZonePtrList<const AstRawString>* labels, bool* ok) {
   if (is_strict(language_mode()) || peek() != Token::FUNCTION) {
     return ParseStatement(labels, ok);
   } else {
@@ -5135,7 +5137,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseScopedStatement(
 template <typename Impl>
 typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseVariableStatement(
     VariableDeclarationContext var_context,
-    ZoneList<const AstRawString*>* names, bool* ok) {
+    ZonePtrList<const AstRawString>* names, bool* ok) {
   // VariableStatement ::
   //   VariableDeclarations ';'
 
@@ -5176,7 +5178,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseDebuggerStatement(
 template <typename Impl>
 typename ParserBase<Impl>::StatementT
 ParserBase<Impl>::ParseExpressionOrLabelledStatement(
-    ZoneList<const AstRawString*>* labels,
+    ZonePtrList<const AstRawString>* labels,
     AllowLabelledFunctionStatement allow_function, bool* ok) {
   // ExpressionStatement | LabelledStatement ::
   //   Expression ';'
@@ -5247,7 +5249,7 @@ ParserBase<Impl>::ParseExpressionOrLabelledStatement(
 
 template <typename Impl>
 typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseIfStatement(
-    ZoneList<const AstRawString*>* labels, bool* ok) {
+    ZonePtrList<const AstRawString>* labels, bool* ok) {
   // IfStatement ::
   //   'if' '(' Expression ')' Statement ('else' Statement)?
 
@@ -5317,7 +5319,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseContinueStatement(
 
 template <typename Impl>
 typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseBreakStatement(
-    ZoneList<const AstRawString*>* labels, bool* ok) {
+    ZonePtrList<const AstRawString>* labels, bool* ok) {
   // BreakStatement ::
   //   'break' Identifier? ';'
 
@@ -5398,7 +5400,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseReturnStatement(
 
 template <typename Impl>
 typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseWithStatement(
-    ZoneList<const AstRawString*>* labels, bool* ok) {
+    ZonePtrList<const AstRawString>* labels, bool* ok) {
   // WithStatement ::
   //   'with' '(' Expression ')' Statement
 
@@ -5428,7 +5430,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseWithStatement(
 
 template <typename Impl>
 typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseDoWhileStatement(
-    ZoneList<const AstRawString*>* labels, bool* ok) {
+    ZonePtrList<const AstRawString>* labels, bool* ok) {
   // DoStatement ::
   //   'do' Statement 'while' '(' Expression ')' ';'
 
@@ -5463,7 +5465,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseDoWhileStatement(
 
 template <typename Impl>
 typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseWhileStatement(
-    ZoneList<const AstRawString*>* labels, bool* ok) {
+    ZonePtrList<const AstRawString>* labels, bool* ok) {
   // WhileStatement ::
   //   'while' '(' Expression ')' Statement
 
@@ -5512,7 +5514,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseThrowStatement(
 
 template <typename Impl>
 typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseSwitchStatement(
-    ZoneList<const AstRawString*>* labels, bool* ok) {
+    ZonePtrList<const AstRawString>* labels, bool* ok) {
   // SwitchStatement ::
   //   'switch' '(' Expression ')' '{' CaseClause* '}'
   // CaseClause ::
@@ -5683,7 +5685,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseTryStatement(
 
 template <typename Impl>
 typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseForStatement(
-    ZoneList<const AstRawString*>* labels, bool* ok) {
+    ZonePtrList<const AstRawString>* labels, bool* ok) {
   // Either a standard for loop
   //   for (<init>; <cond>; <next>) { ... }
   // or a for-each loop
@@ -5795,7 +5797,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseForStatement(
 template <typename Impl>
 typename ParserBase<Impl>::StatementT
 ParserBase<Impl>::ParseForEachStatementWithDeclarations(
-    int stmt_pos, ForInfo* for_info, ZoneList<const AstRawString*>* labels,
+    int stmt_pos, ForInfo* for_info, ZonePtrList<const AstRawString>* labels,
     Scope* inner_block_scope, bool* ok) {
   // Just one declaration followed by in/of.
   if (for_info->parsing_result.declarations.size() != 1) {
@@ -5892,7 +5894,7 @@ template <typename Impl>
 typename ParserBase<Impl>::StatementT
 ParserBase<Impl>::ParseForEachStatementWithoutDeclarations(
     int stmt_pos, ExpressionT expression, int lhs_beg_pos, int lhs_end_pos,
-    ForInfo* for_info, ZoneList<const AstRawString*>* labels, bool* ok) {
+    ForInfo* for_info, ZonePtrList<const AstRawString>* labels, bool* ok) {
   // Initializer is reference followed by in/of.
   if (!expression->IsArrayLiteral() && !expression->IsObjectLiteral()) {
     expression = CheckAndRewriteReferenceExpression(
@@ -5929,7 +5931,7 @@ template <typename Impl>
 typename ParserBase<Impl>::StatementT
 ParserBase<Impl>::ParseStandardForLoopWithLexicalDeclarations(
     int stmt_pos, StatementT init, ForInfo* for_info,
-    ZoneList<const AstRawString*>* labels, bool* ok) {
+    ZonePtrList<const AstRawString>* labels, bool* ok) {
   // The condition and the next statement of the for loop must be parsed
   // in a new scope.
   Scope* inner_scope = NewScope(BLOCK_SCOPE);
@@ -5984,7 +5986,7 @@ ParserBase<Impl>::ParseStandardForLoopWithLexicalDeclarations(
 
 template <typename Impl>
 typename ParserBase<Impl>::ForStatementT ParserBase<Impl>::ParseStandardForLoop(
-    int stmt_pos, ZoneList<const AstRawString*>* labels, ExpressionT* cond,
+    int stmt_pos, ZonePtrList<const AstRawString>* labels, ExpressionT* cond,
     StatementT* next, StatementT* body, bool* ok) {
   ForStatementT loop = factory()->NewForStatement(labels, stmt_pos);
   typename Types::Target target(this, loop);
@@ -6023,7 +6025,7 @@ void ParserBase<Impl>::MarkLoopVariableAsAssigned(
 
 template <typename Impl>
 typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseForAwaitStatement(
-    ZoneList<const AstRawString*>* labels, bool* ok) {
+    ZonePtrList<const AstRawString>* labels, bool* ok) {
   // for await '(' ForDeclaration of AssignmentExpression ')'
   DCHECK(is_async_function());
 

--- a/deps/v8/src/parsing/parser.h
+++ b/deps/v8/src/parsing/parser.h
@@ -125,12 +125,12 @@ struct ParserTypes<Parser> {
   typedef ClassLiteral::Property* ClassLiteralProperty;
   typedef v8::internal::Suspend* Suspend;
   typedef v8::internal::RewritableExpression* RewritableExpression;
-  typedef ZoneList<v8::internal::Expression*>* ExpressionList;
-  typedef ZoneList<ObjectLiteral::Property*>* ObjectPropertyList;
-  typedef ZoneList<ClassLiteral::Property*>* ClassPropertyList;
+  typedef ZonePtrList<v8::internal::Expression>* ExpressionList;
+  typedef ZonePtrList<ObjectLiteral::Property>* ObjectPropertyList;
+  typedef ZonePtrList<ClassLiteral::Property>* ClassPropertyList;
   typedef ParserFormalParameters FormalParameters;
   typedef v8::internal::Statement* Statement;
-  typedef ZoneList<v8::internal::Statement*>* StatementList;
+  typedef ZonePtrList<v8::internal::Statement>* StatementList;
   typedef v8::internal::Block* Block;
   typedef v8::internal::BreakableStatement* BreakableStatement;
   typedef v8::internal::ForStatement* ForStatement;
@@ -216,20 +216,22 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
 
   FunctionLiteral* ParseFunction(Isolate* isolate, ParseInfo* info,
                                  Handle<SharedFunctionInfo> shared_info);
-  FunctionLiteral* DoParseFunction(ParseInfo* info,
+  FunctionLiteral* DoParseFunction(Isolate* isolate, ParseInfo* info,
                                    const AstRawString* raw_name);
 
   // Called by ParseProgram after setting up the scanner.
-  FunctionLiteral* DoParseProgram(ParseInfo* info);
+  FunctionLiteral* DoParseProgram(Isolate* isolate, ParseInfo* info);
 
   // Parse with the script as if the source is implicitly wrapped in a function.
   // We manually construct the AST and scopes for a top-level function and the
   // function wrapper.
-  void ParseWrapped(ParseInfo* info, ZoneList<Statement*>* body,
-                    DeclarationScope* scope, Zone* zone, bool* ok);
+  void ParseWrapped(Isolate* isolate, ParseInfo* info,
+                    ZonePtrList<Statement>* body, DeclarationScope* scope,
+                    Zone* zone, bool* ok);
 
-  ZoneList<const AstRawString*>* PrepareWrappedArguments(ParseInfo* info,
-                                                         Zone* zone);
+  ZonePtrList<const AstRawString>* PrepareWrappedArguments(Isolate* isolate,
+                                                           ParseInfo* info,
+                                                           Zone* zone);
 
   void StitchAst(ParseInfo* top_level_parse_info, Isolate* isolate);
 
@@ -255,15 +257,15 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
     return reusable_preparser_;
   }
 
-  void ParseModuleItemList(ZoneList<Statement*>* body, bool* ok);
+  void ParseModuleItemList(ZonePtrList<Statement>* body, bool* ok);
   Statement* ParseModuleItem(bool* ok);
   const AstRawString* ParseModuleSpecifier(bool* ok);
   void ParseImportDeclaration(bool* ok);
   Statement* ParseExportDeclaration(bool* ok);
   Statement* ParseExportDefault(bool* ok);
-  void ParseExportClause(ZoneList<const AstRawString*>* export_names,
+  void ParseExportClause(ZonePtrList<const AstRawString>* export_names,
                          ZoneList<Scanner::Location>* export_locations,
-                         ZoneList<const AstRawString*>* local_names,
+                         ZonePtrList<const AstRawString>* local_names,
                          Scanner::Location* reserved_loc, bool* ok);
   struct NamedImport : public ZoneObject {
     const AstRawString* import_name;
@@ -275,13 +277,13 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
           local_name(local_name),
           location(location) {}
   };
-  ZoneList<const NamedImport*>* ParseNamedImports(int pos, bool* ok);
+  ZonePtrList<const NamedImport>* ParseNamedImports(int pos, bool* ok);
   Block* BuildInitializationBlock(DeclarationParsingResult* parsing_result,
-                                  ZoneList<const AstRawString*>* names,
+                                  ZonePtrList<const AstRawString>* names,
                                   bool* ok);
-  ZoneList<const AstRawString*>* DeclareLabel(
-      ZoneList<const AstRawString*>* labels, VariableProxy* expr, bool* ok);
-  bool ContainsLabel(ZoneList<const AstRawString*>* labels,
+  ZonePtrList<const AstRawString>* DeclareLabel(
+      ZonePtrList<const AstRawString>* labels, VariableProxy* expr, bool* ok);
+  bool ContainsLabel(ZonePtrList<const AstRawString>* labels,
                      const AstRawString* label);
   Expression* RewriteReturn(Expression* return_value, int pos);
   Statement* RewriteSwitchStatement(SwitchStatement* switch_statement,
@@ -294,10 +296,10 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
                                  const SourceRange& finally_range,
                                  const CatchInfo& catch_info, int pos);
   void ParseAndRewriteGeneratorFunctionBody(int pos, FunctionKind kind,
-                                            ZoneList<Statement*>* body,
+                                            ZonePtrList<Statement>* body,
                                             bool* ok);
   void ParseAndRewriteAsyncGeneratorFunctionBody(int pos, FunctionKind kind,
-                                                 ZoneList<Statement*>* body,
+                                                 ZonePtrList<Statement>* body,
                                                  bool* ok);
   void DeclareFunctionNameVar(const AstRawString* function_name,
                               FunctionLiteral::FunctionType function_type,
@@ -306,14 +308,14 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
   Statement* DeclareFunction(const AstRawString* variable_name,
                              FunctionLiteral* function, VariableMode mode,
                              int pos, bool is_sloppy_block_function,
-                             ZoneList<const AstRawString*>* names, bool* ok);
+                             ZonePtrList<const AstRawString>* names, bool* ok);
   Variable* CreateSyntheticContextVariable(const AstRawString* synthetic_name,
                                            bool* ok);
   FunctionLiteral* CreateInitializerFunction(
-      DeclarationScope* scope, ZoneList<ClassLiteral::Property*>* fields);
+      DeclarationScope* scope, ZonePtrList<ClassLiteral::Property>* fields);
   V8_INLINE Statement* DeclareClass(const AstRawString* variable_name,
                                     Expression* value,
-                                    ZoneList<const AstRawString*>* names,
+                                    ZonePtrList<const AstRawString>* names,
                                     int class_token_pos, int end_pos, bool* ok);
   V8_INLINE void DeclareClassVariable(const AstRawString* name,
                                       ClassInfo* class_info,
@@ -341,7 +343,7 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
   void DeclareAndInitializeVariables(
       Block* block, const DeclarationDescriptor* declaration_descriptor,
       const DeclarationParsingResult::Declaration* declaration,
-      ZoneList<const AstRawString*>* names, bool* ok);
+      ZonePtrList<const AstRawString>* names, bool* ok);
   void RewriteDestructuringAssignment(RewritableExpression* expr);
   Expression* RewriteDestructuringAssignment(Assignment* assignment);
 
@@ -382,7 +384,8 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
       FunctionNameValidity function_name_validity, FunctionKind kind,
       int function_token_position, FunctionLiteral::FunctionType type,
       LanguageMode language_mode,
-      ZoneList<const AstRawString*>* arguments_for_wrapped_function, bool* ok);
+      ZonePtrList<const AstRawString>* arguments_for_wrapped_function,
+      bool* ok);
 
   ObjectLiteral* InitializeObjectLiteral(ObjectLiteral* object_literal) {
     object_literal->CalculateEmitStore(main_zone());
@@ -447,13 +450,14 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
       const ParserFormalParameters& parameters, bool* ok);
   Block* BuildRejectPromiseOnException(Block* block);
 
-  ZoneList<Statement*>* ParseFunction(
+  ZonePtrList<Statement>* ParseFunction(
       const AstRawString* function_name, int pos, FunctionKind kind,
       FunctionLiteral::FunctionType function_type,
       DeclarationScope* function_scope, int* num_parameters,
       int* function_length, bool* has_duplicate_parameters,
       int* expected_property_count, int* suspend_count,
-      ZoneList<const AstRawString*>* arguments_for_wrapped_function, bool* ok);
+      ZonePtrList<const AstRawString>* arguments_for_wrapped_function,
+      bool* ok);
 
   void ThrowPendingError(Isolate* isolate, Handle<Script> script);
 
@@ -462,9 +466,9 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
     TemplateLiteral(Zone* zone, int pos)
         : cooked_(8, zone), raw_(8, zone), expressions_(8, zone), pos_(pos) {}
 
-    const ZoneList<const AstRawString*>* cooked() const { return &cooked_; }
-    const ZoneList<const AstRawString*>* raw() const { return &raw_; }
-    const ZoneList<Expression*>* expressions() const { return &expressions_; }
+    const ZonePtrList<const AstRawString>* cooked() const { return &cooked_; }
+    const ZonePtrList<const AstRawString>* raw() const { return &raw_; }
+    const ZonePtrList<Expression>* expressions() const { return &expressions_; }
     int position() const { return pos_; }
 
     void AddTemplateSpan(const AstRawString* cooked, const AstRawString* raw,
@@ -480,9 +484,9 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
     }
 
    private:
-    ZoneList<const AstRawString*> cooked_;
-    ZoneList<const AstRawString*> raw_;
-    ZoneList<Expression*> expressions_;
+    ZonePtrList<const AstRawString> cooked_;
+    ZonePtrList<const AstRawString> raw_;
+    ZonePtrList<Expression> expressions_;
     int pos_;
   };
 
@@ -502,10 +506,10 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
   Expression* CloseTemplateLiteral(TemplateLiteralState* state, int start,
                                    Expression* tag);
 
-  ArrayLiteral* ArrayLiteralFromListWithSpread(ZoneList<Expression*>* list);
-  Expression* SpreadCall(Expression* function, ZoneList<Expression*>* args,
+  ArrayLiteral* ArrayLiteralFromListWithSpread(ZonePtrList<Expression>* list);
+  Expression* SpreadCall(Expression* function, ZonePtrList<Expression>* args,
                          int pos, Call::PossiblyEval is_possibly_eval);
-  Expression* SpreadCallNew(Expression* function, ZoneList<Expression*>* args,
+  Expression* SpreadCallNew(Expression* function, ZonePtrList<Expression>* args,
                             int pos);
   Expression* RewriteSuperCall(Expression* call_expression);
 
@@ -541,15 +545,16 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
 
   Statement* FinalizeForOfStatement(ForOfStatement* loop, Variable* completion,
                                     IteratorType type, int pos);
-  void BuildIteratorClose(ZoneList<Statement*>* statements, Variable* iterator,
-                          Variable* input, Variable* output, IteratorType type);
-  void BuildIteratorCloseForCompletion(ZoneList<Statement*>* statements,
+  void BuildIteratorClose(ZonePtrList<Statement>* statements,
+                          Variable* iterator, Variable* input, Variable* output,
+                          IteratorType type);
+  void BuildIteratorCloseForCompletion(ZonePtrList<Statement>* statements,
                                        Variable* iterator,
                                        Expression* completion,
                                        IteratorType type);
   Statement* CheckCallable(Variable* var, Expression* error, int pos);
 
-  V8_INLINE void RewriteAsyncFunctionBody(ZoneList<Statement*>* body,
+  V8_INLINE void RewriteAsyncFunctionBody(ZonePtrList<Statement>* body,
                                           Block* block,
                                           Expression* return_value, bool* ok);
 
@@ -709,7 +714,8 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
   // A shortcut for performing a ToString operation
   V8_INLINE Expression* ToString(Expression* expr) {
     if (expr->IsStringLiteral()) return expr;
-    ZoneList<Expression*>* args = new (zone()) ZoneList<Expression*>(1, zone());
+    ZonePtrList<Expression>* args =
+        new (zone()) ZonePtrList<Expression>(1, zone());
     args->Add(expr, zone());
     return factory()->NewCallRuntime(Runtime::kInlineToString, args,
                                      expr->position());
@@ -795,10 +801,12 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
   V8_INLINE static std::nullptr_t NullIdentifier() { return nullptr; }
   V8_INLINE static std::nullptr_t NullExpression() { return nullptr; }
   V8_INLINE static std::nullptr_t NullLiteralProperty() { return nullptr; }
-  V8_INLINE static ZoneList<Expression*>* NullExpressionList() {
+  V8_INLINE static ZonePtrList<Expression>* NullExpressionList() {
     return nullptr;
   }
-  V8_INLINE static ZoneList<Statement*>* NullStatementList() { return nullptr; }
+  V8_INLINE static ZonePtrList<Statement>* NullStatementList() {
+    return nullptr;
+  }
   V8_INLINE static std::nullptr_t NullStatement() { return nullptr; }
 
   template <typename T>
@@ -856,23 +864,23 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
     return factory()->NewStringLiteral(symbol, pos);
   }
 
-  V8_INLINE ZoneList<Expression*>* NewExpressionList(int size) const {
-    return new (zone()) ZoneList<Expression*>(size, zone());
+  V8_INLINE ZonePtrList<Expression>* NewExpressionList(int size) const {
+    return new (zone()) ZonePtrList<Expression>(size, zone());
   }
-  V8_INLINE ZoneList<ObjectLiteral::Property*>* NewObjectPropertyList(
+  V8_INLINE ZonePtrList<ObjectLiteral::Property>* NewObjectPropertyList(
       int size) const {
-    return new (zone()) ZoneList<ObjectLiteral::Property*>(size, zone());
+    return new (zone()) ZonePtrList<ObjectLiteral::Property>(size, zone());
   }
-  V8_INLINE ZoneList<ClassLiteral::Property*>* NewClassPropertyList(
+  V8_INLINE ZonePtrList<ClassLiteral::Property>* NewClassPropertyList(
       int size) const {
-    return new (zone()) ZoneList<ClassLiteral::Property*>(size, zone());
+    return new (zone()) ZonePtrList<ClassLiteral::Property>(size, zone());
   }
-  V8_INLINE ZoneList<Statement*>* NewStatementList(int size) const {
-    return new (zone()) ZoneList<Statement*>(size, zone());
+  V8_INLINE ZonePtrList<Statement>* NewStatementList(int size) const {
+    return new (zone()) ZonePtrList<Statement>(size, zone());
   }
 
   V8_INLINE Expression* NewV8Intrinsic(const AstRawString* name,
-                                       ZoneList<Expression*>* args, int pos,
+                                       ZonePtrList<Expression>* args, int pos,
                                        bool* ok);
 
   V8_INLINE Statement* NewThrowStatement(Expression* exception, int pos) {
@@ -881,7 +889,7 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
   }
 
   V8_INLINE void AddParameterInitializationBlock(
-      const ParserFormalParameters& parameters, ZoneList<Statement*>* body,
+      const ParserFormalParameters& parameters, ZonePtrList<Statement>* body,
       bool is_async, bool* ok) {
     if (parameters.is_simple) return;
     auto* init_block = BuildParameterInitializationBlock(parameters, ok);
@@ -934,7 +942,7 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
                                             Scanner::Location* duplicate_loc,
                                             bool* ok);
 
-  Expression* ExpressionListToExpression(ZoneList<Expression*>* args);
+  Expression* ExpressionListToExpression(ZonePtrList<Expression>* args);
 
   void SetFunctionNameFromPropertyName(LiteralProperty* property,
                                        const AstRawString* name,

--- a/deps/v8/src/parsing/parsing.cc
+++ b/deps/v8/src/parsing/parsing.cc
@@ -24,7 +24,7 @@ bool ParseProgram(ParseInfo* info, Isolate* isolate) {
   VMState<PARSER> state(isolate);
 
   // Create a character stream for the parser.
-  Handle<String> source(String::cast(info->script()->source()));
+  Handle<String> source(String::cast(info->script()->source()), isolate);
   source = String::Flatten(source);
   isolate->counters()->total_parse_size()->Increment(source->length());
   std::unique_ptr<Utf16CharacterStream> stream(ScannerStream::For(source));
@@ -59,7 +59,7 @@ bool ParseFunction(ParseInfo* info, Handle<SharedFunctionInfo> shared_info,
   DCHECK_NULL(info->literal());
 
   // Create a character stream for the parser.
-  Handle<String> source(String::cast(info->script()->source()));
+  Handle<String> source(String::cast(info->script()->source()), isolate);
   source = String::Flatten(source);
   isolate->counters()->total_parse_size()->Increment(source->length());
   std::unique_ptr<Utf16CharacterStream> stream(ScannerStream::For(

--- a/deps/v8/src/parsing/pattern-rewriter.cc
+++ b/deps/v8/src/parsing/pattern-rewriter.cc
@@ -29,7 +29,7 @@ class PatternRewriter final : public AstVisitor<PatternRewriter> {
       Parser* parser, Block* block,
       const DeclarationDescriptor* declaration_descriptor,
       const Parser::DeclarationParsingResult::Declaration* declaration,
-      ZoneList<const AstRawString*>* names, bool* ok);
+      ZonePtrList<const AstRawString>* names, bool* ok);
 
   static void RewriteDestructuringAssignment(Parser* parser,
                                              RewritableExpression* to_rewrite,
@@ -108,7 +108,7 @@ class PatternRewriter final : public AstVisitor<PatternRewriter> {
   int value_beg_position_;
   Block* block_;
   const DeclarationDescriptor* descriptor_;
-  ZoneList<const AstRawString*>* names_;
+  ZonePtrList<const AstRawString>* names_;
   Expression* current_value_;
   int recursion_level_;
   bool* ok_;
@@ -119,7 +119,7 @@ class PatternRewriter final : public AstVisitor<PatternRewriter> {
 void Parser::DeclareAndInitializeVariables(
     Block* block, const DeclarationDescriptor* declaration_descriptor,
     const DeclarationParsingResult::Declaration* declaration,
-    ZoneList<const AstRawString*>* names, bool* ok) {
+    ZonePtrList<const AstRawString>* names, bool* ok) {
   PatternRewriter::DeclareAndInitializeVariables(
       this, block, declaration_descriptor, declaration, names, ok);
 }
@@ -140,7 +140,7 @@ void PatternRewriter::DeclareAndInitializeVariables(
     Parser* parser, Block* block,
     const DeclarationDescriptor* declaration_descriptor,
     const Parser::DeclarationParsingResult::Declaration* declaration,
-    ZoneList<const AstRawString*>* names, bool* ok) {
+    ZonePtrList<const AstRawString>* names, bool* ok) {
   DCHECK(block->ignore_completion_value());
 
   PatternRewriter rewriter(declaration_descriptor->scope, parser, BINDING);
@@ -367,14 +367,14 @@ void PatternRewriter::VisitObjectLiteral(ObjectLiteral* pattern,
                                          Variable** temp_var) {
   auto temp = *temp_var = CreateTempVar(current_value_);
 
-  ZoneList<Expression*>* rest_runtime_callargs = nullptr;
+  ZonePtrList<Expression>* rest_runtime_callargs = nullptr;
   if (pattern->has_rest_property()) {
     // non_rest_properties_count = pattern->properties()->length - 1;
     // args_length = 1 + non_rest_properties_count because we need to
     // pass temp as well to the runtime function.
     int args_length = pattern->properties()->length();
     rest_runtime_callargs =
-        new (zone()) ZoneList<Expression*>(args_length, zone());
+        new (zone()) ZonePtrList<Expression>(args_length, zone());
     rest_runtime_callargs->Add(factory()->NewVariableProxy(temp), zone());
   }
 
@@ -409,7 +409,7 @@ void PatternRewriter::VisitObjectLiteral(ObjectLiteral* pattern,
 
         if (property->is_computed_name()) {
           DCHECK(!key->IsPropertyName() || !key->IsNumberLiteral());
-          auto args = new (zone()) ZoneList<Expression*>(1, zone());
+          auto args = new (zone()) ZonePtrList<Expression>(1, zone());
           args->Add(key, zone());
           auto to_name_key = CreateTempVar(factory()->NewCallRuntime(
               Runtime::kToName, args, kNoSourcePosition));
@@ -592,7 +592,7 @@ void PatternRewriter::VisitArrayLiteral(ArrayLiteral* node,
     // let array = [];
     Variable* array;
     {
-      auto empty_exprs = new (zone()) ZoneList<Expression*>(0, zone());
+      auto empty_exprs = new (zone()) ZonePtrList<Expression>(0, zone());
       array = CreateTempVar(
           factory()->NewArrayLiteral(empty_exprs, kNoSourcePosition));
     }

--- a/deps/v8/src/parsing/preparser.cc
+++ b/deps/v8/src/parsing/preparser.cc
@@ -268,7 +268,7 @@ PreParser::Expression PreParser::ParseFunctionLiteral(
     FunctionNameValidity function_name_validity, FunctionKind kind,
     int function_token_pos, FunctionLiteral::FunctionType function_type,
     LanguageMode language_mode,
-    ZoneList<const AstRawString*>* arguments_for_wrapped_function, bool* ok) {
+    ZonePtrList<const AstRawString>* arguments_for_wrapped_function, bool* ok) {
   // Wrapped functions are not parsed in the preparser.
   DCHECK_NULL(arguments_for_wrapped_function);
   DCHECK_NE(FunctionLiteral::kWrapped, function_type);
@@ -429,7 +429,7 @@ void PreParser::DeclareAndInitializeVariables(
     PreParserStatement block,
     const DeclarationDescriptor* declaration_descriptor,
     const DeclarationParsingResult::Declaration* declaration,
-    ZoneList<const AstRawString*>* names, bool* ok) {
+    ZonePtrList<const AstRawString>* names, bool* ok) {
   if (declaration->pattern.variables_ != nullptr) {
     DCHECK(FLAG_lazy_inner_functions);
     DCHECK(track_unresolved_variables_);

--- a/deps/v8/src/parsing/preparser.h
+++ b/deps/v8/src/parsing/preparser.h
@@ -94,7 +94,7 @@ class PreParserExpression {
   static PreParserExpression Null() { return PreParserExpression(); }
 
   static PreParserExpression Default(
-      ZoneList<VariableProxy*>* variables = nullptr) {
+      ZonePtrList<VariableProxy>* variables = nullptr) {
     return PreParserExpression(TypeField::encode(kExpression), variables);
   }
 
@@ -133,7 +133,7 @@ class PreParserExpression {
     return PreParserExpression(TypeField::encode(kExpression));
   }
 
-  static PreParserExpression Assignment(ZoneList<VariableProxy*>* variables) {
+  static PreParserExpression Assignment(ZonePtrList<VariableProxy>* variables) {
     return PreParserExpression(TypeField::encode(kExpression) |
                                    ExpressionTypeField::encode(kAssignment),
                                variables);
@@ -144,12 +144,13 @@ class PreParserExpression {
   }
 
   static PreParserExpression ObjectLiteral(
-      ZoneList<VariableProxy*>* variables) {
+      ZonePtrList<VariableProxy>* variables) {
     return PreParserExpression(TypeField::encode(kObjectLiteralExpression),
                                variables);
   }
 
-  static PreParserExpression ArrayLiteral(ZoneList<VariableProxy*>* variables) {
+  static PreParserExpression ArrayLiteral(
+      ZonePtrList<VariableProxy>* variables) {
     return PreParserExpression(TypeField::encode(kArrayLiteralExpression),
                                variables);
   }
@@ -168,7 +169,7 @@ class PreParserExpression {
                                IsUseAsmField::encode(true));
   }
 
-  static PreParserExpression This(ZoneList<VariableProxy*>* variables) {
+  static PreParserExpression This(ZonePtrList<VariableProxy>* variables) {
     return PreParserExpression(TypeField::encode(kExpression) |
                                    ExpressionTypeField::encode(kThisExpression),
                                variables);
@@ -371,7 +372,7 @@ class PreParserExpression {
   };
 
   explicit PreParserExpression(uint32_t expression_code,
-                               ZoneList<VariableProxy*>* variables = nullptr)
+                               ZonePtrList<VariableProxy>* variables = nullptr)
       : code_(expression_code), variables_(variables) {}
 
   void AddVariable(VariableProxy* variable, Zone* zone) {
@@ -379,7 +380,7 @@ class PreParserExpression {
       return;
     }
     if (variables_ == nullptr) {
-      variables_ = new (zone) ZoneList<VariableProxy*>(1, zone);
+      variables_ = new (zone) ZonePtrList<VariableProxy>(1, zone);
     }
     variables_->Add(variable, zone);
   }
@@ -406,7 +407,7 @@ class PreParserExpression {
   uint32_t code_;
   // If the PreParser is used in the variable tracking mode, PreParserExpression
   // accumulates variables in that expression.
-  ZoneList<VariableProxy*>* variables_;
+  ZonePtrList<VariableProxy>* variables_;
 
   friend class PreParser;
   friend class PreParserFactory;
@@ -433,7 +434,7 @@ class PreParserList {
  private:
   explicit PreParserList(int n) : length_(n), variables_(nullptr) {}
   int length_;
-  ZoneList<VariableProxy*>* variables_;
+  ZonePtrList<VariableProxy>* variables_;
 
   friend class PreParser;
   friend class PreParserFactory;
@@ -446,7 +447,7 @@ inline void PreParserList<PreParserExpression>::Add(
     DCHECK(FLAG_lazy_inner_functions);
     DCHECK_NOT_NULL(zone);
     if (variables_ == nullptr) {
-      variables_ = new (zone) ZoneList<VariableProxy*>(1, zone);
+      variables_ = new (zone) ZonePtrList<VariableProxy>(1, zone);
     }
     for (auto identifier : (*expression.variables_)) {
       variables_->Add(identifier, zone);
@@ -743,8 +744,9 @@ class PreParserFactory {
     return PreParserStatement::Default();
   }
 
-  PreParserStatement NewBlock(int capacity, bool ignore_completion_value,
-                              ZoneList<const AstRawString*>* labels = nullptr) {
+  PreParserStatement NewBlock(
+      int capacity, bool ignore_completion_value,
+      ZonePtrList<const AstRawString>* labels = nullptr) {
     return PreParserStatement::Default();
   }
 
@@ -784,17 +786,17 @@ class PreParserFactory {
     return PreParserStatement::Default();
   }
 
-  PreParserStatement NewDoWhileStatement(ZoneList<const AstRawString*>* labels,
-                                         int pos) {
+  PreParserStatement NewDoWhileStatement(
+      ZonePtrList<const AstRawString>* labels, int pos) {
     return PreParserStatement::Default();
   }
 
-  PreParserStatement NewWhileStatement(ZoneList<const AstRawString*>* labels,
+  PreParserStatement NewWhileStatement(ZonePtrList<const AstRawString>* labels,
                                        int pos) {
     return PreParserStatement::Default();
   }
 
-  PreParserStatement NewSwitchStatement(ZoneList<const AstRawString*>* labels,
+  PreParserStatement NewSwitchStatement(ZonePtrList<const AstRawString>* labels,
                                         const PreParserExpression& tag,
                                         int pos) {
     return PreParserStatement::Default();
@@ -805,18 +807,18 @@ class PreParserFactory {
     return PreParserStatement::Default();
   }
 
-  PreParserStatement NewForStatement(ZoneList<const AstRawString*>* labels,
+  PreParserStatement NewForStatement(ZonePtrList<const AstRawString>* labels,
                                      int pos) {
     return PreParserStatement::Default();
   }
 
-  PreParserStatement NewForEachStatement(ForEachStatement::VisitMode visit_mode,
-                                         ZoneList<const AstRawString*>* labels,
-                                         int pos) {
+  PreParserStatement NewForEachStatement(
+      ForEachStatement::VisitMode visit_mode,
+      ZonePtrList<const AstRawString>* labels, int pos) {
     return PreParserStatement::Default();
   }
 
-  PreParserStatement NewForOfStatement(ZoneList<const AstRawString*>* labels,
+  PreParserStatement NewForOfStatement(ZonePtrList<const AstRawString>* labels,
                                        int pos) {
     return PreParserStatement::Default();
   }
@@ -842,12 +844,12 @@ class PreParserFactory {
 
 struct PreParserFormalParameters : FormalParametersBase {
   struct Parameter : public ZoneObject {
-    Parameter(ZoneList<VariableProxy*>* variables, bool is_rest)
+    Parameter(ZonePtrList<VariableProxy>* variables, bool is_rest)
         : variables_(variables), is_rest(is_rest) {}
     Parameter** next() { return &next_parameter; }
     Parameter* const* next() const { return &next_parameter; }
 
-    ZoneList<VariableProxy*>* variables_;
+    ZonePtrList<VariableProxy>* variables_;
     Parameter* next_parameter = nullptr;
     bool is_rest : 1;
   };
@@ -1013,7 +1015,8 @@ class PreParser : public ParserBase<PreParser> {
       FunctionNameValidity function_name_validity, FunctionKind kind,
       int function_token_pos, FunctionLiteral::FunctionType function_type,
       LanguageMode language_mode,
-      ZoneList<const AstRawString*>* arguments_for_wrapped_function, bool* ok);
+      ZonePtrList<const AstRawString>* arguments_for_wrapped_function,
+      bool* ok);
 
   PreParserExpression InitializeObjectLiteral(PreParserExpression literal) {
     return literal;
@@ -1065,10 +1068,10 @@ class PreParser : public ParserBase<PreParser> {
       PreParserStatement block,
       const DeclarationDescriptor* declaration_descriptor,
       const DeclarationParsingResult::Declaration* declaration,
-      ZoneList<const AstRawString*>* names, bool* ok);
+      ZonePtrList<const AstRawString>* names, bool* ok);
 
-  V8_INLINE ZoneList<const AstRawString*>* DeclareLabel(
-      ZoneList<const AstRawString*>* labels, const PreParserExpression& expr,
+  V8_INLINE ZonePtrList<const AstRawString>* DeclareLabel(
+      ZonePtrList<const AstRawString>* labels, const PreParserExpression& expr,
       bool* ok) {
     DCHECK(!parsing_module_ || !expr.AsIdentifier().IsAwait());
     DCHECK(IsIdentifier(expr));
@@ -1076,7 +1079,7 @@ class PreParser : public ParserBase<PreParser> {
   }
 
   // TODO(nikolaos): The preparser currently does not keep track of labels.
-  V8_INLINE bool ContainsLabel(ZoneList<const AstRawString*>* labels,
+  V8_INLINE bool ContainsLabel(ZonePtrList<const AstRawString>* labels,
                                const PreParserIdentifier& label) {
     return false;
   }
@@ -1162,7 +1165,7 @@ class PreParser : public ParserBase<PreParser> {
   DeclareFunction(const PreParserIdentifier& variable_name,
                   const PreParserExpression& function, VariableMode mode,
                   int pos, bool is_sloppy_block_function,
-                  ZoneList<const AstRawString*>* names, bool* ok) {
+                  ZonePtrList<const AstRawString>* names, bool* ok) {
     DCHECK_NULL(names);
     if (variable_name.string_ != nullptr) {
       DCHECK(track_unresolved_variables_);
@@ -1177,7 +1180,7 @@ class PreParser : public ParserBase<PreParser> {
 
   V8_INLINE PreParserStatement DeclareClass(
       const PreParserIdentifier& variable_name,
-      const PreParserExpression& value, ZoneList<const AstRawString*>* names,
+      const PreParserExpression& value, ZonePtrList<const AstRawString>* names,
       int class_token_pos, int end_pos, bool* ok) {
     // Preparser shouldn't be used in contexts where we need to track the names.
     DCHECK_NULL(names);
@@ -1380,7 +1383,7 @@ class PreParser : public ParserBase<PreParser> {
 
   V8_INLINE PreParserStatement
   BuildInitializationBlock(DeclarationParsingResult* parsing_result,
-                           ZoneList<const AstRawString*>* names, bool* ok) {
+                           ZonePtrList<const AstRawString>* names, bool* ok) {
     for (auto declaration : parsing_result->declarations) {
       DeclareAndInitializeVariables(PreParserStatement::Default(),
                                     &(parsing_result->descriptor), &declaration,
@@ -1547,13 +1550,13 @@ class PreParser : public ParserBase<PreParser> {
   }
 
   V8_INLINE PreParserExpression ThisExpression(int pos = kNoSourcePosition) {
-    ZoneList<VariableProxy*>* variables = nullptr;
+    ZonePtrList<VariableProxy>* variables = nullptr;
     if (track_unresolved_variables_) {
       VariableProxy* proxy = scope()->NewUnresolved(
           factory()->ast_node_factory(), ast_value_factory()->this_string(),
           pos, THIS_VARIABLE);
 
-      variables = new (zone()) ZoneList<VariableProxy*>(1, zone());
+      variables = new (zone()) ZonePtrList<VariableProxy>(1, zone());
       variables->Add(proxy, zone());
     }
     return PreParserExpression::This(variables);

--- a/deps/v8/src/parsing/rewriter.cc
+++ b/deps/v8/src/parsing/rewriter.cc
@@ -43,7 +43,7 @@ class Processor final : public AstVisitor<Processor> {
     InitializeAstVisitor(parser->stack_limit());
   }
 
-  void Process(ZoneList<Statement*>* statements);
+  void Process(ZonePtrList<Statement>* statements);
   bool result_assigned() const { return result_assigned_; }
 
   Zone* zone() { return zone_; }
@@ -121,8 +121,7 @@ Statement* Processor::AssignUndefinedBefore(Statement* s) {
   return b;
 }
 
-
-void Processor::Process(ZoneList<Statement*>* statements) {
+void Processor::Process(ZonePtrList<Statement>* statements) {
   // If we're in a breakable scope (named block, iteration, or switch), we walk
   // all statements. The last value producing statement before the break needs
   // to assign to .result. If we're not in a breakable scope, only the last
@@ -283,7 +282,7 @@ void Processor::VisitSwitchStatement(SwitchStatement* node) {
   DCHECK(breakable_ || !is_set_);
   BreakableScope scope(this);
   // Rewrite statements in all case clauses.
-  ZoneList<CaseClause*>* clauses = node->cases();
+  ZonePtrList<CaseClause>* clauses = node->cases();
   for (int i = clauses->length() - 1; i >= 0; --i) {
     CaseClause* clause = clauses->at(i);
     Process(clause->statements());
@@ -381,7 +380,7 @@ bool Rewriter::Rewrite(ParseInfo* info) {
     return true;
   }
 
-  ZoneList<Statement*>* body = function->body();
+  ZonePtrList<Statement>* body = function->body();
   DCHECK_IMPLIES(scope->is_module_scope(), !body->is_empty());
   if (!body->is_empty()) {
     Variable* result = scope->AsDeclarationScope()->NewTemporary(
@@ -416,7 +415,7 @@ bool Rewriter::Rewrite(Parser* parser, DeclarationScope* closure_scope,
   DCHECK_EQ(closure_scope, closure_scope->GetClosureScope());
   DCHECK(block->scope() == nullptr ||
          block->scope()->GetClosureScope() == closure_scope);
-  ZoneList<Statement*>* body = block->statements();
+  ZonePtrList<Statement>* body = block->statements();
   VariableProxy* result = expr->result();
   Variable* result_var = result->var();
 

--- a/deps/v8/src/zone/zone-list-inl.h
+++ b/deps/v8/src/zone/zone-list-inl.h
@@ -129,14 +129,6 @@ void ZoneList<T>::Iterate(Visitor* visitor) {
 }
 
 template <typename T>
-bool ZoneList<T>::Contains(const T& elm) const {
-  for (int i = 0; i < length_; i++) {
-    if (data_[i] == elm) return true;
-  }
-  return false;
-}
-
-template <typename T>
 template <typename CompareFunction>
 void ZoneList<T>::Sort(CompareFunction cmp) {
   ToVector().Sort(cmp, 0, length_);

--- a/deps/v8/src/zone/zone.h
+++ b/deps/v8/src/zone/zone.h
@@ -290,6 +290,11 @@ class ZoneList final {
   DISALLOW_COPY_AND_ASSIGN(ZoneList);
 };
 
+// ZonePtrList is a ZoneList of pointers to ZoneObjects allocated in the same
+// zone as the list object.
+template <typename T>
+using ZonePtrList = ZoneList<T*>;
+
 // A zone splay tree.  The config type parameter encapsulates the
 // different configurations of a concrete splay tree (see splay-tree.h).
 // The tree itself and all its elements are allocated in the Zone.

--- a/deps/v8/src/zone/zone.h
+++ b/deps/v8/src/zone/zone.h
@@ -251,7 +251,12 @@ class ZoneList final {
   // Drops all but the first 'pos' elements from the list.
   INLINE(void Rewind(int pos));
 
-  inline bool Contains(const T& elm) const;
+  inline bool Contains(const T& elm) const {
+    for (int i = 0; i < length_; i++) {
+      if (data_[i] == elm) return true;
+    }
+    return false;
+  }
 
   // Iterate through all list entries, starting at index 0.
   template <class Visitor>

--- a/deps/v8/test/inspector/cpu-profiler/coverage-block-expected.txt
+++ b/deps/v8/test/inspector/cpu-profiler/coverage-block-expected.txt
@@ -34,7 +34,7 @@ Running test: testPreciseCountCoverage
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -60,13 +60,8 @@ Running test: testPreciseCountCoverage
                             }
                             [2] : {
                                 count : 7
-                                endOffset : 71
-                                startOffset : 41
-                            }
-                            [3] : {
-                                count : 0
                                 endOffset : 72
-                                startOffset : 71
+                                startOffset : 41
                             }
                         ]
                     }
@@ -90,11 +85,6 @@ Running test: testPreciseCountCoverage
                                 endOffset : 208
                                 startOffset : 177
                             }
-                            [1] : {
-                                count : 0
-                                endOffset : 207
-                                startOffset : 206
-                            }
                         ]
                     }
                 ]
@@ -104,7 +94,7 @@ Running test: testPreciseCountCoverage
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -116,7 +106,7 @@ Running test: testPreciseCountCoverage
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -147,7 +137,7 @@ Running test: testPreciseCountCoverageIncremental
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -173,13 +163,8 @@ Running test: testPreciseCountCoverageIncremental
                             }
                             [2] : {
                                 count : 7
-                                endOffset : 71
-                                startOffset : 41
-                            }
-                            [3] : {
-                                count : 0
                                 endOffset : 72
-                                startOffset : 71
+                                startOffset : 41
                             }
                         ]
                     }
@@ -202,11 +187,6 @@ Running test: testPreciseCountCoverageIncremental
                                 count : 1
                                 endOffset : 208
                                 startOffset : 177
-                            }
-                            [1] : {
-                                count : 0
-                                endOffset : 207
-                                startOffset : 206
                             }
                         ]
                     }
@@ -267,13 +247,8 @@ Running test: testPreciseCountCoverageIncremental
                             }
                             [2] : {
                                 count : 10945
-                                endOffset : 71
-                                startOffset : 41
-                            }
-                            [3] : {
-                                count : 0
                                 endOffset : 72
-                                startOffset : 71
+                                startOffset : 41
                             }
                         ]
                     }
@@ -291,11 +266,6 @@ Running test: testPreciseCountCoverageIncremental
                                 endOffset : 156
                                 startOffset : 143
                             }
-                            [2] : {
-                                count : 0
-                                endOffset : 174
-                                startOffset : 173
-                            }
                         ]
                     }
                 ]
@@ -305,7 +275,7 @@ Running test: testPreciseCountCoverageIncremental
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -317,12 +287,12 @@ Running test: testPreciseCountCoverageIncremental
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
             [2] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -334,7 +304,7 @@ Running test: testPreciseCountCoverageIncremental
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -403,7 +373,7 @@ Running test: testBestEffortCoverageWithPreciseBinaryEnabled
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -453,7 +423,7 @@ Running test: testBestEffortCoverageWithPreciseBinaryEnabled
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -465,7 +435,7 @@ Running test: testBestEffortCoverageWithPreciseBinaryEnabled
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -477,7 +447,7 @@ Running test: testBestEffortCoverageWithPreciseBinaryEnabled
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -527,7 +497,7 @@ Running test: testBestEffortCoverageWithPreciseBinaryEnabled
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -539,7 +509,7 @@ Running test: testBestEffortCoverageWithPreciseBinaryEnabled
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -563,7 +533,7 @@ Running test: testBestEffortCoverageWithPreciseCountEnabled
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -613,7 +583,7 @@ Running test: testBestEffortCoverageWithPreciseCountEnabled
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -625,7 +595,7 @@ Running test: testBestEffortCoverageWithPreciseCountEnabled
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -637,7 +607,7 @@ Running test: testBestEffortCoverageWithPreciseCountEnabled
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -687,7 +657,7 @@ Running test: testBestEffortCoverageWithPreciseCountEnabled
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : false
                         ranges : [
                             [0] : {
@@ -699,7 +669,7 @@ Running test: testBestEffortCoverageWithPreciseCountEnabled
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -721,7 +691,7 @@ Running test: testEnablePreciseCountCoverageAtPause
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -733,7 +703,7 @@ Running test: testEnablePreciseCountCoverageAtPause
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -757,7 +727,7 @@ Running test: testPreciseBinaryCoverage
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -775,11 +745,6 @@ Running test: testPreciseBinaryCoverage
                                 count : 1
                                 endOffset : 73
                                 startOffset : 1
-                            }
-                            [1] : {
-                                count : 0
-                                endOffset : 72
-                                startOffset : 71
                             }
                         ]
                     }
@@ -802,11 +767,6 @@ Running test: testPreciseBinaryCoverage
                                 count : 1
                                 endOffset : 208
                                 startOffset : 177
-                            }
-                            [1] : {
-                                count : 0
-                                endOffset : 207
-                                startOffset : 206
                             }
                         ]
                     }
@@ -862,7 +822,7 @@ Running test: testPreciseBinaryCoverage
                             }
                             [1] : {
                                 count : 1
-                                endOffset : 71
+                                endOffset : 72
                                 startOffset : 32
                             }
                         ]
@@ -876,11 +836,6 @@ Running test: testPreciseBinaryCoverage
                                 endOffset : 175
                                 startOffset : 74
                             }
-                            [1] : {
-                                count : 0
-                                endOffset : 174
-                                startOffset : 173
-                            }
                         ]
                     }
                 ]
@@ -890,7 +845,7 @@ Running test: testPreciseBinaryCoverage
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -902,12 +857,12 @@ Running test: testPreciseBinaryCoverage
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
             [2] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -919,7 +874,7 @@ Running test: testPreciseBinaryCoverage
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }
@@ -950,7 +905,7 @@ Running test: testPreciseCountCoveragePartial
             [0] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -969,11 +924,6 @@ Running test: testPreciseCountCoveragePartial
                                 endOffset : 224
                                 startOffset : 10
                             }
-                            [1] : {
-                                count : 0
-                                endOffset : 223
-                                startOffset : 222
-                            }
                         ]
                     }
                     [2] : {
@@ -984,11 +934,6 @@ Running test: testPreciseCountCoveragePartial
                                 count : 1
                                 endOffset : 176
                                 startOffset : 31
-                            }
-                            [1] : {
-                                count : 0
-                                endOffset : 175
-                                startOffset : 172
                             }
                         ]
                     }
@@ -1001,11 +946,6 @@ Running test: testPreciseCountCoveragePartial
                                 endOffset : 172
                                 startOffset : 64
                             }
-                            [1] : {
-                                count : 0
-                                endOffset : 171
-                                startOffset : 166
-                            }
                         ]
                     }
                     [4] : {
@@ -1016,11 +956,6 @@ Running test: testPreciseCountCoveragePartial
                                 count : 1
                                 endOffset : 166
                                 startOffset : 99
-                            }
-                            [1] : {
-                                count : 0
-                                endOffset : 165
-                                startOffset : 158
                             }
                         ]
                     }
@@ -1068,11 +1003,6 @@ Running test: testPreciseCountCoveragePartial
                                 endOffset : 172
                                 startOffset : 64
                             }
-                            [1] : {
-                                count : 0
-                                endOffset : 171
-                                startOffset : 166
-                            }
                         ]
                     }
                     [1] : {
@@ -1093,7 +1023,7 @@ Running test: testPreciseCountCoveragePartial
             [1] : {
                 functions : [
                     [0] : {
-                        functionName : 
+                        functionName :
                         isBlockCoverage : true
                         ranges : [
                             [0] : {
@@ -1105,7 +1035,7 @@ Running test: testPreciseCountCoveragePartial
                     }
                 ]
                 scriptId : <scriptId>
-                url : 
+                url :
             }
         ]
     }

--- a/deps/v8/test/mjsunit/code-coverage-block-opt.js
+++ b/deps/v8/test/mjsunit/code-coverage-block-opt.js
@@ -17,7 +17,7 @@ f(); f(); f(); f(); f(); f();             // 0150
 `,
 [{"start":0,"end":199,"count":1},
  {"start":0,"end":33,"count":4},   // TODO(jgruber): Invocation count is off.
- {"start":25,"end":32,"count":16},
+ {"start":25,"end":31,"count":16},
  {"start":50,"end":76,"count":2}]  // TODO(jgruber): Invocation count is off.
 );
 
@@ -39,7 +39,7 @@ TestCoverage("Partial coverage collection",
 }();                                      // 0400
 `,
 [{"start":52,"end":153,"count":0},
- {"start":121,"end":152,"count":1}]
+ {"start":121,"end":137,"count":1}]
 );
 
 %DebugToggleBlockCoverage(false);

--- a/deps/v8/test/mjsunit/code-coverage-block.js
+++ b/deps/v8/test/mjsunit/code-coverage-block.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Flags: --allow-natives-syntax --no-always-opt
+// Flags: --allow-natives-syntax --no-always-opt --no-stress-flush-bytecode
 // Files: test/mjsunit/code-coverage-utils.js
 
 %DebugToggleBlockCoverage(true);
@@ -213,7 +213,7 @@ TestCoverage(
     nop();                                // 0100
   }                                       // 0150
 }();                                      // 0200
-%RunMicrotasks();                         // 0250
+%PerformMicrotaskCheckpoint();            // 0250
 `,
 [{"start":0,"end":299,"count":1},
  {"start":1,"end":201,"count":6},  // TODO(jgruber): Invocation count is off.
@@ -246,8 +246,7 @@ function g() {}                           // 0000
  {"start":224,"end":237,"count":12},
  {"start":273,"end":277,"count":0},
  {"start":412,"end":416,"count":12},
- {"start":462,"end":475,"count":12},
- {"start":620,"end":622,"count":0}]
+ {"start":462,"end":475,"count":12}]
 );
 
 TestCoverage(
@@ -354,11 +353,11 @@ TestCoverage(
 [{"start":0,"end":849,"count":1},
  {"start":1,"end":801,"count":1},
  {"start":67,"end":87,"count":0},
- {"start":219,"end":222,"count":0},
+ {"start":221,"end":222,"count":0},
  {"start":254,"end":274,"count":0},
- {"start":369,"end":372,"count":0},
- {"start":390,"end":404,"count":0},
- {"start":513,"end":554,"count":0}]
+ {"start":371,"end":372,"count":0},
+ {"start":403,"end":404,"count":0},
+ {"start":553,"end":554,"count":0}]
 );
 
 TestCoverage("try/catch/finally statements with early return",
@@ -375,11 +374,11 @@ TestCoverage("try/catch/finally statements with early return",
 `,
 [{"start":0,"end":449,"count":1},
  {"start":1,"end":151,"count":1},
- {"start":67,"end":70,"count":0},
- {"start":89,"end":150,"count":0},
+ {"start":69,"end":70,"count":0},
+ {"start":91,"end":150,"count":0},
  {"start":201,"end":401,"count":1},
- {"start":267,"end":270,"count":0},
- {"start":319,"end":400,"count":0}]
+ {"start":269,"end":270,"count":0},
+ {"start":321,"end":400,"count":0}]
 );
 
 TestCoverage(
@@ -410,15 +409,15 @@ TestCoverage(
 `,
 [{"start":0,"end":1099,"count":1},
  {"start":1,"end":151,"count":1},
- {"start":67,"end":70,"count":0},
- {"start":89,"end":150,"count":0},
+ {"start":69,"end":70,"count":0},
+ {"start":91,"end":150,"count":0},
  {"start":201,"end":351,"count":1},
- {"start":284,"end":350,"count":0},
+ {"start":286,"end":350,"count":0},
  {"start":401,"end":701,"count":1},
- {"start":569,"end":700,"count":0},
+ {"start":603,"end":700,"count":0},
  {"start":561,"end":568,"count":0},  // TODO(jgruber): Sorting.
  {"start":751,"end":1051,"count":1},
- {"start":817,"end":820,"count":0},
+ {"start":819,"end":820,"count":0},
  {"start":861,"end":1050,"count":0}]
 );
 
@@ -437,7 +436,7 @@ TestCoverage(
 [{"start":0,"end":399,"count":1},
  {"start":1,"end":351,"count":1},
  {"start":154,"end":204,"count":0},
- {"start":226,"end":303,"count":0}]
+ {"start":226,"end":350,"count":0}]
 );
 
 TestCoverage(
@@ -467,11 +466,7 @@ TestCoverage(
 [{"start":0,"end":999,"count":1},
  {"start":1,"end":951,"count":1},
  {"start":152,"end":202,"count":0},
- {"start":285,"end":353,"count":0},
- {"start":472,"end":503,"count":0},
- {"start":626,"end":653,"count":0},
- {"start":768,"end":803,"count":0},
- {"start":867,"end":869,"count":0}]
+ {"start":285,"end":353,"count":0}]
 );
 
 TestCoverage(
@@ -496,11 +491,8 @@ TestCoverage(
 [{"start":0,"end":749,"count":1},
  {"start":1,"end":701,"count":1},
  {"start":87,"end":153,"count":2},
- {"start":125,"end":153,"count":0},
  {"start":271,"end":403,"count":2},
- {"start":379,"end":403,"count":0},
- {"start":509,"end":653,"count":2},
- {"start":621,"end":653,"count":0}]
+ {"start":509,"end":653,"count":2}]
 );
 
 TestCoverage(
@@ -570,6 +562,7 @@ try {                                     // 0200
 } catch (e) {}                            // 0450
 `,
 [{"start":0,"end":499,"count":1},
+ {"start":451,"end":452,"count":0},
  {"start":12,"end":101,"count":3},
  {"start":60,"end":100,"count":0},
  {"start":264,"end":353,"count":3},
@@ -648,6 +641,7 @@ try {                                     // 0200
 } catch (e) {}                            // 0450
 `,
 [{"start":0,"end":499,"count":1},
+ {"start":451,"end":452,"count":0},
  {"start":12,"end":101,"count":3},
  {"start":65,"end":100,"count":0},
  {"start":264,"end":353,"count":3},
@@ -662,7 +656,7 @@ async function f() {                      // 0000
   await 42;                               // 0100
 };                                        // 0150
 f();                                      // 0200
-%RunMicrotasks();                         // 0250
+%PerformMicrotaskCheckpoint();            // 0250
 `,
 [{"start":0,"end":299,"count":1},
  {"start":0,"end":151,"count":3},
@@ -846,8 +840,205 @@ Util.escape("foo.bar");                   // 0400
 `,
 [{"start":0,"end":449,"count":1},
  {"start":64,"end":351,"count":1},
- {"start":112,"end":203,"count":0},
- {"start":303,"end":350,"count":0}]
+ {"start":112,"end":203,"count":0}]
+);
+
+TestCoverage(
+"https://crbug.com/v8/8237",
+`
+!function() {                             // 0000
+  if (true)                               // 0050
+    while (false) return; else nop();     // 0100
+}();                                      // 0150
+!function() {                             // 0200
+  if (true) l0: { break l0; } else        // 0250
+    if (nop()) { }                        // 0300
+}();                                      // 0350
+!function() {                             // 0400
+  if (true) { if (false) { return; }      // 0450
+  } else if (nop()) { } }();              // 0500
+!function(){                              // 0550
+  if(true)while(false)return;else nop()   // 0600
+}();                                      // 0650
+!function(){                              // 0700
+  if(true) l0:{break l0}else if (nop()){} // 0750
+}();                                      // 0800
+!function(){                              // 0850
+  if(true){if(false){return}}else         // 0900
+    if(nop()){}                           // 0950
+}();                                      // 1000
+`,
+[{"start":0,"end":1049,"count":1},
+ {"start":1,"end":151,"count":1},
+ {"start":118,"end":137,"count":0},
+ {"start":201,"end":351,"count":1},
+ {"start":279,"end":318,"count":0},
+ {"start":401,"end":525,"count":1},
+ {"start":475,"end":486,"count":0},
+ {"start":503,"end":523,"count":0},
+ {"start":551,"end":651,"count":1},
+ {"start":622,"end":639,"count":0},
+ {"start":701,"end":801,"count":1},
+ {"start":774,"end":791,"count":0},
+ {"start":851,"end":1001,"count":1},
+ {"start":920,"end":928,"count":0},
+ {"start":929,"end":965,"count":0}]
+);
+
+TestCoverage(
+"terminal break statement",
+`
+while (true) {                            // 0000
+  const b = false                         // 0050
+  break                                   // 0100
+}                                         // 0150
+let stop = false                          // 0200
+while (true) {                            // 0250
+  if (stop) {                             // 0300
+    break                                 // 0350
+  }                                       // 0400
+  stop = true                             // 0450
+}                                         // 0500
+`,
+[{"start":0,"end":549,"count":1},
+ {"start":263,"end":501,"count":2},
+ {"start":312,"end":501,"count":1}]
+);
+
+TestCoverage(
+"terminal return statement",
+`
+function a () {                           // 0000
+  const b = false                         // 0050
+  return 1                                // 0100
+}                                         // 0150
+const b = (early) => {                    // 0200
+  if (early) {                            // 0250
+    return 2                              // 0300
+  }                                       // 0350
+  return 3                                // 0400
+}                                         // 0450
+const c = () => {                         // 0500
+  if (true) {                             // 0550
+    return                                // 0600
+  }                                       // 0650
+}                                         // 0700
+a(); b(false); b(true); c()               // 0750
+`,
+[{"start":0,"end":799,"count":1},
+ {"start":0,"end":151,"count":1},
+ {"start":210,"end":451,"count":2},
+ {"start":263,"end":450,"count":1},
+ {"start":510,"end":701,"count":1}]
+);
+
+TestCoverage(
+"terminal blocks",
+`
+function a () {                           // 0000
+  {                                       // 0050
+    return 'a'                            // 0100
+  }                                       // 0150
+}                                         // 0200
+function b () {                           // 0250
+  {                                       // 0300
+    {                                     // 0350
+      return 'b'                          // 0400
+    }                                     // 0450
+  }                                       // 0500
+}                                         // 0550
+a(); b()                                  // 0600
+`,
+[{"start":0,"end":649,"count":1},
+ {"start":0,"end":201,"count":1},
+ {"start":250,"end":551,"count":1}]
+);
+
+TestCoverage(
+"terminal if statements",
+`
+function a (branch) {                     // 0000
+  if (branch) {                           // 0050
+    return 'a'                            // 0100
+  } else {                                // 0150
+    return 'b'                            // 0200
+  }                                       // 0250
+}                                         // 0300
+function b (branch) {                     // 0350
+  if (branch) {                           // 0400
+    if (branch) {                         // 0450
+      return 'c'                          // 0500
+    }                                     // 0550
+  }                                       // 0600
+}                                         // 0650
+function c (branch) {                     // 0700
+  if (branch) {                           // 0750
+    return 'c'                            // 0800
+  } else {                                // 0850
+    return 'd'                            // 0900
+  }                                       // 0950
+}                                         // 1000
+function d (branch) {                     // 1050
+  if (branch) {                           // 1100
+    if (!branch) {                        // 1150
+      return 'e'                          // 1200
+    } else {                              // 1250
+      return 'f'                          // 1300
+    }                                     // 1350
+  } else {                                // 1400
+    // noop                               // 1450
+  }                                       // 1500
+}                                         // 1550
+a(true); a(false); b(true); b(false)      // 1600
+c(true); d(true);                         // 1650
+`,
+[{"start":0,"end":1699,"count":1},
+ {"start":0,"end":301,"count":2},
+ {"start":64,"end":253,"count":1},
+ {"start":350,"end":651,"count":2},
+ {"start":414,"end":603,"count":1},
+ {"start":700,"end":1001,"count":1},
+ {"start":853,"end":953,"count":0},
+ {"start":1050,"end":1551,"count":1},
+ {"start":1167,"end":1255,"count":0},
+ {"start":1403,"end":1503,"count":0}]
+);
+
+TestCoverage(
+"https://crbug.com/927464",
+`
+!function f() {                           // 0000
+  function unused() { nop(); }            // 0050
+  nop();                                  // 0100
+}();                                      // 0150
+`,
+[{"start":0,"end":199,"count":1},
+ {"start":1,"end":151,"count":1},
+ {"start":52,"end":80,"count":0}]
+);
+
+TestCoverage(
+"https://crbug.com/v8/8691",
+`
+function f(shouldThrow) {                 // 0000
+  if (shouldThrow) {                      // 0050
+    throw Error('threw')                  // 0100
+  }                                       // 0150
+}                                         // 0200
+try {                                     // 0250
+  f(true)                                 // 0300
+} catch (err) {                           // 0350
+                                          // 0400
+}                                         // 0450
+try {                                     // 0500
+  f(false)                                // 0550
+} catch (err) {}                          // 0600
+`,
+[{"start":0,"end":649,"count":1},
+ {"start":351,"end":352,"count":0},
+ {"start":602,"end":616,"count":0},
+ {"start":0,"end":201,"count":2},
+ {"start":69,"end":153,"count":1}]
 );
 
 %DebugToggleBlockCoverage(false);

--- a/deps/v8/test/mjsunit/code-coverage-block.js
+++ b/deps/v8/test/mjsunit/code-coverage-block.js
@@ -213,7 +213,7 @@ TestCoverage(
     nop();                                // 0100
   }                                       // 0150
 }();                                      // 0200
-%RunMicrotasks();();                      // 0250
+%RunMicrotasks();                         // 0250
 `,
 [{"start":0,"end":299,"count":1},
  {"start":1,"end":201,"count":6},  // TODO(jgruber): Invocation count is off.
@@ -656,7 +656,7 @@ async function f() {                      // 0000
   await 42;                               // 0100
 };                                        // 0150
 f();                                      // 0200
-%RunMicrotasks();();                      // 0250
+%RunMicrotasks();                         // 0250
 `,
 [{"start":0,"end":299,"count":1},
  {"start":0,"end":151,"count":3},

--- a/deps/v8/test/mjsunit/code-coverage-block.js
+++ b/deps/v8/test/mjsunit/code-coverage-block.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Flags: --allow-natives-syntax --no-always-opt --no-stress-flush-bytecode
+// Flags: --allow-natives-syntax --no-always-opt
 // Files: test/mjsunit/code-coverage-utils.js
 
 %DebugToggleBlockCoverage(true);
@@ -213,7 +213,7 @@ TestCoverage(
     nop();                                // 0100
   }                                       // 0150
 }();                                      // 0200
-%PerformMicrotaskCheckpoint();            // 0250
+%RunMicrotasks();();                      // 0250
 `,
 [{"start":0,"end":299,"count":1},
  {"start":1,"end":201,"count":6},  // TODO(jgruber): Invocation count is off.
@@ -656,7 +656,7 @@ async function f() {                      // 0000
   await 42;                               // 0100
 };                                        // 0150
 f();                                      // 0200
-%PerformMicrotaskCheckpoint();            // 0250
+%RunMicrotasks();();                      // 0250
 `,
 [{"start":0,"end":299,"count":1},
  {"start":0,"end":151,"count":3},


### PR DESCRIPTION
Pulls in patches from V8 (https://github.com/v8/v8/commit/52e2b5, https://github.com/v8/v8/commit/512175, https://github.com/v8/v8/commit/aac2f8, https://github.com/v8/v8/commit/9365d09, https://github.com/v8/v8/commit/2d08967)
which address a variety of coverage bugs

This brings coverage in Node v10 to parity with coverage in v11, making coverage more universally consistent for users.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
