### PR TITLE
lib: reduce usage of require('util')

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -30,6 +30,14 @@ function lazyInternalUtil() {
   return internalUtil;
 }
 
+let internalUtilInspect = null;
+function lazyInternalUtilInspect() {
+  if (!internalUtilInspect) {
+    internalUtilInspect = require('internal/util/inspect');
+  }
+  return internalUtilInspect;
+}
+
 let buffer;
 function lazyBuffer() {
   if (buffer === undefined)
@@ -207,7 +215,6 @@ function E(sym, val, def, ...otherClasses) {
 function getMessage(key, args) {
   const msg = messages.get(key);
 
-  if (util === undefined) util = require('util');
   if (assert === undefined) assert = require('internal/assert');
 
   if (typeof msg === 'function') {
@@ -229,7 +236,7 @@ function getMessage(key, args) {
     return msg;
 
   args.unshift(msg);
-  return util.format.apply(null, args);
+  return lazyInternalUtilInspect().format.apply(null, args);
 }
 
 let uvBinding;
@@ -737,7 +744,7 @@ E('ERR_INVALID_ARG_TYPE',
     return msg;
   }, TypeError);
 E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
-  let inspected = util.inspect(value);
+  let inspected = lazyInternalUtilInspect().inspect(value);
   if (inspected.length > 128) {
     inspected = `${inspected.slice(0, 128)}...`;
   }


### PR DESCRIPTION
Replace `require('util').inspect` and `require('util').format` with
`require('util/internal/inspect').inspect` and 
`require('util/internal/inspect').format` in `lib/internal/errors.js`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
