### PR TITLE
process: load internal/async_hooks before inspector hooks registration

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -89,16 +89,6 @@ const emitDestroyNative = emitHookFactory(destroy_symbol, 'emitDestroyNative');
 const emitPromiseResolveNative =
     emitHookFactory(promise_resolve_symbol, 'emitPromiseResolveNative');
 
-// Setup the callbacks that node::AsyncWrap will call when there are hooks to
-// process. They use the same functions as the JS embedder API. These callbacks
-// are setup immediately to prevent async_wrap.setupHooks() from being hijacked
-// and the cost of doing so is negligible.
-async_wrap.setupHooks({ init: emitInitNative,
-                        before: emitBeforeNative,
-                        after: emitAfterNative,
-                        destroy: emitDestroyNative,
-                        promise_resolve: emitPromiseResolveNative });
-
 // Used to fatally abort the process if a callback throws.
 function fatalError(e) {
   if (typeof e.stack === 'string') {
@@ -461,4 +451,11 @@ module.exports = {
   emitAfter: emitAfterScript,
   emitDestroy: emitDestroyScript,
   registerDestroyHook,
+  nativeHooks: {
+    init: emitInitNative,
+    before: emitBeforeNative,
+    after: emitAfterNative,
+    destroy: emitDestroyNative,
+    promise_resolve: emitPromiseResolveNative
+  }
 };

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -150,6 +150,16 @@ if (isMainThread) {
   setupProcessStdio(getStdout, getStdin, getStderr);
 }
 
+// Setup the callbacks that node::AsyncWrap will call when there are hooks to
+// process. They use the same functions as the JS embedder API. These callbacks
+// are setup immediately to prevent async_wrap.setupHooks() from being hijacked
+// and the cost of doing so is negligible.
+const { nativeHooks } = require('internal/async_hooks');
+internalBinding('async_wrap').setupHooks(nativeHooks);
+
+// XXX(joyeecheung): this has to be done after the initial load of
+// `internal/async_hooks` otherwise `async_hooks` cannot require
+// `internal/async_hooks`. Investigate why.
 if (config.hasInspector) {
   const {
     enable,


### PR DESCRIPTION
Otherwise the exports of `internal/async_hooks` may be undefined
when the inspector async hooks are registered.

Refs: https://github.com/nodejs/node/pull/26859
Fixes: https://github.com/nodejs/node/issues/26798

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
