### PR TITLE
src: remove header unneeded by OpenSSL 1.1.1

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -44,8 +44,6 @@
 #endif  // !OPENSSL_NO_ENGINE
 #include <openssl/err.h>
 #include <openssl/evp.h>
-// TODO(shigeki) Remove this after upgrading to 1.1.1
-#include <openssl/obj_mac.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
