### PR TITLE
src: use sizeof(var) instead of sizeof(type)

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1969,7 +1969,7 @@ void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
                                                        args[4]->IsTrue());
 
   struct addrinfo hints;
-  memset(&hints, 0, sizeof(struct addrinfo));
+  memset(&hints, 0, sizeof(hints));
   hints.ai_family = family;
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_flags = flags;


### PR DESCRIPTION
Change `memset(&s, 0, sizeof(type))` to `memset(&s, 0, sizeof(s))`.
The former is dangerous when the type of `s` changes.