### PR TITLE
build: only emit download ICU warnings once

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1253,13 +1253,14 @@ def configure_intl(o):
     if not os.access(options.download_path, os.W_OK):
       error('''Cannot write to desired download path.
         Either create it or verify permissions.''')
+    attemptdownload = nodedownload.candownload(auto_downloads, "icu")
     for icu in icus:
       url = icu['url']
       md5 = icu['md5']
       local = url.split('/')[-1]
       targetfile = os.path.join(options.download_path, local)
       if not os.path.isfile(targetfile):
-        if nodedownload.candownload(auto_downloads, "icu"):
+        if attemptdownload:
           nodedownload.retrievefile(url, targetfile)
       else:
         print('Re-using existing %s' % targetfile)


### PR DESCRIPTION
The check that the user specified `icu` in `--download` only needs to be
done once and not for each entry in `tools/icu/current_ver.dep`.

Fixes: https://github.com/nodejs/node/issues/26860

cc @srl295

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
