### PR TITLE
crypto: add API to retrieve key type OID

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1135,6 +1135,16 @@ For asymmetric keys, this property represents the type of the embedded key
 (`'rsa'`, `'dsa'`, `'ec'`, `'ed25519'`, or `'ed448'`).
 This property is `undefined` for symmetric keys.
 
+### keyObject.asymmetricKeyTypeOid
+<!-- YAML
+added: REPLACEME
+-->
+* {string}
+
+For asymmetric keys, this property represents the numerical representation of
+the OID of the type of the embedded key, e.g., `'1.3.101.113'` for `'ed448'`.
+This property is `undefined` for symmetric keys.
+
 ### keyObject.export([options])
 <!-- YAML
 added: v11.6.0

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -74,11 +74,17 @@ class SecretKeyObject extends KeyObject {
 }
 
 const kAsymmetricKeyType = Symbol('kAsymmetricKeyType');
+const kAsymmetricKeyOid = Symbol('kAsymmetricKeyOid');
 
 class AsymmetricKeyObject extends KeyObject {
   get asymmetricKeyType() {
     return this[kAsymmetricKeyType] ||
            (this[kAsymmetricKeyType] = this[kHandle].getAsymmetricKeyType());
+  }
+
+  get asymmetricKeyTypeOid() {
+    return this[kAsymmetricKeyOid] ||
+           (this[kAsymmetricKeyOid] = this[kHandle].getAsymmetricKeyTypeOid());
   }
 }
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -470,6 +470,10 @@ class KeyObject : public BaseObject {
       const v8::FunctionCallbackInfo<v8::Value>& args);
   v8::Local<v8::String> GetAsymmetricKeyType() const;
 
+  static void GetAsymmetricKeyTypeOid(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+  v8::Local<v8::String> GetAsymmetricKeyTypeOid() const;
+
   static void GetSymmetricKeySize(
       const v8::FunctionCallbackInfo<v8::Value>& args);
 

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -39,6 +39,7 @@ const privatePem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
   assert.strictEqual(key.type, 'secret');
   assert.strictEqual(key.symmetricKeySize, 32);
   assert.strictEqual(key.asymmetricKeyType, undefined);
+  assert.strictEqual(key.asymmetricKeyTypeOid, undefined);
 
   const exportedKey = key.export();
   assert(keybuf.equals(exportedKey));
@@ -91,17 +92,20 @@ const privatePem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
   const publicKey = createPublicKey(publicPem);
   assert.strictEqual(publicKey.type, 'public');
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
+  assert.strictEqual(publicKey.asymmetricKeyTypeOid, '1.2.840.113549.1.1.1');
   assert.strictEqual(publicKey.symmetricKeySize, undefined);
 
   const privateKey = createPrivateKey(privatePem);
   assert.strictEqual(privateKey.type, 'private');
   assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
+  assert.strictEqual(publicKey.asymmetricKeyTypeOid, '1.2.840.113549.1.1.1');
   assert.strictEqual(privateKey.symmetricKeySize, undefined);
 
   // It should be possible to derive a public key from a private key.
   const derivedPublicKey = createPublicKey(privateKey);
   assert.strictEqual(derivedPublicKey.type, 'public');
   assert.strictEqual(derivedPublicKey.asymmetricKeyType, 'rsa');
+  assert.strictEqual(publicKey.asymmetricKeyTypeOid, '1.2.840.113549.1.1.1');
   assert.strictEqual(derivedPublicKey.symmetricKeySize, undefined);
 
   // Test exporting with an invalid options object, this should throw.
@@ -171,10 +175,12 @@ const privatePem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
 [
   { private: fixtures.readSync('test_ed25519_privkey.pem', 'ascii'),
     public: fixtures.readSync('test_ed25519_pubkey.pem', 'ascii'),
-    keyType: 'ed25519' },
+    keyType: 'ed25519',
+    oid: '1.3.101.112' },
   { private: fixtures.readSync('test_ed448_privkey.pem', 'ascii'),
     public: fixtures.readSync('test_ed448_pubkey.pem', 'ascii'),
-    keyType: 'ed448' }
+    keyType: 'ed448',
+    oid: '1.3.101.113' }
 ].forEach((info) => {
   const keyType = info.keyType;
 
@@ -183,6 +189,7 @@ const privatePem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
     const key = createPrivateKey(info.private);
     assert.strictEqual(key.type, 'private');
     assert.strictEqual(key.asymmetricKeyType, keyType);
+    assert.strictEqual(key.asymmetricKeyTypeOid, info.oid);
     assert.strictEqual(key.symmetricKeySize, undefined);
     assert.strictEqual(key.export(exportOptions), info.private);
   }
@@ -193,6 +200,7 @@ const privatePem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
       const key = createPublicKey(pem);
       assert.strictEqual(key.type, 'public');
       assert.strictEqual(key.asymmetricKeyType, keyType);
+      assert.strictEqual(key.asymmetricKeyTypeOid, info.oid);
       assert.strictEqual(key.symmetricKeySize, undefined);
       assert.strictEqual(key.export(exportOptions), info.public);
     });

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -6,6 +6,8 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const {
+  createPrivateKey,
+  createPublicKey,
   createSign,
   createVerify,
   generateKeyPair,
@@ -275,6 +277,15 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     assertApproximateSize(publicKey, 440);
     assertApproximateSize(privateKeyDER, 336);
 
+    assert.strictEqual(createPublicKey(publicKey).asymmetricKeyTypeOid,
+                       '1.2.840.10040.4.1');
+    assert.strictEqual(createPrivateKey({
+                         key: privateKeyDER,
+                         ...privateKeyEncoding,
+                         passphrase: 'secret'
+                       }).asymmetricKeyTypeOid,
+                       '1.2.840.10040.4.1');
+
     // Since the private key is encrypted, signing shouldn't work anymore.
     assert.throws(() => {
       testSignVerify(publicKey, {
@@ -313,6 +324,11 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     assert(spkiExp.test(publicKey));
     assert.strictEqual(typeof privateKey, 'string');
     assert(sec1Exp.test(privateKey));
+
+    assert.strictEqual(createPublicKey(publicKey).asymmetricKeyTypeOid,
+                       '1.2.840.10045.2.1');
+    assert.strictEqual(createPrivateKey(privateKey).asymmetricKeyTypeOid,
+                       '1.2.840.10045.2.1');
 
     testSignVerify(publicKey, privateKey);
   }));

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -108,10 +108,12 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   assert.strictEqual(typeof publicKey, 'object');
   assert.strictEqual(publicKey.type, 'public');
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
+  assert.strictEqual(publicKey.asymmetricKeyTypeOid, '1.2.840.113549.1.1.1');
 
   assert.strictEqual(typeof privateKey, 'object');
   assert.strictEqual(privateKey.type, 'private');
   assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
+  assert.strictEqual(publicKey.asymmetricKeyTypeOid, '1.2.840.113549.1.1.1');
 }
 
 {
@@ -453,6 +455,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     assert.strictEqual(typeof publicKey, 'object');
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
+    assert.strictEqual(publicKey.asymmetricKeyTypeOid, '1.2.840.113549.1.1.1');
 
     // The private key should still be a string.
     assert.strictEqual(typeof privateKey, 'string');
@@ -477,6 +480,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     assert.strictEqual(typeof privateKey, 'object');
     assert.strictEqual(privateKey.type, 'private');
     assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
+    assert.strictEqual(privateKey.asymmetricKeyTypeOid, '1.2.840.113549.1.1.1');
 
     testEncryptDecrypt(publicKey, privateKey);
     testSignVerify(publicKey, privateKey);


### PR DESCRIPTION
Some users suggested that it would be helpful to have access to the OID of `KeyObject`s. Luckily, OpenSSL does manage OIDs, so there is little to do on our side.

What do you think? Should we expose the OID? And if so, is this the right name for such a property?

OpenSSL also provides nice names for most OIDs, but as far as I know, these are not standardized and not guaranteed to exist for all OIDs, and there are sometimes two variants (a short and a long name), so I am not sure whether it would be a good idea to expose these. Maybe someone else knows more.

---

cc @nodejs/crypto, @panva, @omsmith.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
