### PR TITLE
tls: return correct version from getCipher()

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -717,18 +717,25 @@ socket has been destroyed, `null` will be returned.
 ### tlsSocket.getCipher()
 <!-- YAML
 added: v0.11.4
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26625
+    description: Return the minimum cipher version, instead of a fixed string
+      (`'TLSv1/SSLv3'`).
 -->
 
 * Returns: {Object}
+  * `name` {string} The name of the cipher suite.
+  * `version` {string} The minimum TLS protocol version supported by this cipher
+    suite.
 
-Returns an object representing the cipher name. The `version` key is a legacy
-field which always contains the value `'TLSv1/SSLv3'`.
+Returns an object containing information on the negotiated cipher suite.
 
 For example: `{ name: 'AES256-SHA', version: 'TLSv1/SSLv3' }`.
 
-See `SSL_CIPHER_get_name()` in
-<https://www.openssl.org/docs/man1.1.0/ssl/SSL_CIPHER_get_name.html> for more
-information.
+See
+[OpenSSL](https://www.openssl.org/docs/man1.1.1/ssl/SSL_CIPHER_get_name.html)
+for more information.
 
 ### tlsSocket.getEphemeralKeyInfo()
 <!-- YAML

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -734,7 +734,7 @@ Returns an object containing information on the negotiated cipher suite.
 For example: `{ name: 'AES256-SHA', version: 'TLSv1/SSLv3' }`.
 
 See
-[OpenSSL](https://www.openssl.org/docs/man1.1.1/ssl/SSL_CIPHER_get_name.html)
+[OpenSSL](https://www.openssl.org/docs/man1.1.1/man3/SSL_CIPHER_get_name.html)
 for more information.
 
 ### tlsSocket.getEphemeralKeyInfo()

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -737,17 +737,17 @@ function makeSocketMethodProxy(name) {
 }
 
 [
-  'getFinished', 'getPeerFinished', 'getSession', 'isSessionReused',
-  'getEphemeralKeyInfo', 'getProtocol', 'getTLSTicket'
+  'getCipher',
+  'getEphemeralKeyInfo',
+  'getFinished',
+  'getPeerFinished',
+  'getProtocol',
+  'getSession',
+  'getTLSTicket',
+  'isSessionReused',
 ].forEach((method) => {
   TLSSocket.prototype[method] = makeSocketMethodProxy(method);
 });
-
-TLSSocket.prototype.getCipher = function(err) {
-  if (this._handle)
-    return this._handle.getCurrentCipher();
-  return null;
-};
 
 // TODO: support anonymous (nocert) and PSK
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1464,7 +1464,7 @@ void SSLWrap<Base>::AddMethods(Environment* env, Local<FunctionTemplate> t) {
   env->SetProtoMethod(t, "loadSession", LoadSession);
   env->SetProtoMethodNoSideEffect(t, "isSessionReused", IsSessionReused);
   env->SetProtoMethodNoSideEffect(t, "verifyError", VerifyError);
-  env->SetProtoMethodNoSideEffect(t, "getCurrentCipher", GetCurrentCipher);
+  env->SetProtoMethodNoSideEffect(t, "getCipher", GetCipher);
   env->SetProtoMethod(t, "endParser", EndParser);
   env->SetProtoMethod(t, "certCbDone", CertCbDone);
   env->SetProtoMethod(t, "renegotiate", Renegotiate);
@@ -2357,7 +2357,7 @@ void SSLWrap<Base>::VerifyError(const FunctionCallbackInfo<Value>& args) {
 
 
 template <class Base>
-void SSLWrap<Base>::GetCurrentCipher(const FunctionCallbackInfo<Value>& args) {
+void SSLWrap<Base>::GetCipher(const FunctionCallbackInfo<Value>& args) {
   Base* w;
   ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
   Environment* env = w->ssl_env();
@@ -2371,8 +2371,9 @@ void SSLWrap<Base>::GetCurrentCipher(const FunctionCallbackInfo<Value>& args) {
   const char* cipher_name = SSL_CIPHER_get_name(c);
   info->Set(context, env->name_string(),
             OneByteString(args.GetIsolate(), cipher_name)).FromJust();
+  const char* cipher_version = SSL_CIPHER_get_version(c);
   info->Set(context, env->version_string(),
-            OneByteString(args.GetIsolate(), "TLSv1/SSLv3")).FromJust();
+            OneByteString(args.GetIsolate(), cipher_version)).FromJust();
   args.GetReturnValue().Set(info);
 }
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -281,7 +281,7 @@ class SSLWrap {
   static void LoadSession(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void IsSessionReused(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void VerifyError(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void GetCurrentCipher(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetCipher(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void EndParser(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CertCbDone(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Renegotiate(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/parallel/test-tls-multi-key.js
+++ b/test/parallel/test-tls-multi-key.js
@@ -157,7 +157,7 @@ function test(options) {
     }, common.mustCall(function() {
       assert.deepStrictEqual(ecdsa.getCipher(), {
         name: 'ECDHE-ECDSA-AES256-GCM-SHA384',
-        version: 'TLSv1/SSLv3'
+        version: 'TLSv1.2'
       });
       assert.strictEqual(ecdsa.getPeerCertificate().subject.CN, eccCN);
       // XXX(sam) certs don't currently include EC key info, so depend on
@@ -177,7 +177,7 @@ function test(options) {
     }, common.mustCall(function() {
       assert.deepStrictEqual(rsa.getCipher(), {
         name: 'ECDHE-RSA-AES256-GCM-SHA384',
-        version: 'TLSv1/SSLv3'
+        version: 'TLSv1.2'
       });
       assert.strictEqual(rsa.getPeerCertificate().subject.CN, rsaCN);
       assert(rsa.getPeerCertificate().exponent, 'cert for an RSA key');

--- a/test/parallel/test-tls-multi-pfx.js
+++ b/test/parallel/test-tls-multi-pfx.js
@@ -42,9 +42,9 @@ const server = tls.createServer(options, function(conn) {
 process.on('exit', function() {
   assert.deepStrictEqual(ciphers, [{
     name: 'ECDHE-ECDSA-AES256-GCM-SHA384',
-    version: 'TLSv1/SSLv3'
+    version: 'TLSv1.2'
   }, {
     name: 'ECDHE-RSA-AES256-GCM-SHA384',
-    version: 'TLSv1/SSLv3'
+    version: 'TLSv1.2'
   }]);
 });


### PR DESCRIPTION
OpenSSL 1.0.0 returned incorrect version information. OpenSSL 1.1.0
fixed this, but returning the correct information broke our tests, so
was considered semver-major. Because of this, the version was hard-coded
to the OpenSSL 1.0.0 (incorrect) string in 5fe81c8aff03261.

This is ancient history, start returning the correct cipher version.

------

I considered deprecating `version:` for a major cycle, but given its been documented as returning an incorred hard-coded string for ages, I don't think changing its meaning in 12.x is risky.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
