### PR TITLE
src: fix warning in node_messaging

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -30,7 +30,7 @@ using v8::String;
 using v8::Value;
 using v8::ValueDeserializer;
 using v8::ValueSerializer;
-using v8::WasmCompiledModule;
+using v8::WasmModuleObject;
 
 namespace node {
 namespace worker {
@@ -49,7 +49,7 @@ class DeserializerDelegate : public ValueDeserializer::Delegate {
       Environment* env,
       const std::vector<MessagePort*>& message_ports,
       const std::vector<Local<SharedArrayBuffer>>& shared_array_buffers,
-      const std::vector<WasmCompiledModule::TransferrableModule>& wasm_modules)
+      const std::vector<WasmModuleObject::TransferrableModule>& wasm_modules)
       : message_ports_(message_ports),
         shared_array_buffers_(shared_array_buffers),
         wasm_modules_(wasm_modules) {}
@@ -70,10 +70,10 @@ class DeserializerDelegate : public ValueDeserializer::Delegate {
     return shared_array_buffers_[clone_id];
   }
 
-  MaybeLocal<WasmCompiledModule> GetWasmModuleFromId(
+  MaybeLocal<WasmModuleObject> GetWasmModuleFromId(
       Isolate* isolate, uint32_t transfer_id) override {
     CHECK_LE(transfer_id, wasm_modules_.size());
-    return WasmCompiledModule::FromTransferrableModule(
+    return WasmModuleObject::FromTransferrableModule(
         isolate, wasm_modules_[transfer_id]);
   }
 
@@ -82,7 +82,7 @@ class DeserializerDelegate : public ValueDeserializer::Delegate {
  private:
   const std::vector<MessagePort*>& message_ports_;
   const std::vector<Local<SharedArrayBuffer>>& shared_array_buffers_;
-  const std::vector<WasmCompiledModule::TransferrableModule>& wasm_modules_;
+  const std::vector<WasmModuleObject::TransferrableModule>& wasm_modules_;
 };
 
 }  // anonymous namespace
@@ -170,7 +170,7 @@ void Message::AddMessagePort(std::unique_ptr<MessagePortData>&& data) {
   message_ports_.emplace_back(std::move(data));
 }
 
-uint32_t Message::AddWASMModule(WasmCompiledModule::TransferrableModule&& mod) {
+uint32_t Message::AddWASMModule(WasmModuleObject::TransferrableModule&& mod) {
   wasm_modules_.emplace_back(std::move(mod));
   return wasm_modules_.size() - 1;
 }
@@ -235,7 +235,7 @@ class SerializerDelegate : public ValueSerializer::Delegate {
   }
 
   Maybe<uint32_t> GetWasmModuleTransferId(
-      Isolate* isolate, Local<WasmCompiledModule> module) override {
+      Isolate* isolate, Local<WasmModuleObject> module) override {
     return Just(msg_->AddWASMModule(module->GetTransferrableModule()));
   }
 
@@ -302,7 +302,7 @@ Maybe<bool> Message::Serialize(Environment* env,
         Local<ArrayBuffer> ab = entry.As<ArrayBuffer>();
         // If we cannot render the ArrayBuffer unusable in this Isolate and
         // take ownership of its memory, copying the buffer will have to do.
-        if (!ab->IsNeuterable() || ab->IsExternal() ||
+        if (!ab->IsDetachable() || ab->IsExternal() ||
             !env->isolate_data()->uses_node_allocator()) {
           continue;
         }
@@ -368,7 +368,7 @@ Maybe<bool> Message::Serialize(Environment* env,
     // (a.k.a. externalize) the underlying memory region and render
     // it inaccessible in this Isolate.
     ArrayBuffer::Contents contents = ab->Externalize();
-    ab->Neuter();
+    ab->Detach();
 
     CHECK(env->isolate_data()->uses_node_allocator());
     env->isolate_data()->node_allocator()->UnregisterPointer(

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -49,7 +49,7 @@ class Message : public MemoryRetainer {
   void AddMessagePort(std::unique_ptr<MessagePortData>&& data);
   // Internal method of Message that is called when a new WebAssembly.Module
   // object is encountered in the incoming value's structure.
-  uint32_t AddWASMModule(v8::WasmCompiledModule::TransferrableModule&& mod);
+  uint32_t AddWASMModule(v8::WasmModuleObject::TransferrableModule&& mod);
 
   // The MessagePorts that will be transferred, as recorded by Serialize().
   // Used for warning user about posting the target MessagePort to itself,
@@ -68,7 +68,7 @@ class Message : public MemoryRetainer {
   std::vector<MallocedBuffer<char>> array_buffer_contents_;
   std::vector<SharedArrayBufferMetadataReference> shared_array_buffers_;
   std::vector<std::unique_ptr<MessagePortData>> message_ports_;
-  std::vector<v8::WasmCompiledModule::TransferrableModule> wasm_modules_;
+  std::vector<v8::WasmModuleObject::TransferrableModule> wasm_modules_;
 
   friend class MessagePort;
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Got some warning when building `Node.js` from newest master.

So fixed by:
- Use `WasmModuleObject` instead of `WasmCompiledModule`.
- Use `IsDetachable()` instead of `IsNeuterable`.
- Use `Detach()` instead of `Neuter`.

```sh
In file included from /Users/zyszys/Projects/node/out/Release/obj/gen/node_javascript.cc:3:
In file included from ../src/node_internals.h:27:
In file included from ../src/env-inl.h:35:
In file included from ../src/node_worker.h:7:
../src/node_messaging.h:52:48: warning: 'WasmCompiledModule' is deprecated: Use WasmModuleObject [-Wdeprecated-declarations]
  uint32_t AddWASMModule(v8::WasmCompiledModule::TransferrableModule&& mod);
                                               ^
../deps/v8/include/v8.h:4444:1: note: 'WasmCompiledModule' has been explicitly marked deprecated here
V8_DEPRECATED("Use WasmModuleObject",
^
../deps/v8/include/v8config.h:307:29: note: expanded from macro 'V8_DEPRECATED'
  declarator __attribute__((deprecated(message)))
                            ^
In file included from /Users/zyszys/Projects/node/out/Release/obj/gen/node_javascript.cc:3:
In file included from ../src/node_internals.h:27:
In file included from ../src/env-inl.h:35:
In file included from ../src/node_worker.h:7:
../src/node_messaging.h:71:37: warning: 'WasmCompiledModule' is deprecated: Use WasmModuleObject [-Wdeprecated-declarations]
  std::vector<v8::WasmCompiledModule::TransferrableModule> wasm_modules_;
                                    ^
../deps/v8/include/v8.h:4444:1: note: 'WasmCompiledModule' has been explicitly marked deprecated here
V8_DEPRECATED("Use WasmModuleObject",
^
../deps/v8/include/v8config.h:307:29: note: expanded from macro 'V8_DEPRECATED'
  declarator __attribute__((deprecated(message)))
                            ^
2 warnings generated.
```

```sh
../src/node_messaging.cc:73:14: warning: 'WasmCompiledModule' is deprecated: Use
      WasmModuleObject [-Wdeprecated-declarations]
  MaybeLocal<WasmCompiledModule> GetWasmModuleFromId(
             ^
../deps/v8/include/v8.h:4444:1: note: 'WasmCompiledModule' has been explicitly marked
      deprecated here
V8_DEPRECATED("Use WasmModuleObject",
^
../deps/v8/include/v8config.h:307:29: note: expanded from macro 'V8_DEPRECATED'
  declarator __attribute__((deprecated(message)))
                            ^
../src/node_messaging.cc:238:31: warning: 'WasmCompiledModule' is deprecated: Use
      WasmModuleObject [-Wdeprecated-declarations]
      Isolate* isolate, Local<WasmCompiledModule> module) override {
                              ^
../deps/v8/include/v8.h:4444:1: note: 'WasmCompiledModule' has been explicitly marked
      deprecated here
V8_DEPRECATED("Use WasmModuleObject",
^
../deps/v8/include/v8config.h:307:29: note: expanded from macro 'V8_DEPRECATED'
  declarator __attribute__((deprecated(message)))
                            ^
../src/node_messaging.cc:305:18: warning: 'IsNeuterable' is deprecated: Use
      IsDetachable() instead. [-Wdeprecated-declarations]
        if (!ab->IsNeuterable() || ab->IsExternal() ||
                 ^
../deps/v8/include/v8.h:4723:3: note: 'IsNeuterable' has been explicitly marked
      deprecated here
  V8_DEPRECATE_SOON("Use IsDetachable() instead.",
  ^
../deps/v8/include/v8config.h:322:29: note: expanded from macro 'V8_DEPRECATE_SOON'
  declarator __attribute__((deprecated(message)))
                            ^
../src/node_messaging.cc:371:9: warning: 'Neuter' is deprecated: Use Detach() instead.
      [-Wdeprecated-declarations]
    ab->Neuter();
        ^
../deps/v8/include/v8.h:4737:3: note: 'Neuter' has been explicitly marked deprecated
      here
  V8_DEPRECATE_SOON("Use Detach() instead.", inline void Neuter()) { Detach(); }
  ^
../deps/v8/include/v8config.h:322:29: note: expanded from macro 'V8_DEPRECATE_SOON'
  declarator __attribute__((deprecated(message)))
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
