### PR TITLE
test: optimize test-http2-large-file

### DIFF
--- a/test/sequential/test-http2-large-file.js
+++ b/test/sequential/test-http2-large-file.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Test to ensure sending a large stream with a large initial window size works
+// Test sending a large stream with a large initial window size.
 // See: https://github.com/nodejs/node/issues/19141
 
 const common = require('../common');
@@ -18,14 +18,15 @@ server.on('stream', (stream) => {
 
 server.listen(0, common.mustCall(() => {
   let remaining = 1e8;
-  const chunk = 1e6;
+  const chunkLength = 1e6;
+  const chunk = Buffer.alloc(chunkLength, 'a');
   const client = http2.connect(`http://localhost:${server.address().port}`,
                                { settings: { initialWindowSize: 6553500 } });
   const request = client.request({ ':method': 'POST' });
   function writeChunk() {
     if (remaining > 0) {
-      remaining -= chunk;
-      request.write(Buffer.alloc(chunk, 'a'), writeChunk);
+      remaining -= chunkLength;
+      request.write(chunk, writeChunk);
     } else {
       request.end();
     }


### PR DESCRIPTION
Optimize test-http2-large-file so it only allocates a single buffer.

I don't expect that this will resolve https://github.com/nodejs/node/issues/22327, but one small change at a time....

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
