### PR TITLE
inspector: always set process.binding('inspector').callAndPauseOnStart

### DIFF
--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -273,8 +273,6 @@ void Initialize(Local<Object> target, Local<Value> unused,
                 Local<Context> context, void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
-  Agent* agent = env->inspector_agent();
-
   v8::Local<v8::Function> consoleCallFunc =
       env->NewFunctionTemplate(InspectorConsoleCall, v8::Local<v8::Signature>(),
                                v8::ConstructorBehavior::kThrow,
@@ -287,8 +285,7 @@ void Initialize(Local<Object> target, Local<Value> unused,
 
   env->SetMethod(
       target, "setConsoleExtensionInstaller", SetConsoleExtensionInstaller);
-  if (agent->WillWaitForConnect())
-    env->SetMethod(target, "callAndPauseOnStart", CallAndPauseOnStart);
+  env->SetMethod(target, "callAndPauseOnStart", CallAndPauseOnStart);
   env->SetMethod(target, "open", Open);
   env->SetMethodNoSideEffect(target, "url", Url);
 


### PR DESCRIPTION
Since `process.binding('inspector')` is loaded during bootstrap,
simply set `process.binding('inspector').callAndPauseOnStart`
unconditionally instead of relying on `agent->WillWaitForConnect()`
which depends on runtime states,

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
