### PR TITLE
src: fix warning on mismatched fn signature

### DIFF
--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -155,7 +155,8 @@ static void SetReportOnUncaughtException(
 
 static void Initialize(Local<Object> exports,
                        Local<Value> unused,
-                       Local<Context> context) {
+                       Local<Context> context,
+                       void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(exports, "writeReport", WriteReport);


### PR DESCRIPTION
Add the missing `void* priv` to node_report's Initialize().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
