### PR TITLE
stream: inline onwriteStateUpdate()

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -442,13 +442,6 @@ function onwriteError(stream, state, sync, er, cb) {
   }
 }
 
-function onwriteStateUpdate(state) {
-  state.writing = false;
-  state.writecb = null;
-  state.length -= state.writelen;
-  state.writelen = 0;
-}
-
 function onwrite(stream, er) {
   const state = stream._writableState;
   const sync = state.sync;
@@ -457,7 +450,10 @@ function onwrite(stream, er) {
   if (typeof cb !== 'function')
     throw new ERR_MULTIPLE_CALLBACK();
 
-  onwriteStateUpdate(state);
+  state.writing = false;
+  state.writecb = null;
+  state.length -= state.writelen;
+  state.writelen = 0;
 
   if (er)
     onwriteError(stream, state, sync, er, cb);


### PR DESCRIPTION
The function is very simple and is only called from `onwrite()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
