### PR TITLE
http2: window size connection control

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -526,11 +526,11 @@ registered as a listener on the `'timeout'` event.
 
 #### http2session.setConnectionWindowSize(windowSize)
 <!-- YAML
-added: v12.0.0
+added: REPLACEME
 -->
 
 * `windowSize` {number}
-* Returns: 0 
+* Returns: 0 if it succeeds, or one of a negative codes
 In case of allocation error, a new `ERR_OUT_OF_RANGE`
 error will be thrown.
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -524,6 +524,33 @@ Used to set a callback function that is called when there is no activity on
 the `Http2Session` after `msecs` milliseconds. The given `callback` is
 registered as a listener on the `'timeout'` event.
 
+#### http2session.setConnectionWindowSize(windowSize)
+<!-- YAML
+added: v12.0.0
+-->
+
+* `windowSize` {number}
+* Returns: 0 
+In case of allocation error, a new `ERR_OUT_OF_RANGE`
+error will be thrown.
+
+Used to set the local window size (local endpoints's window size).
+The window_size is an absolute value of window size to set, rather
+than the delta.
+
+```js
+clientSession.on('connect', (session) => sendSettings(session, (s) => cb(s)));
+
+function sendSettings(session, cb) {
+    session.setConnectionWindowSize(1024*1024);
+
+    const settings = http2.getDefaultSettings();
+    settings.initialWindowSize = WINDOW_SIZE;
+    settings.maxFrameSize = FRAME_SIZE;
+}
+
+```
+
 #### http2session.socket
 <!-- YAML
 added: v8.4.0
@@ -2221,6 +2248,7 @@ added: v8.4.0
 | `0x0a` | Connect Error       | `http2.constants.NGHTTP2_CONNECT_ERROR`       |
 | `0x0b` | Enhance Your Calm   | `http2.constants.NGHTTP2_ENHANCE_YOUR_CALM`   |
 | `0x0c` | Inadequate Security | `http2.constants.NGHTTP2_INADEQUATE_SECURITY` |
+| `0x0d` | HTTP/1.1 Required   | `http2.constants.NGHTTP2_HTTP_1_1_REQUIRED`   |
 | `0x0d` | HTTP/1.1 Required   | `http2.constants.NGHTTP2_HTTP_1_1_REQUIRED`   |
 
 The `'timeout'` event is emitted when there is no activity on the Server for

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1048,7 +1048,8 @@ class Http2Session extends EventEmitter {
     const ret = this[kHandle].setConnectionWindowSize(windowSize);
 
     if (typeof ret === 'number' && ret === NGHTTP2_ERR_NOMEM) {
-        throw new ERR_OUT_OF_RANGE('windowSize', `> 0 and <= 2^31-1 bytes`, windowSize)
+        throw new ERR_OUT_OF_RANGE('windowSize', `> 0 and <= 2^31-1 bytes`, 
+                                    windowSize);
     }
 
     return ret;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -191,6 +191,7 @@ const {
   NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE,
   NGHTTP2_ERR_INVALID_ARGUMENT,
   NGHTTP2_ERR_STREAM_CLOSED,
+  NGHTTP2_ERR_NOMEM,
 
   HTTP2_HEADER_AUTHORITY,
   HTTP2_HEADER_DATE,
@@ -1034,6 +1035,23 @@ class Http2Session extends EventEmitter {
     if (id <= 0 || id > kMaxStreams)
       throw new ERR_OUT_OF_RANGE('id', `> 0 and <= ${kMaxStreams}`, id);
     this[kHandle].setNextStreamID(id);
+  }
+
+  // Sets the local window size (local endpoints's window size)
+  // Returns 0 if sucess or throw an exception if NGHTTP2_ERR_NOMEM 
+  // if the window allocation fails
+  setConnectionWindowSize(windowSize) {
+    if (this.destroyed)
+      throw new ERR_HTTP2_INVALID_SESSION();
+
+    validateNumber(windowSize, 'windowSize');
+    const ret = this[kHandle].setConnectionWindowSize(windowSize);
+
+    if (typeof ret === 'number' && ret === NGHTTP2_ERR_NOMEM) {
+        throw new ERR_OUT_OF_RANGE('windowSize', `> 0 and <= 2^31-1 bytes`, windowSize)
+    }
+
+    return ret;
   }
 
   // If ping is called while we are still connecting, or after close() has

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2368,7 +2368,7 @@ void Http2Session::SetNextStreamID(const FunctionCallbackInfo<Value>& args) {
 
 // Set local window size (local endpoints's window size) to the given
 // window_size for the stream denoted by 0.
-// If successful, returns 0.
+// This function returns 0 if it succeeds, or one of a negative codes
 void Http2Session::SetConnectionWindowSize(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2366,6 +2366,26 @@ void Http2Session::SetNextStreamID(const FunctionCallbackInfo<Value>& args) {
   Debug(session, "set next stream id to %d", id);
 }
 
+// Set local window size (local endpoints's window size) to the given
+// window_size for the stream denoted by 0.
+// If successful, returns 0.
+void Http2Session::SetConnectionWindowSize(
+    const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  Http2Session* session;
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+
+  int32_t window_size = args[0]->Int32Value(env->context()).ToChecked();
+
+  int result = nghttp2_session_set_local_window_size(
+      session->session(), NGHTTP2_FLAG_NONE, 0, window_size);
+
+  args.GetReturnValue().Set(result);
+
+  Debug(session, "set connection  window size to %d", window_size);
+}
+
+
 // A TypedArray instance is shared between C++ and JS land to contain the
 // SETTINGS (either remote or local). RefreshSettings updates the current
 // values established for each of the settings so those can be read in JS land.
@@ -3032,6 +3052,8 @@ void Initialize(Local<Object> target,
   env->SetProtoMethod(session, "request", Http2Session::Request);
   env->SetProtoMethod(session, "setNextStreamID",
                       Http2Session::SetNextStreamID);
+  env->SetProtoMethod(session, "setConnectionWindowSize",
+                      Http2Session::SetConnectionWindowSize);
   env->SetProtoMethod(session, "updateChunksSent",
                       Http2Session::UpdateChunksSent);
   env->SetProtoMethod(session, "refreshState", Http2Session::RefreshState);
@@ -3092,6 +3114,7 @@ void Initialize(Local<Object> target,
   NODE_DEFINE_HIDDEN_CONSTANT(constants, NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE);
   NODE_DEFINE_HIDDEN_CONSTANT(constants, NGHTTP2_ERR_INVALID_ARGUMENT);
   NODE_DEFINE_HIDDEN_CONSTANT(constants, NGHTTP2_ERR_STREAM_CLOSED);
+  NODE_DEFINE_HIDDEN_CONSTANT(constants, NGHTTP2_ERR_NOMEM);
   NODE_DEFINE_CONSTANT(constants, NGHTTP2_ERR_FRAME_SIZE_ERROR);
 
   NODE_DEFINE_HIDDEN_CONSTANT(constants, STREAM_OPTION_EMPTY_PAYLOAD);

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -789,6 +789,7 @@ class Http2Session : public AsyncWrap, public StreamListener {
   static void Settings(const FunctionCallbackInfo<Value>& args);
   static void Request(const FunctionCallbackInfo<Value>& args);
   static void SetNextStreamID(const FunctionCallbackInfo<Value>& args);
+  static void SetConnectionWindowSize(const FunctionCallbackInfo<Value>& args);
   static void Goaway(const FunctionCallbackInfo<Value>& args);
   static void UpdateChunksSent(const FunctionCallbackInfo<Value>& args);
   static void RefreshState(const FunctionCallbackInfo<Value>& args);


### PR DESCRIPTION
Allow to control the connection window size by setting local window
size (local endpoints's window size) to the given window_size.

To increase window size, this function may submit WINDOW_UPDATE frame
to transmission queue.

Pay attention, this function takes the absolute value of window size to set,
rather than the delta, the delta is computed by the update operation.

