### PR TITLE
build,win: put all compilation artifacts into `out`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,23 +41,19 @@ coverage/
 
 /out
 
-# various stuff that VC++ produces/uses
-Debug/
-!**/node_modules/debug/
-Release/
-!**/node_modules/**/release
+# various stuff that VC++ produces/uses and is not in /out
+/Debug/
+/Release/
 !doc/blog/**
 *.sln
 !nodemsi.sln
 *.suo
-*.vcproj
 *.vcxproj
 !custom_actions.vcxproj
 *.vcxproj.user
 *.vcxproj.filters
 UpgradeLog*.XML
 _UpgradeReport_Files/
-ipch/
 *.sdf
 *.opensdf
 *.VC.db

--- a/common.gypi
+++ b/common.gypi
@@ -1,5 +1,6 @@
 {
   'variables': {
+    'configuring_node%': 0,
     'asan%': 0,
     'werror': '',                     # Turn off -Werror in V8 build.
     'visibility%': 'hidden',          # V8's visibility setting
@@ -280,6 +281,12 @@
     'msvs_cygwin_shell': 0, # prevent actions from trying to use cygwin
 
     'conditions': [
+      [ 'configuring_node', {
+        'msvs_configuration_attributes': {
+          'OutputDirectory': '<(DEPTH)/out/$(Configuration)/',
+          'IntermediateDirectory': '$(OutDir)obj/$(ProjectName)/'
+        },
+      }],
       [ 'target_arch=="x64"', {
         'msvs_configuration_platform': 'x64',
       }],

--- a/configure.py
+++ b/configure.py
@@ -1625,7 +1625,7 @@ if bin_override:
 
 write('config.mk', do_not_edit + config)
 
-gyp_args = ['--no-parallel']
+gyp_args = ['--no-parallel', '-Dconfiguring_node=1']
 
 if options.use_ninja:
   gyp_args += ['-f', 'ninja']

--- a/node.gyp
+++ b/node.gyp
@@ -251,6 +251,31 @@
     ],
   },
 
+  'target_defaults': {
+    # Putting these explicitly here so not to depend on `common.gypi`.
+    # `common.gypi` need to be more general because it is used to build userland native addons.
+    # Refs: https://github.com/nodejs/node-gyp/issues/1118
+    'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
+    'xcode_settings': {
+      'WARNING_CFLAGS': [
+        '-Wall',
+        '-Wendif-labels',
+        '-W',
+        '-Wno-unused-parameter',
+        '-Werror=undefined-inline',
+      ],
+    },
+
+    # Relevant only for x86.
+    # Refs: https://github.com/nodejs/node/pull/25852
+    # Refs: https://docs.microsoft.com/en-us/cpp/build/reference/safeseh-image-has-safe-exception-handlers
+    'msvs_settings': {
+      'VCLinkerTool': {
+        'ImageHasSafeExceptionHandlers': 'false',
+      },
+    },
+  },
+
   'targets': [
     {
       'target_name': '<(node_core_target_name)',

--- a/node.gypi
+++ b/node.gypi
@@ -24,36 +24,20 @@
     },
     'force_load%': '<(force_load)',
   },
-  # Putting these explicitly here so not to be dependant on common.gypi.
-  'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
-  'xcode_settings': {
-    'WARNING_CFLAGS': [
-      '-Wall',
-      '-Wendif-labels',
-      '-W',
-      '-Wno-unused-parameter',
-      '-Werror=undefined-inline',
-    ],
-  },
-  # Relevant only for x86.
-  # Refs: https://docs.microsoft.com/en-us/cpp/build/reference/safeseh-image-has-safe-exception-handlers
-  'msvs_settings': {
-    'VCLinkerTool': {
-      'ImageHasSafeExceptionHandlers': 'false',
-    },
-  },
+
   'conditions': [
     [ 'clang==1', {
       'cflags': [ '-Werror=undefined-inline', ]
     }],
-    [ 'node_shared=="false"', {
+    [ 'node_shared=="false" and "<(_type)"=="executable"', {
       'msvs_settings': {
         'VCManifestTool': {
           'EmbedManifest': 'true',
           'AdditionalManifestFiles': 'src/res/node.exe.extra.manifest'
         }
       },
-    }, {
+    }],
+    [ 'node_shared=="true"', {
       'defines': [
         'NODE_SHARED_MODE',
       ],


### PR DESCRIPTION
Solves (almost completely) the unnecessary distribution of build artifacts all over the repo.
In order to keep this semver-patch I've added a symlinking step:
https://github.com/nodejs/node/blob/2ee659cde1975a247dfa3d30d765eb9fdd3973f4/vcbuild.bat#L326-L327

Also has some small tweaks.

<sub>what's left to solve is the locations of the `.vcxproj` files. That requires a GYP patch</sub>

/CC @nodejs/build-files @nodejs/platform-windows 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
