### PR TITLE
timers: fix refresh inside callback

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -469,7 +469,7 @@ function getTimerCallbacks(runNextTicks) {
           if (start === undefined)
             start = getLibuvNow();
           insert(timer, timer[kRefed], start);
-        } else {
+        } else if (!timer._idleNext && !timer._idlePrev) {
           if (timer[kRefed])
             refCount--;
           timer[kRefed] = null;

--- a/test/parallel/test-timers-refresh-in-callback.js
+++ b/test/parallel/test-timers-refresh-in-callback.js
@@ -1,5 +1,3 @@
-// Flags: --expose-internals
-
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-timers-refresh-in-callback.js
+++ b/test/parallel/test-timers-refresh-in-callback.js
@@ -1,0 +1,16 @@
+// Flags: --expose-internals
+
+'use strict';
+
+const common = require('../common');
+
+// This test checks whether a refresh called inside the callback will keep
+// the event loop alive to run the timer again.
+
+let didCall = false;
+const timer = setTimeout(common.mustCall(() => {
+  if (!didCall) {
+    didCall = true;
+    timer.refresh();
+  }
+}, 2), 1);


### PR DESCRIPTION
When `timers.refresh()` is called inside a callback, the timer would incorrectly end up unrefed and thus not keep the event loop alive.

Fixes: https://github.com/nodejs/node/issues/26642

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
