### PR TITLE
process: remove protection for SyncWriteStream destroy in stdio

### DIFF
--- a/lib/internal/process/stdio.js
+++ b/lib/internal/process/stdio.js
@@ -3,13 +3,7 @@
 exports.getMainThreadStdio = getMainThreadStdio;
 
 function dummyDestroy(err, cb) {
-  // SyncWriteStream does not use the stream
-  // destroy mechanism for some legacy reason.
-  // TODO(mcollina): remove when
-  // https://github.com/nodejs/node/pull/26690 lands.
-  if (typeof cb === 'function') {
-    cb(err);
-  }
+  cb(err);
 
   // We need to emit 'close' anyway so that the closing
   // of the stream is observable. We just make sure we


### PR DESCRIPTION
https://github.com/nodejs/node/pull/26691 introduced an if to protect
against SyncWriteStream not using the default .destroy() mechanism.
This change removes that as SyncWriteStream now use standard .destroy().

See: https://github.com/nodejs/node/pull/26691

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
