### PR TITLE
errors: add more information in case of invalid callbacks

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -633,7 +633,7 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
   if (options === null || typeof options !== 'object')
     throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
   if (callback !== undefined && typeof callback !== 'function')
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(callback);
 
   debug('%s renegotiate()',
         this._tlsOptions.isServer ? 'server' : 'client',

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -98,7 +98,7 @@ function lookup(hostname, options, callback) {
     callback = options;
     family = 0;
   } else if (typeof callback !== 'function') {
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(callback);
   } else if (options !== null && typeof options === 'object') {
     hints = options.hints >>> 0;
     family = options.family >>> 0;
@@ -174,7 +174,7 @@ function lookupService(hostname, port, callback) {
     throw new ERR_SOCKET_BAD_PORT(port);
 
   if (typeof callback !== 'function')
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(callback);
 
   port = +port;
 
@@ -213,7 +213,7 @@ function resolver(bindingName) {
 
     validateString(name, 'name');
     if (typeof callback !== 'function') {
-      throw new ERR_INVALID_CALLBACK();
+      throw new ERR_INVALID_CALLBACK(callback);
     }
 
     const req = new QueryReqWrap();

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -135,7 +135,7 @@ function maybeCallback(cb) {
   if (typeof cb === 'function')
     return cb;
 
-  throw new ERR_INVALID_CALLBACK();
+  throw new ERR_INVALID_CALLBACK(cb);
 }
 
 // Ensure that callbacks run in the global context. Only use this function
@@ -143,7 +143,7 @@ function maybeCallback(cb) {
 // invoked from JS already run in the proper scope.
 function makeCallback(cb) {
   if (typeof cb !== 'function') {
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(cb);
   }
 
   return (...args) => {
@@ -156,7 +156,7 @@ function makeCallback(cb) {
 // transformed anyway.
 function makeStatsCallback(cb) {
   if (typeof cb !== 'function') {
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(cb);
   }
 
   return (err, stats) => {
@@ -1747,7 +1747,7 @@ function copyFile(src, dest, flags, callback) {
     callback = flags;
     flags = 0;
   } else if (typeof callback !== 'function') {
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(callback);
   }
 
   src = toPathIfFileURL(src);

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -76,7 +76,7 @@ class Session extends EventEmitter {
       throw new ERR_INVALID_ARG_TYPE('params', 'Object', params);
     }
     if (callback && typeof callback !== 'function') {
-      throw new ERR_INVALID_CALLBACK();
+      throw new ERR_INVALID_CALLBACK(callback);
     }
 
     if (!this[connectionSymbol]) {

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -46,7 +46,7 @@ function generateKeyPair(type, options, callback) {
   const impl = check(type, options);
 
   if (typeof callback !== 'function')
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(callback);
 
   const wrap = new AsyncWrap(Providers.KEYPAIRGENREQUEST);
   wrap.ondone = (ex, pubkey, privkey) => {

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -26,7 +26,7 @@ function pbkdf2(password, salt, iterations, keylen, digest, callback) {
     check(password, salt, iterations, keylen, digest));
 
   if (typeof callback !== 'function')
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(callback);
 
   const encoding = getDefaultEncoding();
   const keybuf = Buffer.alloc(keylen);

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -45,7 +45,7 @@ function assertSize(size, elementSize, offset, length) {
 function randomBytes(size, cb) {
   size = assertSize(size, 1, 0, Infinity);
   if (cb !== undefined && typeof cb !== 'function')
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(cb);
 
   const buf = Buffer.alloc(size);
 
@@ -93,7 +93,7 @@ function randomFill(buf, offset, size, cb) {
     cb = size;
     size = buf.byteLength - offset;
   } else if (typeof cb !== 'function') {
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(cb);
   }
 
   offset = assertOffset(offset, elementSize, buf.byteLength);

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -32,7 +32,7 @@ function scrypt(password, salt, keylen, options, callback = defaults) {
   ({ password, salt, keylen } = options);
 
   if (typeof callback !== 'function')
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(callback);
 
   const encoding = getDefaultEncoding();
   const keybuf = Buffer.alloc(keylen);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -854,7 +854,8 @@ E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
 E('ERR_INVALID_ASYNC_ID', 'Invalid %s value: %s', RangeError);
 E('ERR_INVALID_BUFFER_SIZE',
   'Buffer size must be a multiple of %s', RangeError);
-E('ERR_INVALID_CALLBACK', 'Callback must be a function', TypeError);
+E('ERR_INVALID_CALLBACK',
+  'Callback must be a function. Received %O', TypeError);
 E('ERR_INVALID_CHAR',
   // Using a default argument here is important so the argument is not counted
   // towards `Function#length`.

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -699,7 +699,7 @@ class Http2ServerResponse extends Stream {
 
   createPushResponse(headers, callback) {
     if (typeof callback !== 'function')
-      throw new ERR_INVALID_CALLBACK();
+      throw new ERR_INVALID_CALLBACK(callback);
     if (this[kState].closed) {
       process.nextTick(callback, new ERR_HTTP2_INVALID_STREAM());
       return;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1056,7 +1056,7 @@ class Http2Session extends EventEmitter {
       throw new ERR_HTTP2_PING_LENGTH();
     }
     if (typeof callback !== 'function')
-      throw new ERR_INVALID_CALLBACK();
+      throw new ERR_INVALID_CALLBACK(callback);
 
     const cb = pingCallback(callback);
     if (this.connecting || this.closed) {
@@ -1146,7 +1146,7 @@ class Http2Session extends EventEmitter {
     validateSettings(settings);
 
     if (callback && typeof callback !== 'function')
-      throw new ERR_INVALID_CALLBACK();
+      throw new ERR_INVALID_CALLBACK(callback);
     debug(`Http2Session ${sessionName(this[kType])}: sending settings`);
 
     this[kState].pendingAck++;
@@ -1898,7 +1898,7 @@ class Http2Stream extends Duplex {
     if (code < 0 || code > kMaxInt)
       throw new ERR_OUT_OF_RANGE('code', `>= 0 && <= ${kMaxInt}`, code);
     if (callback !== undefined && typeof callback !== 'function')
-      throw new ERR_INVALID_CALLBACK();
+      throw new ERR_INVALID_CALLBACK(callback);
 
     if (this.closed)
       return;
@@ -2254,7 +2254,7 @@ class ServerHttp2Stream extends Http2Stream {
     }
 
     if (typeof callback !== 'function')
-      throw new ERR_INVALID_CALLBACK();
+      throw new ERR_INVALID_CALLBACK(callback);
 
     assertIsObject(options, 'options');
     options = { ...options };
@@ -2688,7 +2688,7 @@ class Http2SecureServer extends TLSServer {
     this.timeout = msecs;
     if (callback !== undefined) {
       if (typeof callback !== 'function')
-        throw new ERR_INVALID_CALLBACK();
+        throw new ERR_INVALID_CALLBACK(callback);
       this.on('timeout', callback);
     }
     return this;
@@ -2709,7 +2709,7 @@ class Http2Server extends NETServer {
     this.timeout = msecs;
     if (callback !== undefined) {
       if (typeof callback !== 'function')
-        throw new ERR_INVALID_CALLBACK();
+        throw new ERR_INVALID_CALLBACK(callback);
       this.on('timeout', callback);
     }
     return this;

--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -113,7 +113,7 @@ class TickObject {
 // exit since the callback would not have a chance to be executed.
 function nextTick(callback) {
   if (typeof callback !== 'function')
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(callback);
 
   if (process._exiting)
     return;

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -214,7 +214,7 @@ function setStreamTimeout(msecs, callback) {
   if (msecs === 0) {
     if (callback !== undefined) {
       if (typeof callback !== 'function')
-        throw new ERR_INVALID_CALLBACK();
+        throw new ERR_INVALID_CALLBACK(callback);
       this.removeListener('timeout', callback);
     }
   } else {
@@ -223,7 +223,7 @@ function setStreamTimeout(msecs, callback) {
 
     if (callback !== undefined) {
       if (typeof callback !== 'function')
-        throw new ERR_INVALID_CALLBACK();
+        throw new ERR_INVALID_CALLBACK(callback);
       this.once('timeout', callback);
     }
   }

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -58,7 +58,7 @@ function popCallback(streams) {
   // a single stream. Therefore optimize for the average case instead of
   // checking for length === 0 as well.
   if (typeof streams[streams.length - 1] !== 'function')
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(streams[streams.length - 1]);
   return streams.pop();
 }
 

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -349,7 +349,7 @@ function insert(item, refed, start) {
 function setUnrefTimeout(callback, after) {
   // Type checking identical to setTimeout()
   if (typeof callback !== 'function') {
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(callback);
   }
 
   const timer = new Timeout(callback, after, undefined, false);

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1090,7 +1090,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
       throw new ERR_INVALID_THIS('URLSearchParams');
     }
     if (typeof callback !== 'function') {
-      throw new ERR_INVALID_CALLBACK();
+      throw new ERR_INVALID_CALLBACK(callback);
     }
 
     let list = this[searchParams];

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -283,7 +283,7 @@ let gcTrackingIsEnabled = false;
 class PerformanceObserver extends AsyncResource {
   constructor(callback) {
     if (typeof callback !== 'function') {
-      throw new ERR_INVALID_CALLBACK();
+      throw new ERR_INVALID_CALLBACK(callback);
     }
     super('PerformanceObserver');
     Object.defineProperties(this, {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -120,7 +120,7 @@ function enroll(item, msecs) {
 
 function setTimeout(callback, after, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(callback);
   }
 
   var i, args;
@@ -166,7 +166,7 @@ function clearTimeout(timer) {
 
 function setInterval(callback, repeat, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(callback);
   }
 
   var i, args;
@@ -253,7 +253,7 @@ const Immediate = class Immediate {
 
 function setImmediate(callback, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
-    throw new ERR_INVALID_CALLBACK();
+    throw new ERR_INVALID_CALLBACK(callback);
   }
 
   var i, args;

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -29,6 +29,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 const { kMaxLength } = require('buffer');
+const { inspect } = require('util');
 
 const kMaxUint32 = Math.pow(2, 32) - 1;
 const kMaxPossibleLength = Math.min(kMaxLength, kMaxUint32);
@@ -292,7 +293,7 @@ assert.throws(
     {
       code: 'ERR_INVALID_CALLBACK',
       type: TypeError,
-      message: 'Callback must be a function',
+      message: `Callback must be a function. Received ${inspect(i)}`
     });
 });
 
@@ -302,7 +303,7 @@ assert.throws(
     {
       code: 'ERR_INVALID_CALLBACK',
       type: TypeError,
-      message: 'Callback must be a function',
+      message: `Callback must be a function. Received ${inspect(i)}`
     }
   );
 });

--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -71,7 +71,7 @@ test(new Uint8Array(expected.length),
 assert.throws(
   () => fs.read(fd, Buffer.alloc(1), 0, 1, 0),
   {
-    message: 'Callback must be a function',
+    message: 'Callback must be a function. Received undefined',
     code: 'ERR_INVALID_CALLBACK',
   }
 );

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -5,6 +5,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
+const { inspect } = require('util');
 
 const server = h2.createServer();
 server.on('stream', (stream) => {
@@ -35,7 +36,7 @@ server.listen(0, common.mustCall(() => {
       {
         type: TypeError,
         code: 'ERR_INVALID_CALLBACK',
-        message: 'Callback must be a function'
+        message: `Callback must be a function. Received ${inspect(notFunction)}`
       }
     );
     assert.strictEqual(req.closed, false);

--- a/test/parallel/test-http2-client-settings-before-connect.js
+++ b/test/parallel/test-http2-client-settings-before-connect.js
@@ -4,6 +4,7 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 const h2 = require('http2');
+const { inspect } = require('util');
 
 const server = h2.createServer();
 
@@ -51,7 +52,8 @@ server.listen(0, common.mustCall(() => {
       {
         type: TypeError,
         code: 'ERR_INVALID_CALLBACK',
-        message: 'Callback must be a function'
+        message:
+          `Callback must be a function. Received ${inspect(invalidCallback)}`
       }
     )
   );

--- a/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
+++ b/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
@@ -24,7 +24,7 @@ const server = h2.createServer((request, response) => {
     {
       code: 'ERR_INVALID_CALLBACK',
       type: TypeError,
-      message: 'Callback must be a function'
+      message: 'Callback must be a function. Received undefined'
     }
   );
 

--- a/test/parallel/test-http2-ping.js
+++ b/test/parallel/test-http2-ping.js
@@ -7,6 +7,7 @@ if (!common.hasCrypto)
 const async_hooks = require('async_hooks');
 const assert = require('assert');
 const http2 = require('http2');
+const { inspect } = require('util');
 
 const pings = new Set();
 const events = [0, 0, 0, 0];
@@ -119,7 +120,8 @@ server.listen(0, common.mustCall(() => {
           {
             type: TypeError,
             code: 'ERR_INVALID_CALLBACK',
-            message: 'Callback must be a function'
+            message: 'Callback must be a function. ' +
+                     `Received ${inspect(invalidCallback)}`
           }
         )
       );

--- a/test/parallel/test-http2-server-push-stream-errors-args.js
+++ b/test/parallel/test-http2-server-push-stream-errors-args.js
@@ -22,7 +22,7 @@ server.on('stream', common.mustCall((stream, headers) => {
     }, {}, 'callback'),
     {
       code: 'ERR_INVALID_CALLBACK',
-      message: 'Callback must be a function'
+      message: "Callback must be a function. Received 'callback'"
     }
   );
 

--- a/test/parallel/test-http2-server-settimeout-no-callback.js
+++ b/test/parallel/test-http2-server-settimeout-no-callback.js
@@ -6,23 +6,23 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const http2 = require('http2');
+const { inspect } = require('util');
 
 // Verify that setTimeout callback verifications work correctly
 const verifyCallbacks = (server) => {
   const testTimeout = 10;
-  const notFunctions = [true, 1, {}, [], null, 'test'];
-  const invalidCallBackError = {
-    type: TypeError,
-    code: 'ERR_INVALID_CALLBACK',
-    message: 'Callback must be a function'
-  };
 
-  notFunctions.forEach((notFunction) =>
+  [true, 1, {}, [], null, 'test'].forEach((notFunction) => {
     common.expectsError(
       () => server.setTimeout(testTimeout, notFunction),
-      invalidCallBackError
-    )
-  );
+      {
+        type: TypeError,
+        code: 'ERR_INVALID_CALLBACK',
+        message: 'Callback must be a function. ' +
+                 `Received ${inspect(notFunction)}`
+      }
+    );
+  });
 
   // No callback
   const returnedVal = server.setTimeout(testTimeout);

--- a/test/parallel/test-http2-timeouts.js
+++ b/test/parallel/test-http2-timeouts.js
@@ -29,7 +29,7 @@ server.on('stream', common.mustCall((stream) => {
     {
       code: 'ERR_INVALID_CALLBACK',
       type: TypeError,
-      message: 'Callback must be a function'
+      message: 'Callback must be a function. Received Symbol(test)'
     }
   );
   common.expectsError(
@@ -37,7 +37,7 @@ server.on('stream', common.mustCall((stream) => {
     {
       code: 'ERR_INVALID_CALLBACK',
       type: TypeError,
-      message: 'Callback must be a function'
+      message: 'Callback must be a function. Received {}'
     }
   );
 }));

--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -23,6 +23,7 @@
 const common = require('../common');
 const net = require('net');
 const assert = require('assert');
+const { inspect } = require('util');
 
 // Verify that invalid delays throw
 const s = new net.Socket();
@@ -59,7 +60,8 @@ for (let i = 0; i < invalidCallbacks.length; i++) {
       {
         code: 'ERR_INVALID_CALLBACK',
         type: TypeError,
-        message: 'Callback must be a function'
+        message: 'Callback must be a function. ' +
+                 `Received ${inspect(invalidCallbacks[i])}`
       }
     )
   );

--- a/test/parallel/test-performanceobserver.js
+++ b/test/parallel/test-performanceobserver.js
@@ -4,6 +4,7 @@
 const common = require('../common');
 const Countdown = require('../common/countdown');
 const assert = require('assert');
+const { inspect } = require('util');
 const { internalBinding } = require('internal/test/binding');
 const {
   observerCounts: counts
@@ -30,12 +31,14 @@ assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION], 0);
 
 {
   [1, null, undefined, {}, [], Infinity].forEach((i) => {
-    common.expectsError(() => new PerformanceObserver(i),
-                        {
-                          code: 'ERR_INVALID_CALLBACK',
-                          type: TypeError,
-                          message: 'Callback must be a function'
-                        });
+    common.expectsError(
+      () => new PerformanceObserver(i),
+      {
+        code: 'ERR_INVALID_CALLBACK',
+        type: TypeError,
+        message: `Callback must be a function. Received ${inspect(i)}`
+      }
+    );
   });
   const observer = new PerformanceObserver(common.mustNotCall());
 

--- a/test/parallel/test-process-next-tick.js
+++ b/test/parallel/test-process-next-tick.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const { inspect } = require('util');
 const N = 2;
 
 function cb() {
@@ -38,10 +39,12 @@ process.on('exit', function() {
 });
 
 [null, 1, 'test', {}, [], Infinity, true].forEach((i) => {
-  common.expectsError(() => process.nextTick(i),
-                      {
-                        code: 'ERR_INVALID_CALLBACK',
-                        type: TypeError,
-                        message: 'Callback must be a function'
-                      });
+  common.expectsError(
+    () => process.nextTick(i),
+    {
+      code: 'ERR_INVALID_CALLBACK',
+      type: TypeError,
+      message: `Callback must be a function. Received ${inspect(i)}`
+    }
+  );
 });

--- a/test/parallel/test-timers-refresh.js
+++ b/test/parallel/test-timers-refresh.js
@@ -6,6 +6,7 @@ const common = require('../common');
 
 const { strictEqual } = require('assert');
 const { setUnrefTimeout } = require('internal/timers');
+const { inspect } = require('util');
 
 // Schedule the unrefed cases first so that the later case keeps the event loop
 // active.
@@ -32,14 +33,14 @@ const { setUnrefTimeout } = require('internal/timers');
 
 // Should throw with non-functions
 {
-  const expectedError = {
-    code: 'ERR_INVALID_CALLBACK',
-    message: 'Callback must be a function'
-  };
-
   [null, true, false, 0, 1, NaN, '', 'foo', {}, Symbol()].forEach((cb) => {
-    common.expectsError(() => setUnrefTimeout(cb),
-                        expectedError);
+    common.expectsError(
+      () => setUnrefTimeout(cb),
+      {
+        code: 'ERR_INVALID_CALLBACK',
+        message: `Callback must be a function. Received ${inspect(cb)}`
+      }
+    );
   });
 }
 

--- a/test/sequential/test-inspector-module.js
+++ b/test/sequential/test-inspector-module.js
@@ -5,6 +5,7 @@ const common = require('../common');
 common.skipIfInspectorDisabled();
 
 const { Session } = require('inspector');
+const { inspect } = require('util');
 
 const session = new Session();
 
@@ -52,7 +53,7 @@ session.post('Runtime.evaluate', { expression: '2 + 2' });
     {
       code: 'ERR_INVALID_CALLBACK',
       type: TypeError,
-      message: 'Callback must be a function'
+      message: `Callback must be a function. Received ${inspect(i)}`
     }
   );
 });


### PR DESCRIPTION
This adds the actual callback that is passed through to the error
message in case an ERR_INVALID_CALLBACK error is thrown.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
