### PR TITLE
lib: reduced internal usage of public require('util')

### DIFF
--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -4,7 +4,7 @@ const {
   ERR_MANIFEST_INTEGRITY_MISMATCH,
   ERR_MANIFEST_UNKNOWN_ONERROR,
 } = require('internal/errors').codes;
-const debug = require('util').debuglog('policy');
+const debug = require('internal/util/debuglog').debuglog('policy');
 const SRI = require('internal/policy/sri');
 const {
   SafeWeakMap,


### PR DESCRIPTION
<!--
Changed `require('util').debuglog` to `require('internal/util/debuglog').debuglog`

ref: Issue #26546 
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
