### PR TITLE
doc: fix some links

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -527,7 +527,7 @@ added: v0.1.27
 * `hostname` {string}
 * `callback` {Function}
   - `err` {Error}
-  - `records` {string[][]}
+  - `records` <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type" class="type">&lt;string[][]&gt;</a>
 
 Uses the DNS protocol to resolve text queries (`TXT` records) for the
 `hostname`. The `records` argument passed to the `callback` function is a
@@ -576,7 +576,7 @@ The `dns.setServers()` method must not be called while a DNS query is in
 progress.
 
 The [`dns.setServers()`][] method affects only [`dns.resolve()`][],
-[`dns.resolve*()`][] and [`dns.reverse()`][] (and specifically *not*
+`dns.resolve*()` and [`dns.reverse()`][] (and specifically *not*
 [`dns.lookup()`][]).
 
 Note that this method works much like

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -481,7 +481,7 @@ added: v11.4.0
 
 * {boolean}
 
-Is `true` if it is safe to call [`writable.write()`][].
+Is `true` if it is safe to call [`writable.write()`][stream-write].
 
 ##### writable.writableHighWaterMark
 <!-- YAML
@@ -1066,7 +1066,7 @@ added: v11.4.0
 
 * {boolean}
 
-Is `true` if it is safe to call [`readable.read()`][].
+Is `true` if it is safe to call [`readable.read()`][stream-read].
 
 ##### readable.readableHighWaterMark
 <!-- YAML


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

* Add missing reference ids.
* Un-link impossible wildcard link.
* Hardcode a link that baffles our new doc toolchain (`[][]` part  is parsed as an empty link now instead of two-dimensional array sign).