### PR TITLE
assert: reduce internal usage `require('util')`

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { inspect } = require('util');
+const { inspect } = require('internal/util/inspect');
 const { codes: {
   ERR_INVALID_ARG_TYPE
 } } = require('internal/errors');


### PR DESCRIPTION
Remove the usage of public require('util'), as described in issue:
#26546 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
