### PR TITLE
test: log errors in test-fs-readfile-tostring-fail

### DIFF
--- a/test/pummel/test-fs-readfile-tostring-fail.js
+++ b/test/pummel/test-fs-readfile-tostring-fail.js
@@ -21,6 +21,8 @@ const stream = fs.createWriteStream(file, {
   flags: 'a'
 });
 
+stream.on('error', (err) => { throw err; });
+
 const size = kStringMaxLength / 200;
 const a = Buffer.alloc(size, 'a');
 


### PR DESCRIPTION
The test writes out a large file via `fs.createWriteStream()` but was
not listening for the `error` event, which the [`fs` docs](https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback) describe as the
reliable way to detect write errors.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
