### PR TITLE
src: disallow constructor behaviour for native methods

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -875,9 +875,7 @@ inline void Environment::SetMethod(v8::Local<v8::Object> that,
   v8::Local<v8::Context> context = isolate()->GetCurrentContext();
   v8::Local<v8::Function> function =
       NewFunctionTemplate(callback, v8::Local<v8::Signature>(),
-                          // TODO(TimothyGu): Investigate if SetMethod is ever
-                          // used for constructors.
-                          v8::ConstructorBehavior::kAllow,
+                          v8::ConstructorBehavior::kThrow,
                           v8::SideEffectType::kHasSideEffect)
           ->GetFunction(context)
           .ToLocalChecked();
@@ -895,9 +893,7 @@ inline void Environment::SetMethodNoSideEffect(v8::Local<v8::Object> that,
   v8::Local<v8::Context> context = isolate()->GetCurrentContext();
   v8::Local<v8::Function> function =
       NewFunctionTemplate(callback, v8::Local<v8::Signature>(),
-                          // TODO(TimothyGu): Investigate if SetMethod is ever
-                          // used for constructors.
-                          v8::ConstructorBehavior::kAllow,
+                          v8::ConstructorBehavior::kThrow,
                           v8::SideEffectType::kHasNoSideEffect)
           ->GetFunction(context)
           .ToLocalChecked();

--- a/test/parallel/test-process-chdir.js
+++ b/test/parallel/test-process-chdir.js
@@ -46,7 +46,4 @@ common.expectsError(function() { process.chdir(); }, err);
 // Check that our built-in methods do not have a prototype/constructor behaviour
 // if they don't need to. This could be tested for any of our C++ methods.
 assert.strictEqual(process.cwd.prototype, undefined);
-assert.throws(() => new process.cwd(), /not a constructor/);
-// Make sure that the above checks verify the right thing, i.e. that we're
-// actually looking at a directly exposed C++ binding method.
-assert.strictEqual(process.cwd.toString(), 'function cwd() { [native code] }');
+assert.throws(() => new process.cwd(), TypeError);

--- a/test/parallel/test-process-chdir.js
+++ b/test/parallel/test-process-chdir.js
@@ -42,3 +42,11 @@ const err = {
 };
 common.expectsError(function() { process.chdir({}); }, err);
 common.expectsError(function() { process.chdir(); }, err);
+
+// Check that our built-in methods do not have a prototype/constructor behaviour
+// if they don't need to. This could be tested for any of our C++ methods.
+assert.strictEqual(process.cwd.prototype, undefined);
+assert.throws(() => new process.cwd(), /not a constructor/);
+// Make sure that the above checks verify the right thing, i.e. that we're
+// actually looking at a directly exposed C++ binding method.
+assert.strictEqual(process.cwd.toString(), 'function cwd() { [native code] }');


### PR DESCRIPTION
Disallow constructor behaviour and setting up prototypes
for native methods that are not constructors (i.e. make
them behave like ES6 class methods).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
