### PR TITLE
report: add cwd to report

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -28,6 +28,7 @@ is provided below for reference.
     "dumpEventTime": "2018-12-21T00:50:11Z",
     "dumpEventTimeStamp": "1545371411331",
     "processId": 8974,
+    "cwd": "/home/nodeuser/project/node",
     "commandLine": [
       "/home/nodeuser/project/node/out/Release/node",
       "--experimental-report",

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -63,7 +63,7 @@ function _validateContent(data) {
                         'nodejsVersion', 'wordSize', 'arch', 'platform',
                         'componentVersions', 'release', 'osName', 'osRelease',
                         'osVersion', 'osMachine', 'host', 'glibcVersionRuntime',
-                        'glibcVersionCompiler'];
+                        'glibcVersionCompiler', 'cwd'];
   checkForUnknownFields(header, headerFields);
   assert.strictEqual(typeof header.event, 'string');
   assert.strictEqual(typeof header.trigger, 'string');
@@ -76,6 +76,7 @@ function _validateContent(data) {
     assert(String(+header.dumpEventTimeStamp), header.dumpEventTimeStamp);
 
   assert(Number.isSafeInteger(header.processId));
+  assert.strictEqual(typeof header.cwd, 'string');
   assert(Array.isArray(header.commandLine));
   header.commandLine.forEach((arg) => {
     assert.strictEqual(typeof arg, 'string');


### PR DESCRIPTION
The diagnostic report currently contains command line information, and the environment, which contains the `PWD` environment variable. This combination covers the majority of cases, but it would be useful to have the result of `uv_cwd()` as an additional data point. This commit adds that information.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
