### PR TITLE
Revert "crypto: add KeyObject.asymmetricKeySize"

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1121,15 +1121,6 @@ exposes different functions.
 Most applications should consider using the new `KeyObject` API instead of
 passing keys as strings or `Buffer`s due to improved security features.
 
-### keyObject.asymmetricKeySize
-<!-- YAML
-added: REPLACEME
--->
-* {number}
-
-For asymmetric keys, this property represents the size of the embedded key in
-bytes. This property is `undefined` for symmetric keys.
-
 ### keyObject.asymmetricKeyType
 <!-- YAML
 added: v11.6.0

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -73,15 +73,9 @@ class SecretKeyObject extends KeyObject {
   }
 }
 
-const kAsymmetricKeySize = Symbol('kAsymmetricKeySize');
 const kAsymmetricKeyType = Symbol('kAsymmetricKeyType');
 
 class AsymmetricKeyObject extends KeyObject {
-  get asymmetricKeySize() {
-    return this[kAsymmetricKeySize] ||
-           (this[kAsymmetricKeySize] = this[kHandle].getAsymmetricKeySize());
-  }
-
   get asymmetricKeyType() {
     return this[kAsymmetricKeyType] ||
            (this[kAsymmetricKeyType] = this[kHandle].getAsymmetricKeyType());

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3329,8 +3329,6 @@ Local<Function> KeyObject::Initialize(Environment* env, Local<Object> target) {
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   env->SetProtoMethod(t, "init", Init);
-  env->SetProtoMethodNoSideEffect(t, "getAsymmetricKeySize",
-                                  GetAsymmetricKeySize);
   env->SetProtoMethodNoSideEffect(t, "getSymmetricKeySize",
                                   GetSymmetricKeySize);
   env->SetProtoMethodNoSideEffect(t, "getAsymmetricKeyType",
@@ -3374,11 +3372,6 @@ ManagedEVPPKey KeyObject::GetAsymmetricKey() const {
 const char* KeyObject::GetSymmetricKey() const {
   CHECK_EQ(key_type_, kKeyTypeSecret);
   return this->symmetric_key_.get();
-}
-
-size_t KeyObject::GetAsymmetricKeySize() const {
-  CHECK_NE(key_type_, kKeyTypeSecret);
-  return EVP_PKEY_size(this->asymmetric_key_.get());
 }
 
 size_t KeyObject::GetSymmetricKeySize() const {
@@ -3482,12 +3475,6 @@ void KeyObject::GetAsymmetricKeyType(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
 
   args.GetReturnValue().Set(key->GetAsymmetricKeyType());
-}
-
-void KeyObject::GetAsymmetricKeySize(const FunctionCallbackInfo<Value>& args) {
-  KeyObject* key;
-  ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
-  args.GetReturnValue().Set(static_cast<uint32_t>(key->GetAsymmetricKeySize()));
 }
 
 void KeyObject::GetSymmetricKeySize(const FunctionCallbackInfo<Value>& args) {

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -456,7 +456,6 @@ class KeyObject : public BaseObject {
   // only be used to implement cryptograohic operations requiring the key.
   ManagedEVPPKey GetAsymmetricKey() const;
   const char* GetSymmetricKey() const;
-  size_t GetAsymmetricKeySize() const;
   size_t GetSymmetricKeySize() const;
 
  protected:
@@ -470,9 +469,6 @@ class KeyObject : public BaseObject {
   static void GetAsymmetricKeyType(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   v8::Local<v8::String> GetAsymmetricKeyType() const;
-
-  static void GetAsymmetricKeySize(
-      const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static void GetSymmetricKeySize(
       const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -38,7 +38,6 @@ const privatePem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
   const key = createSecretKey(keybuf);
   assert.strictEqual(key.type, 'secret');
   assert.strictEqual(key.symmetricKeySize, 32);
-  assert.strictEqual(key.asymmetricKeySize, undefined);
   assert.strictEqual(key.asymmetricKeyType, undefined);
 
   const exportedKey = key.export();
@@ -92,13 +91,11 @@ const privatePem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
   const publicKey = createPublicKey(publicPem);
   assert.strictEqual(publicKey.type, 'public');
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
-  assert.strictEqual(publicKey.asymmetricKeySize, 128);
   assert.strictEqual(publicKey.symmetricKeySize, undefined);
 
   const privateKey = createPrivateKey(privatePem);
   assert.strictEqual(privateKey.type, 'private');
   assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
-  assert.strictEqual(privateKey.asymmetricKeySize, 128);
   assert.strictEqual(privateKey.symmetricKeySize, undefined);
 
   // It should be possible to derive a public key from a private key.

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -108,12 +108,10 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   assert.strictEqual(typeof publicKey, 'object');
   assert.strictEqual(publicKey.type, 'public');
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
-  assert.strictEqual(publicKey.asymmetricKeySize, 64);
 
   assert.strictEqual(typeof privateKey, 'object');
   assert.strictEqual(privateKey.type, 'private');
   assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
-  assert.strictEqual(publicKey.asymmetricKeySize, 64);
 }
 
 {
@@ -455,7 +453,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     assert.strictEqual(typeof publicKey, 'object');
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
-    assert.strictEqual(publicKey.asymmetricKeySize, 128);
 
     // The private key should still be a string.
     assert.strictEqual(typeof privateKey, 'string');
@@ -480,7 +477,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     assert.strictEqual(typeof privateKey, 'object');
     assert.strictEqual(privateKey.type, 'private');
     assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
-    assert.strictEqual(privateKey.asymmetricKeySize, 128);
 
     testEncryptDecrypt(publicKey, privateKey);
     testSignVerify(publicKey, privateKey);


### PR DESCRIPTION
This reverts commit 4895927a0a4372e0699f84657e0a299393a3d281 (https://github.com/nodejs/node/pull/26387). While a similar API would be useful, I think the API should not have landed as it is, see https://github.com/nodejs/node/issues/26631 and https://github.com/nodejs/node/issues/26631#issuecomment-472499228.

Fixes: https://github.com/nodejs/node/issues/26631

cc @nodejs/crypto

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
