### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ language: cpp
 cache: ccache
 os: linux
 dist: xenial
+stages:
+  - check
+  - test
 matrix:
   include:
     - name: "First commit message adheres to guidelines at <a href=\"https://goo.gl/p2fr5Q\">https://goo.gl/p2fr5Q</a>"
+      stage: check
       if: type = pull_request
       language: node_js
       node_js: "node"
@@ -13,13 +17,27 @@ matrix:
             bash -x tools/lint-pr-commit-message.sh ${TRAVIS_PULL_REQUEST};
           fi
     - name: "Linter"
+      stage: check
       language: node_js
       node_js: "node"
-      env:
-        - NODE=$(which node)
       script:
-        - make lint
+        - NODE=$(which node) make lint
+    - name: "Prepare ccache"
+      stage: check
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      install:
+        - export CC='ccache gcc-6' CXX='ccache g++-6' JOBS=2
+        - ./configure
+        - make -j2 V=
+      script:
+        - true
     - name: "Test Suite"
+      stage: test
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ matrix:
         - ./configure
         - make -j2 V=
       script:
-        - PARALLEL_ARGS='--flaky-tests=skip' make -j1 test
+        - CI_JS_SUITES='--flaky-tests=skip default' make -j1 test


### PR DESCRIPTION
Supersedes https://github.com/nodejs/node/pull/26992 and incorporates https://github.com/nodejs/node/pull/26968.

First commit:
```
build: add a `Prepare ccache` job in Travis

Combined compile and test of Node.js where lots of files need to be
compiled (e.g. after a V8 update) is exceeding the time limit for
Travis jobs (50 minutes).

Add a job to Travis that compiles Node.js but doesnt run any tests to
populate the ccache. Introduce staging and move the `Test Suite` job
into a later stage so that it can use the populated ccache.
```

Second commit:
```
build: fix skipping of flaky tests on Travis

`PARALLEL_ARGS` is overwritten in the Makefile if `JOBS` is set. Use
`CI_JS_SUITES` instead.
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
