### PR TITLE
repl: remove usage of require('util') in `repl/history`

### DIFF
--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -4,8 +4,7 @@ const { Interface } = require('readline');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const util = require('util');
-const debug = util.debuglog('repl');
+const debug = require('internal/util/debuglog').debuglog('repl');
 
 // XXX(chrisdickinson): The 15ms debounce value is somewhat arbitrary.
 // The debounce is to guard against code pasted into the REPL.


### PR DESCRIPTION
Use `require('internal/util/debuglog').debuglog` instead of 
`require('util').debuglog`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
