### PR TITLE
lib: make queueMicrotask faster

### DIFF
--- a/benchmark/process/queue-microtask-breadth.js
+++ b/benchmark/process/queue-microtask-breadth.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
+  n: [4e5]
+});
+
+function main({ n }) {
+  var j = 0;
+
+  function cb() {
+    j++;
+    if (j === n)
+      bench.end(n);
+  }
+
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    queueMicrotask(cb);
+  }
+}

--- a/benchmark/process/queue-microtask-depth.js
+++ b/benchmark/process/queue-microtask-depth.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
+  n: [12e5]
+});
+
+function main({ n }) {
+  let counter = n;
+  bench.start();
+  queueMicrotask(onNextTick);
+  function onNextTick() {
+    if (--counter)
+      queueMicrotask(onNextTick);
+    else
+      bench.end(n);
+  }
+}

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -25,6 +25,7 @@ const {
   emitBefore,
   emitAfter,
   emitDestroy,
+  initHooksExist,
 } = internal_async_hooks;
 
 // Get symbols
@@ -144,29 +145,31 @@ class AsyncResource {
       throw new ERR_INVALID_ASYNC_ID('triggerAsyncId', triggerAsyncId);
     }
 
-    this[async_id_symbol] = newAsyncId();
+    const asyncId = newAsyncId();
+    this[async_id_symbol] = asyncId;
     this[trigger_async_id_symbol] = triggerAsyncId;
-    // This prop name (destroyed) has to be synchronized with C++
-    this[destroyedSymbol] = { destroyed: false };
 
-    emitInit(
-      this[async_id_symbol], type, this[trigger_async_id_symbol], this
-    );
+    // This prop name (destroyed) has to be synchronized with C++
+    const destroyed = { destroyed: false };
+    this[destroyedSymbol] = destroyed;
+
+    if (initHooksExist()) {
+      emitInit(asyncId, type, triggerAsyncId, this);
+    }
 
     if (!opts.requireManualDestroy) {
-      registerDestroyHook(this, this[async_id_symbol], this[destroyedSymbol]);
+      registerDestroyHook(this, asyncId, destroyed);
     }
   }
 
   runInAsyncScope(fn, thisArg, ...args) {
-    emitBefore(this[async_id_symbol], this[trigger_async_id_symbol]);
-    let ret;
+    const asyncId = this[async_id_symbol];
+    emitBefore(asyncId, this[trigger_async_id_symbol]);
     try {
-      ret = Reflect.apply(fn, thisArg, args);
+      return Reflect.apply(fn, thisArg, args);
     } finally {
-      emitAfter(this[async_id_symbol]);
+      emitAfter(asyncId);
     }
-    return ret;
   }
 
   emitDestroy() {

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -283,14 +283,11 @@ function defaultTriggerAsyncIdScope(triggerAsyncId, block, ...args) {
   const oldDefaultTriggerAsyncId = async_id_fields[kDefaultTriggerAsyncId];
   async_id_fields[kDefaultTriggerAsyncId] = triggerAsyncId;
 
-  let ret;
   try {
-    ret = Reflect.apply(block, null, args);
+    return Reflect.apply(block, null, args);
   } finally {
     async_id_fields[kDefaultTriggerAsyncId] = oldDefaultTriggerAsyncId;
   }
-
-  return ret;
 }
 
 

--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -35,6 +35,8 @@ const {
 } = require('internal/errors').codes;
 const FixedQueue = require('internal/fixed_queue');
 
+const FunctionBind = Function.call.bind(Function.prototype.bind);
+
 // *Must* match Environment::TickInfo::Fields in src/env.h.
 const kHasTickScheduled = 0;
 
@@ -147,28 +149,32 @@ function createMicrotaskResource() {
   });
 }
 
+function runMicrotask() {
+  this.runInAsyncScope(() => {
+    const callback = this.callback;
+    try {
+      callback();
+    } catch (error) {
+      // TODO(devsnek) remove this if
+      // https://bugs.chromium.org/p/v8/issues/detail?id=8326
+      // is resolved such that V8 triggers the fatal exception
+      // handler for microtasks
+      triggerFatalException(error);
+    } finally {
+      this.emitDestroy();
+    }
+  });
+}
+
 function queueMicrotask(callback) {
   if (typeof callback !== 'function') {
     throw new ERR_INVALID_ARG_TYPE('callback', 'function', callback);
   }
 
   const asyncResource = createMicrotaskResource();
+  asyncResource.callback = callback;
 
-  enqueueMicrotask(() => {
-    asyncResource.runInAsyncScope(() => {
-      try {
-        callback();
-      } catch (error) {
-        // TODO(devsnek) remove this if
-        // https://bugs.chromium.org/p/v8/issues/detail?id=8326
-        // is resolved such that V8 triggers the fatal exception
-        // handler for microtasks
-        triggerFatalException(error);
-      } finally {
-        asyncResource.emitDestroy();
-      }
-    });
-  });
+  enqueueMicrotask(FunctionBind(runMicrotask, asyncResource));
 }
 
 module.exports = {


### PR DESCRIPTION
1. async_hooks: improve `AsyncResource` performance
Accessing properties behind a symbol is generally quite expensive and so is `emitInit`, only do both when actually required.

2. lib: make `queueMicrotask` faster
No longer create an additional scope within `queueMicrotask` in order to improve performance.

CI: https://ci.nodejs.org/job/node-test-pull-request/22078/
Benchmark CI: https://ci.nodejs.org/job/benchmark-node-micro-benchmarks/313/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
