### PR TITLE
trace_events: remove usage of require('util')

### DIFF
--- a/lib/trace_events.js
+++ b/lib/trace_events.js
@@ -19,7 +19,7 @@ if (!hasTracing || !ownsProcessState)
 
 const { CategorySet, getEnabledCategories } = internalBinding('trace_events');
 const { customInspectSymbol } = require('internal/util');
-const { format } = require('util');
+const { format } = require('internal/util/inspect');
 
 const enabledTracingObjects = new Set();
 


### PR DESCRIPTION
Use `require('internal/util/inspect').format` instead of 
`require('util').format`.

Refs: https://github.com/nodejs/node/issues/26546

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
