### PR TITLE
assert: validate required arguments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -211,22 +211,6 @@ module.exports = {
         message: 'Use `new` keyword when throwing an `Error`.',
       },
       {
-        selector: "CallExpression[callee.property.name='notDeepStrictEqual'][arguments.length<2]",
-        message: 'assert.notDeepStrictEqual() must be invoked with at least two arguments.',
-      },
-      {
-        selector: "CallExpression[callee.property.name='deepStrictEqual'][arguments.length<2]",
-        message: 'assert.deepStrictEqual() must be invoked with at least two arguments.',
-      },
-      {
-        selector: "CallExpression[callee.property.name='notStrictEqual'][arguments.length<2]",
-        message: 'assert.notStrictEqual() must be invoked with at least two arguments.',
-      },
-      {
-        selector: "CallExpression[callee.property.name='strictEqual'][arguments.length<2]",
-        message: 'assert.strictEqual() must be invoked with at least two arguments.',
-      },
-      {
         selector: "CallExpression[callee.property.name='notDeepStrictEqual'][arguments.0.type='Literal']:not([arguments.1.type='Literal']):not([arguments.1.type='ObjectExpression']):not([arguments.1.type='ArrayExpression']):not([arguments.1.type='UnaryExpression'])",
         message: 'The first argument should be the `actual`, not the `expected` value.',
       },

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -25,7 +25,8 @@ const { codes: {
   ERR_AMBIGUOUS_ARGUMENT,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
-  ERR_INVALID_RETURN_VALUE
+  ERR_INVALID_RETURN_VALUE,
+  ERR_MISSING_ARGS
 } } = require('internal/errors');
 const AssertionError = require('internal/assert/assertion_error');
 const { openSync, closeSync, readSync } = require('fs');
@@ -351,6 +352,9 @@ assert.ok = ok;
 // The equality assertion tests shallow, coercive equality with ==.
 /* eslint-disable no-restricted-properties */
 assert.equal = function equal(actual, expected, message) {
+  if (arguments.length < 2) {
+    throw new ERR_MISSING_ARGS('actual', 'expected');
+  }
   // eslint-disable-next-line eqeqeq
   if (actual != expected) {
     innerFail({
@@ -366,6 +370,9 @@ assert.equal = function equal(actual, expected, message) {
 // The non-equality assertion tests for whether two objects are not
 // equal with !=.
 assert.notEqual = function notEqual(actual, expected, message) {
+  if (arguments.length < 2) {
+    throw new ERR_MISSING_ARGS('actual', 'expected');
+  }
   // eslint-disable-next-line eqeqeq
   if (actual == expected) {
     innerFail({
@@ -380,6 +387,9 @@ assert.notEqual = function notEqual(actual, expected, message) {
 
 // The equivalence assertion tests a deep equality relation.
 assert.deepEqual = function deepEqual(actual, expected, message) {
+  if (arguments.length < 2) {
+    throw new ERR_MISSING_ARGS('actual', 'expected');
+  }
   if (isDeepEqual === undefined) lazyLoadComparison();
   if (!isDeepEqual(actual, expected)) {
     innerFail({
@@ -394,6 +404,9 @@ assert.deepEqual = function deepEqual(actual, expected, message) {
 
 // The non-equivalence assertion tests for any deep inequality.
 assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
+  if (arguments.length < 2) {
+    throw new ERR_MISSING_ARGS('actual', 'expected');
+  }
   if (isDeepEqual === undefined) lazyLoadComparison();
   if (isDeepEqual(actual, expected)) {
     innerFail({
@@ -408,6 +421,9 @@ assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
 /* eslint-enable */
 
 assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
+  if (arguments.length < 2) {
+    throw new ERR_MISSING_ARGS('actual', 'expected');
+  }
   if (isDeepEqual === undefined) lazyLoadComparison();
   if (!isDeepStrictEqual(actual, expected)) {
     innerFail({
@@ -422,6 +438,9 @@ assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
 
 assert.notDeepStrictEqual = notDeepStrictEqual;
 function notDeepStrictEqual(actual, expected, message) {
+  if (arguments.length < 2) {
+    throw new ERR_MISSING_ARGS('actual', 'expected');
+  }
   if (isDeepEqual === undefined) lazyLoadComparison();
   if (isDeepStrictEqual(actual, expected)) {
     innerFail({
@@ -435,6 +454,9 @@ function notDeepStrictEqual(actual, expected, message) {
 }
 
 assert.strictEqual = function strictEqual(actual, expected, message) {
+  if (arguments.length < 2) {
+    throw new ERR_MISSING_ARGS('actual', 'expected');
+  }
   if (!Object.is(actual, expected)) {
     innerFail({
       actual,
@@ -447,6 +469,9 @@ assert.strictEqual = function strictEqual(actual, expected, message) {
 };
 
 assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
+  if (arguments.length < 2) {
+    throw new ERR_MISSING_ARGS('actual', 'expected');
+  }
   if (Object.is(actual, expected)) {
     innerFail({
       actual,

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -560,7 +560,7 @@ assert.throws(
     '- undefined',
   ].join('\n');
   assert.throws(
-    () => assert.deepEqual([1, 2, 1]),
+    () => assert.deepEqual([1, 2, 1], undefined),
     { message });
 
   message = [
@@ -1147,3 +1147,43 @@ assert.throws(
   }
   assert(threw);
 }
+
+assert.throws(
+  () => a.equal(1),
+  { code: 'ERR_MISSING_ARGS' }
+);
+
+assert.throws(
+  () => a.deepEqual(/a/),
+  { code: 'ERR_MISSING_ARGS' }
+);
+
+assert.throws(
+  () => a.notEqual(null),
+  { code: 'ERR_MISSING_ARGS' }
+);
+
+assert.throws(
+  () => a.notDeepEqual('test'),
+  { code: 'ERR_MISSING_ARGS' }
+);
+
+assert.throws(
+  () => a.strictEqual({}),
+  { code: 'ERR_MISSING_ARGS' }
+);
+
+assert.throws(
+  () => a.deepStrictEqual(Symbol()),
+  { code: 'ERR_MISSING_ARGS' }
+);
+
+assert.throws(
+  () => a.notStrictEqual(5n),
+  { code: 'ERR_MISSING_ARGS' }
+);
+
+assert.throws(
+  () => a.notDeepStrictEqual(undefined),
+  { code: 'ERR_MISSING_ARGS' }
+);

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1187,3 +1187,13 @@ assert.throws(
   () => a.notDeepStrictEqual(undefined),
   { code: 'ERR_MISSING_ARGS' }
 );
+
+assert.throws(
+  () => a.strictEqual(),
+  { code: 'ERR_MISSING_ARGS' }
+);
+
+assert.throws(
+  () => a.deepStrictEqual(),
+  { code: 'ERR_MISSING_ARGS' }
+);


### PR DESCRIPTION
This validates most `assert` functions to verify that the required
arguments are indeed passed to the function.

I defensively marked this as semver-major while I guess it could also be
called a bug fix (if any assertion passed with one argument, that's almost
certainly an error).

So if people are fine with this being a patch instead, I am happy to remove the label.

// cc @nodejs/linting @nodejs/assert 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
