### PR TITLE
timers: deprecate active() and _unrefActive()

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2368,6 +2368,38 @@ Type: Runtime
 
 The `_stream_wrap` module is deprecated.
 
+<a id="DEP0126"></a>
+### DEP0126: timers.active()
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26760
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+The previously undocumented `timers.active()` is deprecated.
+Please use the publicly documented [`timeout.refresh()`][] instead.
+If re-referencing the timeout is necessary, [`timeout.ref()`][] can be used
+with no performance impact since Node.js 10.
+
+<a id="DEP0127"></a>
+### DEP0127: timers._unrefActive()
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26760
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+The previously undocumented and "private" `timers._unrefActive()` is deprecated.
+Please use the publicly documented [`timeout.refresh()`][] instead.
+If unreferencing the timeout is necessary, [`timeout.unref()`][] can be used
+with no performance impact since Node.js 10.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
@@ -2423,6 +2455,9 @@ The `_stream_wrap` module is deprecated.
 [`script.createCachedData()`]: vm.html#vm_script_createcacheddata
 [`setInterval()`]: timers.html#timers_setinterval_callback_delay_args
 [`setTimeout()`]: timers.html#timers_settimeout_callback_delay_args
+[`timeout.ref()`]: timers.html#timers_timeout_ref
+[`timeout.refresh()`]: timers.html#timers_timeout_refresh
+[`timeout.unref()`]: timers.html#timers_timeout_unref
 [`tls.CryptoStream`]: tls.html#tls_class_cryptostream
 [`tls.SecureContext`]: tls.html#tls_tls_createsecurecontext_options
 [`tls.SecurePair`]: tls.html#tls_class_securepair

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -376,14 +376,21 @@ function clearImmediate(immediate) {
 }
 
 module.exports = {
-  _unrefActive: unrefActive,
-  active,
   setTimeout,
   clearTimeout,
   setImmediate,
   clearImmediate,
   setInterval,
   clearInterval,
+  _unrefActive: deprecate(
+    unrefActive,
+    'timers._unrefActive() is deprecated.' +
+    ' Please use timeout.refresh() instead.',
+    'DEP0127'),
+  active: deprecate(
+    active,
+    'timers.active() is deprecated. Please use timeout.refresh() instead.',
+    'DEP0126'),
   unenroll: deprecate(
     unenroll,
     'timers.unenroll() is deprecated. Please use clearTimeout instead.',

--- a/test/parallel/test-timers-max-duration-warning.js
+++ b/test/parallel/test-timers-max-duration-warning.js
@@ -19,7 +19,7 @@ process.on('warning', common.mustCall((warning) => {
   assert.strictEqual(lines[0], `${OVERFLOW} does not fit into a 32-bit signed` +
                                ' integer.');
   assert.strictEqual(lines.length, 2);
-}, 5));
+}, 6));
 
 
 {


### PR DESCRIPTION
Another nail in the coffin here, farewell ye ol C-style apis.

These apis caused numerous other issues that required far too many safeguards.
This gets us one step closer to not having to worry about those issues anymore.

Refs: https://github.com/nodejs/node/pull/18066
Refs: https://github.com/nodejs/node/pull/20298

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
