### PR TITLE
lib: lazy load `v8` in error-serdes

### DIFF
--- a/lib/internal/error-serdes.js
+++ b/lib/internal/error-serdes.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Buffer = require('buffer').Buffer;
-const { serialize, deserialize } = require('v8');
 const {
   SafeSet,
   Object,
@@ -84,7 +83,9 @@ function lazyUtil() {
   return util;
 }
 
+let serialize;
 function serializeError(error) {
+  if (!serialize) serialize = require('v8').serialize;
   try {
     if (typeof error === 'object' &&
         ObjectPrototypeToString(error) === '[object Error]') {
@@ -109,7 +110,9 @@ function serializeError(error) {
                         Buffer.from(lazyUtil().inspect(error), 'utf8')]);
 }
 
+let deserialize;
 function deserializeError(error) {
+  if (!deserialize) deserialize = require('v8').deserialize;
   switch (error[0]) {
     case kSerializedError:
       const { constructor, properties } = deserialize(error.subarray(1));

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -71,13 +71,8 @@ if (common.isMainThread) {
   expectedModules.add('NativeModule internal/process/main_thread_only');
   expectedModules.add('NativeModule internal/process/stdio');
 } else {
-  expectedModules.add('Internal Binding heap_utils');
   expectedModules.add('Internal Binding messaging');
-  expectedModules.add('Internal Binding serdes');
-  expectedModules.add('Internal Binding stream_wrap');
   expectedModules.add('Internal Binding symbols');
-  expectedModules.add('Internal Binding uv');
-  expectedModules.add('Internal Binding v8');
   expectedModules.add('Internal Binding worker');
   expectedModules.add('NativeModule _stream_duplex');
   expectedModules.add('NativeModule _stream_passthrough');
@@ -86,7 +81,6 @@ if (common.isMainThread) {
   expectedModules.add('NativeModule _stream_writable');
   expectedModules.add('NativeModule internal/error-serdes');
   expectedModules.add('NativeModule internal/process/worker_thread_only');
-  expectedModules.add('NativeModule internal/stream_base_commons');
   expectedModules.add('NativeModule internal/streams/buffer_list');
   expectedModules.add('NativeModule internal/streams/destroy');
   expectedModules.add('NativeModule internal/streams/end-of-stream');
@@ -97,7 +91,6 @@ if (common.isMainThread) {
   expectedModules.add('NativeModule internal/worker/io');
   expectedModules.add('NativeModule module');
   expectedModules.add('NativeModule stream');
-  expectedModules.add('NativeModule v8');
   expectedModules.add('NativeModule worker_threads');
 }
 


### PR DESCRIPTION
Lazy loading `v8` in `lib/internal/error-serdes.js` reduces the number
of loaded modules by the bootstrap code for Worker threads by seven.

Refs: https://github.com/nodejs/node/pull/26501#discussion_r264849750

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
