### PR TITLE
test: complete console.assert() coverage

### DIFF
--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -193,6 +193,9 @@ console.assert(false, '%s should', 'console.assert', 'not throw');
 assert.strictEqual(errStrings[errStrings.length - 1],
                    'Assertion failed: console.assert should not throw\n');
 
+console.assert(false);
+assert.strictEqual(errStrings[errStrings.length - 1], 'Assertion failed\n');
+
 console.assert(true, 'this should not throw');
 
 console.assert(true);


### PR DESCRIPTION
There is one condition in the `console.assert()` code that is not
tested currently. Add a test to confirm that `console.assert(false)`
does not include a `:` in its output.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
