### PR TITLE
src: apply modernize-use-nullptr in node_win32_etw_provider.cc

### DIFF
--- a/src/node_win32_etw_provider.cc
+++ b/src/node_win32_etw_provider.cc
@@ -107,7 +107,7 @@ void CodeAddressNotification(const JitCodeEvent* jevent) {
       }
       break;
     case JitCodeEvent::CODE_REMOVED:
-      NODE_V8SYMBOL_REMOVE(jevent->code_start, 0);
+      NODE_V8SYMBOL_REMOVE(jevent->code_start, nullptr);
       break;
     case JitCodeEvent::CODE_MOVED:
       NODE_V8SYMBOL_MOVE(jevent->code_start, jevent->new_code_start);


### PR DESCRIPTION
Also from: https://ci.nodejs.org/job/node-clang-tidy/7/console

cc @richardlau @refack 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
