### PR TITLE
dgram: remove usage of public require('util')

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -45,7 +45,7 @@ const {
   validateNumber
 } = require('internal/validators');
 const { Buffer } = require('buffer');
-const util = require('util');
+const { deprecate } = require('internal/util');
 const { isUint8Array } = require('internal/util/types');
 const EventEmitter = require('events');
 const {
@@ -729,61 +729,61 @@ Socket.prototype.getSendBufferSize = function() {
 
 // Deprecated private APIs.
 Object.defineProperty(Socket.prototype, '_handle', {
-  get: util.deprecate(function() {
+  get: deprecate(function() {
     return this[kStateSymbol].handle;
   }, 'Socket.prototype._handle is deprecated', 'DEP0112'),
-  set: util.deprecate(function(val) {
+  set: deprecate(function(val) {
     this[kStateSymbol].handle = val;
   }, 'Socket.prototype._handle is deprecated', 'DEP0112')
 });
 
 
 Object.defineProperty(Socket.prototype, '_receiving', {
-  get: util.deprecate(function() {
+  get: deprecate(function() {
     return this[kStateSymbol].receiving;
   }, 'Socket.prototype._receiving is deprecated', 'DEP0112'),
-  set: util.deprecate(function(val) {
+  set: deprecate(function(val) {
     this[kStateSymbol].receiving = val;
   }, 'Socket.prototype._receiving is deprecated', 'DEP0112')
 });
 
 
 Object.defineProperty(Socket.prototype, '_bindState', {
-  get: util.deprecate(function() {
+  get: deprecate(function() {
     return this[kStateSymbol].bindState;
   }, 'Socket.prototype._bindState is deprecated', 'DEP0112'),
-  set: util.deprecate(function(val) {
+  set: deprecate(function(val) {
     this[kStateSymbol].bindState = val;
   }, 'Socket.prototype._bindState is deprecated', 'DEP0112')
 });
 
 
 Object.defineProperty(Socket.prototype, '_queue', {
-  get: util.deprecate(function() {
+  get: deprecate(function() {
     return this[kStateSymbol].queue;
   }, 'Socket.prototype._queue is deprecated', 'DEP0112'),
-  set: util.deprecate(function(val) {
+  set: deprecate(function(val) {
     this[kStateSymbol].queue = val;
   }, 'Socket.prototype._queue is deprecated', 'DEP0112')
 });
 
 
 Object.defineProperty(Socket.prototype, '_reuseAddr', {
-  get: util.deprecate(function() {
+  get: deprecate(function() {
     return this[kStateSymbol].reuseAddr;
   }, 'Socket.prototype._reuseAddr is deprecated', 'DEP0112'),
-  set: util.deprecate(function(val) {
+  set: deprecate(function(val) {
     this[kStateSymbol].reuseAddr = val;
   }, 'Socket.prototype._reuseAddr is deprecated', 'DEP0112')
 });
 
 
-Socket.prototype._healthCheck = util.deprecate(function() {
+Socket.prototype._healthCheck = deprecate(function() {
   healthCheck(this);
 }, 'Socket.prototype._healthCheck() is deprecated', 'DEP0112');
 
 
-Socket.prototype._stopReceiving = util.deprecate(function() {
+Socket.prototype._stopReceiving = deprecate(function() {
   stopReceiving(this);
 }, 'Socket.prototype._stopReceiving() is deprecated', 'DEP0112');
 
@@ -797,7 +797,7 @@ Object.defineProperty(UDP.prototype, 'owner', {
 
 
 module.exports = {
-  _createSocketHandle: util.deprecate(
+  _createSocketHandle: deprecate(
     _createSocketHandle,
     'dgram._createSocketHandle() is deprecated',
     'DEP0112'


### PR DESCRIPTION
Use `require('internal/util').deprecate` instead of 
`require('util').deprecate`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
