### PR TITLE
stdio: make stdout and stderr emit 'close' on destroy

### DIFF
--- a/lib/internal/process/stdio.js
+++ b/lib/internal/process/stdio.js
@@ -2,7 +2,26 @@
 
 exports.getMainThreadStdio = getMainThreadStdio;
 
-function dummyDestroy(err, cb) { cb(err); }
+function dummyDestroy(err, cb) {
+  // SyncWriteStream does not use the stream
+  // destroy mechanism for some legacy reason.
+  // TODO(mcollina): remove when
+  // https://github.com/nodejs/node/pull/26690 lands.
+  if (typeof cb === 'function') {
+    cb(err);
+  }
+
+  // We need to emit 'close' anyway so that the closing
+  // of the stream is observable. We just make sure we
+  // are not going to do it twice.
+  // The 'close' event is needed so that finished and
+  // pipeline work correctly.
+  if (!this._writableState.emitClose) {
+    process.nextTick(() => {
+      this.emit('close');
+    });
+  }
+}
 
 function getMainThreadStdio() {
   var stdin;

--- a/test/parallel/test-stdout-pipeline-destroy.js
+++ b/test/parallel/test-stdout-pipeline-destroy.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+const { Transform, Readable, pipeline } = require('stream');
+const assert = require('assert');
+
+const reader = new Readable({
+  read(size) { this.push('foo'); }
+});
+
+let count = 0;
+
+const err = new Error('this-error-gets-hidden');
+
+const transform = new Transform({
+  transform(chunk, enc, cb) {
+    if (count++ >= 5)
+      this.emit('error', err);
+    else
+      cb(null, count.toString() + '\n');
+  }
+});
+
+pipeline(
+  reader,
+  transform,
+  process.stdout,
+  common.mustCall((e) => {
+    assert.strictEqual(e, err);
+  })
+);


### PR DESCRIPTION
The problem in #26550 was caused by `net.Socket` having set `emitClose: false`  because it was emitted its own event in `_destroy()`,  and `stdio.js` was overriding `_destroy` without emitting `'close'`.

Fix: https://github.com/nodejs/node/issues/26550

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
