### PR TITLE
worker: remove usage of require('util') 

### DIFF
--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -15,7 +15,7 @@ const { threadId } = internalBinding('worker');
 
 const { Readable, Writable } = require('stream');
 const EventEmitter = require('events');
-const util = require('util');
+const { inspect } = require('internal/util/inspect');
 
 let debuglog;
 function debug(...args) {
@@ -119,7 +119,7 @@ MessagePort.prototype.close = function(cb) {
   MessagePortPrototype.close.call(this);
 };
 
-Object.defineProperty(MessagePort.prototype, util.inspect.custom, {
+Object.defineProperty(MessagePort.prototype, inspect.custom, {
   enumerable: false,
   writable: false,
   value: function inspect() {  // eslint-disable-line func-name-matching


### PR DESCRIPTION
Remove the usage of public require('util').
Use require('internal/util/inspect').inspect instead of require('util').inspect.
Refs: #26546 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
