### PR TITLE
test: make test-cli-node-options more robust

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -24,8 +24,6 @@ test-worker-memory: PASS,FLAKY
 [$system==macos]
 
 [$arch==arm || $arch==arm64]
-# https://github.com/nodejs/node/issues/25028
-test-cli-node-options: PASS,FLAKY
 
 [$system==solaris] # Also applies to SmartOS
 


### PR DESCRIPTION
The test launches over 20 processes asynchronously. That may be too many
for underpowered machines in CI with limited PID space.

Fixes: https://github.com/nodejs/node/issues/25028

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
