### PR TITLE
test: add known_issues test for fs.copyFile()

### DIFF
--- a/test/known_issues/known_issues.status
+++ b/test/known_issues/known_issues.status
@@ -7,18 +7,24 @@ prefix known_issues
 [true] # This section applies to all platforms
 
 [$system==win32]
+test-fs-copyfile-respect-permissions: SKIP
 
 [$system==linux]
 test-vm-timeout-escape-promise: PASS,FLAKY
+test-fs-copyfile-respect-permissions: SKIP
 
 [$system==macos]
 
 [$system==solaris]
+test-fs-copyfile-respect-permissions: SKIP
 
 [$system==freebsd]
+test-fs-copyfile-respect-permissions: SKIP
 
 [$system==aix]
+test-fs-copyfile-respect-permissions: SKIP
 
 [$arch==arm]
 # https://github.com/nodejs/node/issues/24120
 test-vm-timeout-escape-nexttick: PASS,FLAKY
+test-fs-copyfile-respect-permissions: SKIP

--- a/test/known_issues/test-fs-copyfile-respect-permissions.js
+++ b/test/known_issues/test-fs-copyfile-respect-permissions.js
@@ -3,7 +3,7 @@
 // Test that fs.copyFile() respects file permissions.
 // Ref: https://github.com/nodejs/node/issues/26936
 
-require('../common');
+const common = require('../common');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
@@ -19,7 +19,10 @@ fs.writeFileSync(source, 'source');
 fs.writeFileSync(dest, 'dest');
 fs.chmodSync(dest, '444');
 
-fs.copyFile(source, dest, (err) => {
+assert.throws(() => { fs.copyFileSync(source, dest); },
+              { code: 'EACCESS' });
+
+fs.copyFile(source, dest, common.mustCall((err) => {
   assert.strictEqual(err.code, 'EACCESS');
   assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'dest');
-});
+}));

--- a/test/known_issues/test-fs-copyfile-respect-permissions.js
+++ b/test/known_issues/test-fs-copyfile-respect-permissions.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Test that fs.copyFile() respects file permissions.
+// Ref: https://github.com/nodejs/node/issues/26936
+
+require('../common');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const source = path.join(tmpdir.path, 'source');
+const dest = path.join(tmpdir.path, 'dest');
+
+fs.writeFileSync(source, 'source');
+fs.writeFileSync(dest, 'dest');
+fs.chmodSync(dest, '444');
+
+fs.copyFile(source, dest, (err) => {
+  assert.strictEqual(err.code, 'EACCESS');
+  assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'dest');
+});


### PR DESCRIPTION
On macOS, fs.copyFile() may not respect file permissions. There is a PR
for libuv that should fix this, but until it lands and we can either
float a patch or upgrade libuv, have a known_issues test.

Ref: https://github.com/nodejs/node/issues/26936
Ref: https://github.com/libuv/libuv/pull/2233

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
