### PR TITLE
[v11.x] test: fix test by removing node-inspect/lib/_inspect

### DIFF
--- a/test/parallel/test-require-deps-deprecation.js
+++ b/test/parallel/test-require-deps-deprecation.js
@@ -4,7 +4,6 @@ const common = require('../common');
 const assert = require('assert');
 
 const deprecatedModules = [
-  'node-inspect/lib/_inspect',
   'node-inspect/lib/internal/inspect_client',
   'node-inspect/lib/internal/inspect_repl',
   'v8/tools/SourceMap',


### PR DESCRIPTION
If this file is loaded with Node.js build without ssl, it will load
'node-inspect/lib/internal/inspect_client' as well. Due to that two
deprecation warnings will be emitted instead of one and the test
fails.

It should be safe to just test all other cases and to ignore this
specific file.

Fixes: #26480

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
