### PR TITLE
inspector: patch C++ debug options instead of process._breakFirstLine

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -676,6 +676,14 @@ inline void Environment::set_has_run_bootstrapping_code(bool value) {
   has_run_bootstrapping_code_ = value;
 }
 
+inline bool Environment::has_serialized_options() const {
+  return has_serialized_options_;
+}
+
+inline void Environment::set_has_serialized_options(bool value) {
+  has_serialized_options_ = value;
+}
+
 inline bool Environment::is_main_thread() const {
   return flags_ & kIsMainThread;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -830,6 +830,9 @@ class Environment {
   inline bool has_run_bootstrapping_code() const;
   inline void set_has_run_bootstrapping_code(bool has_run_bootstrapping_code);
 
+  inline bool has_serialized_options() const;
+  inline void set_has_serialized_options(bool has_serialized_options);
+
   static uint64_t AllocateThreadId();
   static constexpr uint64_t kNoThreadId = -1;
 
@@ -1073,6 +1076,8 @@ class Environment {
   std::unordered_map<std::string, uint64_t> performance_marks_;
 
   bool has_run_bootstrapping_code_ = false;
+  bool has_serialized_options_ = false;
+
   bool can_call_into_js_ = true;
   Flags flags_;
   uint64_t thread_id_;

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -728,18 +728,12 @@ bool Agent::Start(const std::string& path,
     return false;
   }
 
-  // TODO(joyeecheung): we should not be using process as a global object
-  // to transport --inspect-brk. Instead, the JS land can get this through
-  // require('internal/options') since it should be set once CLI parsing
-  // is done.
+  // Patch the debug options to implement waitForDebuggerOnStart for
+  // the NodeWorker.enable method.
   if (wait_for_connect) {
-    HandleScope scope(parent_env_->isolate());
-    parent_env_->process_object()->DefineOwnProperty(
-        parent_env_->context(),
-        FIXED_ONE_BYTE_STRING(parent_env_->isolate(), "_breakFirstLine"),
-        True(parent_env_->isolate()),
-        static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontEnum))
-        .FromJust();
+    CHECK(!parent_env_->has_serialized_options());
+    debug_options_.EnableBreakFirstLine();
+    parent_env_->options()->get_debug_options()->EnableBreakFirstLine();
     client_->waitForFrontend();
   }
   return true;

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -569,8 +569,6 @@ void GetOptions(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError(
         "Should not query options before bootstrapping is done");
   }
-  // Only allows serialization once.
-  CHECK(!env->has_serialized_options());
   env->set_has_serialized_options(true);
 
   Isolate* isolate = env->isolate();

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -569,6 +569,9 @@ void GetOptions(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError(
         "Should not query options before bootstrapping is done");
   }
+  // Only allows serialization once.
+  CHECK(!env->has_serialized_options());
+  env->set_has_serialized_options(true);
 
   Isolate* isolate = env->isolate();
   Local<Context> context = env->context();

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -75,6 +75,12 @@ class DebugOptions : public Options {
 
   HostPort host_port{"127.0.0.1", kDefaultInspectorPort};
 
+  // Used to patch the options as if --inspect-brk is passed.
+  void EnableBreakFirstLine() {
+    inspector_enabled = true;
+    break_first_line = true;
+  }
+
   bool wait_for_connect() const {
     return break_first_line || break_node_first_line;
   }


### PR DESCRIPTION
Instead of patching process._breakFirstLine to inform the JS land
to wait for the debugger, check that the JS land has not yet
serialized the options and then patch the debug options from C++.
The changes will be carried into JS later during option serialization.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
