### PR TITLE
module: remove usage of require('util') in `esm/loader.js`

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -18,7 +18,7 @@ const translators = require('internal/modules/esm/translators');
 
 const FunctionBind = Function.call.bind(Function.prototype.bind);
 
-const debug = require('util').debuglog('esm');
+const debug = require('internal/util/debuglog').debuglog('esm');
 
 /* A Loader instance is used as the main entry point for loading ES modules.
  * Currently, this is a singleton -- there is only one used for loading


### PR DESCRIPTION
Use `require('internal/util/debuglog').debuglog` instead of 
`require('util').debuglog` in `lib/internal/modules/esm/loader.js`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
