### PR TITLE
lib: fix error name

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -15,6 +15,8 @@ rules:
     # Config specific to lib
     - selector: "NewExpression[callee.name=/Error$/]:not([callee.name=/^(AssertionError|NghttpError)$/])"
       message: "Use an error exported by the internal/errors module."
+    - selector: "CallExpression[callee.object.name='Error'][callee.property.name='captureStackTrace']"
+      message: "Please use `require('internal/errors').hideStackFrames()` instead."
   # Custom rules in tools/eslint-rules
   node-core/require-globals: error
   node-core/no-let-in-for-declaration: error

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -34,16 +34,19 @@ const {
   symbols: { async_id_symbol }
 } = require('internal/async_hooks');
 const {
-  ERR_HTTP_HEADERS_SENT,
-  ERR_HTTP_INVALID_HEADER_VALUE,
-  ERR_HTTP_TRAILER_INVALID,
-  ERR_INVALID_HTTP_TOKEN,
-  ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_CHAR,
-  ERR_METHOD_NOT_IMPLEMENTED,
-  ERR_STREAM_CANNOT_PIPE,
-  ERR_STREAM_WRITE_AFTER_END
-} = require('internal/errors').codes;
+  codes: {
+    ERR_HTTP_HEADERS_SENT,
+    ERR_HTTP_INVALID_HEADER_VALUE,
+    ERR_HTTP_TRAILER_INVALID,
+    ERR_INVALID_HTTP_TOKEN,
+    ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_CHAR,
+    ERR_METHOD_NOT_IMPLEMENTED,
+    ERR_STREAM_CANNOT_PIPE,
+    ERR_STREAM_WRITE_AFTER_END
+  },
+  hideStackFrames
+} = require('internal/errors');
 const { validateString } = require('internal/validators');
 
 const { CRLF, debug } = common;
@@ -443,39 +446,21 @@ function matchHeader(self, state, field, value) {
   }
 }
 
-function validateHeaderName(name) {
+const validateHeaderName = hideStackFrames((name) => {
   if (typeof name !== 'string' || !name || !checkIsHttpToken(name)) {
-    // Reducing the limit improves the performance significantly. We do not
-    // lose the stack frames due to the `captureStackTrace()` function that is
-    // called later.
-    const tmpLimit = Error.stackTraceLimit;
-    Error.stackTraceLimit = 0;
-    const err = new ERR_INVALID_HTTP_TOKEN('Header name', name);
-    Error.stackTraceLimit = tmpLimit;
-    Error.captureStackTrace(err, validateHeaderName);
-    throw err;
+    throw new ERR_INVALID_HTTP_TOKEN('Header name', name);
   }
-}
+});
 
-function validateHeaderValue(name, value) {
-  let err;
-  // Reducing the limit improves the performance significantly. We do not loose
-  // the stack frames due to the `captureStackTrace()` function that is called
-  // later.
-  const tmpLimit = Error.stackTraceLimit;
-  Error.stackTraceLimit = 0;
+const validateHeaderValue = hideStackFrames((name, value) => {
   if (value === undefined) {
-    err = new ERR_HTTP_INVALID_HEADER_VALUE(value, name);
-  } else if (checkInvalidHeaderChar(value)) {
+    throw new ERR_HTTP_INVALID_HEADER_VALUE(value, name);
+  }
+  if (checkInvalidHeaderChar(value)) {
     debug('Header "%s" contains invalid characters', name);
-    err = new ERR_INVALID_CHAR('header content', name);
+    throw new ERR_INVALID_CHAR('header content', name);
   }
-  Error.stackTraceLimit = tmpLimit;
-  if (err !== undefined) {
-    Error.captureStackTrace(err, validateHeaderValue);
-    throw err;
-  }
-}
+});
 
 OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
   if (this._header) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -239,6 +239,7 @@ function getErrMessage(message, fn) {
   // We only need the stack trace. To minimize the overhead use an object
   // instead of an error.
   const err = {};
+  // eslint-disable-next-line no-restricted-syntax
   Error.captureStackTrace(err, fn);
   Error.stackTraceLimit = tmpLimit;
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -62,15 +62,18 @@ const {
 } = require('internal/util/inspect');
 
 const {
-  ERR_BUFFER_OUT_OF_BOUNDS,
-  ERR_OUT_OF_RANGE,
-  ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_ARG_VALUE,
-  ERR_INVALID_BUFFER_SIZE,
-  ERR_INVALID_OPT_VALUE,
-  ERR_NO_LONGER_SUPPORTED,
-  ERR_UNKNOWN_ENCODING
-} = require('internal/errors').codes;
+  codes: {
+    ERR_BUFFER_OUT_OF_BOUNDS,
+    ERR_OUT_OF_RANGE,
+    ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
+    ERR_INVALID_BUFFER_SIZE,
+    ERR_INVALID_OPT_VALUE,
+    ERR_NO_LONGER_SUPPORTED,
+    ERR_UNKNOWN_ENCODING
+  },
+  hideStackFrames
+} = require('internal/errors');
 const { validateString } = require('internal/validators');
 
 const {
@@ -247,20 +250,14 @@ Object.setPrototypeOf(Buffer, Uint8Array);
 // The 'assertSize' method will remove itself from the callstack when an error
 // occurs. This is done simply to keep the internal details of the
 // implementation from bleeding out to users.
-function assertSize(size) {
-  let err = null;
-
+const assertSize = hideStackFrames((size) => {
   if (typeof size !== 'number') {
-    err = new ERR_INVALID_ARG_TYPE('size', 'number', size);
-  } else if (!(size >= 0 && size <= kMaxLength)) {
-    err = new ERR_INVALID_OPT_VALUE.RangeError('size', size);
+    throw new ERR_INVALID_ARG_TYPE('size', 'number', size);
   }
-
-  if (err !== null) {
-    Error.captureStackTrace(err, assertSize);
-    throw err;
+  if (!(size >= 0 && size <= kMaxLength)) {
+    throw new ERR_INVALID_OPT_VALUE.RangeError('size', size);
   }
-}
+});
 
 /**
  * Creates a new filled Buffer instance.

--- a/lib/events.js
+++ b/lib/events.js
@@ -162,6 +162,7 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
       try {
         const { kExpandStackSymbol } = require('internal/util');
         const capture = {};
+        // eslint-disable-next-line no-restricted-syntax
         Error.captureStackTrace(capture, EventEmitter.prototype.emit);
         Object.defineProperty(er, kExpandStackSymbol, {
           value: enhanceStackTrace.bind(null, er, capture),

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -43,13 +43,15 @@ const pathModule = require('path');
 const { isArrayBufferView } = require('internal/util/types');
 const binding = internalBinding('fs');
 const { Buffer, kMaxLength } = require('buffer');
-const errors = require('internal/errors');
 const {
-  ERR_FS_FILE_TOO_LARGE,
-  ERR_INVALID_ARG_VALUE,
-  ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_CALLBACK
-} = errors.codes;
+  codes: {
+    ERR_FS_FILE_TOO_LARGE,
+    ERR_INVALID_ARG_VALUE,
+    ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_CALLBACK
+  },
+  uvException
+} = require('internal/errors');
 
 const { FSReqCallback, statValues } = binding;
 const { toPathIfFileURL } = require('internal/url');
@@ -114,10 +116,11 @@ function showTruncateDeprecation() {
 
 function handleErrorFromBinding(ctx) {
   if (ctx.errno !== undefined) {  // libuv error numbers
-    const err = errors.uvException(ctx);
+    const err = uvException(ctx);
     Error.captureStackTrace(err, handleErrorFromBinding);
     throw err;
-  } else if (ctx.error !== undefined) {  // errors created in C++ land.
+  }
+  if (ctx.error !== undefined) {  // errors created in C++ land.
     // TODO(joyeecheung): currently, ctx.error are encoding errors
     // usually caused by memory problems. We need to figure out proper error
     // code(s) for this.
@@ -310,7 +313,7 @@ function tryStatSync(fd, isUserFd) {
   const stats = binding.fstat(fd, false, undefined, ctx);
   if (ctx.errno !== undefined && !isUserFd) {
     fs.closeSync(fd);
-    throw errors.uvException(ctx);
+    throw uvException(ctx);
   }
   return stats;
 }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -117,6 +117,7 @@ function showTruncateDeprecation() {
 function handleErrorFromBinding(ctx) {
   if (ctx.errno !== undefined) {  // libuv error numbers
     const err = uvException(ctx);
+    // eslint-disable-next-line no-restricted-syntax
     Error.captureStackTrace(err, handleErrorFromBinding);
     throw err;
   }
@@ -124,6 +125,7 @@ function handleErrorFromBinding(ctx) {
     // TODO(joyeecheung): currently, ctx.error are encoding errors
     // usually caused by memory problems. We need to figure out proper error
     // code(s) for this.
+    // eslint-disable-next-line no-restricted-syntax
     Error.captureStackTrace(ctx.error, handleErrorFromBinding);
     throw ctx.error;
   }

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -398,6 +398,7 @@ class AssertionError extends Error {
     this.actual = actual;
     this.expected = expected;
     this.operator = operator;
+    // eslint-disable-next-line no-restricted-syntax
     Error.captureStackTrace(this, stackStartFn);
     // Create error message including the error code in the name.
     this.stack;

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -388,12 +388,25 @@ class AssertionError extends Error {
     }
 
     this.generatedMessage = !message;
-    this.name = 'AssertionError [ERR_ASSERTION]';
+    Object.defineProperty(this, 'name', {
+      value: 'AssertionError [ERR_ASSERTION]',
+      enumerable: false,
+      writable: true,
+      configurable: true
+    });
     this.code = 'ERR_ASSERTION';
     this.actual = actual;
     this.expected = expected;
     this.operator = operator;
     Error.captureStackTrace(this, stackStartFn);
+    // Create error message including the error code in the name.
+    this.stack;
+    // Reset the name.
+    this.name = 'AssertionError';
+  }
+
+  toString() {
+    return `${this.name} [${this.code}]: ${this.message}`;
   }
 
   [inspect.custom](recurseTimes, ctx) {

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -300,6 +300,9 @@ class AssertionError extends Error {
       stackStartFn
     } = options;
 
+    const limit = Error.stackTraceLimit;
+    Error.stackTraceLimit = 0;
+
     if (message != null) {
       super(String(message));
     } else {
@@ -386,6 +389,8 @@ class AssertionError extends Error {
         super(`${res}${other}`);
       }
     }
+
+    Error.stackTraceLimit = limit;
 
     this.generatedMessage = !message;
     Object.defineProperty(this, 'name', {

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -105,6 +105,7 @@ function fatalError(e) {
     process._rawDebug(e.stack);
   } else {
     const o = { message: e };
+    // eslint-disable-next-line no-restricted-syntax
     Error.captureStackTrace(o, fatalError);
     process._rawDebug(o.stack);
   }

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -331,6 +331,7 @@ const consoleMethods = {
       name: 'Trace',
       message: this[kFormatForStderr](args)
     };
+    // eslint-disable-next-line no-restricted-syntax
     Error.captureStackTrace(err, this.trace);
     this.error(err.stack);
   },

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -65,8 +65,8 @@ function check(password, salt, iterations, keylen, digest) {
 
   password = validateArrayBufferView(password, 'password');
   salt = validateArrayBufferView(salt, 'salt');
-  iterations = validateUint32(iterations, 'iterations', 0);
-  keylen = validateUint32(keylen, 'keylen', 0);
+  validateUint32(iterations, 'iterations', 0);
+  validateUint32(keylen, 'keylen', 0);
 
   return { password, salt, iterations, keylen, digest };
 }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -354,6 +354,7 @@ function uvException(ctx) {
     err.dest = dest;
   }
 
+  // eslint-disable-next-line no-restricted-syntax
   Error.captureStackTrace(err, excludedStackFn || uvException);
   return err;
 }
@@ -396,6 +397,7 @@ function uvExceptionWithHostPort(err, syscall, address, port) {
     ex.port = port;
   }
 
+  // eslint-disable-next-line no-restricted-syntax
   Error.captureStackTrace(ex, excludedStackFn || uvExceptionWithHostPort);
   return ex;
 }
@@ -424,6 +426,7 @@ function errnoException(err, syscall, original) {
   ex.code = ex.errno = code;
   ex.syscall = syscall;
 
+  // eslint-disable-next-line no-restricted-syntax
   Error.captureStackTrace(ex, excludedStackFn || errnoException);
   return ex;
 }
@@ -472,6 +475,7 @@ function exceptionWithHostPort(err, syscall, address, port, additional) {
     ex.port = port;
   }
 
+  // eslint-disable-next-line no-restricted-syntax
   Error.captureStackTrace(ex, excludedStackFn || exceptionWithHostPort);
   return ex;
 }
@@ -512,6 +516,7 @@ function dnsException(code, syscall, hostname) {
     ex.hostname = hostname;
   }
 
+  // eslint-disable-next-line no-restricted-syntax
   Error.captureStackTrace(ex, excludedStackFn || dnsException);
   return ex;
 }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -18,7 +18,7 @@ const codes = {};
 const { kMaxLength } = internalBinding('buffer');
 const { defineProperty } = Object;
 
-let useOriginalName = false;
+let excludedStackFn;
 
 // Lazily loaded
 let util;
@@ -49,7 +49,15 @@ function lazyBuffer() {
 // and may have .path and .dest.
 class SystemError extends Error {
   constructor(key, context) {
-    super();
+    if (excludedStackFn === undefined) {
+      super();
+    } else {
+      const limit = Error.stackTraceLimit;
+      Error.stackTraceLimit = 0;
+      super();
+      // Reset the limit and setting the name property.
+      Error.stackTraceLimit = limit;
+    }
     const prefix = getMessage(key, [], this);
     let message = `${prefix}: ${context.syscall} returned ` +
                   `${context.code} (${context.message})`;
@@ -148,7 +156,15 @@ function makeSystemErrorWithCode(key) {
 function makeNodeErrorWithCode(Base, key) {
   return class NodeError extends Base {
     constructor(...args) {
-      super();
+      if (excludedStackFn === undefined) {
+        super();
+      } else {
+        const limit = Error.stackTraceLimit;
+        Error.stackTraceLimit = 0;
+        super();
+        // Reset the limit and setting the name property.
+        Error.stackTraceLimit = limit;
+      }
       const message = getMessage(key, args, this);
       Object.defineProperty(this, 'message', {
         value: message,
@@ -178,9 +194,30 @@ function makeNodeErrorWithCode(Base, key) {
   };
 }
 
+// This function removes unnecessary frames from Node.js core errors.
+function hideStackFrames(fn) {
+  return function hidden(...args) {
+    // Make sure the most outer `hideStackFrames()` function is used.
+    let setStackFn = false;
+    if (excludedStackFn === undefined) {
+      excludedStackFn = hidden;
+      setStackFn = true;
+    }
+    try {
+      return fn(...args);
+    } finally {
+      if (setStackFn === true) {
+        excludedStackFn = undefined;
+      }
+    }
+  };
+}
+
 function addCodeToName(err, name, code) {
-  if (useOriginalName) {
-    return;
+  // Set the stack
+  if (excludedStackFn !== undefined) {
+    // eslint-disable-next-line no-restricted-syntax
+    Error.captureStackTrace(err, excludedStackFn);
   }
   // Add the error code to the name to include it in the stack trace.
   err.name = `${name} [${code}]`;
@@ -308,6 +345,7 @@ function uvException(ctx) {
     err[prop] = ctx[prop];
   }
 
+  // TODO(BridgeAR): Show the `code` property as part of the stack.
   err.code = code;
   if (path) {
     err.path = path;
@@ -316,7 +354,7 @@ function uvException(ctx) {
     err.dest = dest;
   }
 
-  Error.captureStackTrace(err, uvException);
+  Error.captureStackTrace(err, excludedStackFn || uvException);
   return err;
 }
 
@@ -358,7 +396,7 @@ function uvExceptionWithHostPort(err, syscall, address, port) {
     ex.port = port;
   }
 
-  Error.captureStackTrace(ex, uvExceptionWithHostPort);
+  Error.captureStackTrace(ex, excludedStackFn || uvExceptionWithHostPort);
   return ex;
 }
 
@@ -386,7 +424,7 @@ function errnoException(err, syscall, original) {
   ex.code = ex.errno = code;
   ex.syscall = syscall;
 
-  Error.captureStackTrace(ex, errnoException);
+  Error.captureStackTrace(ex, excludedStackFn || errnoException);
   return ex;
 }
 
@@ -434,7 +472,7 @@ function exceptionWithHostPort(err, syscall, address, port, additional) {
     ex.port = port;
   }
 
-  Error.captureStackTrace(ex, exceptionWithHostPort);
+  Error.captureStackTrace(ex, excludedStackFn || exceptionWithHostPort);
   return ex;
 }
 
@@ -473,7 +511,8 @@ function dnsException(code, syscall, hostname) {
   if (hostname) {
     ex.hostname = hostname;
   }
-  Error.captureStackTrace(ex, dnsException);
+
+  Error.captureStackTrace(ex, excludedStackFn || dnsException);
   return ex;
 }
 
@@ -523,21 +562,19 @@ function oneOf(expected, thing) {
 }
 
 module.exports = {
+  addCodeToName, // Exported for NghttpError
+  codes,
   dnsException,
   errnoException,
   exceptionWithHostPort,
+  getMessage,
+  hideStackFrames,
+  isStackOverflowError,
   uvException,
   uvExceptionWithHostPort,
-  isStackOverflowError,
-  getMessage,
   SystemError,
-  codes,
   // This is exported only to facilitate testing.
-  E,
-  // This allows us to tell the type of the errors without using
-  // instanceof, which is necessary in WPT harness.
-  get useOriginalName() { return useOriginalName; },
-  set useOriginalName(value) { useOriginalName = value; }
+  E
 };
 
 // To declare an error message, use the E(sym, val, def) function above. The sym
@@ -556,7 +593,6 @@ module.exports = {
 // Note: Please try to keep these in alphabetical order
 //
 // Note: Node.js specific errors must begin with the prefix ERR_
-
 E('ERR_AMBIGUOUS_ARGUMENT', 'The "%s" argument is ambiguous. %s', TypeError);
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable', TypeError);
 E('ERR_ASSERTION', '%s', Error);
@@ -630,7 +666,10 @@ E('ERR_ENCODING_INVALID_ENCODED_DATA', function(encoding, ret) {
 }, TypeError);
 E('ERR_ENCODING_NOT_SUPPORTED', 'The "%s" encoding is not supported',
   RangeError);
-E('ERR_FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value', Error);
+E('ERR_FALSY_VALUE_REJECTION', function(reason) {
+  this.reason = reason;
+  return 'Promise was rejected with falsy value';
+}, Error);
 E('ERR_FS_FILE_TOO_LARGE', 'File size (%s) is greater than possible Buffer: ' +
     `${kMaxLength} bytes`,
   RangeError);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -18,6 +18,8 @@ const codes = {};
 const { kMaxLength } = internalBinding('buffer');
 const { defineProperty } = Object;
 
+let useOriginalName = false;
+
 // Lazily loaded
 let util;
 let assert;
@@ -74,19 +76,7 @@ class SystemError extends Error {
       value: key,
       writable: true
     });
-  }
-
-  get name() {
-    return `SystemError [${this[kCode]}]`;
-  }
-
-  set name(value) {
-    defineProperty(this, 'name', {
-      configurable: true,
-      enumerable: true,
-      value,
-      writable: true
-    });
+    addCodeToName(this, 'SystemError', key);
   }
 
   get code() {
@@ -141,6 +131,10 @@ class SystemError extends Error {
     this[kInfo].dest = val ?
       lazyBuffer().from(val.toString()) : undefined;
   }
+
+  toString() {
+    return `${this.name} [${this.code}]: ${this.message}`;
+  }
 }
 
 function makeSystemErrorWithCode(key) {
@@ -150,8 +144,6 @@ function makeSystemErrorWithCode(key) {
     }
   };
 }
-
-let useOriginalName = false;
 
 function makeNodeErrorWithCode(Base, key) {
   return class NodeError extends Base {
@@ -164,22 +156,7 @@ function makeNodeErrorWithCode(Base, key) {
         writable: true,
         configurable: true
       });
-    }
-
-    get name() {
-      if (useOriginalName) {
-        return super.name;
-      }
-      return `${super.name} [${key}]`;
-    }
-
-    set name(value) {
-      defineProperty(this, 'name', {
-        configurable: true,
-        enumerable: true,
-        value,
-        writable: true
-      });
+      addCodeToName(this, super.name, key);
     }
 
     get code() {
@@ -194,7 +171,33 @@ function makeNodeErrorWithCode(Base, key) {
         writable: true
       });
     }
+
+    toString() {
+      return `${this.name} [${key}]: ${this.message}`;
+    }
   };
+}
+
+function addCodeToName(err, name, code) {
+  if (useOriginalName) {
+    return;
+  }
+  // Add the error code to the name to include it in the stack trace.
+  err.name = `${name} [${code}]`;
+  // Access the stack to generate the error message including the error code
+  // from the name.
+  err.stack;
+  // Reset the name to the actual name.
+  if (name === 'SystemError') {
+    defineProperty(err, 'name', {
+      value: name,
+      enumerable: false,
+      writable: true,
+      configurable: true
+    });
+  } else {
+    delete err.name;
+  }
 }
 
 // Utility function for registering the error codes. Only used here. Exported

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -2,13 +2,16 @@
 
 const { Buffer, kMaxLength } = require('buffer');
 const {
-  ERR_FS_INVALID_SYMLINK_TYPE,
-  ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_ARG_VALUE,
-  ERR_INVALID_OPT_VALUE,
-  ERR_INVALID_OPT_VALUE_ENCODING,
-  ERR_OUT_OF_RANGE
-} = require('internal/errors').codes;
+  codes: {
+    ERR_FS_INVALID_SYMLINK_TYPE,
+    ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
+    ERR_INVALID_OPT_VALUE,
+    ERR_INVALID_OPT_VALUE_ENCODING,
+    ERR_OUT_OF_RANGE
+  },
+  hideStackFrames
+} = require('internal/errors');
 const { isUint8Array, isArrayBufferView } = require('internal/util/types');
 const { once } = require('internal/util');
 const pathModule = require('path');
@@ -185,7 +188,7 @@ function getOptions(options, defaultOptions) {
 
 // Check if the path contains null types if it is a string nor Uint8Array,
 // otherwise return silently.
-function nullCheck(path, propName, throwError = true) {
+const nullCheck = hideStackFrames((path, propName, throwError = true) => {
   const pathIsString = typeof path === 'string';
   const pathIsUint8Array = isUint8Array(path);
 
@@ -196,26 +199,16 @@ function nullCheck(path, propName, throwError = true) {
     return;
   }
 
-  // Reducing the limit improves the performance significantly. We do not loose
-  // the stack frames due to the `captureStackTrace()` function that is called
-  // later.
-  const tmpLimit = Error.stackTraceLimit;
-  if (throwError) {
-    Error.stackTraceLimit = 0;
-  }
   const err = new ERR_INVALID_ARG_VALUE(
     propName,
     path,
     'must be a string or Uint8Array without null bytes'
   );
-
   if (throwError) {
-    Error.stackTraceLimit = tmpLimit;
-    Error.captureStackTrace(err, nullCheck);
     throw err;
   }
   return err;
-}
+});
 
 function preprocessSymlinkDestination(path, type, linkPath) {
   if (!isWindows) {
@@ -359,7 +352,7 @@ function stringToFlags(flags) {
   throw new ERR_INVALID_OPT_VALUE('flags', flags);
 }
 
-function stringToSymlinkType(type) {
+const stringToSymlinkType = hideStackFrames((type) => {
   let flags = 0;
   if (typeof type === 'string') {
     switch (type) {
@@ -372,13 +365,11 @@ function stringToSymlinkType(type) {
       case 'file':
         break;
       default:
-        const err = new ERR_FS_INVALID_SYMLINK_TYPE(type);
-        Error.captureStackTrace(err, stringToSymlinkType);
-        throw err;
+        throw new ERR_FS_INVALID_SYMLINK_TYPE(type);
     }
   }
   return flags;
-}
+});
 
 // converts Date or number to a fractional UNIX timestamp
 function toUnixTimestamp(time, name = 'time') {
@@ -399,65 +390,51 @@ function toUnixTimestamp(time, name = 'time') {
   throw new ERR_INVALID_ARG_TYPE(name, ['Date', 'Time in seconds'], time);
 }
 
-function validateBuffer(buffer) {
+const validateBuffer = hideStackFrames((buffer) => {
   if (!isArrayBufferView(buffer)) {
-    const err = new ERR_INVALID_ARG_TYPE('buffer',
-                                         ['Buffer', 'TypedArray', 'DataView'],
-                                         buffer);
-    Error.captureStackTrace(err, validateBuffer);
-    throw err;
+    throw new ERR_INVALID_ARG_TYPE('buffer',
+                                   ['Buffer', 'TypedArray', 'DataView'],
+                                   buffer);
   }
-}
+});
 
-function validateOffsetLengthRead(offset, length, bufferLength) {
-  let err;
-
-  if (offset < 0 || offset >= bufferLength) {
-    err = new ERR_OUT_OF_RANGE('offset',
-                               `>= 0 && <= ${bufferLength}`, offset);
-  } else if (length < 0 || offset + length > bufferLength) {
-    err = new ERR_OUT_OF_RANGE('length',
-                               `>= 0 && <= ${bufferLength - offset}`, length);
-  }
-
-  if (err !== undefined) {
-    Error.captureStackTrace(err, validateOffsetLengthRead);
-    throw err;
-  }
-}
-
-function validateOffsetLengthWrite(offset, length, byteLength) {
-  let err;
-
-  if (offset > byteLength) {
-    err = new ERR_OUT_OF_RANGE('offset', `<= ${byteLength}`, offset);
-  } else {
-    const max = byteLength > kMaxLength ? kMaxLength : byteLength;
-    if (length > max - offset) {
-      err = new ERR_OUT_OF_RANGE('length', `<= ${max - offset}`, length);
+const validateOffsetLengthRead = hideStackFrames(
+  (offset, length, bufferLength) => {
+    if (offset < 0 || offset >= bufferLength) {
+      throw new ERR_OUT_OF_RANGE('offset',
+                                 `>= 0 && <= ${bufferLength}`, offset);
+    }
+    if (length < 0 || offset + length > bufferLength) {
+      throw new ERR_OUT_OF_RANGE('length',
+                                 `>= 0 && <= ${bufferLength - offset}`, length);
     }
   }
+);
 
-  if (err !== undefined) {
-    Error.captureStackTrace(err, validateOffsetLengthWrite);
-    throw err;
+const validateOffsetLengthWrite = hideStackFrames(
+  (offset, length, byteLength) => {
+    if (offset > byteLength) {
+      throw new ERR_OUT_OF_RANGE('offset', `<= ${byteLength}`, offset);
+    }
+
+    const max = byteLength > kMaxLength ? kMaxLength : byteLength;
+    if (length > max - offset) {
+      throw new ERR_OUT_OF_RANGE('length', `<= ${max - offset}`, length);
+    }
   }
-}
+);
 
-function validatePath(path, propName = 'path') {
-  let err;
-
+const validatePath = hideStackFrames((path, propName = 'path') => {
   if (typeof path !== 'string' && !isUint8Array(path)) {
-    err = new ERR_INVALID_ARG_TYPE(propName, ['string', 'Buffer', 'URL'], path);
-  } else {
-    err = nullCheck(path, propName, false);
+    throw new ERR_INVALID_ARG_TYPE(propName, ['string', 'Buffer', 'URL'], path);
   }
 
+  const err = nullCheck(path, propName, false);
+
   if (err !== undefined) {
-    Error.captureStackTrace(err, validatePath);
     throw err;
   }
-}
+});
 
 module.exports = {
   assertEncoding,

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -6,17 +6,20 @@ const Readable = Stream.Readable;
 const binding = internalBinding('http2');
 const constants = binding.constants;
 const {
-  ERR_HTTP2_HEADERS_SENT,
-  ERR_HTTP2_INFO_STATUS_NOT_ALLOWED,
-  ERR_HTTP2_INVALID_HEADER_VALUE,
-  ERR_HTTP2_INVALID_STREAM,
-  ERR_HTTP2_NO_SOCKET_MANIPULATION,
-  ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED,
-  ERR_HTTP2_STATUS_INVALID,
-  ERR_INVALID_ARG_VALUE,
-  ERR_INVALID_CALLBACK,
-  ERR_INVALID_HTTP_TOKEN
-} = require('internal/errors').codes;
+  codes: {
+    ERR_HTTP2_HEADERS_SENT,
+    ERR_HTTP2_INFO_STATUS_NOT_ALLOWED,
+    ERR_HTTP2_INVALID_HEADER_VALUE,
+    ERR_HTTP2_INVALID_STREAM,
+    ERR_HTTP2_NO_SOCKET_MANIPULATION,
+    ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED,
+    ERR_HTTP2_STATUS_INVALID,
+    ERR_INVALID_ARG_VALUE,
+    ERR_INVALID_CALLBACK,
+    ERR_INVALID_HTTP_TOKEN
+  },
+  hideStackFrames
+} = require('internal/errors');
 const { validateString } = require('internal/validators');
 const { kSocket, kRequest, kProxySocket } = require('internal/http2/util');
 
@@ -51,22 +54,20 @@ let statusConnectionHeaderWarned = false;
 // HTTP/2 implementation, intended to provide an interface that is as
 // close as possible to the current require('http') API
 
-function assertValidHeader(name, value) {
-  let err;
+const assertValidHeader = hideStackFrames((name, value) => {
   if (name === '' || typeof name !== 'string') {
-    err = new ERR_INVALID_HTTP_TOKEN('Header name', name);
-  } else if (isPseudoHeader(name)) {
-    err = new ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED();
-  } else if (value === undefined || value === null) {
-    err = new ERR_HTTP2_INVALID_HEADER_VALUE(value, name);
-  } else if (!isConnectionHeaderAllowed(name, value)) {
+    throw new ERR_INVALID_HTTP_TOKEN('Header name', name);
+  }
+  if (isPseudoHeader(name)) {
+    throw new ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED();
+  }
+  if (value === undefined || value === null) {
+    throw new ERR_HTTP2_INVALID_HEADER_VALUE(value, name);
+  }
+  if (!isConnectionHeaderAllowed(name, value)) {
     connectionHeaderMessageWarn();
   }
-  if (err !== undefined) {
-    Error.captureStackTrace(err, assertValidHeader);
-    throw err;
-  }
-}
+});
 
 function isPseudoHeader(name) {
   switch (name) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -76,7 +76,8 @@ const {
     ERR_INVALID_OPT_VALUE,
     ERR_OUT_OF_RANGE,
     ERR_SOCKET_CLOSED
-  }
+  },
+  hideStackFrames
 } = require('internal/errors');
 const { validateNumber, validateString } = require('internal/validators');
 const { utcDate } = require('internal/http');
@@ -606,37 +607,31 @@ function requestOnConnect(headers, options) {
 // 4. if specified, options.silent must be a boolean
 //
 // Also sets the default priority options if they are not set.
-function validatePriorityOptions(options) {
-  let err;
+const validatePriorityOptions = hideStackFrames((options) => {
   if (options.weight === undefined) {
     options.weight = NGHTTP2_DEFAULT_WEIGHT;
   } else if (typeof options.weight !== 'number') {
-    err = new ERR_INVALID_OPT_VALUE('weight', options.weight);
+    throw new ERR_INVALID_OPT_VALUE('weight', options.weight);
   }
 
   if (options.parent === undefined) {
     options.parent = 0;
   } else if (typeof options.parent !== 'number' || options.parent < 0) {
-    err = new ERR_INVALID_OPT_VALUE('parent', options.parent);
+    throw new ERR_INVALID_OPT_VALUE('parent', options.parent);
   }
 
   if (options.exclusive === undefined) {
     options.exclusive = false;
   } else if (typeof options.exclusive !== 'boolean') {
-    err = new ERR_INVALID_OPT_VALUE('exclusive', options.exclusive);
+    throw new ERR_INVALID_OPT_VALUE('exclusive', options.exclusive);
   }
 
   if (options.silent === undefined) {
     options.silent = false;
   } else if (typeof options.silent !== 'boolean') {
-    err = new ERR_INVALID_OPT_VALUE('silent', options.silent);
+    throw new ERR_INVALID_OPT_VALUE('silent', options.silent);
   }
-
-  if (err) {
-    Error.captureStackTrace(err, validatePriorityOptions);
-    throw err;
-  }
-}
+});
 
 // When an error occurs internally at the binding level, immediately
 // destroy the session.
@@ -788,7 +783,7 @@ function pingCallback(cb) {
 // 5. maxHeaderListSize must be a number in the range 0 <= n <= kMaxInt
 // 6. enablePush must be a boolean
 // All settings are optional and may be left undefined
-function validateSettings(settings) {
+const validateSettings = hideStackFrames((settings) => {
   settings = { ...settings };
   assertWithinRange('headerTableSize',
                     settings.headerTableSize,
@@ -807,13 +802,11 @@ function validateSettings(settings) {
                     0, kMaxInt);
   if (settings.enablePush !== undefined &&
       typeof settings.enablePush !== 'boolean') {
-    const err = new ERR_HTTP2_INVALID_SETTING_VALUE('enablePush',
-                                                    settings.enablePush);
-    Error.captureStackTrace(err, 'validateSettings');
-    throw err;
+    throw new ERR_HTTP2_INVALID_SETTING_VALUE('enablePush',
+                                              settings.enablePush);
   }
   return settings;
-}
+});
 
 // Creates the internal binding.Http2Session handle for an Http2Session
 // instance. This occurs only after the socket connection has been

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -2,12 +2,16 @@
 
 const binding = internalBinding('http2');
 const {
-  ERR_HTTP2_HEADER_SINGLE_VALUE,
-  ERR_HTTP2_INVALID_CONNECTION_HEADERS,
-  ERR_HTTP2_INVALID_PSEUDOHEADER,
-  ERR_HTTP2_INVALID_SETTING_VALUE,
-  ERR_INVALID_ARG_TYPE
-} = require('internal/errors').codes;
+  codes: {
+    ERR_HTTP2_HEADER_SINGLE_VALUE,
+    ERR_HTTP2_INVALID_CONNECTION_HEADERS,
+    ERR_HTTP2_INVALID_PSEUDOHEADER,
+    ERR_HTTP2_INVALID_SETTING_VALUE,
+    ERR_INVALID_ARG_TYPE
+  },
+  addCodeToName,
+  hideStackFrames
+} = require('internal/errors');
 
 const kSocket = Symbol('socket');
 const kProxySocket = Symbol('proxySocket');
@@ -404,27 +408,21 @@ function isIllegalConnectionSpecificHeader(name, value) {
   }
 }
 
-function assertValidPseudoHeader(key) {
+const assertValidPseudoHeader = hideStackFrames((key) => {
   if (!kValidPseudoHeaders.has(key)) {
-    const err = new ERR_HTTP2_INVALID_PSEUDOHEADER(key);
-    Error.captureStackTrace(err, assertValidPseudoHeader);
-    throw err;
+    throw new ERR_HTTP2_INVALID_PSEUDOHEADER(key);
   }
-}
+});
 
-function assertValidPseudoHeaderResponse(key) {
+const assertValidPseudoHeaderResponse = hideStackFrames((key) => {
   if (key !== ':status') {
-    const err = new ERR_HTTP2_INVALID_PSEUDOHEADER(key);
-    Error.captureStackTrace(err, assertValidPseudoHeaderResponse);
-    throw err;
+    throw new ERR_HTTP2_INVALID_PSEUDOHEADER(key);
   }
-}
+});
 
-function assertValidPseudoHeaderTrailer(key) {
-  const err = new ERR_HTTP2_INVALID_PSEUDOHEADER(key);
-  Error.captureStackTrace(err, assertValidPseudoHeaderTrailer);
-  throw err;
-}
+const assertValidPseudoHeaderTrailer = hideStackFrames((key) => {
+  throw new ERR_HTTP2_INVALID_PSEUDOHEADER(key);
+});
 
 function mapToHeaders(map,
                       assertValuePseudoHeader = assertValidPseudoHeader) {
@@ -496,10 +494,8 @@ class NghttpError extends Error {
   constructor(ret) {
     super(binding.nghttp2ErrorString(ret));
     this.code = 'ERR_HTTP2_ERROR';
-    this.name = 'Error [ERR_HTTP2_ERROR]';
     this.errno = ret;
-    this.stack;
-    delete this.name;
+    addCodeToName(this, super.name, 'ERR_HTTP2_ERROR');
   }
 
   toString() {
@@ -507,26 +503,24 @@ class NghttpError extends Error {
   }
 }
 
-function assertIsObject(value, name, types) {
+const assertIsObject = hideStackFrames((value, name, types) => {
   if (value !== undefined &&
       (value === null ||
        typeof value !== 'object' ||
        Array.isArray(value))) {
-    const err = new ERR_INVALID_ARG_TYPE(name, types || 'Object', value);
-    Error.captureStackTrace(err, assertIsObject);
-    throw err;
+    throw new ERR_INVALID_ARG_TYPE(name, types || 'Object', value);
   }
-}
+});
 
-function assertWithinRange(name, value, min = 0, max = Infinity) {
-  if (value !== undefined &&
+const assertWithinRange = hideStackFrames(
+  (name, value, min = 0, max = Infinity) => {
+    if (value !== undefined &&
       (typeof value !== 'number' || value < min || value > max)) {
-    const err = new ERR_HTTP2_INVALID_SETTING_VALUE.RangeError(
-      name, value, min, max);
-    Error.captureStackTrace(err, assertWithinRange);
-    throw err;
+      throw new ERR_HTTP2_INVALID_SETTING_VALUE.RangeError(
+        name, value, min, max);
+    }
   }
-}
+);
 
 function toHeaderObject(headers) {
   const obj = Object.create(null);

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -498,6 +498,12 @@ class NghttpError extends Error {
     this.code = 'ERR_HTTP2_ERROR';
     this.name = 'Error [ERR_HTTP2_ERROR]';
     this.errno = ret;
+    this.stack;
+    delete this.name;
+  }
+
+  toString() {
+    return `${this.name} [${this.code}]: ${this.message}`;
   }
 }
 

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -112,6 +112,7 @@ function emitWarning(warning, type, code, ctor, now) {
     warning.name = String(type || 'Warning');
     if (code !== undefined) warning.code = code;
     if (detail !== undefined) warning.detail = detail;
+    // eslint-disable-next-line no-restricted-syntax
     Error.captureStackTrace(warning, ctor || process.emitWarning);
   } else if (!(warning instanceof Error)) {
     throw new ERR_INVALID_ARG_TYPE('warning', ['Error', 'string'], warning);

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -993,6 +993,7 @@ function formatPrimitive(fn, value, ctx) {
 }
 
 function formatError(value) {
+  // TODO(BridgeAR): Always show the error code if present.
   return value.stack || errorToString(value);
 }
 

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -1,10 +1,13 @@
 'use strict';
 
 const {
-  ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_ARG_VALUE,
-  ERR_OUT_OF_RANGE
-} = require('internal/errors').codes;
+  hideStackFrames,
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
+    ERR_OUT_OF_RANGE
+  }
+} = require('internal/errors');
 
 function isInt32(value) {
   return value === (value | 0);
@@ -52,66 +55,52 @@ function validateMode(value, name, def) {
   throw new ERR_INVALID_ARG_VALUE(name, value, modeDesc);
 }
 
-function validateInteger(value, name) {
-  let err;
-
+const validateInteger = hideStackFrames((value, name) => {
   if (typeof value !== 'number')
-    err = new ERR_INVALID_ARG_TYPE(name, 'number', value);
-  else if (!Number.isSafeInteger(value))
-    err = new ERR_OUT_OF_RANGE(name, 'an integer', value);
-
-  if (err) {
-    Error.captureStackTrace(err, validateInteger);
-    throw err;
-  }
-
+    throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+  if (!Number.isSafeInteger(value))
+    throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
   return value;
-}
+});
 
-function validateInt32(value, name, min = -2147483648, max = 2147483647) {
-  // The defaults for min and max correspond to the limits of 32-bit integers.
-  if (!isInt32(value)) {
-    let err;
-    if (typeof value !== 'number') {
-      err = new ERR_INVALID_ARG_TYPE(name, 'number', value);
-    } else if (!Number.isInteger(value)) {
-      err = new ERR_OUT_OF_RANGE(name, 'an integer', value);
-    } else {
-      err = new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
+const validateInt32 = hideStackFrames(
+  (value, name, min = -2147483648, max = 2147483647) => {
+    // The defaults for min and max correspond to the limits of 32-bit integers.
+    if (!isInt32(value)) {
+      if (typeof value !== 'number') {
+        throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+      }
+      if (!Number.isInteger(value)) {
+        throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
+      }
+      throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
     }
-    Error.captureStackTrace(err, validateInt32);
-    throw err;
-  } else if (value < min || value > max) {
-    const err = new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
-    Error.captureStackTrace(err, validateInt32);
-    throw err;
+    if (value < min || value > max) {
+      throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
+    }
+    return value;
   }
+);
 
-  return value;
-}
-
-function validateUint32(value, name, positive) {
+const validateUint32 = hideStackFrames((value, name, positive) => {
   if (!isUint32(value)) {
-    let err;
     if (typeof value !== 'number') {
-      err = new ERR_INVALID_ARG_TYPE(name, 'number', value);
-    } else if (!Number.isInteger(value)) {
-      err = new ERR_OUT_OF_RANGE(name, 'an integer', value);
-    } else {
-      const min = positive ? 1 : 0;
-      // 2 ** 32 === 4294967296
-      err = new ERR_OUT_OF_RANGE(name, `>= ${min} && < 4294967296`, value);
+      throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
     }
-    Error.captureStackTrace(err, validateUint32);
-    throw err;
-  } else if (positive && value === 0) {
-    const err = new ERR_OUT_OF_RANGE(name, '>= 1 && < 4294967296', value);
-    Error.captureStackTrace(err, validateUint32);
-    throw err;
+    if (!Number.isInteger(value)) {
+      throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
+    }
+    const min = positive ? 1 : 0;
+    // 2 ** 32 === 4294967296
+    throw new ERR_OUT_OF_RANGE(name, `>= ${min} && < 4294967296`, value);
   }
-
+  if (positive && value === 0) {
+    throw new ERR_OUT_OF_RANGE(name, '>= 1 && < 4294967296', value);
+  }
+  // TODO(BridgeAR): Remove return values from validation functions and
+  // especially reduce side effects caused by validation functions.
   return value;
-}
+});
 
 function validateString(value, name) {
   if (typeof value !== 'string')

--- a/lib/os.js
+++ b/lib/os.js
@@ -26,7 +26,12 @@ const constants = internalBinding('constants').os;
 const { deprecate } = require('internal/util');
 const isWindows = process.platform === 'win32';
 
-const { codes: { ERR_SYSTEM_ERROR } } = require('internal/errors');
+const {
+  codes: {
+    ERR_SYSTEM_ERROR
+  },
+  hideStackFrames
+} = require('internal/errors');
 const { validateInt32 } = require('internal/validators');
 
 const {
@@ -47,16 +52,14 @@ const {
 } = internalBinding('os');
 
 function getCheckedFunction(fn) {
-  return function checkError(...args) {
+  return hideStackFrames(function checkError(...args) {
     const ctx = {};
     const ret = fn(...args, ctx);
     if (ret === undefined) {
-      const err = new ERR_SYSTEM_ERROR(ctx);
-      Error.captureStackTrace(err, checkError);
-      throw err;
+      throw new ERR_SYSTEM_ERROR(ctx);
     }
     return ret;
-  };
+  });
 }
 
 const getHomeDirectory = getCheckedFunction(_getHomeDirectory);

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,18 +21,22 @@
 
 'use strict';
 
-const errors = require('internal/errors');
+const {
+  codes: {
+    ERR_FALSY_VALUE_REJECTION,
+    ERR_INVALID_ARG_TYPE,
+    ERR_OUT_OF_RANGE
+  },
+  errnoException,
+  exceptionWithHostPort,
+  hideStackFrames
+} = require('internal/errors');
 const {
   format,
   formatWithOptions,
   inspect
 } = require('internal/util/inspect');
 const { debuglog } = require('internal/util/debuglog');
-const {
-  ERR_FALSY_VALUE_REJECTION,
-  ERR_INVALID_ARG_TYPE,
-  ERR_OUT_OF_RANGE
-} = errors.codes;
 const { validateNumber } = require('internal/validators');
 const { TextDecoder, TextEncoder } = require('internal/encoding');
 const { isBuffer } = require('buffer').Buffer;
@@ -158,19 +162,16 @@ function _extend(target, source) {
   return target;
 }
 
-function callbackifyOnRejected(reason, cb) {
+const callbackifyOnRejected = hideStackFrames((reason, cb) => {
   // `!reason` guard inspired by bluebird (Ref: https://goo.gl/t5IS6M).
   // Because `null` is a special error value in callbacks which means "no error
   // occurred", we error-wrap so the callback consumer can distinguish between
   // "the promise rejected with null" or "the promise fulfilled with undefined".
   if (!reason) {
-    const newReason = new ERR_FALSY_VALUE_REJECTION();
-    newReason.reason = reason;
-    reason = newReason;
-    Error.captureStackTrace(reason, callbackifyOnRejected);
+    reason = new ERR_FALSY_VALUE_REJECTION(reason);
   }
   return cb(reason);
-}
+});
 
 function callbackify(original) {
   if (typeof original !== 'function') {
@@ -209,8 +210,8 @@ function getSystemErrorName(err) {
 
 // Keep the `exports =` so that various functions can still be monkeypatched
 module.exports = exports = {
-  _errnoException: errors.errnoException,
-  _exceptionWithHostPort: errors.exceptionWithHostPort,
+  _errnoException: errnoException,
+  _exceptionWithHostPort: exceptionWithHostPort,
   _extend,
   callbackify,
   debuglog,

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -22,12 +22,15 @@
 'use strict';
 
 const {
-  ERR_BROTLI_INVALID_PARAM,
-  ERR_BUFFER_TOO_LARGE,
-  ERR_INVALID_ARG_TYPE,
-  ERR_OUT_OF_RANGE,
-  ERR_ZLIB_INITIALIZATION_FAILED,
-} = require('internal/errors').codes;
+  codes: {
+    ERR_BROTLI_INVALID_PARAM,
+    ERR_BUFFER_TOO_LARGE,
+    ERR_INVALID_ARG_TYPE,
+    ERR_OUT_OF_RANGE,
+    ERR_ZLIB_INITIALIZATION_FAILED,
+  },
+  hideStackFrames
+} = require('internal/errors');
 const Transform = require('_stream_transform');
 const {
   deprecate,
@@ -170,7 +173,7 @@ function zlibOnError(message, errno, code) {
 // 2. Returns true for finite numbers
 // 3. Throws ERR_INVALID_ARG_TYPE for non-numbers
 // 4. Throws ERR_OUT_OF_RANGE for infinite numbers
-function checkFiniteNumber(number, name) {
+const checkFiniteNumber = hideStackFrames((number, name) => {
   // Common case
   if (number === undefined) {
     return false;
@@ -186,33 +189,29 @@ function checkFiniteNumber(number, name) {
 
   // Other non-numbers
   if (typeof number !== 'number') {
-    const err = new ERR_INVALID_ARG_TYPE(name, 'number', number);
-    Error.captureStackTrace(err, checkFiniteNumber);
-    throw err;
+    throw new ERR_INVALID_ARG_TYPE(name, 'number', number);
   }
 
   // Infinite numbers
-  const err = new ERR_OUT_OF_RANGE(name, 'a finite number', number);
-  Error.captureStackTrace(err, checkFiniteNumber);
-  throw err;
-}
+  throw new ERR_OUT_OF_RANGE(name, 'a finite number', number);
+});
 
 // 1. Returns def for number when it's undefined or NaN
 // 2. Returns number for finite numbers >= lower and <= upper
 // 3. Throws ERR_INVALID_ARG_TYPE for non-numbers
 // 4. Throws ERR_OUT_OF_RANGE for infinite numbers or numbers > upper or < lower
-function checkRangesOrGetDefault(number, name, lower, upper, def) {
-  if (!checkFiniteNumber(number, name)) {
-    return def;
+const checkRangesOrGetDefault = hideStackFrames(
+  (number, name, lower, upper, def) => {
+    if (!checkFiniteNumber(number, name)) {
+      return def;
+    }
+    if (number < lower || number > upper) {
+      throw new ERR_OUT_OF_RANGE(name,
+                                 `>= ${lower} and <= ${upper}`, number);
+    }
+    return number;
   }
-  if (number < lower || number > upper) {
-    const err = new ERR_OUT_OF_RANGE(name,
-                                     `>= ${lower} and <= ${upper}`, number);
-    Error.captureStackTrace(err, checkRangesOrGetDefault);
-    throw err;
-  }
-  return number;
-}
+);
 
 // The base class for all Zlib-style streams.
 function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1534,33 +1534,6 @@ static inline napi_status set_error_code(napi_env env,
     RETURN_STATUS_IF_FALSE(env,
                            set_maybe.FromMaybe(false),
                            napi_generic_failure);
-
-    // now update the name to be "name [code]" where name is the
-    // original name and code is the code associated with the Error
-    v8::Local<v8::String> name_string;
-    CHECK_NEW_FROM_UTF8(env, name_string, "");
-    v8::Local<v8::Name> name_key;
-    CHECK_NEW_FROM_UTF8(env, name_key, "name");
-
-    auto maybe_name = err_object->Get(context, name_key);
-    if (!maybe_name.IsEmpty()) {
-      v8::Local<v8::Value> name = maybe_name.ToLocalChecked();
-      if (name->IsString()) {
-        name_string =
-            v8::String::Concat(isolate, name_string, name.As<v8::String>());
-      }
-    }
-    name_string = v8::String::Concat(
-        isolate, name_string, NAPI_FIXED_ONE_BYTE_STRING(isolate, " ["));
-    name_string =
-        v8::String::Concat(isolate, name_string, code_value.As<v8::String>());
-    name_string = v8::String::Concat(
-        isolate, name_string, NAPI_FIXED_ONE_BYTE_STRING(isolate, "]"));
-
-    set_maybe = err_object->Set(context, name_key, name_string);
-    RETURN_STATUS_IF_FALSE(env,
-                           set_maybe.FromMaybe(false),
-                           napi_generic_failure);
   }
   return napi_ok;
 }

--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -287,11 +287,6 @@ class WPTRunner {
   // TODO(joyeecheung): work with the upstream to port more tests in .html
   // to .js.
   runJsTests() {
-    // TODO(joyeecheung): it's still under discussion whether we should leave
-    // err.name alone. See https://github.com/nodejs/node/issues/20253
-    const internalErrors = require('internal/errors');
-    internalErrors.useOriginalName = true;
-
     let queue = [];
 
     // If the tests are run as `node test/wpt/test-something.js subset.any.js`,

--- a/test/js-native-api/test_error/test.js
+++ b/test/js-native-api/test_error/test.js
@@ -118,18 +118,18 @@ error = test_error.createErrorCode();
 assert.ok(error instanceof Error, 'expected error to be an instance of Error');
 assert.strictEqual(error.code, 'ERR_TEST_CODE');
 assert.strictEqual(error.message, 'Error [error]');
-assert.strictEqual(error.name, 'Error [ERR_TEST_CODE]');
+assert.strictEqual(error.name, 'Error');
 
 error = test_error.createRangeErrorCode();
 assert.ok(error instanceof RangeError,
           'expected error to be an instance of RangeError');
 assert.strictEqual(error.message, 'RangeError [range error]');
 assert.strictEqual(error.code, 'ERR_TEST_CODE');
-assert.strictEqual(error.name, 'RangeError [ERR_TEST_CODE]');
+assert.strictEqual(error.name, 'RangeError');
 
 error = test_error.createTypeErrorCode();
 assert.ok(error instanceof TypeError,
           'expected error to be an instance of TypeError');
 assert.strictEqual(error.message, 'TypeError [type error]');
 assert.strictEqual(error.code, 'ERR_TEST_CODE');
-assert.strictEqual(error.name, 'TypeError [ERR_TEST_CODE]');
+assert.strictEqual(error.name, 'TypeError');

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -13,7 +13,7 @@ const promises = [];
   const rejectingFn = async () => assert.fail();
   const errObj = {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: 'Failed'
   };
   // `assert.rejects` accepts a function or a promise as first argument.
@@ -38,7 +38,7 @@ const promises = [];
 
   promise = assert.rejects(() => {}, common.mustNotCall());
   promises.push(assert.rejects(promise, {
-    name: 'TypeError [ERR_INVALID_RETURN_VALUE]',
+    name: 'TypeError',
     code: 'ERR_INVALID_RETURN_VALUE',
     message: 'Expected instance of Promise to be returned ' +
              'from the "promiseFn" function but got type undefined.'
@@ -75,7 +75,7 @@ promises.push(assert.rejects(
     message: 'Expected instance of Promise to be returned ' +
              'from the "promiseFn" function but got instance of Map.',
     code: 'ERR_INVALID_RETURN_VALUE',
-    name: 'TypeError [ERR_INVALID_RETURN_VALUE]'
+    name: 'TypeError'
   }));
   promises.push(assert.doesNotReject(async () => {}));
   promises.push(assert.doesNotReject(Promise.resolve()));

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -778,7 +778,7 @@ assert.throws(
 assert.throws(
   () => assert.notDeepStrictEqual(new Date(2000, 3, 14), new Date(2000, 3, 14)),
   {
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: 'Expected "actual" not to be strictly deep-equal to: ' +
              util.inspect(new Date(2000, 3, 14))
   }
@@ -790,35 +790,35 @@ assert.throws(
   () => assert.deepStrictEqual(/ab/, /a/),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n+ /ab/\n- /a/`
   });
 assert.throws(
   () => assert.deepStrictEqual(/a/g, /a/),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n+ /a/g\n- /a/`
   });
 assert.throws(
   () => assert.deepStrictEqual(/a/i, /a/),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n+ /a/i\n- /a/`
   });
 assert.throws(
   () => assert.deepStrictEqual(/a/m, /a/),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n+ /a/m\n- /a/`
   });
 assert.throws(
   () => assert.deepStrictEqual(/a/igm, /a/im),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n+ /a/gim\n- /a/im\n     ^`
   });
 
@@ -844,14 +844,14 @@ assert.deepStrictEqual({ a: 4, b: '2' }, { a: 4, b: '2' });
 assert.throws(() => assert.deepStrictEqual([4], ['4']),
               {
                 code: 'ERR_ASSERTION',
-                name: 'AssertionError [ERR_ASSERTION]',
+                name: 'AssertionError',
                 message: `${defaultMsgStartFull}\n\n  [\n+   4\n-   '4'\n  ]`
               });
 assert.throws(
   () => assert.deepStrictEqual({ a: 4 }, { a: 4, b: true }),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n  ` +
              '{\n    a: 4,\n-   b: true\n  }'
   });
@@ -859,7 +859,7 @@ assert.throws(
   () => assert.deepStrictEqual(['a'], { 0: 'a' }),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n` +
              "+ [\n+   'a'\n+ ]\n- {\n-   '0': 'a'\n- }"
   });
@@ -953,7 +953,7 @@ assert.deepStrictEqual(obj1, obj2);
     () => assert.deepStrictEqual(a, b),
     {
       code: 'ERR_ASSERTION',
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       message: /\.\.\./g
     }
   );
@@ -977,7 +977,7 @@ assert.throws(
   () => assert.deepStrictEqual([1, 2, 3], [1, 2]),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n` +
             '  [\n' +
             '    1,\n' +
@@ -1063,7 +1063,7 @@ assert.throws(
     () => assert.deepStrictEqual(a, b),
     {
       code: 'ERR_ASSERTION',
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       message: /a: \[Getter: 5]\n-   a: \[Getter: 6]\n  /
     }
   );

--- a/test/parallel/test-assert-fail-deprecation.js
+++ b/test/parallel/test-assert-fail-deprecation.js
@@ -15,7 +15,7 @@ assert.throws(() => {
   assert.fail('first', 'second');
 }, {
   code: 'ERR_ASSERTION',
-  name: 'AssertionError [ERR_ASSERTION]',
+  name: 'AssertionError',
   message: '\'first\' != \'second\'',
   operator: '!=',
   actual: 'first',
@@ -28,7 +28,7 @@ assert.throws(() => {
   assert.fail('ignored', 'ignored', 'another custom message');
 }, {
   code: 'ERR_ASSERTION',
-  name: 'AssertionError [ERR_ASSERTION]',
+  name: 'AssertionError',
   message: 'another custom message',
   operator: 'fail',
   actual: 'ignored',
@@ -49,7 +49,7 @@ assert.throws(() => {
   assert.fail('first', 'second', undefined, 'operator');
 }, {
   code: 'ERR_ASSERTION',
-  name: 'AssertionError [ERR_ASSERTION]',
+  name: 'AssertionError',
   message: '\'first\' operator \'second\'',
   operator: 'operator',
   actual: 'first',

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -8,7 +8,7 @@ assert.throws(
   () => { assert.fail(); },
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: 'Failed',
     operator: 'fail',
     actual: undefined,
@@ -22,7 +22,7 @@ assert.throws(() => {
   assert.fail('custom message');
 }, {
   code: 'ERR_ASSERTION',
-  name: 'AssertionError [ERR_ASSERTION]',
+  name: 'AssertionError',
   message: 'custom message',
   operator: 'fail',
   actual: undefined,

--- a/test/parallel/test-assert-first-line.js
+++ b/test/parallel/test-assert-first-line.js
@@ -9,7 +9,7 @@ const { path } = require('../common/fixtures');
 assert.throws(
   () => require(path('assert-first-line')),
   {
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: "The expression evaluated to a falsy value:\n\n  ässört.ok('')\n"
   }
 );
@@ -17,7 +17,7 @@ assert.throws(
 assert.throws(
   () => require(path('assert-long-line')),
   {
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: "The expression evaluated to a falsy value:\n\n  assert.ok('')\n"
   }
 );

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -73,7 +73,7 @@ assert.throws(
   () => a.notStrictEqual(2, 2),
   {
     message: 'Expected "actual" to be strictly unequal to: 2',
-    name: 'AssertionError [ERR_ASSERTION]'
+    name: 'AssertionError'
   }
 );
 
@@ -82,7 +82,7 @@ assert.throws(
   {
     message: 'Expected "actual" to be strictly unequal to: ' +
              `'${'a '.repeat(30)}'`,
-    name: 'AssertionError [ERR_ASSERTION]'
+    name: 'AssertionError'
   }
 );
 
@@ -141,7 +141,7 @@ assert.throws(() => thrower(TypeError));
 assert.throws(
   () => a.doesNotThrow(() => thrower(Error), 'user message'),
   {
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     code: 'ERR_ASSERTION',
     operator: 'doesNotThrow',
     message: 'Got unwanted exception: user message\n' +
@@ -400,7 +400,7 @@ assert.throws(() => {
       () => new assert.AssertionError(input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        name: 'TypeError',
         message: 'The "options" argument must be of type Object. ' +
                  `Received type ${typeof input}`
       });
@@ -411,7 +411,7 @@ assert.throws(
   () => assert.strictEqual(new Error('foo'), new Error('foobar')),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: 'Expected "actual" to be reference-equal to "expected":\n' +
              '+ actual - expected\n\n' +
              '+ [Error: foo]\n- [Error: foobar]'
@@ -438,7 +438,7 @@ assert.throws(
     () => assert(...[]),
     {
       message: 'No value argument passed to `assert.ok()`',
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       generatedMessage: true
     }
   );
@@ -446,7 +446,7 @@ assert.throws(
     () => a(),
     {
       message: 'No value argument passed to `assert.ok()`',
-      name: 'AssertionError [ERR_ASSERTION]'
+      name: 'AssertionError'
     }
   );
 
@@ -886,7 +886,7 @@ common.expectsError(
     () => assert.throws(errFn, errObj),
     {
       code: 'ERR_ASSERTION',
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       message: `${start}\n${actExp}\n\n` +
                '  Comparison {\n' +
                '    code: 404,\n' +
@@ -903,7 +903,7 @@ common.expectsError(
     () => assert.throws(errFn, errObj),
     {
       code: 'ERR_ASSERTION',
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       message: `${start}\n${actExp}\n\n` +
                '  Comparison {\n' +
                '+   code: 404,\n' +
@@ -938,7 +938,7 @@ common.expectsError(
   assert.throws(
     () => assert.throws(() => { throw new TypeError('e'); }, new Error('e')),
     {
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       code: 'ERR_ASSERTION',
       message: `${start}\n${actExp}\n\n` +
                '  Comparison {\n' +
@@ -951,7 +951,7 @@ common.expectsError(
   assert.throws(
     () => assert.throws(() => { throw new Error('foo'); }, new Error('')),
     {
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       code: 'ERR_ASSERTION',
       generatedMessage: true,
       message: `${start}\n${actExp}\n\n` +
@@ -969,7 +969,7 @@ common.expectsError(
     // eslint-disable-next-line no-throw-literal
     () => a.doesNotThrow(() => { throw undefined; }),
     {
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       code: 'ERR_ASSERTION',
       message: 'Got unwanted exception.\nActual message: "undefined"'
     }
@@ -1102,7 +1102,7 @@ assert.throws(
   () => assert.strictEqual('test test', 'test foobar'),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: strictEqualMessageStart +
              '+ actual - expected\n\n' +
              "+ 'test test'\n" +
@@ -1119,7 +1119,7 @@ assert.throws(
   },
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: 'Expected "actual" not to be reference-equal to "expected": {}'
   }
 );
@@ -1131,7 +1131,7 @@ assert.throws(
   },
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: 'Expected "actual" not to be reference-equal to "expected":\n\n' +
              '{\n  a: true\n}\n'
   }

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -967,12 +967,12 @@ common.expectsError(
   });
 
 assert.throws(() => Buffer.from(), {
-  name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+  name: 'TypeError',
   message: 'The first argument must be one of type string, Buffer, ' +
   'ArrayBuffer, Array, or Array-like Object. Received type undefined'
 });
 assert.throws(() => Buffer.from(null), {
-  name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+  name: 'TypeError',
   message: 'The first argument must be one of type string, Buffer, ' +
   'ArrayBuffer, Array, or Array-like Object. Received type object'
 });

--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -42,7 +42,7 @@ assert.throws(function() {
   Buffer.from(new AB());
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
-  name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+  name: 'TypeError',
   message: 'The first argument must be one of type string, Buffer,' +
   ' ArrayBuffer, Array, or Array-like Object. Received type object'
 });
@@ -65,12 +65,12 @@ assert.throws(function() {
 
   assert.throws(() => Buffer.from(ab.buffer, 6), {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
-    name: 'RangeError [ERR_BUFFER_OUT_OF_BOUNDS]',
+    name: 'RangeError',
     message: '"offset" is outside of buffer bounds'
   });
   assert.throws(() => Buffer.from(ab.buffer, 3, 6), {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
-    name: 'RangeError [ERR_BUFFER_OUT_OF_BOUNDS]',
+    name: 'RangeError',
     message: '"length" is outside of buffer bounds'
   });
 }
@@ -93,12 +93,12 @@ assert.throws(function() {
 
   assert.throws(() => Buffer(ab.buffer, 6), {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
-    name: 'RangeError [ERR_BUFFER_OUT_OF_BOUNDS]',
+    name: 'RangeError',
     message: '"offset" is outside of buffer bounds'
   });
   assert.throws(() => Buffer(ab.buffer, 3, 6), {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
-    name: 'RangeError [ERR_BUFFER_OUT_OF_BOUNDS]',
+    name: 'RangeError',
     message: '"length" is outside of buffer bounds'
   });
 }
@@ -120,7 +120,7 @@ assert.throws(function() {
     Buffer.from(ab, Infinity);
   }, {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
-    name: 'RangeError [ERR_BUFFER_OUT_OF_BOUNDS]',
+    name: 'RangeError',
     message: '"offset" is outside of buffer bounds'
   });
 }
@@ -142,7 +142,7 @@ assert.throws(function() {
     Buffer.from(ab, 0, Infinity);
   }, {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
-    name: 'RangeError [ERR_BUFFER_OUT_OF_BOUNDS]',
+    name: 'RangeError',
     message: '"length" is outside of buffer bounds'
   });
 }

--- a/test/parallel/test-buffer-read.js
+++ b/test/parallel/test-buffer-read.js
@@ -54,12 +54,12 @@ read(buf, 'readUIntLE', [2, 2], 0xea48);
 // Error name and message
 const OOR_ERROR =
 {
-  name: 'RangeError [ERR_OUT_OF_RANGE]'
+  name: 'RangeError'
 };
 
 const OOB_ERROR =
 {
-  name: 'RangeError [ERR_BUFFER_OUT_OF_BOUNDS]',
+  name: 'RangeError',
   message: 'Attempt to write outside buffer bounds'
 };
 

--- a/test/parallel/test-buffer-readdouble.js
+++ b/test/parallel/test-buffer-readdouble.js
@@ -116,7 +116,7 @@ assert.strictEqual(buffer.readDoubleLE(0), -Infinity);
       () => buffer[fn](offset),
       {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError [ERR_OUT_OF_RANGE]',
+        name: 'RangeError',
         message: 'The value of "offset" is out of range. ' +
                  `It must be >= 0 and <= 0. Received ${offset}`
       });
@@ -126,7 +126,7 @@ assert.strictEqual(buffer.readDoubleLE(0), -Infinity);
     () => Buffer.alloc(1)[fn](1),
     {
       code: 'ERR_BUFFER_OUT_OF_BOUNDS',
-      name: 'RangeError [ERR_BUFFER_OUT_OF_BOUNDS]',
+      name: 'RangeError',
       message: 'Attempt to write outside buffer bounds'
     });
 
@@ -135,7 +135,7 @@ assert.strictEqual(buffer.readDoubleLE(0), -Infinity);
       () => buffer[fn](offset),
       {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError [ERR_OUT_OF_RANGE]',
+        name: 'RangeError',
         message: 'The value of "offset" is out of range. ' +
                  `It must be an integer. Received ${offset}`
       });

--- a/test/parallel/test-buffer-readfloat.js
+++ b/test/parallel/test-buffer-readfloat.js
@@ -79,7 +79,7 @@ assert.strictEqual(buffer.readFloatLE(0), -Infinity);
       () => buffer[fn](offset),
       {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError [ERR_OUT_OF_RANGE]',
+        name: 'RangeError',
         message: 'The value of "offset" is out of range. ' +
                  `It must be >= 0 and <= 0. Received ${offset}`
       });
@@ -89,7 +89,7 @@ assert.strictEqual(buffer.readFloatLE(0), -Infinity);
     () => Buffer.alloc(1)[fn](1),
     {
       code: 'ERR_BUFFER_OUT_OF_BOUNDS',
-      name: 'RangeError [ERR_BUFFER_OUT_OF_BOUNDS]',
+      name: 'RangeError',
       message: 'Attempt to write outside buffer bounds'
     });
 
@@ -98,7 +98,7 @@ assert.strictEqual(buffer.readFloatLE(0), -Infinity);
       () => buffer[fn](offset),
       {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError [ERR_OUT_OF_RANGE]',
+        name: 'RangeError',
         message: 'The value of "offset" is out of range. ' +
                  `It must be an integer. Received ${offset}`
       });

--- a/test/parallel/test-buffer-readint.js
+++ b/test/parallel/test-buffer-readint.js
@@ -18,7 +18,7 @@ const assert = require('assert');
         () => buffer[`read${fn}`](o),
         {
           code: 'ERR_INVALID_ARG_TYPE',
-          name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+          name: 'TypeError'
         });
     });
 
@@ -27,7 +27,7 @@ const assert = require('assert');
         () => buffer[`read${fn}`](offset),
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]'
+          name: 'RangeError'
         });
     });
 
@@ -36,7 +36,7 @@ const assert = require('assert');
         () => buffer[`read${fn}`](offset),
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "offset" is out of range. ' +
                    `It must be an integer. Received ${offset}`
         });
@@ -152,7 +152,7 @@ const assert = require('assert');
         () => buffer[fn](0, byteLength),
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "byteLength" is out of range. ' +
                    `It must be an integer. Received ${byteLength}`
         });
@@ -167,7 +167,7 @@ const assert = require('assert');
           () => buffer[fn](o, i),
           {
             code: 'ERR_INVALID_ARG_TYPE',
-            name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+            name: 'TypeError'
           });
       });
 
@@ -176,7 +176,7 @@ const assert = require('assert');
           () => buffer[fn](offset, i),
           {
             code: 'ERR_OUT_OF_RANGE',
-            name: 'RangeError [ERR_OUT_OF_RANGE]',
+            name: 'RangeError',
             message: 'The value of "offset" is out of range. ' +
                      `It must be >= 0 and <= ${8 - i}. Received ${offset}`
           });
@@ -187,7 +187,7 @@ const assert = require('assert');
           () => buffer[fn](offset, i),
           {
             code: 'ERR_OUT_OF_RANGE',
-            name: 'RangeError [ERR_OUT_OF_RANGE]',
+            name: 'RangeError',
             message: 'The value of "offset" is out of range. ' +
                      `It must be an integer. Received ${offset}`
           });

--- a/test/parallel/test-buffer-readuint.js
+++ b/test/parallel/test-buffer-readuint.js
@@ -18,7 +18,7 @@ const assert = require('assert');
         () => buffer[`read${fn}`](o),
         {
           code: 'ERR_INVALID_ARG_TYPE',
-          name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+          name: 'TypeError'
         });
     });
 
@@ -27,7 +27,7 @@ const assert = require('assert');
         () => buffer[`read${fn}`](offset),
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]'
+          name: 'RangeError'
         });
     });
 
@@ -36,7 +36,7 @@ const assert = require('assert');
         () => buffer[`read${fn}`](offset),
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "offset" is out of range. ' +
                    `It must be an integer. Received ${offset}`
         });
@@ -120,7 +120,7 @@ const assert = require('assert');
         () => buffer[fn](0, byteLength),
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "byteLength" is out of range. ' +
                    `It must be an integer. Received ${byteLength}`
         });
@@ -135,7 +135,7 @@ const assert = require('assert');
           () => buffer[fn](o, i),
           {
             code: 'ERR_INVALID_ARG_TYPE',
-            name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+            name: 'TypeError'
           });
       });
 
@@ -144,7 +144,7 @@ const assert = require('assert');
           () => buffer[fn](offset, i),
           {
             code: 'ERR_OUT_OF_RANGE',
-            name: 'RangeError [ERR_OUT_OF_RANGE]',
+            name: 'RangeError',
             message: 'The value of "offset" is out of range. ' +
                      `It must be >= 0 and <= ${8 - i}. Received ${offset}`
           });
@@ -155,7 +155,7 @@ const assert = require('assert');
           () => buffer[fn](offset, i),
           {
             code: 'ERR_OUT_OF_RANGE',
-            name: 'RangeError [ERR_OUT_OF_RANGE]',
+            name: 'RangeError',
             message: 'The value of "offset" is out of range. ' +
                      `It must be an integer. Received ${offset}`
           });

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -42,7 +42,7 @@ try {
 // Should throw with invalid length type
 const bufferInvalidTypeMsg = {
   code: 'ERR_INVALID_ARG_TYPE',
-  name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+  name: 'TypeError',
   message: /^The "size" argument must be of type number/,
 };
 assert.throws(() => SlowBuffer(), bufferInvalidTypeMsg);
@@ -53,7 +53,7 @@ assert.throws(() => SlowBuffer(true), bufferInvalidTypeMsg);
 // Should throw with invalid length value
 const bufferMaxSizeMsg = {
   code: 'ERR_INVALID_OPT_VALUE',
-  name: 'RangeError [ERR_INVALID_OPT_VALUE]',
+  name: 'RangeError',
   message: /^The value "[^"]*" is invalid for option "size"$/
 };
 assert.throws(() => SlowBuffer(NaN), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-writedouble.js
+++ b/test/parallel/test-buffer-writedouble.js
@@ -98,7 +98,7 @@ assert.ok(Number.isNaN(buffer.readDoubleLE(8)));
       () => small[fn](11.11, 0),
       {
         code: 'ERR_BUFFER_OUT_OF_BOUNDS',
-        name: 'RangeError [ERR_BUFFER_OUT_OF_BOUNDS]',
+        name: 'RangeError',
         message: 'Attempt to write outside buffer bounds'
       });
 
@@ -113,7 +113,7 @@ assert.ok(Number.isNaN(buffer.readDoubleLE(8)));
         () => buffer[fn](23, offset),
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "offset" is out of range. ' +
                      `It must be >= 0 and <= 8. Received ${offset}`
         });
@@ -124,7 +124,7 @@ assert.ok(Number.isNaN(buffer.readDoubleLE(8)));
         () => buffer[fn](42, offset),
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "offset" is out of range. ' +
                    `It must be an integer. Received ${offset}`
         });

--- a/test/parallel/test-buffer-writefloat.js
+++ b/test/parallel/test-buffer-writefloat.js
@@ -80,7 +80,7 @@ assert.ok(Number.isNaN(buffer.readFloatLE(4)));
       () => small[fn](11.11, 0),
       {
         code: 'ERR_BUFFER_OUT_OF_BOUNDS',
-        name: 'RangeError [ERR_BUFFER_OUT_OF_BOUNDS]',
+        name: 'RangeError',
         message: 'Attempt to write outside buffer bounds'
       });
 
@@ -96,7 +96,7 @@ assert.ok(Number.isNaN(buffer.readFloatLE(4)));
         () => buffer[fn](23, offset),
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "offset" is out of range. ' +
                    `It must be >= 0 and <= 4. Received ${offset}`
         }
@@ -108,7 +108,7 @@ assert.ok(Number.isNaN(buffer.readFloatLE(4)));
         () => buffer[fn](42, offset),
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "offset" is out of range. ' +
                    `It must be an integer. Received ${offset}`
         });

--- a/test/parallel/test-buffer-writeint.js
+++ b/test/parallel/test-buffer-writeint.js
@@ -205,7 +205,7 @@ const errorOutOfBounds = common.expectsError({
         () => data[fn](42, 0, byteLength),
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "byteLength" is out of range. ' +
                    `It must be an integer. Received ${byteLength}`
         });
@@ -223,7 +223,7 @@ const errorOutOfBounds = common.expectsError({
           data[fn](val, 0, i);
         }, {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "value" is out of range. ' +
                    `It must be >= ${min} and <= ${max}. Received ${val}`
         });
@@ -234,7 +234,7 @@ const errorOutOfBounds = common.expectsError({
           () => data[fn](min, o, i),
           {
             code: 'ERR_INVALID_ARG_TYPE',
-            name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+            name: 'TypeError'
           });
       });
 
@@ -243,7 +243,7 @@ const errorOutOfBounds = common.expectsError({
           () => data[fn](min, offset, i),
           {
             code: 'ERR_OUT_OF_RANGE',
-            name: 'RangeError [ERR_OUT_OF_RANGE]',
+            name: 'RangeError',
             message: 'The value of "offset" is out of range. ' +
                      `It must be >= 0 and <= ${8 - i}. Received ${offset}`
           });
@@ -254,7 +254,7 @@ const errorOutOfBounds = common.expectsError({
           () => data[fn](max, offset, i),
           {
             code: 'ERR_OUT_OF_RANGE',
-            name: 'RangeError [ERR_OUT_OF_RANGE]',
+            name: 'RangeError',
             message: 'The value of "offset" is out of range. ' +
                      `It must be an integer. Received ${offset}`
           });

--- a/test/parallel/test-buffer-writeuint.js
+++ b/test/parallel/test-buffer-writeuint.js
@@ -162,7 +162,7 @@ const assert = require('assert');
         () => data[fn](42, 0, byteLength),
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "byteLength" is out of range. ' +
                    `It must be an integer. Received ${byteLength}`
         });
@@ -176,7 +176,7 @@ const assert = require('assert');
         data[fn](val, 0, i);
       }, {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError [ERR_OUT_OF_RANGE]',
+        name: 'RangeError',
         message: 'The value of "value" is out of range. ' +
                  `It must be >= 0 and <= ${val - 1}. Received ${val}`
       });
@@ -186,7 +186,7 @@ const assert = require('assert');
           () => data[fn](23, o, i),
           {
             code: 'ERR_INVALID_ARG_TYPE',
-            name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+            name: 'TypeError'
           });
       });
 
@@ -195,7 +195,7 @@ const assert = require('assert');
           () => data[fn](val - 1, offset, i),
           {
             code: 'ERR_OUT_OF_RANGE',
-            name: 'RangeError [ERR_OUT_OF_RANGE]',
+            name: 'RangeError',
             message: 'The value of "offset" is out of range. ' +
                      `It must be >= 0 and <= ${8 - i}. Received ${offset}`
           });
@@ -206,7 +206,7 @@ const assert = require('assert');
           () => data[fn](val - 1, offset, i),
           {
             code: 'ERR_OUT_OF_RANGE',
-            name: 'RangeError [ERR_OUT_OF_RANGE]',
+            name: 'RangeError',
             message: 'The value of "offset" is out of range. ' +
                      `It must be an integer. Received ${offset}`
           });

--- a/test/parallel/test-child-process-fork.js
+++ b/test/parallel/test-child-process-fork.js
@@ -39,18 +39,18 @@ n.on('message', (m) => {
 // https://github.com/joyent/node/issues/2355 - JSON.stringify(undefined)
 // returns "undefined" but JSON.parse() cannot parse that...
 assert.throws(() => n.send(undefined), {
-  name: 'TypeError [ERR_MISSING_ARGS]',
+  name: 'TypeError',
   message: 'The "message" argument must be specified',
   code: 'ERR_MISSING_ARGS'
 });
 assert.throws(() => n.send(), {
-  name: 'TypeError [ERR_MISSING_ARGS]',
+  name: 'TypeError',
   message: 'The "message" argument must be specified',
   code: 'ERR_MISSING_ARGS'
 });
 
 assert.throws(() => n.send(Symbol()), {
-  name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+  name: 'TypeError',
   message: 'The "message" argument must be one of type string,' +
            ' object, number, or boolean. Received type symbol',
   code: 'ERR_INVALID_ARG_TYPE'

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -64,7 +64,7 @@ assert.throws(
   () => crypto.pbkdf2('password', 'salt', 1, 20, null),
   {
     code: 'ERR_INVALID_CALLBACK',
-    name: 'TypeError [ERR_INVALID_CALLBACK]'
+    name: 'TypeError'
   }
 );
 
@@ -72,7 +72,7 @@ assert.throws(
   () => crypto.pbkdf2Sync('password', 'salt', -1, 20, 'sha1'),
   {
     code: 'ERR_OUT_OF_RANGE',
-    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    name: 'RangeError',
     message: 'The value of "iterations" is out of range. ' +
              'It must be >= 0 && < 4294967296. Received -1'
   }
@@ -84,7 +84,7 @@ assert.throws(
       crypto.pbkdf2Sync('password', 'salt', 1, notNumber, 'sha256');
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: 'The "keylen" argument must be of type number. ' +
                `Received type ${typeof notNumber}`
     });
@@ -97,7 +97,7 @@ assert.throws(
                     common.mustNotCall());
     }, {
       code: 'ERR_OUT_OF_RANGE',
-      name: 'RangeError [ERR_OUT_OF_RANGE]',
+      name: 'RangeError',
       message: 'The value of "keylen" is out of range. It ' +
                `must be an integer. Received ${input}`
     });
@@ -110,7 +110,7 @@ assert.throws(
                     common.mustNotCall());
     }, {
       code: 'ERR_OUT_OF_RANGE',
-      name: 'RangeError [ERR_OUT_OF_RANGE]',
+      name: 'RangeError',
       message: 'The value of "keylen" is out of range. It ' +
                `must be >= 0 && < 4294967296. Received ${input}`
     });
@@ -124,7 +124,7 @@ assert.throws(
   () => crypto.pbkdf2('password', 'salt', 8, 8, common.mustNotCall()),
   {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "digest" argument must be one of type string or null. ' +
              'Received type undefined'
   });
@@ -133,7 +133,7 @@ assert.throws(
   () => crypto.pbkdf2Sync('password', 'salt', 8, 8),
   {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "digest" argument must be one of type string or null. ' +
              'Received type undefined'
   });
@@ -145,7 +145,7 @@ assert.throws(
     () => crypto.pbkdf2(input, 'salt', 8, 8, 'sha256', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: `The "password" argument must be one of type string, ${msgPart2}`
     }
   );
@@ -154,7 +154,7 @@ assert.throws(
     () => crypto.pbkdf2('pass', input, 8, 8, 'sha256', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: `The "salt" argument must be one of type string, ${msgPart2}`
     }
   );
@@ -163,7 +163,7 @@ assert.throws(
     () => crypto.pbkdf2Sync(input, 'salt', 8, 8, 'sha256'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: `The "password" argument must be one of type string, ${msgPart2}`
     }
   );
@@ -172,7 +172,7 @@ assert.throws(
     () => crypto.pbkdf2Sync('pass', input, 8, 8, 'sha256'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: `The "salt" argument must be one of type string, ${msgPart2}`
     }
   );
@@ -184,7 +184,7 @@ assert.throws(
     () => crypto.pbkdf2('pass', 'salt', i, 8, 'sha256', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: `The "iterations" argument must be of type number. ${received}`
     }
   );
@@ -193,7 +193,7 @@ assert.throws(
     () => crypto.pbkdf2Sync('pass', 'salt', i, 8, 'sha256'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: `The "iterations" argument must be of type number. ${received}`
     }
   );
@@ -226,7 +226,7 @@ assert.throws(
   () => crypto.pbkdf2('pass', 'salt', 8, 8, 'md55', common.mustNotCall()),
   {
     code: 'ERR_CRYPTO_INVALID_DIGEST',
-    name: 'TypeError [ERR_CRYPTO_INVALID_DIGEST]',
+    name: 'TypeError',
     message: 'Invalid digest: md55'
   }
 );
@@ -235,7 +235,7 @@ assert.throws(
   () => crypto.pbkdf2Sync('pass', 'salt', 8, 8, 'md55'),
   {
     code: 'ERR_CRYPTO_INVALID_DIGEST',
-    name: 'TypeError [ERR_CRYPTO_INVALID_DIGEST]',
+    name: 'TypeError',
     message: 'Invalid digest: md55'
   }
 );

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -44,7 +44,7 @@ common.expectWarning('DeprecationWarning',
     [undefined, null, false, true, {}, []].forEach((value) => {
       const errObj = {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        name: 'TypeError',
         message: 'The "size" argument must be of type number. ' +
                 `Received type ${typeof value}`
       };
@@ -55,7 +55,7 @@ common.expectWarning('DeprecationWarning',
     [-1, NaN, 2 ** 32].forEach((value) => {
       const errObj = {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError [ERR_OUT_OF_RANGE]',
+        name: 'RangeError',
         message: 'The value of "size" is out of range. It must be >= 0 && <= ' +
                  `${kMaxPossibleLength}. Received ${value}`
       };
@@ -199,7 +199,7 @@ common.expectWarning('DeprecationWarning',
 
     const typeErrObj = {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: 'The "offset" argument must be of type number. ' +
                'Received type string'
     };
@@ -222,7 +222,7 @@ common.expectWarning('DeprecationWarning',
     [NaN, kMaxPossibleLength + 1, -10, (-1 >>> 0) + 1].forEach((offsetSize) => {
       const errObj = {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError [ERR_OUT_OF_RANGE]',
+        name: 'RangeError',
         message: 'The value of "offset" is out of range. ' +
                  `It must be >= 0 && <= 10. Received ${offsetSize}`
       };
@@ -245,7 +245,7 @@ common.expectWarning('DeprecationWarning',
 
     const rangeErrObj = {
       code: 'ERR_OUT_OF_RANGE',
-      name: 'RangeError [ERR_OUT_OF_RANGE]',
+      name: 'RangeError',
       message: 'The value of "size + offset" is out of range. ' +
                'It must be <= 10. Received 11'
     };
@@ -265,7 +265,7 @@ assert.throws(
   () => crypto.randomBytes((-1 >>> 0) + 1),
   {
     code: 'ERR_OUT_OF_RANGE',
-    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    name: 'RangeError',
     message: 'The value of "size" is out of range. ' +
              `It must be >= 0 && <= ${kMaxPossibleLength}. Received 4294967296`
   }

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -323,7 +323,7 @@ common.expectsError(
     const type = typeof input;
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: 'The "algorithm" argument must be of type string. ' +
                `Received type ${type}`
     };
@@ -350,7 +350,7 @@ common.expectsError(
     const type = typeof input;
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: 'The "key" argument must be one of type string, Buffer, ' +
                `TypedArray, DataView, or KeyObject. Received type ${type}`
     };

--- a/test/parallel/test-dgram-send-address-types.js
+++ b/test/parallel/test-dgram-send-address-types.js
@@ -25,7 +25,7 @@ const client = dgram.createSocket('udp4').bind(0, () => {
   [[], 1, true].forEach((invalidInput) => {
     const expectedError = {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: 'The "address" argument must be one of type string or falsy. ' +
                `Received type ${typeof invalidInput}`
     };

--- a/test/parallel/test-dgram-sendto.js
+++ b/test/parallel/test-dgram-sendto.js
@@ -6,7 +6,7 @@ const socket = dgram.createSocket('udp4');
 
 const errObj = {
   code: 'ERR_INVALID_ARG_TYPE',
-  name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+  name: 'TypeError',
   message: 'The "offset" argument must be of type number. Received type ' +
            'undefined'
 };

--- a/test/parallel/test-dns-setservers-type-check.js
+++ b/test/parallel/test-dns-setservers-type-check.js
@@ -19,7 +19,7 @@ const promiseResolver = new dns.promises.Resolver();
   ].forEach((val) => {
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: 'The "servers" argument must be of type Array. Received type ' +
       typeof val
     };
@@ -59,7 +59,7 @@ const promiseResolver = new dns.promises.Resolver();
   ].forEach((val) => {
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: 'The "servers[0]" argument must be of type string. ' +
                `Received type ${typeof val[0]}`
     };

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -81,7 +81,7 @@ assert(existing.length > 0);
         dns.setServers([serv]);
       },
       {
-        name: 'TypeError [ERR_INVALID_IP_ADDRESS]',
+        name: 'TypeError',
         code: 'ERR_INVALID_IP_ADDRESS'
       }
     );

--- a/test/parallel/test-error-serdes.js
+++ b/test/parallel/test-error-serdes.js
@@ -41,6 +41,6 @@ assert.strictEqual(cycle(Function), '[Function: Function]');
 {
   const err = new ERR_INVALID_ARG_TYPE('object', 'Object', 42);
   assert(/^TypeError \[ERR_INVALID_ARG_TYPE\]:/.test(err));
-  assert.strictEqual(err.name, 'TypeError [ERR_INVALID_ARG_TYPE]');
+  assert.strictEqual(err.name, 'TypeError');
   assert.strictEqual(err.code, 'ERR_INVALID_ARG_TYPE');
 }

--- a/test/parallel/test-errors-systemerror.js
+++ b/test/parallel/test-errors-systemerror.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const { E, SystemError, codes } = require('internal/errors');
 
 assert.throws(
-  () => { throw new SystemError(); },
+  () => { new SystemError(); },
   {
     name: 'TypeError',
     message: 'Cannot read property \'match\' of undefined'
@@ -29,7 +29,7 @@ const { ERR_TEST } = codes;
     () => { throw new ERR_TEST(ctx); },
     {
       code: 'ERR_TEST',
-      name: 'SystemError [ERR_TEST]',
+      name: 'SystemError',
       message: 'custom message: syscall_test returned ETEST (code message)' +
                ' /str => /str2',
       info: ctx
@@ -49,7 +49,7 @@ const { ERR_TEST } = codes;
     () => { throw new ERR_TEST(ctx); },
     {
       code: 'ERR_TEST',
-      name: 'SystemError [ERR_TEST]',
+      name: 'SystemError',
       message: 'custom message: syscall_test returned ETEST (code message)' +
                ' /buf => /str2',
       info: ctx
@@ -69,7 +69,7 @@ const { ERR_TEST } = codes;
     () => { throw new ERR_TEST(ctx); },
     {
       code: 'ERR_TEST',
-      name: 'SystemError [ERR_TEST]',
+      name: 'SystemError',
       message: 'custom message: syscall_test returned ETEST (code message)' +
                ' /buf => /buf2',
       info: ctx
@@ -121,12 +121,12 @@ const { ERR_TEST } = codes;
   assert.throws(
     () => {
       const err = new ERR_TEST(ctx);
-      err.name = 'SystemError [CUSTOM_ERR_TEST]';
+      err.name = 'Foobar';
       throw err;
     },
     {
       code: 'ERR_TEST',
-      name: 'SystemError [CUSTOM_ERR_TEST]',
+      name: 'Foobar',
       message: 'custom message: syscall_test returned ERR_TEST ' +
                '(Error occurred)',
       info: ctx

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -150,7 +150,7 @@ if (fs.lchmod) {
 [false, 1, {}, [], null, undefined].forEach((input) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "path" argument must be one of type string, Buffer, or URL.' +
              ` Received type ${typeof input}`
   };

--- a/test/parallel/test-fs-close-errors.js
+++ b/test/parallel/test-fs-close-errors.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 ['', false, null, undefined, {}, []].forEach((input) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "fd" argument must be of type number. ' +
              `Received type ${typeof input}`
   };

--- a/test/parallel/test-fs-fchmod.js
+++ b/test/parallel/test-fs-fchmod.js
@@ -11,7 +11,7 @@ const fs = require('fs');
 [false, null, undefined, {}, [], ''].forEach((input) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "fd" argument must be of type number. Received type ' +
              typeof input
   };
@@ -23,7 +23,7 @@ const fs = require('fs');
 [false, null, undefined, {}, [], '', '123x'].forEach((input) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_VALUE',
-    name: 'TypeError [ERR_INVALID_ARG_VALUE]',
+    name: 'TypeError',
     message: 'The argument \'mode\' must be a 32-bit unsigned integer or an ' +
              `octal string. Received ${util.inspect(input)}`
   };
@@ -34,7 +34,7 @@ const fs = require('fs');
 [-1, 2 ** 32].forEach((input) => {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
-    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    name: 'RangeError',
     message: 'The value of "fd" is out of range. It must be >= 0 && <= ' +
              `2147483647. Received ${input}`
   };
@@ -45,7 +45,7 @@ const fs = require('fs');
 [-1, 2 ** 32].forEach((input) => {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
-    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    name: 'RangeError',
     message: 'The value of "mode" is out of range. It must be >= 0 && <= ' +
              `4294967295. Received ${input}`
   };
@@ -57,7 +57,7 @@ const fs = require('fs');
 [NaN, Infinity].forEach((input) => {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
-    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    name: 'RangeError',
     message: 'The value of "fd" is out of range. It must be an integer. ' +
              `Received ${input}`
   };
@@ -71,7 +71,7 @@ const fs = require('fs');
 [1.5].forEach((input) => {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
-    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    name: 'RangeError',
     message: 'The value of "fd" is out of range. It must be an integer. ' +
              `Received ${input}`
   };

--- a/test/parallel/test-fs-fchown.js
+++ b/test/parallel/test-fs-fchown.js
@@ -18,7 +18,7 @@ function test(input, errObj) {
 ['', false, null, undefined, {}, []].forEach((input) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "fd" argument must be of type number. Received type ' +
              typeof input
   };
@@ -28,7 +28,7 @@ function test(input, errObj) {
 [Infinity, NaN].forEach((input) => {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
-    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    name: 'RangeError',
     message: 'The value of "fd" is out of range. It must be an integer. ' +
              `Received ${input}`
   };
@@ -38,7 +38,7 @@ function test(input, errObj) {
 [-1, 2 ** 32].forEach((input) => {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
-    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    name: 'RangeError',
     message: 'The value of "fd" is out of range. It must be ' +
              `>= 0 && < 4294967296. Received ${input}`
   };

--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -53,7 +53,7 @@ fs.open(fileTemp, 'a', 0o777, common.mustCall(function(err, fd) {
 ['', false, null, undefined, {}, []].forEach((input) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "fd" argument must be of type number. Received type ' +
              typeof input
   };

--- a/test/parallel/test-fs-lchmod.js
+++ b/test/parallel/test-fs-lchmod.js
@@ -41,7 +41,7 @@ assert.throws(() => fs.lchmod(f, {}), { code: 'ERR_INVALID_CALLBACK' });
 [false, null, undefined, {}, [], '', '123x'].forEach((input) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_VALUE',
-    name: 'TypeError [ERR_INVALID_ARG_VALUE]',
+    name: 'TypeError',
     message: 'The argument \'mode\' must be a 32-bit unsigned integer or an ' +
              `octal string. Received ${util.inspect(input)}`
   };
@@ -53,7 +53,7 @@ assert.throws(() => fs.lchmod(f, {}), { code: 'ERR_INVALID_CALLBACK' });
 [-1, 2 ** 32].forEach((input) => {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
-    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    name: 'RangeError',
     message: 'The value of "mode" is out of range. It must be >= 0 && <= ' +
              `4294967295. Received ${input}`
   };

--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -102,7 +102,7 @@ for (const extra of [[], ['r'], ['r', 0], ['r', 0, 'bad callback']]) {
     fs.promises.open(i, 'r'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+      name: 'TypeError'
     }
   );
 });

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -164,7 +164,7 @@ async function getHandle(dest) {
         },
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "gid" is out of range. ' +
                   'It must be >= 0 && < 4294967296. Received -1'
         });
@@ -175,7 +175,7 @@ async function getHandle(dest) {
         },
         {
           code: 'ERR_OUT_OF_RANGE',
-          name: 'RangeError [ERR_OUT_OF_RANGE]',
+          name: 'RangeError',
           message: 'The value of "gid" is out of range. ' +
                     'It must be >= 0 && < 4294967296. Received -1'
         });
@@ -336,7 +336,7 @@ async function getHandle(dest) {
           async () => mkdir(dir, { recursive }),
           {
             code: 'ERR_INVALID_ARG_TYPE',
-            name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+            name: 'TypeError',
             message: 'The "recursive" argument must be of type boolean. ' +
               `Received type ${typeof recursive}`
           }
@@ -352,7 +352,7 @@ async function getHandle(dest) {
         async () => mkdtemp(1),
         {
           code: 'ERR_INVALID_ARG_TYPE',
-          name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+          name: 'TypeError'
         }
       );
     }

--- a/test/parallel/test-fs-read-type.js
+++ b/test/parallel/test-fs-read-type.js
@@ -14,7 +14,7 @@ assert.throws(
   () => fs.read(fd, expected.length, 0, 'utf-8', common.mustNotCall()),
   {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "buffer" argument must be one of type Buffer, TypedArray, ' +
              'or DataView. Received type number'
   }
@@ -30,7 +30,7 @@ assert.throws(
             common.mustNotCall());
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "fd" argument must be of type number. ' +
              `Received type ${typeof value}`
   });
@@ -45,7 +45,7 @@ assert.throws(() => {
           common.mustNotCall());
 }, {
   code: 'ERR_OUT_OF_RANGE',
-  name: 'RangeError [ERR_OUT_OF_RANGE]',
+  name: 'RangeError',
   message: 'The value of "offset" is out of range. It must be >= 0 && <= 4. ' +
            'Received -1'
 });
@@ -59,7 +59,7 @@ assert.throws(() => {
           common.mustNotCall());
 }, {
   code: 'ERR_OUT_OF_RANGE',
-  name: 'RangeError [ERR_OUT_OF_RANGE]',
+  name: 'RangeError',
   message: 'The value of "length" is out of range. ' +
            'It must be >= 0 && <= 4. Received -1'
 });
@@ -69,7 +69,7 @@ assert.throws(
   () => fs.readSync(fd, expected.length, 0, 'utf-8'),
   {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "buffer" argument must be one of type Buffer, TypedArray, ' +
              'or DataView. Received type number'
   }
@@ -84,7 +84,7 @@ assert.throws(
                 0);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "fd" argument must be of type number. ' +
              `Received type ${typeof value}`
   });
@@ -98,7 +98,7 @@ assert.throws(() => {
               0);
 }, {
   code: 'ERR_OUT_OF_RANGE',
-  name: 'RangeError [ERR_OUT_OF_RANGE]',
+  name: 'RangeError',
   message: 'The value of "offset" is out of range. ' +
            'It must be >= 0 && <= 4. Received -1'
 });
@@ -111,7 +111,7 @@ assert.throws(() => {
               0);
 }, {
   code: 'ERR_OUT_OF_RANGE',
-  name: 'RangeError [ERR_OUT_OF_RANGE]',
+  name: 'RangeError',
   message: 'The value of "length" is out of range. ' +
            'It must be >= 0 && <= 4. Received -1'
 });

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -38,12 +38,12 @@ function test(env, cb) {
   const filename = fixtures.path('test-fs-readfile-error.js');
   const execPath = `"${process.execPath}" "${filename}"`;
   const options = { env: Object.assign({}, process.env, env) };
-  exec(execPath, options, common.mustCall((err, stdout, stderr) => {
+  exec(execPath, options, (err, stdout, stderr) => {
     assert(err);
     assert.strictEqual(stdout, '');
     assert.notStrictEqual(stderr, '');
     cb(String(stderr));
-  }));
+  });
 }
 
 test({ NODE_DEBUG: '' }, common.mustCall((data) => {

--- a/test/parallel/test-fs-rename-type-check.js
+++ b/test/parallel/test-fs-rename-type-check.js
@@ -10,7 +10,7 @@ const fs = require('fs');
     () => fs.rename(input, 'does-not-exist', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: `The "oldPath" argument must be one ${type}`
     }
   );
@@ -18,7 +18,7 @@ const fs = require('fs');
     () => fs.rename('does-not-exist', input, common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: `The "newPath" argument must be one ${type}`
     }
   );
@@ -26,7 +26,7 @@ const fs = require('fs');
     () => fs.renameSync(input, 'does-not-exist'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: `The "oldPath" argument must be one ${type}`
     }
   );
@@ -34,7 +34,7 @@ const fs = require('fs');
     () => fs.renameSync('does-not-exist', input),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: `The "newPath" argument must be one ${type}`
     }
   );

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -134,7 +134,7 @@ fs.stat(__filename, common.mustCall(function(err, s) {
       () => fs[fnName](input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        name: 'TypeError',
         message: 'The "fd" argument must be of type number. ' +
                  `Received type ${typeof input}`
       }
@@ -147,28 +147,28 @@ fs.stat(__filename, common.mustCall(function(err, s) {
     () => fs.lstat(input, common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+      name: 'TypeError'
     }
   );
   assert.throws(
     () => fs.lstatSync(input),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+      name: 'TypeError'
     }
   );
   assert.throws(
     () => fs.stat(input, common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+      name: 'TypeError'
     }
   );
   assert.throws(
     () => fs.statSync(input),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+      name: 'TypeError'
     }
   );
 });

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -61,7 +61,7 @@ fs.symlink(linkData, linkPath, common.mustCall(function(err) {
 [false, 1, {}, [], null, undefined].forEach((input) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "target" argument must be one of type string, Buffer, or ' +
              `URL. Received type ${typeof input}`
   };
@@ -75,7 +75,7 @@ fs.symlink(linkData, linkPath, common.mustCall(function(err) {
 
 const errObj = {
   code: 'ERR_FS_INVALID_SYMLINK_TYPE',
-  name: 'Error [ERR_FS_INVALID_SYMLINK_TYPE]',
+  name: 'Error',
   message:
     'Symlink type must be one of "dir", "file", or "junction". Received "🍏"'
 };

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -183,7 +183,7 @@ function testFtruncate(cb) {
       () => fs.truncate(file5, input, common.mustNotCall()),
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        name: 'TypeError',
         message: 'The "len" argument must be of type number. ' +
                  `Received type ${typeof input}`
       }
@@ -193,7 +193,7 @@ function testFtruncate(cb) {
       () => fs.ftruncate(fd, input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        name: 'TypeError',
         message: 'The "len" argument must be of type number. ' +
                  `Received type ${typeof input}`
       }
@@ -205,7 +205,7 @@ function testFtruncate(cb) {
       () => fs.truncate(file5, input),
       {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError [ERR_OUT_OF_RANGE]',
+        name: 'RangeError',
         message: 'The value of "len" is out of range. It must be ' +
                   `an integer. Received ${input}`
       }
@@ -215,7 +215,7 @@ function testFtruncate(cb) {
       () => fs.ftruncate(fd, input),
       {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError [ERR_OUT_OF_RANGE]',
+        name: 'RangeError',
         message: 'The value of "len" is out of range. It must be ' +
                   `an integer. Received ${input}`
       }
@@ -267,7 +267,7 @@ function testFtruncate(cb) {
     () => fs.truncate('/foo/bar', input),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: 'The "len" argument must be of type number. ' +
                `Received type ${typeof input}`
     }
@@ -280,7 +280,7 @@ function testFtruncate(cb) {
       () => fs[fnName](input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        name: 'TypeError',
         message: 'The "fd" argument must be of type number. ' +
                  `Received type ${typeof input}`
       }

--- a/test/parallel/test-http-res-write-end-dont-take-array.js
+++ b/test/parallel/test-http-res-write-end-dont-take-array.js
@@ -37,7 +37,7 @@ server.once('request', common.mustCall((req, res) => {
 
   const expectedError = {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
   };
 
   // Write should not accept an Array

--- a/test/parallel/test-http2-altsvc.js
+++ b/test/parallel/test-http2-altsvc.js
@@ -33,7 +33,7 @@ server.on('session', common.mustCall((session) => {
       () => session.altsvc('h2=":8000"', input),
       {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError [ERR_OUT_OF_RANGE]',
+        name: 'RangeError',
         message: 'The value of "originOrStream" is out of ' +
                  `range. It must be > 0 && < 4294967296. Received ${input}`
       }
@@ -46,7 +46,7 @@ server.on('session', common.mustCall((session) => {
       () => session.altsvc(input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+        name: 'TypeError'
       }
     );
   });
@@ -56,7 +56,7 @@ server.on('session', common.mustCall((session) => {
       () => session.altsvc(input),
       {
         code: 'ERR_INVALID_CHAR',
-        name: 'TypeError [ERR_INVALID_CHAR]',
+        name: 'TypeError',
         message: 'Invalid character in alt'
       }
     );
@@ -67,7 +67,7 @@ server.on('session', common.mustCall((session) => {
       () => session.altsvc('clear', input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+        name: 'TypeError'
       }
     );
   });
@@ -82,7 +82,7 @@ server.on('session', common.mustCall((session) => {
       () => session.altsvc('h2=":8000', input),
       {
         code: 'ERR_HTTP2_ALTSVC_INVALID_ORIGIN',
-        name: 'TypeError [ERR_HTTP2_ALTSVC_INVALID_ORIGIN]',
+        name: 'TypeError',
         message: 'HTTP/2 ALTSVC frames require a valid origin'
       }
     );
@@ -96,7 +96,7 @@ server.on('session', common.mustCall((session) => {
     },
     {
       code: 'ERR_HTTP2_ALTSVC_LENGTH',
-      name: 'TypeError [ERR_HTTP2_ALTSVC_LENGTH]',
+      name: 'TypeError',
       message: 'HTTP/2 ALTSVC frames are limited to 16382 bytes'
     }
   );

--- a/test/parallel/test-http2-client-http1-server.js
+++ b/test/parallel/test-http2-client-http1-server.js
@@ -27,7 +27,7 @@ server.listen(0, common.mustCall(() => {
   client.on('error', common.expectsError({
     code: 'ERR_HTTP2_ERROR',
     type: NghttpError,
-    name: 'Error [ERR_HTTP2_ERROR]',
+    name: 'Error',
     message: 'Protocol error'
   }));
 

--- a/test/parallel/test-http2-client-onconnect-errors.js
+++ b/test/parallel/test-http2-client-onconnect-errors.js
@@ -55,7 +55,7 @@ const genericTests = Object.getOwnPropertyNames(constants)
     error: {
       code: 'ERR_HTTP2_ERROR',
       type: NghttpError,
-      name: 'Error [ERR_HTTP2_ERROR]',
+      name: 'Error',
       message: nghttp2ErrorString(constants[key])
     },
     type: 'session'

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -21,7 +21,7 @@ server.listen(0, common.mustCall(() => {
   assert.throws(
     () => req.close(2 ** 32),
     {
-      name: 'RangeError [ERR_OUT_OF_RANGE]',
+      name: 'RangeError',
       code: 'ERR_OUT_OF_RANGE',
       message: 'The value of "code" is out of range. It must be ' +
                '>= 0 && <= 4294967295. Received 4294967296'

--- a/test/parallel/test-http2-compat-serverrequest-headers.js
+++ b/test/parallel/test-http2-compat-serverrequest-headers.js
@@ -49,7 +49,7 @@ server.listen(0, common.mustCall(function() {
       () => request.method = '   ',
       {
         code: 'ERR_INVALID_ARG_VALUE',
-        name: 'TypeError [ERR_INVALID_ARG_VALUE]',
+        name: 'TypeError',
         message: "The argument 'method' is invalid. Received '   '"
       }
     );
@@ -57,7 +57,7 @@ server.listen(0, common.mustCall(function() {
       () => request.method = true,
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        name: 'TypeError',
         message: 'The "method" argument must be of type string. ' +
                  'Received type boolean'
       }

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -46,7 +46,7 @@ server.listen(0, common.mustCall(function() {
         () => response[fnName](),
         {
           code: 'ERR_INVALID_ARG_TYPE',
-          name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+          name: 'TypeError',
           message: 'The "name" argument must be of type string. Received ' +
                    'type undefined'
         }

--- a/test/parallel/test-http2-createsecureserver-nooptions.js
+++ b/test/parallel/test-http2-createsecureserver-nooptions.js
@@ -13,7 +13,7 @@ invalidOptions.forEach((invalidOption) => {
   assert.throws(
     () => http2.createSecureServer(invalidOption),
     {
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "options" argument must be of type Object. Received ' +
                `type ${typeof invalidOption}`

--- a/test/parallel/test-http2-info-headers-errors.js
+++ b/test/parallel/test-http2-info-headers-errors.js
@@ -28,7 +28,7 @@ const genericTests = Object.getOwnPropertyNames(constants)
     error: {
       code: 'ERR_HTTP2_ERROR',
       type: NghttpError,
-      name: 'Error [ERR_HTTP2_ERROR]',
+      name: 'Error',
       message: nghttp2ErrorString(constants[key])
     },
     type: 'stream'

--- a/test/parallel/test-http2-origin.js
+++ b/test/parallel/test-http2-origin.js
@@ -46,7 +46,7 @@ const ca = readKey('fake-startcom-root-cert.pem', 'binary');
         () => session.origin(input),
         {
           code: 'ERR_INVALID_ARG_TYPE',
-          name: 'TypeError [ERR_INVALID_ARG_TYPE]'
+          name: 'TypeError'
         }
       );
     });
@@ -56,7 +56,7 @@ const ca = readKey('fake-startcom-root-cert.pem', 'binary');
         () => session.origin(input),
         {
           code: 'ERR_HTTP2_INVALID_ORIGIN',
-          name: 'TypeError [ERR_HTTP2_INVALID_ORIGIN]'
+          name: 'TypeError'
         }
       );
     });
@@ -66,7 +66,7 @@ const ca = readKey('fake-startcom-root-cert.pem', 'binary');
         () => session.origin(input),
         {
           code: 'ERR_INVALID_URL',
-          name: 'TypeError [ERR_INVALID_URL]'
+          name: 'TypeError'
         }
       );
     });
@@ -75,7 +75,7 @@ const ca = readKey('fake-startcom-root-cert.pem', 'binary');
       () => session.origin(longInput),
       {
         code: 'ERR_HTTP2_ORIGIN_LENGTH',
-        name: 'TypeError [ERR_HTTP2_ORIGIN_LENGTH]'
+        name: 'TypeError'
       }
     );
   }));

--- a/test/parallel/test-http2-respond-nghttperrors.js
+++ b/test/parallel/test-http2-respond-nghttperrors.js
@@ -29,7 +29,7 @@ const genericTests = Object.getOwnPropertyNames(constants)
     error: {
       code: 'ERR_HTTP2_ERROR',
       type: NghttpError,
-      name: 'Error [ERR_HTTP2_ERROR]',
+      name: 'Error',
       message: nghttp2ErrorString(constants[key])
     },
     type: 'stream'

--- a/test/parallel/test-http2-respond-with-fd-errors.js
+++ b/test/parallel/test-http2-respond-with-fd-errors.js
@@ -36,7 +36,7 @@ const genericTests = Object.getOwnPropertyNames(constants)
     error: {
       code: 'ERR_HTTP2_ERROR',
       type: NghttpError,
-      name: 'Error [ERR_HTTP2_ERROR]',
+      name: 'Error',
       message: nghttp2ErrorString(constants[key])
     },
     type: 'stream'

--- a/test/parallel/test-http2-server-push-stream-errors-args.js
+++ b/test/parallel/test-http2-server-push-stream-errors-args.js
@@ -31,7 +31,7 @@ server.on('stream', common.mustCall((stream, headers) => {
     () => stream.pushStream({ 'connection': 'test' }, {}, () => {}),
     {
       code: 'ERR_HTTP2_INVALID_CONNECTION_HEADERS',
-      name: 'TypeError [ERR_HTTP2_INVALID_CONNECTION_HEADERS]',
+      name: 'TypeError',
       message: 'HTTP/1 Connection specific headers are forbidden: "connection"'
     }
   );

--- a/test/parallel/test-http2-server-push-stream-errors.js
+++ b/test/parallel/test-http2-server-push-stream-errors.js
@@ -53,7 +53,7 @@ const genericTests = Object.getOwnPropertyNames(constants)
     error: {
       code: 'ERR_HTTP2_ERROR',
       type: NghttpError,
-      name: 'Error [ERR_HTTP2_ERROR]',
+      name: 'Error',
       message: nghttp2ErrorString(constants[key])
     },
     type: 'stream'

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -283,7 +283,7 @@ const {
 ].forEach((name) => {
   common.expectsError(() => mapToHeaders({ [name]: 'abc' }), {
     code: 'ERR_HTTP2_INVALID_CONNECTION_HEADERS',
-    name: 'TypeError [ERR_HTTP2_INVALID_CONNECTION_HEADERS]',
+    name: 'TypeError',
     message: 'HTTP/1 Connection specific headers are forbidden: ' +
              `"${name.toLowerCase()}"`
   });
@@ -291,7 +291,7 @@ const {
 
 common.expectsError(() => mapToHeaders({ [HTTP2_HEADER_TE]: ['abc'] }), {
   code: 'ERR_HTTP2_INVALID_CONNECTION_HEADERS',
-  name: 'TypeError [ERR_HTTP2_INVALID_CONNECTION_HEADERS]',
+  name: 'TypeError',
   message: 'HTTP/1 Connection specific headers are forbidden: ' +
            `"${HTTP2_HEADER_TE}"`
 });
@@ -299,7 +299,7 @@ common.expectsError(() => mapToHeaders({ [HTTP2_HEADER_TE]: ['abc'] }), {
 common.expectsError(
   () => mapToHeaders({ [HTTP2_HEADER_TE]: ['abc', 'trailers'] }), {
     code: 'ERR_HTTP2_INVALID_CONNECTION_HEADERS',
-    name: 'TypeError [ERR_HTTP2_INVALID_CONNECTION_HEADERS]',
+    name: 'TypeError',
     message: 'HTTP/1 Connection specific headers are forbidden: ' +
              `"${HTTP2_HEADER_TE}"`
   });

--- a/test/parallel/test-https-options-boolean-check.js
+++ b/test/parallel/test-https-options-boolean-check.js
@@ -87,7 +87,7 @@ const caArrDataView = toDataView(caCert);
     https.createServer({ key, cert });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "options.key" property must be one of type string, Buffer, ' +
              `TypedArray, or DataView. Received type ${type}`
   });
@@ -112,7 +112,7 @@ const caArrDataView = toDataView(caCert);
     https.createServer({ key, cert });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "options.cert" property must be one of type string, Buffer,' +
              ` TypedArray, or DataView. Received type ${type}`
   });
@@ -146,7 +146,7 @@ const caArrDataView = toDataView(caCert);
     https.createServer({ key, cert, ca });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "options.ca" property must be one of type string, Buffer, ' +
              `TypedArray, or DataView. Received type ${type}`
   });

--- a/test/parallel/test-internal-error-original-names.js
+++ b/test/parallel/test-internal-error-original-names.js
@@ -17,7 +17,7 @@ errors.E('TEST_ERROR_1', 'Error for testing purposes: %s',
 {
   const err = new errors.codes.TEST_ERROR_1('test');
   assert(err instanceof Error);
-  assert.strictEqual(err.name, 'Error [TEST_ERROR_1]');
+  assert.strictEqual(err.name, 'Error');
 }
 
 {
@@ -31,5 +31,5 @@ errors.E('TEST_ERROR_1', 'Error for testing purposes: %s',
   errors.useOriginalName = false;
   const err = new errors.codes.TEST_ERROR_1('test');
   assert(err instanceof Error);
-  assert.strictEqual(err.name, 'Error [TEST_ERROR_1]');
+  assert.strictEqual(err.name, 'Error');
 }

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -20,7 +20,7 @@ errors.E('TEST_ERROR_2', (a, b) => `${a} ${b}`, Error);
 {
   const err = new errors.codes.TEST_ERROR_1('test');
   assert(err instanceof Error);
-  assert.strictEqual(err.name, 'Error [TEST_ERROR_1]');
+  assert.strictEqual(err.name, 'Error');
   assert.strictEqual(err.message, 'Error for testing purposes: test');
   assert.strictEqual(err.code, 'TEST_ERROR_1');
 }
@@ -28,7 +28,7 @@ errors.E('TEST_ERROR_2', (a, b) => `${a} ${b}`, Error);
 {
   const err = new errors.codes.TEST_ERROR_1.TypeError('test');
   assert(err instanceof TypeError);
-  assert.strictEqual(err.name, 'TypeError [TEST_ERROR_1]');
+  assert.strictEqual(err.name, 'TypeError');
   assert.strictEqual(err.message, 'Error for testing purposes: test');
   assert.strictEqual(err.code, 'TEST_ERROR_1');
 }
@@ -36,7 +36,7 @@ errors.E('TEST_ERROR_2', (a, b) => `${a} ${b}`, Error);
 {
   const err = new errors.codes.TEST_ERROR_1.RangeError('test');
   assert(err instanceof RangeError);
-  assert.strictEqual(err.name, 'RangeError [TEST_ERROR_1]');
+  assert.strictEqual(err.name, 'RangeError');
   assert.strictEqual(err.message, 'Error for testing purposes: test');
   assert.strictEqual(err.code, 'TEST_ERROR_1');
 }
@@ -44,7 +44,7 @@ errors.E('TEST_ERROR_2', (a, b) => `${a} ${b}`, Error);
 {
   const err = new errors.codes.TEST_ERROR_2('abc', 'xyz');
   assert(err instanceof Error);
-  assert.strictEqual(err.name, 'Error [TEST_ERROR_2]');
+  assert.strictEqual(err.name, 'Error');
   assert.strictEqual(err.message, 'abc xyz');
   assert.strictEqual(err.code, 'TEST_ERROR_2');
 }
@@ -79,27 +79,6 @@ common.expectsError(() => {
   message: 'Error for testing purposes: a'
 });
 
-common.expectsError(() => {
-  common.expectsError(() => {
-    throw new errors.codes.TEST_ERROR_1.TypeError('a');
-  }, { code: 'TEST_ERROR_1', type: RangeError });
-}, {
-  code: 'ERR_ASSERTION',
-  message: /\+   type: \[Function: TypeError]\n-   type: \[Function: RangeError]/
-});
-
-common.expectsError(() => {
-  common.expectsError(() => {
-    throw new errors.codes.TEST_ERROR_1.TypeError('a');
-  }, { code: 'TEST_ERROR_1',
-       type: TypeError,
-       message: /^Error for testing 2/ });
-}, {
-  code: 'ERR_ASSERTION',
-  type: assert.AssertionError,
-  message: /\+   message: 'Error for testing purposes: a',\n-   message: \/\^Error/
-});
-
 // Test that `code` property is mutable and that changing it does not change the
 // name.
 {
@@ -113,7 +92,7 @@ common.expectsError(() => {
   assert.strictEqual(myError.code, 'FHQWHGADS');
   assert.strictEqual(myError.name, initialName);
   assert.deepStrictEqual(Object.keys(myError), ['code']);
-  assert.ok(myError.name.includes('TEST_ERROR_1'));
+  assert.ok(!myError.name.includes('TEST_ERROR_1'));
   assert.ok(!myError.name.includes('FHQWHGADS'));
 }
 

--- a/test/parallel/test-next-tick-errors.js
+++ b/test/parallel/test-next-tick-errors.js
@@ -48,7 +48,7 @@ function testNextTickWith(val) {
     },
     {
       code: 'ERR_INVALID_CALLBACK',
-      name: 'TypeError [ERR_INVALID_CALLBACK]',
+      name: 'TypeError',
       type: TypeError
     }
   );

--- a/test/parallel/test-process-cpuUsage.js
+++ b/test/parallel/test-process-cpuUsage.js
@@ -37,7 +37,7 @@ assert.throws(
   () => process.cpuUsage(1),
   {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "prevValue" argument must be of type object. ' +
              'Received type number'
   }
@@ -53,7 +53,7 @@ assert.throws(
     () => process.cpuUsage(value),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: 'The "prevValue.user" property must be of type number. ' +
                `Received type ${typeof value.user}`
     }
@@ -68,7 +68,7 @@ assert.throws(
     () => process.cpuUsage(value),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: 'The "prevValue.system" property must be of type number. ' +
                `Received type ${typeof value.system}`
     }
@@ -84,7 +84,7 @@ assert.throws(
     () => process.cpuUsage(value),
     {
       code: 'ERR_INVALID_OPT_VALUE',
-      name: 'RangeError [ERR_INVALID_OPT_VALUE]',
+      name: 'RangeError',
       message: `The value "${value.user}" is invalid ` +
                'for option "prevValue.user"'
     }
@@ -99,7 +99,7 @@ assert.throws(
     () => process.cpuUsage(value),
     {
       code: 'ERR_INVALID_OPT_VALUE',
-      name: 'RangeError [ERR_INVALID_OPT_VALUE]',
+      name: 'RangeError',
       message: `The value "${value.system}" is invalid ` +
                'for option "prevValue.system"'
     }

--- a/test/parallel/test-process-initgroups.js
+++ b/test/parallel/test-process-initgroups.js
@@ -17,7 +17,7 @@ if (!common.isMainThread)
     },
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message:
         'The "user" argument must be ' +
         'one of type number or string. ' +
@@ -33,7 +33,7 @@ if (!common.isMainThread)
     },
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message:
         'The "extraGroup" argument must be ' +
         'one of type number or string. ' +

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -41,7 +41,7 @@ const assert = require('assert');
 ['SIGTERM', null, undefined, NaN, Infinity, -Infinity].forEach((val) => {
   assert.throws(() => process.kill(val), {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "pid" argument must be of type number. ' +
              `Received type ${typeof val}`
   });

--- a/test/parallel/test-process-setgroups.js
+++ b/test/parallel/test-process-setgroups.js
@@ -16,7 +16,7 @@ assert.throws(
   },
   {
     code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    name: 'TypeError',
     message: 'The "groups" argument must be of type Array. ' +
              'Received type undefined'
   }
@@ -28,7 +28,7 @@ assert.throws(
   },
   {
     code: 'ERR_OUT_OF_RANGE',
-    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    name: 'RangeError',
     message: 'The value of "groups[1]" is out of range. ' +
               'It must be >= 0 && < 4294967296. Received -1'
   }
@@ -41,7 +41,7 @@ assert.throws(
     },
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      name: 'TypeError',
       message: 'The "groups[0]" argument must be ' +
                'one of type number or string. ' +
                `Received type ${typeof val}`

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -129,21 +129,21 @@ const { promisify } = require('util');
   assert.throws(
     () => finished(rs, 'foo'),
     {
-      name: /ERR_INVALID_ARG_TYPE/,
+      code: 'ERR_INVALID_ARG_TYPE',
       message: /callback/
     }
   );
   assert.throws(
     () => finished(rs, 'foo', () => {}),
     {
-      name: /ERR_INVALID_ARG_TYPE/,
+      code: 'ERR_INVALID_ARG_TYPE',
       message: /opts/
     }
   );
   assert.throws(
     () => finished(rs, {}, 'foo'),
     {
-      name: /ERR_INVALID_ARG_TYPE/,
+      code: 'ERR_INVALID_ARG_TYPE',
       message: /callback/
     }
   );

--- a/test/parallel/test-ttywrap-invalid-fd.js
+++ b/test/parallel/test-ttywrap-invalid-fd.js
@@ -14,7 +14,7 @@ assert.throws(
   () => new tty.WriteStream(-1),
   {
     code: 'ERR_INVALID_FD',
-    name: 'RangeError [ERR_INVALID_FD]',
+    name: 'RangeError',
     message: '"fd" must be a positive integer: -1'
   }
 );
@@ -38,7 +38,7 @@ assert.throws(
       });
     }, {
       code: 'ERR_TTY_INIT_FAILED',
-      name: 'SystemError [ERR_TTY_INIT_FAILED]',
+      name: 'SystemError',
       message,
       info
     }
@@ -51,7 +51,7 @@ assert.throws(
       });
     }, {
       code: 'ERR_TTY_INIT_FAILED',
-      name: 'SystemError [ERR_TTY_INIT_FAILED]',
+      name: 'SystemError',
       message,
       info
     });
@@ -61,7 +61,7 @@ assert.throws(
   () => new tty.ReadStream(-1),
   {
     code: 'ERR_INVALID_FD',
-    name: 'RangeError [ERR_INVALID_FD]',
+    name: 'RangeError',
     message: '"fd" must be a positive integer: -1'
   }
 );

--- a/test/parallel/test-url-format-whatwg.js
+++ b/test/parallel/test-url-format-whatwg.js
@@ -26,7 +26,7 @@ assert.strictEqual(
       () => url.format(myURL, value),
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        name: 'TypeError',
         message: 'The "options" argument must be of type Object. ' +
                  `Received type ${typeof value}`
       }

--- a/test/parallel/test-whatwg-url-custom-parsing.js
+++ b/test/parallel/test-whatwg-url-custom-parsing.js
@@ -56,15 +56,13 @@ for (const test of failureTests) {
   assert.throws(
     () => new URL(test.input, test.base),
     (error) => {
-      if (!expectedError(error))
-        return false;
+      expectedError(error);
 
       // The input could be processed, so we don't do strict matching here
-      const match = (`${error}`).match(/Invalid URL: (.*)$/);
-      if (!match) {
-        return false;
-      }
-      return error.input === match[1];
+      let match;
+      assert(match = (`${error}`).match(/Invalid URL: (.*)$/));
+      assert.strictEqual(error.input, match[1]);
+      return true;
     });
 }
 


### PR DESCRIPTION
This makes sure Node.js errors have a "regular" error name while keeping the error code in the stack trace. Please have a look at the individual commits for a more detailed description.

Fixes: #26669
Fixes: https://github.com/nodejs/node/issues/20253

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
