### PR TITLE
Revert "console: use consolePropAttributes for k-bind properties in c…

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -181,13 +181,15 @@ Console.prototype[kBindProperties] = function(ignoreErrors, colorMode) {
       ...consolePropAttributes,
       value: Boolean(ignoreErrors)
     },
-    '_times': { ...consolePropAttributes, value: new Map() },
-    // Corresponds to https://console.spec.whatwg.org/#count-map
-    [kCounts]: { ...consolePropAttributes, value: new Map() },
-    [kColorMode]: { ...consolePropAttributes, value: colorMode },
-    [kIsConsole]: { ...consolePropAttributes, value: true },
-    [kGroupIndent]: { ...consolePropAttributes, value: '' }
+    '_times': { ...consolePropAttributes, value: new Map() }
   });
+
+  // TODO(joyeecheung): use consolePropAttributes for these
+  // Corresponds to https://console.spec.whatwg.org/#count-map
+  this[kCounts] = new Map();
+  this[kColorMode] = colorMode;
+  this[kIsConsole] = true;
+  this[kGroupIndent] = '';
 };
 
 // Make a function that can serve as the callback passed to `stream.write()`.


### PR DESCRIPTION
…onstructor"

This reverts commit ed5e69d7e6eaf5e887ff48aa3fe941d394c44846.

Refs: https://github.com/nodejs/node/pull/26850#issuecomment-477089697

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
