### PR TITLE
src: replace FromJust() with Check() when possible

### DIFF
--- a/src/api/exceptions.cc
+++ b/src/api/exceptions.cc
@@ -58,17 +58,17 @@ Local<Value> ErrnoException(Isolate* isolate,
   Local<Object> obj = e.As<Object>();
   obj->Set(env->context(),
            env->errno_string(),
-           Integer::New(isolate, errorno)).FromJust();
-  obj->Set(env->context(), env->code_string(), estring).FromJust();
+           Integer::New(isolate, errorno)).Check();
+  obj->Set(env->context(), env->code_string(), estring).Check();
 
   if (path_string.IsEmpty() == false) {
-    obj->Set(env->context(), env->path_string(), path_string).FromJust();
+    obj->Set(env->context(), env->path_string(), path_string).Check();
   }
 
   if (syscall != nullptr) {
     obj->Set(env->context(),
              env->syscall_string(),
-             OneByteString(isolate, syscall)).FromJust();
+             OneByteString(isolate, syscall)).Check();
   }
 
   return e;
@@ -144,13 +144,13 @@ Local<Value> UVException(Isolate* isolate,
 
   e->Set(env->context(),
          env->errno_string(),
-         Integer::New(isolate, errorno)).FromJust();
-  e->Set(env->context(), env->code_string(), js_code).FromJust();
-  e->Set(env->context(), env->syscall_string(), js_syscall).FromJust();
+         Integer::New(isolate, errorno)).Check();
+  e->Set(env->context(), env->code_string(), js_code).Check();
+  e->Set(env->context(), env->syscall_string(), js_syscall).Check();
   if (!js_path.IsEmpty())
-    e->Set(env->context(), env->path_string(), js_path).FromJust();
+    e->Set(env->context(), env->path_string(), js_path).Check();
   if (!js_dest.IsEmpty())
-    e->Set(env->context(), env->dest_string(), js_dest).FromJust();
+    e->Set(env->context(), env->dest_string(), js_dest).Check();
 
   return e;
 }
@@ -219,21 +219,21 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
 
   Local<Object> obj = e.As<Object>();
   obj->Set(env->context(), env->errno_string(), Integer::New(isolate, errorno))
-      .FromJust();
+      .Check();
 
   if (path != nullptr) {
     obj->Set(env->context(),
              env->path_string(),
              String::NewFromUtf8(isolate, path, NewStringType::kNormal)
                  .ToLocalChecked())
-        .FromJust();
+        .Check();
   }
 
   if (syscall != nullptr) {
     obj->Set(env->context(),
              env->syscall_string(),
              OneByteString(isolate, syscall))
-        .FromJust();
+        .Check();
   }
 
   if (must_free) {

--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -49,7 +49,7 @@ int EmitExit(Environment* env) {
       ->Set(env->context(),
             FIXED_ONE_BYTE_STRING(env->isolate(), "_exiting"),
             True(env->isolate()))
-      .FromJust();
+      .Check();
 
   Local<String> exit_code = env->exit_code_string();
   int code = process_object->Get(env->context(), exit_code)

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -487,11 +487,11 @@ void AsyncWrap::Initialize(Local<Object> target,
 
   target->Set(context,
               env->async_ids_stack_string(),
-              env->async_hooks()->async_ids_stack().GetJSArray()).FromJust();
+              env->async_hooks()->async_ids_stack().GetJSArray()).Check();
 
   target->Set(context,
               FIXED_ONE_BYTE_STRING(env->isolate(), "owner_symbol"),
-              env->owner_symbol()).FromJust();
+              env->owner_symbol()).Check();
 
   Local<Object> constants = Object::New(isolate);
 #define SET_HOOKS_CONSTANT(name)                                              \
@@ -542,7 +542,7 @@ void AsyncWrap::Initialize(Local<Object> target,
     instance_template->SetInternalFieldCount(1);
     auto function =
         function_template->GetFunction(env->context()).ToLocalChecked();
-    target->Set(env->context(), class_name, function).FromJust();
+    target->Set(env->context(), class_name, function).Check();
     env->set_async_wrap_object_ctor_template(function_template);
   }
 }

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -374,7 +374,7 @@ Local<Array> HostentToNames(Environment* env,
 
   for (uint32_t i = 0; host->h_aliases[i] != nullptr; ++i) {
     Local<String> address = OneByteString(env->isolate(), host->h_aliases[i]);
-    names->Set(context, i + offset, address).FromJust();
+    names->Set(context, i + offset, address).Check();
   }
 
   return append ? names : scope.Escape(names);
@@ -577,7 +577,7 @@ class QueryWrap : public AsyncWrap {
     // Make sure the channel object stays alive during the query lifetime.
     req_wrap_obj->Set(env()->context(),
                       env()->channel_string(),
-                      channel->object()).FromJust();
+                      channel->object()).Check();
   }
 
   ~QueryWrap() override {
@@ -756,7 +756,7 @@ Local<Array> AddrTTLToArray(Environment* env,
   Local<Array> ttls = Array::New(isolate, naddrttls);
   for (size_t i = 0; i < naddrttls; i++) {
     auto value = Integer::New(isolate, addrttls[i].ttl);
-    ttls->Set(context, i, value).FromJust();
+    ttls->Set(context, i, value).Check();
   }
 
   return escapable_handle_scope.Escape(ttls);
@@ -816,7 +816,7 @@ int ParseGeneralReply(Environment* env,
     *type = ns_t_cname;
     ret->Set(context,
              ret->Length(),
-             OneByteString(env->isolate(), host->h_name)).FromJust();
+             OneByteString(env->isolate(), host->h_name)).Check();
     ares_free_hostent(host);
     return ARES_SUCCESS;
   }
@@ -830,7 +830,7 @@ int ParseGeneralReply(Environment* env,
     uint32_t offset = ret->Length();
     for (uint32_t i = 0; host->h_aliases[i] != nullptr; i++) {
       auto alias = OneByteString(env->isolate(), host->h_aliases[i]);
-      ret->Set(context, i + offset, alias).FromJust();
+      ret->Set(context, i + offset, alias).Check();
     }
   } else {
     uint32_t offset = ret->Length();
@@ -838,7 +838,7 @@ int ParseGeneralReply(Environment* env,
     for (uint32_t i = 0; host->h_addr_list[i] != nullptr; ++i) {
       uv_inet_ntop(host->h_addrtype, host->h_addr_list[i], ip, sizeof(ip));
       auto address = OneByteString(env->isolate(), ip);
-      ret->Set(context, i + offset, address).FromJust();
+      ret->Set(context, i + offset, address).Check();
     }
   }
 
@@ -868,16 +868,16 @@ int ParseMxReply(Environment* env,
     Local<Object> mx_record = Object::New(env->isolate());
     mx_record->Set(context,
                    env->exchange_string(),
-                   OneByteString(env->isolate(), current->host)).FromJust();
+                   OneByteString(env->isolate(), current->host)).Check();
     mx_record->Set(context,
                    env->priority_string(),
-                   Integer::New(env->isolate(), current->priority)).FromJust();
+                   Integer::New(env->isolate(), current->priority)).Check();
     if (need_type)
       mx_record->Set(context,
                      env->type_string(),
-                     env->dns_mx_string()).FromJust();
+                     env->dns_mx_string()).Check();
 
-    ret->Set(context, i + offset, mx_record).FromJust();
+    ret->Set(context, i + offset, mx_record).Check();
   }
 
   ares_free_data(mx_start);
@@ -912,13 +912,13 @@ int ParseTxtReply(Environment* env,
       if (!txt_chunk.IsEmpty()) {
         if (need_type) {
           Local<Object> elem = Object::New(env->isolate());
-          elem->Set(context, env->entries_string(), txt_chunk).FromJust();
+          elem->Set(context, env->entries_string(), txt_chunk).Check();
           elem->Set(context,
                     env->type_string(),
-                    env->dns_txt_string()).FromJust();
-          ret->Set(context, offset + i++, elem).FromJust();
+                    env->dns_txt_string()).Check();
+          ret->Set(context, offset + i++, elem).Check();
         } else {
-          ret->Set(context, offset + i++, txt_chunk).FromJust();
+          ret->Set(context, offset + i++, txt_chunk).Check();
         }
       }
 
@@ -926,20 +926,20 @@ int ParseTxtReply(Environment* env,
       j = 0;
     }
 
-    txt_chunk->Set(context, j++, txt).FromJust();
+    txt_chunk->Set(context, j++, txt).Check();
   }
 
   // Push last chunk if it isn't empty
   if (!txt_chunk.IsEmpty()) {
     if (need_type) {
       Local<Object> elem = Object::New(env->isolate());
-      elem->Set(context, env->entries_string(), txt_chunk).FromJust();
+      elem->Set(context, env->entries_string(), txt_chunk).Check();
       elem->Set(context,
                 env->type_string(),
-                env->dns_txt_string()).FromJust();
-      ret->Set(context, offset + i, elem).FromJust();
+                env->dns_txt_string()).Check();
+      ret->Set(context, offset + i, elem).Check();
     } else {
-      ret->Set(context, offset + i, txt_chunk).FromJust();
+      ret->Set(context, offset + i, txt_chunk).Check();
     }
   }
 
@@ -968,22 +968,22 @@ int ParseSrvReply(Environment* env,
     Local<Object> srv_record = Object::New(env->isolate());
     srv_record->Set(context,
                     env->name_string(),
-                    OneByteString(env->isolate(), current->host)).FromJust();
+                    OneByteString(env->isolate(), current->host)).Check();
     srv_record->Set(context,
                     env->port_string(),
-                    Integer::New(env->isolate(), current->port)).FromJust();
+                    Integer::New(env->isolate(), current->port)).Check();
     srv_record->Set(context,
                     env->priority_string(),
-                    Integer::New(env->isolate(), current->priority)).FromJust();
+                    Integer::New(env->isolate(), current->priority)).Check();
     srv_record->Set(context,
                     env->weight_string(),
-                    Integer::New(env->isolate(), current->weight)).FromJust();
+                    Integer::New(env->isolate(), current->weight)).Check();
     if (need_type)
       srv_record->Set(context,
                       env->type_string(),
-                      env->dns_srv_string()).FromJust();
+                      env->dns_srv_string()).Check();
 
-    ret->Set(context, i + offset, srv_record).FromJust();
+    ret->Set(context, i + offset, srv_record).Check();
   }
 
   ares_free_data(srv_start);
@@ -1012,32 +1012,32 @@ int ParseNaptrReply(Environment* env,
     Local<Object> naptr_record = Object::New(env->isolate());
     naptr_record->Set(context,
                       env->flags_string(),
-                      OneByteString(env->isolate(), current->flags)).FromJust();
+                      OneByteString(env->isolate(), current->flags)).Check();
     naptr_record->Set(context,
                       env->service_string(),
                       OneByteString(env->isolate(),
-                                    current->service)).FromJust();
+                                    current->service)).Check();
     naptr_record->Set(context,
                       env->regexp_string(),
                       OneByteString(env->isolate(),
-                                    current->regexp)).FromJust();
+                                    current->regexp)).Check();
     naptr_record->Set(context,
                       env->replacement_string(),
                       OneByteString(env->isolate(),
-                                    current->replacement)).FromJust();
+                                    current->replacement)).Check();
     naptr_record->Set(context,
                       env->order_string(),
-                      Integer::New(env->isolate(), current->order)).FromJust();
+                      Integer::New(env->isolate(), current->order)).Check();
     naptr_record->Set(context,
                       env->preference_string(),
                       Integer::New(env->isolate(),
-                                   current->preference)).FromJust();
+                                   current->preference)).Check();
     if (need_type)
       naptr_record->Set(context,
                         env->type_string(),
-                        env->dns_naptr_string()).FromJust();
+                        env->dns_naptr_string()).Check();
 
-    ret->Set(context, i + offset, naptr_record).FromJust();
+    ret->Set(context, i + offset, naptr_record).Check();
   }
 
   ares_free_data(naptr_start);
@@ -1131,29 +1131,29 @@ int ParseSoaReply(Environment* env,
       Local<Object> soa_record = Object::New(env->isolate());
       soa_record->Set(context,
                       env->nsname_string(),
-                      OneByteString(env->isolate(), nsname.get())).FromJust();
+                      OneByteString(env->isolate(), nsname.get())).Check();
       soa_record->Set(context,
                       env->hostmaster_string(),
                       OneByteString(env->isolate(),
-                                    hostmaster.get())).FromJust();
+                                    hostmaster.get())).Check();
       soa_record->Set(context,
                       env->serial_string(),
-                      Integer::New(env->isolate(), serial)).FromJust();
+                      Integer::New(env->isolate(), serial)).Check();
       soa_record->Set(context,
                       env->refresh_string(),
-                      Integer::New(env->isolate(), refresh)).FromJust();
+                      Integer::New(env->isolate(), refresh)).Check();
       soa_record->Set(context,
                       env->retry_string(),
-                      Integer::New(env->isolate(), retry)).FromJust();
+                      Integer::New(env->isolate(), retry)).Check();
       soa_record->Set(context,
                       env->expire_string(),
-                      Integer::New(env->isolate(), expire)).FromJust();
+                      Integer::New(env->isolate(), expire)).Check();
       soa_record->Set(context,
                       env->minttl_string(),
-                      Integer::New(env->isolate(), minttl)).FromJust();
+                      Integer::New(env->isolate(), minttl)).Check();
       soa_record->Set(context,
                       env->type_string(),
-                      env->dns_soa_string()).FromJust();
+                      env->dns_soa_string()).Check();
 
 
       *ret = handle_scope.Escape(soa_record);
@@ -1215,25 +1215,25 @@ class QueryAnyWrap: public QueryWrap {
         Local<Object> obj = Object::New(env()->isolate());
         obj->Set(context,
                  env()->address_string(),
-                 ret->Get(context, i).ToLocalChecked()).FromJust();
+                 ret->Get(context, i).ToLocalChecked()).Check();
         obj->Set(context,
                  env()->ttl_string(),
-                 Integer::New(env()->isolate(), addrttls[i].ttl)).FromJust();
+                 Integer::New(env()->isolate(), addrttls[i].ttl)).Check();
         obj->Set(context,
                  env()->type_string(),
-                 env()->dns_a_string()).FromJust();
-        ret->Set(context, i, obj).FromJust();
+                 env()->dns_a_string()).Check();
+        ret->Set(context, i, obj).Check();
       }
     } else {
       for (uint32_t i = 0; i < a_count; i++) {
         Local<Object> obj = Object::New(env()->isolate());
         obj->Set(context,
                  env()->value_string(),
-                 ret->Get(context, i).ToLocalChecked()).FromJust();
+                 ret->Get(context, i).ToLocalChecked()).Check();
         obj->Set(context,
                  env()->type_string(),
-                 env()->dns_cname_string()).FromJust();
-        ret->Set(context, i, obj).FromJust();
+                 env()->dns_cname_string()).Check();
+        ret->Set(context, i, obj).Check();
       }
     }
 
@@ -1261,15 +1261,15 @@ class QueryAnyWrap: public QueryWrap {
       Local<Object> obj = Object::New(env()->isolate());
       obj->Set(context,
                env()->address_string(),
-               ret->Get(context, i).ToLocalChecked()).FromJust();
+               ret->Get(context, i).ToLocalChecked()).Check();
       obj->Set(context,
                env()->ttl_string(),
                Integer::New(env()->isolate(), addr6ttls[i - a_count].ttl))
-          .FromJust();
+          .Check();
       obj->Set(context,
                env()->type_string(),
-               env()->dns_aaaa_string()).FromJust();
-      ret->Set(context, i, obj).FromJust();
+               env()->dns_aaaa_string()).Check();
+      ret->Set(context, i, obj).Check();
     }
 
     /* Parse MX records */
@@ -1291,11 +1291,11 @@ class QueryAnyWrap: public QueryWrap {
       Local<Object> obj = Object::New(env()->isolate());
       obj->Set(context,
                env()->value_string(),
-               ret->Get(context, i).ToLocalChecked()).FromJust();
+               ret->Get(context, i).ToLocalChecked()).Check();
       obj->Set(context,
                env()->type_string(),
-               env()->dns_ns_string()).FromJust();
-      ret->Set(context, i, obj).FromJust();
+               env()->dns_ns_string()).Check();
+      ret->Set(context, i, obj).Check();
     }
 
     /* Parse TXT records */
@@ -1319,11 +1319,11 @@ class QueryAnyWrap: public QueryWrap {
       Local<Object> obj = Object::New(env()->isolate());
       obj->Set(context,
                env()->value_string(),
-               ret->Get(context, i).ToLocalChecked()).FromJust();
+               ret->Get(context, i).ToLocalChecked()).Check();
       obj->Set(context,
                env()->type_string(),
-               env()->dns_ptr_string()).FromJust();
-      ret->Set(context, i, obj).FromJust();
+               env()->dns_ptr_string()).Check();
+      ret->Set(context, i, obj).Check();
     }
 
     /* Parse NAPTR records */
@@ -1341,7 +1341,7 @@ class QueryAnyWrap: public QueryWrap {
       return;
     }
     if (!soa_record.IsEmpty())
-      ret->Set(context, ret->Length(), soa_record).FromJust();
+      ret->Set(context, ret->Length(), soa_record).Check();
 
     CallOnComplete(ret);
   }
@@ -1701,27 +1701,27 @@ class QuerySoaWrap: public QueryWrap {
     soa_record->Set(context,
                     env()->nsname_string(),
                     OneByteString(env()->isolate(),
-                                  soa_out->nsname)).FromJust();
+                                  soa_out->nsname)).Check();
     soa_record->Set(context,
                     env()->hostmaster_string(),
                     OneByteString(env()->isolate(),
-                                  soa_out->hostmaster)).FromJust();
+                                  soa_out->hostmaster)).Check();
     soa_record->Set(context,
                     env()->serial_string(),
-                    Integer::New(env()->isolate(), soa_out->serial)).FromJust();
+                    Integer::New(env()->isolate(), soa_out->serial)).Check();
     soa_record->Set(context,
                     env()->refresh_string(),
                     Integer::New(env()->isolate(),
-                                 soa_out->refresh)).FromJust();
+                                 soa_out->refresh)).Check();
     soa_record->Set(context,
                     env()->retry_string(),
-                    Integer::New(env()->isolate(), soa_out->retry)).FromJust();
+                    Integer::New(env()->isolate(), soa_out->retry)).Check();
     soa_record->Set(context,
                     env()->expire_string(),
-                    Integer::New(env()->isolate(), soa_out->expire)).FromJust();
+                    Integer::New(env()->isolate(), soa_out->expire)).Check();
     soa_record->Set(context,
                     env()->minttl_string(),
-                    Integer::New(env()->isolate(), soa_out->minttl)).FromJust();
+                    Integer::New(env()->isolate(), soa_out->minttl)).Check();
 
     ares_free_data(soa_out);
 
@@ -1844,7 +1844,7 @@ void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
           continue;
 
         Local<String> s = OneByteString(env->isolate(), ip);
-        results->Set(env->context(), n, s).FromJust();
+        results->Set(env->context(), n, s).Check();
         n++;
       }
     };
@@ -2047,12 +2047,12 @@ void GetServers(const FunctionCallbackInfo<Value>& args) {
     CHECK_EQ(err, 0);
 
     Local<Array> ret = Array::New(env->isolate(), 2);
-    ret->Set(env->context(), 0, OneByteString(env->isolate(), ip)).FromJust();
+    ret->Set(env->context(), 0, OneByteString(env->isolate(), ip)).Check();
     ret->Set(env->context(),
              1,
-             Integer::New(env->isolate(), cur->udp_port)).FromJust();
+             Integer::New(env->isolate(), cur->udp_port)).Check();
 
-    server_array->Set(env->context(), i, ret).FromJust();
+    server_array->Set(env->context(), i, ret).Check();
   }
 
   ares_free_data(servers);
@@ -2177,18 +2177,18 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "strerror", StrError);
 
   target->Set(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(), "AF_INET"),
-              Integer::New(env->isolate(), AF_INET)).FromJust();
+              Integer::New(env->isolate(), AF_INET)).Check();
   target->Set(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(), "AF_INET6"),
-              Integer::New(env->isolate(), AF_INET6)).FromJust();
+              Integer::New(env->isolate(), AF_INET6)).Check();
   target->Set(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(),
                                                     "AF_UNSPEC"),
-              Integer::New(env->isolate(), AF_UNSPEC)).FromJust();
+              Integer::New(env->isolate(), AF_UNSPEC)).Check();
   target->Set(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(),
                                                     "AI_ADDRCONFIG"),
-              Integer::New(env->isolate(), AI_ADDRCONFIG)).FromJust();
+              Integer::New(env->isolate(), AI_ADDRCONFIG)).Check();
   target->Set(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(),
                                                     "AI_V4MAPPED"),
-              Integer::New(env->isolate(), AI_V4MAPPED)).FromJust();
+              Integer::New(env->isolate(), AI_V4MAPPED)).Check();
 
   Local<FunctionTemplate> aiw =
       BaseObject::MakeLazilyInitializedJSTemplate(env);
@@ -2198,7 +2198,7 @@ void Initialize(Local<Object> target,
   aiw->SetClassName(addrInfoWrapString);
   target->Set(env->context(),
               addrInfoWrapString,
-              aiw->GetFunction(context).ToLocalChecked()).FromJust();
+              aiw->GetFunction(context).ToLocalChecked()).Check();
 
   Local<FunctionTemplate> niw =
       BaseObject::MakeLazilyInitializedJSTemplate(env);
@@ -2208,7 +2208,7 @@ void Initialize(Local<Object> target,
   niw->SetClassName(nameInfoWrapString);
   target->Set(env->context(),
               nameInfoWrapString,
-              niw->GetFunction(context).ToLocalChecked()).FromJust();
+              niw->GetFunction(context).ToLocalChecked()).Check();
 
   Local<FunctionTemplate> qrw =
       BaseObject::MakeLazilyInitializedJSTemplate(env);
@@ -2218,7 +2218,7 @@ void Initialize(Local<Object> target,
   qrw->SetClassName(queryWrapString);
   target->Set(env->context(),
               queryWrapString,
-              qrw->GetFunction(context).ToLocalChecked()).FromJust();
+              qrw->GetFunction(context).ToLocalChecked()).Check();
 
   Local<FunctionTemplate> channel_wrap =
       env->NewFunctionTemplate(ChannelWrap::New);
@@ -2246,7 +2246,7 @@ void Initialize(Local<Object> target,
       FIXED_ONE_BYTE_STRING(env->isolate(), "ChannelWrap");
   channel_wrap->SetClassName(channelWrapString);
   target->Set(env->context(), channelWrapString,
-              channel_wrap->GetFunction(context).ToLocalChecked()).FromJust();
+              channel_wrap->GetFunction(context).ToLocalChecked()).Check();
 }
 
 }  // anonymous namespace

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -934,7 +934,7 @@ inline void Environment::SetMethod(v8::Local<v8::Object> that,
   const v8::NewStringType type = v8::NewStringType::kInternalized;
   v8::Local<v8::String> name_string =
       v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked();
-  that->Set(context, name_string, function).FromJust();
+  that->Set(context, name_string, function).Check();
   function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
 }
 
@@ -952,7 +952,7 @@ inline void Environment::SetMethodNoSideEffect(v8::Local<v8::Object> that,
   const v8::NewStringType type = v8::NewStringType::kInternalized;
   v8::Local<v8::String> name_string =
       v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked();
-  that->Set(context, name_string, function).FromJust();
+  that->Set(context, name_string, function).Check();
   function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
 }
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -748,33 +748,33 @@ void CollectExceptionInfo(Environment* env,
                           const char* dest) {
   obj->Set(env->context(),
            env->errno_string(),
-           Integer::New(env->isolate(), errorno)).FromJust();
+           Integer::New(env->isolate(), errorno)).Check();
 
   obj->Set(env->context(), env->code_string(),
-           OneByteString(env->isolate(), err_string)).FromJust();
+           OneByteString(env->isolate(), err_string)).Check();
 
   if (message != nullptr) {
     obj->Set(env->context(), env->message_string(),
-             OneByteString(env->isolate(), message)).FromJust();
+             OneByteString(env->isolate(), message)).Check();
   }
 
   Local<Value> path_buffer;
   if (path != nullptr) {
     path_buffer =
       Buffer::Copy(env->isolate(), path, strlen(path)).ToLocalChecked();
-    obj->Set(env->context(), env->path_string(), path_buffer).FromJust();
+    obj->Set(env->context(), env->path_string(), path_buffer).Check();
   }
 
   Local<Value> dest_buffer;
   if (dest != nullptr) {
     dest_buffer =
       Buffer::Copy(env->isolate(), dest, strlen(dest)).ToLocalChecked();
-    obj->Set(env->context(), env->dest_string(), dest_buffer).FromJust();
+    obj->Set(env->context(), env->dest_string(), dest_buffer).Check();
   }
 
   if (syscall != nullptr) {
     obj->Set(env->context(), env->syscall_string(),
-             OneByteString(env->isolate(), syscall)).FromJust();
+             OneByteString(env->isolate(), syscall)).Check();
   }
 }
 
@@ -819,7 +819,7 @@ void AsyncHooks::grow_async_ids_stack() {
   env()->async_hooks_binding()->Set(
       env()->context(),
       env()->async_ids_stack_string(),
-      async_ids_stack_.GetJSArray()).FromJust();
+      async_ids_stack_.GetJSArray()).Check();
 }
 
 uv_key_t Environment::thread_local_env = {};

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -122,7 +122,7 @@ void FSEventWrap::Initialize(Local<Object> target,
 
   target->Set(env->context(),
               fsevent_string,
-              t->GetFunction(context).ToLocalChecked()).FromJust();
+              t->GetFunction(context).ToLocalChecked()).Check();
 }
 
 

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -403,7 +403,7 @@ void NotifyClusterWorkersDebugEnabled(Environment* env) {
   // Send message to enable debug in cluster workers
   Local<Object> message = Object::New(isolate);
   message->Set(context, FIXED_ONE_BYTE_STRING(isolate, "cmd"),
-               FIXED_ONE_BYTE_STRING(isolate, "NODE_DEBUG_ENABLED")).FromJust();
+               FIXED_ONE_BYTE_STRING(isolate, "NODE_DEBUG_ENABLED")).Check();
   ProcessEmit(env, "internalMessage", message);
 }
 

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -280,7 +280,7 @@ void Initialize(Local<Object> target, Local<Value> unused,
           ->GetFunction(context)
           .ToLocalChecked();
   auto name_string = FIXED_ONE_BYTE_STRING(env->isolate(), "consoleCall");
-  target->Set(context, name_string, consoleCallFunc).FromJust();
+  target->Set(context, name_string, consoleCallFunc).Check();
   consoleCallFunc->SetName(name_string);
 
   env->SetMethod(

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -120,7 +120,7 @@ int JSStream::DoWrite(WriteWrap* w,
   Local<Object> buf;
   for (size_t i = 0; i < count; i++) {
     buf = Buffer::Copy(env(), bufs[i].base, bufs[i].len).ToLocalChecked();
-    bufs_arr->Set(env()->context(), i, buf).FromJust();
+    bufs_arr->Set(env()->context(), i, buf).Check();
   }
 
   Local<Value> argv[] = {
@@ -216,7 +216,7 @@ void JSStream::Initialize(Local<Object> target,
   StreamBase::AddMethods(env, t);
   target->Set(env->context(),
               jsStreamString,
-              t->GetFunction(context).ToLocalChecked()).FromJust();
+              t->GetFunction(context).ToLocalChecked()).Check();
 }
 
 }  // namespace node

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -239,7 +239,7 @@ void ModuleWrap::Link(const FunctionCallbackInfo<Value>& args) {
     Local<Promise> resolve_promise = resolve_return_value.As<Promise>();
     obj->resolve_cache_[specifier_std].Reset(env->isolate(), resolve_promise);
 
-    promises->Set(mod_context, i, resolve_promise).FromJust();
+    promises->Set(mod_context, i, resolve_promise).Check();
   }
 
   args.GetReturnValue().Set(promises);
@@ -374,7 +374,7 @@ void ModuleWrap::GetStaticDependencySpecifiers(
   Local<Array> specifiers = Array::New(env->isolate(), count);
 
   for (int i = 0; i < count; i++)
-    specifiers->Set(env->context(), i, module->GetModuleRequest(i)).FromJust();
+    specifiers->Set(env->context(), i, module->GetModuleRequest(i)).Check();
 
   args.GetReturnValue().Set(specifiers);
 }
@@ -1064,7 +1064,7 @@ void ModuleWrap::Initialize(Local<Object> target,
                                   GetStaticDependencySpecifiers);
 
   target->Set(env->context(), FIXED_ONE_BYTE_STRING(isolate, "ModuleWrap"),
-              tpl->GetFunction(context).ToLocalChecked()).FromJust();
+              tpl->GetFunction(context).ToLocalChecked()).Check();
   env->SetMethod(target, "resolve", Resolve);
   env->SetMethod(target, "getPackageType", GetPackageType);
   env->SetMethod(target,

--- a/src/node.cc
+++ b/src/node.cc
@@ -266,7 +266,7 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
   // Expose the global object as a property on itself
   // (Allows you to set stuff on `global` from anywhere in JavaScript.)
   global->Set(context, FIXED_ONE_BYTE_STRING(env->isolate(), "global"), global)
-      .FromJust();
+      .Check();
 
   // Store primordials
   env->set_primordials(Object::New(isolate));

--- a/src/node.cc
+++ b/src/node.cc
@@ -130,7 +130,6 @@ using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::HandleScope;
 using v8::Isolate;
-using v8::Just;
 using v8::Local;
 using v8::Locker;
 using v8::Maybe;

--- a/src/node.h
+++ b/src/node.h
@@ -374,7 +374,7 @@ NODE_DEPRECATED("Use v8::Date::ValueOf() directly",
     (target)->DefineOwnProperty(context,                                      \
                                 constant_name,                                \
                                 constant_value,                               \
-                                constant_attributes).FromJust();              \
+                                constant_attributes).Check();                 \
   }                                                                           \
   while (0)
 
@@ -395,7 +395,7 @@ NODE_DEPRECATED("Use v8::Date::ValueOf() directly",
     (target)->DefineOwnProperty(context,                                      \
                                 constant_name,                                \
                                 constant_value,                               \
-                                constant_attributes).FromJust();              \
+                                constant_attributes).Check();                 \
   }                                                                           \
   while (0)
 
@@ -426,7 +426,7 @@ inline void NODE_SET_METHOD(v8::Local<v8::Object> recv,
   v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name,
       v8::NewStringType::kInternalized).ToLocalChecked();
   fn->SetName(fn_name);
-  recv->Set(context, fn_name, fn).FromJust();
+  recv->Set(context, fn_name, fn).Check();
 }
 #define NODE_SET_METHOD node::NODE_SET_METHOD
 

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -633,7 +633,7 @@ void GetLinkedBinding(const FunctionCallbackInfo<Value>& args) {
   Local<String> exports_prop =
       String::NewFromUtf8(env->isolate(), "exports", NewStringType::kNormal)
           .ToLocalChecked();
-  module->Set(env->context(), exports_prop, exports).FromJust();
+  module->Set(env->context(), exports_prop, exports).Check();
 
   if (mod->nm_context_register_func != nullptr) {
     mod->nm_context_register_func(

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1085,11 +1085,11 @@ void Initialize(Local<Object> target,
 
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "kMaxLength"),
-              Integer::NewFromUnsigned(env->isolate(), kMaxLength)).FromJust();
+              Integer::NewFromUnsigned(env->isolate(), kMaxLength)).Check();
 
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "kStringMaxLength"),
-              Integer::New(env->isolate(), String::kMaxLength)).FromJust();
+              Integer::New(env->isolate(), String::kMaxLength)).Check();
 
   env->SetMethodNoSideEffect(target, "asciiSlice", StringSlice<ASCII>);
   env->SetMethodNoSideEffect(target, "base64Slice", StringSlice<BASE64>);

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1367,31 +1367,31 @@ void DefineConstants(v8::Isolate* isolate, Local<Object> target) {
 
   os_constants->Set(env->context(),
                     OneByteString(isolate, "dlopen"),
-                    dlopen_constants).FromJust();
+                    dlopen_constants).Check();
   os_constants->Set(env->context(),
                     OneByteString(isolate, "errno"),
-                    err_constants).FromJust();
+                    err_constants).Check();
   os_constants->Set(env->context(),
                     OneByteString(isolate, "signals"),
-                    sig_constants).FromJust();
+                    sig_constants).Check();
   os_constants->Set(env->context(),
                     OneByteString(isolate, "priority"),
-                    priority_constants).FromJust();
+                    priority_constants).Check();
   target->Set(env->context(),
               OneByteString(isolate, "os"),
-              os_constants).FromJust();
+              os_constants).Check();
   target->Set(env->context(),
               OneByteString(isolate, "fs"),
-              fs_constants).FromJust();
+              fs_constants).Check();
   target->Set(env->context(),
               OneByteString(isolate, "crypto"),
-              crypto_constants).FromJust();
+              crypto_constants).Check();
   target->Set(env->context(),
               OneByteString(isolate, "zlib"),
-              zlib_constants).FromJust();
+              zlib_constants).Check();
   target->Set(env->context(),
               OneByteString(isolate, "trace"),
-              trace_constants).FromJust();
+              trace_constants).Check();
 }
 
 }  // namespace node

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -405,7 +405,7 @@ void ContextifyContext::PropertySetterCallback(
     args.GetReturnValue().Set(false);
   }
 
-  ctx->sandbox()->Set(ctx->context(), property, value).FromJust();
+  ctx->sandbox()->Set(ctx->context(), property, value).Check();
 }
 
 // static
@@ -469,7 +469,7 @@ void ContextifyContext::PropertyDefinerCallback(
         }
         // Set the property on the sandbox.
         sandbox->DefineProperty(context, property, *desc_for_sandbox)
-            .FromJust();
+            .Check();
       };
 
   if (desc.has_get() || desc.has_set()) {
@@ -620,7 +620,7 @@ void ContextifyScript::Init(Environment* env, Local<Object> target) {
   env->SetProtoMethod(script_tmpl, "runInThisContext", RunInThisContext);
 
   target->Set(env->context(), class_name,
-      script_tmpl->GetFunction(env->context()).ToLocalChecked()).FromJust();
+      script_tmpl->GetFunction(env->context()).ToLocalChecked()).Check();
   env->set_script_context_constructor_template(script_tmpl);
 }
 
@@ -744,7 +744,7 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
     args.This()->Set(
         env->context(),
         env->cached_data_rejected_string(),
-        Boolean::New(isolate, source.GetCachedData()->rejected)).FromJust();
+        Boolean::New(isolate, source.GetCachedData()->rejected)).Check();
   } else if (produce_cached_data) {
     const ScriptCompiler::CachedData* cached_data =
       ScriptCompiler::CreateCodeCache(v8_script.ToLocalChecked());
@@ -756,12 +756,12 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
           cached_data->length);
       args.This()->Set(env->context(),
                        env->cached_data_string(),
-                       buf.ToLocalChecked()).FromJust();
+                       buf.ToLocalChecked()).Check();
     }
     args.This()->Set(
         env->context(),
         env->cached_data_produced_string(),
-        Boolean::New(isolate, cached_data_produced)).FromJust();
+        Boolean::New(isolate, cached_data_produced)).Check();
   }
   TRACE_EVENT_NESTABLE_ASYNC_END0(
       TRACING_CATEGORY_NODE2(vm, script),

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -79,7 +79,7 @@ using v8::Value;
   *valp = obj->Get(env->context(),                                             \
                    OneByteString(env->isolate(), #member)).ToLocalChecked()    \
               ->Int32Value(env->context())                                     \
-              .Check();
+              .FromJust();
 
 #define SLURP_OBJECT(obj, member, valp)                                    \
   if (!(obj)->IsObject()) {                                                \

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -79,7 +79,7 @@ using v8::Value;
   *valp = obj->Get(env->context(),                                             \
                    OneByteString(env->isolate(), #member)).ToLocalChecked()    \
               ->Int32Value(env->context())                                     \
-              .FromJust();
+              .Check();
 
 #define SLURP_OBJECT(obj, member, valp)                                    \
   if (!(obj)->IsObject()) {                                                \

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -70,7 +70,7 @@ void FatalException(v8::Isolate* isolate,
         v8::Exception::type(js_msg)->ToObject(                                \
             isolate->GetCurrentContext()).ToLocalChecked();                   \
     e->Set(isolate->GetCurrentContext(), OneByteString(isolate, "code"),      \
-           js_code).FromJust();                                               \
+           js_code).Check();                                                  \
     return e;                                                                 \
   }                                                                           \
   inline void THROW_ ## code(v8::Isolate* isolate, const char* message) {     \

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -206,7 +206,7 @@ void FileHandle::CloseReq::Resolve() {
   InternalCallbackScope callback_scope(this);
   Local<Promise> promise = promise_.Get(isolate);
   Local<Promise::Resolver> resolver = promise.As<Promise::Resolver>();
-  resolver->Resolve(env()->context(), Undefined(isolate)).FromJust();
+  resolver->Resolve(env()->context(), Undefined(isolate)).Check();
 }
 
 void FileHandle::CloseReq::Reject(Local<Value> reason) {
@@ -215,7 +215,7 @@ void FileHandle::CloseReq::Reject(Local<Value> reason) {
   InternalCallbackScope callback_scope(this);
   Local<Promise> promise = promise_.Get(isolate);
   Local<Promise::Resolver> resolver = promise.As<Promise::Resolver>();
-  resolver->Reject(env()->context(), reason).FromJust();
+  resolver->Reject(env()->context(), reason).Check();
 }
 
 FileHandle* FileHandle::CloseReq::file_handle() {
@@ -269,7 +269,7 @@ inline MaybeLocal<Promise> FileHandle::ClosePromise() {
   } else {
     // Already closed. Just reject the promise immediately
     resolver->Reject(context, UVException(isolate, UV_EBADF, "close"))
-        .FromJust();
+        .Check();
   }
   return scope.Escape(promise);
 }
@@ -668,11 +668,11 @@ void AfterScanDirWithTypes(uv_fs_t* req) {
   result->Set(env->context(),
               0,
               Array::New(isolate, name_v.data(),
-              name_v.size())).FromJust();
+              name_v.size())).Check();
   result->Set(env->context(),
               1,
               Array::New(isolate, type_v.data(),
-              type_v.size())).FromJust();
+              type_v.size())).Check();
   req_wrap->Resolve(result);
 }
 
@@ -739,10 +739,10 @@ inline int SyncCall(Environment* env, Local<Value> ctx, FSReqWrapSync* req_wrap,
     Isolate* isolate = env->isolate();
     ctx_obj->Set(context,
              env->errno_string(),
-             Integer::New(isolate, err)).FromJust();
+             Integer::New(isolate, err)).Check();
     ctx_obj->Set(context,
              env->syscall_string(),
-             OneByteString(isolate, syscall)).FromJust();
+             OneByteString(isolate, syscall)).Check();
   }
   return err;
 }
@@ -1085,7 +1085,7 @@ static void ReadLink(const FunctionCallbackInfo<Value>& args) {
                                                &error);
     if (rc.IsEmpty()) {
       Local<Object> ctx = args[3].As<Object>();
-      ctx->Set(env->context(), env->error_string(), error).FromJust();
+      ctx->Set(env->context(), env->error_string(), error).Check();
       return;
     }
 
@@ -1434,7 +1434,7 @@ static void RealPath(const FunctionCallbackInfo<Value>& args) {
                                                &error);
     if (rc.IsEmpty()) {
       Local<Object> ctx = args[3].As<Object>();
-      ctx->Set(env->context(), env->error_string(), error).FromJust();
+      ctx->Set(env->context(), env->error_string(), error).Check();
       return;
     }
 
@@ -1490,9 +1490,9 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
       if (r != 0) {
         Local<Object> ctx = args[4].As<Object>();
         ctx->Set(env->context(), env->errno_string(),
-                 Integer::New(isolate, r)).FromJust();
+                 Integer::New(isolate, r)).Check();
         ctx->Set(env->context(), env->syscall_string(),
-                 OneByteString(isolate, "readdir")).FromJust();
+                 OneByteString(isolate, "readdir")).Check();
         return;
       }
 
@@ -1504,7 +1504,7 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
 
       if (filename.IsEmpty()) {
         Local<Object> ctx = args[4].As<Object>();
-        ctx->Set(env->context(), env->error_string(), error).FromJust();
+        ctx->Set(env->context(), env->error_string(), error).Check();
         return;
       }
 
@@ -1519,11 +1519,11 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
     Local<Array> names = Array::New(isolate, name_v.data(), name_v.size());
     if (with_types) {
       Local<Array> result = Array::New(isolate, 2);
-      result->Set(env->context(), 0, names).FromJust();
+      result->Set(env->context(), 0, names).Check();
       result->Set(env->context(),
                   1,
                   Array::New(isolate, type_v.data(),
-                             type_v.size())).FromJust();
+                             type_v.size())).Check();
       args.GetReturnValue().Set(result);
     } else {
       args.GetReturnValue().Set(names);
@@ -2126,7 +2126,7 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
         StringBytes::Encode(isolate, path, encoding, &error);
     if (rc.IsEmpty()) {
       Local<Object> ctx = args[3].As<Object>();
-      ctx->Set(env->context(), env->error_string(), error).FromJust();
+      ctx->Set(env->context(), env->error_string(), error).Check();
       return;
     }
     args.GetReturnValue().Set(rc.ToLocalChecked());
@@ -2183,15 +2183,15 @@ void Initialize(Local<Object> target,
   target->Set(context,
               FIXED_ONE_BYTE_STRING(isolate, "kFsStatsFieldsNumber"),
               Integer::New(isolate, kFsStatsFieldsNumber))
-        .FromJust();
+        .Check();
 
   target->Set(context,
               FIXED_ONE_BYTE_STRING(isolate, "statValues"),
-              env->fs_stats_field_array()->GetJSArray()).FromJust();
+              env->fs_stats_field_array()->GetJSArray()).Check();
 
   target->Set(context,
               FIXED_ONE_BYTE_STRING(isolate, "bigintStatValues"),
-              env->fs_stats_field_bigint_array()->GetJSArray()).FromJust();
+              env->fs_stats_field_bigint_array()->GetJSArray()).Check();
 
   StatWatcher::Initialize(env, target);
 
@@ -2205,7 +2205,7 @@ void Initialize(Local<Object> target,
   target
       ->Set(context, wrapString,
             fst->GetFunction(env->context()).ToLocalChecked())
-      .FromJust();
+      .Check();
 
   // Create FunctionTemplate for FileHandleReadWrap. There’s no need
   // to do anything in the constructor, so we only store the instance template.
@@ -2242,7 +2242,7 @@ void Initialize(Local<Object> target,
   target
       ->Set(context, handleString,
             fd->GetFunction(env->context()).ToLocalChecked())
-      .FromJust();
+      .Check();
   env->set_fd_constructor_template(fdt);
 
   // Create FunctionTemplate for FileHandle::CloseReq
@@ -2260,7 +2260,7 @@ void Initialize(Local<Object> target,
   env->set_fs_use_promises_symbol(use_promises_symbol);
   target->Set(context,
               FIXED_ONE_BYTE_STRING(isolate, "kUsePromises"),
-              use_promises_symbol).FromJust();
+              use_promises_symbol).Check();
 }
 
 }  // namespace fs

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2530,7 +2530,7 @@ void Http2Session::UpdateChunksSent(const FunctionCallbackInfo<Value>& args) {
 
   session->object()->Set(env->context(),
                          env->chunks_sent_since_last_write_string(),
-                         Integer::NewFromUnsigned(isolate, length)).FromJust();
+                         Integer::NewFromUnsigned(isolate, length)).Check();
 
   args.GetReturnValue().Set(length);
 }
@@ -3015,7 +3015,7 @@ void Initialize(Local<Object> target,
   env->set_http2stream_constructor_template(streamt);
   target->Set(context,
               FIXED_ONE_BYTE_STRING(env->isolate(), "Http2Stream"),
-              stream->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              stream->GetFunction(env->context()).ToLocalChecked()).Check();
 
   Local<FunctionTemplate> session =
       env->NewFunctionTemplate(Http2Session::New);
@@ -3043,7 +3043,7 @@ void Initialize(Local<Object> target,
       Http2Session::RefreshSettings<nghttp2_session_get_remote_settings>);
   target->Set(context,
               http2SessionClassName,
-              session->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              session->GetFunction(env->context()).ToLocalChecked()).Check();
 
   Local<Object> constants = Object::New(isolate);
   Local<Array> name_for_error_code = Array::New(isolate);
@@ -3078,7 +3078,7 @@ void Initialize(Local<Object> target,
   name_for_error_code->Set(env->context(),                              \
                            static_cast<int>(name),                      \
                            FIXED_ONE_BYTE_STRING(isolate,               \
-                                                 #name)).FromJust();
+                                                 #name)).Check();
   NODE_NGHTTP2_ERROR_CODES(V)
 #undef V
 
@@ -3146,10 +3146,10 @@ HTTP_STATUS_CODES(V)
 
   target->Set(context,
               env->constants_string(),
-              constants).FromJust();
+              constants).Check();
   target->Set(context,
               FIXED_ONE_BYTE_STRING(isolate, "nameForErrorCode"),
-              name_for_error_code).FromJust();
+              name_for_error_code).Check();
 }
 }  // namespace http2
 }  // namespace node

--- a/src/node_http_parser_impl.h
+++ b/src/node_http_parser_impl.h
@@ -733,7 +733,7 @@ class Parser : public AsyncWrap, public StreamListener {
         .ToLocalChecked();
       obj->Set(env()->context(),
                env()->bytes_parsed_string(),
-               nread_obj).FromJust();
+               nread_obj).Check();
 #ifdef NODE_EXPERIMENTAL_HTTP
       const char* errno_reason = llhttp_get_error_reason(&parser_);
 
@@ -750,13 +750,13 @@ class Parser : public AsyncWrap, public StreamListener {
         reason = OneByteString(env()->isolate(), errno_reason);
       }
 
-      obj->Set(env()->context(), env()->code_string(), code).FromJust();
-      obj->Set(env()->context(), env()->reason_string(), reason).FromJust();
+      obj->Set(env()->context(), env()->code_string(), code).Check();
+      obj->Set(env()->context(), env()->reason_string(), reason).Check();
 #else  /* !NODE_EXPERIMENTAL_HTTP */
       obj->Set(env()->context(),
                env()->code_string(),
                OneByteString(env()->isolate(),
-                             http_errno_name(err))).FromJust();
+                             http_errno_name(err))).Check();
 #endif  /* NODE_EXPERIMENTAL_HTTP */
       return scope.Escape(e);
     }
@@ -946,12 +946,12 @@ void InitializeHttpParser(Local<Object> target,
   Local<Array> methods = Array::New(env->isolate());
 #define V(num, name, string)                                                  \
     methods->Set(env->context(),                                              \
-        num, FIXED_ONE_BYTE_STRING(env->isolate(), #string)).FromJust();
+        num, FIXED_ONE_BYTE_STRING(env->isolate(), #string)).Check();
   HTTP_METHOD_MAP(V)
 #undef V
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "methods"),
-              methods).FromJust();
+              methods).Check();
 
   t->Inherit(AsyncWrap::GetConstructorTemplate(env));
   env->SetProtoMethod(t, "close", Parser::Close);
@@ -967,7 +967,7 @@ void InitializeHttpParser(Local<Object> target,
 
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "HTTPParser"),
-              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              t->GetFunction(env->context()).ToLocalChecked()).Check();
 
 #ifndef NODE_EXPERIMENTAL_HTTP
   static uv_once_t init_once = UV_ONCE_INIT;

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -847,9 +847,9 @@ static void MessageChannel(const FunctionCallbackInfo<Value>& args) {
   MessagePort::Entangle(port1, port2);
 
   args.This()->Set(context, env->port1_string(), port1->object())
-      .FromJust();
+      .Check();
   args.This()->Set(context, env->port2_string(), port2->object())
-      .FromJust();
+      .Check();
 }
 
 static void InitMessaging(Local<Object> target,
@@ -865,13 +865,13 @@ static void InitMessaging(Local<Object> target,
     templ->SetClassName(message_channel_string);
     target->Set(context,
                 message_channel_string,
-                templ->GetFunction(context).ToLocalChecked()).FromJust();
+                templ->GetFunction(context).ToLocalChecked()).Check();
   }
 
   target->Set(context,
               env->message_port_constructor_string(),
               GetMessagePortConstructor(env, context).ToLocalChecked())
-                  .FromJust();
+                  .Check();
 
   // These are not methods on the MessagePort prototype, because
   // the browser equivalents do not provide them.

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -112,7 +112,7 @@ Local<Object> MapToObject(Local<Context> context,
   Local<Object> out = Object::New(isolate);
   for (auto const& x : in) {
     Local<String> key = OneByteString(isolate, x.first.c_str(), x.first.size());
-    out->Set(context, key, x.second.ToStringChecked(isolate)).FromJust();
+    out->Set(context, key, x.second.ToStringChecked(isolate)).Check();
   }
   return out;
 }
@@ -156,12 +156,12 @@ void NativeModuleLoader::GetModuleCategories(
       ->Set(context,
             OneByteString(isolate, "cannotBeRequired"),
             ToJsSet(context, cannot_be_required))
-      .FromJust();
+      .Check();
   result
       ->Set(context,
             OneByteString(isolate, "canBeRequired"),
             ToJsSet(context, can_be_required))
-      .FromJust();
+      .Check();
   info.GetReturnValue().Set(result);
 }
 
@@ -175,12 +175,12 @@ void NativeModuleLoader::GetCacheUsage(
       ->Set(env->context(),
             OneByteString(isolate, "compiledWithCache"),
             ToJsSet(context, env->native_modules_with_cache))
-      .FromJust();
+      .Check();
   result
       ->Set(env->context(),
             OneByteString(isolate, "compiledWithoutCache"),
             ToJsSet(context, env->native_modules_without_cache))
-      .FromJust();
+      .Check();
   args.GetReturnValue().Set(result);
 }
 
@@ -418,7 +418,7 @@ void NativeModuleLoader::Initialize(Local<Object> target,
       target, "compileFunction", NativeModuleLoader::CompileFunction);
   env->SetMethod(target, "getCodeCache", NativeModuleLoader::GetCodeCache);
   // internalBinding('native_module') should be frozen
-  target->SetIntegrityLevel(context, IntegrityLevel::kFrozen).FromJust();
+  target->SetIntegrityLevel(context, IntegrityLevel::kFrozen).Check();
 }
 
 }  // namespace native_module

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -755,7 +755,7 @@ void Initialize(Local<Object> target,
   target
       ->Set(
           context, FIXED_ONE_BYTE_STRING(isolate, "envSettings"), env_settings)
-      .FromJust();
+      .Check();
 
   Local<Object> types = Object::New(isolate);
   NODE_DEFINE_CONSTANT(types, kNoOp);
@@ -767,7 +767,7 @@ void Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(types, kHostPort);
   NODE_DEFINE_CONSTANT(types, kStringList);
   target->Set(context, FIXED_ONE_BYTE_STRING(isolate, "types"), types)
-      .FromJust();
+      .Check();
 }
 
 }  // namespace options_parser

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -325,17 +325,17 @@ static void GetUserInfo(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> entry = Object::New(env->isolate());
 
-  entry->Set(env->context(), env->uid_string(), uid).FromJust();
-  entry->Set(env->context(), env->gid_string(), gid).FromJust();
+  entry->Set(env->context(), env->uid_string(), uid).Check();
+  entry->Set(env->context(), env->gid_string(), gid).Check();
   entry->Set(env->context(),
              env->username_string(),
-             username.ToLocalChecked()).FromJust();
+             username.ToLocalChecked()).Check();
   entry->Set(env->context(),
              env->homedir_string(),
-             homedir.ToLocalChecked()).FromJust();
+             homedir.ToLocalChecked()).Check();
   entry->Set(env->context(),
              env->shell_string(),
-             shell.ToLocalChecked()).FromJust();
+             shell.ToLocalChecked()).Check();
 
   args.GetReturnValue().Set(entry);
 }
@@ -401,7 +401,7 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "getPriority", GetPriority);
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "isBigEndian"),
-              Boolean::New(env->isolate(), IsBigEndian())).FromJust();
+              Boolean::New(env->isolate(), IsBigEndian())).Check();
 }
 
 }  // namespace os

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -65,7 +65,7 @@ inline void InitObject(const PerformanceEntry& entry, Local<Object> obj) {
                                              NewStringType::kNormal)
                              .ToLocalChecked(),
                          attr)
-      .FromJust();
+      .Check();
   obj->DefineOwnProperty(context,
                          env->entry_type_string(),
                          String::NewFromUtf8(isolate,
@@ -73,15 +73,15 @@ inline void InitObject(const PerformanceEntry& entry, Local<Object> obj) {
                                              NewStringType::kNormal)
                              .ToLocalChecked(),
                          attr)
-      .FromJust();
+      .Check();
   obj->DefineOwnProperty(context,
                          env->start_time_string(),
                          Number::New(isolate, entry.startTime()),
-                         attr).FromJust();
+                         attr).Check();
   obj->DefineOwnProperty(context,
                          env->duration_string(),
                          Number::New(isolate, entry.duration()),
-                         attr).FromJust();
+                         attr).Check();
 }
 
 // Create a new PerformanceEntry object
@@ -245,7 +245,7 @@ void PerformanceGCCallback(Environment* env, void* ptr) {
     obj->DefineOwnProperty(context,
                            env->kind_string(),
                            Integer::New(env->isolate(), entry->gckind()),
-                           attr).FromJust();
+                           attr).Check();
     PerformanceEntry::Notify(env, entry->kind(), obj);
   }
 }
@@ -351,7 +351,7 @@ void TimerFunctionCall(const FunctionCallbackInfo<Value>& args) {
   Local<Object> obj;
   if (!entry.ToObject().ToLocal(&obj)) return;
   for (idx = 0; idx < count; idx++)
-    obj->Set(context, idx, args[idx]).FromJust();
+    obj->Set(context, idx, args[idx]).Check();
   PerformanceEntry::Notify(env, entry.kind(), obj);
 }
 
@@ -542,10 +542,10 @@ void Initialize(Local<Object> target,
 
   target->Set(context,
               FIXED_ONE_BYTE_STRING(isolate, "observerCounts"),
-              state->observers.GetJSArray()).FromJust();
+              state->observers.GetJSArray()).Check();
   target->Set(context,
               FIXED_ONE_BYTE_STRING(isolate, "milestones"),
-              state->milestones.GetJSArray()).FromJust();
+              state->milestones.GetJSArray()).Check();
 
   Local<String> performanceEntryString =
       FIXED_ONE_BYTE_STRING(isolate, "PerformanceEntry");
@@ -553,7 +553,7 @@ void Initialize(Local<Object> target,
   Local<FunctionTemplate> pe = FunctionTemplate::New(isolate);
   pe->SetClassName(performanceEntryString);
   Local<Function> fn = pe->GetFunction(context).ToLocalChecked();
-  target->Set(context, performanceEntryString, fn).FromJust();
+  target->Set(context, performanceEntryString, fn).Check();
   env->set_performance_entry_template(fn);
 
   env->SetMethod(target, "clearMark", ClearMark);
@@ -617,7 +617,7 @@ void Initialize(Local<Object> target,
   env->SetProtoMethod(eldh, "disable", ELDHistogramDisable);
   env->SetProtoMethod(eldh, "reset", ELDHistogramReset);
   target->Set(context, eldh_classname,
-              eldh->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              eldh->GetFunction(env->context()).ToLocalChecked()).Check();
 }
 
 }  // namespace performance

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -157,13 +157,13 @@ void PatchProcessObject(const FunctionCallbackInfo<Value>& args) {
   // process.argv
   process->Set(context,
                FIXED_ONE_BYTE_STRING(isolate, "argv"),
-               ToV8Value(context, env->argv()).ToLocalChecked()).FromJust();
+               ToV8Value(context, env->argv()).ToLocalChecked()).Check();
 
   // process.execArgv
   process->Set(context,
                FIXED_ONE_BYTE_STRING(isolate, "execArgv"),
                ToV8Value(context, env->exec_argv())
-                   .ToLocalChecked()).FromJust();
+                   .ToLocalChecked()).Check();
 
   READONLY_PROPERTY(process, "pid",
                     Integer::New(isolate, uv_os_getpid()));
@@ -212,7 +212,7 @@ void PatchProcessObject(const FunctionCallbackInfo<Value>& args) {
                                   NewStringType::kInternalized,
                                   exec_path.size())
                   .ToLocalChecked())
-        .FromJust();
+        .Check();
   }
 
   // process.debugPort

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -284,7 +284,7 @@ DeserializerContext::DeserializerContext(Environment* env,
     data_(reinterpret_cast<const uint8_t*>(Buffer::Data(buffer))),
     length_(Buffer::Length(buffer)),
     deserializer_(env->isolate(), data_, length_, this) {
-  object()->Set(env->context(), env->buffer_string(), buffer).FromJust();
+  object()->Set(env->context(), env->buffer_string(), buffer).Check();
   deserializer_.SetExpectInlineWasm(true);
 
   MakeWeak();
@@ -471,7 +471,7 @@ void Initialize(Local<Object> target,
   ser->SetClassName(serializerString);
   target->Set(env->context(),
               serializerString,
-              ser->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              ser->GetFunction(env->context()).ToLocalChecked()).Check();
 
   Local<FunctionTemplate> des =
       env->NewFunctionTemplate(DeserializerContext::New);
@@ -496,7 +496,7 @@ void Initialize(Local<Object> target,
   des->SetClassName(deserializerString);
   target->Set(env->context(),
               deserializerString,
-              des->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              des->GetFunction(env->context()).ToLocalChecked()).Check();
 }
 
 }  // anonymous namespace

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -55,7 +55,7 @@ void StatWatcher::Initialize(Environment* env, Local<Object> target) {
   env->SetProtoMethod(t, "start", StatWatcher::Start);
 
   target->Set(env->context(), statWatcherString,
-              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              t->GetFunction(env->context()).ToLocalChecked()).Check();
 }
 
 

--- a/src/node_symbols.cc
+++ b/src/node_symbols.cc
@@ -18,7 +18,7 @@ static void Initialize(Local<Object> target,
 #define V(PropertyName, StringValue)                                           \
   target                                                                       \
       ->Set(env->context(), env->PropertyName()->Name(), env->PropertyName())  \
-      .FromJust();
+      .Check();
   PER_ISOLATE_SYMBOL_PROPERTIES(V)
 #undef V
 }

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -131,7 +131,7 @@ static void Initialize(Local<Object> target,
   env->SetMethod(target, "runMicrotasks", RunMicrotasks);
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(isolate, "tickInfo"),
-              env->tick_info()->fields().GetJSArray()).FromJust();
+              env->tick_info()->fields().GetJSArray()).Check();
 
   Local<Object> events = Object::New(isolate);
   NODE_DEFINE_CONSTANT(events, kPromiseRejectWithNoHandler);
@@ -141,7 +141,7 @@ static void Initialize(Local<Object> target,
 
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(isolate, "promiseRejectEvents"),
-              events).FromJust();
+              events).Check();
   env->SetMethod(target,
                  "setPromiseRejectCallback",
                  SetPromiseRejectCallback);

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -134,7 +134,7 @@ void NodeCategorySet::Initialize(Local<Object> target,
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "CategorySet"),
               category_set->GetFunction(env->context()).ToLocalChecked())
-              .FromJust();
+              .Check();
 
   Local<String> isTraceCategoryEnabled =
       FIXED_ONE_BYTE_STRING(env->isolate(), "isTraceCategoryEnabled");
@@ -145,9 +145,9 @@ void NodeCategorySet::Initialize(Local<Object> target,
   Local<Object> binding = context->GetExtrasBindingObject();
   target->Set(context, isTraceCategoryEnabled,
               binding->Get(context, isTraceCategoryEnabled).ToLocalChecked())
-                  .FromJust();
+                  .Check();
   target->Set(context, trace,
-              binding->Get(context, trace).ToLocalChecked()).FromJust();
+              binding->Get(context, trace).ToLocalChecked()).Check();
 }
 
 }  // namespace node

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -220,7 +220,7 @@ void Initialize(Local<Object> target,
 #define V(name, _)                                                            \
   target->Set(context,                                                        \
               FIXED_ONE_BYTE_STRING(env->isolate(), #name),                   \
-              Integer::NewFromUnsigned(env->isolate(), index++)).FromJust();
+              Integer::NewFromUnsigned(env->isolate(), index++)).Check();
   {
     uint32_t index = 0;
     PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)
@@ -261,7 +261,7 @@ void Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(constants, SKIP_SYMBOLS);
   target->Set(context,
               FIXED_ONE_BYTE_STRING(env->isolate(), "propertyFilter"),
-              constants).FromJust();
+              constants).Check();
 
   Local<String> should_abort_on_uncaught_toggle =
       FIXED_ONE_BYTE_STRING(env->isolate(), "shouldAbortOnUncaughtToggle");
@@ -279,7 +279,7 @@ void Initialize(Local<Object> target,
   weak_ref->SetClassName(weak_ref_string);
   env->SetProtoMethod(weak_ref, "get", WeakReference::Get);
   target->Set(context, weak_ref_string,
-              weak_ref->GetFunction(context).ToLocalChecked()).FromJust();
+              weak_ref->GetFunction(context).ToLocalChecked()).Check();
 }
 
 }  // namespace util

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -139,12 +139,12 @@ void Initialize(Local<Object> target,
                                     "heapStatisticsArrayBuffer"),
               ArrayBuffer::New(env->isolate(),
                                env->heap_statistics_buffer(),
-                               heap_statistics_buffer_byte_length)).FromJust();
+                               heap_statistics_buffer_byte_length)).Check();
 
 #define V(i, _, name)                                                         \
   target->Set(env->context(),                                                 \
               FIXED_ONE_BYTE_STRING(env->isolate(), #name),                   \
-              Uint32::NewFromUnsigned(env->isolate(), i)).FromJust();
+              Uint32::NewFromUnsigned(env->isolate(), i)).Check();
 
   HEAP_STATISTICS_PROPERTIES(V)
 #undef V
@@ -154,7 +154,7 @@ void Initialize(Local<Object> target,
                                     "kHeapSpaceStatisticsPropertiesCount"),
               Uint32::NewFromUnsigned(env->isolate(),
                                       kHeapSpaceStatisticsPropertiesCount))
-              .FromJust();
+              .Check();
 
   size_t number_of_heap_spaces = env->isolate()->NumberOfHeapSpaces();
 
@@ -169,11 +169,11 @@ void Initialize(Local<Object> target,
                                                         s.space_name(),
                                                         NewStringType::kNormal)
                                         .ToLocalChecked();
-    heap_spaces->Set(env->context(), i, heap_space_name).FromJust();
+    heap_spaces->Set(env->context(), i, heap_space_name).Check();
   }
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "kHeapSpaces"),
-              heap_spaces).FromJust();
+              heap_spaces).Check();
 
   env->SetMethod(target,
                  "updateHeapSpaceStatisticsArrayBuffer",
@@ -193,12 +193,12 @@ void Initialize(Local<Object> target,
               ArrayBuffer::New(env->isolate(),
                                env->heap_space_statistics_buffer(),
                                heap_space_statistics_buffer_byte_length))
-              .FromJust();
+              .Check();
 
 #define V(i, _, name)                                                         \
   target->Set(env->context(),                                                 \
               FIXED_ONE_BYTE_STRING(env->isolate(), #name),                   \
-              Uint32::NewFromUnsigned(env->isolate(), i)).FromJust();
+              Uint32::NewFromUnsigned(env->isolate(), i)).Check();
 
   HEAP_SPACE_STATISTICS_PROPERTIES(V)
 #undef V

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -84,12 +84,12 @@ Worker::Worker(Environment* env,
 
   object()->Set(env->context(),
                 env->message_port_string(),
-                parent_port_->object()).FromJust();
+                parent_port_->object()).Check();
 
   object()->Set(env->context(),
                 env->thread_id_string(),
                 Number::New(env->isolate(), static_cast<double>(thread_id_)))
-      .FromJust();
+      .Check();
 
 #if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
   inspector_parent_handle_ =
@@ -372,7 +372,7 @@ void Worker::OnThreadStopped() {
     // Reset the parent port as we're closing it now anyway.
     object()->Set(env()->context(),
                   env()->message_port_string(),
-                  Undefined(env()->isolate())).FromJust();
+                  Undefined(env()->isolate())).Check();
 
     Local<Value> code = Integer::New(env()->isolate(), exit_code_);
     MakeCallback(env()->onexit_string(), 1, &code);
@@ -602,7 +602,7 @@ void InitWorker(Local<Object> target,
     w->SetClassName(workerString);
     target->Set(env->context(),
                 workerString,
-                w->GetFunction(env->context()).ToLocalChecked()).FromJust();
+                w->GetFunction(env->context()).ToLocalChecked()).Check();
   }
 
   env->SetMethod(target, "getEnvMessagePort", GetEnvMessagePort);
@@ -611,19 +611,19 @@ void InitWorker(Local<Object> target,
       ->Set(env->context(),
             env->thread_id_string(),
             Number::New(env->isolate(), static_cast<double>(env->thread_id())))
-      .FromJust();
+      .Check();
 
   target
       ->Set(env->context(),
             FIXED_ONE_BYTE_STRING(env->isolate(), "isMainThread"),
             Boolean::New(env->isolate(), env->is_main_thread()))
-      .FromJust();
+      .Check();
 
   target
       ->Set(env->context(),
             FIXED_ONE_BYTE_STRING(env->isolate(), "ownsProcessState"),
             Boolean::New(env->isolate(), env->owns_process_state()))
-      .FromJust();
+      .Check();
 }
 
 }  // anonymous namespace

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -1225,7 +1225,7 @@ struct MakeClass {
     z->SetClassName(zlibString);
     target->Set(env->context(),
                 zlibString,
-                z->GetFunction(env->context()).ToLocalChecked()).FromJust();
+                z->GetFunction(env->context()).ToLocalChecked()).Check();
   }
 };
 
@@ -1241,7 +1241,7 @@ void Initialize(Local<Object> target,
 
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "ZLIB_VERSION"),
-              FIXED_ONE_BYTE_STRING(env->isolate(), ZLIB_VERSION)).FromJust();
+              FIXED_ONE_BYTE_STRING(env->isolate(), ZLIB_VERSION)).Check();
 }
 
 }  // anonymous namespace

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -90,7 +90,7 @@ void PipeWrap::Initialize(Local<Object> target,
 
   target->Set(env->context(),
               pipeString,
-              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              t->GetFunction(env->context()).ToLocalChecked()).Check();
   env->set_pipe_constructor_template(t);
 
   // Create FunctionTemplate for PipeConnectWrap.
@@ -101,7 +101,7 @@ void PipeWrap::Initialize(Local<Object> target,
   cwt->SetClassName(wrapString);
   target->Set(env->context(),
               wrapString,
-              cwt->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              cwt->GetFunction(env->context()).ToLocalChecked()).Check();
 
   // Define constants
   Local<Object> constants = Object::New(env->isolate());
@@ -112,7 +112,7 @@ void PipeWrap::Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(constants, UV_WRITABLE);
   target->Set(context,
               env->constants_string(),
-              constants).FromJust();
+              constants).Check();
 }
 
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -64,7 +64,7 @@ class ProcessWrap : public HandleWrap {
 
     target->Set(env->context(),
                 processString,
-                constructor->GetFunction(context).ToLocalChecked()).FromJust();
+                constructor->GetFunction(context).ToLocalChecked()).Check();
   }
 
   SET_NO_MEMORY_INFO()
@@ -261,7 +261,7 @@ class ProcessWrap : public HandleWrap {
       CHECK_EQ(wrap->process_.data, wrap);
       wrap->object()->Set(context, env->pid_string(),
                           Integer::New(env->isolate(),
-                                       wrap->process_.pid)).FromJust();
+                                       wrap->process_.pid)).Check();
     }
 
     if (options.args) {

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -59,7 +59,7 @@ class SignalWrap : public HandleWrap {
 
     target->Set(env->context(), signalString,
                 constructor->GetFunction(env->context()).ToLocalChecked())
-                .FromJust();
+                .Check();
   }
 
   SET_NO_MEMORY_INFO()

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -677,22 +677,22 @@ Local<Object> SyncProcessRunner::BuildResultObject() {
 
   if (GetError() != 0) {
     js_result->Set(context, env()->error_string(),
-                   Integer::New(env()->isolate(), GetError())).FromJust();
+                   Integer::New(env()->isolate(), GetError())).Check();
   }
 
   if (exit_status_ >= 0) {
     if (term_signal_ > 0) {
       js_result->Set(context, env()->status_string(),
-                     Null(env()->isolate())).FromJust();
+                     Null(env()->isolate())).Check();
     } else {
       js_result->Set(context, env()->status_string(),
                      Number::New(env()->isolate(),
-                                 static_cast<double>(exit_status_))).FromJust();
+                                 static_cast<double>(exit_status_))).Check();
     }
   } else {
     // If exit_status_ < 0 the process was never started because of some error.
     js_result->Set(context, env()->status_string(),
-                   Null(env()->isolate())).FromJust();
+                   Null(env()->isolate())).Check();
   }
 
   if (term_signal_ > 0)
@@ -701,20 +701,20 @@ Local<Object> SyncProcessRunner::BuildResultObject() {
                                        signo_string(term_signal_),
                                        v8::NewStringType::kNormal)
                        .ToLocalChecked())
-        .FromJust();
+        .Check();
   else
     js_result->Set(context, env()->signal_string(),
-                   Null(env()->isolate())).FromJust();
+                   Null(env()->isolate())).Check();
 
   if (exit_status_ >= 0)
     js_result->Set(context, env()->output_string(),
-                   BuildOutputArray()).FromJust();
+                   BuildOutputArray()).Check();
   else
     js_result->Set(context, env()->output_string(),
-                   Null(env()->isolate())).FromJust();
+                   Null(env()->isolate())).Check();
 
   js_result->Set(context, env()->pid_string(),
-                 Number::New(env()->isolate(), uv_process_.pid)).FromJust();
+                 Number::New(env()->isolate(), uv_process_.pid)).Check();
 
   return scope.Escape(js_result);
 }
@@ -731,9 +731,9 @@ Local<Array> SyncProcessRunner::BuildOutputArray() {
   for (uint32_t i = 0; i < stdio_pipes_.size(); i++) {
     SyncProcessStdioPipe* h = stdio_pipes_[i].get();
     if (h != nullptr && h->writable())
-      js_output->Set(context, i, h->GetOutputAsBuffer(env())).FromJust();
+      js_output->Set(context, i, h->GetOutputAsBuffer(env())).Check();
     else
-      js_output->Set(context, i, Null(env()->isolate())).FromJust();
+      js_output->Set(context, i, Null(env()->isolate())).Check();
   }
 
   return scope.Escape(js_output);
@@ -1045,7 +1045,7 @@ Maybe<int> SyncProcessRunner::CopyJsStringArray(Local<Value> js_value,
                 i,
                 value->ToString(env()->isolate()->GetCurrentContext())
                     .ToLocalChecked())
-          .FromJust();
+          .Check();
     }
 
     Maybe<size_t> maybe_size = StringBytes::StorageSize(isolate, value, UTF8);

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -170,7 +170,7 @@ inline int StreamBase::Shutdown(v8::Local<v8::Object> req_wrap_obj) {
   if (msg != nullptr) {
     req_wrap_obj->Set(
         env->context(),
-        env->error_string(), OneByteString(env->isolate(), msg)).FromJust();
+        env->error_string(), OneByteString(env->isolate(), msg)).Check();
     ClearError();
   }
 
@@ -223,7 +223,7 @@ inline StreamWriteResult StreamBase::Write(
   if (msg != nullptr) {
     req_wrap_obj->Set(env->context(),
                       env->error_string(),
-                      OneByteString(env->isolate(), msg)).FromJust();
+                      OneByteString(env->isolate(), msg)).Check();
     ClearError();
   }
 
@@ -295,7 +295,7 @@ inline void StreamReq::Done(int status, const char* error_str) {
     async_wrap->object()->Set(env->context(),
                               env->error_string(),
                               OneByteString(env->isolate(), error_str))
-                              .FromJust();
+                              .Check();
   }
 
   OnDone(status);

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -276,7 +276,7 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
     // collected before `AfterWrite` is called.
     req_wrap_obj->Set(env->context(),
                       env->handle_string(),
-                      send_handle_obj).FromJust();
+                      send_handle_obj).Check();
   }
 
   StreamWriteResult res = Write(&buf, 1, send_handle, req_wrap_obj);

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -31,13 +31,13 @@ StreamPipe::StreamPipe(StreamBase* source,
   // if that applies to the given streams (for example, Http2Streams use
   // weak references).
   obj->Set(env()->context(), env()->source_string(), source->GetObject())
-      .FromJust();
+      .Check();
   source->GetObject()->Set(env()->context(), env()->pipe_target_string(), obj)
-      .FromJust();
+      .Check();
   obj->Set(env()->context(), env()->sink_string(), sink->GetObject())
-      .FromJust();
+      .Check();
   sink->GetObject()->Set(env()->context(), env()->pipe_source_string(), obj)
-      .FromJust();
+      .Check();
 }
 
 StreamPipe::~StreamPipe() {
@@ -267,7 +267,7 @@ void InitializeStreamPipe(Local<Object> target,
   target
       ->Set(context, stream_pipe_string,
             pipe->GetFunction(context).ToLocalChecked())
-      .FromJust();
+      .Check();
 }
 
 }  // anonymous namespace

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -89,7 +89,7 @@ void LibuvStreamWrap::Initialize(Local<Object> target,
 
   target->Set(env->context(),
               wrapString,
-              sw->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              sw->GetFunction(env->context()).ToLocalChecked()).Check();
   env->set_shutdown_wrap_template(sw->InstanceTemplate());
 
   Local<FunctionTemplate> ww =
@@ -101,7 +101,7 @@ void LibuvStreamWrap::Initialize(Local<Object> target,
   ww->Inherit(AsyncWrap::GetConstructorTemplate(env));
   target->Set(env->context(),
               writeWrapString,
-              ww->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              ww->GetFunction(env->context()).ToLocalChecked()).Check();
   env->set_write_wrap_template(ww->InstanceTemplate());
 
   NODE_DEFINE_CONSTANT(target, kReadBytesOrError);
@@ -109,7 +109,7 @@ void LibuvStreamWrap::Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(target, kBytesWritten);
   NODE_DEFINE_CONSTANT(target, kLastWriteWasAsync);
   target->Set(context, FIXED_ONE_BYTE_STRING(env->isolate(), "streamBaseState"),
-              env->stream_base_state().GetJSArray()).FromJust();
+              env->stream_base_state().GetJSArray()).Check();
 }
 
 
@@ -274,7 +274,7 @@ void LibuvStreamWrap::OnUvRead(ssize_t nread, const uv_buf_t* buf) {
           ->Set(env()->context(),
                 env()->pending_handle_string(),
                 pending_obj.ToLocalChecked())
-          .FromJust();
+          .Check();
     }
   }
 

--- a/src/string_decoder.cc
+++ b/src/string_decoder.cc
@@ -309,11 +309,11 @@ void InitializeStringDecoder(Local<Object> target,
 
   target->Set(context,
               FIXED_ONE_BYTE_STRING(isolate, "encodings"),
-              encodings).FromJust();
+              encodings).Check();
 
   target->Set(context,
               FIXED_ONE_BYTE_STRING(isolate, "kSize"),
-              Integer::New(isolate, sizeof(StringDecoder))).FromJust();
+              Integer::New(isolate, sizeof(StringDecoder))).Check();
 
   env->SetMethod(target, "decode", DecodeData);
   env->SetMethod(target, "flush", FlushData);

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -107,7 +107,7 @@ void TCPWrap::Initialize(Local<Object> target,
 
   target->Set(env->context(),
               tcpString,
-              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              t->GetFunction(env->context()).ToLocalChecked()).Check();
   env->set_tcp_constructor_template(t);
 
   // Create FunctionTemplate for TCPConnectWrap.
@@ -119,7 +119,7 @@ void TCPWrap::Initialize(Local<Object> target,
   cwt->SetClassName(wrapString);
   target->Set(env->context(),
               wrapString,
-              cwt->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              cwt->GetFunction(env->context()).ToLocalChecked()).Check();
 
   // Define constants
   Local<Object> constants = Object::New(env->isolate());
@@ -128,7 +128,7 @@ void TCPWrap::Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(constants, UV_TCP_IPV6ONLY);
   target->Set(context,
               env->constants_string(),
-              constants).FromJust();
+              constants).Check();
 }
 
 
@@ -353,13 +353,13 @@ Local<Object> AddressToJS(Environment* env,
     port = ntohs(a6->sin6_port);
     info->Set(env->context(),
               env->address_string(),
-              OneByteString(env->isolate(), ip)).FromJust();
+              OneByteString(env->isolate(), ip)).Check();
     info->Set(env->context(),
               env->family_string(),
-              env->ipv6_string()).FromJust();
+              env->ipv6_string()).Check();
     info->Set(env->context(),
               env->port_string(),
-              Integer::New(env->isolate(), port)).FromJust();
+              Integer::New(env->isolate(), port)).Check();
     break;
 
   case AF_INET:
@@ -368,19 +368,19 @@ Local<Object> AddressToJS(Environment* env,
     port = ntohs(a4->sin_port);
     info->Set(env->context(),
               env->address_string(),
-              OneByteString(env->isolate(), ip)).FromJust();
+              OneByteString(env->isolate(), ip)).Check();
     info->Set(env->context(),
               env->family_string(),
-              env->ipv4_string()).FromJust();
+              env->ipv4_string()).Check();
     info->Set(env->context(),
               env->port_string(),
-              Integer::New(env->isolate(), port)).FromJust();
+              Integer::New(env->isolate(), port)).Check();
     break;
 
   default:
     info->Set(env->context(),
               env->address_string(),
-              String::Empty(env->isolate())).FromJust();
+              String::Empty(env->isolate())).Check();
   }
 
   return scope.Escape(info);

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -57,7 +57,7 @@ void Initialize(Local<Object> target,
 
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "immediateInfo"),
-              env->immediate_info()->fields().GetJSArray()).FromJust();
+              env->immediate_info()->fields().GetJSArray()).Check();
 }
 
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -436,13 +436,13 @@ Local<Value> TLSWrap::GetSSLError(int status, int* err, std::string* msg) {
 
         if (ls != nullptr)
           obj->Set(context, env()->library_string(),
-                   OneByteString(isolate, ls)).FromJust();
+                   OneByteString(isolate, ls)).Check();
         if (fs != nullptr)
           obj->Set(context, env()->function_string(),
-                   OneByteString(isolate, fs)).FromJust();
+                   OneByteString(isolate, fs)).Check();
         if (rs != nullptr) {
           obj->Set(context, env()->reason_string(),
-                   OneByteString(isolate, rs)).FromJust();
+                   OneByteString(isolate, rs)).Check();
 
           // SSL has no API to recover the error name from the number, so we
           // transform reason strings like "this error" to "ERR_SSL_THIS_ERROR",
@@ -457,7 +457,7 @@ Local<Value> TLSWrap::GetSSLError(int status, int* err, std::string* msg) {
           }
           obj->Set(context, env()->code_string(),
                    OneByteString(isolate, ("ERR_SSL_" + code).c_str()))
-                     .FromJust();
+                     .Check();
         }
 
         if (msg != nullptr)
@@ -1094,7 +1094,7 @@ void TLSWrap::Initialize(Local<Object> target,
 
   target->Set(env->context(),
               tlsWrapString,
-              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              t->GetFunction(env->context()).ToLocalChecked()).Check();
 }
 
 }  // namespace node

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -117,8 +117,8 @@ void TTYWrap::GetWindowSize(const FunctionCallbackInfo<Value>& args) {
 
   if (err == 0) {
     Local<Array> a = args[0].As<Array>();
-    a->Set(env->context(), 0, Integer::New(env->isolate(), width)).FromJust();
-    a->Set(env->context(), 1, Integer::New(env->isolate(), height)).FromJust();
+    a->Set(env->context(), 0, Integer::New(env->isolate(), width)).Check();
+    a->Set(env->context(), 1, Integer::New(env->isolate(), height)).Check();
   }
 
   args.GetReturnValue().Set(err);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -139,7 +139,7 @@ void UDPWrap::Initialize(Local<Object> target,
 
   target->Set(env->context(),
               udpString,
-              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              t->GetFunction(env->context()).ToLocalChecked()).Check();
   env->set_udp_constructor_function(
       t->GetFunction(env->context()).ToLocalChecked());
 
@@ -152,13 +152,13 @@ void UDPWrap::Initialize(Local<Object> target,
   swt->SetClassName(sendWrapString);
   target->Set(env->context(),
               sendWrapString,
-              swt->GetFunction(env->context()).ToLocalChecked()).FromJust();
+              swt->GetFunction(env->context()).ToLocalChecked()).Check();
 
   Local<Object> constants = Object::New(env->isolate());
   NODE_DEFINE_CONSTANT(constants, UV_UDP_IPV6ONLY);
   target->Set(context,
               env->constants_string(),
-              constants).FromJust();
+              constants).Check();
 }
 
 

--- a/src/util.h
+++ b/src/util.h
@@ -582,7 +582,7 @@ inline v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
   do {                                                                         \
     obj->DefineOwnProperty(                                                    \
            context, FIXED_ONE_BYTE_STRING(isolate, name), value, v8::ReadOnly) \
-        .FromJust();                                                           \
+        .Check();                                                              \
   } while (0)
 
 #define READONLY_DONT_ENUM_PROPERTY(obj, name, var)                            \
@@ -592,7 +592,7 @@ inline v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
            OneByteString(isolate, name),                                       \
            var,                                                                \
            static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontEnum))    \
-        .FromJust();                                                           \
+        .Check();                                                              \
   } while (0)
 
 #define READONLY_FALSE_PROPERTY(obj, name)                                     \
@@ -621,7 +621,7 @@ inline v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
                             constant_name,                                     \
                             constant_value,                                    \
                             constant_attributes)                               \
-        .FromJust();                                                           \
+        .Check();                                                              \
   } while (0)
 
 enum Endianness {

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -111,7 +111,7 @@ void Initialize(Local<Object> target,
               FIXED_ONE_BYTE_STRING(isolate, "errname"),
               env->NewFunctionTemplate(ErrName)
                   ->GetFunction(env->context())
-                  .ToLocalChecked()).FromJust();
+                  .ToLocalChecked()).Check();
 
   // TODO(joyeecheung): This should be deprecated in user land in favor of
   // `util.getSystemErrorName(err)`.
@@ -124,7 +124,7 @@ void Initialize(Local<Object> target,
     const std::string prefixed_name = prefix + error.name;
     Local<String> name = OneByteString(isolate, prefixed_name.c_str());
     Local<Integer> value = Integer::New(isolate, error.value);
-    target->DefineOwnProperty(context, name, value, attributes).FromJust();
+    target->DefineOwnProperty(context, name, value, attributes).Check();
   }
 
   env->SetMethod(target, "getErrorMap", GetErrMap);


### PR DESCRIPTION
FromJust() is often used not for its return value, but for its
side-effects. In these cases, Check() exists, and is more clear as to
the intent. From its comment:

  To be used, where the actual value of the Maybe is not needed like
  Object::Set.

See: https://github.com/nodejs/node/pull/26929/files#r269256335

--------------

I'm not dead sure this is a good idea, because Check() doesn't exist on 11.x, but on the other hand, it's
a trivial method, we could probably backport the v8 patch for it to 11.x if it's absence was painful.

`Check()` is much more clear in its intent, IMO, than FromJust() called just for its side-effect.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
