### PR TITLE
doc: remove outdated link

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -165,8 +165,7 @@ after the VM has started may result in unpredictable behavior, including
 crashes and data loss; or it may simply do nothing.
 
 The V8 options available for a version of Node.js may be determined by running
-`node --v8-options`. An unofficial, community-maintained list of options
-and their effects is available [here][].
+`node --v8-options`.
 
 Usage:
 
@@ -488,4 +487,3 @@ A subclass of [`Deserializer`][] corresponding to the format written by
 [HTML structured clone algorithm]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 [V8]: https://developers.google.com/v8/
 [Worker Threads]: worker_threads.html
-[here]: https://github.com/thlorenz/v8-flags/blob/master/flags-0.11.md


### PR DESCRIPTION
The community maintained material hasn't been updated for almost five years, corresponds to Node 0.11, and is no longer accurate. This commit removes the references.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
