### PR TITLE
test: fix test-benchmark-module

### DIFF
--- a/test/benchmark/test-benchmark-module.js
+++ b/test/benchmark/test-benchmark-module.js
@@ -5,7 +5,11 @@ require('../common');
 const runBenchmark = require('../common/benchmark');
 
 runBenchmark('module', [
+  'cache=true',
+  'dir=rel',
+  'ext=',
+  'fullPath=true',
   'n=1',
+  'name=/',
   'useCache=true',
-  'fullPath=true'
 ]);


### PR DESCRIPTION
A recent commit broke test-benchmark-module. This fixes it.

Culprit is https://github.com/nodejs/node/pull/26970.

Collaborators, please 👍 here if you approve fast-tracking.

@BridgeAR @nodejs/testing 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
