### PR TITLE
worker: handle exception when creating execArgv errors

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -459,13 +459,15 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
     // The first argument is program name.
     invalid_args.erase(invalid_args.begin());
     if (errors.size() > 0 || invalid_args.size() > 0) {
-      v8::Local<v8::Value> error =
-          ToV8Value(env->context(),
-                    errors.size() > 0 ? errors : invalid_args)
-              .ToLocalChecked();
+      v8::Local<v8::Value> error;
+      if (!ToV8Value(env->context(),
+                     errors.size() > 0 ? errors : invalid_args)
+                         .ToLocal(&error)) {
+        return;
+      }
       Local<String> key =
           FIXED_ONE_BYTE_STRING(env->isolate(), "invalidExecArgv");
-      USE(args.This()->Set(env->context(), key, error).FromJust());
+      USE(args.This()->Set(env->context(), key, error));
       return;
     }
   }

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -467,6 +467,8 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
       }
       Local<String> key =
           FIXED_ONE_BYTE_STRING(env->isolate(), "invalidExecArgv");
+      // Ignore the return value of Set() because exceptions bubble up to JS
+      // when we return anyway.
       USE(args.This()->Set(env->context(), key, error));
       return;
     }


### PR DESCRIPTION
Handle possible JS exceptions that can occur by returning to JS land
immediately.

The motivation for this change is that `USE(….FromJust());` is an
anti-pattern, and `.FromJust()` with an unused return value is
superseded by `.Check()`. However, in this case, checking that the
operation succeeded is not necessary.

Refs: https://github.com/nodejs/node/pull/27162

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
