### PR TITLE
test: do not require flags when executing a file

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -48,8 +48,11 @@ const hasCrypto = Boolean(process.versions.openssl);
 
 // Check for flags. Skip this for workers (both, the `cluster` module and
 // `worker_threads`) and child processes.
+// If the binary was built without-ssl then the crypto flags are
+// invalid (bad option). The test itself should handle this case.
 if (process.argv.length === 2 &&
     isMainThread &&
+    hasCrypto &&
     module.parent &&
     require('cluster').isMaster) {
   // The copyright notice is relatively big and the flags could come afterwards.
@@ -74,9 +77,6 @@ if (process.argv.length === 2 &&
     const args = process.execArgv.map((arg) => arg.replace(/_/g, '-'));
     for (const flag of flags) {
       if (!args.includes(flag) &&
-          // If the binary was built without-ssl then the crypto flags are
-          // invalid (bad option). The test itself should handle this case.
-          hasCrypto &&
           // If the binary is build without `intl` the inspect option is
           // invalid. The test itself should handle this case.
           (process.features.inspector || !flag.startsWith('--inspect'))) {

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -81,7 +81,7 @@ if (process.argv.length === 2 &&
           // invalid. The test itself should handle this case.
           (process.features.inspector || !flag.startsWith('--inspect'))) {
         console.log(
-          'NOTE: The test started as child_process using these flags:',
+          'NOTE: The test started as a child_process using these flags:',
           util.inspect(flags)
         );
         const args = [...flags, ...process.execArgv, ...process.argv.slice(1)];

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -80,7 +80,12 @@ if (process.argv.length === 2 &&
           // If the binary is build without `intl` the inspect option is
           // invalid. The test itself should handle this case.
           (process.features.inspector || !flag.startsWith('--inspect'))) {
-        throw new Error(`Test has to be started with the flag: '${flag}'`);
+        const args = [...flags, ...process.execArgv, ...process.argv.slice(1)];
+        const options = { encoding: 'utf8', stdio: 'inherit' };
+        const result = spawnSync(process.execPath, args, options);
+        assert.ifError(result.error);
+        process.exit(result.status);
+        return;
       }
     }
   }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -83,9 +83,7 @@ if (process.argv.length === 2 &&
         const args = [...flags, ...process.execArgv, ...process.argv.slice(1)];
         const options = { encoding: 'utf8', stdio: 'inherit' };
         const result = spawnSync(process.execPath, args, options);
-        assert.ifError(result.error);
-        process.exit(result.status);
-        return;
+        process.exit(result.signal || result.status);
       }
     }
   }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -83,7 +83,11 @@ if (process.argv.length === 2 &&
         const args = [...flags, ...process.execArgv, ...process.argv.slice(1)];
         const options = { encoding: 'utf8', stdio: 'inherit' };
         const result = spawnSync(process.execPath, args, options);
-        process.exit(result.signal || result.status);
+        if (result.signal) {
+          process.kill(0, result.signal);
+        } else {
+          process.exit(result.status);
+        }
       }
     }
   }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -80,6 +80,10 @@ if (process.argv.length === 2 &&
           // If the binary is build without `intl` the inspect option is
           // invalid. The test itself should handle this case.
           (process.features.inspector || !flag.startsWith('--inspect'))) {
+        console.log(
+          'NOTE: The test started as child_process using these flags:',
+          util.inspect(flags)
+        );
         const args = [...flags, ...process.execArgv, ...process.argv.slice(1)];
         const options = { encoding: 'utf8', stdio: 'inherit' };
         const result = spawnSync(process.execPath, args, options);


### PR DESCRIPTION
Instead of throwing an error in case a flag is missing, just start
a `child_process` that includes all flags. This improves the situation
for all developers in case they want to just plainly run a test.

Co-authored-by: Rich Trott <rtrott@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
