### PR TITLE
build: don't use lint-ci on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
       install:
         - make lint-py-build || true
       script:
-        - NODE=$(which node) make lint-ci
+        - NODE=$(which node) make lint lint-py
 
     - name: "Compile V8"
       language: cpp


### PR DESCRIPTION
The `lint-ci` Makefile target differs from `lint` in that it writes to
a tap file and not stdout and also stops execution when an error is
found (e.g. if JavaScript linting fails the C++ and docs linting are
not run).

The switch to `lint-ci` was to enable Python linting. Revert to `lint`
and add the `lint-py` target.

Example Travis run where `lint` is used (note that C++ and docs linting occur after the JavaScript linter fails):
https://travis-ci.com/nodejs/node/jobs/189665652

Example Travis run where `lint-ci` is used (note that C++ and docs linting are not attempted after JavaScript linter fails and the actual linter failure is not visible):
https://travis-ci.com/nodejs/node/jobs/189720838
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
