### PR TITLE
src: fix check for accepting Buffers into Node’s allocator

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -138,7 +138,11 @@ void DebuggingArrayBufferAllocator::UnregisterPointerInternal(void* data,
   if (data == nullptr) return;
   auto it = allocations_.find(data);
   CHECK_NE(it, allocations_.end());
-  CHECK_EQ(it->second, size);
+  if (size > 0) {
+    // We allow allocations with size 1 for 0-length buffers to avoid having
+    // to deal with nullptr values.
+    CHECK_EQ(it->second, size);
+  }
   allocations_.erase(it);
 }
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -420,7 +420,7 @@ MaybeLocal<Object> New(Environment* env,
   }
 
   if (uses_malloc) {
-    if (env->isolate_data()->uses_node_allocator()) {
+    if (!env->isolate_data()->uses_node_allocator()) {
       // We don't know for sure that the allocator is malloc()-based, so we need
       // to fall back to the FreeCallback variant.
       auto free_callback = [](char* data, void* hint) { free(data); };


### PR DESCRIPTION
This condition was incorrect. We currently take the fallback
path in default Node builds, which always works, but may come with
some overhead, whereas the intention was that we use the fast path
in this condition.

This is causing issues for embedders, because we would erroneously
try to take the fast path when they don’t provide a Node.js-style
`ArrayBufferAlloactor`, and crash as a consequence of that.

This also requires us to relax the check in the debugging ArrayBuffer
allocator a bit, because since d117e41e50667d7a36, 0-sized ArrayBuffers
may actually point to allocations of size 1. Previously, that wasn’t
caught because the fallback path circumvented our ArrayBufferAllocator.

Refs: https://github.com/nodejs/node/commit/84e02b178ad14fae0df2a514e8a39bfa50ffdc2d#r33116006

/cc @zcbenz

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
