### PR TITLE
child_process: change the defaults maxBuffer size

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -151,7 +151,7 @@ changes:
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
     stderr. If exceeded, the child process is terminated and any output is
     truncated. See caveat at [`maxBuffer` and Unicode][].
-    **Default:** `200 * 1024`.
+    **Default:** `1024 * 1024`.
   * `killSignal` {string|integer} **Default:** `'SIGTERM'`
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
@@ -250,7 +250,7 @@ changes:
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
     stderr. If exceeded, the child process is terminated and any output is
     truncated. See caveat at [`maxBuffer` and Unicode][].
-    **Default:** `200 * 1024`.
+    **Default:** `1024 * 1024`.
   * `killSignal` {string|integer} **Default:** `'SIGTERM'`
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
@@ -721,7 +721,7 @@ changes:
     process will be killed. **Default:** `'SIGTERM'`.
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
     stderr. If exceeded, the child process is terminated. See caveat at
-    [`maxBuffer` and Unicode][]. **Default:** `200 * 1024`.
+    [`maxBuffer` and Unicode][]. **Default:** `1024 * 1024`.
   * `encoding` {string} The encoding used for all stdio inputs and outputs.
     **Default:** `'buffer'`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
@@ -788,7 +788,7 @@ changes:
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
     stderr. If exceeded, the child process is terminated and any output is
     truncated. See caveat at [`maxBuffer` and Unicode][].
-    **Default:** `200 * 1024`.
+    **Default:** `1024 * 1024`.
   * `encoding` {string} The encoding used for all stdio inputs and outputs.
     **Default:** `'buffer'`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
@@ -852,7 +852,7 @@ changes:
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
     stderr. If exceeded, the child process is terminated and any output is
     truncated. See caveat at [`maxBuffer` and Unicode][].
-    **Default:** `200 * 1024`.
+    **Default:** `1024 * 1024`.
   * `encoding` {string} The encoding used for all stdio inputs and outputs.
     **Default:** `'buffer'`.
   * `shell` {boolean|string} If `true`, runs `command` inside of a shell. Uses

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -46,7 +46,7 @@ const {
   ChildProcess
 } = child_process;
 
-const MAX_BUFFER = 200 * 1024;
+const MAX_BUFFER = 1024 * 1024;
 
 exports.ChildProcess = ChildProcess;
 

--- a/test/parallel/test-child-process-exec-maxbuf.js
+++ b/test/parallel/test-child-process-exec-maxbuf.js
@@ -12,7 +12,8 @@ function runChecks(err, stdio, streamName, expected) {
 
 // default value
 {
-  const cmd = `"${process.execPath}" -e "console.log('a'.repeat(200 * 1024))"`;
+  const cmd =
+    `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024))"`;
 
   cp.exec(cmd, common.mustCall((err) => {
     assert(err instanceof RangeError);
@@ -24,11 +25,11 @@ function runChecks(err, stdio, streamName, expected) {
 // default value
 {
   const cmd =
-    `${process.execPath} -e "console.log('a'.repeat(200 * 1024 - 1))"`;
+    `${process.execPath} -e "console.log('a'.repeat(1024 * 1024 - 1))"`;
 
   cp.exec(cmd, common.mustCall((err, stdout, stderr) => {
     assert.ifError(err);
-    assert.strictEqual(stdout.trim(), 'a'.repeat(200 * 1024 - 1));
+    assert.strictEqual(stdout.trim(), 'a'.repeat(1024 * 1024 - 1));
     assert.strictEqual(stderr, '');
   }));
 }
@@ -58,12 +59,18 @@ function runChecks(err, stdio, streamName, expected) {
 
 // default value
 {
-  const cmd = `"${process.execPath}" -e "console.log('a'.repeat(200 * 1024))"`;
+  const cmd =
+    `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024))"`;
 
   cp.exec(
     cmd,
     common.mustCall((err, stdout, stderr) => {
-      runChecks(err, { stdout, stderr }, 'stdout', 'a'.repeat(200 * 1024));
+      runChecks(
+        err,
+        { stdout, stderr },
+        'stdout',
+        'a'.repeat(1024 * 1024)
+      );
     })
   );
 }
@@ -71,11 +78,11 @@ function runChecks(err, stdio, streamName, expected) {
 // default value
 {
   const cmd =
-    `"${process.execPath}" -e "console.log('a'.repeat(200 * 1024 - 1))"`;
+    `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024 - 1))"`;
 
   cp.exec(cmd, common.mustCall((err, stdout, stderr) => {
     assert.ifError(err);
-    assert.strictEqual(stdout.trim(), 'a'.repeat(200 * 1024 - 1));
+    assert.strictEqual(stdout.trim(), 'a'.repeat(1024 * 1024 - 1));
     assert.strictEqual(stderr, '');
   }));
 }

--- a/test/parallel/test-child-process-execfile-maxbuf.js
+++ b/test/parallel/test-child-process-execfile-maxbuf.js
@@ -15,7 +15,7 @@ function checkFactory(streamName) {
 {
   execFile(
     process.execPath,
-    ['-e', 'console.log("a".repeat(200 * 1024))'],
+    ['-e', 'console.log("a".repeat(1024 * 1024))'],
     checkFactory('stdout')
   );
 }
@@ -24,10 +24,10 @@ function checkFactory(streamName) {
 {
   execFile(
     process.execPath,
-    ['-e', 'console.log("a".repeat(200 * 1024 - 1))'],
+    ['-e', 'console.log("a".repeat(1024 * 1024 - 1))'],
     common.mustCall((err, stdout, stderr) => {
       assert.ifError(err);
-      assert.strictEqual(stdout.trim(), 'a'.repeat(200 * 1024 - 1));
+      assert.strictEqual(stdout.trim(), 'a'.repeat(1024 * 1024 - 1));
       assert.strictEqual(stderr, '');
     })
   );

--- a/test/parallel/test-child-process-execfilesync-maxBuffer.js
+++ b/test/parallel/test-child-process-execfilesync-maxBuffer.js
@@ -35,12 +35,12 @@ const args = [
   assert.deepStrictEqual(ret, msgOutBuf);
 }
 
-// Default maxBuffer size is 200 * 1024.
+// Default maxBuffer size is 1024 * 1024.
 {
   assert.throws(() => {
     execFileSync(
       process.execPath,
-      ['-e', "console.log('a'.repeat(200 * 1024))"]
+      ['-e', "console.log('a'.repeat(1024 * 1024))"]
     );
   }, (e) => {
     assert.ok(e, 'maxBuffer should error');

--- a/test/parallel/test-child-process-execfilesync-maxbuf.js
+++ b/test/parallel/test-child-process-execfilesync-maxbuf.js
@@ -34,13 +34,13 @@ const args = [
   assert.deepStrictEqual(ret, msgOutBuf);
 }
 
-// maxBuffer size is 200 * 1024 at default.
+// maxBuffer size is 1024 * 1024 at default.
 {
   assert.throws(
     () => {
       execFileSync(
         process.execPath,
-        ['-e', "console.log('a'.repeat(200 * 1024))"],
+        ['-e', "console.log('a'.repeat(1024 * 1024))"],
         { encoding: 'utf-8' }
       );
     }, (e) => {

--- a/test/parallel/test-child-process-execsync-maxbuf.js
+++ b/test/parallel/test-child-process-execsync-maxbuf.js
@@ -38,10 +38,12 @@ const args = [
   assert.deepStrictEqual(ret, msgOutBuf);
 }
 
-// Default maxBuffer size is 200 * 1024.
+// Default maxBuffer size is 1024 * 1024.
 {
   assert.throws(() => {
-    execSync(`"${process.execPath}" -e "console.log('a'.repeat(200 * 1024))"`);
+    execSync(
+      `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024))"`
+    );
   }, (e) => {
     assert.ok(e, 'maxBuffer should error');
     assert.strictEqual(e.errno, 'ENOBUFS');
@@ -49,11 +51,14 @@ const args = [
   });
 }
 
-// Default maxBuffer size is 200 * 1024.
+// Default maxBuffer size is 1024 * 1024.
 {
   const ret = execSync(
-    `"${process.execPath}" -e "console.log('a'.repeat(200 * 1024 - 1))"`
+    `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024 - 1))"`
   );
 
-  assert.deepStrictEqual(ret.toString().trim(), 'a'.repeat(200 * 1024 - 1));
+  assert.deepStrictEqual(
+    ret.toString().trim(),
+    'a'.repeat(1024 * 1024 - 1)
+  );
 }

--- a/test/parallel/test-child-process-spawnsync-maxbuf.js
+++ b/test/parallel/test-child-process-spawnsync-maxbuf.js
@@ -33,23 +33,23 @@ const args = [
   assert.deepStrictEqual(ret.stdout, msgOutBuf);
 }
 
-// Default maxBuffer size is 200 * 1024.
+// Default maxBuffer size is 1024 * 1024.
 {
-  const args = ['-e', "console.log('a'.repeat(200 * 1024))"];
+  const args = ['-e', "console.log('a'.repeat(1024 * 1024))"];
   const ret = spawnSync(process.execPath, args);
 
   assert.ok(ret.error, 'maxBuffer should error');
   assert.strictEqual(ret.error.errno, 'ENOBUFS');
 }
 
-// Default maxBuffer size is 200 * 1024.
+// Default maxBuffer size is 1024 * 1024.
 {
-  const args = ['-e', "console.log('a'.repeat(200 * 1024 - 1))"];
+  const args = ['-e', "console.log('a'.repeat(1024 * 1024 - 1))"];
   const ret = spawnSync(process.execPath, args);
 
   assert.ifError(ret.error);
   assert.deepStrictEqual(
     ret.stdout.toString().trim(),
-    'a'.repeat(200 * 1024 - 1)
+    'a'.repeat(1024 * 1024 - 1)
   );
 }


### PR DESCRIPTION
I changed the defaults for all the maxBuffer sizes to a much larger value.

Refs: https://github.com/nodejs/node/pull/23027

Requested in https://github.com/nodejs/node/pull/23027#pullrequestreview-224504975 by @mcollina 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
