### PR TITLE
errors: remove usage of require('util')

### DIFF
--- a/lib/internal/error-serdes.js
+++ b/lib/internal/error-serdes.js
@@ -76,11 +76,12 @@ function GetName(object) {
   return desc && desc.value;
 }
 
-let util;
-function lazyUtil() {
-  if (!util)
-    util = require('util');
-  return util;
+let internalUtilInspect;
+function inspect(...args) {
+  if (!internalUtilInspect) {
+    internalUtilInspect = require('internal/util/inspect');
+  }
+  return internalUtilInspect.inspect(...args);
 }
 
 let serialize;
@@ -107,7 +108,7 @@ function serializeError(error) {
     return Buffer.concat([Buffer.from([kSerializedObject]), serialized]);
   } catch {}
   return Buffer.concat([Buffer.from([kInspectedError]),
-                        Buffer.from(lazyUtil().inspect(error), 'utf8')]);
+                        Buffer.from(inspect(error), 'utf8')]);
 }
 
 let deserialize;


### PR DESCRIPTION
Remove internal usage of `require('util').inspect` in `lib/internal/error-serdes.js`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
