### PR TITLE
module: remove usage of require('util') in `esm/translators.js`

### DIFF
--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -19,7 +19,8 @@ const {
   StringPrototype
 } = primordials;
 const { URL } = require('url');
-const { debuglog, promisify } = require('util');
+const { debuglog } = require('internal/util/debuglog');
+const { promisify } = require('internal/util');
 const esmLoader = require('internal/process/esm_loader');
 const {
   ERR_UNKNOWN_BUILTIN_MODULE


### PR DESCRIPTION
Use `require('internal/util/debuglog').debuglog` and 
`require('internal/util').promisify`
instead of `require('util').debuglog` and `require('util').promisify` in 
`lib/internal/modules/translators.js`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
