### PR TITLE
lib: reduce usage of require('util')

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -18,7 +18,6 @@ const net = require('net');
 const { Duplex } = require('stream');
 const tls = require('tls');
 const { URL } = require('url');
-const util = require('util');
 
 const { kIncomingMessage } = require('_http_common');
 const { kServerResponse } = require('_http_server');
@@ -118,6 +117,7 @@ const {
 } = require('internal/stream_base_commons');
 const { kTimeout } = require('internal/timers');
 const { isArrayBufferView } = require('internal/util/types');
+const { format } = require('internal/util/inspect');
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -132,7 +132,7 @@ const { UV_EOF } = internalBinding('uv');
 
 const { StreamPipe } = internalBinding('stream_pipe');
 const { _connectionListener: httpConnectionListener } = http;
-const debug = util.debuglog('http2');
+const debug = require('internal/util/debuglog').debuglog('http2');
 
 const kMaxFrameSize = (2 ** 24) - 1;
 const kMaxInt = (2 ** 32) - 1;
@@ -1085,7 +1085,7 @@ class Http2Session extends EventEmitter {
       localSettings: this.localSettings,
       remoteSettings: this.remoteSettings
     };
-    return `Http2Session ${util.format(obj)}`;
+    return `Http2Session ${format(obj)}`;
   }
 
   // The socket owned by this session
@@ -1666,7 +1666,7 @@ class Http2Stream extends Duplex {
       readableState: this._readableState,
       writableState: this._writableState
     };
-    return `Http2Stream ${util.format(obj)}`;
+    return `Http2Stream ${format(obj)}`;
   }
 
   get bufferSize() {


### PR DESCRIPTION
Remove the usage of public require('util')
Replace require('util').debuglog with require('internal/util/debuglog').debuglog
Replace require('util').format with require('internal/util/inspect').format, as described in issue:
#26546 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]