### PR TITLE
stream: do not unconditionally call `_read()` on `resume()`

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -475,7 +475,7 @@ Readable.prototype.read = function(n) {
     ret = null;
 
   if (ret === null) {
-    state.needReadable = true;
+    state.needReadable = state.length <= state.highWaterMark;
     n = 0;
   } else {
     state.length -= n;

--- a/test/parallel/test-stream-readable-resume-hwm.js
+++ b/test/parallel/test-stream-readable-resume-hwm.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+const { Readable } = require('stream');
+
+// readable.resume() should not lead to a ._read() call being scheduled
+// when we exceed the high water mark already.
+
+const readable = new Readable({
+  read: common.mustNotCall(),
+  highWaterMark: 100
+});
+
+// Fill up the internal buffer so that we definitely exceed the HWM:
+for (let i = 0; i < 10; i++)
+  readable.push('a'.repeat(200));
+
+// Call resume, and pause after one chunk.
+// The .pause() is just so that we don’t empty the buffer fully, which would
+// be a valid reason to call ._read().
+readable.resume();
+readable.once('data', common.mustCall(() => readable.pause()));


### PR DESCRIPTION
`readable.resume()` calls `.read(0)`, which in turn previously set
`needReadable = true`, and so a subsequent `.read()` call would
call `_read()` even though enough data was already available.

This can lead to elevated memory usage, because calling `_read()`
when enough data is in the readable buffer means that backpressure
is not being honoured.

Fixes: https://github.com/nodejs/node/issues/26957

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
