### PR TITLE
build: fix skipping of flaky tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ matrix:
         - ./configure
         - make -j2 V=
       script:
-        - PARALLEL_ARGS='--flaky-tests=skip' make -j1 test
+        - CI_JS_SUITES='--flaky-tests=skip default' make -j1 test


### PR DESCRIPTION
`PARALLEL_ARGS` is overwritten in the Makefile if `JOBS` is set. 
https://github.com/nodejs/node/blob/2c73868b0471fbd4038f500d076df056cbf697fe/Makefile#L20-L24
Use `CI_JS_SUITES` instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
