### PR TITLE
fs: use proper .destroy() implementation for SyncWriteStream

### DIFF
--- a/lib/internal/fs/sync_write_stream.js
+++ b/lib/internal/fs/sync_write_stream.js
@@ -4,15 +4,13 @@ const { Writable } = require('stream');
 const { closeSync, writeSync } = require('fs');
 
 function SyncWriteStream(fd, options) {
-  Writable.call(this);
+  Writable.call(this, { autoDestroy: true });
 
   options = options || {};
 
   this.fd = fd;
   this.readable = false;
   this.autoClose = options.autoClose === undefined ? true : options.autoClose;
-
-  this.on('end', () => this._destroy());
 }
 
 Object.setPrototypeOf(SyncWriteStream.prototype, Writable.prototype);
@@ -24,22 +22,18 @@ SyncWriteStream.prototype._write = function(chunk, encoding, cb) {
   return true;
 };
 
-SyncWriteStream.prototype._destroy = function() {
+SyncWriteStream.prototype._destroy = function(err, cb) {
   if (this.fd === null) // already destroy()ed
-    return;
+    return cb(err);
 
   if (this.autoClose)
     closeSync(this.fd);
 
   this.fd = null;
-  return true;
+  cb(err);
 };
 
 SyncWriteStream.prototype.destroySoon =
-SyncWriteStream.prototype.destroy = function() {
-  this._destroy();
-  this.emit('close');
-  return true;
-};
+  SyncWriteStream.prototype.destroy;
 
 module.exports = SyncWriteStream;

--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -19,7 +19,6 @@ const filename = path.join(tmpdir.path, 'sync-write-stream.txt');
   assert.strictEqual(stream.fd, 1);
   assert.strictEqual(stream.readable, false);
   assert.strictEqual(stream.autoClose, true);
-  assert.strictEqual(stream.listenerCount('end'), 1);
 }
 
 // Verify constructing the instance with specified options.
@@ -29,7 +28,6 @@ const filename = path.join(tmpdir.path, 'sync-write-stream.txt');
   assert.strictEqual(stream.fd, 1);
   assert.strictEqual(stream.readable, false);
   assert.strictEqual(stream.autoClose, false);
-  assert.strictEqual(stream.listenerCount('end'), 1);
 }
 
 // Verify that the file will be written synchronously.
@@ -47,21 +45,28 @@ const filename = path.join(tmpdir.path, 'sync-write-stream.txt');
   const fd = fs.openSync(filename, 'w');
   const stream = new SyncWriteStream(fd);
 
-  stream.on('close', common.mustCall(3));
-
-  assert.strictEqual(stream.destroy(), true);
+  stream.on('close', common.mustCall());
+  assert.strictEqual(stream.destroy(), stream);
   assert.strictEqual(stream.fd, null);
-  assert.strictEqual(stream.destroy(), true);
-  assert.strictEqual(stream.destroySoon(), true);
 }
 
-// Verify that the 'end' event listener will also destroy the stream.
+// Verify that the stream will unset the fd after destroySoon().
+{
+  const fd = fs.openSync(filename, 'w');
+  const stream = new SyncWriteStream(fd);
+
+  stream.on('close', common.mustCall());
+  assert.strictEqual(stream.destroySoon(), stream);
+  assert.strictEqual(stream.fd, null);
+}
+
+// Verify that calling end() will also destroy the stream.
 {
   const fd = fs.openSync(filename, 'w');
   const stream = new SyncWriteStream(fd);
 
   assert.strictEqual(stream.fd, fd);
 
-  stream.emit('end');
+  stream.end();
   assert.strictEqual(stream.fd, null);
 }


### PR DESCRIPTION
This PR is just a refactoring of `SyncWriteStream` to use the shared implementation of `.destroy()`.
This is used by stdio.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
