### PR TITLE
console: replace process.hrtime() with process.hrtime.bigint()

### DIFF
--- a/benchmark/console/console-time-time-end.js
+++ b/benchmark/console/console-time-time-end.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+});
+
+function main({ n }) {
+  // This is necessary not to mess up stdout
+  const consoleLog = console.log;
+  console.log = function() {};
+
+  bench.start();
+
+  for (var i = 0; i < n; i++) {
+    console.time();
+    console.timeEnd();
+  }
+
+  bench.end(n);
+
+  console.log = consoleLog;
+}

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -305,7 +305,7 @@ const consoleMethods = {
       return;
     }
     trace(kTraceBegin, kTraceConsoleCategory, `time::${label}`, 0);
-    this._times.set(label, process.hrtime());
+    this._times.set(label, process.hrtime.bigint());
   },
 
   timeEnd(label = 'default') {
@@ -516,8 +516,8 @@ function timeLogImpl(self, name, label, data) {
     process.emitWarning(`No such label '${label}' for console.${name}()`);
     return true;
   }
-  const duration = process.hrtime(time);
-  const ms = duration[0] * 1000 + duration[1] / 1e6;
+  const duration = process.hrtime.bigint() - time;
+  const ms = Number(duration / 1000n) / 1000;
   if (data === undefined) {
     self.log('%s: %sms', label, ms.toFixed(3));
   } else {

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -521,12 +521,13 @@ function timeLogImpl(self, name, label, data) {
   const duration = (process.hrtime.bigint() - time) / 1000n;
 
   // Format it to string like '**.***ms'.
-  let durationStr = duration.toString();
-  if (durationStr.length < 4)
-    durationStr = '0'.repeat(4 - durationStr.length) + durationStr;
-  const beforeDecimalPoint = durationStr.substr(0, durationStr.length - 3);
-  const afterDecimalPoint = durationStr.substr(durationStr.length - 3);
-  const durationFormatted = `${beforeDecimalPoint}.${afterDecimalPoint}ms`;
+  let durationFormatted;
+  if (duration < 10n)
+    durationFormatted = `0.00${duration}ms`;
+  else if (duration < 100n)
+    durationFormatted = `0.0${duration}ms`;
+  else
+    durationFormatted = `${duration / 1000n}.${duration % 1000n}ms`;
 
   if (data === undefined) {
     self.log('%s: %s', label, durationFormatted);

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -516,12 +516,22 @@ function timeLogImpl(self, name, label, data) {
     process.emitWarning(`No such label '${label}' for console.${name}()`);
     return true;
   }
-  const duration = process.hrtime.bigint() - time;
-  const ms = Number(duration / 1000n) / 1000;
+
+  // Time duration in microseconds.
+  const duration = (process.hrtime.bigint() - time) / 1000n;
+
+  // Format it to string like '**.***ms'.
+  let durationStr = duration.toString();
+  if (durationStr.length < 4)
+    durationStr = '0'.repeat(4 - durationStr.length) + durationStr;
+  const beforeDecimalPoint = durationStr.substr(0, durationStr.length - 3);
+  const afterDecimalPoint = durationStr.substr(durationStr.length - 3);
+  const durationFormatted = `${beforeDecimalPoint}.${afterDecimalPoint}ms`;
+
   if (data === undefined) {
-    self.log('%s: %sms', label, ms.toFixed(3));
+    self.log('%s: %s', label, durationFormatted);
   } else {
-    self.log('%s: %sms', label, ms.toFixed(3), ...data);
+    self.log('%s: %s', label, durationFormatted, ...data);
   }
   return false;
 }


### PR DESCRIPTION
This replaces process.hrtime() used in console.time() and console.timeEnd() and adds a relevant benchmark.
This makes the code more straightforward and performant as it is no longer necessary to handle arrays of numbers when process.hrtime.bigint() is used.

The result of a benchmark comparison is as follows. (`node benchmark/run.js` was run without optional configurations)

```
                                           confidence improvement accuracy (*)    (**)   (***)
 console/console-time-time-end.js n=100000        ***     -5.35 %      ±0.94% ±1.25% ±1.63%
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
