### PR TITLE
lib: use Object spread instead of Object.assign

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -98,7 +98,7 @@ function ClientRequest(input, options, cb) {
     cb = options;
     options = input || {};
   } else {
-    options = Object.assign(input || {}, options);
+    options = { ...input, ...options };
   }
 
   var agent = options.agent;

--- a/lib/https.js
+++ b/lib/https.js
@@ -295,7 +295,7 @@ function request(...args) {
   }
 
   if (args[0] && typeof args[0] !== 'function') {
-    Object.assign(options, args.shift());
+    options = { ...options, ...args.shift() };
   }
 
   options._defaultAgent = module.exports.globalAgent;

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -117,7 +117,7 @@ function onStreamData(chunk) {
 function onStreamTrailers(trailers, flags, rawTrailers) {
   const request = this[kRequest];
   if (request !== undefined) {
-    Object.assign(request[kTrailers], trailers);
+    request[kTrailers] = { ...request[kTrailers], ...trailers };
     request[kRawTrailers].push(...rawTrailers);
   }
 }


### PR DESCRIPTION
To optimize performance, use Object spread instead of `Object.assign`
### Performance comparison chart
![performance](https://user-images.githubusercontent.com/5035902/54408698-282edd00-4726-11e9-952f-7f34a8dc5a9b.jpg)
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
