### PR TITLE
doc: add option to require 'process' to api docs

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -5,7 +5,7 @@
 
 The `process` object is a `global` that provides information about, and control
 over, the current Node.js process. As a global, it is always available to
-Node.js applications without using `require()`. However, it can also be
+Node.js applications without using `require()`. It can also be
 explicitly accessed using `require()`:
 
 ```js

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -5,8 +5,8 @@
 
 The `process` object is a `global` that provides information about, and control
 over, the current Node.js process. As a global, it is always available to
-Node.js applications without using `require()`. It can also be
-explicitly accessed using `require()`:
+Node.js applications without using `require()`. It can also be explicitly
+accessed using `require()`:
 
 ```js
 const process = require('process');

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -5,7 +5,12 @@
 
 The `process` object is a `global` that provides information about, and control
 over, the current Node.js process. As a global, it is always available to
-Node.js applications without using `require()`.
+Node.js applications without using `require()`. However, it can also be
+explicitly accessed using `require()`:
+
+```js
+const process = require('process');
+```
 
 ## Process Events
 


### PR DESCRIPTION
It is possible to require the 'process' module and with the upcoming
support for ES Modules, importing 'process' might be the more favorable
way for developers. This commit adds that option to the documentation as suggested by @MylesBorins. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
