### PR TITLE
src: remove unnecessary function call

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -6085,9 +6085,8 @@ class RSAKeyPairGenerationConfig : public KeyPairGenerationConfig {
       CHECK_NOT_NULL(bn.get());
       CHECK(BN_set_word(bn.get(), exponent_));
       // EVP_CTX acceps ownership of bn on success.
-      if (EVP_PKEY_CTX_set_rsa_keygen_pubexp(ctx.get(), bn.get()) <= 0)
+      if (EVP_PKEY_CTX_set_rsa_keygen_pubexp(ctx.get(), bn.release()) <= 0)
         return false;
-      bn.release();
     }
 
     return true;


### PR DESCRIPTION
Personally, I prefer a single call to `.release()` over `.get()` followed by `.release()` without using the return value since the former is closer to "move semantics". As always, feel free to disagree :-)

Refs: https://github.com/nodejs/node/pull/27092

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
