### PR TITLE
doc: add Note of options.stdio into child_process

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -637,7 +637,8 @@ pipes between the parent and child. The value is one of the following:
    occurred).
 6. Positive integer - The integer value is interpreted as a file descriptor
    that is currently open in the parent process. It is shared with the child
-   process, similar to how {Stream} objects can be shared.
+   process, similar to how {Stream} objects can be shared. Passing sockets
+   is not supported on Windows.
 7. `null`, `undefined` - Use default value. For stdio fds 0, 1, and 2 (in other
    words, stdin, stdout, and stderr) a pipe is created. For fd 3 and up, the
    default is `'ignore'`.


### PR DESCRIPTION
add Note of `options.stdio` into child_process.

Ref: https://github.com/nodejs/node/pull/22892#issuecomment-469173273

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
