### PR TITLE
doc: remove unnecessary await

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -131,7 +131,7 @@ process.on('multipleResolves', (type, promise, reason) => {
 
 async function main() {
   try {
-    return await new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       resolve('First call');
       resolve('Swallowed resolve');
       reject(new Error('Swallowed reject'));


### PR DESCRIPTION
 In here https://nodejs.org/api/process.html#process_event_multipleresolves
In the following code, since we are already resolving the promise in `main.then`, `await` in the return seems to be redundant.
```
async function main() {
  try {
    return await new Promise((resolve, reject) => {
      resolve('First call');
      resolve('Swallowed resolve');
      reject(new Error('Swallowed reject'));
    });
  } catch {
    throw new Error('Failed');
  }
}

main().then(console.log);
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
