### PR TITLE
repl: remove usage of require('util') in `repl.js`

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -51,8 +51,12 @@ const {
   isIdentifierStart,
   isIdentifierChar
 } = require('internal/deps/acorn/acorn/dist/acorn');
-const internalUtil = require('internal/util');
-const util = require('util');
+const {
+  decorateErrorStack,
+  isError,
+  deprecate
+} = require('internal/util');
+const { inspect } = require('internal/util/inspect');
 const Stream = require('stream');
 const vm = require('vm');
 const path = require('path');
@@ -61,7 +65,7 @@ const { Interface } = require('readline');
 const { Console } = require('console');
 const CJSModule = require('internal/modules/cjs/loader');
 const domain = require('domain');
-const debug = util.debuglog('repl');
+const debug = require('internal/util/debuglog').debuglog('repl');
 const {
   ERR_CANNOT_WATCH_SIGINT,
   ERR_INVALID_ARG_TYPE,
@@ -120,8 +124,8 @@ function hasOwnProperty(obj, prop) {
 // This is the default "writer" value, if none is passed in the REPL options,
 // and it can be overridden by custom print functions, such as `probe` or
 // `eyes.js`.
-const writer = exports.writer = (obj) => util.inspect(obj, writer.options);
-writer.options = { ...util.inspect.defaultOptions, showProxy: true };
+const writer = exports.writer = (obj) => inspect(obj, writer.options);
+writer.options = { ...inspect.defaultOptions, showProxy: true };
 
 exports._builtinLibs = builtinLibs;
 
@@ -204,10 +208,10 @@ function REPLServer(prompt,
 
   let rli = this;
   Object.defineProperty(this, 'rli', {
-    get: util.deprecate(() => rli,
-                        'REPLServer.rli is deprecated', 'DEP0124'),
-    set: util.deprecate((val) => rli = val,
-                        'REPLServer.rli is deprecated', 'DEP0124'),
+    get: deprecate(() => rli,
+                   'REPLServer.rli is deprecated', 'DEP0124'),
+    set: deprecate((val) => rli = val,
+                   'REPLServer.rli is deprecated', 'DEP0124'),
     enumerable: true,
     configurable: true
   });
@@ -430,7 +434,7 @@ function REPLServer(prompt,
     if (typeof e === 'object' && e !== null) {
       const pstrace = Error.prepareStackTrace;
       Error.prepareStackTrace = prepareStackTrace(pstrace);
-      internalUtil.decorateErrorStack(e);
+      decorateErrorStack(e);
       Error.prepareStackTrace = pstrace;
 
       if (e.domainThrown) {
@@ -438,7 +442,7 @@ function REPLServer(prompt,
         delete e.domainThrown;
       }
 
-      if (internalUtil.isError(e)) {
+      if (isError(e)) {
         if (e.stack) {
           if (e.name === 'SyntaxError') {
             // Remove stack trace.
@@ -482,10 +486,12 @@ function REPLServer(prompt,
 
   self.clearBufferedCommand();
   Object.defineProperty(this, 'bufferedCommand', {
-    get: util.deprecate(() => self[kBufferedCommandSymbol],
-                        'REPLServer.bufferedCommand is deprecated', 'DEP0074'),
-    set: util.deprecate((val) => self[kBufferedCommandSymbol] = val,
-                        'REPLServer.bufferedCommand is deprecated', 'DEP0074'),
+    get: deprecate(() => self[kBufferedCommandSymbol],
+                   'REPLServer.bufferedCommand is deprecated',
+                   'DEP0074'),
+    set: deprecate((val) => self[kBufferedCommandSymbol] = val,
+                   'REPLServer.bufferedCommand is deprecated',
+                   'DEP0074'),
     enumerable: true
   });
 
@@ -518,7 +524,7 @@ function REPLServer(prompt,
     writer.options.colors = self.useColors;
 
     if (options[kStandaloneREPL]) {
-      Object.defineProperty(util.inspect, 'replDefaults', {
+      Object.defineProperty(inspect, 'replDefaults', {
         get() {
           return writer.options;
         },
@@ -567,7 +573,7 @@ function REPLServer(prompt,
     return false;
   }
 
-  self.parseREPLKeyword = util.deprecate(
+  self.parseREPLKeyword = deprecate(
     _parseREPLKeyword,
     'REPLServer.parseREPLKeyword() is deprecated',
     'DEP0075');
@@ -924,7 +930,7 @@ REPLServer.prototype.setPrompt = function setPrompt(prompt) {
   Interface.prototype.setPrompt.call(this, prompt);
 };
 
-REPLServer.prototype.turnOffEditorMode = util.deprecate(
+REPLServer.prototype.turnOffEditorMode = deprecate(
   function() { _turnOffEditorMode(this); },
   'REPLServer.turnOffEditorMode() is deprecated',
   'DEP0078');
@@ -1315,7 +1321,7 @@ REPLServer.prototype.defineCommand = function(keyword, cmd) {
   this.commands[keyword] = cmd;
 };
 
-REPLServer.prototype.memory = util.deprecate(
+REPLServer.prototype.memory = deprecate(
   _memory,
   'REPLServer.memory() is deprecated',
   'DEP0082');


### PR DESCRIPTION
Use `require('internal/util/inspect').inspect` and 
`require('internal/util/debuglog').debuglog` instead of
`require('util').inspect` and `require('util').debuglog`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
