### PR TITLE
process: check no handle or request is active after bootstrap

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -165,7 +165,7 @@ if (isMainThread) {
   setupProcessStdio(getStdout, getStdin, getStderr);
 } else {
   const { getStdout, getStdin, getStderr } =
-    workerThreadSetup.initializeWorkerStdio();
+    workerThreadSetup.createStdioGetters();
   setupProcessStdio(getStdout, getStdin, getStderr);
 }
 

--- a/lib/internal/process/worker_thread_only.js
+++ b/lib/internal/process/worker_thread_only.js
@@ -2,32 +2,25 @@
 
 // This file contains process bootstrappers that can only be
 // run in the worker thread.
-const {
-  getEnvMessagePort
-} = internalBinding('worker');
 
 const {
-  kWaitingStreams,
-  ReadableWorkerStdio,
-  WritableWorkerStdio
+  createWorkerStdio
 } = require('internal/worker/io');
 
 const {
   codes: { ERR_WORKER_UNSUPPORTED_OPERATION }
 } = require('internal/errors');
-const workerStdio = {};
 
-function initializeWorkerStdio() {
-  const port = getEnvMessagePort();
-  port[kWaitingStreams] = 0;
-  workerStdio.stdin = new ReadableWorkerStdio(port, 'stdin');
-  workerStdio.stdout = new WritableWorkerStdio(port, 'stdout');
-  workerStdio.stderr = new WritableWorkerStdio(port, 'stderr');
-
+let workerStdio;
+function lazyWorkerStdio() {
+  if (!workerStdio) workerStdio = createWorkerStdio();
+  return workerStdio;
+}
+function createStdioGetters() {
   return {
-    getStdout() { return workerStdio.stdout; },
-    getStderr() { return workerStdio.stderr; },
-    getStdin() { return workerStdio.stdin; }
+    getStdout() { return lazyWorkerStdio().stdout; },
+    getStderr() { return lazyWorkerStdio().stderr; },
+    getStdin() { return lazyWorkerStdio().stdin; }
   };
 }
 
@@ -55,7 +48,7 @@ function unavailable(name) {
 }
 
 module.exports = {
-  initializeWorkerStdio,
+  createStdioGetters,
   unavailable,
   wrapProcessMethods
 };

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -11,7 +11,10 @@ const {
   moveMessagePortToContext,
   stopMessagePort
 } = internalBinding('messaging');
-const { threadId } = internalBinding('worker');
+const {
+  threadId,
+  getEnvMessagePort
+} = internalBinding('worker');
 
 const { Readable, Writable } = require('stream');
 const EventEmitter = require('events');
@@ -227,6 +230,16 @@ class WritableWorkerStdio extends Writable {
   }
 }
 
+function createWorkerStdio() {
+  const port = getEnvMessagePort();
+  port[kWaitingStreams] = 0;
+  return {
+    stdin: new ReadableWorkerStdio(port, 'stdin'),
+    stdout: new WritableWorkerStdio(port, 'stdout'),
+    stderr: new WritableWorkerStdio(port, 'stderr')
+  };
+}
+
 module.exports = {
   drainMessagePort,
   messageTypes,
@@ -239,5 +252,6 @@ module.exports = {
   MessageChannel,
   setupPortReferencing,
   ReadableWorkerStdio,
-  WritableWorkerStdio
+  WritableWorkerStdio,
+  createWorkerStdio
 };

--- a/src/node.cc
+++ b/src/node.cc
@@ -358,6 +358,17 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
           .IsNothing())
     return MaybeLocal<Value>();
 
+  // Make sure that no request or handle is created during bootstrap -
+  // if necessary those should be done in pre-exeuction.
+  // TODO(joyeecheung): print requests before aborting
+  if (env->event_loop()->active_handles > 0) {
+    PrintLibuvHandleInformation(env->event_loop(), stderr);
+    CHECK_EQ(env->event_loop()->active_handles, 0);
+  }
+  CHECK(env->req_wrap_queue()->IsEmpty());
+  CHECK(env->handle_wrap_queue()->IsEmpty());
+  CHECK_EQ(env->event_loop()->active_reqs.count, 0);
+
   env->set_has_run_bootstrapping_code(true);
 
   return scope.EscapeMaybe(result);

--- a/src/node.cc
+++ b/src/node.cc
@@ -360,14 +360,9 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
 
   // Make sure that no request or handle is created during bootstrap -
   // if necessary those should be done in pre-exeuction.
-  // TODO(joyeecheung): print requests before aborting
-  if (env->event_loop()->active_handles > 0) {
-    PrintLibuvHandleInformation(env->event_loop(), stderr);
-    CHECK_EQ(env->event_loop()->active_handles, 0);
-  }
+  // TODO(joyeecheung): print handles/requests before aborting
   CHECK(env->req_wrap_queue()->IsEmpty());
   CHECK(env->handle_wrap_queue()->IsEmpty());
-  CHECK_EQ(env->event_loop()->active_reqs.count, 0);
 
   env->set_has_run_bootstrapping_code(true);
 

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -50,7 +50,7 @@ class Worker : public AsyncWrap {
 
  private:
   void OnThreadStopped();
-
+  void CreateEnvMessagePort(Environment* env);
   const std::string url_;
 
   std::shared_ptr<PerIsolateOptions> per_isolate_opts_;


### PR DESCRIPTION
#### worker: create per-Environment message port after bootstrap

#### process: check no handle or request is active after bootstrap

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
