### PR TITLE
src: remove unused INT_MAX constant

### DIFF
--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1063,9 +1063,6 @@ void DefineCryptoConstants(Local<Object> target) {
   NODE_DEFINE_CONSTANT(target, TLS1_3_VERSION);
 #endif
 
-  // Unused by node, but removing it is semver-major.
-  NODE_DEFINE_CONSTANT(target, INT_MAX);
-
 #if HAVE_OPENSSL
   // NOTE: These are not defines
   NODE_DEFINE_CONSTANT(target, POINT_CONVERSION_COMPRESSED);


### PR DESCRIPTION
Node doesn't use it, and its not documented. Remove it.

Will need rebasing after https://github.com/nodejs/node/pull/27077

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
