### PR TITLE
lib: use freelist for WriteWrap instances

### DIFF
--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -23,6 +23,7 @@ const {
   setUnrefTimeout,
   validateTimerDuration
 } = require('internal/timers');
+const { FreeList } = require('internal/freelist');
 
 const kMaybeDestroy = Symbol('kMaybeDestroy');
 const kUpdateTimer = Symbol('kUpdateTimer');
@@ -31,6 +32,10 @@ const kHandle = Symbol('kHandle');
 const kSession = Symbol('kSession');
 
 const debug = require('util').debuglog('stream');
+
+const writeWrapFreelist = new FreeList('writeWraps', 100, function makeWrap() {
+  return new WriteWrap();
+});
 
 function handleWriteReq(req, data, encoding) {
   const { handle } = req;
@@ -75,12 +80,14 @@ function onWriteComplete(status) {
   if (stream.destroyed) {
     if (typeof this.callback === 'function')
       this.callback(null);
+    writeWrapFreelist.free(this);
     return;
   }
 
   if (status < 0) {
     const ex = errnoException(status, 'write', this.error);
     stream.destroy(ex, this.callback);
+    writeWrapFreelist.free(this);
     return;
   }
 
@@ -89,10 +96,11 @@ function onWriteComplete(status) {
 
   if (typeof this.callback === 'function')
     this.callback(null);
+  writeWrapFreelist.free(this);
 }
 
 function createWriteWrap(handle) {
-  var req = new WriteWrap();
+  var req = writeWrapFreelist.alloc();
 
   req.handle = handle;
   req.oncomplete = onWriteComplete;


### PR DESCRIPTION
`WriteWrap` JS objects can be re-used across writes, since the
associated C++ objects are created and destroyed independently
from the JS ones.
Since the `WriteWrap` JS constructor calls into C++, re-using the JS
objects instead of creating new ones leads to a minor
performance improvement.

At 500 runs:

                                            confidence improvement accuracy (*)   (**)  (***)
     net/net-c2s.js dur=5 type='buf' len=64        ***      1.59 %       ±0.43% ±0.57% ±0.73%

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
