### PR TITLE
report: remove unnecessary return in setters

### DIFF
--- a/lib/internal/process/report.js
+++ b/lib/internal/process/report.js
@@ -34,14 +34,14 @@ const report = {
   },
   set directory(dir) {
     validateString(dir, 'directory');
-    return nr.setDirectory(dir);
+    nr.setDirectory(dir);
   },
   get filename() {
     return nr.getFilename();
   },
   set filename(name) {
     validateString(name, 'filename');
-    return nr.setFilename(name);
+    nr.setFilename(name);
   },
   get signal() {
     return nr.getSignal();
@@ -51,7 +51,7 @@ const report = {
     convertToValidSignal(sig); // Validate that the signal is recognized.
     removeSignalHandler();
     addSignalHandler(sig);
-    return nr.setSignal(sig);
+    nr.setSignal(sig);
   },
   get reportOnFatalError() {
     return nr.shouldReportOnFatalError();
@@ -60,7 +60,7 @@ const report = {
     if (typeof trigger !== 'boolean')
       throw new ERR_INVALID_ARG_TYPE('trigger', 'boolean', trigger);
 
-    return nr.setReportOnFatalError(trigger);
+    nr.setReportOnFatalError(trigger);
   },
   get reportOnSignal() {
     return nr.shouldReportOnSignal();
@@ -80,7 +80,7 @@ const report = {
     if (typeof trigger !== 'boolean')
       throw new ERR_INVALID_ARG_TYPE('trigger', 'boolean', trigger);
 
-    return nr.setReportOnUncaughtException(trigger);
+    nr.setReportOnUncaughtException(trigger);
   }
 };
 


### PR DESCRIPTION
Barring shenanigans such as using Object.getOwnPropertyDescriptor(), return values from a setter function will always be inaccessible. Remove
the `return` statements as they can be misleading, suggesting that the
return value is accessible and perhaps used somewhere.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
