### PR TITLE
module: simpler esm loading

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -62,13 +62,6 @@ let asyncESM;
 let ModuleJob;
 let createDynamicModule;
 
-function lazyLoadESM() {
-  asyncESM = require('internal/process/esm_loader');
-  ModuleJob = require('internal/modules/esm/module_job');
-  createDynamicModule = require(
-    'internal/modules/esm/create_dynamic_module');
-}
-
 const {
   CHAR_UPPERCASE_A,
   CHAR_LOWERCASE_A,
@@ -705,7 +698,6 @@ Module.prototype.load = function(filename) {
   this.loaded = true;
 
   if (experimentalModules) {
-    if (asyncESM === undefined) lazyLoadESM();
     const ESMLoader = asyncESM.ESMLoader;
     const url = `${pathToFileURL(filename)}`;
     const module = ESMLoader.moduleMap.get(url);
@@ -772,7 +764,6 @@ Module.prototype._compile = function(content, filename) {
       lineOffset: 0,
       displayErrors: true,
       importModuleDynamically: experimentalModules ? async (specifier) => {
-        if (asyncESM === undefined) lazyLoadESM();
         const loader = await asyncESM.loaderPromise;
         return loader.import(specifier, normalizeReferrerURL(filename));
       } : undefined,
@@ -799,7 +790,6 @@ Module.prototype._compile = function(content, filename) {
       const { callbackMap } = internalBinding('module_wrap');
       callbackMap.set(compiledWrapper, {
         importModuleDynamically: async (specifier) => {
-          if (asyncESM === undefined) lazyLoadESM();
           const loader = await asyncESM.loaderPromise;
           return loader.import(specifier, normalizeReferrerURL(filename));
         }
@@ -879,7 +869,6 @@ Module._extensions['.node'] = function(module, filename) {
 };
 
 if (experimentalModules) {
-  if (asyncESM === undefined) lazyLoadESM();
   Module._extensions['.mjs'] = function(module, filename) {
     throw new ERR_REQUIRE_ESM(filename);
   };
@@ -889,7 +878,6 @@ if (experimentalModules) {
 Module.runMain = function() {
   // Load the main module--the command line argument.
   if (experimentalModules) {
-    if (asyncESM === undefined) lazyLoadESM();
     asyncESM.loaderPromise.then((loader) => {
       return loader.import(pathToFileURL(process.argv[1]).pathname);
     })
@@ -974,3 +962,11 @@ Module._initPaths();
 
 // Backwards compatibility
 Module.Module = Module;
+
+// We have to load the esm things after module.exports!
+if (experimentalModules) {
+  asyncESM = require('internal/process/esm_loader');
+  ModuleJob = require('internal/modules/esm/module_job');
+  createDynamicModule = require(
+    'internal/modules/esm/create_dynamic_module');
+}


### PR DESCRIPTION
This simplifies loading the experimental modules. Instead of always
checking for them we should eagerly load the functions in case the
experimental modules flag is passed through.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
