### PR TITLE
Bootstrap: make global.process, global.Buffer getters

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { getOptionValue } = require('internal/options');
+const { Buffer } = require('buffer');
 
 function prepareMainThreadExecution() {
   // Patch the process object with legacy properties and normalizations
@@ -221,6 +222,33 @@ function initializeDeprecations() {
                                 'process.binding() is deprecated. ' +
                                 'Please use public APIs instead.', 'DEP0111');
   }
+
+  // Create global.process and global.Buffer as getters so that we have a
+  // deprecation path for these in ES Modules.
+  // See https://github.com/nodejs/node/pull/26334.
+  let _process = process;
+  Object.defineProperty(global, 'process', {
+    get() {
+      return _process;
+    },
+    set(value) {
+      _process = value;
+    },
+    enumerable: false,
+    configurable: true
+  });
+
+  let _Buffer = Buffer;
+  Object.defineProperty(global, 'Buffer', {
+    get() {
+      return _Buffer;
+    },
+    set(value) {
+      _Buffer = value;
+    },
+    enumerable: false,
+    configurable: true
+  });
 }
 
 function setupChildProcessIpcChannel() {

--- a/test/parallel/test-global-setters.js
+++ b/test/parallel/test-global-setters.js
@@ -11,6 +11,9 @@ assert.strictEqual(process, 'asdf');
 assert.strictEqual(global.process, 'asdf');
 global.process = _process;
 assert.strictEqual(process, _process);
+assert.strictEqual(
+  typeof Object.getOwnPropertyDescriptor(global, 'process').get,
+  'function');
 
 assert.strictEqual(Buffer, _Buffer);
 // eslint-disable-next-line no-global-assign
@@ -19,3 +22,6 @@ assert.strictEqual(Buffer, 'asdf');
 assert.strictEqual(global.Buffer, 'asdf');
 global.Buffer = _Buffer;
 assert.strictEqual(Buffer, _Buffer);
+assert.strictEqual(
+  typeof Object.getOwnPropertyDescriptor(global, 'Buffer').get,
+  'function');

--- a/test/parallel/test-global-setters.js
+++ b/test/parallel/test-global-setters.js
@@ -1,0 +1,21 @@
+/* eslint-disable strict */
+require('../common');
+const assert = require('assert');
+const _process = require('process');
+const { Buffer: _Buffer } = require('buffer');
+
+assert.strictEqual(process, _process);
+// eslint-disable-next-line no-global-assign
+process = 'asdf';
+assert.strictEqual(process, 'asdf');
+assert.strictEqual(global.process, 'asdf');
+global.process = _process;
+assert.strictEqual(process, _process);
+
+assert.strictEqual(Buffer, _Buffer);
+// eslint-disable-next-line no-global-assign
+Buffer = 'asdf';
+assert.strictEqual(Buffer, 'asdf');
+assert.strictEqual(global.Buffer, 'asdf');
+global.Buffer = _Buffer;
+assert.strictEqual(Buffer, _Buffer);


### PR DESCRIPTION
This implements just the semver major breaking changes from [#26334 Restrict process and Buffer globals to CommonJS](https://github.com/nodejs/node/pull/26334), which is to make `global.process` and `global.Buffer` getters / setters over value properties.

I've split this out because we need two TSC approvals for this to make the 12 major release, if this is to be considered a breaking change.

So this is the bare minimum prerequisite to ensure that #26334 remains possible in the design of ES Modules in Node.js. If we miss this target, it will be very difficult to implement these important security properties later on.

As well as the CIGTM run on that PR, I also ran these builds against Jest running on the ncc test suite, which tests a large number of ecosystem packages as well. These have all been passing fine.

It would be amazing to get those two TSC approvals to be able to ensure these important security approaches for modules remain possible.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
