### PR TITLE
buffer: fix concat error message

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -430,8 +430,7 @@ Buffer[kIsEncodingSymbol] = Buffer.isEncoding;
 Buffer.concat = function concat(list, length) {
   let i;
   if (!Array.isArray(list)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'list', ['Array', 'Buffer', 'Uint8Array'], list);
+    throw new ERR_INVALID_ARG_TYPE('list', 'Array', list);
   }
 
   if (list.length === 0)

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -49,8 +49,8 @@ assert.strictEqual(flatLongLen.toString(), check);
     Buffer.concat(value);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "list" argument must be one of type Array, Buffer, ' +
-             `or Uint8Array. Received type ${typeof value}`
+    message: 'The "list" argument must be of type Array. ' +
+             `Received type ${typeof value}`
   });
 });
 


### PR DESCRIPTION
The list argument may only be of type array, not of any other type
as it actually suggests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
