### PR TITLE
Remove public util use in lib/vm.js and lib/zlib.js

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -32,7 +32,10 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_VM_MODULE_NOT_MODULE,
 } = require('internal/errors').codes;
-const { isModuleNamespaceObject, isArrayBufferView } = require('internal/util/types');
+const { 
+  isModuleNamespaceObject, 
+  isArrayBufferView 
+} = require('internal/util/types');
 const {
   validateInt32,
   validateUint32,

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -32,7 +32,7 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_VM_MODULE_NOT_MODULE,
 } = require('internal/errors').codes;
-const { isModuleNamespaceObject, isArrayBufferView } = require('util').types;
+const { isModuleNamespaceObject, isArrayBufferView } = require('internal/util/types');
 const {
   validateInt32,
   validateUint32,

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -32,9 +32,9 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_VM_MODULE_NOT_MODULE,
 } = require('internal/errors').codes;
-const { 
-  isModuleNamespaceObject, 
-  isArrayBufferView 
+const {
+  isModuleNamespaceObject,
+  isArrayBufferView
 } = require('internal/util/types');
 const {
   validateInt32,

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -35,7 +35,7 @@ const {
     isAnyArrayBuffer,
     isArrayBufferView
   }
-} = require('util');
+} = require('internals/util');
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');
 const {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -33,10 +33,8 @@ const {
   deprecate
 } = require('internal/util');
 const {
-  types: {
     isAnyArrayBuffer,
     isArrayBufferView
-  }
 } = require('internal/util/types');
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -30,14 +30,14 @@ const {
 } = require('internal/errors').codes;
 const Transform = require('_stream_transform');
 const {
+  deprecate
+} = require('internal/util').deprecate;
+const {
   types: {
     isAnyArrayBuffer,
     isArrayBufferView
   }
 } = require('internal/util/types');
-const {
-  deprecate
-} = require('internal/util').deprecate;
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');
 const {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -35,7 +35,7 @@ const {
     isAnyArrayBuffer,
     isArrayBufferView
   }
-} = require('internals/util');
+} = require('internal/util');
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');
 const {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -37,7 +37,7 @@ const {
     isAnyArrayBuffer,
     isArrayBufferView
   }
-} = require('internal/util/types');
+} = require('internal/util');
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');
 const {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -34,10 +34,10 @@ const {
     isAnyArrayBuffer,
     isArrayBufferView
   }
-}= require('internal/util/types');
+} = require('internal/util/types');
 const {
   deprecate
-}= require('internal/util').deprecate;
+} = require('internal/util').deprecate;
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');
 const {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -35,7 +35,8 @@ const {
     isAnyArrayBuffer,
     isArrayBufferView
   }
-} = require('internal/util');
+} 
+= require('internal/util');
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');
 const {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -37,7 +37,7 @@ const {
     isAnyArrayBuffer,
     isArrayBufferView
   }
-} = require('internal/util');
+} = require('internal/util/types');
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');
 const {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -31,7 +31,7 @@ const {
 const Transform = require('_stream_transform');
 const {
   deprecate
-} = require('internal/util').deprecate;
+} = require('internal/util');
 const {
   types: {
     isAnyArrayBuffer,

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -36,7 +36,7 @@ const {
   }
 }= require('internal/util/types');
 const {
-  deprecate,
+  deprecate
 }= require('internal/util').deprecate;
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -30,13 +30,14 @@ const {
 } = require('internal/errors').codes;
 const Transform = require('_stream_transform');
 const {
-  deprecate,
   types: {
     isAnyArrayBuffer,
     isArrayBufferView
   }
-} 
-= require('internal/util');
+}= require('internal/util/types');
+const {
+  deprecate,
+}= require('internal/util').deprecate;
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');
 const {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -33,8 +33,8 @@ const {
   deprecate
 } = require('internal/util');
 const {
-    isAnyArrayBuffer,
-    isArrayBufferView
+  isAnyArrayBuffer,
+  isArrayBufferView
 } = require('internal/util/types');
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -26,7 +26,6 @@ const expectedModules = new Set([
   'Internal Binding trace_events',
   'Internal Binding types',
   'Internal Binding url',
-  'Internal Binding util',
   'NativeModule buffer',
   'NativeModule events',
   'NativeModule fs',


### PR DESCRIPTION
Removed public use of util in lib/vm.js and lib/zlib.js

##### Checklist
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
