### PR TITLE
fs: check initialized flag and exit if false in FSWatcher onchange

### DIFF
--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -110,10 +110,13 @@ function FSWatcher() {
   this._handle[owner_symbol] = this;
 
   this._handle.onchange = (status, eventType, filename) => {
-    // TODO(joyeecheung): we may check self._handle.initialized here
-    // and return if that is false. This allows us to avoid firing the event
-    // after the handle is closed, and to fire both UV_RENAME and UV_CHANGE
-    // if they are set by libuv at the same time.
+    // Check .initialized flag, and return if that is false. This allows us to
+    // avoid firing the event after the handle is closed, and to fire both
+    // UV_RENAME and UV_CHANGE if they are set by libuv at the same time.
+    if (!this._handle.initialized) {
+      return;
+    }
+
     if (status < 0) {
       if (this._handle !== null) {
         // We don't use this.close() here to avoid firing the close event.


### PR DESCRIPTION
After checking out the TODO comment in `lib/internal/fs/watchers.js`, this PR follows the suggestion to check `initialized` flag, and exits when "_falsy_", in favor to avoid firing events after the handle is closed.

https://github.com/nodejs/node/blob/e3340023f3c9759f9c6cff380cf75cbecb6130da/lib/internal/fs/watchers.js#L113-L116

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
