### PR TITLE
http2: stricter settings validation

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -789,7 +789,11 @@ function pingCallback(cb) {
 // 6. enablePush must be a boolean
 // All settings are optional and may be left undefined
 function validateSettings(settings) {
-  if (settings === undefined) return;
+  if (settings === undefined) {
+    const err = new ERR_INVALID_ARG_TYPE('settings', 'object', settings);
+    Error.captureStackTrace(err, 'validateSettings');
+    throw err;
+  }
   assertWithinRange('headerTableSize',
                     settings.headerTableSize,
                     0, kMaxInt);

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -789,7 +789,7 @@ function pingCallback(cb) {
 // 6. enablePush must be a boolean
 // All settings are optional and may be left undefined
 function validateSettings(settings) {
-  settings = { ...settings };
+  if (settings === undefined) return;
   assertWithinRange('headerTableSize',
                     settings.headerTableSize,
                     0, kMaxInt);
@@ -813,7 +813,6 @@ function validateSettings(settings) {
     Error.captureStackTrace(err, 'validateSettings');
     throw err;
   }
-  return settings;
 }
 
 // Creates the internal binding.Http2Session handle for an Http2Session
@@ -1152,7 +1151,7 @@ class Http2Session extends EventEmitter {
     if (this.destroyed)
       throw new ERR_HTTP2_INVALID_SESSION();
     assertIsObject(settings, 'settings');
-    settings = validateSettings(settings);
+    validateSettings(settings);
 
     if (callback && typeof callback !== 'function')
       throw new ERR_INVALID_CALLBACK();
@@ -1160,7 +1159,7 @@ class Http2Session extends EventEmitter {
 
     this[kState].pendingAck++;
 
-    const settingsFn = submitSettings.bind(this, settings, callback);
+    const settingsFn = submitSettings.bind(this, { ...settings }, callback);
     if (this.connecting) {
       this.once('connect', settingsFn);
       return;
@@ -2830,7 +2829,8 @@ function createServer(options, handler) {
 // HTTP2-Settings header frame.
 function getPackedSettings(settings) {
   assertIsObject(settings, 'settings');
-  updateSettingsBuffer(validateSettings(settings));
+  validateSettings(settings);
+  updateSettingsBuffer({ ...settings });
   return binding.packSettings();
 }
 

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -88,8 +88,10 @@ http2.getPackedSettings({ enablePush: false });
 
 // Check for not passing settings.
 {
-  const packed = http2.getPackedSettings();
-  assert.strictEqual(packed.length, 0);
+  assert.throws(
+    () => http2.getPackedSettings(),
+    { code: 'ERR_INVALID_ARG_TYPE' }
+  );
 }
 
 {


### PR DESCRIPTION
<s>This relies upon https://github.com/nodejs/node/pull/26809 and should not yet be merged. I just wanted to open the PR to get it out early.</s>

Update: It is actually not important in what order these PRs land. I'll update what ever comes first.

// cc @nodejs/http2 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
