### PR TITLE
doc: add --inspect-brk-node

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -227,6 +227,14 @@ added: v7.6.0
 Activate inspector on `host:port` and break at start of user script.
 Default `host:port` is `127.0.0.1:9229`.
 
+### `--inspect-brk-node[=[host:]port]`
+<!-- YAML
+added: v7.6.0
+-->
+
+Activate inspector on `host:port` and break at start of node script.
+Default `host:port` is `127.0.0.1:9229`.
+
 ### `--inspect-port=[host:]port`
 <!-- YAML
 added: v7.6.0
@@ -710,6 +718,7 @@ Node.js options that are allowed are:
 - `--icu-data-dir`
 - `--inspect`
 - `--inspect-brk`
+- `--inspect-brk-node`
 - `--inspect-port`
 - `--loader`
 - `--max-http-header-size`


### PR DESCRIPTION
added in cli documentation `--inspect-brk-node`.

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
