### PR TITLE
src: use explicit casts to silence conversion warnings

### DIFF
--- a/src/node_file.h
+++ b/src/node_file.h
@@ -194,16 +194,16 @@ constexpr uint64_t ToNative(uv_timespec_t ts) {
 template <typename NativeT, typename V8T>
 constexpr void FillStatsArray(AliasedBuffer<NativeT, V8T>* fields,
                               const uv_stat_t* s, const size_t offset = 0) {
-  fields->SetValue(offset + 0, s->st_dev);
-  fields->SetValue(offset + 1, s->st_mode);
-  fields->SetValue(offset + 2, s->st_nlink);
-  fields->SetValue(offset + 3, s->st_uid);
-  fields->SetValue(offset + 4, s->st_gid);
-  fields->SetValue(offset + 5, s->st_rdev);
-  fields->SetValue(offset + 6, s->st_blksize);
-  fields->SetValue(offset + 7, s->st_ino);
-  fields->SetValue(offset + 8, s->st_size);
-  fields->SetValue(offset + 9, s->st_blocks);
+  fields->SetValue(offset + 0, static_cast<NativeT>(s->st_dev));
+  fields->SetValue(offset + 1, static_cast<NativeT>(s->st_mode));
+  fields->SetValue(offset + 2, static_cast<NativeT>(s->st_nlink));
+  fields->SetValue(offset + 3, static_cast<NativeT>(s->st_uid));
+  fields->SetValue(offset + 4, static_cast<NativeT>(s->st_gid));
+  fields->SetValue(offset + 5, static_cast<NativeT>(s->st_rdev));
+  fields->SetValue(offset + 6, static_cast<NativeT>(s->st_blksize));
+  fields->SetValue(offset + 7, static_cast<NativeT>(s->st_ino));
+  fields->SetValue(offset + 8, static_cast<NativeT>(s->st_size));
+  fields->SetValue(offset + 9, static_cast<NativeT>(s->st_blocks));
 // Dates.
   fields->SetValue(offset + 10, ToNative<NativeT>(s->st_atim));
   fields->SetValue(offset + 11, ToNative<NativeT>(s->st_mtim));


### PR DESCRIPTION
Addresses ~30 of the warnings posted in https://github.com/nodejs/node/issues/26733#issuecomment-473894753. (I don't think there's a better solution than accepting the precision loss, since bigint is already an available option.)

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
