### PR TITLE
dns: refactor internal/dns/promises.js

### DIFF
--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -7,7 +7,7 @@ const {
 } = require('internal/dns/utils');
 const { codes, dnsException } = require('internal/errors');
 const { toASCII } = require('internal/idna');
-const { isIP, isIPv4, isLegalPort } = require('internal/net');
+const { isIP, isLegalPort } = require('internal/net');
 const {
   getaddrinfo,
   getnameinfo,
@@ -31,7 +31,7 @@ function onlookup(err, addresses) {
     return;
   }
 
-  const family = this.family ? this.family : isIPv4(addresses[0]) ? 4 : 6;
+  const family = this.family ? this.family : isIP(addresses[0]);
   this.resolve({ address: addresses[0], family });
 }
 
@@ -48,7 +48,7 @@ function onlookupall(err, addresses) {
 
     addresses[i] = {
       address,
-      family: family ? family : isIPv4(addresses[i]) ? 4 : 6
+      family: family ? family : isIP(addresses[i])
     };
   }
 


### PR DESCRIPTION
Use `isIP()` instead of `isIPv4()` since it does the additional
functionality that we were adding after our calls to `isIP()`.

This not-so-incidentally also increases code coverage from tests. At
least one of the replaced ternaries was difficult to cover reliably
because operating system/configuration variances were too unpredictable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
