### PR TITLE
readline: remove usage of require('util')

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -32,7 +32,7 @@ const {
   ERR_INVALID_OPT_VALUE
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
-const { inspect } = require('util');
+const { inspect } = require('internal/util/inspect');
 const { emitExperimentalWarning } = require('internal/util');
 const { Buffer } = require('buffer');
 const EventEmitter = require('events');


### PR DESCRIPTION
Use `require('internal/util/inspect').inspect` instead of 
`require('util').inspect`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
