### PR TITLE
finish test coverage for lib/internal/dns/utils.js

### DIFF
--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -65,8 +65,7 @@ class Resolver {
 
         if (ipVersion !== 0) {
           const port =
-            parseInt(serv.replace(addrSplitRE, '$2')) ||
-            IANA_DNS_PORT;
+            parseInt(serv.replace(addrSplitRE, '$2')) || IANA_DNS_PORT;
           return newSet.push([ipVersion, match[1], port]);
         }
       }
@@ -103,18 +102,18 @@ let defaultResolver = new Resolver();
 const resolverKeys = [
   'getServers',
   'resolve',
-  'resolveAny',
   'resolve4',
   'resolve6',
+  'resolveAny',
   'resolveCname',
   'resolveMx',
-  'resolveNs',
-  'resolveTxt',
-  'resolveSrv',
-  'resolvePtr',
   'resolveNaptr',
+  'resolveNs',
+  'resolvePtr',
   'resolveSoa',
-  'reverse'
+  'resolveSrv',
+  'resolveTxt',
+  'reverse',
 ];
 
 function getDefaultResolver() {

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -121,13 +121,15 @@ const ports = [
   '4.4.4.4:53',
   '[2001:4860:4860::8888]:53',
   '103.238.225.181:666',
-  '[fe80::483a:5aff:fee6:1f04]:666'
+  '[fe80::483a:5aff:fee6:1f04]:666',
+  '[fe80::483a:5aff:fee6:1f04]',
 ];
 const portsExpected = [
   '4.4.4.4',
   '2001:4860:4860::8888',
   '103.238.225.181:666',
-  '[fe80::483a:5aff:fee6:1f04]:666'
+  '[fe80::483a:5aff:fee6:1f04]:666',
+  'fe80::483a:5aff:fee6:1f04',
 ];
 dns.setServers(ports);
 assert.deepStrictEqual(dns.getServers(), portsExpected);


### PR DESCRIPTION
Add coverage to achieve 100% code coverage in tests for `lib/internal/dns/utils.js`.

First commit:     

    dns: refactor lib/internal/dns/utils.js
    
    * alphabetize contenst of `resolverKeys` array
    * less line-wrapping for increased code clarity

Second commit:

    test: add IPv6 brackets but no port to test-dns
    
    Add a test case to test-dns to check that supply an IPv6 host with
    brackets but no explicit port to `dns.setServers()` yields expected
    results. This is the final bit of test coverage missing for
    lib/internal/dns/utils.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
