### PR TITLE
[v8.x] assert: fix backport regression

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -720,7 +720,8 @@ function getActual(block) {
 
 async function waitForActual(block) {
   if (typeof block !== 'function') {
-    throw new errors.ERR_INVALID_ARG_TYPE('block', 'Function', block);
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'block', 'Function',
+                               block);
   }
 
   // Return a rejected promise if `block` throws synchronously.


### PR DESCRIPTION
This fixes a regression for an error case with `assert.rejects` and
`assert.doesNotReject`.

Fixes: https://github.com/nodejs/node/issues/27185

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
