### PR TITLE
path: remove dead code

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1053,7 +1053,7 @@ const posix = {
     if (from === to)
       return '';
 
-    // Trim any leading backslashes
+    // Trim leading forward slashes.
     from = posix.resolve(from);
     to = posix.resolve(to);
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -1053,29 +1053,18 @@ const posix = {
     if (from === to)
       return '';
 
+    // Trim any leading backslashes
     from = posix.resolve(from);
     to = posix.resolve(to);
 
     if (from === to)
       return '';
 
-    // Trim any leading backslashes
-    let fromStart = 1;
-    while (fromStart < from.length &&
-           from.charCodeAt(fromStart) === CHAR_FORWARD_SLASH) {
-      fromStart++;
-    }
+    const fromStart = 1;
     const fromEnd = from.length;
-    const fromLen = (fromEnd - fromStart);
-
-    // Trim any leading backslashes
-    let toStart = 1;
-    while (toStart < to.length &&
-           to.charCodeAt(toStart) === CHAR_FORWARD_SLASH) {
-      toStart++;
-    }
-    const toEnd = to.length;
-    const toLen = (toEnd - toStart);
+    const fromLen = fromEnd - fromStart;
+    const toStart = 1;
+    const toLen = to.length - toStart;
 
     // Compare paths to find the longest common path from root
     const length = (fromLen < toLen ? fromLen : toLen);
@@ -1100,38 +1089,26 @@ const posix = {
           // For example: from='/'; to='/foo'
           return to.slice(toStart + i);
         }
-      } else if (fromLen > length) {
-        if (from.charCodeAt(fromStart + i) === CHAR_FORWARD_SLASH) {
-          // We get here if `to` is the exact base path for `from`.
-          // For example: from='/foo/bar/baz'; to='/foo/bar'
-          lastCommonSep = i;
-        } else if (i === 0) {
-          // We get here if `to` is the root.
-          // For example: from='/foo'; to='/'
-          lastCommonSep = 0;
-        }
+      } else if (fromLen > length &&
+                 from.charCodeAt(fromStart + i) === CHAR_FORWARD_SLASH) {
+        // We get here if `to` is the exact base path for `from`.
+        // For example: from='/foo/bar/baz'; to='/foo/bar'
+        lastCommonSep = i;
       }
     }
 
-    var out = '';
+    let out = '';
     // Generate the relative path based on the path difference between `to`
-    // and `from`
+    // and `from`.
     for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
       if (i === fromEnd || from.charCodeAt(i) === CHAR_FORWARD_SLASH) {
         out += out.length === 0 ? '..' : '/..';
       }
     }
 
-    toStart += lastCommonSep;
-
     // Lastly, append the rest of the destination (`to`) path that comes after
-    // the common path parts
-    if (out.length > 0)
-      return `${out}${to.slice(toStart)}`;
-
-    if (to.charCodeAt(toStart) === CHAR_FORWARD_SLASH)
-      ++toStart;
-    return to.slice(toStart);
+    // the common path parts.
+    return `${out}${to.slice(toStart + lastCommonSep)}`;
   },
 
   toNamespacedPath(path) {


### PR DESCRIPTION
A couple of code parts could not be reached due to resolving the path
in the beginning. That "normalizes" the path in a way that some code
branches became obsolete.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
