### PR TITLE
tools: add clang-tidy rule in src

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,0 +1,28 @@
+---
+Checks:          '-*,
+                 # modernize-use-auto,
+                 # modernize-use-equals-delete,
+                 modernize-deprecated-headers,
+                 modernize-make-unique,
+                 modernize-make-shared,
+                 modernize-redundant-void-arg,
+                 modernize-replace-random-shuffle,
+                 modernize-shrink-to-fit,
+                 modernize-use-bool-literals,
+                 modernize-use-emplace,
+                 modernize-use-equals-default,
+                 modernize-use-nullptr,
+                 modernize-use-override,
+                 performance-faster-string-find,
+                 # performance-unnecessary-value-param, see https://github.com/nodejs/node/pull/26042
+                 readability-delete-null-pointer, '
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+User:            nodejs/cpp
+CheckOptions:
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           1
+...
+

--- a/src/env.h
+++ b/src/env.h
@@ -589,7 +589,7 @@ struct AllocatedBuffer {
 class AsyncRequest : public MemoryRetainer {
  public:
   AsyncRequest() = default;
-  ~AsyncRequest();
+  ~AsyncRequest() override;
 
   AsyncRequest(const AsyncRequest&) = delete;
   AsyncRequest& operator=(const AsyncRequest&) = delete;
@@ -907,7 +907,7 @@ class Environment : public MemoryRetainer {
               const std::vector<std::string>& exec_args,
               Flags flags = Flags(),
               uint64_t thread_id = kNoThreadId);
-  ~Environment();
+  ~Environment() override;
 
   void InitializeLibuv(bool start_profiler_idle_notifier);
   inline const std::vector<std::string>& exec_argv();
@@ -1379,7 +1379,8 @@ class Environment : public MemoryRetainer {
   bool http_parser_buffer_in_use_ = false;
   std::unique_ptr<http2::Http2State> http2_state_;
 
-  bool debug_enabled_[static_cast<int>(DebugCategory::CATEGORY_COUNT)] = {0};
+  bool debug_enabled_[static_cast<int>(DebugCategory::CATEGORY_COUNT)] = {
+      false};
 
   AliasedFloat64Array fs_stats_field_array_;
   AliasedBigUint64Array fs_stats_field_bigint_array_;

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -64,7 +64,7 @@ class FSEventWrap: public HandleWrap {
   static const encoding kDefaultEncoding = UTF8;
 
   FSEventWrap(Environment* env, Local<Object> object);
-  ~FSEventWrap() = default;
+  ~FSEventWrap() override = default;
 
   static void OnEvent(uv_fs_event_t* handle, const char* filename, int events,
     int status);

--- a/src/node.cc
+++ b/src/node.cc
@@ -877,7 +877,7 @@ int InitializeNodeWithArgs(std::vector<std::string>* argv,
       }
 
       if (will_start_new_arg) {
-        env_argv.push_back(std::string(1, c));
+        env_argv.emplace_back(std::string(1, c));
         will_start_new_arg = false;
       } else {
         env_argv.back() += c;

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "node_main_instance.h"
 #include "node_internals.h"
 #include "node_options-inl.h"
@@ -34,7 +36,8 @@ NodeMainInstance::NodeMainInstance(Isolate* isolate,
       isolate_data_(nullptr),
       owns_isolate_(false),
       deserialize_mode_(false) {
-  isolate_data_.reset(new IsolateData(isolate_, event_loop, platform, nullptr));
+  isolate_data_ =
+      std::make_unique<IsolateData>(isolate_, event_loop, platform, nullptr);
 
   IsolateSettings misc;
   SetIsolateMiscHandlers(isolate_, misc);
@@ -76,11 +79,11 @@ NodeMainInstance::NodeMainInstance(
   deserialize_mode_ = per_isolate_data_indexes != nullptr;
   // If the indexes are not nullptr, we are not deserializing
   CHECK_IMPLIES(deserialize_mode_, params->external_references != nullptr);
-  isolate_data_.reset(new IsolateData(isolate_,
-                                      event_loop,
-                                      platform,
-                                      array_buffer_allocator_.get(),
-                                      per_isolate_data_indexes));
+  isolate_data_ = std::make_unique<IsolateData>(isolate_,
+                                                event_loop,
+                                                platform,
+                                                array_buffer_allocator_.get(),
+                                                per_isolate_data_indexes);
   IsolateSettings s;
   SetIsolateMiscHandlers(isolate_, s);
   if (!deserialize_mode_) {

--- a/src/tracing/traced_value.h
+++ b/src/tracing/traced_value.h
@@ -18,7 +18,7 @@ namespace tracing {
 
 class TracedValue : public v8::ConvertableToTraceFormat {
  public:
-  ~TracedValue() = default;
+  ~TracedValue() override = default;
 
   static std::unique_ptr<TracedValue> Create();
   static std::unique_ptr<TracedValue> CreateArray();


### PR DESCRIPTION
In short
* make cpp check rules explicit and get checked by CI
* select the rules most collaborators are comfortable with

## Todo

### Tools to ensure the rules
@refack told me some rules are checked.
Basically the rules should check most operating systems because we have platform-specific code such as using macro.
And should keep clang-tidy in same version when possible.
I have some thought on docker get involved in this. Hopefully I can put my thought
in `node\build` group this weekends.

### Google Cpp Guideline
Related to https://github.com/nodejs/node/pull/24315.
clang-tidy can handle some google cpp guideline rules.
I don't know should we 
* use clang-tidy to ensure google-related rule
* should we add all `google-` or just some of them.
see https://clang.llvm.org/extra/clang-tidy/

### Rules need to be select.
The rules now included are already applied or in-review.

### How to deal with false positive and make exceptions
.

cc @addaleax @bnoordhuis @refack @joyeecheung @jasnell @richardlau @danbev @Trott @BridgeAR 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
