### PR TITLE
benchmark: remove deprecated argument

### DIFF
--- a/benchmark/dns/lookup.js
+++ b/benchmark/dns/lookup.js
@@ -4,7 +4,7 @@ const common = require('../common.js');
 const lookup = require('dns').lookup;
 
 const bench = common.createBenchmark(main, {
-  name: ['', '127.0.0.1', '::1'],
+  name: ['127.0.0.1', '::1'],
   all: ['true', 'false'],
   n: [5e6]
 });


### PR DESCRIPTION
The benchmarks for dns.lookup() include calling it with an empty
hostname which results in a deprecation warning. This benchmark seems to
be subject to some odd side effects (see Ref below) and we probably
generally don't want to benchmark deprecated things by default anyway.
Remove the deprecated value from the default list. Bonus is that this
will speed up the benchmark.

Refs: https://github.com/nodejs/node/pull/27081#issuecomment-479981874

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
