### PR TITLE
test: fix test-worker-memory.js for large cpu #s

### DIFF
--- a/test/parallel/test-worker-memory.js
+++ b/test/parallel/test-worker-memory.js
@@ -4,7 +4,13 @@ const assert = require('assert');
 const util = require('util');
 const { Worker } = require('worker_threads');
 
-const numWorkers = +process.env.JOBS || require('os').cpus().length;
+let numWorkers = +process.env.JOBS || require('os').cpus().length;
+if (numWorkers > 20) {
+  // Cap the number of workers at 20 (as an even divsor of 60 used as
+  // the total number of workers started) otherwise the test fails on
+  // machines with high core counts.
+  numWorkers = 20;
+}
 
 // Verify that a Worker's memory isn't kept in memory after the thread finishes.
 

--- a/test/parallel/test-worker-memory.js
+++ b/test/parallel/test-worker-memory.js
@@ -6,7 +6,7 @@ const { Worker } = require('worker_threads');
 
 let numWorkers = +process.env.JOBS || require('os').cpus().length;
 if (numWorkers > 20) {
-  // Cap the number of workers at 20 (as an even divsor of 60 used as
+  // Cap the number of workers at 20 (as an even divisor of 60 used as
   // the total number of workers started) otherwise the test fails on
   // machines with high core counts.
   numWorkers = 20;


### PR DESCRIPTION
This test consistently failed on a system with a
large number of cores (~120). Cap the number of
concurrent workers so we'll stay consistently within
the "slack" allowed with respect to rss.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
