### PR TITLE
path: simplify normalizeString

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -50,11 +50,11 @@ function isWindowsDeviceRoot(code) {
 
 // Resolves . and .. elements in a path with directory names
 function normalizeString(path, allowAboveRoot, separator, isPathSeparator) {
-  var res = '';
-  var lastSegmentLength = 0;
-  var lastSlash = -1;
-  var dots = 0;
-  var code;
+  let res = '';
+  let lastSegmentLength = 0;
+  let lastSlash = -1;
+  let dots = 0;
+  let code = 0;
   for (var i = 0; i <= path.length; ++i) {
     if (i < path.length)
       code = path.charCodeAt(i);
@@ -66,7 +66,7 @@ function normalizeString(path, allowAboveRoot, separator, isPathSeparator) {
     if (isPathSeparator(code)) {
       if (lastSlash === i - 1 || dots === 1) {
         // NOOP
-      } else if (lastSlash !== i - 1 && dots === 2) {
+      } else if (dots === 2) {
         if (res.length < 2 || lastSegmentLength !== 2 ||
             res.charCodeAt(res.length - 1) !== CHAR_DOT ||
             res.charCodeAt(res.length - 2) !== CHAR_DOT) {
@@ -82,7 +82,7 @@ function normalizeString(path, allowAboveRoot, separator, isPathSeparator) {
             lastSlash = i;
             dots = 0;
             continue;
-          } else if (res.length === 2 || res.length === 1) {
+          } else if (res.length !== 0) {
             res = '';
             lastSegmentLength = 0;
             lastSlash = i;


### PR DESCRIPTION
This improves the `path.normalize()` and `path.resolve()` performance a
very tiny bit.
One statement could never be truthy, another check could be simplified
and count is now monomorphic.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
