### PR TITLE
fs: remove experimental warning for fs.promises

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3699,7 +3699,7 @@ this API: [`fs.write(fd, string...)`][].
 
 ## fs Promises API
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 The `fs.promises` API provides an alternative set of asynchronous file system
 methods that return `Promise` objects rather than using callbacks. The

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1930,7 +1930,7 @@ Object.defineProperties(fs, {
   },
   promises: {
     configurable: true,
-    enumerable: false,
+    enumerable: true,
     get() {
       if (promises === null)
         promises = require('internal/fs/promises');

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1932,11 +1932,8 @@ Object.defineProperties(fs, {
     configurable: true,
     enumerable: false,
     get() {
-      if (promises === null) {
+      if (promises === null)
         promises = require('internal/fs/promises');
-        process.emitWarning('The fs.promises API is experimental',
-                            'ExperimentalWarning');
-      }
       return promises;
     }
   }

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -40,9 +40,8 @@ function nextdir() {
   return `test${++dirc}`;
 }
 
-// fs.promises should not be enumerable as long as it causes a warning to be
-// emitted.
-assert.strictEqual(Object.keys(fs).includes('promises'), false);
+// fs.promises should not enumerable.
+assert.strictEqual(Object.keys(fs).includes('promises'), true);
 
 {
   access(__filename, 'r')


### PR DESCRIPTION
This has been warning for long enough, without any API changes
in the last few months.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
