### PR TITLE
worker: improve coverage

### DIFF
--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -45,6 +45,8 @@ const {
 
 const publicWorker = require('worker_threads');
 
+const assert = require('internal/assert');
+
 patchProcessObject();
 setupInspectorHooks();
 setupDebugEnv();
@@ -122,18 +124,17 @@ port.on('message', (message) => {
       process.argv[1] = filename; // script filename
       require('module').runMain();
     }
-    return;
   } else if (message.type === STDIO_PAYLOAD) {
     const { stream, chunk, encoding } = message;
     process[stream].push(chunk, encoding);
-    return;
-  } else if (message.type === STDIO_WANTS_MORE_DATA) {
+  } else {
+    assert(
+      message.type === STDIO_WANTS_MORE_DATA,
+      `Unknown worker message type ${message.type}`
+    );
     const { stream } = message;
     process[stream][kStdioWantsMoreDataCallback]();
-    return;
   }
-
-  require('assert').fail(`Unknown worker message type ${message.type}`);
 });
 
 // Overwrite fatalException


### PR DESCRIPTION
This improves the worker coverage by using `internal/assert` instead
of relying on `assert` in case a faulty worker message type is
received (AFAIK this is only set internally, if it's public, this should be replaced with a test).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
