### PR TITLE
path: add --pending-deprecation for path._makeLong

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1625,12 +1625,15 @@ may be specified.
 ### DEP0080: path.\_makeLong()
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: ???
+    description: Added support for `--pending-deprecation`.
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/14956
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Documentation-only (supports [`--pending-deprecation`][])
 
 The internal `path._makeLong()` was not intended for public use. However,
 userland modules have found it useful. The internal API is deprecated

--- a/lib/path.js
+++ b/lib/path.js
@@ -34,6 +34,7 @@ const {
   CHAR_QUESTION_MARK,
 } = require('internal/constants');
 const { validateString } = require('internal/validators');
+const { deprecate } = require('internal/util');
 
 function isPathSeparator(code) {
   return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
@@ -1363,7 +1364,24 @@ posix.win32 = win32.win32 = win32;
 posix.posix = win32.posix = posix;
 
 // Legacy internal API, docs-only deprecated: DEP0080
-win32._makeLong = win32.toNamespacedPath;
-posix._makeLong = posix.toNamespacedPath;
+let pendingDeprecation;
+for (const obj of [posix, win32]) {
+  const deprecatedMakeLong = deprecate(obj.toNamespacedPath,
+                                       'path._makeLong is deprecated.',
+                                       'DEP0080');
+
+  Object.defineProperty(obj, '_makeLong', {
+    get() {
+      if (pendingDeprecation === undefined) {
+        const { getOptionValue } = require('internal/options');
+        pendingDeprecation = getOptionValue('--pending-deprecation');
+      }
+      return pendingDeprecation ? deprecatedMakeLong : obj.toNamespacedPath;
+    },
+    // TODO(tniessen): Change to false when DEP0080 is a runtime deprecation
+    enumerable: true,
+    configurable: true
+  });
+}
 
 module.exports = process.platform === 'win32' ? win32 : posix;

--- a/test/parallel/test-path-makelong.js
+++ b/test/parallel/test-path-makelong.js
@@ -19,11 +19,16 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// Flags: --pending-deprecation
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const path = require('path');
+
+common.expectWarning('DeprecationWarning', 'path._makeLong is deprecated.',
+                     'DEP0080');
+assert.strictEqual(path.posix._makeLong('/foo/bar'), '/foo/bar');
 
 if (common.isWindows) {
   const file = fixtures.path('a.js');


### PR DESCRIPTION
This adds support for `--pending-deprecation` to `path._makeLong`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
