### PR TITLE
module: significantly improve loader performance

### DIFF
--- a/benchmark/module/module-loader-deep.js
+++ b/benchmark/module/module-loader-deep.js
@@ -1,0 +1,51 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const common = require('../common.js');
+
+const tmpdir = require('../../test/common/tmpdir');
+const benchmarkDirectory = path.join(tmpdir.path, 'nodejs-benchmark-module');
+
+const bench = common.createBenchmark(main, {
+  ext: ['', '.js'],
+  files: [1e3],
+  cache: ['true', 'false']
+});
+
+function main({ ext, cache, files }) {
+  tmpdir.refresh();
+  fs.mkdirSync(benchmarkDirectory);
+  fs.writeFileSync(
+    `${benchmarkDirectory}/a.js`,
+    'module.exports = {};'
+  );
+  for (var i = 0; i <= files; i++) {
+    fs.mkdirSync(`${benchmarkDirectory}/${i}`);
+    fs.writeFileSync(
+      `${benchmarkDirectory}/${i}/package.json`,
+      '{"main": "index.js"}'
+    );
+    fs.writeFileSync(
+      `${benchmarkDirectory}/${i}/index.js`,
+      `require('../a${ext}');`
+    );
+  }
+
+  measureDir(cache === 'true', files);
+
+  tmpdir.refresh();
+}
+
+function measureDir(cache, files) {
+  var i;
+  if (cache) {
+    for (i = 0; i <= files; i++) {
+      require(`${benchmarkDirectory}/${i}`);
+    }
+  }
+  bench.start();
+  for (i = 0; i <= files; i++) {
+    require(`${benchmarkDirectory}/${i}`);
+  }
+  bench.end(files);
+}

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -625,13 +625,7 @@ Module._load = function(request, parent, isMain) {
 
   Module._cache[filename] = module;
 
-  tryModuleLoad(module, filename);
-
-  return module.exports;
-};
-
-function tryModuleLoad(module, filename) {
-  var threw = true;
+  let threw = true;
   try {
     module.load(filename);
     threw = false;
@@ -640,7 +634,9 @@ function tryModuleLoad(module, filename) {
       delete Module._cache[filename];
     }
   }
-}
+
+  return module.exports;
+};
 
 Module._resolveFilename = function(request, parent, isMain, options) {
   if (NativeModule.canBeRequiredByUsers(request)) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -85,6 +85,8 @@ const {
 
 const isWindows = process.platform === 'win32';
 
+const relativeResolveCache = Object.create(null);
+
 let requireDepth = 0;
 let statCache = new Map();
 function stat(filename) {
@@ -598,14 +600,28 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
 //    Then have it load  the file contents before returning its exports
 //    object.
 Module._load = function(request, parent, isMain) {
+  let relResolveCacheIdentifier;
   if (parent) {
     debug('Module._load REQUEST %s parent: %s', request, parent.id);
+    // Fast path for (lazy loaded) modules in the same directory. The indirect
+    // caching is required to allow cache invalidation without changing the old
+    // cache key names.
+    relResolveCacheIdentifier = `${parent.path}\x00${request}`;
+    const filename = relativeResolveCache[relResolveCacheIdentifier];
+    if (filename !== undefined) {
+      const cachedModule = Module._cache[filename];
+      if (cachedModule !== undefined) {
+        updateChildren(parent, cachedModule, true);
+        return cachedModule.exports;
+      }
+      delete relativeResolveCache[relResolveCacheIdentifier];
+    }
   }
 
   const filename = Module._resolveFilename(request, parent, isMain);
 
   const cachedModule = Module._cache[filename];
-  if (cachedModule) {
+  if (cachedModule !== undefined) {
     updateChildren(parent, cachedModule, true);
     return cachedModule.exports;
   }
@@ -625,6 +641,9 @@ Module._load = function(request, parent, isMain) {
   }
 
   Module._cache[filename] = module;
+  if (parent !== undefined) {
+    relativeResolveCache[relResolveCacheIdentifier] = filename;
+  }
 
   let threw = true;
   try {
@@ -633,6 +652,9 @@ Module._load = function(request, parent, isMain) {
   } finally {
     if (threw) {
       delete Module._cache[filename];
+      if (parent !== undefined) {
+        delete relativeResolveCache[relResolveCacheIdentifier];
+      }
     }
   }
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -103,8 +103,9 @@ function updateChildren(parent, child, scan) {
     children.push(child);
 }
 
-function Module(id, parent) {
+function Module(id = '', parent) {
   this.id = id;
+  this.path = path.dirname(id);
   this.exports = {};
   this.parent = parent;
   updateChildren(parent, this, false);

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -16,4 +16,3 @@ AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
     at *
     at *
     at *
-    at *

--- a/test/message/console.out
+++ b/test/message/console.out
@@ -7,4 +7,3 @@ Trace: foo
     at *
     at *
     at *
-    at *

--- a/test/message/core_line_numbers.out
+++ b/test/message/core_line_numbers.out
@@ -9,7 +9,6 @@ RangeError: Invalid input
     at Module._compile (internal/modules/cjs/loader.js:*:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*:*)
     at Module.load (internal/modules/cjs/loader.js:*:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at internal/main/run_main_module.js:*:*

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -11,7 +11,6 @@ AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
     at Module._compile (internal/modules/cjs/loader.js:*:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*:*)
     at Module.load (internal/modules/cjs/loader.js:*:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at internal/main/run_main_module.js:*:*

--- a/test/message/events_unhandled_error_common_trace.out
+++ b/test/message/events_unhandled_error_common_trace.out
@@ -9,7 +9,6 @@ Error: foo:bar
     at Module._compile (internal/modules/cjs/loader.js:*:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*:*)
     at Module.load (internal/modules/cjs/loader.js:*:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at internal/main/run_main_module.js:*:*

--- a/test/message/events_unhandled_error_nexttick.out
+++ b/test/message/events_unhandled_error_nexttick.out
@@ -7,7 +7,6 @@ Error
     at Module._compile (internal/modules/cjs/loader.js:*:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*:*)
     at Module.load (internal/modules/cjs/loader.js:*:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at internal/main/run_main_module.js:*:*

--- a/test/message/events_unhandled_error_sameline.out
+++ b/test/message/events_unhandled_error_sameline.out
@@ -7,7 +7,6 @@ Error
     at Module._compile (internal/modules/cjs/loader.js:*:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*:*)
     at Module.load (internal/modules/cjs/loader.js:*:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at internal/main/run_main_module.js:*:*

--- a/test/message/if-error-has-good-stack.out
+++ b/test/message/if-error-has-good-stack.out
@@ -14,6 +14,6 @@ AssertionError [ERR_ASSERTION]: ifError got unwanted exception: test error
     at Module._compile (internal/modules/cjs/loader.js:*:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*:*)
     at Module.load (internal/modules/cjs/loader.js:*:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
+    at internal/main/run_main_module.js:*:*

--- a/test/message/undefined_reference_in_new_context.out
+++ b/test/message/undefined_reference_in_new_context.out
@@ -12,5 +12,5 @@ ReferenceError: foo is not defined
     at Module._compile (internal/modules/cjs/loader.js:*)
     at *..js (internal/modules/cjs/loader.js:*)
     at Module.load (internal/modules/cjs/loader.js:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*:*)
+    at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)

--- a/test/message/unhandled_promise_trace_warnings.out
+++ b/test/message/unhandled_promise_trace_warnings.out
@@ -12,10 +12,8 @@
     at *
     at *
     at *
-    at *
 (node:*) Error: This was rejected
     at * (*test*message*unhandled_promise_trace_warnings.js:*)
-    at *
     at *
     at *
     at *

--- a/test/message/util_inspect_error.out
+++ b/test/message/util_inspect_error.out
@@ -8,13 +8,11 @@
        at *
        at *
        at *
-       at *
   nested:
    { err:
       Error: foo
       bar
           at *util_inspect_error*
-          at *
           at *
           at *
           at *
@@ -31,12 +29,10 @@
       at *
       at *
       at *
-      at *
   nested: {
     err: Error: foo
     bar
         at *util_inspect_error*
-        at *
         at *
         at *
         at *
@@ -48,7 +44,6 @@
 { Error: foo
 bar
     at *util_inspect_error*
-    at *
     at *
     at *
     at *

--- a/test/message/vm_display_runtime_error.out
+++ b/test/message/vm_display_runtime_error.out
@@ -11,9 +11,9 @@ Error: boo!
     at Module._compile (internal/modules/cjs/loader.js:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*)
     at Module.load (internal/modules/cjs/loader.js:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*)
+    at internal/main/run_main_module.js:*:*
 test.vm:1
 throw new Error("spooky!")
 ^
@@ -26,6 +26,6 @@ Error: spooky!
     at Module._compile (internal/modules/cjs/loader.js:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*)
     at Module.load (internal/modules/cjs/loader.js:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*)
+    at internal/main/run_main_module.js:*:*

--- a/test/message/vm_display_syntax_error.out
+++ b/test/message/vm_display_syntax_error.out
@@ -10,9 +10,9 @@ SyntaxError: Unexpected number
     at Module._compile (internal/modules/cjs/loader.js:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*)
     at Module.load (internal/modules/cjs/loader.js:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*)
+    at internal/main/run_main_module.js:*:*
 test.vm:1
 var 5;
     ^
@@ -24,6 +24,6 @@ SyntaxError: Unexpected number
     at Module._compile (internal/modules/cjs/loader.js:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*)
     at Module.load (internal/modules/cjs/loader.js:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*)
+    at internal/main/run_main_module.js:*:*

--- a/test/message/vm_dont_display_runtime_error.out
+++ b/test/message/vm_dont_display_runtime_error.out
@@ -12,6 +12,6 @@ Error: boo!
     at Module._compile (internal/modules/cjs/loader.js:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*)
     at Module.load (internal/modules/cjs/loader.js:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*)
+    at internal/main/run_main_module.js:*:*

--- a/test/message/vm_dont_display_syntax_error.out
+++ b/test/message/vm_dont_display_syntax_error.out
@@ -12,6 +12,7 @@ SyntaxError: Unexpected number
     at Module._compile (internal/modules/cjs/loader.js:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*)
     at Module.load (internal/modules/cjs/loader.js:*)
-    at tryModuleLoad (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*)
+    at internal/main/run_main_module.js:*:*
+


### PR DESCRIPTION
This is a significant performance boost for require in case a module is loaded more than once. This came up as a botteneck for @jasnell and @mcollina as far as I know.

It is now possible to use require lazily without sacrificing much performance. Loading files with relative paths is now up to 4-5x faster when loaded frequently!

Loading relative or absolute paths now has the same performance profile. The native startup will likely not be impacted.

I introduced a new cache which sits on top of the former main cache and caches the filename of already loaded modules. This is then used to check for lazy require calls and for identical require calls from different files in the same directory.

Refs: #25362

Benchmark: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/311/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
