### PR TITLE
src: prevent crash in TTYWrap::Initialize

### DIFF
--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -32,6 +32,7 @@ namespace node {
 
 using v8::Array;
 using v8::Context;
+using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Integer;
@@ -39,7 +40,6 @@ using v8::Local;
 using v8::Object;
 using v8::String;
 using v8::Value;
-
 
 void TTYWrap::Initialize(Local<Object> target,
                          Local<Value> unused,
@@ -61,10 +61,11 @@ void TTYWrap::Initialize(Local<Object> target,
   env->SetMethodNoSideEffect(target, "isTTY", IsTTY);
   env->SetMethodNoSideEffect(target, "guessHandleType", GuessHandleType);
 
-  target->Set(env->context(),
-              ttyString,
-              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
-  env->set_tty_constructor_template(t);
+  Local<Value> func;
+  if (t->GetFunction(env->context()).ToLocal(&func) &&
+      target->Set(env->context(), ttyString, func).IsJust()) {
+    env->set_tty_constructor_template(t);
+  }
 }
 
 

--- a/test/parallel/test-ttywrap-stack.js
+++ b/test/parallel/test-ttywrap-stack.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+
+// This test ensures that console.log
+// will not crash the process if there
+// is not enough space on the V8 stack
+
+const done = common.mustCall(() => {});
+
+async function test() {
+  await test();
+}
+
+(async () => {
+  try {
+    await test();
+  } catch (err) {
+    console.log(err);
+  }
+})().then(done, done);


### PR DESCRIPTION
When console.log is called for the first time it initializes
TTYWrap object. However, if there is not enough space on the
V8 stack, creating function template fails and triggers
empty maybe local exception.

Fixes #26829

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
