### PR TITLE
[v11.x] deps: V8: backport 61f4c22

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -30,7 +30,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.18',
+    'v8_embedder_string': '-node.19',
 
     # Turn on SipHash for hash seed generation, addresses HashWick
     'v8_use_siphash': 'true',

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -2424,44 +2424,29 @@ MaybeLocal<Module> ScriptCompiler::CompileModule(
   return ToApiHandle<Module>(i_isolate->factory()->NewModule(shared));
 }
 
-
-class IsIdentifierHelper {
- public:
-  IsIdentifierHelper() : is_identifier_(false), first_char_(true) {}
-
-  bool Check(i::String* string) {
-    i::ConsString* cons_string = i::String::VisitFlat(this, string, 0);
-    if (cons_string == nullptr) return is_identifier_;
-    // We don't support cons strings here.
-    return false;
-  }
-  void VisitOneByteString(const uint8_t* chars, int length) {
-    for (int i = 0; i < length; ++i) {
-      if (first_char_) {
-        first_char_ = false;
-        is_identifier_ = unicode_cache_.IsIdentifierStart(chars[0]);
-      } else {
-        is_identifier_ &= unicode_cache_.IsIdentifierPart(chars[i]);
-      }
-    }
-  }
-  void VisitTwoByteString(const uint16_t* chars, int length) {
-    for (int i = 0; i < length; ++i) {
-      if (first_char_) {
-        first_char_ = false;
-        is_identifier_ = unicode_cache_.IsIdentifierStart(chars[0]);
-      } else {
-        is_identifier_ &= unicode_cache_.IsIdentifierPart(chars[i]);
-      }
-    }
-  }
-
- private:
-  bool is_identifier_;
-  bool first_char_;
+namespace {
+bool IsIdentifier(i::Isolate* isolate, i::Handle<i::String> string) {
   i::UnicodeCache unicode_cache_;
-  DISALLOW_COPY_AND_ASSIGN(IsIdentifierHelper);
-};
+  string = i::String::Flatten(isolate, string);
+  const int length = string->length();
+  if (length == 0) return false;
+  if (!unicode_cache_.IsIdentifierStart(string->Get(0))) return false;
+  i::DisallowHeapAllocation no_gc;
+  i::String::FlatContent flat = string->GetFlatContent();
+  if (flat.IsOneByte()) {
+    auto vector = flat.ToOneByteVector();
+    for (int i = 1; i < length; i++) {
+      if (!unicode_cache_.IsIdentifierPart(vector[i])) return false;
+    }
+  } else {
+    auto vector = flat.ToUC16Vector();
+    for (int i = 1; i < length; i++) {
+      if (!unicode_cache_.IsIdentifierPart(vector[i])) return false;
+    }
+  }
+  return true;
+}
+}  // anonymous namespace
 
 MaybeLocal<Function> ScriptCompiler::CompileFunctionInContext(
     Local<Context> v8_context, Source* source, size_t arguments_count,
@@ -2486,9 +2471,8 @@ MaybeLocal<Function> ScriptCompiler::CompileFunctionInContext(
   i::Handle<i::FixedArray> arguments_list =
       isolate->factory()->NewFixedArray(static_cast<int>(arguments_count));
   for (int i = 0; i < static_cast<int>(arguments_count); i++) {
-    IsIdentifierHelper helper;
     i::Handle<i::String> argument = Utils::OpenHandle(*arguments[i]);
-    if (!helper.Check(*argument)) return Local<Function>();
+    if (!IsIdentifier(isolate, argument)) return Local<Function>();
     arguments_list->set(i, *argument);
   }
 

--- a/deps/v8/test/cctest/test-compiler.cc
+++ b/deps/v8/test/cctest/test-compiler.cc
@@ -487,8 +487,8 @@ TEST(CompileFunctionInContextArgs) {
   v8::Local<v8::Object> ext[1];
   ext[0] = v8::Local<v8::Object>::Cast(
       env->Global()->Get(env.local(), v8_str("a")).ToLocalChecked());
-  v8::ScriptCompiler::Source script_source(v8_str("result = x + b"));
-  v8::Local<v8::String> arg = v8_str("b");
+  v8::ScriptCompiler::Source script_source(v8_str("result = x + abc"));
+  v8::Local<v8::String> arg = v8_str("abc");
   v8::Local<v8::Function> fun =
       v8::ScriptCompiler::CompileFunctionInContext(env.local(), &script_source,
                                                    1, &arg, 1, ext)
@@ -498,8 +498,8 @@ TEST(CompileFunctionInContextArgs) {
                   ->ToInt32(env.local())
                   .ToLocalChecked()
                   ->Value());
-  v8::Local<v8::Value> b_value = v8::Number::New(CcTest::isolate(), 42.0);
-  fun->Call(env.local(), env->Global(), 1, &b_value).ToLocalChecked();
+  v8::Local<v8::Value> arg_value = v8::Number::New(CcTest::isolate(), 42.0);
+  fun->Call(env.local(), env->Global(), 1, &arg_value).ToLocalChecked();
   CHECK(env->Global()->Has(env.local(), v8_str("result")).FromJust());
   v8::Local<v8::Value> result =
       env->Global()->Get(env.local(), v8_str("result")).ToLocalChecked();
@@ -516,16 +516,17 @@ TEST(CompileFunctionInContextComments) {
   v8::Local<v8::Object> ext[1];
   ext[0] = v8::Local<v8::Object>::Cast(
       env->Global()->Get(env.local(), v8_str("a")).ToLocalChecked());
-  v8::ScriptCompiler::Source script_source(
-      v8_str("result = /* y + */ x + b // + z"));
-  v8::Local<v8::String> arg = v8_str("b");
+  v8::Local<v8::String> source =
+      CompileRun("'result = /* y + */ x + a\\u4e00 // + z'").As<v8::String>();
+  v8::ScriptCompiler::Source script_source(source);
+  v8::Local<v8::String> arg = CompileRun("'a\\u4e00'").As<v8::String>();
   v8::Local<v8::Function> fun =
       v8::ScriptCompiler::CompileFunctionInContext(env.local(), &script_source,
                                                    1, &arg, 1, ext)
           .ToLocalChecked();
   CHECK(!fun.IsEmpty());
-  v8::Local<v8::Value> b_value = v8::Number::New(CcTest::isolate(), 42.0);
-  fun->Call(env.local(), env->Global(), 1, &b_value).ToLocalChecked();
+  v8::Local<v8::Value> arg_value = v8::Number::New(CcTest::isolate(), 42.0);
+  fun->Call(env.local(), env->Global(), 1, &arg_value).ToLocalChecked();
   CHECK(env->Global()->Has(env.local(), v8_str("result")).FromJust());
   v8::Local<v8::Value> result =
       env->Global()->Get(env.local(), v8_str("result")).ToLocalChecked();


### PR DESCRIPTION
The differences to the original patch are the replacement of
`i::IsIdentifier...()` with `unicode_cache_.IsIdentifier...()`,
because the former is not available on Node.js v11.x, as well
as the omitted `no_gc` argument for `GetFlatContent()`.

Original commit message:

    Assume flat string when checking CompileFunctionInContext arguments.

    R=jkummerow@chromium.org

    Change-Id: I54c6137a3c6e14d4102188f154aa7216e7414dbc
    Reviewed-on: https://chromium-review.googlesource.com/c/1388533
    Reviewed-by: Jakob Kummerow <jkummerow@chromium.org>
    Commit-Queue: Yang Guo <yangguo@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#58562}

Refs: https://github.com/v8/v8/commit/61f4c2251e107aebca620054701f2faec36209a8
Fixes: https://github.com/nodejs/node/issues/27256

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
