### PR TITLE
test: make module test pass with NODE_PENDING_DEPRECATION

### DIFF
--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -29,7 +29,8 @@ const path = require('path');
 
 const backslash = /\\/g;
 
-process.on('warning', common.mustNotCall());
+if (!process.env.NODE_PENDING_DEPRECATION)
+  process.on('warning', common.mustNotCall());
 
 console.error('load test-module-loading.js');
 


### PR DESCRIPTION
Some people set the `NODE_PENDING_DEPRECATION` environment variable
globally. This makes the test added in 115f0f5a57f50f6b039f28a
pass when that is the case.

Refs: https://github.com/nodejs/node/pull/26823

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
