### PR TITLE
tools: enable getter-return lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,6 +83,7 @@ module.exports = {
     'func-call-spacing': 'error',
     'func-name-matching': 'error',
     'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
+    'getter-return': 'error',
     'indent': ['error', 2, {
       ArrayExpression: 'first',
       CallExpression: { arguments: 'first' },

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -462,7 +462,7 @@ class Http2ServerResponse extends Stream {
     // This is compatible with http1 which removes socket reference
     // only from ServerResponse but not IncomingMessage
     if (this[kState].closed)
-      return;
+      return undefined;
 
     const stream = this[kStream];
     const proxySocket = stream[kProxySocket];

--- a/lib/net.js
+++ b/lib/net.js
@@ -495,7 +495,7 @@ Object.defineProperty(Socket.prototype, 'readyState', {
 
 
 Object.defineProperty(Socket.prototype, 'bufferSize', {
-  get: function() {
+  get: function() { // eslint-disable-line getter-return
     if (this._handle) {
       return this[kLastWriteQueueSize] + this.writableLength;
     }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -289,11 +289,11 @@ assert.strictEqual(
 // Dynamic properties.
 {
   assert.strictEqual(
-    util.inspect({ get readonly() {} }),
+    util.inspect({ get readonly() { return 1; } }),
     '{ readonly: [Getter] }');
 
   assert.strictEqual(
-    util.inspect({ get readwrite() {}, set readwrite(val) {} }),
+    util.inspect({ get readwrite() { return 1; }, set readwrite(val) {} }),
     '{ readwrite: [Getter/Setter] }');
 
   assert.strictEqual(


### PR DESCRIPTION
We use getters a lot throughout core. I think it makes sense to lint for them returning values.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
