### PR TITLE
doc: link bigint type to MDN instead of proposal

### DIFF
--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -28,7 +28,7 @@ const customTypesMap = {
 
   'AsyncIterator': 'https://tc39.github.io/ecma262/#sec-asynciterator-interface',
 
-  'bigint': 'https://github.com/tc39/proposal-bigint',
+  'bigint': `${jsDocPrefix}Reference/Global_Objects/BigInt`,
 
   'Iterable':
     `${jsDocPrefix}Reference/Iteration_protocols#The_iterable_protocol`,


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

It is not an ideal solution yet: `bigint` as a new primitive currently absent in the [MDN section](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Data_types) we usually link primitives to, so we need to refer to a [global object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) which may be a bit confusing. But maybe this is better than to link to the [proposal](https://github.com/tc39/proposal-bigint) now.