### PR TITLE
tools: print a better message for unexpected use of globals

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -4,11 +4,11 @@ rules:
   no-restricted-globals:
     - error
     - name: JSON
-      message: "Use `const { JSON } = primordials;` instead of the global"
+      message: "Use `const { JSON } = primordials;` instead of the global."
     - name: Math
-      message: "Use `const { Math } = primordials;` instead of the global"
+      message: "Use `const { Math } = primordials;` instead of the global."
     - name: Reflect
-      message: "Use `const { Reflect } = primordials;` instead of the global"
+      message: "Use `const { Reflect } = primordials;` instead of the global."
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -1,7 +1,14 @@
 rules:
   prefer-object-spread: error
   no-buffer-constructor: error
-  no-restricted-globals: ["error", "JSON", "Math", "Reflect"]
+  no-restricted-globals:
+    - error
+    - name: JSON
+      message: "Use `const { JSON } = primordials;` instead of the global"
+    - name: Math
+      message: "Use `const { Math } = primordials;` instead of the global"
+    - name: Reflect
+      message: "Use `const { Reflect } = primordials;` instead of the global"
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error


### PR DESCRIPTION
The error looks like this now:

```
  23:11  error  Unexpected use of 'Reflect'. Use `const { Reflect } = primordials;` instead of the global  no-restricted-globals
```