### PR TITLE
test: fix test-repl-require-after-write

### DIFF
--- a/test/parallel/test-repl-require-after-write.js
+++ b/test/parallel/test-repl-require-after-write.js
@@ -8,15 +8,15 @@ const path = require('path');
 
 tmpdir.refresh();
 
-const requirePath = path.join(tmpdir.path, 'non-existent.json');
+const requirePath = JSON.stringify(path.join(tmpdir.path, 'non-existent.json'));
 
 // Use -i to force node into interactive mode, despite stdout not being a TTY
 const child = spawn(process.execPath, ['-i']);
 
 let out = '';
-const input = `try { require('${requirePath}'); } catch {} ` +
-              `require('fs').writeFileSync('${requirePath}', '1');` +
-              `require('${requirePath}');`;
+const input = `try { require(${requirePath}); } catch {} ` +
+              `require('fs').writeFileSync(${requirePath}, '1');` +
+              `require(${requirePath});`;
 
 child.stderr.on('data', common.mustNotCall());
 

--- a/test/parallel/test-repl-require-after-write.js
+++ b/test/parallel/test-repl-require-after-write.js
@@ -4,10 +4,11 @@ const common = require('../common');
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
+const path = require('path');
 
 tmpdir.refresh();
 
-const requirePath = tmpdir.path + '/non-existent.json';
+const requirePath = path.join(tmpdir.path, 'non-existent.json');
 
 // Use -i to force node into interactive mode, despite stdout not being a TTY
 const child = spawn(process.execPath, ['-i']);

--- a/test/parallel/test-repl-require-after-write.js
+++ b/test/parallel/test-repl-require-after-write.js
@@ -1,16 +1,21 @@
 'use strict';
 
 const common = require('../common');
+const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
-
 const spawn = require('child_process').spawn;
+
+tmpdir.refresh();
+
+const requirePath = tmpdir.path + 'non-existent.json';
+
 // Use -i to force node into interactive mode, despite stdout not being a TTY
 const child = spawn(process.execPath, ['-i']);
 
 let out = '';
-const input = "try { require('./non-existent.json'); } catch {} " +
-              "require('fs').writeFileSync('./non-existent.json', '1');" +
-              "require('./non-existent.json');";
+const input = `try { require('${requirePath}'); } catch {} ` +
+              `require('fs').writeFileSync('${requirePath}', '1');` +
+              `require('${requirePath}');`;
 
 child.stderr.on('data', common.mustNotCall());
 

--- a/test/parallel/test-repl-require-after-write.js
+++ b/test/parallel/test-repl-require-after-write.js
@@ -7,7 +7,7 @@ const spawn = require('child_process').spawn;
 
 tmpdir.refresh();
 
-const requirePath = tmpdir.path + 'non-existent.json';
+const requirePath = tmpdir.path + '/non-existent.json';
 
 // Use -i to force node into interactive mode, despite stdout not being a TTY
 const child = spawn(process.execPath, ['-i']);


### PR DESCRIPTION
Currently, the test creates a file in the cwd and doesn't clean it up.
Use a temporary directory instead.
