### PR TITLE
https: remove usage of public require('util')

### DIFF
--- a/lib/https.js
+++ b/lib/https.js
@@ -25,7 +25,6 @@ require('internal/util').assertCrypto();
 
 const tls = require('tls');
 const url = require('url');
-const util = require('util');
 const { Agent: HttpAgent } = require('_http_agent');
 const {
   Server: HttpServer,
@@ -33,8 +32,7 @@ const {
   kServerResponse
 } = require('_http_server');
 const { ClientRequest } = require('_http_client');
-const { inherits } = util;
-const debug = util.debuglog('https');
+const debug = require('internal/util/debuglog').debuglog('https');
 const { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
 const { IncomingMessage, ServerResponse } = require('http');
 const { kIncomingMessage } = require('_http_common');
@@ -76,7 +74,8 @@ function Server(opts, requestListener) {
   this.maxHeadersCount = null;
   this.headersTimeout = 40 * 1000; // 40 seconds
 }
-inherits(Server, tls.Server);
+Object.setPrototypeOf(Server.prototype, tls.Server.prototype);
+Object.setPrototypeOf(Server, tls.Server);
 
 Server.prototype.setTimeout = HttpServer.prototype.setTimeout;
 


### PR DESCRIPTION
Use `require('internal/util/debuglog').debuglog`
and `Object.setPrototypeOf` instead of `require('util').debuglog`
and `require('util').inherits`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
