### PR TITLE
console: remove trace frame

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -330,13 +330,13 @@ const consoleMethods = {
     trace(kTraceInstant, kTraceConsoleCategory, `time::${label}`, 0);
   },
 
-  trace(...args) {
+  trace: function trace(...args) {
     const err = {
       name: 'Trace',
       message: this[kFormatForStderr](args)
     };
     // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(err, this.trace);
+    Error.captureStackTrace(err, trace);
     this.error(err.stack);
   },
 

--- a/test/message/console.out
+++ b/test/message/console.out
@@ -1,5 +1,4 @@
 Trace: foo
-    at Object.trace (*)
     at Object.<anonymous> (*console.js:*:*)
     at *
     at *


### PR DESCRIPTION
The own function's frame was removed originally. This restors that
behavior.

Fixes: https://github.com/nodejs/node/issues/27134

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
