### PR TITLE
timers: fix refreshed timers exiting too early

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -76,6 +76,7 @@ function Timeout(callback, after, args, isRepeat) {
   this._timerArgs = args;
   this._repeat = isRepeat ? after : null;
   this._destroyed = false;
+  this._refreshed = false;
 
   this[kRefed] = null;
 
@@ -98,7 +99,7 @@ Timeout.prototype.refresh = function() {
     getTimers().active(this);
   else
     getTimers()._unrefActive(this);
-
+  this._refreshed = true;
   return this;
 };
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -342,8 +342,9 @@ function listOnTimeout(list, now) {
           start = getLibuvNow();
         insert(timer, timer[kRefed], start);
       } else {
-        if (timer[kRefed])
+        if (timer[kRefed] && !timer._refreshed)
           refCount--;
+        timer._refreshed = false;
         timer[kRefed] = null;
 
         if (destroyHooksExist() && !timer._destroyed) {

--- a/test/parallel/test-timers-refresh.js
+++ b/test/parallel/test-timers-refresh.js
@@ -87,3 +87,15 @@ const { setUnrefTimeout } = require('internal/timers');
 
   strictEqual(timer.refresh(), timer);
 }
+
+// refresh timeout in callback
+{
+  let called = 0;
+  const timer = setTimeout(common.mustCall(() => {
+    called += 1;
+    if (called === 2) {
+      clearTimeout(timer);
+    }
+    timer.refresh();
+  }, 2), 1);
+}


### PR DESCRIPTION
If a timer is refreshed in its callback, we should not decrease `refCount` to prevent exiting event loop ahead of time.

Fixes: https://github.com/nodejs/node/issues/26642

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
