### PR TITLE
lib: reduce internal usage of public util for manifest.js

### DIFF
--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -4,7 +4,7 @@ const {
   ERR_MANIFEST_INTEGRITY_MISMATCH,
   ERR_MANIFEST_UNKNOWN_ONERROR,
 } = require('internal/errors').codes;
-const debug = require('util').debuglog('policy');
+const debug = require('internal/util/debuglog').debuglog('policy');
 const SRI = require('internal/policy/sri');
 const {
   SafeWeakMap,


### PR DESCRIPTION
This PR is part of issue #26546

Replaced usage of public `require('util')`

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
