### PR TITLE
doc: add Nodeiflux Discord Community to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ resources:
 * [#node.js channel on chat.freenode.net][]
 * [Node.js Slack Community](https://node-js.slack.com/)
   * To register: [nodeslackers.com](http://www.nodeslackers.com/)
+* [Nodeiflux Discord Community](https://discordapp.com/invite/vUsrbjd)
 
 GitHub issues are for tracking enhancements and bugs, not general support.
 


### PR DESCRIPTION
I don't want the list of unofficial resources to become a laundry list
of everything that exists, but it seems like a Discord community belongs
there, and this is Node.js one that seems active/maintained/moderated.

@vcarl

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
