### PR TITLE
lib: remove usage of require('util')

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -15,10 +15,13 @@ const {
 } = require('internal/errors');
 const { previewEntries } = internalBinding('util');
 const { Buffer: { isBuffer } } = require('buffer');
-const util = require('util');
+const {
+  inspect,
+  formatWithOptions
+} = require('internal/util/inspect');
 const {
   isTypedArray, isSet, isMap, isSetIterator, isMapIterator,
-} = util.types;
+} = require('internal/util/types');
 const kCounts = Symbol('counts');
 
 const kTraceConsoleCategory = 'node,node.console';
@@ -271,12 +274,12 @@ Console.prototype[kGetInspectOptions] = function(stream) {
 
 Console.prototype[kFormatForStdout] = function(args) {
   const opts = this[kGetInspectOptions](this._stdout);
-  return util.formatWithOptions(opts, ...args);
+  return formatWithOptions(opts, ...args);
 };
 
 Console.prototype[kFormatForStderr] = function(args) {
   const opts = this[kGetInspectOptions](this._stderr);
-  return util.formatWithOptions(opts, ...args);
+  return formatWithOptions(opts, ...args);
 };
 
 const consoleMethods = {
@@ -291,7 +294,7 @@ const consoleMethods = {
 
 
   dir(object, options) {
-    this[kWriteToConsole](kUseStdout, util.inspect(object, {
+    this[kWriteToConsole](kUseStdout, inspect(object, {
       customInspect: false,
       ...this[kGetInspectOptions](this._stdout),
       ...options
@@ -405,7 +408,7 @@ const consoleMethods = {
     if (cliTable === undefined) cliTable = require('internal/cli_table');
     const final = (k, v) => this.log(cliTable(k, v));
 
-    const inspect = (v) => {
+    const _inspect = (v) => {
       const depth = v !== null &&
                     typeof v === 'object' &&
                     !isArray(v) &&
@@ -415,10 +418,10 @@ const consoleMethods = {
         maxArrayLength: 3,
         ...this[kGetInspectOptions](this._stdout)
       };
-      return util.inspect(v, opt);
+      return inspect(v, opt);
     };
     const getIndexArray = (length) => ArrayFrom(
-      { length }, (_, i) => inspect(i));
+      { length }, (_, i) => _inspect(i));
 
     const mapIter = isMapIterator(tabularData);
     let isKeyValue = false;
@@ -435,14 +438,14 @@ const consoleMethods = {
       let length = 0;
       if (mapIter) {
         for (; i < tabularData.length / 2; ++i) {
-          keys.push(inspect(tabularData[i * 2]));
-          values.push(inspect(tabularData[i * 2 + 1]));
+          keys.push(_inspect(tabularData[i * 2]));
+          values.push(_inspect(tabularData[i * 2 + 1]));
           length++;
         }
       } else {
         for (const [k, v] of tabularData) {
-          keys.push(inspect(k));
-          values.push(inspect(v));
+          keys.push(_inspect(k));
+          values.push(_inspect(v));
           length++;
         }
       }
@@ -464,7 +467,7 @@ const consoleMethods = {
       const values = [];
       let length = 0;
       for (const v of tabularData) {
-        values.push(inspect(v));
+        values.push(_inspect(v));
         length++;
       }
       return final([setlike ? iterKey : indexKey, valuesKey], [
@@ -484,7 +487,7 @@ const consoleMethods = {
           (typeof item !== 'function' && typeof item !== 'object');
       if (properties === undefined && primitive) {
         hasPrimitives = true;
-        valuesKeyArray[i] = inspect(item);
+        valuesKeyArray[i] = _inspect(item);
       } else {
         const keys = properties || ObjectKeys(item);
         for (const key of keys) {
@@ -493,7 +496,7 @@ const consoleMethods = {
           if ((primitive && properties) || !hasOwnProperty(item, key))
             map[key][i] = '';
           else
-            map[key][i] = item == null ? item : inspect(item[key]);
+            map[key][i] = item == null ? item : _inspect(item[key]);
         }
       }
     }


### PR DESCRIPTION
Remove usage of public `require('util').inspect`,
`require('util').formatWithOptions` and `require('util').types`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
