### PR TITLE
stream: reduce internal usage of public require of util

### DIFF
--- a/lib/internal/js_stream_socket.js
+++ b/lib/internal/js_stream_socket.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const assert = require('internal/assert');
-const util = require('util');
 const { Socket } = require('net');
 const { JSStream } = internalBinding('js_stream');
 const uv = internalBinding('uv');
-const debug = util.debuglog('stream_socket');
+const debug = require('internal/util/debuglog').debuglog('stream_socket');
 const { owner_symbol } = require('internal/async_hooks').symbols;
 const { ERR_STREAM_WRAP } = require('internal/errors').codes;
 

--- a/lib/internal/streams/buffer_list.js
+++ b/lib/internal/streams/buffer_list.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Buffer } = require('buffer');
-const { inspect } = require('util');
+const { inspect } = require('internal/util/inspect');
 
 function copyBuffer(src, target, offset) {
   Buffer.prototype.copy.call(src, target, offset);

--- a/lib/internal/streams/lazy_transform.js
+++ b/lib/internal/streams/lazy_transform.js
@@ -4,7 +4,6 @@
 'use strict';
 
 const stream = require('stream');
-const util = require('util');
 
 const {
   getDefaultEncoding
@@ -17,7 +16,8 @@ function LazyTransform(options) {
   this.writable = true;
   this.readable = true;
 }
-util.inherits(LazyTransform, stream.Transform);
+Object.setPrototypeOf(LazyTransform.prototype, stream.Transform.prototype);
+Object.setPrototypeOf(LazyTransform, stream.Transform);
 
 function makeGetter(name) {
   return function() {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -43,7 +43,7 @@ Stream.Stream = Stream;
 
 // Internal utilities
 try {
-  const types = require('util').types;
+  const types = require('internal/util/types');
   if (types && typeof types.isUint8Array === 'function') {
     Stream._isUint8Array = types.isUint8Array;
   } else {


### PR DESCRIPTION
Refs #26546 

Reduce internal usage of public require of `util` in the scope of stream.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
