### PR TITLE
errors: make range mandatory in ERR_OUT_OF_RANGE

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -980,10 +980,10 @@ E('ERR_NO_ICU',
 E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported', Error);
 E('ERR_OUT_OF_RANGE',
   (str, range, input, replaceDefaultBoolean = false) => {
+    assert(range, 'Missing "range" argument');
     let msg = replaceDefaultBoolean ? str :
       `The value of "${str}" is out of range.`;
-    if (range !== undefined) msg += ` It must be ${range}.`;
-    msg += ` Received ${input}`;
+    msg += ` It must be ${range}. Received ${input}`;
     return msg;
   }, RangeError);
 E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s', Error);


### PR DESCRIPTION
So far the range argument was allowed to be undefined. This is not
used in the codebase anymore and therefore it is best to make it
mandatory for the best user experience.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
