### PR TITLE
crypto: fail early if passphrase is too long

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1822,7 +1822,7 @@ string or `Buffer`, `format` is assumed to be `'pem'`; otherwise, `key`
 must be an object with the properties described above.
 
 If the private key is encrypted, a `passphrase` must be specified. The length
-of the passphrase is limited.
+of the passphrase is limited to 1024 bytes.
 
 ### crypto.createPublicKey(key)
 <!-- YAML

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1821,6 +1821,9 @@ Creates and returns a new key object containing a private key. If `key` is a
 string or `Buffer`, `format` is assumed to be `'pem'`; otherwise, `key`
 must be an object with the properties described above.
 
+If the private key is encrypted, a `passphrase` must be specified. The length
+of the passphrase is limited.
+
 ### crypto.createPublicKey(key)
 <!-- YAML
 added: v11.6.0

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -178,7 +178,8 @@ static int PasswordCallback(char* buf, int size, int rwflag, void* u) {
   if (passphrase != nullptr) {
     size_t buflen = static_cast<size_t>(size);
     size_t len = strlen(passphrase);
-    len = len > buflen ? buflen : len;
+    if (buflen <= len)
+      return -1;
     memcpy(buf, passphrase, len);
     return len;
   }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -178,7 +178,7 @@ static int PasswordCallback(char* buf, int size, int rwflag, void* u) {
   if (passphrase != nullptr) {
     size_t buflen = static_cast<size_t>(size);
     size_t len = strlen(passphrase);
-    if (buflen <= len)
+    if (buflen < len)
       return -1;
     memcpy(buf, passphrase, len);
     return len;

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -228,10 +228,20 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   common.expectsError(() => createPrivateKey({
     key: privateDsa,
     format: 'pem',
-    passphrase: Buffer.alloc(16 * 1024, 'a')
+    passphrase: Buffer.alloc(1025, 'a')
   }), {
     code: 'ERR_OSSL_PEM_BAD_PASSWORD_READ',
     type: Error
+  });
+
+  // The buffer has a size of 1024 bytes, so this passphrase should be permitted
+  // (but will fail decryption).
+  common.expectsError(() => createPrivateKey({
+    key: privateDsa,
+    format: 'pem',
+    passphrase: Buffer.alloc(1024, 'a')
+  }), {
+    message: /bad decrypt/
   });
 
   const publicKey = createPublicKey(publicDsa);

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -223,6 +223,17 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
     message: 'Passphrase required for encrypted key'
   });
 
+  // Reading an encrypted key with a passphrase that exceeds OpenSSL's buffer
+  // size limit should fail with an appropriate error code.
+  common.expectsError(() => createPrivateKey({
+    key: privateDsa,
+    format: 'pem',
+    passphrase: Buffer.alloc(16 * 1024, 'a')
+  }), {
+    code: 'ERR_OSSL_PEM_BAD_PASSWORD_READ',
+    type: Error
+  });
+
   const publicKey = createPublicKey(publicDsa);
   assert.strictEqual(publicKey.type, 'public');
   assert.strictEqual(publicKey.asymmetricKeyType, 'dsa');


### PR DESCRIPTION
This causes OpenSSL to fail early if the decryption passphrase is too long, and produces a somewhat helpful error message. OpenSSL gives us a buffer of limited size (currently 1024 bytes), so there is no way to pass longer passphrases.

Refs: https://github.com/nodejs/node/pull/25208

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
