### PR TITLE
fs: changed isWindows to a function in utils and added test

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -52,7 +52,9 @@ const {
   UV_DIRENT_BLOCK
 } = internalBinding('constants').fs;
 
-const isWindows = process.platform === 'win32';
+function isWindows() {
+  return process.platform === 'win32';
+}
 
 let fs;
 function lazyLoadFs() {
@@ -215,7 +217,7 @@ const nullCheck = hideStackFrames((path, propName, throwError = true) => {
 });
 
 function preprocessSymlinkDestination(path, type, linkPath) {
-  if (!isWindows) {
+  if (!isWindows()) {
     // No preprocessing is needed on Unix.
     return path;
   } else if (type === 'junction') {
@@ -271,7 +273,7 @@ function Stats(
 }
 
 Stats.prototype._checkModeProperty = function(property) {
-  if (isWindows && (property === S_IFIFO || property === S_IFBLK ||
+  if (isWindows() && (property === S_IFIFO || property === S_IFBLK ||
     property === S_IFSOCK)) {
     return false;  // Some types are not available on Windows
   }

--- a/test/parallel/test-internal-fs.js
+++ b/test/parallel/test-internal-fs.js
@@ -1,8 +1,10 @@
 // Flags: --expose-internals
 'use strict';
 
+const assert = require('assert');
 const common = require('../common');
 const fs = require('internal/fs/utils');
+const pathModule = require('path');
 
 // Valid encodings and no args should not throw.
 fs.assertEncoding();
@@ -12,3 +14,42 @@ common.expectsError(
   () => fs.assertEncoding('foo'),
   { code: 'ERR_INVALID_OPT_VALUE_ENCODING', type: TypeError }
 );
+
+{
+  // Enable monkey patching for
+  // 1. path.resolve
+  const originalResolve = pathModule.resolve;
+
+  // 2. path.toNamespacedPath
+  const originalToNamespacedPath = pathModule.toNamespacedPath;
+
+  // 3. process.platform
+  const originalPlatform = process.platform;
+  let platform = null;
+  Object.defineProperty(process, 'platform', { get: () => platform });
+
+  function test(newPlatform, pathString, linkPath) {
+    platform = newPlatform;
+    pathModule.resolve = pathModule[newPlatform].resolve;
+    pathModule.toNamespacedPath = pathModule[newPlatform].toNamespacedPath;
+
+    const preprocessSymlinkDestination = fs.preprocessSymlinkDestination(
+      pathString,
+      'junction',
+      linkPath
+    );
+
+    const constructedPath = pathModule[newPlatform].toNamespacedPath(
+      pathModule[newPlatform].resolve(linkPath, '..', pathString)
+    );
+
+    assert.strictEqual(preprocessSymlinkDestination, constructedPath);
+  }
+
+  test('win32', '\\test2', '\\test1');
+  test('posix', '\\test2', '\\test1');
+
+  platform = originalPlatform;
+  pathModule.resolve = originalResolve;
+  pathModule.toNamespacedPath = originalToNamespacedPath;
+}


### PR DESCRIPTION
fs: changed isWindows to a function in utils and Added tests for preprocessSymlinkDestination.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
