### PR TITLE
build: increase MACOS_DEPLOYMENT_TARGET to 10.10 for Node 12

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -436,7 +436,7 @@
           'GCC_ENABLE_CPP_RTTI': 'NO',              # -fno-rtti
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
           'PREBINDING': 'NO',                       # No -Wl,-prebind
-          'MACOSX_DEPLOYMENT_TARGET': '10.7',       # -mmacosx-version-min=10.7
+          'MACOSX_DEPLOYMENT_TARGET': '10.10',      # -mmacosx-version-min=10.10
           'USE_HEADERMAP': 'NO',
           'OTHER_CFLAGS': [
             '-fno-strict-aliasing',


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/pull/26714/
Ref: https://github.com/nodejs/build/issues/1768

This is part of the Node 12 compiler & supported platforms work. It was last bumped in #6402 in 2016. 

From https://github.com/nodejs/node/pull/26714/#issuecomment-483566074:

> The trade-off goes something like this: users who are on a macOS older than this number won't be able to run our binaries, but by including support for old versions we locking ourselves into supporting header layouts that may not hold (the only instance of this that I recall happened only recently but I can't find the issue for it) and perhaps there's missed optimization opportunities by forcing binding to older APIs.

But I'll add that I'm not fully confident about this, I'm still hoping for help making this decision.

10.9 is Mavericks, it was released in 2013 and had its last security update mid-2016. This change will mean that 10.9 and prior versions won't be able to run Node binaries because they'll (probably) have newer symbols.

If, for some reason, we find that 10.10 is too aggressive, we can always roll this back a bit without it being a breaking change, we just can't roll it forward for the lifetime of Node 12.