### PR TITLE
url: remove usage of require('util') 

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const util = require('util');
+const { inspect } = require('internal/util/inspect');
 const {
   encodeStr,
   hexTable,
@@ -184,7 +184,7 @@ class URLSearchParams {
     this[context] = null;
   }
 
-  [util.inspect.custom](recurseTimes, ctx) {
+  [inspect.custom](recurseTimes, ctx) {
     if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new ERR_INVALID_THIS('URLSearchParams');
     }
@@ -197,7 +197,7 @@ class URLSearchParams {
     if (recurseTimes !== null) {
       innerOpts.depth = recurseTimes - 1;
     }
-    var innerInspect = (v) => util.inspect(v, innerOpts);
+    var innerInspect = (v) => inspect(v, innerOpts);
 
     var list = this[searchParams];
     var output = [];
@@ -336,7 +336,7 @@ class URL {
             scheme === 'file:');
   }
 
-  [util.inspect.custom](depth, opts) {
+  [inspect.custom](depth, opts) {
     if (this == null ||
         Object.getPrototypeOf(this[context]) !== URLContext.prototype) {
       throw new ERR_INVALID_THIS('URL');
@@ -370,7 +370,7 @@ class URL {
       obj[context] = this[context];
     }
 
-    return util.inspect(obj, opts);
+    return inspect(obj, opts);
   }
 }
 
@@ -1196,7 +1196,7 @@ defineIDLClass(URLSearchParamsIteratorPrototype, 'URLSearchParams Iterator', {
       done: false
     };
   },
-  [util.inspect.custom](recurseTimes, ctx) {
+  [inspect.custom](recurseTimes, ctx) {
     if (this == null || this[context] == null || this[context].target == null)
       throw new ERR_INVALID_THIS('URLSearchParamsIterator');
 
@@ -1223,8 +1223,8 @@ defineIDLClass(URLSearchParamsIteratorPrototype, 'URLSearchParams Iterator', {
       }
       return prev;
     }, []);
-    const breakLn = util.inspect(output, innerOpts).includes('\n');
-    const outputStrs = output.map((p) => util.inspect(p, innerOpts));
+    const breakLn = inspect(output, innerOpts).includes('\n');
+    const outputStrs = output.map((p) => inspect(p, innerOpts));
     let outputStr;
     if (breakLn) {
       outputStr = `\n  ${outputStrs.join(',\n  ')}`;


### PR DESCRIPTION
Remove the usage of public require('util').
Use require('internal/util/inspect').inspect instead of require('util').inspect.
Refs: #26546 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
