### PR TITLE
lib: make FreeList faster

### DIFF
--- a/benchmark/http/headers.js
+++ b/benchmark/http/headers.js
@@ -14,7 +14,9 @@ function main({ len, n }) {
     'Transfer-Encoding': 'chunked',
   };
 
-  const Is = [ ...Array(n / len).keys() ];
+  // TODO(BridgeAR): Change this benchmark to use grouped arguments when
+  // implemented. https://github.com/nodejs/node/issues/26425
+  const Is = [ ...Array(Math.max(n / len, 1)).keys() ];
   const Js = [ ...Array(len).keys() ];
   for (const i of Is) {
     headers[`foo${i}`] = Js.map(() => `some header value ${i}`);

--- a/benchmark/misc/freelist.js
+++ b/benchmark/misc/freelist.js
@@ -9,7 +9,9 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
-  const { FreeList } = require('internal/freelist');
+  let FreeList = require('internal/freelist');
+  if (FreeList.FreeList)
+    FreeList = FreeList.FreeList;
   const poolSize = 1000;
   const list = new FreeList('test', poolSize, Object);
   var j;

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -46,7 +46,6 @@ const {
   ERR_UNESCAPED_CHARACTERS
 } = require('internal/errors').codes;
 const { getTimerDuration } = require('internal/timers');
-const is_reused_symbol = require('internal/freelist').symbols.is_reused_symbol;
 const {
   DTRACE_HTTP_CLIENT_REQUEST,
   DTRACE_HTTP_CLIENT_RESPONSE
@@ -631,10 +630,11 @@ function emitFreeNT(socket) {
 }
 
 function tickOnSocket(req, socket) {
+  const isParserReused = parsers.hasItems();
   const parser = parsers.alloc();
   req.socket = socket;
   req.connection = socket;
-  parser.reinitialize(HTTPParser.RESPONSE, parser[is_reused_symbol]);
+  parser.reinitialize(HTTPParser.RESPONSE, isParserReused);
   parser.socket = socket;
   parser.outgoing = req;
   req.parser = parser;

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -27,7 +27,7 @@ const { methods, HTTPParser } =
   getOptionValue('--http-parser') === 'legacy' ?
     internalBinding('http_parser') : internalBinding('http_parser_llhttp');
 
-const { FreeList } = require('internal/freelist');
+const FreeList = require('internal/freelist');
 const { ondrain } = require('internal/http');
 const incoming = require('_http_incoming');
 const {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -41,7 +41,6 @@ const {
   defaultTriggerAsyncIdScope,
   getOrSetAsyncId
 } = require('internal/async_hooks');
-const is_reused_symbol = require('internal/freelist').symbols.is_reused_symbol;
 const { IncomingMessage } = require('_http_incoming');
 const {
   ERR_HTTP_HEADERS_SENT,
@@ -348,8 +347,9 @@ function connectionListenerInternal(server, socket) {
     socket.setTimeout(server.timeout);
   socket.on('timeout', socketOnTimeout);
 
+  const isParserReused = parsers.hasItems();
   const parser = parsers.alloc();
-  parser.reinitialize(HTTPParser.REQUEST, parser[is_reused_symbol]);
+  parser.reinitialize(HTTPParser.REQUEST, isParserReused);
   parser.socket = socket;
 
   // We are starting to wait for our headers.

--- a/lib/internal/freelist.js
+++ b/lib/internal/freelist.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const is_reused_symbol = Symbol('isReused');
+const { Reflect } = primordials;
 
 class FreeList {
   constructor(name, max, ctor) {
@@ -10,16 +10,14 @@ class FreeList {
     this.list = [];
   }
 
+  hasItems() {
+    return this.list.length > 0;
+  }
+
   alloc() {
-    let item;
-    if (this.list.length > 0) {
-      item = this.list.pop();
-      item[is_reused_symbol] = true;
-    } else {
-      item = this.ctor.apply(this, arguments);
-      item[is_reused_symbol] = false;
-    }
-    return item;
+    return this.list.length > 0 ?
+      this.list.pop() :
+      Reflect.apply(this.ctor, this, arguments);
   }
 
   free(obj) {
@@ -31,9 +29,4 @@ class FreeList {
   }
 }
 
-module.exports = {
-  FreeList,
-  symbols: {
-    is_reused_symbol
-  }
-};
+module.exports = FreeList;

--- a/test/parallel/test-freelist.js
+++ b/test/parallel/test-freelist.js
@@ -4,7 +4,7 @@
 
 require('../common');
 const assert = require('assert');
-const { FreeList } = require('internal/freelist');
+const FreeList = require('internal/freelist');
 
 assert.strictEqual(typeof FreeList, 'function');
 

--- a/test/sequential/test-http-regr-gh-2928.js
+++ b/test/sequential/test-http-regr-gh-2928.js
@@ -6,7 +6,6 @@
 const common = require('../common');
 const assert = require('assert');
 const httpCommon = require('_http_common');
-const is_reused_symbol = require('internal/freelist').symbols.is_reused_symbol;
 const { HTTPParser } = require('_http_common');
 const net = require('net');
 
@@ -25,7 +24,7 @@ function execAndClose() {
   process.stdout.write('.');
 
   const parser = parsers.pop();
-  parser.reinitialize(HTTPParser.RESPONSE, parser[is_reused_symbol]);
+  parser.reinitialize(HTTPParser.RESPONSE, !!parser.reused);
 
   const socket = net.connect(common.PORT);
   socket.on('error', (e) => {
@@ -33,6 +32,7 @@ function execAndClose() {
     // https://github.com/nodejs/node/issues/2663.
     if (common.isSunOS && e.code === 'ECONNREFUSED') {
       parsers.push(parser);
+      parser.reused = true;
       socket.destroy();
       setImmediate(execAndClose);
       return;


### PR DESCRIPTION
1st commit makes FreeList alloc faster by using `Reflect.apply` and removing `is_reused_symbol`.

2nd commit fixes a benchmark that I needed to run to confirm the results.

CI: https://ci.nodejs.org/job/node-test-pull-request/22260/
Benchmarks: https://ci.nodejs.org/job/benchmark-node-micro-benchmarks/312/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
