### PR TITLE
build: run flaky tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,4 @@ jobs:
         - make -j2 > /dev/null
         - make -j1 build-addons build-js-native-api-tests build-node-api-tests > /dev/null
       script:
-        - JOBS=2 FLAKY_TESTS=skip make -s -j1 V= test-ci | grep -F -e "---" -e "..." -v
+        - JOBS=2 FLAKY_TESTS=dontcare make -s -j1 V= test-ci | grep -F -e "---" -e "..." -v


### PR DESCRIPTION
Continuation of https://github.com/nodejs/node/pull/27015

Skipping flaky tests in CI is an anti-pattern that should be avoided,
as we do in our ownCI. Failing flaky tests don’t need to be blockers
for a green CI result, but they should be run and reported *somehow*.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
