### PR TITLE
stream: fix end-of-stream for silent `.destroy()`

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -13,6 +13,15 @@ function isRequest(stream) {
   return stream.setHeader && typeof stream.abort === 'function';
 }
 
+function isStreamEmittingClose(stream) {
+  if (stream._writableState && !stream._writableState.emitClose)
+    return false;
+  if (stream._readableState && !stream._readableState.emitClose)
+    return false;
+
+  return true;
+}
+
 function eos(stream, opts, callback) {
   if (arguments.length === 2) {
     callback = opts;
@@ -70,6 +79,18 @@ function eos(stream, opts, callback) {
   const onrequest = () => {
     stream.req.on('finish', onfinish);
   };
+
+  const isEmittingClose = isStreamEmittingClose(stream);
+
+  if (!isEmittingClose) {
+    const _destroy = stream._destroy;
+    stream._destroy = function(err, cb) {
+      _destroy.call(stream, err, (_err) => {
+        if (!_err) process.nextTick(() => callback.call(stream, _err));
+        cb(_err);
+      });
+    };
+  }
 
   if (isRequest(stream)) {
     stream.on('complete', onfinish);


### PR DESCRIPTION
Each stream can get `emitClose` option which, when set
in `false` will prevent stream to emit `close` event in
case if `.destroy()` was called without error argument.

If this stream is passed as a last element in streams
aray in `.pipeline()` method it could lead to a problem
because `end-of-stream` won't be able to recognize that
stream has been ended.

For example:
```
const read = new Readable({
  read() {}
});

const write = new Writable({
  emitClose: false,
  write(data, enc, cb) {
    cb();
  }
});

setImmediate(() => read.destroy());

pipeline(read, write, (err) => {
  // this never be called because `write` won't emit 'close'
});
```

This can be fixed by checking if this option is
specified and overriding `_destroy()` method in order
to be aware of this method has been called.

Fixes: https://github.com/nodejs/node/issues/26550

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
