### PR TITLE
src: apply clang-tidy rule modernize-use-equals-default

### DIFF
--- a/src/debug_utils.h
+++ b/src/debug_utils.h
@@ -100,7 +100,7 @@ class NativeSymbolDebuggingContext {
   };
 
   NativeSymbolDebuggingContext() = default;
-  virtual ~NativeSymbolDebuggingContext() {}
+  virtual ~NativeSymbolDebuggingContext() = default;
 
   virtual SymbolInfo LookupSymbol(void* address) { return {}; }
   virtual bool IsMapped(void* address) { return false; }

--- a/src/env.h
+++ b/src/env.h
@@ -540,7 +540,7 @@ struct AllocatedBuffer {
 
 class AsyncRequest : public MemoryRetainer {
  public:
-  AsyncRequest() {}
+  AsyncRequest() = default;
   ~AsyncRequest();
   void Install(Environment* env, void* data, uv_async_cb target);
   void Uninstall();

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -65,7 +65,7 @@ class FSEventWrap: public HandleWrap {
   static const encoding kDefaultEncoding = UTF8;
 
   FSEventWrap(Environment* env, Local<Object> object);
-  ~FSEventWrap() override;
+  ~FSEventWrap() = default;
 
   static void OnEvent(uv_fs_event_t* handle, const char* filename, int events,
     int status);
@@ -83,9 +83,6 @@ FSEventWrap::FSEventWrap(Environment* env, Local<Object> object)
   MarkAsUninitialized();
 }
 
-
-FSEventWrap::~FSEventWrap() {
-}
 
 void FSEventWrap::GetInitialized(const FunctionCallbackInfo<Value>& args) {
   FSEventWrap* wrap = Unwrap<FSEventWrap>(args.This());

--- a/src/inspector/main_thread_interface.h
+++ b/src/inspector/main_thread_interface.h
@@ -26,12 +26,12 @@ class MainThreadInterface;
 class Request {
  public:
   virtual void Call(MainThreadInterface*) = 0;
-  virtual ~Request() {}
+  virtual ~Request() = default;
 };
 
 class Deletable {
  public:
-  virtual ~Deletable() {}
+  virtual ~Deletable() = default;
 };
 
 std::unique_ptr<v8_inspector::StringBuffer> Utf8ToStringView(

--- a/src/inspector/worker_inspector.h
+++ b/src/inspector/worker_inspector.h
@@ -21,7 +21,7 @@ class WorkerDelegate {
                              const std::string& url,
                              bool waiting,
                              std::shared_ptr<MainThreadHandle> worker) = 0;
-  virtual ~WorkerDelegate() {}
+  virtual ~WorkerDelegate() = default;
 };
 
 class WorkerManagerEventHandle {

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -354,7 +354,7 @@ class InspectorTimer {
     // Unique_ptr goes out of scope here and pointer is deleted.
   }
 
-  ~InspectorTimer() {}
+  ~InspectorTimer() = default;
 
   Environment* env_;
   uv_timer_t timer_;

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -30,7 +30,7 @@ class WorkerManager;
 
 class InspectorSession {
  public:
-  virtual ~InspectorSession() {}
+  virtual ~InspectorSession() = default;
   virtual void Dispatch(const v8_inspector::StringView& message) = 0;
 };
 

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -217,8 +217,7 @@ class InspectorIoDelegate: public node::inspector::SocketServerDelegate {
                       const std::string& target_id,
                       const std::string& script_path,
                       const std::string& script_name);
-  ~InspectorIoDelegate() override {
-  }
+  ~InspectorIoDelegate() override = default;
 
   void StartSession(int session_id, const std::string& target_id) override;
   void MessageReceived(int session_id, const std::string& message) override;

--- a/src/inspector_socket.h
+++ b/src/inspector_socket.h
@@ -25,7 +25,7 @@ class InspectorSocket {
                                  const std::string& path,
                                  const std::string& accept_key) = 0;
     virtual void OnWsFrame(const std::vector<char>& frame) = 0;
-    virtual ~Delegate() {}
+    virtual ~Delegate() = default;
   };
 
   using DelegatePointer = std::unique_ptr<Delegate>;

--- a/src/inspector_socket_server.h
+++ b/src/inspector_socket_server.h
@@ -31,7 +31,7 @@ class SocketServerDelegate {
   virtual std::vector<std::string> GetTargetIds() = 0;
   virtual std::string GetTargetTitle(const std::string& id) = 0;
   virtual std::string GetTargetUrl(const std::string& id) = 0;
-  virtual ~SocketServerDelegate() {}
+  virtual ~SocketServerDelegate() = default;
 };
 
 // HTTP Server, writes messages requested as TransportActions, and responds

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -12,7 +12,7 @@ struct napi_env__ {
         context_persistent(isolate, context) {
     CHECK_EQ(isolate, context->GetIsolate());
   }
-  virtual ~napi_env__() {}
+  virtual ~napi_env__() = default;
   v8::Isolate* const isolate;  // Shortcut for context()->GetIsolate()
   v8impl::Persistent<v8::Context> context_persistent;
 
@@ -167,8 +167,7 @@ class Finalizer {
       _finalize_hint(finalize_hint) {
   }
 
-  ~Finalizer() {
-  }
+  ~Finalizer() = default;
 
  public:
   static Finalizer* New(napi_env env,

--- a/src/memory_tracker.h
+++ b/src/memory_tracker.h
@@ -109,7 +109,7 @@ class CleanupHookCallback;
  */
 class MemoryRetainer {
  public:
-  virtual ~MemoryRetainer() {}
+  virtual ~MemoryRetainer() = default;
 
   // Subclasses should implement these methods to provide information
   // for the V8 heap snapshot generator.

--- a/src/node.h
+++ b/src/node.h
@@ -248,7 +248,7 @@ NODE_EXTERN void FreeArrayBufferAllocator(ArrayBufferAllocator* allocator);
 
 class NODE_EXTERN MultiIsolatePlatform : public v8::Platform {
  public:
-  ~MultiIsolatePlatform() override { }
+  ~MultiIsolatePlatform() override = default;
   // Returns true if work was dispatched or executed. New tasks that are
   // posted during flushing of the queue are postponed until the next
   // flushing.

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -841,7 +841,7 @@ class Work : public node::AsyncResource, public node::ThreadPoolWork {
       _complete(complete) {
   }
 
-  ~Work() override { }
+  ~Work() override = default;
 
  public:
   static Work* New(node_napi_env env,

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -6069,7 +6069,7 @@ class KeyPairGenerationConfig {
   virtual bool Configure(const EVPKeyCtxPointer& ctx) {
     return true;
   }
-  virtual ~KeyPairGenerationConfig() {}
+  virtual ~KeyPairGenerationConfig() = default;
 };
 
 class RSAKeyPairGenerationConfig : public KeyPairGenerationConfig {

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -50,7 +50,7 @@ class MapKVStore final : public KVStore {
 
   std::shared_ptr<KVStore> Clone(Isolate* isolate) const override;
 
-  MapKVStore() {}
+  MapKVStore() = default;
   MapKVStore(const MapKVStore& other) : map_(other.map_) {}
 
  private:

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -681,7 +681,7 @@ void AfterScanDirWithTypes(uv_fs_t* req) {
 // For async calls FSReqCallback is used.
 class FSReqWrapSync {
  public:
-  FSReqWrapSync() {}
+  FSReqWrapSync() = default;
   ~FSReqWrapSync() { uv_fs_req_cleanup(&req); }
   uv_fs_t req;
 

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -1208,7 +1208,7 @@ class ExternalHeader :
 class Headers {
  public:
   Headers(Isolate* isolate, Local<Context> context, Local<Array> headers);
-  ~Headers() {}
+  ~Headers() = default;
 
   nghttp2_nv* operator*() {
     return reinterpret_cast<nghttp2_nv*>(*buf_);
@@ -1229,7 +1229,7 @@ class Origins {
           Local<Context> context,
           Local<v8::String> origin_string,
           size_t origin_count);
-  ~Origins() {}
+  ~Origins() = default;
 
   nghttp2_origin_entry* operator*() {
     return reinterpret_cast<nghttp2_origin_entry*>(*buf_);

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -152,7 +152,7 @@ class ConverterObject : public BaseObject, Converter {
     CONVERTER_FLAGS_IGNORE_BOM = 0x4
   };
 
-  ~ConverterObject() override {}
+  ~ConverterObject() override = default;
 
   static void Has(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -47,7 +47,7 @@ class HostPort {
 class Options {
  public:
   virtual void CheckOptions(std::vector<std::string>* errors) {}
-  virtual ~Options() {}
+  virtual ~Options() = default;
 };
 
 // These options are currently essentially per-Environment, but it can be nice
@@ -240,7 +240,7 @@ enum OptionType {
 template <typename Options>
 class OptionsParser {
  public:
-  virtual ~OptionsParser() {}
+  virtual ~OptionsParser() = default;
 
   typedef Options TargetType;
 
@@ -338,7 +338,7 @@ class OptionsParser {
   // Represents a field within `Options`.
   class BaseOptionField {
    public:
-    virtual ~BaseOptionField() {}
+    virtual ~BaseOptionField() = default;
     virtual void* LookupImpl(Options* options) const = 0;
 
     template <typename T>

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -71,7 +71,7 @@ class PerformanceEntry {
                                        startTime_(startTime),
                                        endTime_(endTime) { }
 
-  virtual ~PerformanceEntry() { }
+  virtual ~PerformanceEntry() = default;
 
   virtual v8::MaybeLocal<Object> ToObject() const;
 

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -24,7 +24,7 @@ template <class T>
 class TaskQueue {
  public:
   TaskQueue();
-  ~TaskQueue() {}
+  ~TaskQueue() = default;
 
   void Push(std::unique_ptr<T> task);
   std::unique_ptr<T> Pop();
@@ -134,7 +134,7 @@ class NodePlatform : public MultiIsolatePlatform {
  public:
   NodePlatform(int thread_pool_size,
                node::tracing::TracingController* tracing_controller);
-  ~NodePlatform() override {}
+  ~NodePlatform() override = default;
 
   void DrainTasks(v8::Isolate* isolate) override;
   void CancelPendingDelayedTasks(v8::Isolate* isolate) override;

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -33,7 +33,7 @@ class SerializerContext : public BaseObject,
   SerializerContext(Environment* env,
                     Local<Object> wrap);
 
-  ~SerializerContext() override {}
+  ~SerializerContext() override = default;
 
   void ThrowDataCloneError(Local<String> message) override;
   Maybe<bool> WriteHostObject(Isolate* isolate, Local<Object> object) override;
@@ -68,7 +68,7 @@ class DeserializerContext : public BaseObject,
                       Local<Object> wrap,
                       Local<Value> buffer);
 
-  ~DeserializerContext() override {}
+  ~DeserializerContext() override = default;
 
   MaybeLocal<Object> ReadHostObject(Isolate* isolate) override;
 

--- a/src/node_v8_platform-inl.h
+++ b/src/node_v8_platform-inl.h
@@ -72,7 +72,7 @@ class NodeTraceStateObserver
 
   explicit NodeTraceStateObserver(v8::TracingController* controller)
       : controller_(controller) {}
-  ~NodeTraceStateObserver() override {}
+  ~NodeTraceStateObserver() override = default;
 
  private:
   v8::TracingController* controller_;

--- a/src/req_wrap.h
+++ b/src/req_wrap.h
@@ -14,7 +14,7 @@ class ReqWrapBase {
  public:
   explicit inline ReqWrapBase(Environment* env);
 
-  virtual ~ReqWrapBase() {}
+  virtual ~ReqWrapBase() = default;
 
   virtual void Cancel() = 0;
   virtual AsyncWrap* GetAsyncWrap() = 0;

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -49,11 +49,6 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 
-
-SyncProcessOutputBuffer::SyncProcessOutputBuffer() {
-}
-
-
 void SyncProcessOutputBuffer::OnAlloc(size_t suggested_size,
                                       uv_buf_t* buf) const {
   if (used() == kBufferSize)

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -41,7 +41,7 @@ class SyncProcessOutputBuffer {
   static const unsigned int kBufferSize = 65536;
 
  public:
-  inline SyncProcessOutputBuffer();
+  inline SyncProcessOutputBuffer() = default;
 
   inline void OnAlloc(size_t suggested_size, uv_buf_t* buf) const;
   inline void OnRead(const uv_buf_t* buf, size_t nread);

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -36,7 +36,7 @@ class StreamReq {
     AttachToObject(req_wrap_obj);
   }
 
-  virtual ~StreamReq() {}
+  virtual ~StreamReq() = default;
   virtual AsyncWrap* GetAsyncWrap() = 0;
   v8::Local<v8::Object> object();
 

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -22,7 +22,7 @@ class Agent;
 
 class AsyncTraceWriter {
  public:
-  virtual ~AsyncTraceWriter() {}
+  virtual ~AsyncTraceWriter() = default;
   virtual void AppendTraceEvent(TraceObject* trace_event) = 0;
   virtual void Flush(bool blocking) = 0;
   virtual void InitializeOnThread(uv_loop_t* loop) {}
@@ -48,7 +48,7 @@ class TracingController : public v8::platform::tracing::TracingController {
 
 class AgentWriterHandle {
  public:
-  inline AgentWriterHandle() {}
+  inline AgentWriterHandle() = default;
   inline ~AgentWriterHandle() { reset(); }
 
   inline AgentWriterHandle(AgentWriterHandle&& other);

--- a/src/tracing/traced_value.cc
+++ b/src/tracing/traced_value.cc
@@ -113,8 +113,6 @@ std::unique_ptr<TracedValue> TracedValue::CreateArray() {
 TracedValue::TracedValue(bool root_is_array) :
     first_item_(true), root_is_array_(root_is_array) {}
 
-TracedValue::~TracedValue() {}
-
 void TracedValue::SetInteger(const char* name, int value) {
   WriteName(name);
   data_ += std::to_string(value);

--- a/src/tracing/traced_value.h
+++ b/src/tracing/traced_value.h
@@ -18,7 +18,7 @@ namespace tracing {
 
 class TracedValue : public v8::ConvertableToTraceFormat {
  public:
-  ~TracedValue() override;
+  ~TracedValue() = default;
 
   static std::unique_ptr<TracedValue> Create();
   static std::unique_ptr<TracedValue> CreateArray();

--- a/src/util.h
+++ b/src/util.h
@@ -427,7 +427,7 @@ class MaybeStackBuffer {
 template <typename T, size_t kStackStorageSize = 64>
 class ArrayBufferViewContents {
  public:
-  ArrayBufferViewContents() {}
+  ArrayBufferViewContents() = default;
 
   explicit inline ArrayBufferViewContents(v8::Local<v8::Value> value);
   explicit inline ArrayBufferViewContents(v8::Local<v8::ArrayBufferView> abv);


### PR DESCRIPTION
Also from: https://ci.nodejs.org/job/node-clang-tidy/7/console.
Rule def: https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-equals-default.html.

cc @refack 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
