### PR TITLE
util: use minimal object inspection with %s specifier

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -220,15 +220,17 @@ as a `printf`-like format string which can contain zero or more format
 specifiers. Each specifier is replaced with the converted value from the
 corresponding argument. Supported specifiers are:
 
-* `%s` - `String`.
-* `%d` - `Number` (integer or floating point value) or `BigInt`.
-* `%i` - Integer or `BigInt`.
-* `%f` - Floating point value.
-* `%j` - JSON. Replaced with the string `'[Circular]'` if the argument
-contains circular references.
-* `%o` - `Object`. A string representation of an object
-  with generic JavaScript object formatting.
-  Similar to `util.inspect()` with options
+* `%s` - `String` will be used to convert all values besides `BigInt` and
+  `Object`. `BigInt` values will be represented with an `n` and Objects are
+  inspected using `util.inspect()` with options
+  `{ depth: 0, colors: false, compact: true, breakLength: 120 }`.
+* `%d` - `Number` will be used to convert all values besides `BigInt`.
+* `%i` - `parseInt(value, 10)` is used for all values besides `BigInt`.
+* `%f` - `parseFloat(value)` is used for all values.
+* `%j` - JSON. Replaced with the string `'[Circular]'` if the argument contains
+  circular references.
+* `%o` - `Object`. A string representation of an object with generic JavaScript
+  object formatting. Similar to `util.inspect()` with options
   `{ showHidden: true, showProxy: true }`. This will show the full object
   including non-enumerable properties and proxies.
 * `%O` - `Object`. A string representation of an object with generic JavaScript

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -220,12 +220,12 @@ as a `printf`-like format string which can contain zero or more format
 specifiers. Each specifier is replaced with the converted value from the
 corresponding argument. Supported specifiers are:
 
-* `%s` - `String` will be used to convert all values besides `BigInt` and
+* `%s` - `String` will be used to convert all values except `BigInt` and
   `Object`. `BigInt` values will be represented with an `n` and Objects are
   inspected using `util.inspect()` with options
-  `{ depth: 0, colors: false, compact: true, breakLength: 120 }`.
-* `%d` - `Number` will be used to convert all values besides `BigInt`.
-* `%i` - `parseInt(value, 10)` is used for all values besides `BigInt`.
+  `{ depth: 0, colors: false, compact: 3 }`.
+* `%d` - `Number` will be used to convert all values except `BigInt`.
+* `%i` - `parseInt(value, 10)` is used for all values except `BigInt`.
 * `%f` - `parseFloat(value)` is used for all values.
 * `%j` - JSON. Replaced with the string `'[Circular]'` if the argument contains
   circular references.

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1416,8 +1416,7 @@ function formatWithOptions(inspectOptions, ...args) {
               if (typeof tempArg === 'object' && tempArg !== null) {
                 tempStr = inspect(tempArg, {
                   ...inspectOptions,
-                  breakLength: 120,
-                  compact: true,
+                  compact: 3,
                   colors: false,
                   depth: 0
                 });

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1412,7 +1412,21 @@ function formatWithOptions(inspectOptions, ...args) {
         if (a + 1 !== args.length) {
           switch (nextChar) {
             case 115: // 's'
-              tempStr = String(args[++a]);
+              const tempArg = args[++a];
+              if (typeof tempArg === 'object' && tempArg !== null) {
+                tempStr = inspect(tempArg, {
+                  ...inspectOptions,
+                  breakLength: 120,
+                  compact: true,
+                  colors: false,
+                  depth: 0
+                });
+              // eslint-disable-next-line valid-typeof
+              } else if (typeof tempArg === 'bigint') {
+                tempStr = `${tempArg}n`;
+              } else {
+                tempStr = String(tempArg);
+              }
               break;
             case 106: // 'j'
               tempStr = tryStringify(args[++a]);

--- a/test/parallel/test-http-response-statuscode.js
+++ b/test/parallel/test-http-response-statuscode.js
@@ -29,7 +29,7 @@ const server = http.Server(common.mustCall(function(req, res) {
       test(res, NaN, 'NaN');
       break;
     case 3:
-      test(res, {}, '[object Object]');
+      test(res, {}, '{}');
       break;
     case 4:
       test(res, 99, '99');
@@ -47,7 +47,7 @@ const server = http.Server(common.mustCall(function(req, res) {
       test(res, true, 'true');
       break;
     case 9:
-      test(res, [], '');
+      test(res, [], '[]');
       break;
     case 10:
       test(res, 'this is not valid', 'this is not valid');

--- a/test/parallel/test-stream-writable-change-default-encoding.js
+++ b/test/parallel/test-stream-writable-change-default-encoding.js
@@ -63,7 +63,7 @@ common.expectsError(function changeDefaultEncodingToInvalidValue() {
 }, {
   type: TypeError,
   code: 'ERR_UNKNOWN_ENCODING',
-  message: 'Unknown encoding: [object Object]'
+  message: 'Unknown encoding: {}'
 });
 
 (function checkVairableCaseEncoding() {

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -123,11 +123,17 @@ assert.strictEqual(util.format('%f %f', 42), '42 %f');
 // String format specifier
 assert.strictEqual(util.format('%s'), '%s');
 assert.strictEqual(util.format('%s', undefined), 'undefined');
+assert.strictEqual(util.format('%s', null), 'null');
 assert.strictEqual(util.format('%s', 'foo'), 'foo');
 assert.strictEqual(util.format('%s', 42), '42');
 assert.strictEqual(util.format('%s', '42'), '42');
 assert.strictEqual(util.format('%s %s', 42, 43), '42 43');
 assert.strictEqual(util.format('%s %s', 42), '42 %s');
+assert.strictEqual(util.format('%s', 42n), '42n');
+assert.strictEqual(util.format('%s', Symbol('foo')), 'Symbol(foo)');
+assert.strictEqual(util.format('%s', true), 'true');
+assert.strictEqual(util.format('%s', { a: [1, 2, 3] }), '{ a: [Array] }');
+assert.strictEqual(util.format('%s', () => 5), '() => 5');
 
 // JSON format specifier
 assert.strictEqual(util.format('%j'), '%j');
@@ -345,4 +351,12 @@ assert.strictEqual(
 assert.strictEqual(
   util.format(new SharedArrayBuffer(4)),
   'SharedArrayBuffer { [Uint8Contents]: <00 00 00 00>, byteLength: 4 }'
+);
+
+assert.strictEqual(
+  util.formatWithOptions(
+    { colors: true, compact: 3 },
+    '%s', [ 1, { a: true }]
+  ),
+  '[ 1, [Object] ]'
 );


### PR DESCRIPTION
This improves `util.format()` by returning more meaningful results
when using `%s` as specifier and any object as value. Besides that
`BigInt` will also be represented with an `n` at the end to indicate
that it's of type `BigInt`.

@Trott @vsemozhetbyt the documentation does not seem very intuitive
and I fail to find brief words to describe everything properly. It would
be great if you could have a look to suggest improvements.

Most `format` or `inspect` changes are treated as patch but this could
be considered semver-major even though I doubt that it would break anything. I would like to get the opinion of others on that and I'll trigger CITGM to see if anything pops up.

CITGM https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1777/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
