### PR TITLE
test: simplify tests by using assert.rejects

### DIFF
--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -353,11 +353,13 @@ async function tests() {
       assert.strictEqual(e, err);
     }));
     readable.destroy(err);
-    try {
-      await readable[Symbol.asyncIterator]().next();
-    } catch (e) {
-      assert.strictEqual(e, err);
-    }
+    await assert.rejects(
+      readable[Symbol.asyncIterator]().next(),
+      (e) => {
+        assert.strictEqual(e, err);
+        return true;
+      }
+    );
   }
 
   {


### PR DESCRIPTION
Please check the commit descriptions for details.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
