### PR TITLE
crypto: remove legacy native handles

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2237,18 +2237,21 @@ use the [WHATWG URL API][] instead.
 ### DEP0117: Native crypto handles
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/27011
+    description: End-of-Life.
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/22747
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
 Previous versions of Node.js exposed handles to internal native objects through
 the `_handle` property of the `Cipher`, `Decipher`, `DiffieHellman`,
 `DiffieHellmanGroup`, `ECDH`, `Hash`, `Hmac`, `Sign`, and `Verify` classes.
-Using the `_handle` property to access the native object is deprecated because
-improper use of the native object can lead to crashing the application.
+The `_handle` property has been removed because improper use of the native
+object can lead to crashing the application.
 
 <a id="DEP0118"></a>
 ### DEP0118: dns.lookup() support for a falsy hostname

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -20,7 +20,6 @@ const {
 const {
   getDefaultEncoding,
   kHandle,
-  legacyNativeHandle,
   toBuf
 } = require('internal/crypto/util');
 
@@ -219,8 +218,6 @@ Cipher.prototype.setAAD = function setAAD(aadbuf, options) {
   return this;
 };
 
-legacyNativeHandle(Cipher);
-
 function Cipheriv(cipher, key, iv, options) {
   if (!(this instanceof Cipheriv))
     return new Cipheriv(cipher, key, iv, options);
@@ -245,7 +242,6 @@ function addCipherPrototypeFunctions(constructor) {
 Object.setPrototypeOf(Cipheriv.prototype, LazyTransform.prototype);
 Object.setPrototypeOf(Cipheriv, LazyTransform);
 addCipherPrototypeFunctions(Cipheriv);
-legacyNativeHandle(Cipheriv);
 
 function Decipher(cipher, password, options) {
   if (!(this instanceof Decipher))
@@ -257,7 +253,6 @@ function Decipher(cipher, password, options) {
 Object.setPrototypeOf(Decipher.prototype, LazyTransform.prototype);
 Object.setPrototypeOf(Decipher, LazyTransform);
 addCipherPrototypeFunctions(Decipher);
-legacyNativeHandle(Decipher);
 
 
 function Decipheriv(cipher, key, iv, options) {
@@ -270,7 +265,6 @@ function Decipheriv(cipher, key, iv, options) {
 Object.setPrototypeOf(Decipheriv.prototype, LazyTransform.prototype);
 Object.setPrototypeOf(Decipheriv, LazyTransform);
 addCipherPrototypeFunctions(Decipheriv);
-legacyNativeHandle(Decipheriv);
 
 module.exports = {
   Cipher,

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -11,7 +11,6 @@ const { isArrayBufferView } = require('internal/util/types');
 const {
   getDefaultEncoding,
   kHandle,
-  legacyNativeHandle,
   toBuf
 } = require('internal/crypto/util');
 const {
@@ -165,9 +164,6 @@ DiffieHellman.prototype.setPrivateKey = function setPrivateKey(key, encoding) {
   return this;
 };
 
-legacyNativeHandle(DiffieHellman);
-legacyNativeHandle(DiffieHellmanGroup);
-
 
 function ECDH(curve) {
   if (!(this instanceof ECDH))
@@ -194,8 +190,6 @@ ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
   encoding = encoding || getDefaultEncoding();
   return encode(key, encoding);
 };
-
-legacyNativeHandle(ECDH);
 
 ECDH.convertKey = function convertKey(key, curve, inEnc, outEnc, format) {
   if (typeof key !== 'string' && !isArrayBufferView(key)) {

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -8,7 +8,6 @@ const {
 const {
   getDefaultEncoding,
   kHandle,
-  legacyNativeHandle,
   toBuf
 } = require('internal/crypto/util');
 
@@ -89,8 +88,6 @@ Hash.prototype.digest = function digest(outputEncoding) {
   return ret;
 };
 
-legacyNativeHandle(Hash);
-
 
 function Hmac(hmac, key, options) {
   if (!(this instanceof Hmac))
@@ -129,8 +126,6 @@ Hmac.prototype.digest = function digest(outputEncoding) {
 
 Hmac.prototype._flush = Hash.prototype._flush;
 Hmac.prototype._transform = Hash.prototype._transform;
-
-legacyNativeHandle(Hmac);
 
 module.exports = {
   Hash,

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -19,7 +19,6 @@ const {
 const {
   getDefaultEncoding,
   kHandle,
-  legacyNativeHandle,
   toBuf,
   validateArrayBufferView,
 } = require('internal/crypto/util');
@@ -55,8 +54,6 @@ Sign.prototype.update = function update(data, encoding) {
   this[kHandle].update(data);
   return this;
 };
-
-legacyNativeHandle(Sign);
 
 function getPadding(options) {
   return getIntOption('padding', RSA_PKCS1_PADDING, options);
@@ -165,8 +162,6 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
   return this[kHandle].verify(data, format, type, passphrase, signature,
                               rsaPadding, pssSaltLength);
 };
-
-legacyNativeHandle(Verify);
 
 function verifyOneShot(algorithm, data, key, signature) {
   if (algorithm != null)

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -30,18 +30,6 @@ const {
 
 const kHandle = Symbol('kHandle');
 
-function legacyNativeHandle(clazz) {
-  Object.defineProperty(clazz.prototype, '_handle', {
-    get: deprecate(function() { return this[kHandle]; },
-                   `${clazz.name}._handle is deprecated. Use the public API ` +
-                   'instead.', 'DEP0117'),
-    set: deprecate(function(h) { this[kHandle] = h; },
-                   `${clazz.name}._handle is deprecated. Use the public API ` +
-                   'instead.', 'DEP0117'),
-    enumerable: false
-  });
-}
-
 var defaultEncoding = 'buffer';
 
 function setDefaultEncoding(val) {
@@ -116,7 +104,6 @@ module.exports = {
   getDefaultEncoding,
   getHashes,
   kHandle,
-  legacyNativeHandle,
   setDefaultEncoding,
   setEngine,
   timingSafeEqual,

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -21,7 +21,6 @@ const { validateString } = require('internal/validators');
 const { Buffer } = require('buffer');
 const {
   cachedResult,
-  deprecate,
   filterDuplicateStrings
 } = require('internal/util');
 const {


### PR DESCRIPTION
The `_handle` property on crypto classes was runtime deprecated in node 11, this removes them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
