### PR TITLE
doc: note about dns ANY queries / RFC 8482

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -367,6 +367,10 @@ Here is an example of the `ret` object passed to the callback:
     minttl: 60 } ]
 ```
 
+Note that the operator of a DNS server might choose not to respond to `ANY`
+queries. It may be better to call individual methods like [`dns.resolve4()`][],
+[`dns.resolveMx()`][], and so on. For more details, see [RFC 8482][].
+
 ## dns.resolveCname(hostname, callback)
 <!-- YAML
 added: v0.3.2
@@ -1143,4 +1147,5 @@ uses. For instance, _they do not use the configuration from `/etc/hosts`_.
 [DNS error codes]: #dns_error_codes
 [Implementation considerations section]: #dns_implementation_considerations
 [rfc5952]: https://tools.ietf.org/html/rfc5952#section-6
+[RFC 8482]: https://tools.ietf.org/html/rfc8482
 [supported `getaddrinfo` flags]: #dns_supported_getaddrinfo_flags

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -367,7 +367,7 @@ Here is an example of the `ret` object passed to the callback:
     minttl: 60 } ]
 ```
 
-Note that the operator of a DNS server might choose not to respond to `ANY`
+DNS server operators may choose not to respond to `ANY`
 queries. It may be better to call individual methods like [`dns.resolve4()`][],
 [`dns.resolveMx()`][], and so on. For more details, see [RFC 8482][].
 


### PR DESCRIPTION
This was inspired by the Cloudflare post, [RFC8482 - Saying goodbye to ANY](https://blog.cloudflare.com/rfc8482-saying-goodbye-to-any/) / [RFC 8482](https://tools.ietf.org/html/rfc8482).

The post calls out that the `ANY` query isn't always honored by various services and so this PR warns the developer that such discrepancies can exist and that they may need to call other methods one at a time instead.

##### Checklist

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
