### PR TITLE
stream: make async iteration stable

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -312,9 +312,13 @@ The `rl.write()` method will write the data to the `readline` `Interface`'s
 ### rl\[Symbol.asyncIterator\]()
 <!-- YAML
 added: v11.4.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26989
+    description: AsyncIterator support is not experimental anymore.
 -->
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 * Returns: {AsyncIterator}
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1270,9 +1270,13 @@ myReader.on('readable', () => {
 ##### readable\[Symbol.asyncIterator\]()
 <!-- YAML
 added: v10.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/26989
+    description: AsyncIterator support is not experimental anymore.
 -->
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 * Returns: {AsyncIterator} to fully consume the stream.
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -45,7 +45,6 @@ const {
   ERR_METHOD_NOT_IMPLEMENTED,
   ERR_STREAM_UNSHIFT_AFTER_END_EVENT
 } = require('internal/errors').codes;
-const { emitExperimentalWarning } = require('internal/util');
 
 // Lazy loaded to improve the startup performance.
 let StringDecoder;
@@ -1036,7 +1035,6 @@ Readable.prototype.wrap = function(stream) {
 };
 
 Readable.prototype[Symbol.asyncIterator] = function() {
-  emitExperimentalWarning('Readable[Symbol.asyncIterator]');
   if (createReadableStreamAsyncIterator === undefined) {
     createReadableStreamAsyncIterator =
       require('internal/streams/async_iterator');

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -33,7 +33,6 @@ const {
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
 const { inspect } = require('internal/util/inspect');
-const { emitExperimentalWarning } = require('internal/util');
 const EventEmitter = require('events');
 const {
   CSI,
@@ -1068,8 +1067,6 @@ Interface.prototype._ttyWrite = function(s, key) {
 };
 
 Interface.prototype[Symbol.asyncIterator] = function() {
-  emitExperimentalWarning('readline Interface [Symbol.asyncIterator]');
-
   if (this[kLineObjectStream] === undefined) {
     if (Readable === undefined) {
       Readable = require('stream').Readable;


### PR DESCRIPTION
I think it's about time we make `Readable` async iteration stable.
It has been around for a while - we have fixed a bunch of bugs so far, and I expect there will still be some. I do not expect major changes.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
