### PR TITLE
src: make PushPath move strings by default

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1241,7 +1241,7 @@ int MKDirpSync(uv_loop_t* loop,
                int mode,
                uv_fs_cb cb) {
   FSContinuationData continuation_data(req, mode, cb);
-  continuation_data.PushPath(std::move(path));
+  continuation_data.PushPath(path);
 
   while (continuation_data.paths.size() > 0) {
     std::string next_path = continuation_data.PopPath();
@@ -1257,8 +1257,8 @@ int MKDirpSync(uv_loop_t* loop,
           std::string dirname = next_path.substr(0,
                                         next_path.find_last_of(kPathSeparator));
           if (dirname != next_path) {
-            continuation_data.PushPath(std::move(next_path));
-            continuation_data.PushPath(std::move(dirname));
+            continuation_data.PushPath(next_path);
+            continuation_data.PushPath(dirname);
           } else if (continuation_data.paths.size() == 0) {
             err = UV_EEXIST;
             continue;
@@ -1293,7 +1293,7 @@ int MKDirpAsync(uv_loop_t* loop,
   if (req_wrap->continuation_data == nullptr) {
     req_wrap->continuation_data =
         std::make_unique<FSContinuationData>(req, mode, cb);
-    req_wrap->continuation_data->PushPath(std::move(path));
+    req_wrap->continuation_data->PushPath(path);
   }
 
   // on each iteration of algorithm, mkdir directory on top of stack.
@@ -1322,8 +1322,8 @@ int MKDirpAsync(uv_loop_t* loop,
           std::string dirname = path.substr(0,
                                             path.find_last_of(kPathSeparator));
           if (dirname != path) {
-            req_wrap->continuation_data->PushPath(std::move(path));
-            req_wrap->continuation_data->PushPath(std::move(dirname));
+            req_wrap->continuation_data->PushPath(path);
+            req_wrap->continuation_data->PushPath(dirname);
           } else if (req_wrap->continuation_data->paths.size() == 0) {
             err = UV_EEXIST;
             continue;

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -37,7 +37,7 @@ class FSContinuationData : public MemoryRetainer {
   }
 
   void PushPath(const std::string& path) {
-    paths.push_back(path);
+    paths.push_back(std::move(path));
   }
 
   std::string PopPath() {


### PR DESCRIPTION
All the calls made to `FSContinuationData::PushPath` are done after
`std::move` of the argument. This patch does `std::move` in the
`PushPath` itself.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
