### PR TITLE
expose Z_STREAM_END

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -504,9 +504,11 @@ function processCallback() {
 
   var availOutAfter = state[0];
   var availInAfter = state[1];
+  var result = state[2];
 
   const inDelta = handle.availInBefore - availInAfter;
   self.bytesWritten += inDelta;
+  self.result = result;
 
   var have = handle.availOutBefore - availOutAfter;
   if (have > 0) {
@@ -545,17 +547,7 @@ function processCallback() {
                self._chunkSize); // out_len
     return;
   }
-
-  if (availInAfter > 0) {
-    // If we have more input that should be written, but we also have output
-    // space available, that means that the compression library was not
-    // interested in receiving more data, and in particular that the input
-    // stream has ended early.
-    // This applies to streams where we don't check data past the end of
-    // what was consumed; that is, everything except Gunzip/Unzip.
-    self.push(null);
-  }
-
+  
   // finished with the chunk.
   this.buffer = null;
   this.cb();
@@ -632,7 +624,7 @@ function Zlib(opts, mode) {
   // Ideally, we could let ZlibBase() set up _writeState. I haven't been able
   // to come up with a good solution that doesn't break our internal API,
   // and with it all supported npm versions at the time of writing.
-  this._writeState = new Uint32Array(2);
+  this._writeState = new Uint32Array(3);
   if (!handle.init(windowBits,
                    level,
                    memLevel,
@@ -790,7 +782,7 @@ function Brotli(opts, mode) {
   const handle = mode === BROTLI_DECODE ?
     new binding.BrotliDecoder(mode) : new binding.BrotliEncoder(mode);
 
-  this._writeState = new Uint32Array(2);
+  this._writeState = new Uint32Array(3);
   if (!handle.init(brotliInitParamsArray,
                    this._writeState,
                    processCallback)) {

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -127,7 +127,7 @@ class ZlibContext : public MemoryRetainer {
   void DoThreadPoolWork();
   void SetBuffers(char* in, uint32_t in_len, char* out, uint32_t out_len);
   void SetFlush(int flush);
-  void GetAfterWriteOffsets(uint32_t* avail_in, uint32_t* avail_out) const;
+  void GetAfterWriteOffsets(uint32_t* ret, uint32_t* avail_in, uint32_t* avail_out) const;
   CompressionError GetErrorInfo() const;
   inline void SetMode(node_zlib_mode mode) { mode_ = mode; }
   CompressionError ResetStream();
@@ -172,7 +172,7 @@ class BrotliContext : public MemoryRetainer {
 
   void SetBuffers(char* in, uint32_t in_len, char* out, uint32_t out_len);
   void SetFlush(int flush);
-  void GetAfterWriteOffsets(uint32_t* avail_in, uint32_t* avail_out) const;
+  void GetAfterWriteOffsets(uint32_t* ret,uint32_t* avail_in, uint32_t* avail_out) const;
   inline void SetMode(node_zlib_mode mode) { mode_ = mode; }
 
  protected:
@@ -359,7 +359,7 @@ class CompressionStream : public AsyncWrap, public ThreadPoolWork {
   }
 
   void UpdateWriteResult() {
-    ctx_.GetAfterWriteOffsets(&write_result_[1], &write_result_[0]);
+    ctx_.GetAfterWriteOffsets(&write_result_[2], &write_result_[1], &write_result_[0]);
   }
 
   // thread pool!
@@ -846,8 +846,10 @@ void ZlibContext::SetFlush(int flush) {
 }
 
 
-void ZlibContext::GetAfterWriteOffsets(uint32_t* avail_in,
+void ZlibContext::GetAfterWriteOffsets(uint32_t* ret,
+                                       uint32_t* avail_in,
                                        uint32_t* avail_out) const {
+  *ret = err_;
   *avail_in = strm_.avail_in;
   *avail_out = strm_.avail_out;
 }
@@ -1063,8 +1065,10 @@ void BrotliContext::SetFlush(int flush) {
 }
 
 
-void BrotliContext::GetAfterWriteOffsets(uint32_t* avail_in,
+void BrotliContext::GetAfterWriteOffsets(uint32_t* ret,
+                                         uint32_t* avail_in,
                                          uint32_t* avail_out) const {
+  *ret = 0;
   *avail_in = avail_in_;
   *avail_out = avail_out_;
 }


### PR DESCRIPTION
Zlib streams self terminate and need a way to report that case. 

I've use the same convention as is used to report the number of decompressed bytes (`bytesWritten`). The number of decompressed bytes cannot be reported via a first class stream abstraction. Similarly, stream self termination cannot be reported via a first class stream abstraction. So I figured it made sense to use the same mechanism to report both out-of-stream-abstraction conditions. Also, kinda makes sense: The state of the write of a chunk of data to inflate includes not only how much was consumed during inflation but also whether the EOF was encountered. 

This feature is necessary for streaming decompression of zip files (say, during download). A zip file is partitioned into headers followed by deflated streams. The headers do not necessarily have to contain the length of the stream. So the zlib inflate stream needs to report the deflated stream's EOF up to the unzip algorithm. That way the unzip algorithm knows when to stop writing bytes to the inflate stream (and then do the accounting to know how many bytes were tossed by the inflate stream and backup to that position in the download stream to look for the next header).

Will do checklist pending discussion on https://github.com/nodejs/node/issues/26603. 

##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
