### PR TITLE
src: use uv_gettimeofday()

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -209,11 +209,14 @@ static void WriteNodeReport(Isolate* isolate,
            tm_struct.tm_min,
            tm_struct.tm_sec);
   writer.json_keyvalue("dumpEventTime", timebuf);
-  struct timeval ts;
-  gettimeofday(&ts, nullptr);
-  writer.json_keyvalue("dumpEventTimeStamp",
-                       std::to_string(ts.tv_sec * 1000 + ts.tv_usec / 1000));
 #endif
+
+  uv_timeval64_t ts;
+  if (uv_gettimeofday(&ts) == 0) {
+    writer.json_keyvalue("dumpEventTimeStamp",
+                         std::to_string(ts.tv_sec * 1000 + ts.tv_usec / 1000));
+  }
+
   // Report native process ID
   writer.json_keyvalue("processId", pid);
 

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -5,10 +5,7 @@
 #include "uv.h"
 #include "v8.h"
 
-#ifdef _WIN32
-#include <time.h>
-#else
-#include <sys/time.h>
+#ifndef _WIN32
 #include <sys/types.h>
 #include <unistd.h>
 #endif

--- a/src/util.cc
+++ b/src/util.cc
@@ -50,9 +50,6 @@ static std::atomic_int seq = {0};  // Sequence number for diagnostic filenames.
 
 namespace node {
 
-// Microseconds in a second, as a float.
-#define MICROS_PER_SEC 1e6
-
 using v8::ArrayBufferView;
 using v8::Isolate;
 using v8::Local;
@@ -166,20 +163,10 @@ void ThrowErrStringTooLong(Isolate* isolate) {
 }
 
 double GetCurrentTimeInMicroseconds() {
-#ifdef _WIN32
-// The difference between the Unix Epoch and the Windows Epoch in 100-ns ticks.
-#define TICKS_TO_UNIX_EPOCH 116444736000000000LL
-  FILETIME ft;
-  GetSystemTimeAsFileTime(&ft);
-  uint64_t filetime_int =
-      static_cast<uint64_t>(ft.dwHighDateTime) << 32 | ft.dwLowDateTime;
-  // FILETIME is measured in terms of 100 ns. Convert that to 1 us (1000 ns).
-  return (filetime_int - TICKS_TO_UNIX_EPOCH) / 10.;
-#else
-  struct timeval tp;
-  gettimeofday(&tp, nullptr);
-  return MICROS_PER_SEC * tp.tv_sec + tp.tv_usec;
-#endif
+  constexpr double kMicrosecondsPerSecond = 1e6;
+  uv_timeval64_t tv;
+  CHECK_EQ(0, uv_gettimeofday(&tv));
+  return kMicrosecondsPerSecond * tv.tv_sec + tv.tv_usec;
 }
 
 int WriteFileSync(const char* path, uv_buf_t buf) {

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -70,11 +70,7 @@ function _validateContent(data) {
   assert(typeof header.filename === 'string' || header.filename === null);
   assert.notStrictEqual(new Date(header.dumpEventTime).toString(),
                         'Invalid Date');
-  if (isWindows)
-    assert.strictEqual(header.dumpEventTimeStamp, undefined);
-  else
-    assert(String(+header.dumpEventTimeStamp), header.dumpEventTimeStamp);
-
+  assert(String(+header.dumpEventTimeStamp), header.dumpEventTimeStamp);
   assert(Number.isSafeInteger(header.processId));
   assert.strictEqual(typeof header.cwd, 'string');
   assert(Array.isArray(header.commandLine));


### PR DESCRIPTION
Labeled as a WIP until the next libuv update (ignore the first commit here).

The next version of libuv will provide `uv_gettimeofday()` as a cross platform alternative to `gettimeofday()`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
