### PR TITLE
stream: ensure state existed when getting property

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -74,6 +74,10 @@ Object.defineProperty(Duplex.prototype, 'writableHighWaterMark', {
   // userland will fail
   enumerable: false,
   get() {
+    if (this._writableState === undefined) {
+      // Default value
+      return 16 * 1024;
+    }
     return this._writableState.highWaterMark;
   }
 });
@@ -94,6 +98,9 @@ Object.defineProperty(Duplex.prototype, 'writableLength', {
   // userland will fail
   enumerable: false,
   get() {
+    if (this._writableState === undefined) {
+      return 0;
+    }
     return this._writableState.length;
   }
 });

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1046,6 +1046,10 @@ Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
   // userland will fail
   enumerable: false,
   get: function() {
+    if (this._readableState === undefined) {
+      // Default value
+      return 16 * 1024;
+    }
     return this._readableState.highWaterMark;
   }
 });
@@ -1066,6 +1070,9 @@ Object.defineProperty(Readable.prototype, 'readableFlowing', {
   // userland will fail
   enumerable: false,
   get: function() {
+    if (this._readableState === undefined) {
+      return false;
+    }
     return this._readableState.flowing;
   },
   set: function(state) {
@@ -1084,6 +1091,9 @@ Object.defineProperty(Readable.prototype, 'readableLength', {
   // userland will fail
   enumerable: false,
   get() {
+    if (this._readableState === undefined) {
+      return 0;
+    }
     return this._readableState.length;
   }
 });

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -357,6 +357,10 @@ Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
   // userland will fail
   enumerable: false,
   get: function() {
+    if (this._writableState === undefined) {
+      // Default value
+      return 16 * 1024;
+    }
     return this._writableState.highWaterMark;
   }
 });
@@ -600,6 +604,9 @@ Object.defineProperty(Writable.prototype, 'writableLength', {
   // userland will fail
   enumerable: false,
   get() {
+    if (this._writableState === undefined) {
+      return 0;
+    }
     return this._writableState.length;
   }
 });

--- a/test/parallel/test-stream-prototype-property.js
+++ b/test/parallel/test-stream-prototype-property.js
@@ -1,0 +1,57 @@
+'use strict';
+
+require('../common');
+
+// This test ensure state has initialized when accessing property
+// from prototype.
+// Make sure it wouldn't throw TypeError when accessing
+// readableLength, readableHighWaterMark from
+// stream.Readable.prototype. Same for `Duplex` and `Writable`.
+
+const { Duplex, Readable, Writable } = require('stream');
+const assert = require('assert');
+
+const defaultHighWaterMark = 16 * 1024;
+
+{
+  function MyDuplex() {
+    assert.strictEqual(this.readableHighWaterMark, defaultHighWaterMark);
+    assert.strictEqual(this.readableFlowing, false);
+    assert.strictEqual(this.readableLength, 0);
+    assert.strictEqual(this.writableHighWaterMark, defaultHighWaterMark);
+    assert.strictEqual(this.writableLength, 0);
+    Duplex.call(this);
+  }
+
+  Object.setPrototypeOf(MyDuplex.prototype, Duplex.prototype);
+  Object.setPrototypeOf(MyDuplex, Duplex);
+
+  new MyDuplex();
+}
+
+{
+  function MyReadable() {
+    assert.strictEqual(this.readableHighWaterMark, defaultHighWaterMark);
+    assert.strictEqual(this.readableFlowing, false);
+    assert.strictEqual(this.readableLength, 0);
+    Readable.call(this);
+  }
+
+  Object.setPrototypeOf(MyReadable.prototype, Readable.prototype);
+  Object.setPrototypeOf(MyReadable, Readable);
+
+  new MyReadable();
+}
+
+{
+  function MyWritable() {
+    assert.strictEqual(this.writableHighWaterMark, defaultHighWaterMark);
+    assert.strictEqual(this.writableLength, 0);
+    Writable.call(this);
+  }
+
+  Object.setPrototypeOf(MyWritable.prototype, Writable.prototype);
+  Object.setPrototypeOf(MyWritable, Writable);
+
+  new MyWritable();
+}


### PR DESCRIPTION
Ensure state has initialized when getting property from prototype.
On the other hand, it wouldn't throw `TypeError` when accessing
`readableLength`, `readableHighWaterMark` and e.g. from
`stream.Readable.prototype`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
