### PR TITLE
console: fix trace function

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -331,7 +331,7 @@ const consoleMethods = {
       name: 'Trace',
       message: this[kFormatForStderr](args)
     };
-    Error.captureStackTrace(err, trace);
+    Error.captureStackTrace(err, this.trace);
     this.error(err.stack);
   },
 

--- a/test/message/console.js
+++ b/test/message/console.js
@@ -1,0 +1,5 @@
+'use strict';
+
+require('../common');
+
+console.trace('foo');

--- a/test/message/console.out
+++ b/test/message/console.out
@@ -1,0 +1,10 @@
+Trace: foo
+    at Object.trace (*)
+    at Object.<anonymous> (*console.js:*:*)
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *


### PR DESCRIPTION
A recent refactoring made the slight mistake of using `trace()`
instead of `this.trace()`.

Fixes: https://github.com/nodejs/node/issues/26763

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
