### PR TITLE
lib: force using primordials for JSON, Math and Reflect

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -1,6 +1,7 @@
 rules:
   prefer-object-spread: error
   no-buffer-constructor: error
+  no-restricted-globals: ["error", "JSON", "Math", "Reflect"]
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -21,6 +21,8 @@
 
 'use strict';
 
+const { Math } = primordials;
+
 const { getOptionValue } = require('internal/options');
 
 const { methods, HTTPParser } =

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Reflect } = primordials;
+
 const {
   ERR_ASYNC_CALLBACK,
   ERR_INVALID_ASYNC_ID

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -21,6 +21,8 @@
 
 'use strict';
 
+const { Math } = primordials;
+
 const {
   byteLengthUtf8,
   copy: _copy,

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -26,6 +26,8 @@
 // No new pull requests targeting this module will be accepted
 // unless they address existing, critical bugs.
 
+const { Reflect } = primordials;
+
 const util = require('util');
 const EventEmitter = require('events');
 const {

--- a/lib/events.js
+++ b/lib/events.js
@@ -21,6 +21,8 @@
 
 'use strict';
 
+const { Math, Reflect } = primordials;
+
 var spliceOne;
 
 const {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -24,6 +24,8 @@
 
 'use strict';
 
+const { Math, Reflect } = primordials;
+
 const { fs: constants } = internalBinding('constants');
 const {
   S_IFIFO,

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { JSON } = primordials;
+
 const {
   ERR_INSPECTOR_ALREADY_CONNECTED,
   ERR_INSPECTOR_CLOSED,

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Math } = primordials;
+
 const { inspect } = require('internal/util/inspect');
 const { codes: {
   ERR_INVALID_ARG_TYPE

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Reflect } = primordials;
+
 const {
   ERR_ASYNC_TYPE,
   ERR_INVALID_ASYNC_ID

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -34,9 +34,8 @@
 // This file is compiled as if it's wrapped in a function with arguments
 // passed by node::RunBootstrapping()
 /* global process, require, internalBinding, isMainThread, ownsProcessState */
-/* global primordials */
 
-const { Object, Symbol } = primordials;
+const { JSON, Object, Symbol } = primordials;
 const config = internalBinding('config');
 const { deprecate } = require('internal/util');
 

--- a/lib/internal/bootstrap/primordials.js
+++ b/lib/internal/bootstrap/primordials.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global primordials */
+/* eslint-disable no-restricted-globals */
 
 // This file subclasses and stores the JS builtins that come from the VM
 // so that Node.js's builtin modules do not need to later look these up from

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Math } = primordials;
+
 const {
   ERR_BUFFER_OUT_OF_BOUNDS,
   ERR_INVALID_ARG_TYPE,

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { JSON } = primordials;
+
 const {
   errnoException,
   codes: {

--- a/lib/internal/cli_table.js
+++ b/lib/internal/cli_table.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Math } = primordials;
+
 const { Buffer } = require('buffer');
 const { removeColors } = require('internal/util');
 const HasOwnProperty = Function.call.bind(Object.prototype.hasOwnProperty);

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -3,6 +3,8 @@
 // The Console constructor is not actually used to construct the global
 // console. It's exported for backwards compatibility.
 
+const { Reflect } = primordials;
+
 const { trace } = internalBinding('trace_events');
 const {
   isStackOverflowError,

--- a/lib/internal/console/global.js
+++ b/lib/internal/console/global.js
@@ -12,6 +12,8 @@
 // Therefore, the console.Console.prototype is not
 // in the global console prototype chain anymore.
 
+const { Reflect } = primordials;
+
 const {
   Console,
   kBindStreamsLazy,

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Math } = primordials;
+
 const { AsyncWrap, Providers } = internalBinding('async_wrap');
 const { Buffer, kMaxLength } = require('buffer');
 const { randomBytes: _randomBytes } = internalBinding('crypto');

--- a/lib/internal/freeze_intrinsics.js
+++ b/lib/internal/freeze_intrinsics.js
@@ -20,7 +20,9 @@
 // https://github.com/tc39/proposal-frozen-realms/blob/91ac390e3451da92b5c27e354b39e52b7636a437/shim/src/deep-freeze.js
 
 /* global WebAssembly, SharedArrayBuffer, console */
+/* eslint-disable no-restricted-globals */
 'use strict';
+
 module.exports = function() {
 
   const intrinsics = [

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Math } = primordials;
+
 const {
   F_OK,
   O_SYMLINK,

--- a/lib/internal/fs/read_file_context.js
+++ b/lib/internal/fs/read_file_context.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Math } = primordials;
+
 const { Buffer } = require('buffer');
 
 const { FSReqCallback, close, read } = internalBinding('fs');

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Math } = primordials;
+
 const {
   FSReqCallback,
   writeBuffers

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Reflect } = primordials;
+
 const { Buffer, kMaxLength } = require('buffer');
 const {
   codes: {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Reflect } = primordials;
+
 const assert = require('internal/assert');
 const Stream = require('stream');
 const Readable = Stream.Readable;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2,6 +2,8 @@
 
 /* eslint-disable no-use-before-define */
 
+const { Math, Reflect } = primordials;
+
 const {
   assertCrypto,
   customInspectSymbol: kInspect,

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Math } = primordials;
+
 const binding = internalBinding('http2');
 const {
   codes: {

--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint-disable no-restricted-globals */
+
 const { types } = internalBinding('options');
 const hasCrypto = Boolean(process.versions.openssl);
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -21,6 +21,8 @@
 
 'use strict';
 
+const { JSON, Reflect } = primordials;
+
 const { NativeModule } = require('internal/bootstrap/loaders');
 const { pathToFileURL } = require('internal/url');
 const { deprecate } = require('internal/util');

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { JSON } = primordials;
+
 const path = require('path');
 
 const {

--- a/lib/internal/process/policy.js
+++ b/lib/internal/process/policy.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { JSON, Reflect } = primordials;
+
 const {
   ERR_MANIFEST_TDZ,
 } = require('internal/errors').codes;

--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Reflect } = primordials;
+
 const {
   // For easy access to the nextTick state in the C++ land,
   // and to avoid unnecessary calls into JS land.

--- a/lib/internal/profiler.js
+++ b/lib/internal/profiler.js
@@ -3,6 +3,8 @@
 // Implements coverage collection exposed by the `NODE_V8_COVERAGE`
 // environment variable which can also be used in the user land.
 
+const { JSON } = primordials;
+
 let coverageDirectory;
 
 function writeCoverage() {

--- a/lib/internal/streams/state.js
+++ b/lib/internal/streams/state.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Math } = primordials;
+
 const { ERR_INVALID_OPT_VALUE } = require('internal/errors').codes;
 
 function highWaterMarkFrom(options, isDuplex, duplexKey) {

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -72,6 +72,8 @@
 // timers within (or creation of a new list). However, these operations combined
 // have shown to be trivial in comparison to other timers architectures.
 
+const { Math, Reflect } = primordials;
+
 const {
   scheduleTimer,
   toggleTimerRef,

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Reflect } = primordials;
+
 const { inspect } = require('internal/util/inspect');
 const {
   encodeStr,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Reflect } = primordials;
+
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_NO_CRYPTO,

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { JSON, Math } = primordials;
+
 const {
   getOwnNonIndexProperties,
   getPromiseDetails,

--- a/lib/internal/v8_prof_processor.js
+++ b/lib/internal/v8_prof_processor.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { JSON } = primordials;
+
 const vm = require('vm');
 
 const scriptFiles = [

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -27,6 +27,8 @@
 
 'use strict';
 
+const { Math } = primordials;
+
 const {
   ERR_INVALID_CURSOR_POS,
   ERR_INVALID_OPT_VALUE

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -42,6 +42,8 @@
 
 'use strict';
 
+const { Math } = primordials;
+
 const {
   builtinLibs,
   makeRequireFunction,

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -21,6 +21,8 @@
 
 'use strict';
 
+const { Math } = primordials;
+
 const {
   immediateInfo,
   toggleImmediateRef

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,6 +21,8 @@
 
 'use strict';
 
+const { Reflect } = primordials;
+
 const {
   codes: {
     ERR_FALSY_VALUE_REJECTION,

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -21,6 +21,8 @@
 
 'use strict';
 
+const { Math } = primordials;
+
 const {
   codes: {
     ERR_BROTLI_INVALID_PARAM,


### PR DESCRIPTION
Use the "no-restricted-globals" ESLint rule to lint for it.
