### PR TITLE
src: check uv_fs_close() return value

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -494,7 +494,7 @@ inline Maybe<uv_file> OpenDescriptor(const std::string& path) {
 
 inline void CloseDescriptor(uv_file fd) {
   uv_fs_t fs_req;
-  uv_fs_close(nullptr, &fs_req, fd, nullptr);
+  CHECK_EQ(0, uv_fs_close(nullptr, &fs_req, fd, nullptr));
   uv_fs_req_cleanup(&fs_req);
 }
 


### PR DESCRIPTION
Coverity was complaining about not checking the return value.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
