### PR TITLE
fs: improve readFile performance

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -264,19 +264,17 @@ function readFileAfterStat(err, stats) {
 
   const size = context.size = isFileType(stats, S_IFREG) ? stats[8] : 0;
 
-  if (size === 0) {
-    context.buffers = [];
-    context.read();
-    return;
-  }
-
   if (size > kMaxLength) {
     err = new ERR_FS_FILE_TOO_LARGE(size);
     return context.close(err);
   }
 
   try {
-    context.buffer = Buffer.allocUnsafeSlow(size);
+    if (size === 0) {
+      context.buffers = [];
+    } else {
+      context.buffer = Buffer.allocUnsafeSlow(size);
+    }
   } catch (err) {
     return context.close(err);
   }

--- a/lib/internal/fs/read_file_context.js
+++ b/lib/internal/fs/read_file_context.js
@@ -79,7 +79,8 @@ class ReadFileContext {
     } else {
       buffer = this.buffer;
       offset = this.pos;
-      length = Math.min(kReadFileBufferLength, this.size - this.pos);
+      // Read up to 256kb.
+      length = Math.min(256 * 1024, this.size - this.pos);
     }
 
     const req = new FSReqCallback();

--- a/lib/internal/fs/read_file_context.js
+++ b/lib/internal/fs/read_file_context.js
@@ -4,8 +4,8 @@ const { Buffer } = require('buffer');
 
 const { FSReqCallback, close, read } = internalBinding('fs');
 
-const kReadFileUnknownBufferLength = 8 * 1024;
-const kReadFileBufferLength = 256 * 1024;
+const kReadFileUnknownBufferLength = 16 * 1024;
+const kReadFileBufferLength = 512 * 1024;
 
 function readFileAfterRead(err, bytesRead) {
   const context = this.context;
@@ -73,9 +73,9 @@ class ReadFileContext {
 
     if (this.size === 0) {
       buffer = Buffer.allocUnsafeSlow(kReadFileUnknownBufferLength);
-      this.buffer = buffer;
       offset = 0;
       length = kReadFileUnknownBufferLength;
+      this.buffer = buffer;
     } else {
       buffer = this.buffer;
       offset = this.pos;

--- a/lib/internal/fs/read_file_context.js
+++ b/lib/internal/fs/read_file_context.js
@@ -4,7 +4,13 @@ const { Buffer } = require('buffer');
 
 const { FSReqCallback, close, read } = internalBinding('fs');
 
-const kReadFileUnknownBufferLength = 16 * 1024;
+// Use 64kb in case the file type is not a regular file and thus do not know the
+// actual file size. Increasing the value further results in more frequent over
+// allocation for small files and consumes CPU time and memory that should be
+// used else wise.
+// Use up to 512kb per read otherwise to partition reading big files to prevent
+// blocking other threads in case the available threads are all in use.
+const kReadFileUnknownBufferLength = 64 * 1024;
 const kReadFileBufferLength = 512 * 1024;
 
 function readFileAfterRead(err, bytesRead) {

--- a/lib/internal/fs/read_file_context.js
+++ b/lib/internal/fs/read_file_context.js
@@ -4,7 +4,8 @@ const { Buffer } = require('buffer');
 
 const { FSReqCallback, close, read } = internalBinding('fs');
 
-const kReadFileBufferLength = 8 * 1024;
+const kReadFileUnknownBufferLength = 8 * 1024;
+const kReadFileBufferLength = 256 * 1024;
 
 function readFileAfterRead(err, bytesRead) {
   const context = this.context;
@@ -12,19 +13,17 @@ function readFileAfterRead(err, bytesRead) {
   if (err)
     return context.close(err);
 
-  if (bytesRead === 0)
-    return context.close();
-
   context.pos += bytesRead;
 
-  if (context.size !== 0) {
-    if (context.pos === context.size)
-      context.close();
-    else
-      context.read();
+  if (context.pos === context.size || bytesRead === 0) {
+    context.close();
   } else {
-    // Unknown size, just read until we don't get bytes.
-    context.buffers.push(context.buffer.slice(0, bytesRead));
+    if (context.size === 0) {
+      // Unknown size, just read until we don't get bytes.
+      const buffer = bytesRead === kReadFileUnknownBufferLength ?
+        context.buffer : context.buffer.slice(0, bytesRead);
+      context.buffers.push(buffer);
+    }
     context.read();
   }
 }
@@ -58,7 +57,7 @@ class ReadFileContext {
   constructor(callback, encoding) {
     this.fd = undefined;
     this.isUserFd = undefined;
-    this.size = undefined;
+    this.size = 0;
     this.callback = callback;
     this.buffers = null;
     this.buffer = null;
@@ -73,14 +72,14 @@ class ReadFileContext {
     let length;
 
     if (this.size === 0) {
-      buffer = this.buffer = Buffer.allocUnsafeSlow(kReadFileBufferLength);
+      buffer = Buffer.allocUnsafeSlow(kReadFileUnknownBufferLength);
+      this.buffer = buffer;
       offset = 0;
-      length = kReadFileBufferLength;
+      length = kReadFileUnknownBufferLength;
     } else {
       buffer = this.buffer;
       offset = this.pos;
-      // Read up to 256kb.
-      length = Math.min(256 * 1024, this.size - this.pos);
+      length = Math.min(kReadFileBufferLength, this.size - this.pos);
     }
 
     const req = new FSReqCallback();


### PR DESCRIPTION
This increases the maximum buffer size per read to 256kb when using
`fs.readFile`. This is important to improve the read performance for
bigger files.

Refs: https://github.com/nodejs/node/issues/25741

Benchmark (512kb):

```
17:32:35                                                  confidence improvement accuracy (*)    (**)   (***)
17:32:35  fs/readfile.js concurrent=10 len=1024 dur=5                    -3.29 %       ±4.88%  ±6.48%  ±8.40%
17:32:35  fs/readfile.js concurrent=10 len=16777216 dur=5        ***    592.66 %      ±18.04% ±24.13% ±31.68%
17:32:35  fs/readfile.js concurrent=1 len=1024 dur=5                      2.18 %       ±4.41%  ±5.84%  ±7.57%
17:32:35  fs/readfile.js concurrent=1 len=16777216 dur=5         ***    356.82 %      ±25.96% ±34.72% ±45.57%
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
