### PR TITLE
test: fix test-console-stdio-setters to test setters

### DIFF
--- a/test/parallel/test-console-stdio-setters.js
+++ b/test/parallel/test-console-stdio-setters.js
@@ -4,17 +4,15 @@
 const common = require('../common');
 
 const { Writable } = require('stream');
-const { Console } = require('console');
 
 const streamToNowhere = new Writable({ write: common.mustCall() });
 const anotherStreamToNowhere = new Writable({ write: common.mustCall() });
-const myConsole = new Console(process.stdout);
 
-// Overriding the _stdout and _stderr properties this way is what we are
-// testing. Don't change this to be done via arguments passed to the constructor
-// above.
-myConsole._stdout = streamToNowhere;
-myConsole._stderr = anotherStreamToNowhere;
+// Overriding the lazy-loaded _stdout and _stderr properties this way is what we
+// are testing. Don't change this to be a Console instance from calling a
+// constructor. It has to be the global `console` object.
+console._stdout = streamToNowhere;
+console._stderr = anotherStreamToNowhere;
 
-myConsole.log('fhqwhgads');
-myConsole.error('fhqwhgads');
+console.log('fhqwhgads');
+console.error('fhqwhgads');


### PR DESCRIPTION
test-console-stdio-setters needs to test against the global console in
order to test the setters for the lazy-loaded _stdout and _stderr
properties.

Debugging shows that the current form of the test doesn't call into the setters (which also show as uncovered in the current coverage report). Using the global `console` fixes it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
