### PR TITLE
src: initialize worker's stack_base_ field

### DIFF
--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -70,7 +70,7 @@ class Worker : public AsyncWrap {
   bool thread_joined_ = true;
   int exit_code_ = 0;
   uint64_t thread_id_ = -1;
-  uintptr_t stack_base_;
+  uintptr_t stack_base_ = 0;
 
   // Full size of the thread's stack.
   static constexpr size_t kStackSize = 4 * 1024 * 1024;


### PR DESCRIPTION
Coverity was complaining that this field was not initialized.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
