### PR TITLE
net: do not manipulate potential user code

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -971,12 +971,6 @@ function lookupAndConnect(self, options) {
         // net.createConnection() creates a net.Socket object and immediately
         // calls net.Socket.connect() on it (that's us). There are no event
         // listeners registered yet so defer the error event to the next tick.
-        // TODO(BridgeAR): The error could either originate from user code or
-        // by the C++ layer. The port is never the cause for the error as it is
-        // not used in the lookup. We should probably just remove this.
-        err.host = options.host;
-        err.port = options.port;
-        err.message = err.message + ' ' + options.host + ':' + options.port;
         process.nextTick(connectErrorNT, self, err);
       } else if (addressType !== 4 && addressType !== 6) {
         err = new ERR_INVALID_ADDRESS_FAMILY(addressType,

--- a/test/parallel/test-net-better-error-messages-port-hostname.js
+++ b/test/parallel/test-net-better-error-messages-port-hostname.js
@@ -6,7 +6,6 @@
 
 const common = require('../common');
 const net = require('net');
-const assert = require('assert');
 
 const { addresses } = require('../common/internet');
 const {
@@ -23,8 +22,9 @@ const c = net.createConnection({
 
 c.on('connect', common.mustNotCall());
 
-c.on('error', common.mustCall(function(e) {
-  assert.strictEqual(e.code, mockedErrorCode);
-  assert.strictEqual(e.port, 0);
-  assert.strictEqual(e.hostname, addresses.INVALID_HOST);
+c.on('error', common.expectsError({
+  code: mockedErrorCode,
+  hostname: addresses.INVALID_HOST,
+  port: undefined,
+  host: undefined
 }));

--- a/test/parallel/test-net-connect-immediate-finish.js
+++ b/test/parallel/test-net-connect-immediate-finish.js
@@ -26,7 +26,6 @@
 // 'connect' and defer the handling until the 'connect' event is handled.
 
 const common = require('../common');
-const assert = require('assert');
 const net = require('net');
 
 const { addresses } = require('../common/internet');
@@ -42,13 +41,14 @@ const client = net.connect({
   lookup: common.mustCall(errorLookupMock())
 }, common.mustNotCall());
 
-client.once('error', common.mustCall((err) => {
-  assert(err);
-  assert.strictEqual(err.code, err.errno);
-  assert.strictEqual(err.code, mockedErrorCode);
-  assert.strictEqual(err.host, err.hostname);
-  assert.strictEqual(err.host, addresses.INVALID_HOST);
-  assert.strictEqual(err.syscall, mockedSysCall);
+client.once('error', common.expectsError({
+  code: mockedErrorCode,
+  errno: mockedErrorCode,
+  syscall: mockedSysCall,
+  hostname: addresses.INVALID_HOST,
+  message: 'getaddrinfo ENOTFOUND something.invalid',
+  port: undefined,
+  host: undefined
 }));
 
 client.end();


### PR DESCRIPTION
The error provided in this function could come from user code. Thus
the error should not be manipulated in any way. The added properties
do not seem to provide any actual value either as can not be part
of the error. The `hostname` is already set on the error and adding
the `host` property with the identical value does not seem right in
this case.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
