### PR TITLE
test: use EC cert property now that it exists

### DIFF
--- a/test/parallel/test-tls-multi-key.js
+++ b/test/parallel/test-tls-multi-key.js
@@ -160,9 +160,7 @@ function test(options) {
         version: 'TLSv1/SSLv3'
       });
       assert.strictEqual(ecdsa.getPeerCertificate().subject.CN, eccCN);
-      // XXX(sam) certs don't currently include EC key info, so depend on
-      // absence of RSA key info to indicate key is EC.
-      assert(!ecdsa.getPeerCertificate().exponent, 'not cert for an RSA key');
+      assert.strictEqual(ecdsa.getPeerCertificate().asn1Curve, 'prime256v1');
       ecdsa.end();
       connectWithRsa();
     }));


### PR DESCRIPTION
Remove XXX, there has been an EC specific cert property since
https://github.com/nodejs/node/pull/24358

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
