### PR TITLE
doc: remove How Does LTS Work section from Collaborator Guide

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -643,20 +643,9 @@ Long Term Support (often referred to as *LTS*) guarantees application developers
 a 30-month support cycle with specific versions of Node.js.
 
 You can find more information
-[in the full release plan](https://github.com/nodejs/Release#release-plan).
-
-#### How does LTS work?
-
-Once a Current branch enters LTS, changes in that branch are limited to bug
-fixes, security updates, possible npm updates, documentation updates, and
-certain performance improvements that can be demonstrated to not break existing
-applications. Semver-minor changes are only permitted if required for bug fixes
-and then only on a case-by-case basis with LTS WG and possibly Technical
-Steering Committee (TSC) review. Semver-major changes are permitted only if
-required for security-related fixes.
-
-Once a Current branch moves into Maintenance mode, only **critical** bugs,
-**critical** security fixes, and documentation updates will be permitted.
+[in the full release plan](https://github.com/nodejs/Release#release-plan). Once
+a branch enters LTS, the release plan limits the types of changes permitted in
+the branch.
 
 #### Landing semver-minor commits in LTS
 


### PR DESCRIPTION
The How Does LTS Work section duplicates material in the release plan,
to which there is already a link in the doc. Unfortunately, it has gone
out of sync with the release plan, resulting in incorrect material being
in the Collaborator Guide. (The Release WG needs to approve certain
changes, not LTS WG as the guide currently says. It used to be the LTS
WG, but that changed.)

Instead of duplicating material in the Collaborator Guide and risking
that the two documents contradict each other again, instruct the reader
to refer to the release plan as the canonical source of information.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
