### PR TITLE
Fix typos in CLI docs, --entry-type error message

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -131,6 +131,9 @@ conjunction with native stack and other runtime environment data.
 added: v6.0.0
 -->
 
+Enable FIPS-compliant crypto at startup. (Requires Node.js to be built with
+`./configure --openssl-fips`.)
+
 ### `--entry-type=type`
 <!-- YAML
 added: REPLACEME
@@ -143,9 +146,6 @@ Valid values are `"commonjs"` and `"module"`. The default is to infer from
 the file extension and the `"type"` field in the nearest parent `package.json`.
 
 Works for executing a file as well as `--eval`, `--print`, `STDIN`.
-
-Enable FIPS-compliant crypto at startup. (Requires Node.js to be built with
-`./configure --openssl-fips`.)
 
 ### `--es-module-specifier-resolution=mode`
 <!-- YAML

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -113,7 +113,7 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
                         "--experimental-modules to be enabled");
     }
     if (module_type != "commonjs" && module_type != "module") {
-      errors->push_back("--entry-type must \"module\" or \"commonjs\"");
+      errors->push_back("--entry-type must be \"module\" or \"commonjs\"");
     }
   }
 


### PR DESCRIPTION
Fix some minor typos in docs and an error message.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
