### PR TITLE
lib: run prepareMainThreadExecution for third_party_main

### DIFF
--- a/lib/internal/main/run_third_party_main.js
+++ b/lib/internal/main/run_third_party_main.js
@@ -1,9 +1,13 @@
 'use strict';
 
-// Legacy _third_party_main.js support
+const {
+  prepareMainThreadExecution
+} = require('internal/bootstrap/pre_execution');
 
+prepareMainThreadExecution();
 markBootstrapComplete();
 
+// Legacy _third_party_main.js support
 process.nextTick(() => {
   require('_third_party_main');
 });


### PR DESCRIPTION
Treat `_third_party_main` like any other CJS entry point, as it
was done before 6967f91368cbb9cad3877ee59874cc83ccef4653.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
