### PR TITLE
[v11.x] backport warning handler refactoring

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -115,12 +115,9 @@ if (isMainThread) {
 }
 
 const {
-  onWarning,
   emitWarning
 } = NativeModule.require('internal/process/warning');
-if (!process.noProcessWarnings && process.env.NODE_NO_WARNINGS !== '1') {
-  process.on('warning', onWarning);
-}
+
 process.emitWarning = emitWarning;
 
 const {

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -303,29 +303,6 @@ Object.defineProperty(process, 'features', {
     hasUncaughtExceptionCaptureCallback;
 }
 
-// User-facing NODE_V8_COVERAGE environment variable that writes
-// ScriptCoverage to a specified file.
-if (process.env.NODE_V8_COVERAGE) {
-  const originalReallyExit = process.reallyExit;
-  const cwd = NativeModule.require('internal/process/execution').tryGetCwd();
-  const { resolve } = NativeModule.require('path');
-  // Resolve the coverage directory to an absolute path, and
-  // overwrite process.env so that the original path gets passed
-  // to child processes even when they switch cwd.
-  const coverageDirectory = resolve(cwd, process.env.NODE_V8_COVERAGE);
-  process.env.NODE_V8_COVERAGE = coverageDirectory;
-  const {
-    writeCoverage,
-    setCoverageDirectory
-  } = NativeModule.require('internal/coverage-gen/with_profiler');
-  setCoverageDirectory(coverageDirectory);
-  process.on('exit', writeCoverage);
-  process.reallyExit = (code) => {
-    writeCoverage();
-    originalReallyExit(code);
-  };
-}
-
 function setupProcessObject() {
   const EventEmitter = NativeModule.require('events');
   const origProcProto = Object.getPrototypeOf(process);

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -222,20 +222,6 @@ Object.defineProperty(process, 'argv0', {
 });
 process.argv[0] = process.execPath;
 
-// Handle `--debug*` deprecation and invalidation.
-if (process._invalidDebug) {
-  process.emitWarning(
-    '`node --debug` and `node --debug-brk` are invalid. ' +
-      'Please use `node --inspect` or `node --inspect-brk` instead.',
-    'DeprecationWarning', 'DEP0062', undefined, true);
-  process.exit(9);
-} else if (process._deprecatedDebugBrk) {
-  process.emitWarning(
-    '`node --inspect --debug-brk` is deprecated. ' +
-      'Please use `node --inspect-brk` instead.',
-    'DeprecationWarning', 'DEP0062', undefined, true);
-}
-
 // TODO(jasnell): The following have been globals since around 2012.
 // That's just silly. The underlying perfctr support has been removed
 // so these are now deprecated non-ops that can be removed after one

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -106,6 +106,23 @@ function initializeDeprecations() {
   const { deprecate } = require('internal/util');
   const pendingDeprecation = getOptionValue('--pending-deprecation');
 
+  // Handle `--debug*` deprecation and invalidation.
+  if (getOptionValue('--debug')) {
+    if (!getOptionValue('--inspect')) {
+      process.emitWarning(
+        '`node --debug` and `node --debug-brk` are invalid. ' +
+          'Please use `node --inspect` or `node --inspect-brk` instead.',
+        'DeprecationWarning', 'DEP0062', undefined, true);
+      process.exit(9);
+    } else if (getOptionValue('--inspect-brk')) {
+      process._deprecatedDebugBrk = true;
+      process.emitWarning(
+        '`node --inspect --debug-brk` is deprecated. ' +
+          'Please use `node --inspect-brk` instead.',
+        'DeprecationWarning', 'DEP0062', undefined, true);
+    }
+  }
+
   // DEP0103: access to `process.binding('util').isX` type checkers
   // TODO(addaleax): Turn into a full runtime deprecation.
   const utilBinding = internalBinding('util');

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -10,6 +10,14 @@ function prepareMainThreadExecution() {
 
   setupWarningHandler();
 
+  // Resolve the coverage directory to an absolute path, and
+  // overwrite process.env so that the original path gets passed
+  // to child processes even when they switch cwd.
+  if (process.env.NODE_V8_COVERAGE) {
+    process.env.NODE_V8_COVERAGE =
+      setupCoverageHooks(process.env.NODE_V8_COVERAGE);
+  }
+
   // Only main thread receives signals.
   setupSignalHandlers();
 
@@ -45,6 +53,26 @@ function setupWarningHandler() {
   if (!process.noProcessWarnings && process.env.NODE_NO_WARNINGS !== '1') {
     process.on('warning', onWarning);
   }
+}
+
+// Setup User-facing NODE_V8_COVERAGE environment variable that writes
+// ScriptCoverage to a specified file.
+function setupCoverageHooks(dir) {
+  const originalReallyExit = process.reallyExit;
+  const cwd = require('internal/process/execution').tryGetCwd();
+  const { resolve } = require('path');
+  const coverageDirectory = resolve(cwd, dir);
+  const {
+    writeCoverage,
+    setCoverageDirectory
+  } = require('internal/coverage-gen/with_profiler');
+  setCoverageDirectory(coverageDirectory);
+  process.on('exit', writeCoverage);
+  process.reallyExit = (code) => {
+    writeCoverage();
+    originalReallyExit(code);
+  };
+  return coverageDirectory;
 }
 
 function initializeReport() {
@@ -279,6 +307,7 @@ function loadPreloadModules() {
 }
 
 module.exports = {
+  setupCoverageHooks,
   setupWarningHandler,
   prepareMainThreadExecution,
   initializeDeprecations,

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -8,6 +8,8 @@ let traceEventsAsyncHook;
 function prepareMainThreadExecution() {
   setupTraceCategoryState();
 
+  setupWarningHandler();
+
   // Only main thread receives signals.
   setupSignalHandlers();
 
@@ -34,6 +36,15 @@ function prepareMainThreadExecution() {
   initializeFrozenIntrinsics();
   initializeESMLoader();
   loadPreloadModules();
+}
+
+function setupWarningHandler() {
+  const {
+    onWarning
+  } = require('internal/process/warning');
+  if (!process.noProcessWarnings && process.env.NODE_NO_WARNINGS !== '1') {
+    process.on('warning', onWarning);
+  }
 }
 
 function initializeReport() {
@@ -268,6 +279,7 @@ function loadPreloadModules() {
 }
 
 module.exports = {
+  setupWarningHandler,
   prepareMainThreadExecution,
   initializeDeprecations,
   initializeESMLoader,

--- a/lib/internal/main/inspect.js
+++ b/lib/internal/main/inspect.js
@@ -2,6 +2,12 @@
 
 // `node inspect ...` or `node debug ...`
 
+const {
+  prepareMainThreadExecution
+} = require('internal/bootstrap/pre_execution');
+
+prepareMainThreadExecution();
+
 if (process.argv[1] === 'debug') {
   process.emitWarning(
     '`node debug` is deprecated. Please use `node inspect` instead.',

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -4,6 +4,7 @@
 // message port.
 
 const {
+  setupWarningHandler,
   initializeDeprecations,
   initializeESMLoader,
   initializeFrozenIntrinsics,
@@ -38,6 +39,8 @@ const {
 
 const publicWorker = require('worker_threads');
 const debug = require('util').debuglog('worker');
+
+setupWarningHandler();
 
 debug(`[${threadId}] is setting up worker child environment`);
 

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -4,6 +4,7 @@
 // message port.
 
 const {
+  setupCoverageHooks,
   setupWarningHandler,
   initializeDeprecations,
   initializeESMLoader,
@@ -41,6 +42,12 @@ const publicWorker = require('worker_threads');
 const debug = require('util').debuglog('worker');
 
 setupWarningHandler();
+
+// Since worker threads cannot switch cwd, we do not need to
+// overwrite the process.env.NODE_V8_COVERAGE variable.
+if (process.env.NODE_V8_COVERAGE) {
+  setupCoverageHooks(process.env.NODE_V8_COVERAGE);
+}
 
 debug(`[${threadId}] is setting up worker child environment`);
 

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -256,18 +256,6 @@ MaybeLocal<Object> CreateProcessObject(
                                 "_breakNodeFirstLine", True(env->isolate()));
   }
 
-  // --inspect --debug-brk
-  if (env->options()->debug_options().deprecated_invocation()) {
-    READONLY_DONT_ENUM_PROPERTY(process,
-                                "_deprecatedDebugBrk", True(env->isolate()));
-  }
-
-  // --debug or, --debug-brk without --inspect
-  if (env->options()->debug_options().invalid_invocation()) {
-    READONLY_DONT_ENUM_PROPERTY(process,
-                                "_invalidDebug", True(env->isolate()));
-  }
-
   // --security-revert flags
 #define V(code, _, __)                                                        \
   do {                                                                        \


### PR DESCRIPTION
#### process: handle node --debug deprecation in pre-execution

In addition, shim `process._deprecatedDebugBrk` in pre-execution.
This is a non-semver-major v11.x backport for
https://github.com/nodejs/node/pull/25828.

Refs: https://github.com/nodejs/node/pull/25828

#### process: call `prepareMainThreadExecution` in `node inspect`

Since we should treat the node-inspect as third-party
user code.

PR-URL: https://github.com/nodejs/node/pull/26466
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>

#### process: set up process warning handler in pre-execution

Since it depends on environment variables.

PR-URL: https://github.com/nodejs/node/pull/26466
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>

#### process: handle process.env.NODE_V8_COVERAGE in pre-execution

Since this depends on environment variable, and the worker threads
do not need to persist the variable value because they cannot
switch cwd.

PR-URL: https://github.com/nodejs/node/pull/26466
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
