### PR TITLE
net: inline maybeDestroy()

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -541,19 +541,9 @@ function onReadableStreamEnd() {
     if (this.writable)
       this.end();
   }
-  maybeDestroy(this);
-}
 
-
-// Call whenever we set writable=false or readable=false
-function maybeDestroy(socket) {
-  if (!socket.readable &&
-      !socket.writable &&
-      !socket.destroyed &&
-      !socket.connecting &&
-      !socket.writableLength) {
-    socket.destroy();
-  }
+  if (!this.destroyed && !this.writable && !this.writableLength)
+    this.destroy();
 }
 
 


### PR DESCRIPTION
`maybeDestroy()` is only called from the listener of the `'end'` event.
That event is only emitted after the socket is connected (after `UV_EOF`
is read) and after `socket.readable` is set to `false`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
