### PR TITLE
test: test vm.runInNewContext() filename option

### DIFF
--- a/test/parallel/test-vm-run-in-new-context.js
+++ b/test/parallel/test-vm-run-in-new-context.js
@@ -72,21 +72,21 @@ global.gc();
 fn();
 // Should not crash
 
-{
-  // Verify that providing a custom filename as a string argument works.
+const filename = 'test_file.vm';
+for (const arg of [filename, { filename }]) {
+  // Verify that providing a custom filename works.
   const code = 'throw new Error("foo");';
-  const file = 'test_file.vm';
 
   assert.throws(() => {
-    vm.runInNewContext(code, {}, file);
+    vm.runInNewContext(code, {}, arg);
   }, (err) => {
     const lines = err.stack.split('\n');
 
-    assert.strictEqual(lines[0].trim(), `${file}:1`);
+    assert.strictEqual(lines[0].trim(), `${filename}:1`);
     assert.strictEqual(lines[1].trim(), code);
     // Skip lines[2] and lines[3]. They're just a ^ and blank line.
     assert.strictEqual(lines[4].trim(), 'Error: foo');
-    assert.strictEqual(lines[5].trim(), `at ${file}:1:7`);
+    assert.strictEqual(lines[5].trim(), `at ${filename}:1:7`);
     // The rest of the stack is uninteresting.
     return true;
   });


### PR DESCRIPTION
The 'filename as a string' case was already being tested. This commit
also exercises the 'filename as an option' case.