### PR TITLE
build: fix test failures not failing Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,5 @@ jobs:
         - make -j2 > /dev/null
         - make -j1 build-addons build-js-native-api-tests build-node-api-tests > /dev/null
       script:
+        - set -o pipefail
         - JOBS=2 FLAKY_TESTS=dontcare make -s -j1 V= test-ci | grep -F -e "---" -e "..." -v


### PR DESCRIPTION
The exit code of the make command used to execute tests was being lost
after being piped through to grep.

Refs: https://github.com/nodejs/node/pull/25947#issuecomment-481633400
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
