### PR TITLE
fs: reduce usage of require('util')

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -12,10 +12,13 @@ const {
   },
   hideStackFrames
 } = require('internal/errors');
-const { isUint8Array, isArrayBufferView } = require('internal/util/types');
+const {
+  isUint8Array,
+  isArrayBufferView,
+  isDate
+} = require('internal/util/types');
 const { once } = require('internal/util');
 const pathModule = require('path');
-const util = require('util');
 const kType = Symbol('type');
 const kStats = Symbol('stats');
 
@@ -383,7 +386,7 @@ function toUnixTimestamp(time, name = 'time') {
     }
     return time;
   }
-  if (util.isDate(time)) {
+  if (isDate(time)) {
     // Convert to 123.456 UNIX timestamp
     return time.getTime() / 1000;
   }


### PR DESCRIPTION
Remove the usage of public require('util'), as described in issue:
#26546 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
