### PR TITLE
module: remove dead code

### DIFF
--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -23,7 +23,7 @@ function makeRequireFunction(mod) {
 
   function paths(request) {
     validateString(request, 'request');
-    return Module._resolveLookupPaths(request, mod, true);
+    return Module._resolveLookupPaths(request, mod);
   }
 
   resolve.paths = paths;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -63,16 +63,9 @@ let ModuleJob;
 let createDynamicModule;
 
 const {
-  CHAR_UPPERCASE_A,
-  CHAR_LOWERCASE_A,
-  CHAR_UPPERCASE_Z,
-  CHAR_LOWERCASE_Z,
   CHAR_FORWARD_SLASH,
   CHAR_BACKWARD_SLASH,
-  CHAR_COLON,
-  CHAR_UNDERSCORE,
-  CHAR_0,
-  CHAR_9,
+  CHAR_COLON
 } = require('internal/constants');
 
 const isWindows = process.platform === 'win32';
@@ -466,14 +459,10 @@ if (isWindows) {
   };
 }
 
-
-// 'index.' character codes
-const indexChars = [ 105, 110, 100, 101, 120, 46 ];
-const indexLen = indexChars.length;
-Module._resolveLookupPaths = function(request, parent, newReturn) {
+Module._resolveLookupPaths = function(request, parent) {
   if (NativeModule.canBeRequiredByUsers(request)) {
     debug('looking for %j in []', request);
-    return (newReturn ? null : [request, []]);
+    return null;
   }
 
   // Check for node modules paths.
@@ -489,71 +478,24 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
     }
 
     debug('looking for %j in %j', request, paths);
-    return (newReturn ? (paths.length > 0 ? paths : null) : [request, paths]);
+    return paths.length > 0 ? paths : null;
   }
 
   // With --eval, parent.id is not set and parent.filename is null.
   if (!parent || !parent.id || !parent.filename) {
     // Make require('./path/to/foo') work - normally the path is taken
     // from realpath(__filename) but with eval there is no filename
-    var mainPaths = ['.'].concat(Module._nodeModulePaths('.'), modulePaths);
+    const mainPaths = ['.'].concat(Module._nodeModulePaths('.'), modulePaths);
 
     debug('looking for %j in %j', request, mainPaths);
-    return (newReturn ? mainPaths : [request, mainPaths]);
+    return mainPaths;
   }
 
-  // Is the parent an index module?
-  // We can assume the parent has a valid extension,
-  // as it already has been accepted as a module.
-  const base = path.basename(parent.filename);
-  var parentIdPath;
-  if (base.length > indexLen) {
-    var i = 0;
-    for (; i < indexLen; ++i) {
-      if (indexChars[i] !== base.charCodeAt(i))
-        break;
-    }
-    if (i === indexLen) {
-      // We matched 'index.', let's validate the rest
-      for (; i < base.length; ++i) {
-        const code = base.charCodeAt(i);
-        if (code !== CHAR_UNDERSCORE &&
-            (code < CHAR_0 || code > CHAR_9) &&
-            (code < CHAR_UPPERCASE_A || code > CHAR_UPPERCASE_Z) &&
-            (code < CHAR_LOWERCASE_A || code > CHAR_LOWERCASE_Z))
-          break;
-      }
-      if (i === base.length) {
-        // Is an index module
-        parentIdPath = parent.id;
-      } else {
-        // Not an index module
-        parentIdPath = path.dirname(parent.id);
-      }
-    } else {
-      // Not an index module
-      parentIdPath = path.dirname(parent.id);
-    }
-  } else {
-    // Not an index module
-    parentIdPath = path.dirname(parent.id);
-  }
-  var id = path.resolve(parentIdPath, request);
-
-  // Make sure require('./path') and require('path') get distinct ids, even
-  // when called from the toplevel js file
-  if (parentIdPath === '.' &&
-      id.indexOf('/') === -1 &&
-      (!isWindows || id.indexOf('\\') === -1)) {
-    id = './' + id;
-  }
-
-  debug('RELATIVE: requested: %s set ID to: %s from %s', request, id,
-        parent.id);
+  debug('RELATIVE: requested: %s from parent.id %s', request, parent.id);
 
   const parentDir = [path.dirname(parent.filename)];
-  debug('looking for %j in %j', id, parentDir);
-  return (newReturn ? parentDir : [id, parentDir]);
+  debug('looking for %j', parentDir);
+  return parentDir;
 };
 
 // Check the cache for the requested file.
@@ -625,7 +567,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
     for (var i = 0; i < options.paths.length; i++) {
       const path = options.paths[i];
       fakeParent.paths = Module._nodeModulePaths(path);
-      const lookupPaths = Module._resolveLookupPaths(request, fakeParent, true);
+      const lookupPaths = Module._resolveLookupPaths(request, fakeParent);
 
       for (var j = 0; j < lookupPaths.length; j++) {
         if (!paths.includes(lookupPaths[j]))
@@ -633,7 +575,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
       }
     }
   } else {
-    paths = Module._resolveLookupPaths(request, parent, true);
+    paths = Module._resolveLookupPaths(request, parent);
   }
 
   // Look up the filename first, since that's the cache key.

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -855,8 +855,7 @@ REPLServer.prototype.createContext = function() {
   }
 
   const module = new CJSModule('<repl>');
-  module.paths =
-    CJSModule._resolveLookupPaths('<repl>', parentModule, true) || [];
+  module.paths = CJSModule._resolveLookupPaths('<repl>', parentModule) || [];
 
   Object.defineProperty(context, 'module', {
     configurable: true,

--- a/test/parallel/test-module-relative-lookup.js
+++ b/test/parallel/test-module-relative-lookup.js
@@ -10,12 +10,11 @@ function testFirstInPath(moduleName, isLocalModule) {
     assert.strictEqual :
     assert.notStrictEqual;
 
-  const lookupResults = _module._resolveLookupPaths(moduleName);
+  let paths = _module._resolveLookupPaths(moduleName);
 
-  let paths = lookupResults[1];
   assertFunction(paths[0], '.');
 
-  paths = _module._resolveLookupPaths(moduleName, null, true);
+  paths = _module._resolveLookupPaths(moduleName, null);
   assertFunction(paths && paths[0], '.');
 }
 


### PR DESCRIPTION
This removes a lot of code that has no functionality anymore. All
Node.js internal code calls `_resolveLookupPaths` with two arguments.

The code that validates `index.js` is not required at all as we check
for these files anyway, so it's just redundant code that should be
removed.

I defensively marked this as semver-major even though I did not find any usage of the third argument outside of Node.js and that would only be an issue if that part was monkey patched.

Refs: #25362

@nodejs/modules PTAL

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
