### PR TITLE
src: always use diagnostic file sequence number

### DIFF
--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -334,15 +334,13 @@ class DiagnosticFilename {
 
   DiagnosticFilename(Environment* env,
                      const char* prefix,
-                     const char* ext,
-                     int seq = -1) :
-      filename_(MakeFilename(env->thread_id(), prefix, ext, seq)) {}
+                     const char* ext) :
+      filename_(MakeFilename(env->thread_id(), prefix, ext)) {}
 
   DiagnosticFilename(uint64_t thread_id,
                      const char* prefix,
-                     const char* ext,
-                     int seq = -1) :
-      filename_(MakeFilename(thread_id, prefix, ext, seq)) {}
+                     const char* ext) :
+      filename_(MakeFilename(thread_id, prefix, ext)) {}
 
   const char* operator*() const { return filename_.c_str(); }
 
@@ -350,8 +348,7 @@ class DiagnosticFilename {
   static std::string MakeFilename(
       uint64_t thread_id,
       const char* prefix,
-      const char* ext,
-      int seq = -1);
+      const char* ext);
 
   std::string filename_;
 };

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -15,7 +15,6 @@
 #include <cstring>
 #include <ctime>
 #include <cwctype>
-#include <atomic>
 #include <fstream>
 #include <iomanip>
 #include <climits>  // PATH_MAX
@@ -73,9 +72,6 @@ static void PrintLoadedLibraries(JSONWriter* writer);
 static void PrintComponentVersions(JSONWriter* writer);
 static void PrintRelease(JSONWriter* writer);
 
-// Global variables
-static std::atomic_int seq = {0};  // sequence number for report filenames
-
 // External function to trigger a report, writing to file.
 // The 'name' parameter is in/out: an input filename is used
 // if supplied, and the actual filename is returned.
@@ -99,7 +95,7 @@ std::string TriggerNodeReport(Isolate* isolate,
     filename = options->report_filename;
   } else {
     filename = *DiagnosticFilename(env != nullptr ? env->thread_id() : 0,
-                                   "report", "json", seq++);
+                                   "report", "json");
   }
 
   // Open the report file stream for writing. Supports stdout/err,

--- a/src/util.cc
+++ b/src/util.cc
@@ -41,9 +41,12 @@
 #include <sys/types.h>
 #endif
 
+#include <atomic>
 #include <cstdio>
 #include <iomanip>
 #include <sstream>
+
+static std::atomic_int seq = {0};  // Sequence number for diagnostic filenames.
 
 namespace node {
 
@@ -225,8 +228,7 @@ void DiagnosticFilename::LocalTime(TIME_TYPE* tm_struct) {
 std::string DiagnosticFilename::MakeFilename(
     uint64_t thread_id,
     const char* prefix,
-    const char* ext,
-    int seq) {
+    const char* ext) {
   std::ostringstream oss;
   TIME_TYPE tm_struct;
   LocalTime(&tm_struct);
@@ -262,8 +264,7 @@ std::string DiagnosticFilename::MakeFilename(
 #endif
   oss << "." << uv_os_getpid();
   oss << "." << thread_id;
-  if (seq >= 0)
-    oss << "." << std::setfill('0') << std::setw(3) << ++seq;
+  oss << "." << std::setfill('0') << std::setw(3) << ++seq;
   oss << "." << ext;
   return oss.str();
 }


### PR DESCRIPTION
This commit attaches a sequence number to all filenames that are automatically generated by `DiagnosticFilename`. This prevents accidental overwriting of existing files.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
