### PR TITLE
fix changelog date typo (v6.17.0)

### DIFF
--- a/doc/changelogs/CHANGELOG_V6.md
+++ b/doc/changelogs/CHANGELOG_V6.md
@@ -78,7 +78,7 @@
 will be supported actively until April 2018 and maintained until April 2019.
 
 <a id="6.17.0"></a>
-## 2018-02-28, Version 6.17.0 'Boron' (LTS), @rvagg
+## 2019-02-28, Version 6.17.0 'Boron' (LTS), @rvagg
 
 This is a security release. All Node.js users should consult the security release summary at:
 


### PR DESCRIPTION
Same typo is also at the top of https://nodejs.org/en/blog/vulnerability/february-2019-security-releases/.

On a side note, I must be misunderstanding something because I'm not seeing how the contributing advice for identifying subsystems touched when writing a commit message would help:

> Check the output of `git log --oneline files/you/changed` to find out what subsystems your changes touch.

That output doesn't seem to help identify changed files / it's actually saying to list changed files as input to the command. I feel like the intention here would be to do something more like?:

```
git log --name-only master..
```

But even so not sure how helpful that is in identifying the expected prefix. E.g. the examples given are `src`, which I assume refers to the top-level `src/` directory, and `net`, which I assume refers to `lib/net.js`.