### PR TITLE
src: inline macro DISALLOW_COPY_AND_ASSIGN

### DIFF
--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -112,6 +112,8 @@ class AsyncWrap : public BaseObject {
 
   ~AsyncWrap() override;
 
+  AsyncWrap() = delete;
+
   static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
       Environment* env);
 
@@ -200,7 +202,6 @@ class AsyncWrap : public BaseObject {
             ProviderType provider,
             double execution_async_id,
             bool silent);
-  inline AsyncWrap();
   const ProviderType provider_type_;
   // Because the values may be Reset(), cannot be made const.
   double async_id_ = -1;

--- a/src/env.h
+++ b/src/env.h
@@ -426,6 +426,8 @@ class IsolateData {
 
   std::unordered_map<nghttp2_rcbuf*, v8::Eternal<v8::String>> http2_static_strs;
   inline v8::Isolate* isolate() const;
+  IsolateData(const IsolateData&) = delete;
+  IsolateData& operator=(const IsolateData&) = delete;
 
  private:
 #define VP(PropertyName, StringValue) V(v8::Private, PropertyName)
@@ -448,8 +450,6 @@ class IsolateData {
   const bool uses_node_allocator_;
   MultiIsolatePlatform* platform_;
   std::shared_ptr<PerIsolateOptions> options_;
-
-  DISALLOW_COPY_AND_ASSIGN(IsolateData);
 };
 
 struct ContextInfo {
@@ -534,6 +534,9 @@ class AsyncRequest : public MemoryRetainer {
 
 class Environment {
  public:
+  Environment(const Environment&) = delete;
+  Environment& operator=(const Environment&) = delete;
+
   class AsyncHooks {
    public:
     // Reason for both UidFields and Fields are that one is stored as a double*
@@ -571,6 +574,9 @@ class Environment {
     inline bool pop_async_id(double async_id);
     inline void clear_async_id_stack();  // Used in fatal exceptions.
 
+    AsyncHooks(const AsyncHooks&) = delete;
+    AsyncHooks& operator=(const AsyncHooks&) = delete;
+
     // Used to set the kDefaultTriggerAsyncId in a scope. This is instead of
     // passing the trigger_async_id along with other constructor arguments.
     class DefaultTriggerAsyncIdScope {
@@ -581,11 +587,13 @@ class Environment {
       explicit DefaultTriggerAsyncIdScope(AsyncWrap* async_wrap);
       ~DefaultTriggerAsyncIdScope();
 
+      DefaultTriggerAsyncIdScope(const DefaultTriggerAsyncIdScope&) = delete;
+      DefaultTriggerAsyncIdScope& operator=(const DefaultTriggerAsyncIdScope&) =
+          delete;
+
      private:
       AsyncHooks* async_hooks_;
       double old_default_trigger_async_id_;
-
-      DISALLOW_COPY_AND_ASSIGN(DefaultTriggerAsyncIdScope);
     };
 
 
@@ -603,8 +611,6 @@ class Environment {
     AliasedBuffer<double, v8::Float64Array> async_id_fields_;
 
     void grow_async_ids_stack();
-
-    DISALLOW_COPY_AND_ASSIGN(AsyncHooks);
   };
 
   class AsyncCallbackScope {
@@ -612,11 +618,11 @@ class Environment {
     AsyncCallbackScope() = delete;
     explicit AsyncCallbackScope(Environment* env);
     ~AsyncCallbackScope();
+    AsyncCallbackScope(const AsyncCallbackScope&) = delete;
+    AsyncCallbackScope& operator=(const AsyncCallbackScope&) = delete;
 
    private:
     Environment* env_;
-
-    DISALLOW_COPY_AND_ASSIGN(AsyncCallbackScope);
   };
 
   inline size_t makecallback_depth() const;
@@ -634,6 +640,9 @@ class Environment {
     inline void ref_count_inc(uint32_t increment);
     inline void ref_count_dec(uint32_t decrement);
 
+    ImmediateInfo(const ImmediateInfo&) = delete;
+    ImmediateInfo& operator=(const ImmediateInfo&) = delete;
+
    private:
     friend class Environment;  // So we can call the constructor.
     inline explicit ImmediateInfo(v8::Isolate* isolate);
@@ -646,8 +655,6 @@ class Environment {
     };
 
     AliasedBuffer<uint32_t, v8::Uint32Array> fields_;
-
-    DISALLOW_COPY_AND_ASSIGN(ImmediateInfo);
   };
 
   class TickInfo {
@@ -655,6 +662,9 @@ class Environment {
     inline AliasedBuffer<uint8_t, v8::Uint8Array>& fields();
     inline bool has_tick_scheduled() const;
     inline bool has_rejection_to_warn() const;
+
+    TickInfo(const TickInfo&) = delete;
+    TickInfo& operator=(const TickInfo&) = delete;
 
    private:
     friend class Environment;  // So we can call the constructor.
@@ -667,8 +677,6 @@ class Environment {
     };
 
     AliasedBuffer<uint8_t, v8::Uint8Array> fields_;
-
-    DISALLOW_COPY_AND_ASSIGN(TickInfo);
   };
 
   enum Flags {
@@ -1211,8 +1219,6 @@ class Environment {
 #define V(PropertyName, TypeName) Persistent<TypeName> PropertyName ## _;
   ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)
 #undef V
-
-  DISALLOW_COPY_AND_ASSIGN(Environment);
 };
 
 }  // namespace node

--- a/src/inspector_socket.h
+++ b/src/inspector_socket.h
@@ -41,13 +41,14 @@ class InspectorSocket {
   void SwitchProtocol(ProtocolHandler* handler);
   std::string GetHost();
 
+  InspectorSocket(const InspectorSocket&) = delete;
+  InspectorSocket& operator=(const InspectorSocket&) = delete;
+
  private:
   static void Shutdown(ProtocolHandler*);
   InspectorSocket() = default;
 
   DeleteFnPtr<ProtocolHandler, Shutdown> protocol_handler_;
-
-  DISALLOW_COPY_AND_ASSIGN(InspectorSocket);
 };
 
 

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -80,8 +80,8 @@ class DLib {
 #endif
   bool has_entry_in_global_handle_map_ = false;
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(DLib);
+  DLib(const DLib&) = delete;
+  DLib& operator=(const DLib&) = delete;
 };
 
 // Call _register<module_name> functions for all of

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -87,6 +87,10 @@ class CallbackInfo {
                                   FreeCallback callback,
                                   char* data,
                                   void* hint = nullptr);
+
+  CallbackInfo(const CallbackInfo&) = delete;
+  CallbackInfo& operator=(const CallbackInfo&) = delete;
+
  private:
   static void WeakCallback(const WeakCallbackInfo<CallbackInfo>&);
   inline void WeakCallback(Isolate* isolate);
@@ -99,7 +103,6 @@ class CallbackInfo {
   FreeCallback const callback_;
   char* const data_;
   void* const hint_;
-  DISALLOW_COPY_AND_ASSIGN(CallbackInfo);
 };
 
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -367,6 +367,9 @@ class ByteSource {
 
   static ByteSource FromSymmetricKeyObject(v8::Local<v8::Value> handle);
 
+  ByteSource(const ByteSource&) = delete;
+  ByteSource& operator=(const ByteSource&) = delete;
+
  private:
   const char* data_ = nullptr;
   char* allocated_data_ = nullptr;
@@ -376,8 +379,6 @@ class ByteSource {
 
   static ByteSource Allocated(char* data, size_t size);
   static ByteSource Foreign(const char* data, size_t size);
-
-  DISALLOW_COPY_AND_ASSIGN(ByteSource);
 };
 
 enum PKEncodingType {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -682,8 +682,8 @@ class FSReqWrapSync {
   ~FSReqWrapSync() { uv_fs_req_cleanup(&req); }
   uv_fs_t req;
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(FSReqWrapSync);
+  FSReqWrapSync(const FSReqWrapSync&) = delete;
+  FSReqWrapSync& operator=(const FSReqWrapSync&) = delete;
 };
 
 // Returns nullptr if the operation fails from the start.

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -114,6 +114,9 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
     return static_cast<FSReqBase*>(ReqWrap::from_req(req));
   }
 
+  FSReqBase(const FSReqBase&) = delete;
+  FSReqBase& operator=(const FSReqBase&) = delete;
+
  private:
   enum encoding encoding_ = UTF8;
   bool has_data_ = false;
@@ -123,8 +126,6 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
   // Typically, the content of buffer_ is something like a file name, so
   // something around 64 bytes should be enough.
   FSReqBuffer buffer_;
-
-  DISALLOW_COPY_AND_ASSIGN(FSReqBase);
 };
 
 class FSReqCallback : public FSReqBase {
@@ -144,8 +145,8 @@ class FSReqCallback : public FSReqBase {
   SET_MEMORY_INFO_NAME(FSReqCallback)
   SET_SELF_SIZE(FSReqCallback)
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(FSReqCallback);
+  FSReqCallback(const FSReqCallback&) = delete;
+  FSReqCallback& operator=(const FSReqCallback&) = delete;
 };
 
 // Wordaround a GCC4.9 bug that C++14 N3652 was not implemented

--- a/src/node_mutex.h
+++ b/src/node_mutex.h
@@ -23,6 +23,9 @@ class MutexBase {
   inline void Lock();
   inline void Unlock();
 
+  MutexBase(const MutexBase&) = delete;
+  MutexBase& operator=(const MutexBase&) = delete;
+
   class ScopedLock;
   class ScopedUnlock;
 
@@ -32,11 +35,13 @@ class MutexBase {
     inline explicit ScopedLock(const ScopedUnlock& scoped_unlock);
     inline ~ScopedLock();
 
+    ScopedLock(const ScopedLock&) = delete;
+    ScopedLock& operator=(const ScopedLock&) = delete;
+
    private:
     template <typename> friend class ConditionVariableBase;
     friend class ScopedUnlock;
     const MutexBase& mutex_;
-    DISALLOW_COPY_AND_ASSIGN(ScopedLock);
   };
 
   class ScopedUnlock {
@@ -44,16 +49,17 @@ class MutexBase {
     inline explicit ScopedUnlock(const ScopedLock& scoped_lock);
     inline ~ScopedUnlock();
 
+    ScopedUnlock(const ScopedUnlock&) = delete;
+    ScopedUnlock& operator=(const ScopedUnlock&) = delete;
+
    private:
     friend class ScopedLock;
     const MutexBase& mutex_;
-    DISALLOW_COPY_AND_ASSIGN(ScopedUnlock);
   };
 
  private:
   template <typename> friend class ConditionVariableBase;
   mutable typename Traits::MutexT mutex_;
-  DISALLOW_COPY_AND_ASSIGN(MutexBase);
 };
 
 template <typename Traits>
@@ -67,9 +73,11 @@ class ConditionVariableBase {
   inline void Signal(const ScopedLock&);
   inline void Wait(const ScopedLock& scoped_lock);
 
+  ConditionVariableBase(const ConditionVariableBase&) = delete;
+  ConditionVariableBase& operator=(const ConditionVariableBase&) = delete;
+
  private:
   typename Traits::CondT cond_;
-  DISALLOW_COPY_AND_ASSIGN(ConditionVariableBase);
 };
 
 struct LibuvMutexTraits {

--- a/src/node_union_bytes.h
+++ b/src/node_union_bytes.h
@@ -24,10 +24,14 @@ class NonOwningExternalOneByteResource
   }
   size_t length() const override { return length_; }
 
+  NonOwningExternalOneByteResource(const NonOwningExternalOneByteResource&) =
+      delete;
+  NonOwningExternalOneByteResource& operator=(
+      const NonOwningExternalOneByteResource&) = delete;
+
  private:
   const uint8_t* data_;
   size_t length_;
-  DISALLOW_COPY_AND_ASSIGN(NonOwningExternalOneByteResource);
 };
 
 class NonOwningExternalTwoByteResource
@@ -40,10 +44,14 @@ class NonOwningExternalTwoByteResource
   const uint16_t* data() const override { return data_; }
   size_t length() const override { return length_; }
 
+  NonOwningExternalTwoByteResource(const NonOwningExternalTwoByteResource&) =
+      delete;
+  NonOwningExternalTwoByteResource& operator=(
+      const NonOwningExternalTwoByteResource&) = delete;
+
  private:
   const uint16_t* data_;
   size_t length_;
-  DISALLOW_COPY_AND_ASSIGN(NonOwningExternalTwoByteResource);
 };
 
 // Similar to a v8::String, but it's independent from Isolates

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -145,6 +145,9 @@ class ZlibContext : public MemoryRetainer {
     tracker->TrackField("dictionary", dictionary_);
   }
 
+  ZlibContext(const ZlibContext&) = delete;
+  ZlibContext& operator=(const ZlibContext&) = delete;
+
  private:
   CompressionError ErrorForMessage(const char* message) const;
   CompressionError SetDictionary();
@@ -160,8 +163,6 @@ class ZlibContext : public MemoryRetainer {
   std::vector<unsigned char> dictionary_;
 
   z_stream strm_;
-
-  DISALLOW_COPY_AND_ASSIGN(ZlibContext);
 };
 
 // Brotli has different data types for compression and decompression streams,
@@ -174,6 +175,9 @@ class BrotliContext : public MemoryRetainer {
   void SetFlush(int flush);
   void GetAfterWriteOffsets(uint32_t* avail_in, uint32_t* avail_out) const;
   inline void SetMode(node_zlib_mode mode) { mode_ = mode; }
+
+  BrotliContext(const BrotliContext&) = delete;
+  BrotliContext& operator=(const BrotliContext&) = delete;
 
  protected:
   node_zlib_mode mode_ = NONE;
@@ -188,9 +192,6 @@ class BrotliContext : public MemoryRetainer {
   brotli_alloc_func alloc_ = nullptr;
   brotli_free_func free_ = nullptr;
   void* alloc_opaque_ = nullptr;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(BrotliContext);
 };
 
 class BrotliEncoderContext final : public BrotliContext {

--- a/src/tracing/trace_event_common.h
+++ b/src/tracing/trace_event_common.h
@@ -150,9 +150,11 @@
 //     void AppendAsTraceFormat(std::string* out) const override {
 //       out->append("{\"foo\":1}");
 //     }
+//     MyData(const MyData&) = delete;
+//     MyData& operator=(const MyData&) = delete;
+//
 //    private:
 //     ~MyData() override {}
-//     DISALLOW_COPY_AND_ASSIGN(MyData);
 //   };
 //
 //   TRACE_EVENT1("foo", "bar", "data",

--- a/src/tracing/traced_value.h
+++ b/src/tracing/traced_value.h
@@ -50,6 +50,9 @@ class TracedValue : public v8::ConvertableToTraceFormat {
   // ConvertableToTraceFormat implementation.
   void AppendAsTraceFormat(std::string* out) const override;
 
+  TracedValue(const TracedValue&) = delete;
+  TracedValue& operator=(const TracedValue&) = delete;
+
  private:
   explicit TracedValue(bool root_is_array = false);
 
@@ -59,8 +62,6 @@ class TracedValue : public v8::ConvertableToTraceFormat {
   std::string data_;
   bool first_item_;
   bool root_is_array_;
-
-  DISALLOW_COPY_AND_ASSIGN(TracedValue);
 };
 
 }  // namespace tracing

--- a/src/util.h
+++ b/src/util.h
@@ -97,10 +97,6 @@ struct AssertionInfo {
 [[noreturn]] void Abort();
 void DumpBacktrace(FILE* fp);
 
-#define DISALLOW_COPY_AND_ASSIGN(TypeName)                                    \
-  TypeName(const TypeName&) = delete;                                         \
-  TypeName& operator=(const TypeName&) = delete
-
 // Windows 8+ does not like abort() in Release mode
 #ifdef _WIN32
 #define ABORT_NO_BACKTRACE() _exit(134)
@@ -188,12 +184,14 @@ class ListNode {
   inline void Remove();
   inline bool IsEmpty() const;
 
+  ListNode(const ListNode&) = delete;
+  ListNode& operator=(const ListNode&) = delete;
+
  private:
   template <typename U, ListNode<U> (U::*M)> friend class ListHead;
   friend int GenDebugSymbols();
   ListNode* prev_;
   ListNode* next_;
-  DISALLOW_COPY_AND_ASSIGN(ListNode);
 };
 
 template <typename T, ListNode<T> (T::*M)>
@@ -220,10 +218,12 @@ class ListHead {
   inline Iterator begin() const;
   inline Iterator end() const;
 
+  ListHead(const ListHead&) = delete;
+  ListHead& operator=(const ListHead&) = delete;
+
  private:
   friend int GenDebugSymbols();
   ListNode<T> head_;
-  DISALLOW_COPY_AND_ASSIGN(ListHead);
 };
 
 // The helper is for doing safe downcasts from base types to derived types.

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -149,11 +149,13 @@ class EnvironmentTestFixture : public NodeTestFixture {
       return context_;
     }
 
+    Env(const Env&) = delete;
+    Env& operator=(const Env&) = delete;
+
    private:
     v8::Local<v8::Context> context_;
     node::IsolateData* isolate_data_;
     node::Environment* environment_;
-    DISALLOW_COPY_AND_ASSIGN(Env);
   };
 };
 


### PR DESCRIPTION
This one is similar like https://github.com/nodejs/node/pull/25764, following Effective Modern C++ `Items 11: Prefer deleted functions to private undefined ones`.

This time I tried this on godbolt.
When deleted functions are declared private,
GCC 6.2 error message is not very clear.
GCC 8.x and Clang 7.x error message is clear.
demo: https://godbolt.org/z/k6O9wc.

This commit also add commit `use deleted function instead of private function in class AsyncWrap`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
