### PR TITLE
test: add ability to skip common flag checks

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -51,6 +51,7 @@ const hasCrypto = Boolean(process.versions.openssl);
 // If the binary was built without-ssl then the crypto flags are
 // invalid (bad option). The test itself should handle this case.
 if (process.argv.length === 2 &&
+    !process.env.NODE_SKIP_FLAG_CHECK &&
     isMainThread &&
     hasCrypto &&
     module.parent &&

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -83,7 +83,8 @@ if (process.argv.length === 2 &&
           (process.features.inspector || !flag.startsWith('--inspect'))) {
         console.log(
           'NOTE: The test started as a child_process using these flags:',
-          util.inspect(flags)
+          util.inspect(flags),
+          'Use NODE_SKIP_FLAG_CHECK to run the test with the original flags.'
         );
         const args = [...flags, ...process.execArgv, ...process.argv.slice(1)];
         const options = { encoding: 'utf8', stdio: 'inherit' };


### PR DESCRIPTION
Currently, `common/index.js` checks that our test files are
spawned with the flags specified in `// Flags:`, and re-spawns
with them if they are not found.

This can be very annoying, for example when debugging using
debuggers that attach to the parent process, or when intentionally
testing with flags that are different from the specified ones.

This adds a `NODE_SKIP_FLAG_CHECK` environment variable check.
Setting it to a non-empty value will skip the flag checks altogether.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
