### PR TITLE
stream: remove dead code

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -521,11 +521,7 @@ function onEofChunk(stream, state) {
     state.emittedReadable = true;
     // We have to emit readable now that we are EOF. Modules
     // in the ecosystem (e.g. dicer) rely on this event being sync.
-    if (state.ended) {
-      emitReadable_(stream);
-    } else {
-      process.nextTick(emitReadable_, stream);
-    }
+    emitReadable_(stream);
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Removed unreachable code. In line `511`, `state.ended` is set to `true`. So `process.nextTick(emitReadable_, stream);` can't be reached.
