### PR TITLE
doc: update spawnSync() status value possibilities

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -868,7 +868,8 @@ changes:
   * `output` {Array} Array of results from stdio output.
   * `stdout` {Buffer|string} The contents of `output[1]`.
   * `stderr` {Buffer|string} The contents of `output[2]`.
-  * `status` {number} The exit code of the child process.
+  * `status` {number|null} The exit code of the subprocess, or `null` if the
+    child process exited due to a signal.
   * `signal` {string} The signal used to kill the child process.
   * `error` {Error} The error object if the child process failed or timed out.
 

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -871,7 +871,7 @@ changes:
   * `status` {number|null} The exit code of the subprocess, or `null` if the
     subprocess terminated due to a signal.
   * `signal` {string|null} The signal used to kill the subprocess, or `null` if
-    the subprocess did not end due to a signal.
+    the subprocess did not terminate due to a signal.
   * `error` {Error} The error object if the child process failed or timed out.
 
 The `child_process.spawnSync()` method is generally identical to

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -869,8 +869,9 @@ changes:
   * `stdout` {Buffer|string} The contents of `output[1]`.
   * `stderr` {Buffer|string} The contents of `output[2]`.
   * `status` {number|null} The exit code of the subprocess, or `null` if the
-    child process exited due to a signal.
-  * `signal` {string} The signal used to kill the child process.
+    subprocess ended due to a signal.
+  * `signal` {string|null} The signal used to kill the subprocess, or `null` if
+    the subprocess did not end due to a signal.
   * `error` {Error} The error object if the child process failed or timed out.
 
 The `child_process.spawnSync()` method is generally identical to

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -869,7 +869,7 @@ changes:
   * `stdout` {Buffer|string} The contents of `output[1]`.
   * `stderr` {Buffer|string} The contents of `output[2]`.
   * `status` {number|null} The exit code of the subprocess, or `null` if the
-    subprocess ended due to a signal.
+    subprocess terminated due to a signal.
   * `signal` {string|null} The signal used to kill the subprocess, or `null` if
     the subprocess did not end due to a signal.
   * `error` {Error} The error object if the child process failed or timed out.


### PR DESCRIPTION
The object returned by `child_process.spawnSync()` can have the `status`
property set to `null` if the process terminated due to a signal. We
even test for this in
test/parallel/test-child-process-spawnsync-kill-signal.js.

Update the documentation to reflect this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
