### PR TITLE
tls: remove usage of public require('util')

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -21,17 +21,21 @@
 
 'use strict';
 
-require('internal/util').assertCrypto();
+const {
+  assertCrypto,
+  deprecate
+} = require('internal/util');
+
+assertCrypto();
 
 const assert = require('internal/assert');
 const crypto = require('crypto');
 const net = require('net');
 const tls = require('tls');
-const util = require('util');
 const common = require('_tls_common');
 const JSStreamSocket = require('internal/js_stream_socket');
 const { Buffer } = require('buffer');
-const debug = util.debuglog('tls');
+const debug = require('internal/util/debuglog').debuglog('tls');
 const { TCP, constants: TCPConstants } = internalBinding('tcp_wrap');
 const tls_wrap = internalBinding('tls_wrap');
 const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');
@@ -370,7 +374,8 @@ function TLSSocket(socket, opts) {
   // Read on next tick so the caller has a chance to setup listeners
   process.nextTick(initRead, this, socket);
 }
-util.inherits(TLSSocket, net.Socket);
+Object.setPrototypeOf(TLSSocket.prototype, net.Socket.prototype);
+Object.setPrototypeOf(TLSSocket, net.Socket);
 exports.TLSSocket = TLSSocket;
 
 var proxiedMethods = [
@@ -924,7 +929,8 @@ function Server(options, listener) {
   }
 }
 
-util.inherits(Server, net.Server);
+Object.setPrototypeOf(Server.prototype, net.Server.prototype);
+Object.setPrototypeOf(Server, net.Server);
 exports.Server = Server;
 exports.createServer = function createServer(options, listener) {
   return new Server(options, listener);
@@ -1072,7 +1078,7 @@ Server.prototype.setTicketKeys = function setTicketKeys(keys) {
 };
 
 
-Server.prototype.setOptions = util.deprecate(function(options) {
+Server.prototype.setOptions = deprecate(function(options) {
   this.requestCert = options.requestCert === true;
   this.rejectUnauthorized = options.rejectUnauthorized !== false;
 


### PR DESCRIPTION
Remove the usage of public require('util'), as described in issue:
  https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
