### PR TITLE
doc fix: align code example for module.createRequireFromPath() with actual code behavior.

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -919,7 +919,7 @@ added: v10.12.0
 
 ```js
 const { createRequireFromPath } = require('module');
-const requireUtil = createRequireFromPath('../src/utils');
+const requireUtil = createRequireFromPath('../src/utils/index.js');
 
 // Require `../src/utils/some-tool`
 requireUtil('./some-tool');


### PR DESCRIPTION
module.createRequireFromPath() takes a filename as argument.
But the accompanying code example in the documentation makes it seem
like it can take a directory argument as well.
However, if a directory is passed as argument instead of a filename,
then the function does not work as expected.

Therefore, the fix is to make explicit in the code example that
only filenames could be passed to module.createRequireFromPath()
and not directory names.

Fixes: https://github.com/nodejs/node/issues/23710
Refs: https://github.com/nodejs/node/pull/24763#discussion_r238051920

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
