### PR TITLE
src: enable V8's WASM trap handlers

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -119,7 +119,7 @@ std::vector<std::string> Split(const std::string& string,
 }
 
 #ifdef __POSIX__
-static void StartIoThreadWakeup(int signo) {
+static void StartIoThreadWakeup(int signo, siginfo_t* info, void* ucontext) {
   uv_sem_post(&start_io_thread_semaphore);
 }
 

--- a/src/node.h
+++ b/src/node.h
@@ -66,6 +66,10 @@
 
 #include <memory>
 
+#ifdef __POSIX__
+#include <signal.h>
+#endif  // __POSIX__
+
 #define NODE_MAKE_VERSION(major, minor, patch)                                \
   ((major) * 0x1000 + (minor) * 0x100 + (patch))
 
@@ -815,6 +819,17 @@ class NODE_EXTERN AsyncResource {
   v8::Persistent<v8::Object> resource_;
   async_context async_context_;
 };
+
+#ifdef __POSIX__
+// Register a signal handler without interrupting
+// any handlers that node itself needs.
+NODE_EXTERN
+void RegisterSignalHandler(int signal,
+                           void (*handler)(int signal,
+                                           siginfo_t* info,
+                                           void* ucontext),
+                           bool reset_handler = false);
+#endif  // __POSIX__
 
 }  // namespace node
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -91,11 +91,8 @@ void PrintCaughtException(v8::Isolate* isolate,
                           const v8::TryCatch& try_catch);
 
 void WaitForInspectorDisconnect(Environment* env);
-void SignalExit(int signo);
 #ifdef __POSIX__
-void RegisterSignalHandler(int signal,
-                           void (*handler)(int signal),
-                           bool reset_handler = false);
+void SignalExit(int signal, siginfo_t* info, void* ucontext);
 #endif
 
 std::string GetHumanReadableProcessName();

--- a/src/node_watchdog.cc
+++ b/src/node_watchdog.cc
@@ -127,8 +127,9 @@ void* SigintWatchdogHelper::RunSigintWatchdog(void* arg) {
   return nullptr;
 }
 
-
-void SigintWatchdogHelper::HandleSignal(int signum) {
+void SigintWatchdogHelper::HandleSignal(int signum,
+                                        siginfo_t* info,
+                                        void* ucontext) {
   uv_sem_post(&instance.sem_);
 }
 

--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -99,7 +99,7 @@ class SigintWatchdogHelper {
   bool stopping_;
 
   static void* RunSigintWatchdog(void* arg);
-  static void HandleSignal(int signum);
+  static void HandleSignal(int signum, siginfo_t* info, void* ucontext);
 #else
   bool watchdog_disabled_;
   static BOOL WINAPI WinCtrlCHandlerRoutine(DWORD dwCtrlType);


### PR DESCRIPTION
This uses SIGSEGV handlers to catch WASM out of bound (OOB) memory
accesses instead of inserting OOB checks inline, resulting in a 25%-30%
speed increase.

Note that installing a custom SIGSEGV handler will break this, resulting
in potentially scary behaviour. Users should use node::RegisterSignalHandler instead.

Refs: https://github.com/nodejs/node/issues/14927

Closes #14927 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
