### PR TITLE
doc: remove reference to "credentials object"

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1406,9 +1406,9 @@ to `true`, other APIs that create secure contexts leave it unset.
 from `process.argv` as the default value of the `sessionIdContext` option, other
 APIs that create secure contexts have no default value.
 
-The `tls.createSecureContext()` method creates a `SecureContext` object. The
-object has no public methods, but is accepted as an argument to several `tls`
-APIs, such as [`tls.createServer()`][] and [`server.addContext()`][].
+The `tls.createSecureContext()` method creates a `SecureContext` object. It is
+usable as an argument to several `tls` APIs, such as [`tls.createServer()`][]
+and [`server.addContext()`][], but has no public methods.
 
 A key is *required* for ciphers that make use of certificates. Either `key` or
 `pfx` can be used to provide it.

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1406,7 +1406,9 @@ to `true`, other APIs that create secure contexts leave it unset.
 from `process.argv` as the default value of the `sessionIdContext` option, other
 APIs that create secure contexts have no default value.
 
-The `tls.createSecureContext()` method creates a credentials object.
+The `tls.createSecureContext()` method creates a `SecureContext` object. The
+object has no public methods, but is accepted as an argument to several `tls`
+APIs, such as [`tls.createServer()`][] and [`server.addContext()`][].
 
 A key is *required* for ciphers that make use of certificates. Either `key` or
 `pfx` can be used to provide it.
@@ -1658,6 +1660,7 @@ where `secureSocket` has the same API as `pair.cleartext`.
 [`net.Server.address()`]: net.html#net_server_address
 [`net.Server`]: net.html#net_class_net_server
 [`net.Socket`]: net.html#net_class_net_socket
+[`server.addContext()`]: #tls_server_addcontext_hostname_context
 [`server.getConnections()`]: net.html#net_server_getconnections_callback
 [`server.getTicketKeys()`]: #tls_server_getticketkeys
 [`server.listen()`]: net.html#net_server_listen


### PR DESCRIPTION
The reference is confusing because the object is actually of class
SecureContext. There is no object with class "credentials".

See: https://github.com/nodejs/node/issues/20432#issuecomment-441819285

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
