### PR TITLE
esm: use primordials

### DIFF
--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -17,7 +17,12 @@ const { pathToFileURL, fileURLToPath } = require('internal/url');
 const { ERR_ENTRY_TYPE_MISMATCH,
         ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
 
-const realpathCache = new Map();
+const {
+  Object,
+  SafeMap
+} = primordials;
+
+const realpathCache = new SafeMap();
 
 // const TYPE_NONE = 0;
 const TYPE_COMMONJS = 1;

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -22,6 +22,11 @@ const FunctionBind = Function.call.bind(Function.prototype.bind);
 
 const debug = require('internal/util/debuglog').debuglog('esm');
 
+const {
+  Object,
+  SafeMap
+} = primordials;
+
 /* A Loader instance is used as the main entry point for loading ES modules.
  * Currently, this is a singleton -- there is only one used for loading
  * the main module and everything in its dependency graph. */
@@ -35,7 +40,7 @@ class Loader {
     this.moduleMap = new ModuleMap();
 
     // Map of already-loaded CJS modules to use
-    this.cjsCache = new Map();
+    this.cjsCache = new SafeMap();
 
     // The resolver has the signature
     //   (specifier : string, parentURL : string, defaultResolve)

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -13,6 +13,7 @@ const createDynamicModule = require(
 const fs = require('fs');
 const {
   SafeMap,
+  JSON
 } = primordials;
 const { fileURLToPath, URL } = require('url');
 const { debuglog } = require('internal/util/debuglog');


### PR DESCRIPTION
Converted uses of Object and Map to use frozen built
in primordials.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes