### PR TITLE
build: pin Python version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
       language: node_js
       node_js: "node"
       install:
+        - pyenv global 2.7.15
         - make lint-py-build || true
       script:
         - NODE=$(which node) make lint lint-py
@@ -37,6 +38,7 @@ jobs:
             - g++-6
       install: *ccache-setup-steps
       script:
+        - pyenv global 2.7.15
         - ./configure
         - make -j2 -C out V=1 v8
 
@@ -50,6 +52,7 @@ jobs:
             - g++-6
       install: *ccache-setup-steps
       script:
+        - pyenv global 2.7.15
         - ./configure
         - make -j2 V=1
         - cp out/Release/node /home/travis/.ccache
@@ -62,6 +65,7 @@ jobs:
         - mkdir -p out/Release
         - cp /home/travis/.ccache/node out/Release/node
       script:
+        - pyenv global 2.7.15
         - python tools/test.py -j 2 -p dots --report --mode=release --flaky-tests=dontcare default
 
     - name: "Test C++ Suites"
@@ -77,6 +81,7 @@ jobs:
         - cp /home/travis/.ccache/cctest out/Release/cctest
         - touch config.gypi
       script:
+        - pyenv global 2.7.15
         - out/Release/cctest
         - make -j1 V=1 test/addons/.buildstamp test/js-native-api/.buildstamp test/node-api/.buildstamp
         - python tools/test.py -j 2 -p dots --report --mode=release --flaky-tests=dontcare addons js-native-api node-api


### PR DESCRIPTION
Travis will be switching the default version of Python from 2.7 to 3.6 on April 16th 2019.

This PR pins the Travis builds to Python 2.7 as we're not at Python 3 compatibility yet. If we can get there before April 16th we can drop this PR, otherwise it will be necessary for our Travis builds to continue to function.

Refs: https://changelog.travis-ci.com/upcoming-python-default-version-update-96873
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
