### PR TITLE
module: mark DEP0019 as End-of-Life

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -442,6 +442,9 @@ code.
 ### DEP0019: require('.') resolved outside directory
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Removed functionality.
   - version:
     - v4.8.6
     - v6.12.0
@@ -452,11 +455,10 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-In certain cases, `require('.')` may resolve outside the package directory.
-This behavior is deprecated and will be removed in a future major Node.js
-release.
+In certain cases, `require('.')` could resolve outside the package directory.
+This behavior has been removed.
 
 <a id="DEP0020"></a>
 ### DEP0020: Server.connections

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -77,7 +77,6 @@ const {
   CHAR_FORWARD_SLASH,
   CHAR_BACKWARD_SLASH,
   CHAR_COLON,
-  CHAR_DOT,
   CHAR_UNDERSCORE,
   CHAR_0,
   CHAR_9,
@@ -382,18 +381,6 @@ Module._findPath = function(request, paths, isMain) {
     }
 
     if (filename) {
-      // Warn once if '.' resolved outside the module dir
-      if (request === '.' && i > 0) {
-        if (!warned) {
-          warned = true;
-          process.emitWarning(
-            'warning: require(\'.\') resolved outside the package ' +
-            'directory. This functionality is deprecated and will be removed ' +
-            'soon.',
-            'DeprecationWarning', 'DEP0019');
-        }
-      }
-
       Module._pathCache[cacheKey] = filename;
       return filename;
     }
@@ -497,35 +484,23 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
     return (newReturn ? null : [request, []]);
   }
 
-  // Check for non-relative path
-  if (request.length < 2 ||
-      request.charCodeAt(0) !== CHAR_DOT ||
-      (request.charCodeAt(1) !== CHAR_DOT &&
-       request.charCodeAt(1) !== CHAR_FORWARD_SLASH &&
-       (!isWindows || request.charCodeAt(1) !== CHAR_BACKWARD_SLASH))) {
-    var paths = modulePaths;
-    if (parent) {
-      if (!parent.paths)
-        paths = parent.paths = [];
-      else
-        paths = parent.paths.concat(paths);
-    }
+  // Check for node modules paths.
+  if (request.charAt(0) !== '.' ||
+      (request.length > 1 &&
+      request.charAt(1) !== '.' &&
+      request.charAt(1) !== '/' &&
+      (!isWindows || request.charAt(1) !== '\\'))) {
 
-    // Maintain backwards compat with certain broken uses of require('.')
-    // by putting the module's directory in front of the lookup paths.
-    if (request === '.') {
-      if (parent && parent.filename) {
-        paths.unshift(path.dirname(parent.filename));
-      } else {
-        paths.unshift(path.resolve(request));
-      }
+    let paths = modulePaths;
+    if (parent != null && parent.paths && parent.paths.length) {
+      paths = parent.paths.concat(paths);
     }
 
     debug('looking for %j in %j', request, paths);
     return (newReturn ? (paths.length > 0 ? paths : null) : [request, paths]);
   }
 
-  // with --eval, parent.id is not set and parent.filename is null
+  // With --eval, parent.id is not set and parent.filename is null.
   if (!parent || !parent.id || !parent.filename) {
     // Make require('./path/to/foo') work - normally the path is taken
     // from realpath(__filename) but with eval there is no filename

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -312,7 +312,6 @@ function findLongestRegisteredExtension(filename) {
   return '.js';
 }
 
-var warned = false;
 Module._findPath = function(request, paths, isMain) {
   if (path.isAbsolute(request)) {
     paths = [''];

--- a/test/parallel/test-require-dot.js
+++ b/test/parallel/test-require-dot.js
@@ -14,9 +14,10 @@ assert.strictEqual(a, b);
 process.env.NODE_PATH = fixtures.path('module-require', 'relative');
 m._initPaths();
 
-const c = require('.');
-assert.strictEqual(
-  c.value,
-  42,
-  `require(".") should honor NODE_PATH; expected 42, found ${c.value}`
+assert.throws(
+  () => require('.'),
+  {
+    message: /Cannot find module '\.'/,
+    code: 'MODULE_NOT_FOUND'
+  }
 );


### PR DESCRIPTION
In certain cases, `require('.')` could resolve outside the package
directory. This behavior has been removed.

This was already removed in version 9 (#3384) but the code to remove it contained a bug and it was therefore reverted at that point of time.

Refs: #3384

CITGM: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1788/ :heavy_check_mark: 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
