### PR TITLE
console: remove unreachable code

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -467,10 +467,7 @@ const consoleMethods = {
         values.push(inspect(v));
         length++;
       }
-      return final([setlike ? iterKey : indexKey, valuesKey], [
-        getIndexArray(length),
-        values,
-      ]);
+      return final([iterKey, valuesKey], [getIndexArray(length), values]);
     }
 
     const map = {};


### PR DESCRIPTION
The current version of lib/internal/console/constructor.js includes this
as part of line 470:

  setlike ? iterKey : indexKey

However, `setlike` is guaranteed to be true because we are inside of an
`if` block (starting on line 463) that explicitly checks that `setlike`
is true.

Coverage reporting confirms that `setlike` is always true when it is
reached in our tests.

Remove the ternary as the value provided will always be `iterKey`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
