### PR TITLE
src: add SecureContext.getCertificateObject method

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -70,6 +70,10 @@ function SecureContext(secureProtocol, secureOptions, minVersion, maxVersion) {
   if (secureOptions) this.context.setOptions(secureOptions);
 }
 
+SecureContext.prototype.getCertificate = function() {
+  return this.context.getCertificateObject();
+};
+
 function validateKeyCert(name, value) {
   if (typeof value !== 'string' && !isArrayBufferView(value)) {
     throw new ERR_INVALID_ARG_TYPE(

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -171,6 +171,7 @@ class SecureContext : public BaseObject {
 
   template <bool primary>
   static void GetCertificate(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetCertificateObject(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static int TicketKeyCallback(SSL* ssl,
                                unsigned char* name,


### PR DESCRIPTION
Added a method in the native secure context class that works the same as the already existing [tlsSocket.getCertificate() method](https://nodejs.org/api/tls.html#tls_tlssocket_getcertificate) (only difference is it returns null and not an empty object when there is no local certificate).

This is useful if you need to access certificate fields when there are no clients connected (and thus no tlsSocket object to call getCertificate on). For example, I want to periodically check the certificate's expiration date and warn the user if it needs to be updated.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
