### PR TITLE
process: patch more process properties during pre-execution

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -3,9 +3,9 @@
 const { getOptionValue } = require('internal/options');
 const { Buffer } = require('buffer');
 
-function prepareMainThreadExecution() {
+function prepareMainThreadExecution(expandArgv1 = false) {
   // Patch the process object with legacy properties and normalizations
-  patchProcessObject();
+  patchProcessObject(expandArgv1);
   setupTraceCategoryState();
   setupInspectorHooks();
   setupWarningHandler();
@@ -48,13 +48,25 @@ function prepareMainThreadExecution() {
   loadPreloadModules();
 }
 
-function patchProcessObject() {
+function patchProcessObject(expandArgv1) {
+  const {
+    patchProcessObject: patchProcessObjectNative
+  } = internalBinding('process_methods');
+
+  patchProcessObjectNative(process);
+
   Object.defineProperty(process, 'argv0', {
     enumerable: true,
     configurable: false,
     value: process.argv[0]
   });
   process.argv[0] = process.execPath;
+
+  if (expandArgv1 && process.argv[1] && !process.argv[1].startsWith('-')) {
+    // Expand process.argv[1] into a full path.
+    const path = require('path');
+    process.argv[1] = path.resolve(process.argv[1]);
+  }
 
   // TODO(joyeecheung): most of these should be deprecated and removed,
   // execpt some that we need to be able to mutate during run time.

--- a/lib/internal/main/check_syntax.js
+++ b/lib/internal/main/check_syntax.js
@@ -18,20 +18,18 @@ const {
   stripShebang, stripBOM
 } = require('internal/modules/cjs/helpers');
 
-let CJSModule;
-function CJSModuleInit() {
-  if (!CJSModule)
-    CJSModule = require('internal/modules/cjs/loader');
-}
+// TODO(joyeecheung): not every one of these are necessary
+prepareMainThreadExecution(true);
 
 if (process.argv[1] && process.argv[1] !== '-') {
   // Expand process.argv[1] into a full path.
   const path = require('path');
   process.argv[1] = path.resolve(process.argv[1]);
 
-  // TODO(joyeecheung): not every one of these are necessary
-  prepareMainThreadExecution();
-  CJSModuleInit();
+  // This has to be done after prepareMainThreadExecution because it
+  // relies on process.execPath
+  const CJSModule = require('internal/modules/cjs/loader');
+
   // Read the source.
   const filename = CJSModule._resolveFilename(process.argv[1]);
 
@@ -42,9 +40,6 @@ if (process.argv[1] && process.argv[1] !== '-') {
 
   checkSyntax(source, filename);
 } else {
-  // TODO(joyeecheung): not every one of these are necessary
-  prepareMainThreadExecution();
-  CJSModuleInit();
   markBootstrapComplete();
 
   readStdin((code) => {
@@ -55,6 +50,10 @@ if (process.argv[1] && process.argv[1] !== '-') {
 function checkSyntax(source, filename) {
   // Remove Shebang.
   source = stripShebang(source);
+
+  // This has to be done after prepareMainThreadExecution because it
+  // relies on process.execPath
+  const CJSModule = require('internal/modules/cjs/loader');
 
   const { getOptionValue } = require('internal/options');
   const experimentalModules = getOptionValue('--experimental-modules');

--- a/lib/internal/main/run_main_module.js
+++ b/lib/internal/main/run_main_module.js
@@ -4,11 +4,7 @@ const {
   prepareMainThreadExecution
 } = require('internal/bootstrap/pre_execution');
 
-// Expand process.argv[1] into a full path.
-const path = require('path');
-process.argv[1] = path.resolve(process.argv[1]);
-
-prepareMainThreadExecution();
+prepareMainThreadExecution(true);
 
 const CJSModule = require('internal/modules/cjs/loader');
 

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const prefix = `(${process.release.name}:${process.pid}) `;
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 
 // Lazily loaded
@@ -55,7 +54,7 @@ function onWarning(warning) {
   if (isDeprecation && process.noDeprecation) return;
   const trace = process.traceProcessWarnings ||
                 (isDeprecation && process.traceDeprecation);
-  var msg = prefix;
+  var msg = `(${process.release.name}:${process.pid}) `;
   if (warning.code)
     msg += `[${warning.code}] `;
   if (trace && warning.stack) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -630,6 +630,10 @@ inline std::shared_ptr<EnvironmentOptions> Environment::options() {
   return options_;
 }
 
+inline const std::vector<std::string>& Environment::argv() {
+  return argv_;
+}
+
 inline const std::vector<std::string>& Environment::exec_argv() {
   return exec_argv_;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -350,16 +350,8 @@ void Environment::ExitEnv() {
 MaybeLocal<Object> Environment::ProcessCliArgs(
     const std::vector<std::string>& args,
     const std::vector<std::string>& exec_args) {
-  if (args.size() > 1) {
-    std::string first_arg = args[1];
-    if (first_arg == "inspect") {
-      execution_mode_ = ExecutionMode::kInspect;
-    } else if (first_arg == "debug") {
-      execution_mode_ = ExecutionMode::kDebug;
-    } else if (first_arg != "-") {
-      execution_mode_ = ExecutionMode::kRunMainModule;
-    }
-  }
+  argv_ = args;
+  exec_argv_ = exec_args;
 
   if (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
           TRACING_CATEGORY_NODE1(environment)) != 0) {
@@ -377,7 +369,6 @@ MaybeLocal<Object> Environment::ProcessCliArgs(
                                       std::move(traced_value));
   }
 
-  exec_argv_ = exec_args;
   Local<Object> process_object =
       node::CreateProcessObject(this, args, exec_args)
           .FromMaybe(Local<Object>());

--- a/src/env.h
+++ b/src/env.h
@@ -761,6 +761,7 @@ class Environment {
       const std::vector<std::string>& args,
       const std::vector<std::string>& exec_args);
   inline const std::vector<std::string>& exec_argv();
+  inline const std::vector<std::string>& argv();
 
   typedef void (*HandleCleanupCb)(Environment* env,
                                   uv_handle_t* handle,
@@ -1057,23 +1058,6 @@ class Environment {
   inline std::shared_ptr<EnvironmentOptions> options();
   inline std::shared_ptr<HostPort> inspector_host_port();
 
-  enum class ExecutionMode {
-    kDefault,
-    kInspect,              // node inspect
-    kDebug,                // node debug
-    kPrintHelp,            // node --help
-    kPrintBashCompletion,  // node --completion-bash
-    kProfProcess,          // node --prof-process
-    kEvalString,           // node --eval without --interactive
-    kCheckSyntax,          // node --check (incompatible with --eval)
-    kRepl,
-    kEvalStdin,
-    kRunMainModule
-  };
-
-  inline ExecutionMode execution_mode() { return execution_mode_; }
-
-  inline void set_execution_mode(ExecutionMode mode) { execution_mode_ = mode; }
   inline AsyncRequest* thread_stopper() { return &thread_stopper_; }
 
  private:
@@ -1085,7 +1069,6 @@ class Environment {
   inline void ThrowError(v8::Local<v8::Value> (*fun)(v8::Local<v8::String>),
                          const char* errmsg);
 
-  ExecutionMode execution_mode_ = ExecutionMode::kDefault;
   std::list<binding::DLib> loaded_addons_;
   v8::Isolate* const isolate_;
   IsolateData* const isolate_data_;
@@ -1117,6 +1100,7 @@ class Environment {
   // used.
   std::shared_ptr<HostPort> inspector_host_port_;
   std::vector<std::string> exec_argv_;
+  std::vector<std::string> argv_;
 
   uint32_t module_id_counter_ = 0;
   uint32_t script_id_counter_ = 0;

--- a/src/node.cc
+++ b/src/node.cc
@@ -403,47 +403,44 @@ MaybeLocal<Value> StartMainThreadExecution(Environment* env) {
     return StartExecution(env, "internal/main/run_third_party_main");
   }
 
-  if (env->execution_mode() == Environment::ExecutionMode::kInspect ||
-      env->execution_mode() == Environment::ExecutionMode::kDebug) {
+  std::string first_argv;
+  if (env->argv().size() > 1) {
+    first_argv = env->argv()[1];
+  }
+
+  if (first_argv == "inspect" || first_argv == "debug") {
     return StartExecution(env, "internal/main/inspect");
   }
 
   if (per_process::cli_options->print_help) {
-    env->set_execution_mode(Environment::ExecutionMode::kPrintHelp);
     return StartExecution(env, "internal/main/print_help");
   }
 
   if (per_process::cli_options->print_bash_completion) {
-    env->set_execution_mode(Environment::ExecutionMode::kPrintBashCompletion);
     return StartExecution(env, "internal/main/print_bash_completion");
   }
 
   if (env->options()->prof_process) {
-    env->set_execution_mode(Environment::ExecutionMode::kProfProcess);
     return StartExecution(env, "internal/main/prof_process");
   }
 
   // -e/--eval without -i/--interactive
   if (env->options()->has_eval_string && !env->options()->force_repl) {
-    env->set_execution_mode(Environment::ExecutionMode::kEvalString);
     return StartExecution(env, "internal/main/eval_string");
   }
 
   if (env->options()->syntax_check_only) {
-    env->set_execution_mode(Environment::ExecutionMode::kCheckSyntax);
     return StartExecution(env, "internal/main/check_syntax");
   }
 
-  if (env->execution_mode() == Environment::ExecutionMode::kRunMainModule) {
+  if (!first_argv.empty() && first_argv != "-") {
     return StartExecution(env, "internal/main/run_main_module");
   }
 
   if (env->options()->force_repl || uv_guess_handle(STDIN_FILENO) == UV_TTY) {
-    env->set_execution_mode(Environment::ExecutionMode::kRepl);
     return StartExecution(env, "internal/main/repl");
   }
 
-  env->set_execution_mode(Environment::ExecutionMode::kEvalStdin);
   return StartExecution(env, "internal/main/eval_stdin");
 }
 

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -35,7 +35,7 @@ v8::MaybeLocal<v8::Object> CreateProcessObject(
     Environment* env,
     const std::vector<std::string>& args,
     const std::vector<std::string>& exec_args);
-
+void PatchProcessObject(const v8::FunctionCallbackInfo<v8::Value>& args);
 }  // namespace node
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 #endif  // SRC_NODE_PROCESS_H_

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -426,6 +426,7 @@ static void InitializeProcessMethods(Local<Object> target,
   env->SetMethod(target, "dlopen", binding::DLOpen);
   env->SetMethod(target, "reallyExit", ReallyExit);
   env->SetMethodNoSideEffect(target, "uptime", Uptime);
+  env->SetMethod(target, "patchProcessObject", PatchProcessObject);
 }
 
 }  // namespace node

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -13,6 +13,7 @@ using v8::Context;
 using v8::DEFAULT;
 using v8::EscapableHandleScope;
 using v8::Function;
+using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Integer;
@@ -84,20 +85,6 @@ MaybeLocal<Object> CreateProcessObject(
     return MaybeLocal<Object>();
   }
 
-  // process.title
-  auto title_string = FIXED_ONE_BYTE_STRING(env->isolate(), "title");
-  CHECK(process
-            ->SetAccessor(
-                env->context(),
-                title_string,
-                ProcessTitleGetter,
-                env->owns_process_state() ? ProcessTitleSetter : nullptr,
-                env->as_callback_data(),
-                DEFAULT,
-                None,
-                SideEffectType::kHasNoSideEffect)
-            .FromJust());
-
   // process.version
   READONLY_PROPERTY(process,
                     "version",
@@ -140,34 +127,56 @@ MaybeLocal<Object> CreateProcessObject(
 #endif  // _WIN32
 #endif  // NODE_HAS_RELEASE_URLS
 
+  // process._rawDebug: may be overwritten later in JS land, but should be
+  // availbale from the begining for debugging purposes
+  env->SetMethod(process, "_rawDebug", RawDebug);
+
+  return scope.Escape(process);
+}
+
+void PatchProcessObject(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  Environment* env = Environment::GetCurrent(context);
+  CHECK(args[0]->IsObject());
+  Local<Object> process = args[0].As<Object>();
+
+  // process.title
+  CHECK(process
+            ->SetAccessor(
+                context,
+                FIXED_ONE_BYTE_STRING(isolate, "title"),
+                ProcessTitleGetter,
+                env->owns_process_state() ? ProcessTitleSetter : nullptr,
+                env->as_callback_data(),
+                DEFAULT,
+                None,
+                SideEffectType::kHasNoSideEffect)
+            .FromJust());
+
   // process.argv
-  process->Set(env->context(),
-               FIXED_ONE_BYTE_STRING(env->isolate(), "argv"),
-               ToV8Value(env->context(), args).ToLocalChecked()).FromJust();
+  process->Set(context,
+               FIXED_ONE_BYTE_STRING(isolate, "argv"),
+               ToV8Value(context, env->argv()).ToLocalChecked()).FromJust();
 
   // process.execArgv
-  process->Set(env->context(),
-               FIXED_ONE_BYTE_STRING(env->isolate(), "execArgv"),
-               ToV8Value(env->context(), exec_args)
+  process->Set(context,
+               FIXED_ONE_BYTE_STRING(isolate, "execArgv"),
+               ToV8Value(context, env->exec_argv())
                    .ToLocalChecked()).FromJust();
 
   READONLY_PROPERTY(process, "pid",
-                    Integer::New(env->isolate(), uv_os_getpid()));
+                    Integer::New(isolate, uv_os_getpid()));
 
-  CHECK(process->SetAccessor(env->context(),
-                             FIXED_ONE_BYTE_STRING(env->isolate(), "ppid"),
+  CHECK(process->SetAccessor(context,
+                             FIXED_ONE_BYTE_STRING(isolate, "ppid"),
                              GetParentProcessId).FromJust());
-
-  // TODO(joyeecheung): make this available in JS during pre-execution.
-  // Note that to use this in releases the code doing the revert need to be
-  // careful to delay the check until after the bootstrap but that may not
-  // be possible depending on the feature being reverted.
 
   // --security-revert flags
 #define V(code, _, __)                                                        \
   do {                                                                        \
     if (IsReverted(SECURITY_REVERT_ ## code)) {                               \
-      READONLY_PROPERTY(process, "REVERT_" #code, True(env->isolate()));      \
+      READONLY_PROPERTY(process, "REVERT_" #code, True(isolate));             \
     }                                                                         \
   } while (0);
   SECURITY_REVERSIONS(V)
@@ -181,7 +190,7 @@ MaybeLocal<Object> CreateProcessObject(
     if (uv_exepath(exec_path_buf, &exec_path_len) == 0) {
       exec_path = std::string(exec_path_buf, exec_path_len);
     } else {
-      exec_path = args[0];
+      exec_path = env->argv()[0];
     }
     // On OpenBSD process.execPath will be relative unless we
     // get the full path before process.execPath is used.
@@ -195,9 +204,9 @@ MaybeLocal<Object> CreateProcessObject(
     }
 #endif
     process
-        ->Set(env->context(),
-              FIXED_ONE_BYTE_STRING(env->isolate(), "execPath"),
-              String::NewFromUtf8(env->isolate(),
+        ->Set(context,
+              FIXED_ONE_BYTE_STRING(isolate, "execPath"),
+              String::NewFromUtf8(isolate,
                                   exec_path.c_str(),
                                   NewStringType::kInternalized,
                                   exec_path.size())
@@ -206,20 +215,13 @@ MaybeLocal<Object> CreateProcessObject(
   }
 
   // process.debugPort
-  auto debug_port_string = FIXED_ONE_BYTE_STRING(env->isolate(), "debugPort");
   CHECK(process
-            ->SetAccessor(env->context(),
-                          debug_port_string,
+            ->SetAccessor(context,
+                          FIXED_ONE_BYTE_STRING(isolate, "debugPort"),
                           DebugPortGetter,
                           env->owns_process_state() ? DebugPortSetter : nullptr,
                           env->as_callback_data())
             .FromJust());
-
-  // process._rawDebug: may be overwritten later in JS land, but should be
-  // availbale from the begining for debugging purposes
-  env->SetMethod(process, "_rawDebug", RawDebug);
-
-  return scope.Escape(process);
 }
 
 }  // namespace node

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -96,6 +96,7 @@ Worker::Worker(Environment* env,
       env->inspector_agent()->GetParentHandle(thread_id_, url);
 #endif
 
+  argv_ = std::vector<std::string>{env->argv()[0]};
   // Mark this Worker object as weak until we actually start the thread.
   MakeWeak();
 
@@ -260,8 +261,7 @@ void Worker::Run() {
         env_->set_worker_context(this);
 
         env_->InitializeLibuv(profiler_idle_notifier_started_);
-        env_->ProcessCliArgs(std::vector<std::string>{},
-                             std::move(exec_argv_));
+        env_->ProcessCliArgs(std::move(argv_), std::move(exec_argv_));
       }
       {
         Mutex::ScopedLock lock(mutex_);

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -58,6 +58,8 @@ class Worker : public AsyncWrap {
 
   std::shared_ptr<PerIsolateOptions> per_isolate_opts_;
   std::vector<std::string> exec_argv_;
+  std::vector<std::string> argv_;
+
   MultiIsolatePlatform* platform_;
   v8::Isolate* isolate_ = nullptr;
   bool profiler_idle_notifier_started_;


### PR DESCRIPTION
#### process: store argv in Environment

This gets rid of Environment::ExecutionMode as well now that
we use the original arguments to determine execution mode.

#### process: patch more process properties during pre-execution

Delay the creation of process properties that depend on
runtime states and properties that should not be accessed
during bootstrap and patch them during pre-execution:

- process.argv
- process.execPath
- process.title
- process.pid
- process.ppid
- process.REVERT_*
- process.debugPort

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
