### PR TITLE
crypto: rename generateKeyPairEdDSA

### DIFF
--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -5,7 +5,7 @@ const {
   generateKeyPairRSA,
   generateKeyPairDSA,
   generateKeyPairEC,
-  generateKeyPairEdDSA,
+  generateKeyPairNid,
   EVP_PKEY_ED25519,
   EVP_PKEY_ED448,
   EVP_PKEY_X25519,
@@ -217,10 +217,10 @@ function check(type, options, callback) {
             id = EVP_PKEY_X448;
             break;
         }
-        impl = (wrap) => generateKeyPairEdDSA(id,
-                                              publicFormat, publicType,
-                                              privateFormat, privateType,
-                                              cipher, passphrase, wrap);
+        impl = (wrap) => generateKeyPairNid(id,
+                                            publicFormat, publicType,
+                                            privateFormat, privateType,
+                                            cipher, passphrase, wrap);
       }
       break;
     default:

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5835,9 +5835,9 @@ class ECKeyPairGenerationConfig : public KeyPairGenerationConfig {
   const int param_encoding_;
 };
 
-class EdDSAKeyPairGenerationConfig : public KeyPairGenerationConfig {
+class NidKeyPairGenerationConfig : public KeyPairGenerationConfig {
  public:
-  explicit EdDSAKeyPairGenerationConfig(int id) : id_(id) {}
+  explicit NidKeyPairGenerationConfig(int id) : id_(id) {}
 
   EVPKeyCtxPointer Setup() override {
     return EVPKeyCtxPointer(EVP_PKEY_CTX_new_id(id_, nullptr));
@@ -6020,11 +6020,11 @@ void GenerateKeyPairEC(const FunctionCallbackInfo<Value>& args) {
   GenerateKeyPair(args, 2, std::move(config));
 }
 
-void GenerateKeyPairEdDSA(const FunctionCallbackInfo<Value>& args) {
+void GenerateKeyPairNid(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsInt32());
   const int id = args[0].As<Int32>()->Value();
   std::unique_ptr<KeyPairGenerationConfig> config(
-      new EdDSAKeyPairGenerationConfig(id));
+      new NidKeyPairGenerationConfig(id));
   GenerateKeyPair(args, 1, std::move(config));
 }
 
@@ -6447,7 +6447,7 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "generateKeyPairRSA", GenerateKeyPairRSA);
   env->SetMethod(target, "generateKeyPairDSA", GenerateKeyPairDSA);
   env->SetMethod(target, "generateKeyPairEC", GenerateKeyPairEC);
-  env->SetMethod(target, "generateKeyPairEdDSA", GenerateKeyPairEdDSA);
+  env->SetMethod(target, "generateKeyPairNid", GenerateKeyPairNid);
   NODE_DEFINE_CONSTANT(target, EVP_PKEY_ED25519);
   NODE_DEFINE_CONSTANT(target, EVP_PKEY_ED448);
   NODE_DEFINE_CONSTANT(target, EVP_PKEY_X25519);


### PR DESCRIPTION
Now that support for X25519 and X448 has been added, this function is not used exclusively for EdDSA keys anymore. "NID" is the term OpenSSL uses for numerical representations of OIDs such as `EVP_PKEY_X448`.

Refs: https://github.com/nodejs/node/pull/26774

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
