### PR TITLE
doc: simplify force-push guidelines

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -628,7 +628,7 @@ git push upstream master
   people's forks. It is permissible for simpler slip-ups such as typos in commit
   messages. You are only allowed to force push to any Node.js branch within 10
   minutes from your original push. If someone else pushes to the branch or the
-  10 minute period passes, consider the commit final.
+  10-minute period passes, consider the commit final.
   * Use `--force-with-lease` to minimize the chance of overwriting
   someone else's change.
   * Post to `#node-dev` (IRC) if you force push.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -624,13 +624,11 @@ git push upstream master
 * Ping a TSC member.
 * `#node-dev` on freenode
 * With `git`, there's a way to override remote trees by force pushing
-(`git push -f`). This should generally be seen as forbidden (since
-you're rewriting history on a repository other people are working
-against) but is allowed for simpler slip-ups such as typos in commit
-messages. However, you are only allowed to force push to any Node.js
-branch within 10 minutes from your original push. If someone else
-pushes to the branch or the 10 minute period passes, consider the
-commit final.
+  (`git push -f`). This is generally forbidden as it creates conflicts in other
+  people's forks. It is permissible for simpler slip-ups such as typos in commit
+  messages. You are only allowed to force push to any Node.js branch within 10
+  minutes from your original push. If someone else pushes to the branch or the
+  10 minute period passes, consider the commit final.
   * Use `--force-with-lease` to minimize the chance of overwriting
   someone else's change.
   * Post to `#node-dev` (IRC) if you force push.


### PR DESCRIPTION
Edit the guildelines for force-pushing in Collaborator Guide. There are
no policy changes, but the material is simplified a bit and the
sentences are now shorter.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
