### PR TITLE
process: inspect error in case of a fatal exception

### DIFF
--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -138,8 +138,12 @@ function createFatalException() {
     if (exceptionHandlerState.captureFn !== null) {
       exceptionHandlerState.captureFn(er);
     } else if (!process.emit('uncaughtException', er, type)) {
-      // If someone handled it, then great.  otherwise, die in C++ land
+      // If someone handled it, then great. Otherwise, die in C++ land
       // since that means that we'll exit the process, emit the 'exit' event.
+      const { inspect } = require('internal/util/inspect');
+      const colors = internalBinding('util').guessHandleType(2) === 'TTY' &&
+                     require('internal/tty').hasColors() ||
+                     inspect.defaultOptions.colors;
       try {
         if (!process._exiting) {
           process._exiting = true;
@@ -153,6 +157,7 @@ function createFatalException() {
         const { kExpandStackSymbol } = require('internal/util');
         if (typeof er[kExpandStackSymbol] === 'function')
           er[kExpandStackSymbol]();
+        er.stack = inspect(er, { colors });
       } catch {
         // Nothing to be done about it at this point.
       }

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -15,4 +15,20 @@ AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
     at *
     at *
     at *
-    at *
+    at * {
+  generatedMessage: true,
+  code: 'ERR_ASSERTION',
+  actual: Error: foo
+      at assert.throws.bar (*assert_throws_stack.js:*)
+      at getActual (assert.js:*)
+      at Function.throws (assert.js:*)
+      at Object.<anonymous> (*assert_throws_stack.js:*:*)
+      at *
+      at *
+      at *
+      at *
+      at *
+      at *,
+  expected: [Object],
+  operator: 'throws'
+}

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -13,4 +13,10 @@ AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
     at Module.load (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
-    at internal/main/run_main_module.js:*:*
+    at internal/main/run_main_module.js:*:* {
+  generatedMessage: true,
+  code: 'ERR_ASSERTION',
+  actual: 1,
+  expected: 2,
+  operator: 'strictEqual'
+}

--- a/test/message/if-error-has-good-stack.out
+++ b/test/message/if-error-has-good-stack.out
@@ -16,4 +16,20 @@ AssertionError [ERR_ASSERTION]: ifError got unwanted exception: test error
     at Module.load (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
-    at internal/main/run_main_module.js:*:*
+    at internal/main/run_main_module.js:*:* {
+  generatedMessage: false,
+  code: 'ERR_ASSERTION',
+  actual: Error: test error
+      at c (*if-error-has-good-stack.js:*:*)
+      at b (*if-error-has-good-stack.js:*:*)
+      at a (*if-error-has-good-stack.js:*:*)
+      at Object.<anonymous> (*if-error-has-good-stack.js:*:*)
+      at Module._compile (internal/modules/cjs/loader.js:*:*)
+      at Object.Module._extensions..js (internal/modules/cjs/loader.js:*:*)
+      at Module.load (internal/modules/cjs/loader.js:*:*)
+      at Function.Module._load (internal/modules/cjs/loader.js:*:*)
+      at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
+      at internal/main/run_main_module.js:*:*
+  expected: null,
+  operator: 'ifError'
+}

--- a/test/message/stack_overflow.out
+++ b/test/message/stack_overflow.out
@@ -3,4 +3,4 @@ before
 JSON.stringify(array);
      ^
 
-RangeError: Maximum call stack size exceeded
+[RangeError: Maximum call stack size exceeded]

--- a/test/message/throw_custom_error.out
+++ b/test/message/throw_custom_error.out
@@ -1,4 +1,4 @@
 *test*message*throw_custom_error.js:*
 throw ({ name: 'MyCustomError', message: 'This is a custom message' });
 ^
-MyCustomError: This is a custom message
+{ name: 'MyCustomError', message: 'This is a custom message' }

--- a/test/message/throw_in_line_with_tabs.out
+++ b/test/message/throw_in_line_with_tabs.out
@@ -2,4 +2,4 @@ before
 *test*message*throw_in_line_with_tabs.js:*
 	throw ({ foo: 'bar' });
 	^
-[object Object]
+{ foo: 'bar' }

--- a/test/message/throw_non_error.out
+++ b/test/message/throw_non_error.out
@@ -1,4 +1,4 @@
 *test*message*throw_non_error.js:*
 throw ({ foo: 'bar' });
 ^
-[object Object]
+{ foo: 'bar' }

--- a/test/parallel/test-error-reporting.js
+++ b/test/parallel/test-error-reporting.js
@@ -77,5 +77,5 @@ errExec('throws_error6.js', common.mustCall((err, stdout, stderr) => {
 
 // Object that throws in toString() doesn't print garbage
 errExec('throws_error7.js', common.mustCall((err, stdout, stderr) => {
-  assert.ok(/<toString\(\) threw exception/.test(stderr));
+  assert.ok(/throw {\r?\n\^\r?\n{ toString: \[Function: toString] }\r?\n$/.test(stderr));
 }));

--- a/test/pseudo-tty/test-fatal-error.js
+++ b/test/pseudo-tty/test-fatal-error.js
@@ -1,0 +1,10 @@
+'use strict';
+require('../common');
+
+const { inspect } = require('util');
+
+inspect.defaultOptions.colors = true;
+
+const err = new TypeError('foobar');
+err.bla = true;
+throw err;

--- a/test/pseudo-tty/test-fatal-error.out
+++ b/test/pseudo-tty/test-fatal-error.out
@@ -1,0 +1,14 @@
+*test-fatal-error.js:*
+throw err;
+^
+
+TypeError: foobar
+    at Object.<anonymous> (*test-fatal-error.js:*)
+*[90m    at *(internal*loader.js:*:*)*[39m
+*[90m    at *(internal*loader.js:*:*)*[39m
+*[90m    at *(internal*loader.js:*:*)*[39m
+*[90m    at *(internal*loader.js:*:*)*[39m
+*[90m    at *[39m
+*[90m    at *[39m {
+  bla: *[33mtrue*[39m
+}


### PR DESCRIPTION
This makes sure that errors that shut down the application are
inspected with `util.inspect()`. That makes sure that all extra
properties on the error will be visible and also that the stack trace
is highlighted (Node.js internal frames will be grey and node modules
are underlined).

That should overall improve the debugging experience for users.

This should be semver-minor, since this only applies in case of an
fatal exception and it always ends up for the actual application user.

![image](https://user-images.githubusercontent.com/8822573/56155857-2887f580-5fbc-11e9-8e51-9dbacfd6f423.png)


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
