### PR TITLE
test: remove unnecessary semicolon after macro

### DIFF
--- a/test/cctest/test_linked_binding.cc
+++ b/test/cctest/test_linked_binding.cc
@@ -16,7 +16,7 @@ void InitializeBinding(v8::Local<v8::Object> exports,
       .FromJust();
 }
 
-NODE_MODULE_LINKED(cctest_linkedbinding, InitializeBinding);
+NODE_MODULE_LINKED(cctest_linkedbinding, InitializeBinding)
 
 class LinkedBindingTest : public EnvironmentTestFixture {};
 


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
