### PR TITLE
child_process: reduce internal usage of public require of util

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -21,10 +21,13 @@
 
 'use strict';
 
-const util = require('util');
-const { convertToValidSignal, getSystemErrorName } = require('internal/util');
+const {
+  promisify,
+  convertToValidSignal,
+  getSystemErrorName
+} = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
-const debug = util.debuglog('child_process');
+const debug = require('internal/util/debuglog').debuglog('child_process');
 const { Buffer } = require('buffer');
 const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');
 const {
@@ -168,7 +171,7 @@ const customPromiseExecFunction = (orig) => {
   };
 };
 
-Object.defineProperty(exports.exec, util.promisify.custom, {
+Object.defineProperty(exports.exec, promisify.custom, {
   enumerable: false,
   value: customPromiseExecFunction(exports.exec)
 });
@@ -389,7 +392,7 @@ exports.execFile = function execFile(file /* , args, options, callback */) {
   return child;
 };
 
-Object.defineProperty(exports.execFile, util.promisify.custom, {
+Object.defineProperty(exports.execFile, promisify.custom, {
   enumerable: false,
   value: customPromiseExecFunction(exports.execFile)
 });


### PR DESCRIPTION
Remove the usage of public require('util'), as described in issue:
#26546 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]