### PR TITLE
lib: use getOptionValue instead of process underscore aliases

### DIFF
--- a/lib/internal/main/eval_stdin.js
+++ b/lib/internal/main/eval_stdin.js
@@ -6,6 +6,8 @@ const {
   prepareMainThreadExecution
 } = require('internal/bootstrap/pre_execution');
 
+const { getOptionValue } = require('internal/options');
+
 const {
   evalModule,
   evalScript,
@@ -16,9 +18,16 @@ prepareMainThreadExecution();
 markBootstrapComplete();
 
 readStdin((code) => {
+  // This is necessary for fork() and CJS module compilation.
+  // TODO(joyeecheung): pass this with something really internal.
   process._eval = code;
-  if (require('internal/options').getOptionValue('--input-type') === 'module')
-    evalModule(process._eval);
+
+  const print = getOptionValue('--print');
+  if (getOptionValue('--input-type') === 'module')
+    evalModule(code, print);
   else
-    evalScript('[stdin]', process._eval, process._breakFirstLine);
+    evalScript('[stdin]',
+               code,
+               getOptionValue('--inspect-brk'),
+               print);
 });

--- a/lib/internal/main/eval_string.js
+++ b/lib/internal/main/eval_string.js
@@ -10,11 +10,17 @@ const { evalModule, evalScript } = require('internal/process/execution');
 const { addBuiltinLibsToObject } = require('internal/modules/cjs/helpers');
 
 const { getOptionValue } = require('internal/options');
-const source = getOptionValue('--eval');
+
 prepareMainThreadExecution();
 addBuiltinLibsToObject(global);
 markBootstrapComplete();
+
+const source = getOptionValue('--eval');
+const print = getOptionValue('--print');
 if (getOptionValue('--input-type') === 'module')
-  evalModule(source);
+  evalModule(source, print);
 else
-  evalScript('[eval]', source, process._breakFirstLine);
+  evalScript('[eval]',
+             source,
+             getOptionValue('--inspect-brk'),
+             print);

--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -13,10 +13,14 @@ const {
 
 const console = require('internal/console/global');
 
+const { getOptionValue } = require('internal/options');
+
 prepareMainThreadExecution();
 
+markBootstrapComplete();
+
 // --input-type flag not supported in REPL
-if (require('internal/options').getOptionValue('--input-type')) {
+if (getOptionValue('--input-type')) {
   // If we can't write to stderr, we'd like to make this a noop,
   // so use console.error.
   console.error('Cannot specify --input-type for REPL');
@@ -44,8 +48,10 @@ cliRepl.createInternalRepl(process.env, (err, repl) => {
 
 // If user passed '-e' or '--eval' along with `-i` or `--interactive`,
 // evaluate the code in the current context.
-if (process._eval != null) {
-  evalScript('[eval]', process._eval, process._breakFirstLine);
+const source = getOptionValue('--eval');
+if (source != null) {
+  evalScript('[eval]',
+             source,
+             getOptionValue('--inspect-brk'),
+             getOptionValue('--print'));
 }
-
-markBootstrapComplete();

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -680,7 +680,7 @@ Module.prototype.require = function(id) {
 // Resolved path to process.argv[1] will be lazily placed here
 // (needed for setting breakpoint when called with --inspect-brk)
 var resolvedArgv;
-
+let hasPausedEntry = false;
 
 // Run the file contents in the correct scope or sandbox. Expose
 // the correct helper variables (require, module, exports) to
@@ -736,7 +736,7 @@ Module.prototype._compile = function(content, filename) {
   }
 
   var inspectorWrapper = null;
-  if (process._breakFirstLine && process._eval == null) {
+  if (getOptionValue('--inspect-brk') && process._eval == null) {
     if (!resolvedArgv) {
       // We enter the repl if we're not given a filename argument.
       if (process.argv[1]) {
@@ -747,8 +747,8 @@ Module.prototype._compile = function(content, filename) {
     }
 
     // Set breakpoint on module start
-    if (filename === resolvedArgv) {
-      delete process._breakFirstLine;
+    if (!hasPausedEntry && filename === resolvedArgv) {
+      hasPausedEntry = true;
       inspectorWrapper = internalBinding('inspector').callAndPauseOnStart;
     }
   }

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -9,10 +9,13 @@ const {
 const { ModuleWrap } = internalBinding('module_wrap');
 
 const { decorateErrorStack } = require('internal/util');
+const { getOptionValue } = require('internal/options');
 const assert = require('internal/assert');
 const resolvedPromise = SafePromise.resolve();
 
 function noop() {}
+
+let hasPausedEntry = false;
 
 /* A ModuleJob tracks the loading of a single Module, and the ModuleJobs of
  * its dependencies, over time. */
@@ -82,8 +85,8 @@ class ModuleJob {
     };
     await addJobsToDependencyGraph(this);
     try {
-      if (this.isMain && process._breakFirstLine) {
-        delete process._breakFirstLine;
+      if (!hasPausedEntry && this.isMain && getOptionValue('--inspect-brk')) {
+        hasPausedEntry = true;
         const initWrapper = internalBinding('inspector').callAndPauseOnStart;
         initWrapper(this.module.instantiate, this.module);
       } else {

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -35,13 +35,13 @@ function tryGetCwd() {
   }
 }
 
-function evalModule(source) {
+function evalModule(source, print) {
   const { log, error } = require('internal/console/global');
   const { decorateErrorStack } = require('internal/util');
   const asyncESM = require('internal/process/esm_loader');
   asyncESM.loaderPromise.then(async (loader) => {
     const { result } = await loader.eval(source);
-    if (require('internal/options').getOptionValue('--print')) {
+    if (print) {
       log(result);
     }
   })
@@ -54,7 +54,7 @@ function evalModule(source) {
   process._tickCallback();
 }
 
-function evalScript(name, body, breakFirstLine) {
+function evalScript(name, body, breakFirstLine, print) {
   const CJSModule = require('internal/modules/cjs/loader');
   const { kVmBreakFirstLineSymbol } = require('internal/util');
 
@@ -79,7 +79,7 @@ function evalScript(name, body, breakFirstLine) {
         [kVmBreakFirstLineSymbol]: ${!!breakFirstLine}
       });\n`;
   const result = module._compile(script, `${name}-wrapper`);
-  if (require('internal/options').getOptionValue('--print')) {
+  if (print) {
     const { log } = require('internal/console/global');
     log(result);
   }


### PR DESCRIPTION
This patch reduce usage of `process._breakFirstLine` and
`process._eval` in the internals and use
`getOptionValue('--inspect-brk')` and `getOptionValue('--eval')`
instead wherever possible.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
