### PR TITLE
build: move doc tests to separate Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ language: cpp
 cache: ccache
 os: linux
 dist: xenial
+stages:
+  - check
+  - test
 matrix:
   include:
     - name: "First commit message adheres to guidelines at <a href=\"https://goo.gl/p2fr5Q\">https://goo.gl/p2fr5Q</a>"
+      stage: check
       if: type = pull_request
       language: node_js
       node_js: "node"
@@ -13,11 +17,13 @@ matrix:
             bash -x tools/lint-pr-commit-message.sh ${TRAVIS_PULL_REQUEST};
           fi
     - name: "Linter"
+      stage: check
       language: node_js
       node_js: "node"
       script:
         - NODE=$(which node) make lint
     - name: "Documentation"
+      stage: check
       addons:
         apt:
           sources:
@@ -31,6 +37,7 @@ matrix:
       script:
         - make test-doc
     - name: "Test Suite"
+      stage: test
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,21 @@ matrix:
     - name: "Linter"
       language: node_js
       node_js: "node"
-      env:
-        - NODE=$(which node)
       script:
-        - make lint
+        - NODE=$(which node) make lint
+    - name: "Documentation"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      install:
+        - export CC='ccache gcc-6' CXX='ccache g++-6' JOBS=2
+        - ./configure
+        - make -j2 V=
+      script:
+        - make test-doc
     - name: "Test Suite"
       addons:
         apt:
@@ -31,4 +42,4 @@ matrix:
         - ./configure
         - make -j2 V=
       script:
-        - PARALLEL_ARGS='--flaky-tests=skip' make -j1 test
+        - PARALLEL_ARGS='--flaky-tests=skip' make -j1 test-only


### PR DESCRIPTION
Move the doc tests to a separate Travis job to reduce the overall time for the `Test Suite` job. This should (hopefully) bring the time for the `Test Suite` job back under the 50 minute time limit Travis imposes.

The `test` target currently differs from `test-only` in that `test-only` doesn't run `test-docs`: https://github.com/nodejs/node/blob/415a825dc0f53710394d51482ff9b7b65473d5e2/Makefile#L288-L296

https://github.com/nodejs/node/blob/415a825dc0f53710394d51482ff9b7b65473d5e2/Makefile#L298-L304

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
