### PR TITLE
module: remove usage of require('util') `cjs/loader.js`

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -23,7 +23,7 @@
 
 const { NativeModule } = require('internal/bootstrap/loaders');
 const { pathToFileURL } = require('internal/url');
-const util = require('util');
+const { deprecate } = require('internal/util');
 const vm = require('vm');
 const assert = require('internal/assert');
 const fs = require('fs');
@@ -182,8 +182,8 @@ function debug(...args) {
   debuglog(...args);
 }
 
-Module._debug = util.deprecate(debug, 'Module._debug is deprecated.',
-                               'DEP0077');
+Module._debug = deprecate(debug, 'Module._debug is deprecated.',
+                          'DEP0077');
 
 // Given a module name, and a list of paths to test, returns the first
 // matching file in the following precedence.


### PR DESCRIPTION
Use `require('internal/util').deprecate` instead of 
`require('util').deprecate` in `lib/internal/modules/cjs/loader.js`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
