### PR TITLE
lib: remove usage of require('util')

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -18,7 +18,7 @@ const { validateString } = require('internal/validators');
 const EventEmitter = require('events');
 const net = require('net');
 const dgram = require('dgram');
-const util = require('util');
+const inspect = require('internal/util/inspect').inspect;
 const assert = require('internal/assert');
 
 const { Process } = internalBinding('process_wrap');
@@ -887,7 +887,7 @@ function _validateStdio(stdio, sync) {
         throw new ERR_INVALID_OPT_VALUE('stdio', stdio);
     }
   } else if (!Array.isArray(stdio)) {
-    throw new ERR_INVALID_OPT_VALUE('stdio', util.inspect(stdio));
+    throw new ERR_INVALID_OPT_VALUE('stdio', inspect(stdio));
   }
 
   // At least 3 stdio will be created
@@ -967,12 +967,12 @@ function _validateStdio(stdio, sync) {
     } else if (isArrayBufferView(stdio) || typeof stdio === 'string') {
       if (!sync) {
         cleanup();
-        throw new ERR_INVALID_SYNC_FORK_INPUT(util.inspect(stdio));
+        throw new ERR_INVALID_SYNC_FORK_INPUT(inspect(stdio));
       }
     } else {
       // Cleanup
       cleanup();
-      throw new ERR_INVALID_OPT_VALUE('stdio', util.inspect(stdio));
+      throw new ERR_INVALID_OPT_VALUE('stdio', inspect(stdio));
     }
 
     return acc;


### PR DESCRIPTION
Remove usage of public require('util') in
`internal/child_process`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
