### PR TITLE
http2: reduce usage of public require('util') in core.js

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -7,8 +7,8 @@ const {
   customInspectSymbol: kInspect,
   promisify
 } = require('internal/util');
-const { debuglog } = require('internal/util/debuglog')
-const { format } = require('internal/util/inspect')
+const { debuglog } = require('internal/util/debuglog');
+const { format } = require('internal/util/inspect');
 
 assertCrypto();
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -7,6 +7,8 @@ const {
   customInspectSymbol: kInspect,
   promisify
 } = require('internal/util');
+const { debuglog } = require('internal/util/debuglog')
+const { format } = require('internal/util/inspect')
 
 assertCrypto();
 
@@ -18,8 +20,6 @@ const net = require('net');
 const { Duplex } = require('stream');
 const tls = require('tls');
 const { URL } = require('url');
-const util = require('util');
-
 const { kIncomingMessage } = require('_http_common');
 const { kServerResponse } = require('_http_server');
 const JSStreamSocket = require('internal/js_stream_socket');
@@ -132,7 +132,7 @@ const { UV_EOF } = internalBinding('uv');
 
 const { StreamPipe } = internalBinding('stream_pipe');
 const { _connectionListener: httpConnectionListener } = http;
-const debug = util.debuglog('http2');
+const debug = debuglog('http2');
 
 const kMaxFrameSize = (2 ** 24) - 1;
 const kMaxInt = (2 ** 32) - 1;
@@ -1085,7 +1085,7 @@ class Http2Session extends EventEmitter {
       localSettings: this.localSettings,
       remoteSettings: this.remoteSettings
     };
-    return `Http2Session ${util.format(obj)}`;
+    return `Http2Session ${format(obj)}`;
   }
 
   // The socket owned by this session
@@ -1666,7 +1666,7 @@ class Http2Stream extends Duplex {
       readableState: this._readableState,
       writableState: this._writableState
     };
-    return `Http2Stream ${util.format(obj)}`;
+    return `Http2Stream ${format(obj)}`;
   }
 
   get bufferSize() {


### PR DESCRIPTION
This PR is part of issue #26546

Replaced usage of public `require('util')` 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
