### PR TITLE
lib: require globals instead of using the global proxy

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -56,13 +56,3 @@ globals:
   module: false
   internalBinding: false
   primordials: false
-  # Globals
-  # TODO(joyeecheung): if possible, get these in native modules
-  # through `require` instead of grabbing them from the global proxy.
-  clearTimeout: false
-  setTimeout: false
-  clearInterval: false
-  setInterval: false
-  setImmediate: false
-  clearImmediate: false
-  console: false

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const { Math } = primordials;
+const { setImmediate } = require('timers');
 
 const { getOptionValue } = require('internal/options');
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -28,6 +28,7 @@ const {
 
 assertCrypto();
 
+const { setImmediate } = require('timers');
 const assert = require('internal/assert');
 const crypto = require('crypto');
 const net = require('net');

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -38,6 +38,7 @@ const {
   ERR_INVALID_OPT_VALUE,
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
+const { clearTimeout, setTimeout } = require('timers');
 const { validateString, isInt32 } = require('internal/validators');
 const child_process = require('internal/child_process');
 const {

--- a/lib/internal/freeze_intrinsics.js
+++ b/lib/internal/freeze_intrinsics.js
@@ -19,11 +19,20 @@
 // https://github.com/google/caja/blob/master/src/com/google/caja/ses/repairES5.js
 // https://github.com/tc39/proposal-frozen-realms/blob/91ac390e3451da92b5c27e354b39e52b7636a437/shim/src/deep-freeze.js
 
-/* global WebAssembly, SharedArrayBuffer, console */
+/* global WebAssembly, SharedArrayBuffer */
 /* eslint-disable no-restricted-globals */
 'use strict';
 
 module.exports = function() {
+  const {
+    clearImmediate,
+    clearInterval,
+    clearTimeout,
+    setImmediate,
+    setInterval,
+    setTimeout
+  } = require('timers');
+  const console = require('internal/console/global');
 
   const intrinsics = [
     // Anonymous Intrinsics
@@ -124,16 +133,12 @@ module.exports = function() {
     clearImmediate,
     clearInterval,
     clearTimeout,
-    decodeURI,
-    decodeURIComponent,
-    encodeURI,
-    encodeURIComponent,
     setImmediate,
     setInterval,
     setTimeout,
+    console,
 
     // Other APIs
-    console,
     BigInt,
     Atomics,
     WebAssembly,

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -20,6 +20,7 @@ const net = require('net');
 const { Duplex } = require('stream');
 const tls = require('tls');
 const { URL } = require('url');
+const { setImmediate } = require('timers');
 
 const { kIncomingMessage } = require('_http_common');
 const { kServerResponse } = require('_http_server');

--- a/lib/internal/js_stream_socket.js
+++ b/lib/internal/js_stream_socket.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { setImmediate } = require('timers');
 const assert = require('internal/assert');
 const { Socket } = require('net');
 const { JSStream } = internalBinding('js_stream');

--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -15,7 +15,10 @@ prepareMainThreadExecution();
 
 // --entry-type flag not supported in REPL
 if (require('internal/options').getOptionValue('--entry-type')) {
-  console.error('Cannot specify --entry-type for REPL');
+  // If we can't write to stderr, we'd like to make this a noop,
+  // so use console.error.
+  const { error } = require('internal/console/global');
+  error('Cannot specify --entry-type for REPL');
   process.exit(1);
 }
 

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -36,17 +36,18 @@ function tryGetCwd() {
 }
 
 function evalModule(source) {
+  const { log, error } = require('internal/console/global');
   const { decorateErrorStack } = require('internal/util');
   const asyncESM = require('internal/process/esm_loader');
   asyncESM.loaderPromise.then(async (loader) => {
     const { result } = await loader.eval(source);
     if (require('internal/options').getOptionValue('--print')) {
-      console.log(result);
+      log(result);
     }
   })
   .catch((e) => {
     decorateErrorStack(e);
-    console.error(e);
+    error(e);
     process.exit(1);
   });
   // Handle any nextTicks added in the first tick of the program.
@@ -79,7 +80,8 @@ function evalScript(name, body, breakFirstLine) {
       });\n`;
   const result = module._compile(script, `${name}-wrapper`);
   if (require('internal/options').getOptionValue('--print')) {
-    console.log(result);
+    const { log } = require('internal/console/global');
+    log(result);
   }
   // Handle any nextTicks added in the first tick of the program.
   process._tickCallback();

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -17,10 +17,14 @@ function lazyOption() {
   return warningFile;
 }
 
+// If we can't write to stderr, we'd like to make this a noop,
+// so use console.error.
+let error;
 function writeOut(message) {
-  if (console && typeof console.error === 'function')
-    return console.error(message);
-  process._rawDebug(message);
+  if (!error) {
+    error = require('internal/console/global').error;
+  }
+  error(message);
 }
 
 function writeToFile(message) {

--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -5,6 +5,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const debug = require('internal/util/debuglog').debuglog('repl');
+const { clearTimeout, setTimeout } = require('timers');
 
 // XXX(chrisdickinson): The 15ms debounce value is somewhat arbitrary.
 // The debounce is to guard against code pasted into the REPL.

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -23,6 +23,7 @@ const {
   setUnrefTimeout,
   getTimerDuration
 } = require('internal/timers');
+const { clearTimeout } = require('timers');
 
 const kMaybeDestroy = Symbol('kMaybeDestroy');
 const kUpdateTimer = Symbol('kUpdateTimer');

--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -39,7 +39,7 @@ function debuglog(set) {
       emitWarningIfNeeded(set);
       debugs[set] = function debug(...args) {
         const msg = format(...args);
-        console.error('%s %d: %s', set, pid, msg);
+        process.stderr.write(format('%s %d: %s\n', set, pid, msg));
       };
     } else {
       debugs[set] = function debug() {};

--- a/lib/net.js
+++ b/lib/net.js
@@ -95,6 +95,7 @@ const {
 let cluster;
 let dns;
 
+const { clearTimeout } = require('timers');
 const { kTimeout } = require('internal/timers');
 
 const DEFAULT_IPV4_ADDR = '0.0.0.0';

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -45,6 +45,7 @@ const {
   ERR_INVALID_PERFORMANCE_MARK
 } = require('internal/errors').codes;
 
+const { setImmediate } = require('timers');
 const kHandle = Symbol('handle');
 const kMap = Symbol('map');
 const kCallback = Symbol('callback');

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -44,6 +44,7 @@ const {
   stripVTControlCharacters
 } = require('internal/readline');
 
+const { clearTimeout, setTimeout } = require('timers');
 const {
   kEscape,
   kClearToBeginning,

--- a/lib/util.js
+++ b/lib/util.js
@@ -113,8 +113,12 @@ function timestamp() {
   return [d.getDate(), months[d.getMonth()], time].join(' ');
 }
 
+let console;
 // Log is just a thin wrapper to console.log that prepends a timestamp
 function log(...args) {
+  if (!console) {
+    console = require('internal/console/global');
+  }
   console.log('%s - %s', timestamp(), format(...args));
 }
 


### PR DESCRIPTION
In addition, use process.stderr instead of console.error when
there is no need to swallow the error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
