### PR TITLE
util: fix wrong usage of Error.prepareStackTrace

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -347,7 +347,7 @@ function isInsideNodeModules() {
     // the perf implications should be okay.
     getStructuredStack = runInNewContext(`(function() {
       Error.prepareStackTrace = function(err, trace) {
-        err.stack = trace;
+        return trace;
       };
       Error.stackTraceLimit = Infinity;
 


### PR DESCRIPTION
The return value of Error.prepareStackTrace will become the result
of Error.stack accesses. Setting Error.stack inside this callback
relies on the fact that the magic get accessor detects the change in
the middle of formatting, and is unnecessary in this instance.

Refs: https://github.com/v8/node/pull/96

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
