### PR TITLE
build: add Travis job to check for dead URL links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
         - npm install -g linkinator
       script:
         - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-            DOC_FILES=`curl -sL https://github.com/nodejs/node/pull/${TRAVIS_PULL_REQUEST}.patch | grep -o '\bdoc/api/.*\.md\b'`
+            DOC_FILES=`curl -sL https://github.com/nodejs/node/pull/${TRAVIS_PULL_REQUEST}.patch | grep -o '\bdoc/api/.*\.md\b'`;
             if [ -n "${DOC_FILES}" ]; then
               linkinator out/doc/api -r;
             fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ jobs:
             DOC_FILES=`curl -sL https://github.com/nodejs/node/pull/${TRAVIS_PULL_REQUEST}.patch | grep -o '\bdoc/api/.*\.md\b'`
             if [ -n "${DOC_FILES}" ]; then
               linkinator out/doc/api -r;
-            fi
+            fi;
           fi
 
     - name: "First commit message adheres to guidelines at <a href=\"https://goo.gl/p2fr5Q\">https://goo.gl/p2fr5Q</a>"

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,16 @@ jobs:
       script:
         - NODE=$(which node) make lint lint-py
 
+    - name: "Docs"
+      language: node_js
+      node_js: "node"
+      install:
+        - pyenv global 2.7.15
+        - make doc-only
+        - npm install -g linkinator
+      script:
+        - linkinator out/doc/api -r
+
     - name: "First commit message adheres to guidelines at <a href=\"https://goo.gl/p2fr5Q\">https://goo.gl/p2fr5Q</a>"
       if: type = pull_request
       language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ jobs:
         - NODE=$(which node) make lint lint-py
 
     - name: "Docs"
+      if: type = pull_request
       language: node_js
       node_js: "node"
       install:
@@ -85,7 +86,12 @@ jobs:
         - make doc-only
         - npm install -g linkinator
       script:
-        - linkinator out/doc/api -r
+        - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+            DOC_FILES=`curl -sL https://github.com/nodejs/node/pull/${TRAVIS_PULL_REQUEST}.patch | grep -o '\bdoc/api/.*\.md\b'`
+            if [ -n "${DOC_FILES}" ]; then
+              linkinator out/doc/api -r;
+            fi
+          fi
 
     - name: "First commit message adheres to guidelines at <a href=\"https://goo.gl/p2fr5Q\">https://goo.gl/p2fr5Q</a>"
       if: type = pull_request


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/27168#issuecomment-483678744
> In the long run we should add tools to prevent this ?
> I wonder can https://github.com/JustinBeckwith/linkinator integrate to travis-ci ? (Suggested by @bnb )

Seems easy enough to put together.

This is a proof of concept of running https://github.com/JustinBeckwith/linkinator 
on our built HTML docs to find broken URL links. I don't think we want to be
running this for every PR as when I run it locally it checks 900+ links which could 
be seen as a denial of service attack if we run it too often.

Also it seems to be flagging some URL's as broken which I appear to be able to 
navigate to in web browser (although there does appear to be redirecting going
on). If anyone wants to look into that or adopt this PR then great as I probably 
won't be spending much time on it. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
