### PR TITLE
querystring: simplify stringify method

### DIFF
--- a/benchmark/querystring/querystring-stringify.js
+++ b/benchmark/querystring/querystring-stringify.js
@@ -3,8 +3,8 @@ const common = require('../common.js');
 const querystring = require('querystring');
 
 const bench = common.createBenchmark(main, {
-  type: ['noencode', 'encodemany', 'encodelast'],
-  n: [1e7],
+  type: ['noencode', 'encodemany', 'encodelast', 'array'],
+  n: [1e6],
 });
 
 function main({ type, n }) {
@@ -23,6 +23,11 @@ function main({ type, n }) {
       foo: 'bar',
       baz: 'quux',
       xyzzy: 'thu\u00AC'
+    },
+    array: {
+      foo: [],
+      baz: ['bar'],
+      xyzzy: ['bar', 'quux', 'thud']
     }
   };
   const input = inputs[type];

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -176,19 +176,19 @@ function stringify(obj, sep, eq, options) {
 
       if (Array.isArray(v)) {
         var vlen = v.length;
+        if (vlen === 0) continue;
         var vlast = vlen - 1;
         for (var j = 0; j < vlen; ++j) {
           fields += ks + encode(stringifyPrimitive(v[j]));
           if (j < vlast)
             fields += sep;
         }
-        if (vlen && i < flast)
-          fields += sep;
       } else {
         fields += ks + encode(stringifyPrimitive(v));
-        if (i < flast)
-          fields += sep;
       }
+
+      if (i < flast)
+        fields += sep;
     }
     return fields;
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Since there is no obvious improvement in `stringify` method, try to simplify `stringify` method without performance regression.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
