### PR TITLE
stream: use an assertion for weird error cases

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1822,16 +1822,6 @@ cannot be serialized.
 This can only happen when native addons create `SharedArrayBuffer`s in
 "externalized" mode, or put existing `SharedArrayBuffer` into externalized mode.
 
-<a id="ERR_TRANSFORM_ALREADY_TRANSFORMING"></a>
-### ERR_TRANSFORM_ALREADY_TRANSFORMING
-
-A `Transform` stream finished while it was still transforming.
-
-<a id="ERR_TRANSFORM_WITH_LENGTH_0"></a>
-### ERR_TRANSFORM_WITH_LENGTH_0
-
-A `Transform` stream finished with data still in the write buffer.
-
 <a id="ERR_TTY_INIT_FAILED"></a>
 ### ERR_TTY_INIT_FAILED
 
@@ -2164,6 +2154,24 @@ removed: v10.0.0
 -->
 
 Used when a TLS renegotiation request has failed in a non-specific way.
+
+<a id="ERR_TRANSFORM_ALREADY_TRANSFORMING"></a>
+### ERR_TRANSFORM_ALREADY_TRANSFORMING
+<!-- YAML
+added: v8.0.0
+removed: REPLACEME
+-->
+
+A `Transform` stream finished while it was still transforming.
+
+<a id="ERR_TRANSFORM_WITH_LENGTH_0"></a>
+### ERR_TRANSFORM_WITH_LENGTH_0
+<!-- YAML
+added: v8.0.0
+removed: REPLACEME
+-->
+
+A `Transform` stream finished with data still in the write buffer.
 
 <a id="ERR_UNKNOWN_BUILTIN_MODULE"></a>
 ### ERR_UNKNOWN_BUILTIN_MODULE

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -66,10 +66,9 @@
 module.exports = Transform;
 const {
   ERR_METHOD_NOT_IMPLEMENTED,
-  ERR_MULTIPLE_CALLBACK,
-  ERR_TRANSFORM_ALREADY_TRANSFORMING,
-  ERR_TRANSFORM_WITH_LENGTH_0
+  ERR_MULTIPLE_CALLBACK
 } = require('internal/errors').codes;
+const assert = require('internal/assert');
 const Duplex = require('_stream_duplex');
 Object.setPrototypeOf(Transform.prototype, Duplex.prototype);
 Object.setPrototypeOf(Transform, Duplex);
@@ -207,13 +206,10 @@ function done(stream, er, data) {
   if (data != null) // Single equals check for both `null` and `undefined`
     stream.push(data);
 
-  // TODO(BridgeAR): Write a test for these two error cases
-  // if there's nothing in the write buffer, then that means
-  // that nothing more will ever be provided
-  if (stream._writableState.length)
-    throw new ERR_TRANSFORM_WITH_LENGTH_0();
-
-  if (stream._transformState.transforming)
-    throw new ERR_TRANSFORM_ALREADY_TRANSFORMING();
+  assert(
+    stream._writableState.length === 0 && !stream._transformState.transforming,
+    'Transform done was called while still transforming or writing. ' +
+      'Please report this.'
+  );
   return stream.push(null);
 }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1060,12 +1060,6 @@ E('ERR_TLS_SNI_FROM_SERVER',
 E('ERR_TRACE_EVENTS_CATEGORY_REQUIRED',
   'At least one category is required', TypeError);
 E('ERR_TRACE_EVENTS_UNAVAILABLE', 'Trace events are unavailable', Error);
-E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
-  'Calling transform done when still transforming', Error);
-
-// This should probably be a `RangeError`.
-E('ERR_TRANSFORM_WITH_LENGTH_0',
-  'Calling transform done when writableState.length != 0', Error);
 E('ERR_TTY_INIT_FAILED', 'TTY initialization failed', SystemError);
 E('ERR_UNCAUGHT_EXCEPTION_CAPTURE_ALREADY_SET',
   '`process.setupUncaughtExceptionCapture()` was called while a capture ' +
@@ -1086,7 +1080,6 @@ E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s', TypeError);
 E('ERR_UNKNOWN_FILE_EXTENSION', 'Unknown file extension: %s', TypeError);
 E('ERR_UNKNOWN_MODULE_FORMAT', 'Unknown module format: %s', RangeError);
 E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s', TypeError);
-
 E('ERR_V8BREAKITERATOR',
   'Full ICU data not installed. See https://github.com/nodejs/node/wiki/Intl',
   Error);


### PR DESCRIPTION
These two cases should only happen in case there's a bug in our
implementation or the user manipulated things pretty bad. So instead
of using our regular error system for these two cases, use a simple
assertion.

I guess this should be semver-major even though it has always been just a sanity check (from the original implementation on).

@nodejs/streams PTAL

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
