### PR TITLE
src: apply clang-tidy performance-faster-string-find

### DIFF
--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -156,10 +156,10 @@ static void generate_accept_string(const std::string& client_key,
 }
 
 static std::string TrimPort(const std::string& host) {
-  size_t last_colon_pos = host.rfind(":");
+  size_t last_colon_pos = host.rfind(':');
   if (last_colon_pos == std::string::npos)
     return host;
-  size_t bracket = host.rfind("]");
+  size_t bracket = host.rfind(']');
   if (bracket == std::string::npos || last_colon_pos > bracket)
     return host.substr(0, last_colon_pos);
   return host;

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -507,7 +507,7 @@ static void PrintSystemInformation(JSONWriter* writer) {
       WideCharToMultiByte(
           CP_UTF8, 0, lpszVariable, -1, str, size, nullptr, nullptr);
       std::string env(str);
-      int sep = env.rfind("=");
+      int sep = env.rfind('=');
       std::string key = env.substr(0, sep);
       std::string value = env.substr(sep + 1);
       writer->json_keyvalue(key, value);


### PR DESCRIPTION
rule def: https://clang.llvm.org/extra/clang-tidy/checks/performance-faster-string-find.html.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
