### PR TITLE
repl: add autocomplete for filesystem modules

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1115,7 +1115,30 @@ function complete(line, callback) {
     }
 
     completionGroupsLoaded();
+  } else if (match = line.match(/fs\.\s*[a-z][a-zA-Z]+\(\s*["'](.*)/)) {
 
+    let filePath = match[1];
+    let fileList;
+    filter = '';
+
+    try {
+      fileList = fs.readdirSync(filePath, { withFileTypes: true });
+      completionGroups.push(fileList.map((dirent) => dirent.name));
+      completeOn = '';
+    } catch {
+      try {
+        const baseName = path.basename(filePath);
+        filePath = path.dirname(filePath);
+        fileList = fs.readdirSync(filePath, { withFileTypes: true });
+        const filteredValue = fileList.filter((d) =>
+          d.name.startsWith(baseName))
+          .map((d) => d.name);
+        completionGroups.push(filteredValue);
+        completeOn = filePath;
+      } catch {}
+    }
+
+    completionGroupsLoaded();
   // Handle variable member lookup.
   // We support simple chained expressions like the following (no function
   // calls, etc.). That is for simplicity and also because we *eval* that

--- a/test/fixtures/test-repl-tab-completion/.hiddenfiles
+++ b/test/fixtures/test-repl-tab-completion/.hiddenfiles
@@ -1,0 +1,1 @@
+This is hidden

--- a/test/fixtures/test-repl-tab-completion/hellorandom.txt
+++ b/test/fixtures/test-repl-tab-completion/hellorandom.txt
@@ -1,0 +1,1 @@
+Random txt

--- a/test/fixtures/test-repl-tab-completion/helloworld.js
+++ b/test/fixtures/test-repl-tab-completion/helloworld.js
@@ -1,0 +1,1 @@
+console.log("hello world");

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -397,6 +397,45 @@ testMe.complete('obj.', common.mustCall((error, data) => {
   assert(data[0].includes('obj.key'));
 }));
 
+// Tab completion for files/directories
+{
+  putIn.run(['.clear']);
+  process.chdir(__dirname);
+
+  const readFileSync = 'fs.readFileSync("';
+  const fixturePath = `${readFileSync}../fixtures/test-repl-tab-completion`;
+  if (!common.isWindows) {
+    testMe.complete(fixturePath, common.mustCall((err, data) => {
+      assert.strictEqual(err, null);
+      assert.ok(data[0][0].includes('.hiddenfiles'));
+      assert.ok(data[0][1].includes('hellorandom.txt'));
+      assert.ok(data[0][2].includes('helloworld.js'));
+    }));
+
+    testMe.complete(`${fixturePath}/hello`,
+                    common.mustCall((err, data) => {
+                      assert.strictEqual(err, null);
+                      assert.ok(data[0][0].includes('hellorandom.txt'));
+                      assert.ok(data[0][1].includes('helloworld.js'));
+                    })
+    );
+
+    testMe.complete(`${fixturePath}/.h`,
+                    common.mustCall((err, data) => {
+                      assert.strictEqual(err, null);
+                      assert.ok(data[0][0].includes('.hiddenfiles'));
+                    })
+    );
+
+    testMe.complete(`${readFileSync}./xxxRandom/random`,
+                    common.mustCall((err, data) => {
+                      assert.strictEqual(err, null);
+                      assert.strictEqual(data[0].length, 0);
+                    })
+    );
+  }
+}
+
 [
   Array,
   Buffer,


### PR DESCRIPTION
This is a implementation of: https://github.com/nodejs/node/issues/17764

~~There are other few things to be done like handling autocompletion for filenames etc.~~
~~Marking it as WIP. But would love to get feedback from @nodejs/repl~~ 