### PR TITLE
worker: allow synchronously draining message ports

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -49,6 +49,26 @@ The above example spawns a Worker thread for each `parse()` call. In actual
 practice, use a pool of Workers instead for these kinds of tasks. Otherwise, the
 overhead of creating Workers would likely exceed their benefit.
 
+## worker.drainMessagePort(port)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `port` {MessagePort}
+
+Make `port` emit all currently pending messages synchronously.
+
+```js
+const { MessageChannel, drainMessagePort } = require('worker_threads');
+const { port1, port2 } = new MessageChannel();
+
+port1.postMessage({ hello: 'world' });
+port2.once('message', (message) => console.log(message));
+
+drainMessagePort(port2);
+console.log('done emitting messages');  // This is printed *after* the message.
+```
+
 ## worker.isMainThread
 <!-- YAML
 added: v10.5.0

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -251,6 +251,7 @@ function pipeWithoutWarning(source, dest) {
 }
 
 module.exports = {
+  drainMessagePort,
   ownsProcessState,
   isMainThread,
   threadId,

--- a/lib/worker_threads.js
+++ b/lib/worker_threads.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  drainMessagePort,
   isMainThread,
   threadId,
   Worker
@@ -13,6 +14,7 @@ const {
 } = require('internal/worker/io');
 
 module.exports = {
+  drainMessagePort,
   isMainThread,
   MessagePort,
   MessageChannel,

--- a/test/parallel/test-worker-message-port-drain-manual.js
+++ b/test/parallel/test-worker-message-port-drain-manual.js
@@ -1,0 +1,19 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { MessageChannel, drainMessagePort } = require('worker_threads');
+
+const { port1, port2 } = new MessageChannel();
+const messages = [];
+port2.on('message', (message) => messages.push(message));
+
+const message = { hello: 'world' };
+
+assert.deepStrictEqual(messages, []);
+port1.postMessage(message);
+port1.postMessage(message);
+assert.deepStrictEqual(messages, []);
+drainMessagePort(port2);
+assert.deepStrictEqual(messages, [ message, message ]);
+
+port1.close();


### PR DESCRIPTION
In combination with Atomics, this makes it possible to implement
generic synchronous functionality, e.g. `importScript()`, in Workers
purely by communicating with other threads.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
