### PR TITLE
module: remove usage of require('util')

### DIFF
--- a/lib/internal/modules/esm/module_map.js
+++ b/lib/internal/modules/esm/module_map.js
@@ -4,7 +4,7 @@ const ModuleJob = require('internal/modules/esm/module_job');
 const {
   SafeMap
 } = primordials;
-const debug = require('util').debuglog('esm');
+const debug = require('internal/util/debuglog').debuglog('esm');
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
 


### PR DESCRIPTION
Use `require('internal/util/debuglog').debuglog` instead of 
`require('util').debuglog` in `lib/internal/modules/esm/module_map.js`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
