### PR TITLE
doc: add missing n-api version indicator

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -4602,6 +4602,7 @@ prevent the event loop from exiting. The APIs `napi_ref_threadsafe_function` and
 
 <!-- YAML
 added: v10.6.0
+napiVersion: 4
 -->
 ```C
 NAPI_EXTERN napi_status
@@ -4645,6 +4646,7 @@ parameters and with `undefined` as its `this` value.
 
 <!-- YAML
 added: v10.6.0
+napiVersion: 4
 -->
 ```C
 NAPI_EXTERN napi_status
@@ -4663,6 +4665,7 @@ This API may be called from any thread which makes use of `func`.
 
 <!-- YAML
 added: v10.6.0
+napiVersion: 4
 -->
 ```C
 NAPI_EXTERN napi_status
@@ -4691,6 +4694,7 @@ This API may be called from any thread which makes use of `func`.
 
 <!-- YAML
 added: v10.6.0
+napiVersion: 4
 -->
 ```C
 NAPI_EXTERN napi_status
@@ -4713,6 +4717,7 @@ This API may be called from any thread which will start making use of `func`.
 
 <!-- YAML
 added: v10.6.0
+napiVersion: 4
 -->
 ```C
 NAPI_EXTERN napi_status
@@ -4741,6 +4746,7 @@ This API may be called from any thread which will stop making use of `func`.
 
 <!-- YAML
 added: v10.6.0
+napiVersion: 4
 -->
 ```C
 NAPI_EXTERN napi_status
@@ -4762,6 +4768,7 @@ This API may only be called from the main thread.
 
 <!-- YAML
 added: v10.6.0
+napiVersion: 4
 -->
 ```C
 NAPI_EXTERN napi_status


### PR DESCRIPTION
When the threadsafe functions were promoted to
version 4 from experimental we missed documenting
that. Add the version indicator for these functions
in the doc.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
