### PR TITLE
http2: allow to control the connection window size

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -535,6 +535,21 @@ In case of allocation error, a new `ERR_OUT_OF_RANGE`
 error will be thrown.
 
 Used to set the local window size (local endpoints's window size).
+The window_size is an absolute value of window size to set, rather
+than the delta.
+
+```js
+clientSession.on('connect', (session) => sendSettings(session, (s) => cb(s)));
+
+function sendSettings(session, cb) {
+    session.setConnectionWindowSize(1024*1024);
+
+    const settings = http2.getDefaultSettings();
+    settings.initialWindowSize = WINDOW_SIZE;
+    settings.maxFrameSize = FRAME_SIZE;
+}
+
+```
 
 #### http2session.socket
 <!-- YAML

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -524,6 +524,18 @@ Used to set a callback function that is called when there is no activity on
 the `Http2Session` after `msecs` milliseconds. The given `callback` is
 registered as a listener on the `'timeout'` event.
 
+#### http2session.setConnectionWindowSize(windowSize)
+<!-- YAML
+added: v12.0.0
+-->
+
+* `windowSize` {number}
+* Returns: 0 
+In case of allocation error, a new `ERR_OUT_OF_RANGE`
+error will be thrown.
+
+Used to set the local window size (local endpoints's window size).
+
 #### http2session.socket
 <!-- YAML
 added: v8.4.0
@@ -2221,6 +2233,7 @@ added: v8.4.0
 | `0x0a` | Connect Error       | `http2.constants.NGHTTP2_CONNECT_ERROR`       |
 | `0x0b` | Enhance Your Calm   | `http2.constants.NGHTTP2_ENHANCE_YOUR_CALM`   |
 | `0x0c` | Inadequate Security | `http2.constants.NGHTTP2_INADEQUATE_SECURITY` |
+| `0x0d` | HTTP/1.1 Required   | `http2.constants.NGHTTP2_HTTP_1_1_REQUIRED`   |
 | `0x0d` | HTTP/1.1 Required   | `http2.constants.NGHTTP2_HTTP_1_1_REQUIRED`   |
 
 The `'timeout'` event is emitted when there is no activity on the Server for

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -60,8 +60,8 @@ function getSaltLength(options) {
 }
 
 function getIntOption(name, defaultValue, options) {
-  if (options.hasOwnProperty(name)) {
-    const value = options[name];
+  const value = options[name];
+  if (value !== undefined) {
     if (value === value >> 0) {
       return value;
     } else {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -191,6 +191,7 @@ const {
   NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE,
   NGHTTP2_ERR_INVALID_ARGUMENT,
   NGHTTP2_ERR_STREAM_CLOSED,
+  NGHTTP2_ERR_NOMEM,
 
   HTTP2_HEADER_AUTHORITY,
   HTTP2_HEADER_DATE,
@@ -1034,6 +1035,23 @@ class Http2Session extends EventEmitter {
     if (id <= 0 || id > kMaxStreams)
       throw new ERR_OUT_OF_RANGE('id', `> 0 and <= ${kMaxStreams}`, id);
     this[kHandle].setNextStreamID(id);
+  }
+
+  // Sets the local window size (local endpoints's window size)
+  // Returns 0 if sucess or throw an exception if NGHTTP2_ERR_NOMEM 
+  // if the window allocation fails
+  setConnectionWindowSize(windowSize) {
+    if (this.destroyed)
+      throw new ERR_HTTP2_INVALID_SESSION();
+
+    validateNumber(windowSize, 'windowSize');
+    const ret = this[kHandle].setConnectionWindowSize(windowSize);
+
+    if (typeof ret === 'number' && ret === NGHTTP2_ERR_NOMEM) {
+        throw new ERR_OUT_OF_RANGE('windowSize', `> 0 and <= 2^31-1 bytes`, windowSize)
+    }
+
+    return ret;
   }
 
   // If ping is called while we are still connecting, or after close() has

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2366,7 +2366,8 @@ void Http2Session::SetNextStreamID(const FunctionCallbackInfo<Value>& args) {
   Debug(session, "set next stream id to %d", id);
 }
 
-// Set local window size (local endpoints's window size) to the given window_size for the stream denoted by 0.
+// Set local window size (local endpoints's window size) to the given
+// window_size for the stream denoted by 0.
 // If successful, returns 0.
 void Http2Session::SetConnectionWindowSize(
     const FunctionCallbackInfo<Value>& args) {

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -789,6 +789,7 @@ class Http2Session : public AsyncWrap, public StreamListener {
   static void Settings(const FunctionCallbackInfo<Value>& args);
   static void Request(const FunctionCallbackInfo<Value>& args);
   static void SetNextStreamID(const FunctionCallbackInfo<Value>& args);
+  static void SetConnectionWindowSize(const FunctionCallbackInfo<Value>& args);
   static void Goaway(const FunctionCallbackInfo<Value>& args);
   static void UpdateChunksSent(const FunctionCallbackInfo<Value>& args);
   static void RefreshState(const FunctionCallbackInfo<Value>& args);

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -32,23 +32,23 @@ const modSize = 1024;
 common.expectsError(
   () => crypto.createVerify('SHA256').verify({
     key: certPem,
-    padding: undefined,
+    padding: null,
   }, ''),
   {
     code: 'ERR_INVALID_OPT_VALUE',
     type: TypeError,
-    message: 'The value "undefined" is invalid for option "padding"'
+    message: 'The value "null" is invalid for option "padding"'
   });
 
 common.expectsError(
   () => crypto.createVerify('SHA256').verify({
     key: certPem,
-    saltLength: undefined,
+    saltLength: null,
   }, ''),
   {
     code: 'ERR_INVALID_OPT_VALUE',
     type: TypeError,
-    message: 'The value "undefined" is invalid for option "saltLength"'
+    message: 'The value "null" is invalid for option "saltLength"'
   });
 
 // Test signing and verifying
@@ -233,7 +233,7 @@ common.expectsError(
 
 // Test exceptions for invalid `padding` and `saltLength` values
 {
-  [null, undefined, NaN, 'boom', {}, [], true, false]
+  [null, NaN, 'boom', {}, [], true, false]
     .forEach((invalidValue) => {
       common.expectsError(() => {
         crypto.createSign('SHA256')


### PR DESCRIPTION
In order to increase performance, it may necessary to allow an HTTP/2 connection to update its own WINDOW_SIZE, it is necessary to nghttp2_session_set_local_window_size

Every stream, and the connection as a whole maintains a send window, which is the amount of data that the server is allowed to send on the stream/connection, but it was not possible to control the connection window.

To increase window size, this function may submit WINDOW_UPDATE frame to transmission queue.
Pay attention, this function takes the absolute value of window size to set, rather than the delta, the delta is computed by the update operation.

So, with the help of: session.setConnectionWindowSize(windowSize), the function invokes nghttp2_session_set_local_window_size is invoked with the stream[0]



