### PR TITLE
tools: fix `test.py --time`

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1511,7 +1511,7 @@ def FormatTime(d):
 
 
 def FormatTimedelta(td):
-  if hasattr(td.total, 'total_seconds'):
+  if hasattr(td, 'total_seconds'):
     d = td.total_seconds()
   else: # python2.6 compat
     d =  td.seconds + (td.microseconds / 10.0**6)


### PR DESCRIPTION
Before:
```console
-bash-4.2$ ./tools/test.py --time doctool
[00:02|% 100|+   4|-   0]: Done

--- Total time: 00:02.770 ---
Traceback (most recent call last):
  File "./tools/test.py", line 1765, in <module>
    sys.exit(Main())
  File "./tools/test.py", line 1758, in Main
    t = FormatTimedelta(entry.duration)
  File "./tools/test.py", line 1514, in FormatTimedelta
    if hasattr(td.total, 'total_seconds'):
AttributeError: 'datetime.timedelta' object has no attribute 'total'
-bash-4.2$
```

After:
```console
-bash-4.2$ ./tools/test.py --time doctool
[00:02|% 100|+   4|-   0]: Done

--- Total time: 00:02.905 ---
   1 (00:01.612) release test-apilinks
   2 (00:00.710) release test-doctool-html
   3 (00:00.411) release test-doctool-json
   4 (00:00.171) release test-make-doc
-bash-4.2$
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
