### PR TITLE
net: remove usage of require('util')

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -23,7 +23,8 @@
 
 const EventEmitter = require('events');
 const stream = require('stream');
-const util = require('util');
+const { inspect } = require('internal/util/inspect');
+const { debuglog } = require('internal/util/debuglog');
 const internalUtil = require('internal/util');
 const {
   isIP,
@@ -130,7 +131,7 @@ function getNewAsyncId(handle) {
 }
 
 
-const debug = util.debuglog('net');
+const debug = debuglog('net');
 
 function isPipeName(s) {
   return typeof s === 'string' && toNumber(s) === false;
@@ -335,7 +336,8 @@ function Socket(options) {
   this[kBytesRead] = 0;
   this[kBytesWritten] = 0;
 }
-util.inherits(Socket, stream.Duplex);
+Object.setPrototypeOf(Socket.prototype, stream.Duplex.prototype);
+Object.setPrototypeOf(Socket, stream.Duplex);
 
 // Refresh existing timeouts.
 Socket.prototype._unrefTimer = function _unrefTimer() {
@@ -1411,7 +1413,7 @@ Server.prototype.listen = function(...args) {
                                     'must have the property "port" or "path"');
   }
 
-  throw new ERR_INVALID_OPT_VALUE('options', util.inspect(options));
+  throw new ERR_INVALID_OPT_VALUE('options', inspect(options));
 };
 
 function lookupAndListen(self, port, address, backlog, exclusive, flags) {


### PR DESCRIPTION
Use `require('internal/util/inspect').inspect` and 
`require('internal/util/debuglog').debuglog` instead of 
`require('util').debuglog` and `require('util').inspect`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
