### PR TITLE
src: apply clang-tidy modernize-deprecated-headers found by Jenkins CI

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1,4 +1,4 @@
-#include <limits.h>  // INT_MAX
+#include <climits>  // INT_MAX
 #include <cmath>
 #include <algorithm>
 #define NAPI_EXPERIMENTAL

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -20,19 +20,21 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <errno.h>   // NOLINT(build/include)
-#include <fcntl.h>   // _O_RDWR
-#include <limits.h>  // PATH_MAX
-#include <locale.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
+#include "node_large_page.h"
+
+#include <fcntl.h>  // _O_RDWR
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <unistd.h>  // readlink
 
+#include <cerrno>   // NOLINT(build/include)
+#include <climits>  // PATH_MAX
+#include <clocale>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
 #include <string>
 #include <fstream>
 #include <iostream>

--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -23,7 +23,7 @@
 #define SRC_NODE_OBJECT_WRAP_H_
 
 #include "v8.h"
-#include <assert.h>
+#include <cassert>
 
 
 namespace node {


### PR DESCRIPTION
Found by https://ci.nodejs.org/job/node-clang-tidy/7/console.

cc @refack 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
