### PR TITLE
test: add test of policy about parse error

### DIFF
--- a/test/parallel/test-policy-parse-integrity.js
+++ b/test/parallel/test-policy-parse-integrity.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto) common.skip('missing crypto');
+
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+tmpdir.refresh();
+
+function hash(algo, body) {
+  const h = crypto.createHash(algo);
+  h.update(body);
+  return h.digest('base64');
+}
+
+const policyFilepath = path.join(tmpdir.path, 'policy');
+
+const parentFilepath = path.join(tmpdir.path, 'parent.js');
+const parentBody = "require('./dep.js')";
+
+const depFilepath = path.join(tmpdir.path, 'dep.js');
+const depURL = pathToFileURL(depFilepath);
+const depBody = '';
+
+fs.writeFileSync(parentFilepath, parentBody);
+fs.writeFileSync(depFilepath, depBody);
+
+const tmpdirURL = pathToFileURL(tmpdir.path);
+if (!tmpdirURL.pathname.endsWith('/')) {
+  tmpdirURL.pathname += '/';
+}
+
+function test({ shouldFail = false, entry, resources = {} }) {
+  const manifest = {
+    resources: {},
+  };
+  for (const [url, { body, integrity }] of Object.entries(resources)) {
+    manifest.resources[url] = {
+      integrity,
+    };
+    fs.writeFileSync(new URL(url, tmpdirURL.href), body);
+  }
+  fs.writeFileSync(policyFilepath, JSON.stringify(manifest, null, 2));
+  const { status } = spawnSync(process.execPath, [
+    '--experimental-policy',
+    policyFilepath,
+    entry,
+  ]);
+  if (shouldFail) {
+    assert.notStrictEqual(status, 0);
+  } else {
+    assert.strictEqual(status, 0);
+  }
+}
+
+test({
+  shouldFail: false,
+  entry: depFilepath,
+  resources: {
+    [depURL]: {
+      body: depBody,
+      integrity: `sha256-${hash('sha256', depBody)}`,
+    },
+  },
+});
+test({
+  shouldFail: true,
+  entry: depFilepath,
+  resources: {
+    [depURL]: {
+      body: depBody,
+      integrity: `1sha256-${hash('sha256', depBody)}`,
+    },
+  },
+});
+test({
+  shouldFail: true,
+  entry: depFilepath,
+  resources: {
+    [depURL]: {
+      body: depBody,
+      integrity: 'hoge',
+    },
+  },
+});
+test({
+  shouldFail: true,
+  entry: depFilepath,
+  resources: {
+    [depURL]: {
+      body: depBody,
+      integrity: `sha256-${hash('sha256', depBody)}sha256-${hash(
+        'sha256',
+        depBody
+      )}`,
+    },
+  },
+});

--- a/test/parallel/test-policy-parse-integrity.js
+++ b/test/parallel/test-policy-parse-integrity.js
@@ -36,7 +36,13 @@ if (!tmpdirURL.pathname.endsWith('/')) {
   tmpdirURL.pathname += '/';
 }
 
-function test({ shouldFail = false, entry, resources = {} }) {
+function test({ shouldFail, integrity }) {
+  const resources = {
+    [depURL]: {
+      body: depBody,
+      integrity
+    }
+  };
   const manifest = {
     resources: {},
   };
@@ -50,7 +56,7 @@ function test({ shouldFail = false, entry, resources = {} }) {
   const { status } = spawnSync(process.execPath, [
     '--experimental-policy',
     policyFilepath,
-    entry,
+    depFilepath
   ]);
   if (shouldFail) {
     assert.notStrictEqual(status, 0);
@@ -61,44 +67,20 @@ function test({ shouldFail = false, entry, resources = {} }) {
 
 test({
   shouldFail: false,
-  entry: depFilepath,
-  resources: {
-    [depURL]: {
-      body: depBody,
-      integrity: `sha256-${hash('sha256', depBody)}`,
-    },
-  },
+  integrity: `sha256-${hash('sha256', depBody)}`,
 });
 test({
   shouldFail: true,
-  entry: depFilepath,
-  resources: {
-    [depURL]: {
-      body: depBody,
-      integrity: `1sha256-${hash('sha256', depBody)}`,
-    },
-  },
+  integrity: `1sha256-${hash('sha256', depBody)}`,
 });
 test({
   shouldFail: true,
-  entry: depFilepath,
-  resources: {
-    [depURL]: {
-      body: depBody,
-      integrity: 'hoge',
-    },
-  },
+  integrity: 'hoge',
 });
 test({
   shouldFail: true,
-  entry: depFilepath,
-  resources: {
-    [depURL]: {
-      body: depBody,
-      integrity: `sha256-${hash('sha256', depBody)}sha256-${hash(
-        'sha256',
-        depBody
-      )}`,
-    },
-  },
+  integrity: `sha256-${hash('sha256', depBody)}sha256-${hash(
+    'sha256',
+    depBody
+  )}`,
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Add test cases of policy when the error `ERR_SRI_PARSE` occurs.
The current coverage about sri is [here](https://coverage.nodejs.org/coverage-ce14a5ef3a949c24/lib/internal/policy/sri.js.html).

I add a new file `test-policy-parse-integrity.js` because I think it's too complicated when I enhanced the `test-policy-integrity.js` to pass the invalid integrity string.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
