### PR TITLE
crypto: add OID constants for EVP_PKEY_ types

### DIFF
--- a/test/parallel/test-crypto-oids.js
+++ b/test/parallel/test-crypto-oids.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const {
+  constants,
+} = require('crypto');
+
+assert.strictEqual(constants.EVP_PKEY_RSA, '1.2.840.113549.1.1.1');
+assert.strictEqual(constants.EVP_PKEY_RSA_PSS, '1.2.840.113549.1.1.10');
+assert.strictEqual(constants.EVP_PKEY_DSA, '1.2.840.10040.4.1');
+assert.strictEqual(constants.EVP_PKEY_DH, '1.2.840.113549.1.3.1');
+assert.strictEqual(constants.EVP_PKEY_EC, '1.2.840.10045.2.1');
+assert.strictEqual(constants.EVP_PKEY_ED25519, '1.3.101.112');
+assert.strictEqual(constants.EVP_PKEY_ED448, '1.3.101.113');
+assert.strictEqual(constants.EVP_PKEY_X25519, '1.3.101.110');
+assert.strictEqual(constants.EVP_PKEY_X448, '1.3.101.111');


### PR DESCRIPTION
The existence of the constant can be used to check for support for the
key types, and the value is useful when encoding/decoding keys using
ASN.1.

-----

Follow-on to https://github.com/nodejs/node/pull/26786#issuecomment-478097964, these values might be useful if we move to key type constants, rather  than strings like "rsa", etc.

Also, when PRs are backported from master to 11.x that use EVP key types that aren't supported by OpenSSL 1.1.0, it is trivial to ifdef out the C++ code that uses them. It's less trivial to deal with in the tests. Checking openssl version numbers explicitly is fragile (and hard if range checks are required). It will be easier to just test for existence of the define (effectively) from js. I didn't want to expose the NIDs, but the OIDs are useful values (I think).

@tniessen @panva Thoughts? 


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
