### PR TITLE
net: remove usage of require('util')

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -23,8 +23,9 @@
 
 const EventEmitter = require('events');
 const stream = require('stream');
-const util = require('util');
-const internalUtil = require('internal/util');
+const { inspect } = require('internal/util/inspect');
+const debug = require('internal/util/debuglog').debuglog('net');
+const { deprecate } = require('internal/util');
 const {
   isIP,
   isIPv4,
@@ -129,8 +130,6 @@ function getNewAsyncId(handle) {
     newAsyncId() : handle.getAsyncId();
 }
 
-
-const debug = util.debuglog('net');
 
 function isPipeName(s) {
   return typeof s === 'string' && toNumber(s) === false;
@@ -335,7 +334,8 @@ function Socket(options) {
   this[kBytesRead] = 0;
   this[kBytesWritten] = 0;
 }
-util.inherits(Socket, stream.Duplex);
+Object.setPrototypeOf(Socket.prototype, stream.Duplex.prototype);
+Object.setPrototypeOf(Socket, stream.Duplex);
 
 // Refresh existing timeouts.
 Socket.prototype._unrefTimer = function _unrefTimer() {
@@ -1094,7 +1094,7 @@ function Server(options, connectionListener) {
   this._connections = 0;
 
   Object.defineProperty(this, 'connections', {
-    get: internalUtil.deprecate(() => {
+    get: deprecate(() => {
 
       if (this._usingWorkers) {
         return null;
@@ -1102,9 +1102,9 @@ function Server(options, connectionListener) {
       return this._connections;
     }, 'Server.connections property is deprecated. ' +
        'Use Server.getConnections method instead.', 'DEP0020'),
-    set: internalUtil.deprecate((val) => (this._connections = val),
-                                'Server.connections property is deprecated.',
-                                'DEP0020'),
+    set: deprecate((val) => (this._connections = val),
+                   'Server.connections property is deprecated.',
+                   'DEP0020'),
     configurable: true, enumerable: false
   });
 
@@ -1406,7 +1406,7 @@ Server.prototype.listen = function(...args) {
                                     'must have the property "port" or "path"');
   }
 
-  throw new ERR_INVALID_OPT_VALUE('options', util.inspect(options));
+  throw new ERR_INVALID_OPT_VALUE('options', inspect(options));
 };
 
 function lookupAndListen(self, port, address, backlog, exclusive, flags) {
@@ -1590,10 +1590,10 @@ Object.defineProperty(Socket.prototype, '_handle', {
 });
 
 
-Server.prototype.listenFD = internalUtil.deprecate(function(fd, type) {
+Server.prototype.listenFD = deprecate(function(fd, type) {
   return this.listen({ fd: fd });
 }, 'Server.listenFD is deprecated. Use Server.listen({fd: <number>}) instead.',
-                                                   'DEP0021');
+                                      'DEP0021');
 
 Server.prototype._setupWorker = function(socketList) {
   this._usingWorkers = true;

--- a/test/parallel/test-net-access-byteswritten.js
+++ b/test/parallel/test-net-access-byteswritten.js
@@ -12,8 +12,10 @@ const tty = require('tty');
 // Check that the bytesWritten getter doesn't crash if object isn't
 // constructed.
 assert.strictEqual(net.Socket.prototype.bytesWritten, undefined);
-assert.strictEqual(tls.TLSSocket.super_.prototype.bytesWritten, undefined);
+assert.strictEqual(Object.getPrototypeOf(tls.TLSSocket).prototype.bytesWritten,
+                   undefined);
 assert.strictEqual(tls.TLSSocket.prototype.bytesWritten, undefined);
-assert.strictEqual(tty.ReadStream.super_.prototype.bytesWritten, undefined);
+assert.strictEqual(Object.getPrototypeOf(tty.ReadStream).prototype.bytesWritten,
+                   undefined);
 assert.strictEqual(tty.ReadStream.prototype.bytesWritten, undefined);
 assert.strictEqual(tty.WriteStream.prototype.bytesWritten, undefined);


### PR DESCRIPTION
Use `require('internal/util/inspect').inspect`, 
`require('internal/util/debuglog').debuglog`, 
`require('internal/util').deprecate` and `Object.setPrototypeOf` instead 
of `require('util')`.
Fix test in `test/parallel/test-net-access-byteswritten.js` to do not 
check the `super_` property that was set when using 
`require('util').inherits`.

Refs: https://github.com/nodejs/node/issues/26546
Refs: https://github.com/nodejs/node/pull/26896

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
