### PR TITLE
console: use consolePropAttributes for k-bind properties in constructor

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -178,15 +178,13 @@ Console.prototype[kBindProperties] = function(ignoreErrors, colorMode) {
       ...consolePropAttributes,
       value: Boolean(ignoreErrors)
     },
-    '_times': { ...consolePropAttributes, value: new Map() }
+    '_times': { ...consolePropAttributes, value: new Map() },
+    // Corresponds to https://console.spec.whatwg.org/#count-map
+    [kCounts]: { ...consolePropAttributes, value: new Map() },
+    [kColorMode]: { ...consolePropAttributes, value: colorMode },
+    [kIsConsole]: { ...consolePropAttributes, value: true },
+    [kGroupIndent]: { ...consolePropAttributes, value: '' }
   });
-
-  // TODO(joyeecheung): use consolePropAttributes for these
-  // Corresponds to https://console.spec.whatwg.org/#count-map
-  this[kCounts] = new Map();
-  this[kColorMode] = colorMode;
-  this[kIsConsole] = true;
-  this[kGroupIndent] = '';
 };
 
 // Make a function that can serve as the callback passed to `stream.write()`.


### PR DESCRIPTION
After checking out the TODO comment in `lib/internal/console/constructor.js`, this PR follows the suggestion to use `consolePropAttributes` when defining these k-bind properties in the `this` object.

https://github.com/nodejs/node/blob/db40b4ab32cca3805975a63288e9995674ebc0a5/lib/internal/console/constructor.js#L184-L189

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
