### PR TITLE
doc: remove unnecessary intro in governance doc

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,9 +1,5 @@
 # Node.js Project Governance
 
-The Node.js project is governed by its Collaborators, including a Technical
-Steering Committee (TSC) which is responsible for high-level guidance of the
-project.
-
 <!-- TOC -->
 
 - [Collaborators](#collaborators)


### PR DESCRIPTION
The introductory paragraph in GOVERNANCE.md does not add anything that
isn't obvious from the document itself. Remove it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
