### PR TITLE
build,win: bail vcbuild if mklink fails

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -325,7 +325,10 @@ if errorlevel 1 (
 if "%target%" == "Clean" goto exit
 
 :after-build
+rd %config%
+if errorlevel 1 echo "Old build output exists at 'out\%config%'. Please remove." & exit /B
 if EXIST out\%config% mklink /D %config% out\%config%
+if errorlevel 1 exit /B
 
 :sign
 @rem Skip signing unless the `sign` option was specified.


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/27149#issuecomment-482811243

Otherwise vcbuild will continue even if `mklink` fails, and will use old artifacts if present.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
