### PR TITLE
Remove discord community

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ resources:
 
 * [Questions tagged 'node.js' on StackOverflow][]
 * [#node.js channel on chat.freenode.net][]
-* [Node.js Discord Community](https://discordapp.com/invite/v7rrPdE)
 * [Node.js Slack Community](https://node-js.slack.com/)
   * To register: [nodeslackers.com](http://www.nodeslackers.com/)
 


### PR DESCRIPTION
I think it is better to remove it since it is no longer an active community.

> Official(?) discord abandoned : #25494



The last Message on discord is dated  14/01/2019

@nodejs/collaborators 
@nodejs/tsc 
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
