### PR TITLE
lib,report: improve signal name validation

### DIFF
--- a/lib/internal/process/report.js
+++ b/lib/internal/process/report.js
@@ -1,10 +1,9 @@
 'use strict';
-const { convertToValidSignal } = require('internal/util');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_SYNTHETIC
 } = require('internal/errors').codes;
-const { validateString } = require('internal/validators');
+const { validateSignalName, validateString } = require('internal/validators');
 const nr = internalBinding('report');
 const report = {
   writeReport(file, err) {
@@ -47,8 +46,7 @@ const report = {
     return nr.getSignal();
   },
   set signal(sig) {
-    validateString(sig, 'signal');
-    convertToValidSignal(sig); // Validate that the signal is recognized.
+    validateSignalName(sig, 'signal');
     removeSignalHandler();
     addSignalHandler(sig);
     nr.setSignal(sig);

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -5,12 +5,14 @@ const {
   codes: {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
-    ERR_OUT_OF_RANGE
+    ERR_OUT_OF_RANGE,
+    ERR_UNKNOWN_SIGNAL
   }
 } = require('internal/errors');
 const {
   isArrayBufferView
 } = require('internal/util/types');
+const { signals } = internalBinding('constants').os;
 
 function isInt32(value) {
   return value === (value | 0);
@@ -110,6 +112,20 @@ function validateNumber(value, name) {
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
 }
 
+function validateSignalName(signal, name = 'signal') {
+  if (typeof signal !== 'string')
+    throw new ERR_INVALID_ARG_TYPE(name, 'string', signal);
+
+  if (signals[signal] === undefined) {
+    if (signals[signal.toUpperCase()] !== undefined) {
+      throw new ERR_UNKNOWN_SIGNAL(signal +
+                                   ' (signals must use all capital letters)');
+    }
+
+    throw new ERR_UNKNOWN_SIGNAL(signal);
+  }
+}
+
 // TODO(BridgeAR): We have multiple validation functions that call
 // `require('internal/utils').toBuf()` before validating for array buffer views.
 // Those should likely also be consolidated in here.
@@ -130,5 +146,6 @@ module.exports = {
   validateInt32,
   validateUint32,
   validateString,
-  validateNumber
+  validateNumber,
+  validateSignalName
 };

--- a/test/report/test-report-config.js
+++ b/test/report/test-report-config.js
@@ -68,7 +68,16 @@ if (!common.isWindows) {
   }, { code: 'ERR_INVALID_ARG_TYPE' });
   common.expectsError(() => {
     process.report.signal = 'foo';
-  }, { code: 'ERR_UNKNOWN_SIGNAL' });
+  }, {
+    code: 'ERR_UNKNOWN_SIGNAL',
+    message: 'Unknown signal: foo'
+  });
+  common.expectsError(() => {
+    process.report.signal = 'sigusr1';
+  }, {
+    code: 'ERR_UNKNOWN_SIGNAL',
+    message: 'Unknown signal: sigusr1 (signals must use all capital letters)'
+  });
   assert.strictEqual(process.report.signal, 'SIGUSR2');
   process.report.signal = 'SIGUSR1';
   assert.strictEqual(process.report.signal, 'SIGUSR1');


### PR DESCRIPTION
- Add a signal name validator to enforce type and check for known signals.
- Improve error message when the signal name casing is incorrect.
- Use the new validator in the `report` module.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
