### PR TITLE
src: do not make `Resize(0)`’d buffers base `nullptr`

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -751,8 +751,10 @@ inline AllocatedBuffer::AllocatedBuffer(Environment* env, uv_buf_t buf)
     : env_(env), buffer_(buf) {}
 
 inline void AllocatedBuffer::Resize(size_t len) {
-  char* new_data = env_->Reallocate(buffer_.base, buffer_.len, len);
-  CHECK_IMPLIES(len > 0, new_data != nullptr);
+  // The `len` check is to make sure we don't end up with `nullptr` as our base.
+  char* new_data = env_->Reallocate(buffer_.base, buffer_.len,
+                                    len > 0 ? len : 1);
+  CHECK_NOT_NULL(new_data);
   buffer_ = uv_buf_init(new_data, len);
 }
 


### PR DESCRIPTION
This fixes issues in which APIs that accept pointers created this way
treat `nullptr` and a zero-length buffer differently.
We already do something similar for our `Malloc()` implementation.

Fixes: https://github.com/nodejs/node/issues/26514

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
