### PR TITLE
stream: use `Math.floor()` instead of `parseInt()`

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -381,7 +381,7 @@ function howMuchToRead(n, state) {
 // You can override either this method, or the async _read(n) below.
 Readable.prototype.read = function(n) {
   debug('read', n);
-  n = parseInt(n, 10);
+  n = Math.floor(n);  // This is NaN if read() was called with no arguments.
   const state = this._readableState;
   const nOrig = n;
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -27,6 +27,7 @@ Readable.ReadableState = ReadableState;
 const EE = require('events');
 const Stream = require('stream');
 const { Buffer } = require('buffer');
+const { Math } = primordials;
 
 let debuglog;
 function debug(...args) {

--- a/test/parallel/test-stream-readable-read-string.js
+++ b/test/parallel/test-stream-readable-read-string.js
@@ -1,0 +1,13 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { Readable } = require('stream');
+
+// This test verifies that we coerce input to `.read()` to Number according to
+// the typical JS rules, and not using `parseInt()`. Passing strings to
+// `.read()` is not part of the public API, so in a way this is purely an
+// internals test.
+
+const readable = new Readable({ read() {} });
+readable.push('a'.repeat(100));
+assert.strictEqual(readable.read('1e2').length, 100);


### PR DESCRIPTION
Do not use `parseInt()`, since the argument is typically either
`undefined` or an integer, but `parseInt()` expects a string
argument. Also, be explicit about the fact that a value of `NaN`
is a common scenario.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
