### PR TITLE
build: remove unused label from vcbuild.bat

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -239,7 +239,7 @@ if defined msi (
     goto msbuild-not-found
   )
   if not exist "%VCINSTALLDIR%\..\MSBuild\Microsoft\WiX" (
-    echo Failed to find the Wix Toolset Visual Studio 2017 Extension
+    echo Failed to find the WiX Toolset Visual Studio 2017 Extension
     goto msbuild-not-found
   )
 )
@@ -265,10 +265,6 @@ echo Failed to find a suitable Visual Studio installation.
 echo Try to run in a "Developer Command Prompt" or consult
 echo https://github.com/nodejs/node/blob/master/BUILDING.md#windows-1
 goto exit
-
-:wix-not-found
-echo Build skipped. To generate installer, you need to install Wix.
-goto install-doctools
 
 :msbuild-found
 


### PR DESCRIPTION
Remove the :wix-not-found label and harmonize the spelling of "WiX".