### PR TITLE
util: fix map entries inspection

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1181,27 +1181,28 @@ function formatMapIterInner(ctx, recurseTimes, entries, state) {
   const remaining = len - maxArrayLength;
   const maxLength = Math.min(maxArrayLength, len);
   let output = new Array(maxLength);
-  let start = '';
-  let end = '';
-  let middle = ' => ';
   let i = 0;
-  if (state === kMapEntries) {
-    start = '[ ';
-    end = ' ]';
-    middle = ', ';
-  }
   ctx.indentationLvl += 2;
-  for (; i < maxLength; i++) {
-    const pos = i * 2;
-    output[i] = `${start}${formatValue(ctx, entries[pos], recurseTimes)}` +
-      `${middle}${formatValue(ctx, entries[pos + 1], recurseTimes)}${end}`;
-  }
-  ctx.indentationLvl -= 2;
   if (state === kWeak) {
+    for (; i < maxLength; i++) {
+      const pos = i * 2;
+      output[i] = `${formatValue(ctx, entries[pos], recurseTimes)}` +
+        ` => ${formatValue(ctx, entries[pos + 1], recurseTimes)}`;
+    }
     // Sort all entries to have a halfway reliable output (if more entries
     // than retrieved ones exist, we can not reliably return the same output).
     output = output.sort();
+  } else {
+    for (; i < maxLength; i++) {
+      const pos = i * 2;
+      const res = [
+        formatValue(ctx, entries[pos], recurseTimes),
+        formatValue(ctx, entries[pos + 1], recurseTimes)
+      ];
+      output[i] = reduceToSingleString(ctx, res, '', ['[', ']']);
+    }
   }
+  ctx.indentationLvl -= 2;
   if (remaining > 0) {
     output.push(`... ${remaining} more item${remaining > 1 ? 's' : ''}`);
   }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1017,7 +1017,10 @@ if (typeof Symbol !== 'undefined') {
 
 // Test Set iterators.
 {
-  const aSet = new Set([1, 3]);
+  const aSet = new Set([1]);
+  assert.strictEqual(util.inspect(aSet.entries(), { compact: false }),
+                     '[Set Entries] {\n  [\n    1,\n    1\n  ]\n}');
+  aSet.add(3);
   assert.strictEqual(util.inspect(aSet.keys()), '[Set Iterator] { 1, 3 }');
   assert.strictEqual(util.inspect(aSet.values()), '[Set Iterator] { 1, 3 }');
   const setEntries = aSet.entries();


### PR DESCRIPTION
This makes sure the arrays returned by Map#entries() are handled as
any other array instead of just visualizing the entries as array.
Therefore options should have an impact on the arrays.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
