### PR TITLE
modules: fix repl require calling the same file again

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -86,14 +86,15 @@ const {
 const isWindows = process.platform === 'win32';
 
 let requireDepth = 0;
-let statCache = new Map();
+let statCache = null;
 function stat(filename) {
   filename = path.toNamespacedPath(filename);
-  if (statCache === null) statCache = new Map();
-  let result = statCache.get(filename);
-  if (result !== undefined) return result;
-  result = internalModuleStat(filename);
-  statCache.set(filename, result);
+  if (statCache !== null) {
+    const result = statCache.get(filename);
+    if (result !== undefined) return result;
+  }
+  const result = internalModuleStat(filename);
+  if (statCache !== null) statCache.set(filename, result);
   return result;
 }
 
@@ -196,7 +197,7 @@ Module._debug = deprecate(debug, 'Module._debug is deprecated.', 'DEP0077');
 //   -> a.<ext>
 //   -> a/index.<ext>
 
-// check if the directory is a package.json dir
+// Check if the directory is a package.json dir.
 const packageMainCache = Object.create(null);
 
 function readPackage(requestPath) {
@@ -830,6 +831,7 @@ Module.prototype._compile = function(content, filename) {
   const exports = this.exports;
   const thisValue = exports;
   const module = this;
+  if (requireDepth === 0) statCache = new Map();
   if (inspectorWrapper) {
     result = inspectorWrapper(compiledWrapper, thisValue, exports,
                               require, module, filename, dirname);

--- a/test/parallel/test-repl-require-after-write.js
+++ b/test/parallel/test-repl-require-after-write.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const spawn = require('child_process').spawn;
+// Use -i to force node into interactive mode, despite stdout not being a TTY
+const child = spawn(process.execPath, ['-i']);
+
+let out = '';
+const input = "try { require('./non-existent.json'); } catch {} " +
+              "require('fs').writeFileSync('./non-existent.json', '1');" +
+              "require('./non-existent.json');";
+
+child.stderr.on('data', common.mustNotCall());
+
+child.stdout.setEncoding('utf8');
+child.stdout.on('data', (c) => {
+  out += c;
+});
+child.stdout.on('end', common.mustCall(() => {
+  assert.strictEqual(out, '> 1\n> ');
+}));
+
+child.stdin.end(input);


### PR DESCRIPTION
This makes sure multiple require calls will not fail in case a file
was created after the first attempt.

Fixes: https://github.com/nodejs/node/issues/26926

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
