### PR TITLE
lib: remove usage of require('util')

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -327,7 +327,7 @@ class TextEncoder {
     });
     obj.encoding = this.encoding;
     // Lazy to avoid circular dependency
-    return require('util').inspect(obj, opts);
+    return require('internal/util/inspect').inspect(obj, opts);
   }
 }
 
@@ -530,7 +530,7 @@ function makeTextDecoderJS() {
           obj[kHandle] = this[kHandle];
         }
         // Lazy to avoid circular dependency
-        return require('util').inspect(obj, opts);
+        return require('internal/util/inspect').inspect(obj, opts);
       }
     }));
   Object.defineProperties(TextDecoder.prototype, {


### PR DESCRIPTION
Remove the usage of `require('util').inspect`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
