### PR TITLE
perf_hooks: reset prev_ before starting ELD timer

### DIFF
--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -539,6 +539,7 @@ bool ELDHistogram::RecordDelta() {
 bool ELDHistogram::Enable() {
   if (enabled_) return false;
   enabled_ = true;
+  prev_ = 0;
   uv_timer_start(timer_,
                  ELDHistogramDelayInterval,
                  resolution_,


### PR DESCRIPTION
reset `ELDHistogram.prev_` before staring timer to ensure that start
timer doesn't leak across `disable()` `enable()` calls.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

@jasnell I have seen this nit late during review of #26556 and it's not directly related to your changes. But feel free to integrate it into your PR to avoid a later on merge conflict.
