### PR TITLE
deps: V8: cherry-pick 385aa80

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -37,7 +37,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.6',
+    'v8_embedder_string': '-node.7',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -46,6 +46,7 @@ Alexander Botero-Lowry <alexbl@FreeBSD.org>
 Alexander Karpinsky <homm86@gmail.com>
 Alexandre Vassalotti <avassalotti@gmail.com>
 Alexis Campailla <alexis@janeasystems.com>
+Allan Sandfeld Jensen <allan.jensen@qt.io>
 Amos Lim <eui-sang.lim@samsung.com>
 Andreas Anyuru <andreas.anyuru@gmail.com>
 Andrew Paprocki <andrew@ishiboo.com>

--- a/deps/v8/src/compiler/backend/gap-resolver.cc
+++ b/deps/v8/src/compiler/backend/gap-resolver.cc
@@ -96,8 +96,7 @@ void GapResolver::Resolve(ParallelMove* moves) {
   for (auto it = moves->begin(); it != moves->end();) {
     MoveOperands* move = *it;
     if (move->IsRedundant()) {
-      *it = moves->back();
-      moves->pop_back();
+      it = moves->erase(it);
       continue;
     }
     source_kinds.Add(GetKind(move->source()));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/26694

Original commit message:

    Correct removal of redundant moves

    The logic for removing while iterating is non-standard and
    a left over from a previous index based loop. This patch
    replaces it with a standard erase based version.

    This fixes a runtime crash with MSVC that invalidates the
    iterator and then asserts. This also makes the code safe
    in case the last move can be redundant.

    Change-Id: Ie6990e0d65a3b83a4b7da3e2e89ed4e60a6cd215
    Reviewed-on: https://chromium-review.googlesource.com/c/1488762
    Reviewed-by: Ben Titzer <titzer@chromium.org>
    Commit-Queue: Ben Titzer <titzer@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#59868}

Refs: https://github.com/v8/v8/commit/385aa80aff32210d098498d1cd44d42bc70ee1d4

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
