### PR TITLE
process: deprecate toStringTag assignment

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2361,6 +2361,15 @@ changes:
     description: Runtime deprecation.
 -->
 
+<a id="DEP0126"></a>
+### DEP0126: writing to process[Symbol.toStringTag]
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26715
+    description: Runtime deprecation.
+-->
+
 Type: Runtime
 
 The `_stream_wrap` module is deprecated.

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -279,11 +279,16 @@ function setupProcessObject() {
   const origProcProto = Object.getPrototypeOf(process);
   Object.setPrototypeOf(origProcProto, EventEmitter.prototype);
   EventEmitter.call(process);
+  let toStringTag = 'process';
   Object.defineProperty(process, Symbol.toStringTag, {
     enumerable: false,
-    writable: true,
     configurable: false,
-    value: 'process'
+    get() {
+      return toStringTag;
+    },
+    set: deprecate((value) => toStringTag = value,
+                   'Setting \'process[Symbol.toStringTag]\' is deprecated',
+                   'DEP0126')
   });
   // Make process globally available to users by putting it on the global proxy
   Object.defineProperty(global, 'process', {

--- a/test/es-module/test-esm-process.mjs
+++ b/test/es-module/test-esm-process.mjs
@@ -1,7 +1,13 @@
 // Flags: --experimental-modules
 import '../common';
+import { expectWarning } from '../common/index.mjs';
 import assert from 'assert';
 import process from 'process';
 
 assert.strictEqual(Object.prototype.toString.call(process), '[object process]');
-assert(Object.getOwnPropertyDescriptor(process, Symbol.toStringTag).writable);
+process[Symbol.toStringTag] = 'custom process';
+expectWarning('DeprecationWarning',
+              'Setting \'process[Symbol.toStringTag]\' is deprecated',
+              'DEP0126');
+assert.strictEqual(Object.prototype.toString.call(process),
+                   '[object custom process]');


### PR DESCRIPTION
As a follow-on to #26488 this makes writing to `process[Symbol.toStringTag]` a full deprecation in Node.js.

Most intrinsics with `Symbol.toStringTag` set (eg `Promise.prototype`), have this as non-writeable, so it seems to make sense that `process` should do the same.

I'm not strongly set on this by any means either if anyone has reasons against it (perhaps the warnings will turn out more annoying than the strict error previously!).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
