### PR TITLE
worker: remove usage of require('util') in worker_thread.js

### DIFF
--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -45,7 +45,7 @@ const publicWorker = require('worker_threads');
 patchProcessObject();
 setupDebugEnv();
 
-const debug = require('util').debuglog('worker');
+const debug = require('internal/util/debuglog').debuglog('worker');
 
 setupWarningHandler();
 


### PR DESCRIPTION
Use `require('internal/util/debuglog').debuglog` instead of
`require('util').debuglog` in `lib/internal/main/worker_thread.js`.

Refs: #26546 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]