### PR TITLE
tools,doc: fix 404 broken links in docs

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -137,16 +137,18 @@ function linkManPages(text) {
       if (BSD_ONLY_SYSCALLS.has(name)) {
         return `${beginning}<a href="https://www.freebsd.org/cgi/man.cgi` +
           `?query=${name}&sektion=${number}">${displayAs}</a>`;
-      } else if (LINUX_DIE_ONLY_SYSCALLS.has(name)) {
+      }
+      if (LINUX_DIE_ONLY_SYSCALLS.has(name)) {
         return `${beginning}<a href="https://linux.die.net/man/` +
                 `${number}/${name}">${displayAs}</a>`;
-      } else if (HAXX_ONLY_SYSCALLS.has(name)) {
+      }
+      if (HAXX_ONLY_SYSCALLS.has(name)) {
         return `${beginning}<a href="https://${name}.haxx.se/docs/manpage.html">${displayAs}</a>`;
-      } 
-      
+      }
+
       return `${beginning}<a href="http://man7.org/linux/man-pages/man${number}` +
         `/${name}.${number}${optionalCharacter}.html">${displayAs}</a>`;
-  });
+    });
 }
 
 const TYPE_SIGNATURE = /\{[^}]+\}/g;

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -142,11 +142,11 @@ function linkManPages(text) {
                 `${number}/${name}">${displayAs}</a>`;
       } else if (HAXX_ONLY_SYSCALLS.has(name)) {
         return `${beginning}<a href="https://${name}.haxx.se/docs/manpage.html">${displayAs}</a>`;
-      } else {
-        return `${beginning}<a href="http://man7.org/linux/man-pages/man${number}` +
-          `/${name}.${number}${optionalCharacter}.html">${displayAs}</a>`;
-      }
-    });
+      } 
+      
+      return `${beginning}<a href="http://man7.org/linux/man-pages/man${number}` +
+        `/${name}.${number}${optionalCharacter}.html">${displayAs}</a>`;
+  });
 }
 
 const TYPE_SIGNATURE = /\{[^}]+\}/g;

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -120,6 +120,8 @@ function preprocessText() {
 
 // Syscalls which appear in the docs, but which only exist in BSD / macOS.
 const BSD_ONLY_SYSCALLS = new Set(['lchmod']);
+const LINUX_DIE_ONLY_SYSCALLS = new Set(['uname']);
+const HAXX_ONLY_SYSCALLS = new Set(['curl']);
 const MAN_PAGE = /(^|\s)([a-z.]+)\((\d)([a-z]?)\)/gm;
 
 // Handle references to man pages, eg "open(2)" or "lchmod(2)".
@@ -135,9 +137,15 @@ function linkManPages(text) {
       if (BSD_ONLY_SYSCALLS.has(name)) {
         return `${beginning}<a href="https://www.freebsd.org/cgi/man.cgi` +
           `?query=${name}&sektion=${number}">${displayAs}</a>`;
+      } else if (LINUX_DIE_ONLY_SYSCALLS.has(name)) {
+        return `${beginning}<a href="https://linux.die.net/man/` +
+                `${number}/${name}">${displayAs}</a>`;
+      } else if (HAXX_ONLY_SYSCALLS.has(name)) {
+        return `${beginning}<a href="https://${name}.haxx.se/docs/manpage.html">${displayAs}</a>`;
+      } else {
+        return `${beginning}<a href="http://man7.org/linux/man-pages/man${number}` +
+          `/${name}.${number}${optionalCharacter}.html">${displayAs}</a>`;
       }
-      return `${beginning}<a href="http://man7.org/linux/man-pages/man${number}` +
-        `/${name}.${number}${optionalCharacter}.html">${displayAs}</a>`;
     });
 }
 


### PR DESCRIPTION
Change the linkManPages function to catch the `uname` and `curl` correct websites on the docs page.

Fixes: https://github.com/nodejs/node/issues/26074

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

![image](https://user-images.githubusercontent.com/2708687/55853056-05c19100-5b25-11e9-9d0b-d905b8d758a2.png)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
