### PR TITLE
dns: remove unreachable code

### DIFF
--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -90,11 +90,7 @@ function createLookupPromise(family, hostname, all, hints, verbatim) {
     req.resolve = resolve;
     req.reject = reject;
 
-    const err = getaddrinfo(req, toASCII(hostname), family, hints, verbatim);
-
-    if (err) {
-      reject(dnsException(err, 'getaddrinfo', hostname));
-    }
+    getaddrinfo(req, toASCII(hostname), family, hints, verbatim);
   });
 }
 
@@ -144,10 +140,7 @@ function createLookupServicePromise(hostname, port) {
     req.resolve = resolve;
     req.reject = reject;
 
-    const err = getnameinfo(req, hostname, port);
-
-    if (err)
-      reject(dnsException(err, 'getnameinfo', hostname));
+    getnameinfo(req, hostname, port);
   });
 }
 


### PR DESCRIPTION
cares_wrap.getaddrinfo() and cares_wrap.getnameinfo() map to void
functions. They cannot return a truthy value. Remove code that checks
the return code. (Coverage report confirms that the code is not
covered.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
