### PR TITLE
src: disallow calling env-dependent methods during bootstrap

### DIFF
--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -172,21 +172,29 @@ static gid_t gid_by_name(Isolate* isolate, Local<Value> value) {
 }
 
 static void GetUid(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(env->has_run_bootstrapping_code());
   // uid_t is an uint32_t on all supported platforms.
   args.GetReturnValue().Set(static_cast<uint32_t>(getuid()));
 }
 
 static void GetGid(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(env->has_run_bootstrapping_code());
   // gid_t is an uint32_t on all supported platforms.
   args.GetReturnValue().Set(static_cast<uint32_t>(getgid()));
 }
 
 static void GetEUid(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(env->has_run_bootstrapping_code());
   // uid_t is an uint32_t on all supported platforms.
   args.GetReturnValue().Set(static_cast<uint32_t>(geteuid()));
 }
 
 static void GetEGid(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(env->has_run_bootstrapping_code());
   // gid_t is an uint32_t on all supported platforms.
   args.GetReturnValue().Set(static_cast<uint32_t>(getegid()));
 }
@@ -269,6 +277,7 @@ static void SetEUid(const FunctionCallbackInfo<Value>& args) {
 
 static void GetGroups(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  CHECK(env->has_run_bootstrapping_code());
 
   int ngroups = getgroups(0, nullptr);
   if (ngroups == -1) return env->ThrowErrnoException(errno, "getgroups");

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -118,6 +118,7 @@ static void CPUUsage(const FunctionCallbackInfo<Value>& args) {
 
 static void Cwd(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  CHECK(env->has_run_bootstrapping_code());
   char buf[CHDIR_BUFSIZE];
   size_t cwd_len = sizeof(buf);
   int err = uv_cwd(buf, &cwd_len);
@@ -226,12 +227,13 @@ static void StopProfilerIdleNotifier(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void Umask(const FunctionCallbackInfo<Value>& args) {
-  uint32_t old;
-
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(env->has_run_bootstrapping_code());
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsUndefined() || args[0]->IsUint32());
   Mutex::ScopedLock scoped_lock(per_process::umask_mutex);
 
+  uint32_t old;
   if (args[0]->IsUndefined()) {
     old = umask(0);
     umask(static_cast<mode_t>(old));


### PR DESCRIPTION
These cannot be preserved correctly in v8 snapshot. Currently
none of these are called during bootstrap, this adds assertions
to make sure future contributors do not accidentally call
these in the wrong time.

Consider this, on the machine that builds releases:

```
process.cwd();  // "/home/iojs/build/workspace/"
```

User downloads this binary to their machine:

```
$ cd ~/
$ pwd  # "/User/foo"
$ node -p "process.cwd()" # Cached "/home/iojs/build/workspace/"
```

This patch only adds checks in methods that get states from the
environment - it's not likely that the setters would be called
during bootstrap, and if they are called, we'll just ignore them
and whatever tests that test the change would fail when snapshot
is enabled. However the getters may be called in order
to persist information into strings and that would be harder
to catch (the test is only likely to test the format of these
strings which won't be useful).

Refs: https://github.com/nodejs/node/pull/27224

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
