### PR TITLE
buffer: fix custom inspection with extra properties

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -57,8 +57,7 @@ const {
   isUint8Array
 } = require('internal/util/types');
 const {
-  formatProperty,
-  kObjectType
+  inspect: utilInspect
 } = require('internal/util/inspect');
 
 const {
@@ -663,13 +662,24 @@ Buffer.prototype[customInspectSymbol] = function inspect(recurseTimes, ctx) {
     str += ` ... ${remaining} more byte${remaining > 1 ? 's' : ''}`;
   // Inspect special properties as well, if possible.
   if (ctx) {
+    let extras = false;
     const filter = ctx.showHidden ? ALL_PROPERTIES : ONLY_ENUMERABLE;
-    str += getOwnNonIndexProperties(this, filter).reduce((str, key) => {
-      // Using `formatProperty()` expects an indentationLvl to be set.
-      ctx.indentationLvl = 0;
-      str += `, ${formatProperty(ctx, this, recurseTimes, key, kObjectType)}`;
-      return str;
-    }, '');
+    const obj = getOwnNonIndexProperties(this, filter).reduce((obj, key) => {
+      extras = true;
+      obj[key] = this[key];
+      return obj;
+    }, Object.create(null));
+    if (extras) {
+      if (this.length !== 0)
+        str += ', ';
+      // '[Object: null prototype] {'.length === 26
+      // This is guarded with a test.
+      str += utilInspect(obj, {
+        ...ctx,
+        breakLength: Infinity,
+        compact: true
+      }).slice(27, -2);
+    }
   }
   return `<${this.constructor.name} ${str}>`;
 };

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1531,8 +1531,6 @@ function formatWithOptions(inspectOptions, ...args) {
 
 module.exports = {
   inspect,
-  formatProperty,
-  kObjectType,
   format,
   formatWithOptions
 };

--- a/test/parallel/test-buffer-inspect.js
+++ b/test/parallel/test-buffer-inspect.js
@@ -55,4 +55,16 @@ assert.strictEqual(util.inspect(b), expected);
 assert.strictEqual(util.inspect(s), expected);
 
 b.inspect = undefined;
-assert.strictEqual(util.inspect(b), '<Buffer 31 32, inspect: undefined>');
+b.prop = new Uint8Array(0);
+assert.strictEqual(
+  util.inspect(b),
+  '<Buffer 31 32, inspect: undefined, prop: Uint8Array []>'
+);
+
+b = Buffer.alloc(0);
+b.prop = 123;
+
+assert.strictEqual(
+  util.inspect(b),
+  '<Buffer prop: 123>'
+);


### PR DESCRIPTION
This broke due to a recent change that prevents exposing inspect
internals. It now relies on the public API instead and should be a
bit more "robust" due to that (it's still bad but I see no good alternative :D).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
