### PR TITLE
readline: replace quadratic regex with linear one

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -570,8 +570,11 @@ function commonPrefix(strings) {
 
 Interface.prototype._wordLeft = function() {
   if (this.cursor > 0) {
+    // Reverse the string and match a word near beginning
+    // to avoid quadratic time complexity
     var leading = this.line.slice(0, this.cursor);
-    var match = leading.match(/(?:[^\w\s]+|\w+|)\s*$/);
+    var reversed = leading.split('').reverse().join('');
+    var match = reversed.match(/^\s*(?:[^\w\s]+|\w+)?/);
     this._moveCursor(-match[0].length);
   }
 };
@@ -627,8 +630,11 @@ Interface.prototype._deleteRight = function() {
 
 Interface.prototype._deleteWordLeft = function() {
   if (this.cursor > 0) {
+    // Reverse the string and match a word near beginning
+    // to avoid quadratic time complexity
     var leading = this.line.slice(0, this.cursor);
-    var match = leading.match(/(?:[^\w\s]+|\w+|)\s*$/);
+    var reversed = leading.split('').reverse().join('');
+    var match = reversed.match(/^\s*(?:[^\w\s]+|\w+)?/);
     leading = leading.slice(0, leading.length - match[0].length);
     this.line = leading + this.line.slice(this.cursor, this.line.length);
     this.cursor = leading.length;

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -1272,3 +1272,26 @@ const crlfDelay = Infinity;
     }), delay);
   }
 });
+
+// Ensure that the _wordLeft method works even for large input
+{
+  const input = new Readable({
+    read() {
+      this.push('\x1B[1;5D'); // CTRL + Left
+      this.push(null);
+    },
+  });
+  const output = new Writable({
+    write: common.mustCall((data, encoding, cb) => {
+      assert.strictEqual(rl.cursor, rl.line.length - 1);
+      cb();
+    }),
+  });
+  const rl = new readline.createInterface({
+    input: input,
+    output: output,
+    terminal: true,
+  });
+  rl.line = `a${' '.repeat(1e6)}a`;
+  rl.cursor = rl.line.length;
+}


### PR DESCRIPTION
Simplify regular expression in _wordLeft readline method.

Note: If the test can be improved in any way, let me know. Tried using `FakeInput`, but writing one million characters takes a very long time. Or should a benchmark be used instead of the test?

Fixes https://github.com/nodejs/node/issues/26596

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
