### PR TITLE
lib: move DEP0021 to end of life

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -483,6 +483,9 @@ The [`Server.connections`][] property is deprecated. Please use the
 ### DEP0021: Server.listenFD
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/27127
+    description: End-of-Life.
   - version:
     - v4.8.6
     - v6.12.0
@@ -493,9 +496,9 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-The `Server.listenFD()` method is deprecated. Please use
+The `Server.listenFD()` method was deprecated and removed. Please use
 [`Server.listen({fd: <number>})`][] instead.
 
 <a id="DEP0022"></a>

--- a/lib/net.js
+++ b/lib/net.js
@@ -1590,12 +1590,6 @@ Object.defineProperty(Socket.prototype, '_handle', {
   set(v) { return this[kHandle] = v; }
 });
 
-
-Server.prototype.listenFD = deprecate(function(fd, type) {
-  return this.listen({ fd: fd });
-}, 'Server.listenFD is deprecated. Use Server.listen({fd: <number>}) instead.',
-                                      'DEP0021');
-
 Server.prototype._setupWorker = function(socketList) {
   this._usingWorkers = true;
   this._workers.push(socketList);


### PR DESCRIPTION
`Server.listenFD()` has been runtime deprecated since Node 0.7.12. This commit moves the deprecation to end-of-life.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
