### PR TITLE
lib: load internal/errors eagerly in events.js and perf_hooks.js

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -23,6 +23,12 @@
 
 var spliceOne;
 
+const {
+  ERR_INVALID_ARG_TYPE,
+  ERR_OUT_OF_RANGE,
+  ERR_UNHANDLED_ERROR
+} = require('internal/errors').codes;
+
 function EventEmitter() {
   EventEmitter.init.call(this);
 }
@@ -42,17 +48,9 @@ EventEmitter.prototype._maxListeners = undefined;
 // added to it. This is a useful default which helps finding memory leaks.
 var defaultMaxListeners = 10;
 
-var errors;
-function lazyErrors() {
-  if (errors === undefined)
-    errors = require('internal/errors').codes;
-  return errors;
-}
-
 function checkListener(listener) {
   if (typeof listener !== 'function') {
-    const errors = lazyErrors();
-    throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
+    throw new ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
   }
 }
 
@@ -63,10 +61,9 @@ Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
   },
   set: function(arg) {
     if (typeof arg !== 'number' || arg < 0 || Number.isNaN(arg)) {
-      const errors = lazyErrors();
-      throw new errors.ERR_OUT_OF_RANGE('defaultMaxListeners',
-                                        'a non-negative number',
-                                        arg);
+      throw new ERR_OUT_OF_RANGE('defaultMaxListeners',
+                                 'a non-negative number',
+                                 arg);
     }
     defaultMaxListeners = arg;
   }
@@ -87,8 +84,7 @@ EventEmitter.init = function() {
 // that to be increased. Set to zero for unlimited.
 EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
   if (typeof n !== 'number' || n < 0 || Number.isNaN(n)) {
-    const errors = lazyErrors();
-    throw new errors.ERR_OUT_OF_RANGE('n', 'a non-negative number', n);
+    throw new ERR_OUT_OF_RANGE('n', 'a non-negative number', n);
   }
   this._maxListeners = n;
   return this;
@@ -183,8 +179,7 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
     }
 
     // At least give some kind of context to the user
-    const errors = lazyErrors();
-    const err = new errors.ERR_UNHANDLED_ERROR(stringifiedEr);
+    const err = new ERR_UNHANDLED_ERROR(stringifiedEr);
     err.context = er;
     throw err; // Unhandled 'error' event
   }

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -36,6 +36,15 @@ const { AsyncResource } = require('async_hooks');
 const L = require('internal/linkedlist');
 const kInspect = require('internal/util').customInspectSymbol;
 
+const {
+  ERR_INVALID_CALLBACK,
+  ERR_INVALID_ARG_VALUE,
+  ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_OPT_VALUE,
+  ERR_VALID_PERFORMANCE_ENTRY_TYPE,
+  ERR_INVALID_PERFORMANCE_MARK
+} = require('internal/errors').codes;
+
 const kHandle = Symbol('handle');
 const kMap = Symbol('map');
 const kCallback = Symbol('callback');
@@ -123,14 +132,6 @@ function collectHttp2Stats(entry) {
         sessionStats[IDX_SESSION_STATS_MAX_CONCURRENT_STREAMS];
       break;
   }
-}
-
-
-let errors;
-function lazyErrors() {
-  if (errors === undefined)
-    errors = require('internal/errors').codes;
-  return errors;
 }
 
 function now() {
@@ -282,8 +283,7 @@ let gcTrackingIsEnabled = false;
 class PerformanceObserver extends AsyncResource {
   constructor(callback) {
     if (typeof callback !== 'function') {
-      const errors = lazyErrors();
-      throw new errors.ERR_INVALID_CALLBACK();
+      throw new ERR_INVALID_CALLBACK();
     }
     super('PerformanceObserver');
     Object.defineProperties(this, {
@@ -329,16 +329,15 @@ class PerformanceObserver extends AsyncResource {
   }
 
   observe(options) {
-    const errors = lazyErrors();
     if (typeof options !== 'object' || options == null) {
-      throw new errors.ERR_INVALID_ARG_TYPE('options', 'Object', options);
+      throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
     if (!Array.isArray(options.entryTypes)) {
-      throw new errors.ERR_INVALID_OPT_VALUE('entryTypes', options);
+      throw new ERR_INVALID_OPT_VALUE('entryTypes', options);
     }
     const entryTypes = options.entryTypes.filter(filterTypes).map(mapTypes);
     if (entryTypes.length === 0) {
-      throw new errors.ERR_VALID_PERFORMANCE_ENTRY_TYPE();
+      throw new ERR_VALID_PERFORMANCE_ENTRY_TYPE();
     }
     if (entryTypes.includes(NODE_PERFORMANCE_ENTRY_TYPE_GC) &&
       !gcTrackingIsEnabled) {
@@ -391,8 +390,7 @@ class Performance {
     startMark = startMark !== undefined ? `${startMark}` : '';
     const marks = this[kIndex][kMarks];
     if (!marks.has(endMark) && !(endMark in nodeTiming)) {
-      const errors = lazyErrors();
-      throw new errors.ERR_INVALID_PERFORMANCE_MARK(endMark);
+      throw new ERR_INVALID_PERFORMANCE_MARK(endMark);
     }
     _measure(name, startMark, endMark);
   }
@@ -410,8 +408,7 @@ class Performance {
 
   timerify(fn) {
     if (typeof fn !== 'function') {
-      const errors = lazyErrors();
-      throw new errors.ERR_INVALID_ARG_TYPE('fn', 'Function', fn);
+      throw new ERR_INVALID_ARG_TYPE('fn', 'Function', fn);
     }
     if (fn[kTimerified])
       return fn[kTimerified];
@@ -565,13 +562,11 @@ class ELDHistogram {
   get stddev() { return this[kHandle].stddev(); }
   percentile(percentile) {
     if (typeof percentile !== 'number') {
-      const errors = lazyErrors();
-      throw new errors.ERR_INVALID_ARG_TYPE('percentile', 'number', percentile);
+      throw new ERR_INVALID_ARG_TYPE('percentile', 'number', percentile);
     }
     if (percentile <= 0 || percentile > 100) {
-      const errors = lazyErrors();
-      throw new errors.ERR_INVALID_ARG_VALUE.RangeError('percentile',
-                                                        percentile);
+      throw new ERR_INVALID_ARG_VALUE.RangeError('percentile',
+                                                 percentile);
     }
     return this[kHandle].percentile(percentile);
   }
@@ -595,18 +590,15 @@ class ELDHistogram {
 
 function monitorEventLoopDelay(options = {}) {
   if (typeof options !== 'object' || options === null) {
-    const errors = lazyErrors();
-    throw new errors.ERR_INVALID_ARG_TYPE('options', 'Object', options);
+    throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
   }
   const { resolution = 10 } = options;
   if (typeof resolution !== 'number') {
-    const errors = lazyErrors();
-    throw new errors.ERR_INVALID_ARG_TYPE('options.resolution',
-                                          'number', resolution);
+    throw new ERR_INVALID_ARG_TYPE('options.resolution',
+                                   'number', resolution);
   }
   if (resolution <= 0 || !Number.isSafeInteger(resolution)) {
-    const errors = lazyErrors();
-    throw new errors.ERR_INVALID_OPT_VALUE.RangeError('resolution', resolution);
+    throw new ERR_INVALID_OPT_VALUE.RangeError('resolution', resolution);
   }
   return new ELDHistogram(new _ELDHistogram(resolution));
 }


### PR DESCRIPTION
Since `internal/errors` is loaded by many builtin modules and is
currently the first module loaded during bootstrap, it is
fine to load it eagerly. We just need to make sure
that `internal/errors` itself load other modules lazily.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
