### PR TITLE
Revert "net: remove usage of require('util')"

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -23,8 +23,7 @@
 
 const EventEmitter = require('events');
 const stream = require('stream');
-const { inspect } = require('internal/util/inspect');
-const { debuglog } = require('internal/util/debuglog');
+const util = require('util');
 const internalUtil = require('internal/util');
 const {
   isIP,
@@ -131,7 +130,7 @@ function getNewAsyncId(handle) {
 }
 
 
-const debug = debuglog('net');
+const debug = util.debuglog('net');
 
 function isPipeName(s) {
   return typeof s === 'string' && toNumber(s) === false;
@@ -336,8 +335,7 @@ function Socket(options) {
   this[kBytesRead] = 0;
   this[kBytesWritten] = 0;
 }
-Object.setPrototypeOf(Socket.prototype, stream.Duplex.prototype);
-Object.setPrototypeOf(Socket, stream.Duplex);
+util.inherits(Socket, stream.Duplex);
 
 // Refresh existing timeouts.
 Socket.prototype._unrefTimer = function _unrefTimer() {
@@ -1414,7 +1412,7 @@ Server.prototype.listen = function(...args) {
                                     'must have the property "port" or "path"');
   }
 
-  throw new ERR_INVALID_OPT_VALUE('options', inspect(options));
+  throw new ERR_INVALID_OPT_VALUE('options', util.inspect(options));
 };
 
 function lookupAndListen(self, port, address, backlog, exclusive, flags) {


### PR DESCRIPTION
This reverts commit e112fb4c221f9749fd9271c95a5f544476511292.
This commit broke parallel/test-net-access-byteswritten.

Refs: https://github.com/nodejs/node/pull/26807#issuecomment-476016632

Did a bisect and arrived at the same conclusion.

Collaborators, please 👍 here to fast-track.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
