### PR TITLE
src: enable non-nestable V8 platform tasks

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -257,6 +257,16 @@ void PerIsolatePlatformData::PostDelayedTask(
   uv_async_send(flush_tasks_);
 }
 
+void PerIsolatePlatformData::PostNonNestableTask(std::unique_ptr<Task> task) {
+  PostTask(std::move(task));
+}
+
+void PerIsolatePlatformData::PostNonNestableDelayedTask(
+    std::unique_ptr<Task> task,
+    double delay_in_seconds) {
+  PostDelayedTask(std::move(task), delay_in_seconds);
+}
+
 PerIsolatePlatformData::~PerIsolatePlatformData() {
   Shutdown();
 }

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -64,6 +64,13 @@ class PerIsolatePlatformData :
                        double delay_in_seconds) override;
   bool IdleTasksEnabled() override { return false; }
 
+  // Non-nestable tasks are treated like regular tasks.
+  bool NonNestableTasksEnabled() const override { return true; }
+  bool NonNestableDelayedTasksEnabled() const override { return true; }
+  void PostNonNestableTask(std::unique_ptr<v8::Task> task) override;
+  void PostNonNestableDelayedTask(std::unique_ptr<v8::Task> task,
+                                  double delay_in_seconds) override;
+
   void AddShutdownCallback(void (*callback)(void*), void* data);
   void Shutdown();
 


### PR DESCRIPTION
We never execute tasks in a nested fashion, so enabling them should
be as simple as forwarding tasks to the existing `Post*` methods.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
