### PR TITLE
timers: remove usage of require('util') in timers.js

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -39,8 +39,8 @@ const {
   initAsyncResource,
   validateTimerDuration
 } = require('internal/timers');
-const internalUtil = require('internal/util');
-const util = require('util');
+const { promisify, deprecate } = require('internal/util');
+const { inspect } = require('internal/util/inspect');
 const { ERR_INVALID_CALLBACK } = require('internal/errors').codes;
 
 let debuglog;
@@ -250,8 +250,8 @@ function TimersList(expiry, msecs) {
 }
 
 // Make sure the linked list only shows the minimal necessary information.
-TimersList.prototype[util.inspect.custom] = function(_, options) {
-  return util.inspect(this, {
+TimersList.prototype[inspect.custom] = function(_, options) {
+  return inspect(this, {
     ...options,
     // Only inspect one level.
     depth: 0,
@@ -406,10 +406,10 @@ function unenroll(item) {
   item._idleTimeout = -1;
 }
 
-exports.unenroll = util.deprecate(unenroll,
-                                  'timers.unenroll() is deprecated. ' +
-                                  'Please use clearTimeout instead.',
-                                  'DEP0096');
+exports.unenroll = deprecate(unenroll,
+                             'timers.unenroll() is deprecated. ' +
+                             'Please use clearTimeout instead.',
+                             'DEP0096');
 
 
 // Make a regular object able to act as a timer by setting some properties.
@@ -426,10 +426,10 @@ function enroll(item, msecs) {
   item._idleTimeout = msecs;
 }
 
-exports.enroll = util.deprecate(enroll,
-                                'timers.enroll() is deprecated. ' +
-                                'Please use setTimeout instead.',
-                                'DEP0095');
+exports.enroll = deprecate(enroll,
+                           'timers.enroll() is deprecated. ' +
+                           'Please use setTimeout instead.',
+                           'DEP0095');
 
 
 /*
@@ -469,7 +469,7 @@ function setTimeout(callback, after, arg1, arg2, arg3) {
   return timeout;
 }
 
-setTimeout[internalUtil.promisify.custom] = function(after, value) {
+setTimeout[promisify.custom] = function(after, value) {
   const args = value !== undefined ? [value] : value;
   return new Promise((resolve) => {
     active(new Timeout(resolve, after, args, false));
@@ -735,7 +735,7 @@ function setImmediate(callback, arg1, arg2, arg3) {
   return new Immediate(callback, args);
 }
 
-setImmediate[internalUtil.promisify.custom] = function(value) {
+setImmediate[promisify.custom] = function(value) {
   return new Promise((resolve) => new Immediate(resolve, [value]));
 };
 


### PR DESCRIPTION
Remove the usage of public require('util').
Use `require('internal/util/inspect').inspect` and `require('internal/util').deprecate` instead of `require('util').inspect` and `require('util').deprecate`.
Refs: #26546 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
