### PR TITLE
process: remove usage of require('util') in `per_thread.js`

### DIFF
--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -15,7 +15,7 @@ const {
     ERR_UNKNOWN_SIGNAL
   }
 } = require('internal/errors');
-const util = require('util');
+const format = require('internal/util/inspect').format;
 const constants = internalBinding('constants').os.signals;
 
 function assert(x, msg) {
@@ -32,7 +32,7 @@ function wrapProcessMethods(binding) {
   } = binding;
 
   function _rawDebug(...args) {
-    binding._rawDebug(util.format.apply(null, args));
+    binding._rawDebug(format.apply(null, args));
   }
 
   // Create the argument array that will be passed to the native function.


### PR DESCRIPTION
Use `require('internal/util/inspect').format` instead of 
`require('util').format`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
