### PR TITLE
test: fix test-heapdump-worker

### DIFF
--- a/test/pummel/test-heapdump-worker.js
+++ b/test/pummel/test-heapdump-worker.js
@@ -9,7 +9,6 @@ const worker = new Worker('setInterval(() => {}, 100);', { eval: true });
 validateSnapshotNodes('Node / Worker', [
   {
     children: [
-      { node_name: 'Node / AsyncRequest', edge_name: 'thread_stopper_' },
       { node_name: 'Node / AsyncRequest', edge_name: 'on_thread_finished_' },
       { node_name: 'Node / MessagePort', edge_name: 'parent_port' },
       { node_name: 'Worker', edge_name: 'wrapped' }


### PR DESCRIPTION
This test was broken by d35af56e5f3b1334c4360dbf8a013d0c522fe5f8.

Refs: https://github.com/nodejs/node/pull/21283
Fixes: https://github.com/nodejs/node/issues/26712

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
