### PR TITLE
stream: remove TODO and add a description instead

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -207,7 +207,7 @@ function done(stream, er, data) {
   if (data != null) // Single equals check for both `null` and `undefined`
     stream.push(data);
 
-  // These two error cases are sanity checks that can likely not be tested.
+  // These two error cases are coherence checks that can likely not be tested.
   if (stream._writableState.length)
     throw new ERR_TRANSFORM_WITH_LENGTH_0();
 

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -207,9 +207,7 @@ function done(stream, er, data) {
   if (data != null) // Single equals check for both `null` and `undefined`
     stream.push(data);
 
-  // TODO(BridgeAR): Write a test for these two error cases
-  // if there's nothing in the write buffer, then that means
-  // that nothing more will ever be provided
+  // These two error cases are sanity checks that can likely not be tested.
   if (stream._writableState.length)
     throw new ERR_TRANSFORM_WITH_LENGTH_0();
 


### PR DESCRIPTION
After looking into this it turned out that these two errors are
sanity checks that should not be reached. It is unfortunate that
we assigned error codes for these but changing it into an assertion
seems to be a hassle for `readable-streams`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
