### PR TITLE
fix private key export without cipher crash

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -196,7 +196,7 @@ function parseKeyEncoding(enc, keyType, isPublic, objName) {
           throw new ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS(
             encodingNames[type], 'does not support encryption');
         }
-      } else if (passphrase !== undefined && typeof cipher !== 'string') {
+      } else if (passphrase !== undefined) {
         throw new ERR_INVALID_OPT_VALUE(option('cipher', objName), cipher);
       }
     }

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -186,14 +186,20 @@ function parseKeyEncoding(enc, keyType, isPublic, objName) {
   if (isPublic !== true) {
     ({ cipher, passphrase } = enc);
 
-    if (!isInput && cipher != null) {
-      if (typeof cipher !== 'string')
+    if (!isInput) {
+      if (cipher != null) {
+        if (typeof cipher !== 'string')
+          throw new ERR_INVALID_OPT_VALUE(option('cipher', objName), cipher);
+        if (format === kKeyFormatDER &&
+            (type === kKeyEncodingPKCS1 ||
+             type === kKeyEncodingSEC1)) {
+          throw new ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS(
+            encodingNames[type], 'does not support encryption');
+        }
+      }
+
+      if (passphrase !== undefined && typeof cipher !== 'string') {
         throw new ERR_INVALID_OPT_VALUE(option('cipher', objName), cipher);
-      if (format === kKeyFormatDER &&
-          (type === kKeyEncodingPKCS1 ||
-           type === kKeyEncodingSEC1)) {
-        throw new ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS(
-          encodingNames[type], 'does not support encryption');
       }
     }
 

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -196,9 +196,7 @@ function parseKeyEncoding(enc, keyType, isPublic, objName) {
           throw new ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS(
             encodingNames[type], 'does not support encryption');
         }
-      }
-
-      if (passphrase !== undefined && typeof cipher !== 'string') {
+      } else if (passphrase !== undefined && typeof cipher !== 'string') {
         throw new ERR_INVALID_OPT_VALUE(option('cipher', objName), cipher);
       }
     }

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -244,3 +244,17 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.strictEqual(privateKey.asymmetricKeyType, 'dsa');
   assert.strictEqual(privateKey.symmetricKeySize, undefined);
 }
+
+{
+  // Exporting an encrypted private key requires a cipher
+  const privateKey = createPrivateKey(privatePem);
+  common.expectsError(() => {
+    privateKey.export({
+      format: 'pem', type: 'pkcs8', passphrase: 'super-secret'
+    });
+  }, {
+    type: TypeError,
+    code: 'ERR_INVALID_OPT_VALUE',
+    message: 'The value "undefined" is invalid for option "cipher"'
+  });
+}


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


Fixes the following by type checking the cipher before sending of to `node_crypto.cc`

```js
const { generateKeyPairSync } = require('crypto')
const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
privateKey.export({ format: 'pem', type: 'pkcs8', passphrase: 'super-secret' })
```

```
node[13162]: ../src/node_crypto.cc:3096:NonCopyableMaybe<node::crypto::PrivateKeyEncodingConfig> node::crypto::GetPrivateKeyEncodingFromJs(const FunctionCallbackInfo<v8::Value> &, unsigned int *, node::crypto::KeyEncodingContext): Assertion `!(context != kKeyContextInput) || (result.cipher_ != nullptr)' failed.
 1: 0x10006778e node::Abort() [/.nvm/versions/node/v11.13.0/bin/node]
 2: 0x1000676c0 node::PrintErrorString(char const*, ...) [/.nvm/versions/node/v11.13.0/bin/node]
 3: 0x10011f2d8 node::crypto::KeyObject::ExportPrivateKey(node::crypto::PrivateKeyEncodingConfig const&) const [/.nvm/versions/node/v11.13.0/bin/node]
 4: 0x10011e16f node::crypto::KeyObject::Export(v8::FunctionCallbackInfo<v8::Value> const&) [/.nvm/versions/node/v11.13.0/bin/node]
 5: 0x10023f927 v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo*) [/.nvm/versions/node/v11.13.0/bin/node]
 6: 0x10023eef6 v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) [/.nvm/versions/node/v11.13.0/bin/node]
 7: 0x10023e5f0 v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments, v8::internal::Isolate*) [/.nvm/versions/node/v11.13.0/bin/node]
 8: 0xd92061cfc7d 
 9: 0xd920618e458 
10: 0xd920618e458 
11: 0xd920618ba89 
[1]    13162 abort      node
```