### PR TITLE
src: do not call into JS in the maxAsyncCallStackDepthChanged interrupt

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -157,17 +157,6 @@ if (isMainThread) {
 const { nativeHooks } = require('internal/async_hooks');
 internalBinding('async_wrap').setupHooks(nativeHooks);
 
-// XXX(joyeecheung): this has to be done after the initial load of
-// `internal/async_hooks` otherwise `async_hooks` cannot require
-// `internal/async_hooks`. Investigate why.
-if (config.hasInspector) {
-  const {
-    enable,
-    disable
-  } = require('internal/inspector_async_hook');
-  internalBinding('inspector').registerAsyncHook(enable, disable);
-}
-
 const {
   setupTaskQueue,
   queueMicrotask

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -7,7 +7,7 @@ function prepareMainThreadExecution() {
   // Patch the process object with legacy properties and normalizations
   patchProcessObject();
   setupTraceCategoryState();
-
+  setupInspectorHooks();
   setupWarningHandler();
 
   // Resolve the coverage directory to an absolute path, and
@@ -166,6 +166,21 @@ function setupTraceCategoryState() {
   const { isTraceCategoryEnabled } = internalBinding('trace_events');
   const { toggleTraceCategoryState } = require('internal/process/per_thread');
   toggleTraceCategoryState(isTraceCategoryEnabled('node.async_hooks'));
+}
+
+function setupInspectorHooks() {
+  // If Debugger.setAsyncCallStackDepth is sent during bootstrap,
+  // we cannot immediately call into JS to enable the hooks, which could
+  // interrupt the JS execution of bootstrap. So instead we save the
+  // notification in the inspector agent if it's sent in the middle of
+  // bootstrap, and process the notification later here.
+  if (internalBinding('config').hasInspector) {
+    const {
+      enable,
+      disable
+    } = require('internal/inspector_async_hook');
+    internalBinding('inspector').registerAsyncHook(enable, disable);
+  }
 }
 
 // In general deprecations are intialized wherever the APIs are implemented,
@@ -357,5 +372,6 @@ module.exports = {
   initializeFrozenIntrinsics,
   loadPreloadModules,
   setupTraceCategoryState,
+  setupInspectorHooks,
   initializeReport
 };

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -6,6 +6,7 @@
 const {
   patchProcessObject,
   setupCoverageHooks,
+  setupInspectorHooks,
   setupWarningHandler,
   setupDebugEnv,
   initializeDeprecations,
@@ -43,6 +44,7 @@ const {
 const publicWorker = require('worker_threads');
 
 patchProcessObject();
+setupInspectorHooks();
 setupDebugEnv();
 
 const debug = require('internal/util/debuglog').debuglog('worker');

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -835,6 +835,7 @@ void Agent::DisableAsyncHook() {
 
 void Agent::ToggleAsyncHook(Isolate* isolate,
                             const node::Persistent<Function>& fn) {
+  CHECK(parent_env_->has_run_bootstrapping_code());
   HandleScope handle_scope(isolate);
   CHECK(!fn.IsEmpty());
   auto context = parent_env_->context();


### PR DESCRIPTION
If Debugger.setAsyncCallStackDepth is sent during bootstrap,
we cannot immediately call into JS to enable the hooks, which could
interrupt the JS execution of bootstrap. So instead we save the
notification in the inspector agent if it's sent in the middle of
bootstrap, and process the notification later during pre-execution.

Example error caused by the interrupt calling into JS directly:

```
00:28:08     [err] async_hooks.js:32
00:28:08     [err]   async_id_symbol, trigger_async_id_symbol,
00:28:08     [err]   ^
00:28:08     [err] 
00:28:08     [err] TypeError: Cannot destructure property `async_id_symbol` of 'undefined' or 'null'.
00:28:08     [err]     at async_hooks.js:31:7
00:28:08     [err]     at NativeModule.compile (internal/bootstrap/loaders.js:300:5)
00:28:08     [err]     at nativeModuleRequire (internal/bootstrap/loaders.js:188:14)
00:28:08     [err]     at lazyHookCreation (internal/inspector_async_hook.js:8:26)
00:28:08     [err]     at enable (internal/inspector_async_hook.js:47:27)
00:28:08     [err]     at internal/async_hooks.js:1:1
00:28:08     [err]     at NativeModule.compile (internal/bootstrap/loaders.js:300:5)
00:28:08     [err]     at nativeModuleRequire (internal/bootstrap/loaders.js:188:14)
00:28:08     [err]     at internal/process/task_queues.js:31:5
00:28:08     [err]     at NativeModule.compile (internal/bootstrap/loaders.js:300:5)
00:28:08     [err]     at nativeModuleRequire (internal/bootstrap/loaders.js:188:14)
```

Refs: https://github.com/nodejs/node/issues/26798

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
