### PR TITLE
zlib: remove usage of require('util')

### DIFF
--- a/benchmark/http/headers.js
+++ b/benchmark/http/headers.js
@@ -14,7 +14,9 @@ function main({ len, n }) {
     'Transfer-Encoding': 'chunked',
   };
 
-  const Is = [ ...Array(n / len).keys() ];
+  // TODO(BridgeAR): Change this benchmark to use grouped arguments when
+  // implemented. https://github.com/nodejs/node/issues/26425
+  const Is = [ ...Array(Math.max(n / len, 1)).keys() ];
   const Js = [ ...Array(len).keys() ];
   for (const i of Is) {
     headers[`foo${i}`] = Js.map(() => `some header value ${i}`);

--- a/benchmark/misc/freelist.js
+++ b/benchmark/misc/freelist.js
@@ -9,7 +9,9 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
-  const { FreeList } = require('internal/freelist');
+  let FreeList = require('internal/freelist');
+  if (FreeList.FreeList)
+    FreeList = FreeList.FreeList;
   const poolSize = 1000;
   const list = new FreeList('test', poolSize, Object);
   var j;

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -46,7 +46,6 @@ const {
   ERR_UNESCAPED_CHARACTERS
 } = require('internal/errors').codes;
 const { getTimerDuration } = require('internal/timers');
-const is_reused_symbol = require('internal/freelist').symbols.is_reused_symbol;
 const {
   DTRACE_HTTP_CLIENT_REQUEST,
   DTRACE_HTTP_CLIENT_RESPONSE
@@ -631,10 +630,11 @@ function emitFreeNT(socket) {
 }
 
 function tickOnSocket(req, socket) {
+  const isParserReused = parsers.hasItems();
   const parser = parsers.alloc();
   req.socket = socket;
   req.connection = socket;
-  parser.reinitialize(HTTPParser.RESPONSE, parser[is_reused_symbol]);
+  parser.reinitialize(HTTPParser.RESPONSE, isParserReused);
   parser.socket = socket;
   parser.outgoing = req;
   req.parser = parser;

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -29,7 +29,7 @@ const { methods, HTTPParser } =
   getOptionValue('--http-parser') === 'legacy' ?
     internalBinding('http_parser') : internalBinding('http_parser_llhttp');
 
-const { FreeList } = require('internal/freelist');
+const FreeList = require('internal/freelist');
 const { ondrain } = require('internal/http');
 const incoming = require('_http_incoming');
 const {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -41,7 +41,6 @@ const {
   defaultTriggerAsyncIdScope,
   getOrSetAsyncId
 } = require('internal/async_hooks');
-const is_reused_symbol = require('internal/freelist').symbols.is_reused_symbol;
 const { IncomingMessage } = require('_http_incoming');
 const {
   ERR_HTTP_HEADERS_SENT,
@@ -348,8 +347,9 @@ function connectionListenerInternal(server, socket) {
     socket.setTimeout(server.timeout);
   socket.on('timeout', socketOnTimeout);
 
+  const isParserReused = parsers.hasItems();
   const parser = parsers.alloc();
-  parser.reinitialize(HTTPParser.REQUEST, parser[is_reused_symbol]);
+  parser.reinitialize(HTTPParser.REQUEST, isParserReused);
   parser.socket = socket;
 
   // We are starting to wait for our headers.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -521,11 +521,7 @@ function onEofChunk(stream, state) {
     state.emittedReadable = true;
     // We have to emit readable now that we are EOF. Modules
     // in the ecosystem (e.g. dicer) rely on this event being sync.
-    if (state.ended) {
-      emitReadable_(stream);
-    } else {
-      process.nextTick(emitReadable_, stream);
-    }
+    emitReadable_(stream);
   }
 }
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -600,6 +600,11 @@ function checkIsPromise(obj) {
   // Accept native ES6 promises and promises that are implemented in a similar
   // way. Do not accept thenables that use a function as `obj` and that have no
   // `catch` handler.
+
+  // TODO: thenables are checked up until they have the correct methods,
+  // but according to documentation, the `then` method should receive
+  // the `fulfill` and `reject` arguments as well or it may be never resolved.
+
   return isPromise(obj) ||
     obj !== null && typeof obj === 'object' &&
     typeof obj.then === 'function' &&

--- a/lib/internal/freelist.js
+++ b/lib/internal/freelist.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const is_reused_symbol = Symbol('isReused');
+const { Reflect } = primordials;
 
 class FreeList {
   constructor(name, max, ctor) {
@@ -10,16 +10,14 @@ class FreeList {
     this.list = [];
   }
 
+  hasItems() {
+    return this.list.length > 0;
+  }
+
   alloc() {
-    let item;
-    if (this.list.length > 0) {
-      item = this.list.pop();
-      item[is_reused_symbol] = true;
-    } else {
-      item = this.ctor.apply(this, arguments);
-      item[is_reused_symbol] = false;
-    }
-    return item;
+    return this.list.length > 0 ?
+      this.list.pop() :
+      Reflect.apply(this.ctor, this, arguments);
   }
 
   free(obj) {
@@ -31,9 +29,4 @@ class FreeList {
   }
 }
 
-module.exports = {
-  FreeList,
-  symbols: {
-    is_reused_symbol
-  }
-};
+module.exports = FreeList;

--- a/lib/internal/modules/esm/create_dynamic_module.js
+++ b/lib/internal/modules/esm/create_dynamic_module.js
@@ -3,7 +3,7 @@
 const { ArrayPrototype } = primordials;
 
 const { ModuleWrap, callbackMap } = internalBinding('module_wrap');
-const debug = require('util').debuglog('esm');
+const debug = require('internal/util/debuglog').debuglog('esm');
 
 const createDynamicModule = (exports, url = '', evaluate) => {
   debug('creating ESM facade for %s with exports: %j', url, exports);

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -6,7 +6,7 @@ const {
   SafePromise
 } = primordials;
 
-const { decorateErrorStack } = require('internal/util/decorateErrorStack');
+const { decorateErrorStack } = require('internal/util/decorateErrorStack').decorateErrorStack;
 const assert = require('internal/assert');
 const resolvedPromise = SafePromise.resolve();
 

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -6,7 +6,7 @@ const {
   SafePromise
 } = primordials;
 
-const { decorateErrorStack } = require('internal/util');
+const { decorateErrorStack } = require('internal/util/decorateErrorStack');
 const assert = require('internal/assert');
 const resolvedPromise = SafePromise.resolve();
 

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -36,7 +36,7 @@ function tryGetCwd() {
 }
 
 function evalModule(source) {
-  const { decorateErrorStack } = require('internal/util');
+  const { decorateErrorStack } = require('internal/util/decorateErrorStack');
   const asyncESM = require('internal/process/esm_loader');
   asyncESM.loaderPromise.then(async (loader) => {
     const { result } = await loader.eval(source);

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -36,7 +36,7 @@ function tryGetCwd() {
 }
 
 function evalModule(source) {
-  const { decorateErrorStack } = require('internal/util/decorateErrorStack');
+  const { decorateErrorStack } = require('internal/util/decorateErrorStack').decorateErrorStack;
   const asyncESM = require('internal/process/esm_loader');
   asyncESM.loaderPromise.then(async (loader) => {
     const { result } = await loader.eval(source);

--- a/lib/internal/process/report.js
+++ b/lib/internal/process/report.js
@@ -1,10 +1,9 @@
 'use strict';
-const { convertToValidSignal } = require('internal/util');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_SYNTHETIC
 } = require('internal/errors').codes;
-const { validateString } = require('internal/validators');
+const { validateSignalName, validateString } = require('internal/validators');
 const nr = internalBinding('report');
 const report = {
   writeReport(file, err) {
@@ -47,8 +46,7 @@ const report = {
     return nr.getSignal();
   },
   set signal(sig) {
-    validateString(sig, 'signal');
-    convertToValidSignal(sig); // Validate that the signal is recognized.
+    validateSignalName(sig, 'signal');
     removeSignalHandler();
     addSignalHandler(sig);
     nr.setSignal(sig);

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -14,7 +14,6 @@ const {
   arrow_message_private_symbol: kArrowMessagePrivateSymbolIndex,
   decorated_private_symbol: kDecoratedPrivateSymbolIndex
 } = internalBinding('util');
-const { isNativeError } = internalBinding('types');
 
 const noCrypto = !process.versions.openssl;
 
@@ -24,13 +23,6 @@ const colorRegExp = /\u001b\[\d\d?m/g; // eslint-disable-line no-control-regex
 
 function removeColors(str) {
   return str.replace(colorRegExp, '');
-}
-
-function isError(e) {
-  // An error could be an instance of Error while not being a native error
-  // or could be from a different realm and not be instance of Error but still
-  // be a native error.
-  return isNativeError(e) || e instanceof Error;
 }
 
 function objectToString(o) {
@@ -81,19 +73,6 @@ function deprecate(fn, msg, code) {
   }
 
   return deprecated;
-}
-
-function decorateErrorStack(err) {
-  if (!(isError(err) && err.stack) ||
-      getHiddenValue(err, kDecoratedPrivateSymbolIndex) === true)
-    return;
-
-  const arrow = getHiddenValue(err, kArrowMessagePrivateSymbolIndex);
-
-  if (arrow) {
-    err.stack = arrow + err.stack;
-    setHiddenValue(err, kDecoratedPrivateSymbolIndex, true);
-  }
 }
 
 function assertCrypto() {
@@ -391,14 +370,12 @@ module.exports = {
   assertCrypto,
   cachedResult,
   convertToValidSignal,
-  createClassWrapper,
-  decorateErrorStack,
+  createClassWrapper,  
   deprecate,
   emitExperimentalWarning,
   filterDuplicateStrings,
   getConstructorOf,
-  getSystemErrorName,
-  isError,
+  getSystemErrorName,  
   isInsideNodeModules,
   join,
   normalizeEncoding,

--- a/lib/internal/util/decorateErrorStack.js
+++ b/lib/internal/util/decorateErrorStack.js
@@ -1,0 +1,18 @@
+'use strict';
+
+function decorateErrorStack(err) {
+    if (!(isError(err) && err.stack) ||
+        getHiddenValue(err, kDecoratedPrivateSymbolIndex) === true)
+      return;
+  
+    const arrow = getHiddenValue(err, kArrowMessagePrivateSymbolIndex);
+  
+    if (arrow) {
+      err.stack = arrow + err.stack;
+      setHiddenValue(err, kDecoratedPrivateSymbolIndex, true);
+    }
+  }
+
+  module.exports = {
+    decorateErrorStack
+  }

--- a/lib/internal/util/isError.js
+++ b/lib/internal/util/isError.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { isNativeError } = internalBinding('types');
+
+function isError(e) {
+  // An error could be an instance of Error while not being a native error
+  // or could be from a different realm and not be instance of Error but still
+  // be a native error.
+  return isNativeError(e) || e instanceof Error;
+}
+
+module.exports = {
+    isError
+}

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -5,12 +5,14 @@ const {
   codes: {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
-    ERR_OUT_OF_RANGE
+    ERR_OUT_OF_RANGE,
+    ERR_UNKNOWN_SIGNAL
   }
 } = require('internal/errors');
 const {
   isArrayBufferView
 } = require('internal/util/types');
+const { signals } = internalBinding('constants').os;
 
 function isInt32(value) {
   return value === (value | 0);
@@ -110,6 +112,20 @@ function validateNumber(value, name) {
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
 }
 
+function validateSignalName(signal, name = 'signal') {
+  if (typeof signal !== 'string')
+    throw new ERR_INVALID_ARG_TYPE(name, 'string', signal);
+
+  if (signals[signal] === undefined) {
+    if (signals[signal.toUpperCase()] !== undefined) {
+      throw new ERR_UNKNOWN_SIGNAL(signal +
+                                   ' (signals must use all capital letters)');
+    }
+
+    throw new ERR_UNKNOWN_SIGNAL(signal);
+  }
+}
+
 // TODO(BridgeAR): We have multiple validation functions that call
 // `require('internal/utils').toBuf()` before validating for array buffer views.
 // Those should likely also be consolidated in here.
@@ -130,5 +146,6 @@ module.exports = {
   validateInt32,
   validateUint32,
   validateString,
-  validateNumber
+  validateNumber,
+  validateSignalName
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -541,19 +541,9 @@ function onReadableStreamEnd() {
     if (this.writable)
       this.end();
   }
-  maybeDestroy(this);
-}
 
-
-// Call whenever we set writable=false or readable=false
-function maybeDestroy(socket) {
-  if (!socket.readable &&
-      !socket.writable &&
-      !socket.destroyed &&
-      !socket.connecting &&
-      !socket.writableLength) {
-    socket.destroy();
-  }
+  if (!this.destroyed && !this.writable && !this.writableLength)
+    this.destroy();
 }
 
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -54,10 +54,10 @@ const {
   isIdentifierChar
 } = require('internal/deps/acorn/acorn/dist/acorn');
 const {
-  decorateErrorStack,
-  isError,
   deprecate
 } = require('internal/util');
+const { isError } = require('internal/util/isError').isError;
+const { decorateErrorStack } = require('internal/util/decorateErrorStack');
 const { inspect } = require('internal/util/inspect');
 const Stream = require('stream');
 const vm = require('vm');

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -57,7 +57,7 @@ const {
   deprecate
 } = require('internal/util');
 const { isError } = require('internal/util/isError').isError;
-const { decorateErrorStack } = require('internal/util/decorateErrorStack');
+const { decorateErrorStack } = require('internal/util/decorateErrorStack').decorateErrorStack;
 const { inspect } = require('internal/util/inspect');
 const Stream = require('stream');
 const vm = require('vm');

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -40,7 +40,7 @@ const {
     isAnyArrayBuffer,
     isArrayBufferView
   }
-} = require('internal/util').deprecate;
+} = require('internal/util');
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');
 const {

--- a/node.gyp
+++ b/node.gyp
@@ -345,16 +345,7 @@
           ],
           'conditions': [
             ['OS=="win"', {
-              'libraries': [
-                'dbghelp.lib',
-                'PsApi.lib',
-                'Ws2_32.lib',
-              ],
-              'dll_files': [
-                'dbghelp.dll',
-                'PsApi.dll',
-                'Ws2_32.dll',
-              ],
+              'libraries': [ 'Ws2_32' ],
             }],
           ],
         }],
@@ -623,7 +614,10 @@
               ],
             }],
           ],
-          'libraries': [ '-lpsapi.lib' ]
+          'libraries': [
+            'Dbghelp',
+            'Psapi',
+          ],
         }],
         [ 'node_use_etw=="true"', {
           'defines': [ 'HAVE_ETW=1' ],
@@ -718,16 +712,7 @@
           ],
           'conditions': [
             ['OS=="win"', {
-              'libraries': [
-                'dbghelp.lib',
-                'PsApi.lib',
-                'Ws2_32.lib',
-              ],
-              'dll_files': [
-                'dbghelp.dll',
-                'PsApi.dll',
-                'Ws2_32.dll',
-              ],
+              'libraries': [ 'Ws2_32' ],
             }],
           ],
         }],
@@ -1083,16 +1068,7 @@
           ],
           'conditions': [
             ['OS=="win"', {
-              'libraries': [
-                'dbghelp.lib',
-                'PsApi.lib',
-                'Ws2_32.lib',
-              ],
-              'dll_files': [
-                'dbghelp.dll',
-                'PsApi.dll',
-                'Ws2_32.dll',
-              ],
+              'libraries': [ 'Ws2_32' ],
             }],
           ],
         }],

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -334,15 +334,13 @@ class DiagnosticFilename {
 
   DiagnosticFilename(Environment* env,
                      const char* prefix,
-                     const char* ext,
-                     int seq = -1) :
-      filename_(MakeFilename(env->thread_id(), prefix, ext, seq)) {}
+                     const char* ext) :
+      filename_(MakeFilename(env->thread_id(), prefix, ext)) {}
 
   DiagnosticFilename(uint64_t thread_id,
                      const char* prefix,
-                     const char* ext,
-                     int seq = -1) :
-      filename_(MakeFilename(thread_id, prefix, ext, seq)) {}
+                     const char* ext) :
+      filename_(MakeFilename(thread_id, prefix, ext)) {}
 
   const char* operator*() const { return filename_.c_str(); }
 
@@ -350,8 +348,7 @@ class DiagnosticFilename {
   static std::string MakeFilename(
       uint64_t thread_id,
       const char* prefix,
-      const char* ext,
-      int seq = -1);
+      const char* ext);
 
   std::string filename_;
 };

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -15,7 +15,6 @@
 #include <cstring>
 #include <ctime>
 #include <cwctype>
-#include <atomic>
 #include <fstream>
 #include <iomanip>
 #include <climits>  // PATH_MAX
@@ -73,9 +72,6 @@ static void PrintLoadedLibraries(JSONWriter* writer);
 static void PrintComponentVersions(JSONWriter* writer);
 static void PrintRelease(JSONWriter* writer);
 
-// Global variables
-static std::atomic_int seq = {0};  // sequence number for report filenames
-
 // External function to trigger a report, writing to file.
 // The 'name' parameter is in/out: an input filename is used
 // if supplied, and the actual filename is returned.
@@ -99,7 +95,7 @@ std::string TriggerNodeReport(Isolate* isolate,
     filename = options->report_filename;
   } else {
     filename = *DiagnosticFilename(env != nullptr ? env->thread_id() : 0,
-                                   "report", "json", seq++);
+                                   "report", "json");
   }
 
   // Open the report file stream for writing. Supports stdout/err,

--- a/src/util.cc
+++ b/src/util.cc
@@ -41,9 +41,12 @@
 #include <sys/types.h>
 #endif
 
+#include <atomic>
 #include <cstdio>
 #include <iomanip>
 #include <sstream>
+
+static std::atomic_int seq = {0};  // Sequence number for diagnostic filenames.
 
 namespace node {
 
@@ -225,8 +228,7 @@ void DiagnosticFilename::LocalTime(TIME_TYPE* tm_struct) {
 std::string DiagnosticFilename::MakeFilename(
     uint64_t thread_id,
     const char* prefix,
-    const char* ext,
-    int seq) {
+    const char* ext) {
   std::ostringstream oss;
   TIME_TYPE tm_struct;
   LocalTime(&tm_struct);
@@ -262,8 +264,7 @@ std::string DiagnosticFilename::MakeFilename(
 #endif
   oss << "." << uv_os_getpid();
   oss << "." << thread_id;
-  if (seq >= 0)
-    oss << "." << std::setfill('0') << std::setw(3) << ++seq;
+  oss << "." << std::setfill('0') << std::setw(3) << ++seq;
   oss << "." << ext;
   return oss.str();
 }

--- a/test/js-native-api/test_function/test.js
+++ b/test/js-native-api/test_function/test.js
@@ -35,3 +35,10 @@ let tracked_function = test_function.MakeTrackedFunction(common.mustCall());
 assert(!!tracked_function);
 tracked_function = null;
 global.gc();
+
+assert.deepStrictEqual(test_function.TestCreateFunctionParameters(), {
+  envIsNull: 'pass',
+  nameIsNull: 'pass',
+  cbIsNull: 'pass',
+  resultIsNull: 'pass'
+});

--- a/test/js-native-api/test_function/test_function.c
+++ b/test/js-native-api/test_function/test_function.c
@@ -1,6 +1,85 @@
 #include <js_native_api.h>
 #include "../common.h"
 
+static napi_value TestCreateFunctionParameters(napi_env env,
+                                               napi_callback_info info) {
+  napi_status ret[4];
+  napi_value result, return_value, prop_value;
+
+
+  ret[0] = napi_create_function(NULL,
+                                "TrackedFunction",
+                                NAPI_AUTO_LENGTH,
+                                TestCreateFunctionParameters,
+                                NULL,
+                                &result);
+
+  ret[1] = napi_create_function(env,
+                                NULL,
+                                NAPI_AUTO_LENGTH,
+                                TestCreateFunctionParameters,
+                                NULL,
+                                &result);
+
+  ret[2] = napi_create_function(env,
+                                "TrackedFunction",
+                                NAPI_AUTO_LENGTH,
+                                NULL,
+                                NULL,
+                                &result);
+
+  ret[3] = napi_create_function(env,
+                                "TrackedFunction",
+                                NAPI_AUTO_LENGTH,
+                                TestCreateFunctionParameters,
+                                NULL,
+                                NULL);
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[0] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_value));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         return_value,
+                                         "envIsNull",
+                                         prop_value));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[1] == napi_ok ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_value));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         return_value,
+                                         "nameIsNull",
+                                         prop_value));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[2] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_value));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         return_value,
+                                         "cbIsNull",
+                                         prop_value));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[3] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_value));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         return_value,
+                                         "resultIsNull",
+                                         prop_value));
+
+  return return_value;
+}
+
 static napi_value TestCallFunction(napi_env env, napi_callback_info info) {
   size_t argc = 10;
   napi_value args[10];
@@ -124,6 +203,14 @@ napi_value Init(napi_env env, napi_value exports) {
                                       NULL,
                                       &fn4));
 
+  napi_value fn5;
+  NAPI_CALL(env, napi_create_function(env,
+                                      "TestCreateFunctionParameters",
+                                      NAPI_AUTO_LENGTH,
+                                      TestCreateFunctionParameters,
+                                      NULL,
+                                      &fn5));
+
   NAPI_CALL(env, napi_set_named_property(env, exports, "TestCall", fn1));
   NAPI_CALL(env, napi_set_named_property(env, exports, "TestName", fn2));
   NAPI_CALL(env, napi_set_named_property(env, exports, "TestNameShort", fn3));
@@ -131,6 +218,11 @@ napi_value Init(napi_env env, napi_value exports) {
                                          exports,
                                          "MakeTrackedFunction",
                                          fn4));
+
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         exports,
+                                         "TestCreateFunctionParameters",
+                                         fn5));
 
   return exports;
 }

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -2,11 +2,33 @@
 const common = require('../common');
 const assert = require('assert');
 
-// Test assert.rejects() and assert.doesNotReject() by checking their
-// expected output and by verifying that they do not work sync
-
 // Run all tests in parallel and check their outcome at the end.
 const promises = [];
+
+// Thenable object without `catch` method,
+// shouldn't be considered as a valid Thenable
+const invalidThenable = {
+  then: (fulfill, reject) => {
+    fulfill();
+  },
+};
+
+// Function that returns a Thenable function,
+// a function with `catch` and `then` methods attached,
+// shouldn't be considered as a valid Thenable.
+const invalidThenableFunc = () => {
+  function f() {}
+
+  f.then = (fulfill, reject) => {
+    fulfill();
+  };
+  f.catch = () => {};
+
+  return f;
+};
+
+// Test assert.rejects() and assert.doesNotReject() by checking their
+// expected output and by verifying that they do not work sync
 
 // Check `assert.rejects`.
 {
@@ -16,9 +38,34 @@ const promises = [];
     name: 'AssertionError',
     message: 'Failed'
   };
-  // `assert.rejects` accepts a function or a promise as first argument.
+
+  // `assert.rejects` accepts a function or a promise
+  // or a thenable as first argument.
   promises.push(assert.rejects(rejectingFn, errObj));
   promises.push(assert.rejects(rejectingFn(), errObj));
+
+  const validRejectingThenable = {
+    then: (fulfill, reject) => {
+      reject({ code: 'FAIL' });
+    },
+    catch: () => {}
+  };
+  promises.push(assert.rejects(validRejectingThenable, { code: 'FAIL' }));
+
+  // `assert.rejects` should not accept thenables that
+  // use a function as `obj` and that have no `catch` handler.
+  promises.push(assert.rejects(
+    assert.rejects(invalidThenable, {}),
+    {
+      code: 'ERR_INVALID_ARG_TYPE'
+    })
+  );
+  promises.push(assert.rejects(
+    assert.rejects(invalidThenableFunc, {}),
+    {
+      code: 'ERR_INVALID_RETURN_VALUE'
+    })
+  );
 }
 
 {
@@ -69,7 +116,8 @@ promises.push(assert.rejects(
 
 // Check `assert.doesNotReject`.
 {
-  // `assert.doesNotReject` accepts a function or a promise as first argument.
+  // `assert.doesNotReject` accepts a function or a promise
+  // or a thenable as first argument.
   const promise = assert.doesNotReject(() => new Map(), common.mustNotCall());
   promises.push(assert.rejects(promise, {
     message: 'Expected instance of Promise to be returned ' +
@@ -79,6 +127,28 @@ promises.push(assert.rejects(
   }));
   promises.push(assert.doesNotReject(async () => {}));
   promises.push(assert.doesNotReject(Promise.resolve()));
+
+  // `assert.doesNotReject` should not accept thenables that
+  // use a function as `obj` and that have no `catch` handler.
+  const validFulfillingThenable = {
+    then: (fulfill, reject) => {
+      fulfill();
+    },
+    catch: () => {}
+  };
+  promises.push(assert.doesNotReject(validFulfillingThenable));
+  promises.push(assert.rejects(
+    assert.doesNotReject(invalidThenable),
+    {
+      code: 'ERR_INVALID_ARG_TYPE'
+    })
+  );
+  promises.push(assert.rejects(
+    assert.doesNotReject(invalidThenableFunc),
+    {
+      code: 'ERR_INVALID_RETURN_VALUE'
+    })
+  );
 }
 
 {

--- a/test/parallel/test-freelist.js
+++ b/test/parallel/test-freelist.js
@@ -4,7 +4,7 @@
 
 require('../common');
 const assert = require('assert');
-const { FreeList } = require('internal/freelist');
+const FreeList = require('internal/freelist');
 
 assert.strictEqual(typeof FreeList, 'function');
 

--- a/test/parallel/test-internal-util-helpers.js
+++ b/test/parallel/test-internal-util-helpers.js
@@ -4,7 +4,7 @@
 require('../common');
 const assert = require('assert');
 const { types } = require('util');
-const { isError } = require('internal/util');
+const { isError } = require('internal/util/isError').isError;
 const vm = require('vm');
 
 // Special cased errors. Test the internal function which is used in

--- a/test/report/test-report-config.js
+++ b/test/report/test-report-config.js
@@ -68,7 +68,16 @@ if (!common.isWindows) {
   }, { code: 'ERR_INVALID_ARG_TYPE' });
   common.expectsError(() => {
     process.report.signal = 'foo';
-  }, { code: 'ERR_UNKNOWN_SIGNAL' });
+  }, {
+    code: 'ERR_UNKNOWN_SIGNAL',
+    message: 'Unknown signal: foo'
+  });
+  common.expectsError(() => {
+    process.report.signal = 'sigusr1';
+  }, {
+    code: 'ERR_UNKNOWN_SIGNAL',
+    message: 'Unknown signal: sigusr1 (signals must use all capital letters)'
+  });
   assert.strictEqual(process.report.signal, 'SIGUSR2');
   process.report.signal = 'SIGUSR1';
   assert.strictEqual(process.report.signal, 'SIGUSR1');

--- a/test/sequential/test-http-regr-gh-2928.js
+++ b/test/sequential/test-http-regr-gh-2928.js
@@ -6,7 +6,6 @@
 const common = require('../common');
 const assert = require('assert');
 const httpCommon = require('_http_common');
-const is_reused_symbol = require('internal/freelist').symbols.is_reused_symbol;
 const { HTTPParser } = require('_http_common');
 const net = require('net');
 
@@ -25,7 +24,7 @@ function execAndClose() {
   process.stdout.write('.');
 
   const parser = parsers.pop();
-  parser.reinitialize(HTTPParser.RESPONSE, parser[is_reused_symbol]);
+  parser.reinitialize(HTTPParser.RESPONSE, !!parser.reused);
 
   const socket = net.connect(common.PORT);
   socket.on('error', (e) => {
@@ -33,6 +32,7 @@ function execAndClose() {
     // https://github.com/nodejs/node/issues/2663.
     if (common.isSunOS && e.code === 'ECONNREFUSED') {
       parsers.push(parser);
+      parser.reused = true;
       socket.destroy();
       setImmediate(execAndClose);
       return;


### PR DESCRIPTION
Use `require('internal/util').deprecate` instead of 
`require('util')` in 
`lib/zlibs.js`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
