### PR TITLE
crypto: fix rsa key gen with non-default exponent

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -6068,8 +6068,10 @@ class RSAKeyPairGenerationConfig : public KeyPairGenerationConfig {
       BignumPointer bn(BN_new());
       CHECK_NOT_NULL(bn.get());
       CHECK(BN_set_word(bn.get(), exponent_));
+      // EVP_CTX acceps ownership of bn on success.
       if (EVP_PKEY_CTX_set_rsa_keygen_pubexp(ctx.get(), bn.get()) <= 0)
         return false;
+      bn.release();
     }
 
     return true;

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -73,7 +73,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   // To make the test faster, we will only test sync key generation once and
   // with a relatively small key.
   const ret = generateKeyPairSync('rsa', {
-    publicExponent: 0x10001,
+    publicExponent: 3,
     modulusLength: 512,
     publicKeyEncoding: {
       type: 'pkcs1',
@@ -146,7 +146,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 
   // Now do the same with an encrypted private key.
   generateKeyPair('rsa', {
-    publicExponent: 0x10001,
+    publicExponent: 0x1001,
     modulusLength: 512,
     publicKeyEncoding,
     privateKeyEncoding: {


### PR DESCRIPTION
EVP_PKEY_CTX_set_rsa_keygen_pubexp() accepts ownership of the exponent
on success, so do not free it.

Fixes: https://github.com/nodejs/node/issues/27087

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
