### PR TITLE
src: apply clang-tidy rule bugprone-incorrect-roundings

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -5,6 +5,7 @@
 #include "debug_utils.h"
 #include "util.h"
 #include <algorithm>
+#include <cmath>
 #include <memory>
 
 namespace node {
@@ -126,8 +127,7 @@ class WorkerThreadsTaskRunner::DelayedTaskScheduler {
         delay_in_seconds_(delay_in_seconds) {}
 
     void Run() override {
-      uint64_t delay_millis =
-          static_cast<uint64_t>(delay_in_seconds_ + 0.5) * 1000;
+      uint64_t delay_millis = llround(delay_in_seconds_ * 1000);
       std::unique_ptr<uv_timer_t> timer(new uv_timer_t());
       CHECK_EQ(0, uv_timer_init(&scheduler_->loop_, timer.get()));
       timer->data = task_.release();
@@ -387,8 +387,8 @@ bool PerIsolatePlatformData::FlushForegroundTasksInternal() {
   while (std::unique_ptr<DelayedTask> delayed =
       foreground_delayed_tasks_.Pop()) {
     did_work = true;
-    uint64_t delay_millis =
-        static_cast<uint64_t>(delayed->timeout + 0.5) * 1000;
+    uint64_t delay_millis = llround(delayed->timeout * 1000);
+
     delayed->timer.data = static_cast<void*>(delayed.get());
     uv_timer_init(loop_, &delayed->timer);
     // Timers may not guarantee queue ordering of events with the same delay if


### PR DESCRIPTION
see https://clang.llvm.org/extra/clang-tidy/checks/bugprone-incorrect-roundings.html.

> Checks the usage of patterns known to produce incorrect rounding. Programmers often use:
> 
> (int)(double_expression + 0.5)
> to round the double expression to an integer. The problem with this:
> 
> It is unnecessarily slow.
> It is incorrect. The number 0.499999975 (smallest representable float number below 0.5) rounds to 1.0. Even worse behavior for negative numbers where both -0.5f and -1.4f both round to 0.0.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
