### PR TITLE
src: guard exit label when inspector disabled

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -856,7 +856,9 @@ inline int StartNodeWithIsolate(Isolate* isolate,
 
   WaitForInspectorDisconnect(&env);
 
+#if HAVE_INSPECTOR && NODE_USE_V8_PLATFORM
 exit:
+#endif
   env.set_can_call_into_js(false);
   env.stop_sub_worker_contexts();
   uv_tty_reset_mode();


### PR DESCRIPTION
Currently, when configured `--without-inspector` the following warning
will be generated:
```console
../src/node.cc:859:1: warning: unused label 'exit' [-Wunused-label]
exit:
```
This commit adds a guard to exclude the label when there is no
inspector support.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
