### PR TITLE
assert: fix rejects stack trace and operator

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -502,7 +502,7 @@ class Comparison {
   }
 }
 
-function compareExceptionKey(actual, expected, key, message, keys) {
+function compareExceptionKey(actual, expected, key, message, keys, fn) {
   if (!(key in actual) || !isDeepStrictEqual(actual[key], expected[key])) {
     if (!message) {
       // Create placeholder objects to create a nice output.
@@ -513,24 +513,24 @@ function compareExceptionKey(actual, expected, key, message, keys) {
         actual: a,
         expected: b,
         operator: 'deepStrictEqual',
-        stackStartFn: assert.throws
+        stackStartFn: fn
       });
       err.actual = actual;
       err.expected = expected;
-      err.operator = 'throws';
+      err.operator = fn.name;
       throw err;
     }
     innerFail({
       actual,
       expected,
       message,
-      operator: 'throws',
-      stackStartFn: assert.throws
+      operator: fn.name,
+      stackStartFn: fn
     });
   }
 }
 
-function expectedException(actual, expected, msg) {
+function expectedException(actual, expected, msg, fn) {
   if (typeof expected !== 'function') {
     if (isRegExp(expected))
       return expected.test(actual);
@@ -548,9 +548,9 @@ function expectedException(actual, expected, msg) {
         expected,
         message: msg,
         operator: 'deepStrictEqual',
-        stackStartFn: assert.throws
+        stackStartFn: fn
       });
-      err.operator = 'throws';
+      err.operator = fn.name;
       throw err;
     }
 
@@ -570,7 +570,7 @@ function expectedException(actual, expected, msg) {
           expected[key].test(actual[key])) {
         continue;
       }
-      compareExceptionKey(actual, expected, key, msg, keys);
+      compareExceptionKey(actual, expected, key, msg, keys, fn);
     }
     return true;
   }
@@ -676,7 +676,7 @@ function expectsError(stackStartFn, actual, error, message) {
       stackStartFn
     });
   }
-  if (error && expectedException(actual, error, message) === false) {
+  if (error && !expectedException(actual, error, message, stackStartFn)) {
     throw actual;
   }
 }

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -93,7 +93,6 @@ promises.push(assert.rejects(
     assert(err instanceof assert.AssertionError,
            `${err.name} is not instance of AssertionError`);
     assert.strictEqual(err.code, 'ERR_ASSERTION');
-    assert.strictEqual(err.operator, 'doesNotReject');
     assert.strictEqual(err.message,
                        'Got unwanted rejection.\nActual message: "Failed"');
     assert.strictEqual(err.operator, 'doesNotReject');
@@ -125,7 +124,6 @@ promises.push(assert.rejects(
 
 {
   const handler = (generated, actual, err) => {
-    assert.strictEqual(err.operator, 'rejects');
     assert.strictEqual(err.generatedMessage, generated);
     assert.strictEqual(err.code, 'ERR_ASSERTION');
     assert.strictEqual(err.actual, actual);

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -93,9 +93,11 @@ promises.push(assert.rejects(
     assert(err instanceof assert.AssertionError,
            `${err.name} is not instance of AssertionError`);
     assert.strictEqual(err.code, 'ERR_ASSERTION');
+    assert.strictEqual(err.operator, 'doesNotReject');
     assert.strictEqual(err.message,
                        'Got unwanted rejection.\nActual message: "Failed"');
     assert.strictEqual(err.operator, 'doesNotReject');
+    assert.ok(err.stack);
     assert.ok(!err.stack.includes('at Function.doesNotReject'));
     return true;
   };
@@ -120,6 +122,31 @@ promises.push(assert.rejects(
              'Function or Promise. Received type number'
   }
 ));
+
+{
+  const handler = (generated, actual, err) => {
+    assert.strictEqual(err.operator, 'rejects');
+    assert.strictEqual(err.generatedMessage, generated);
+    assert.strictEqual(err.code, 'ERR_ASSERTION');
+    assert.strictEqual(err.actual, actual);
+    assert.strictEqual(err.operator, 'rejects');
+    assert(/rejects/.test(err.stack));
+    return true;
+  };
+  const err = new Error();
+  promises.push(assert.rejects(
+    assert.rejects(Promise.reject(null), { code: 'FOO' }),
+    handler.bind(null, true, null)
+  ));
+  promises.push(assert.rejects(
+    assert.rejects(Promise.reject(5), { code: 'FOO' }, 'AAAAA'),
+    handler.bind(null, false, 5)
+  ));
+  promises.push(assert.rejects(
+    assert.rejects(Promise.reject(err), { code: 'FOO' }, 'AAAAA'),
+    handler.bind(null, false, err)
+  ));
+}
 
 // Make sure all async code gets properly executed.
 Promise.all(promises).then(common.mustCall());


### PR DESCRIPTION
This makes sure the stack trace is not removed due to a wrong stack
start function being used. It also fixes the wrong operator caused
by the same reason. This only applies in case an validation object
was used to validate the rejection passed to `assert.reject()` as
first argument.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
