### PR TITLE
module: remove usage of require('util')

### DIFF
--- a/lib/internal/modules/esm/create_dynamic_module.js
+++ b/lib/internal/modules/esm/create_dynamic_module.js
@@ -3,7 +3,7 @@
 const { ArrayPrototype } = primordials;
 
 const { ModuleWrap, callbackMap } = internalBinding('module_wrap');
-const debug = require('util').debuglog('esm');
+const debug = require('internal/util/debuglog').debuglog('esm');
 
 const createDynamicModule = (exports, url = '', evaluate) => {
   debug('creating ESM facade for %s with exports: %j', url, exports);


### PR DESCRIPTION
Use `require('internal/util/debuglog').debuglog` instead of 
`require('util').debuglog` in 
`lib/internal/modules/esm/create_dynamic_module.js`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
