### PR TITLE
process: handle --expose-internals during pre-execution

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -41,8 +41,7 @@
 
 // This file is compiled as if it's wrapped in a function with arguments
 // passed by node::RunBootstrapping()
-/* global process, getLinkedBinding, getInternalBinding */
-/* global exposeInternals, primordials */
+/* global process, getLinkedBinding, getInternalBinding, primordials */
 
 const {
   Reflect,
@@ -157,15 +156,19 @@ function NativeModule(id) {
   this.exportKeys = undefined;
   this.loaded = false;
   this.loading = false;
-  if (id === loaderId) {
-    // Do not expose this to user land even with --expose-internals.
-    this.canBeRequiredByUsers = false;
-  } else if (id.startsWith('internal/')) {
-    this.canBeRequiredByUsers = exposeInternals;
-  } else {
-    this.canBeRequiredByUsers = true;
-  }
+  this.canBeRequiredByUsers = !id.startsWith('internal/');
 }
+
+// To be called during pre-execution when --expose-internals is on.
+// Enables the user-land module loader to access internal modules.
+NativeModule.exposeInternals = function() {
+  for (const [id, mod] of NativeModule.map) {
+    // Do not expose this to user land even with --expose-internals.
+    if (id.startsWith('internal/') && id !== loaderId) {
+      mod.canBeRequiredByUsers = true;
+    }
+  }
+};
 
 const {
   moduleIds,

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -164,7 +164,7 @@ function NativeModule(id) {
 NativeModule.exposeInternals = function() {
   for (const [id, mod] of NativeModule.map) {
     // Do not expose this to user land even with --expose-internals.
-    if (id.startsWith('internal/') && id !== loaderId) {
+    if (id !== loaderId) {
       mod.canBeRequiredByUsers = true;
     }
   }

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -132,6 +132,9 @@ function initializeReport() {
 
 function setupDebugEnv() {
   require('internal/util/debuglog').initializeDebugEnv(process.env.NODE_DEBUG);
+  if (getOptionValue('--expose-internals')) {
+    require('internal/bootstrap/loaders').NativeModule.exposeInternals();
+  }
 }
 
 function setupSignalHandlers() {

--- a/src/node.cc
+++ b/src/node.cc
@@ -296,8 +296,6 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
       env->process_string(),
       FIXED_ONE_BYTE_STRING(isolate, "getLinkedBinding"),
       FIXED_ONE_BYTE_STRING(isolate, "getInternalBinding"),
-      // --expose-internals
-      FIXED_ONE_BYTE_STRING(isolate, "exposeInternals"),
       env->primordials_string()};
   std::vector<Local<Value>> loaders_args = {
       process,
@@ -307,7 +305,6 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
       env->NewFunctionTemplate(binding::GetInternalBinding)
           ->GetFunction(context)
           .ToLocalChecked(),
-      Boolean::New(isolate, env->options()->expose_internals),
       env->primordials()};
 
   // Bootstrap internal loaders


### PR DESCRIPTION
Instead of relying on the value of the CLI option when
executing bootstrap/loaders.js.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
