### PR TITLE
crypto: allow undefined for saltLength and padding

### DIFF
--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -60,8 +60,8 @@ function getSaltLength(options) {
 }
 
 function getIntOption(name, defaultValue, options) {
-  if (options.hasOwnProperty(name)) {
-    const value = options[name];
+  const value = options[name];
+  if (value !== undefined) {
     if (value === value >> 0) {
       return value;
     } else {

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -32,23 +32,23 @@ const modSize = 1024;
 common.expectsError(
   () => crypto.createVerify('SHA256').verify({
     key: certPem,
-    padding: undefined,
+    padding: null,
   }, ''),
   {
     code: 'ERR_INVALID_OPT_VALUE',
     type: TypeError,
-    message: 'The value "undefined" is invalid for option "padding"'
+    message: 'The value "null" is invalid for option "padding"'
   });
 
 common.expectsError(
   () => crypto.createVerify('SHA256').verify({
     key: certPem,
-    saltLength: undefined,
+    saltLength: null,
   }, ''),
   {
     code: 'ERR_INVALID_OPT_VALUE',
     type: TypeError,
-    message: 'The value "undefined" is invalid for option "saltLength"'
+    message: 'The value "null" is invalid for option "saltLength"'
   });
 
 // Test signing and verifying
@@ -233,7 +233,7 @@ common.expectsError(
 
 // Test exceptions for invalid `padding` and `saltLength` values
 {
-  [null, undefined, NaN, 'boom', {}, [], true, false]
+  [null, NaN, 'boom', {}, [], true, false]
     .forEach((invalidValue) => {
       common.expectsError(() => {
         crypto.createSign('SHA256')


### PR DESCRIPTION
Using `options.hasOwnProperty` is not how we usually validate options. Passing `{ saltLength }` where `saltLength === undefined` should be equivalent to not passing a `saltLength` option in my opinion. Feel free to disagree!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
