### PR TITLE
build: fix inspector dependency resolution

### DIFF
--- a/src/inspector/node_inspector.gypi
+++ b/src/inspector/node_inspector.gypi
@@ -1,7 +1,6 @@
 {
   'variables': {
     'protocol_tool_path': '../../tools/inspector_protocol',
-    'node_inspector_path': '../../src/inspector',
     'node_inspector_generated_sources': [
       '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/Forward.h',
       '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/Protocol.cpp',
@@ -67,23 +66,14 @@
     '<(SHARED_INTERMEDIATE_DIR)',
     '<(SHARED_INTERMEDIATE_DIR)/src', # for inspector
   ],
-  'copies': [
-    {
-      'files': [
-        '<(node_inspector_path)/node_protocol_config.json',
-        '<(node_inspector_path)/node_protocol.pdl'
-      ],
-      'destination': '<(SHARED_INTERMEDIATE_DIR)',
-    }
-  ],
   'actions': [
     {
       'action_name': 'convert_node_protocol_to_json',
       'inputs': [
-        '<(SHARED_INTERMEDIATE_DIR)/node_protocol.pdl',
+        'node_protocol.pdl',
       ],
       'outputs': [
-        '<(SHARED_INTERMEDIATE_DIR)/node_protocol.json',
+        '<(SHARED_INTERMEDIATE_DIR)/src/node_protocol.json',
       ],
       'action': [
         'python',
@@ -95,8 +85,8 @@
     {
       'action_name': 'node_protocol_generated_sources',
       'inputs': [
-        '<(SHARED_INTERMEDIATE_DIR)/node_protocol_config.json',
-        '<(SHARED_INTERMEDIATE_DIR)/node_protocol.json',
+        'node_protocol_config.json',
+        '<(SHARED_INTERMEDIATE_DIR)/src/node_protocol.json',
         '<@(node_protocol_files)',
       ],
       'outputs': [
@@ -108,7 +98,7 @@
         'tools/inspector_protocol/code_generator.py',
         '--jinja_dir', '<@(protocol_tool_path)/..',
         '--output_base', '<(SHARED_INTERMEDIATE_DIR)/src/',
-        '--config', '<(SHARED_INTERMEDIATE_DIR)/node_protocol_config.json',
+        '--config', 'src/inspector/node_protocol_config.json',
       ],
       'message': 'Generating node protocol sources from protocol json',
     },
@@ -116,7 +106,7 @@
       'action_name': 'concatenate_protocols',
       'inputs': [
         '../../deps/v8/src/inspector/js_protocol.pdl',
-        '<(SHARED_INTERMEDIATE_DIR)/node_protocol.json',
+        '<(SHARED_INTERMEDIATE_DIR)/src/node_protocol.json',
       ],
       'outputs': [
         '<(SHARED_INTERMEDIATE_DIR)/concatenated_protocol.json',

--- a/tools/inspector_protocol/code_generator.py
+++ b/tools/inspector_protocol/code_generator.py
@@ -29,9 +29,9 @@ module_path, module_filename = os.path.split(os.path.realpath(__file__))
 
 def read_config():
     # pylint: disable=W0703
-    def json_to_object(data, output_base, config_base):
+    def json_to_object(data, output_base):
         def json_object_hook(object_dict):
-            items = [(k, os.path.join(config_base, v) if k == "path" else v) for (k, v) in object_dict.items()]
+            items = [(k, os.path.join(output_base, v) if k == "path" else v) for (k, v) in object_dict.items()]
             items = [(k, os.path.join(output_base, v) if k == "output" else v) for (k, v) in items]
             keys, values = list(zip(*items))
             return collections.namedtuple('X', keys)(*values)
@@ -71,7 +71,6 @@ def read_config():
         if not config_file:
             raise Exception("Config file name must be specified")
         config_file = config_file.decode('utf8')
-        config_base = os.path.dirname(config_file)
         config_values = arg_options.config_value
         if not config_values:
             config_values = []
@@ -84,7 +83,7 @@ def read_config():
     try:
         config_json_file = open(config_file, "r")
         config_json_string = config_json_file.read()
-        config_partial = json_to_object(config_json_string, output_base, config_base)
+        config_partial = json_to_object(config_json_string, output_base)
         config_json_file.close()
         defaults = {
             ".use_snake_file_names": False,


### PR DESCRIPTION
It was reported that parallel builds on Windows sometimes error because
of missing intermediate files.

On closer inspection I noticed that some files are copied from src/ to
the intermediate build directory in a way where they don't participate
in dependency resolution. Put another way, the build system doesn't
know to wait for the copy to complete because we don't tell it to.

Fix that by not copying around files but instead making the script that
processes them a little smarter about where to find them and where to
store the results.

Fixes: https://github.com/nodejs/node/issues/27025
CI: https://ci.nodejs.org/job/node-test-pull-request/22050/