### PR TITLE
util: access process states lazily in debuglog

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -30,14 +30,7 @@ const EE = require('events');
 const Stream = require('stream');
 const { Buffer } = require('buffer');
 
-let debuglog;
-function debug(...args) {
-  if (!debuglog) {
-    debuglog = require('internal/util/debuglog').debuglog('stream');
-  }
-  debuglog(...args);
-}
-
+const debug = require('internal/util/debuglog').debuglog('stream');
 const BufferList = require('internal/streams/buffer_list');
 const destroyImpl = require('internal/streams/destroy');
 const { getHighWaterMark } = require('internal/streams/state');

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -44,12 +44,11 @@ const {
 } = require('internal/process/execution');
 
 const publicWorker = require('worker_threads');
+const debug = require('internal/util/debuglog').debuglog('worker');
 
 patchProcessObject();
 setupInspectorHooks();
 setupDebugEnv();
-
-const debug = require('internal/util/debuglog').debuglog('worker');
 
 setupWarningHandler();
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -166,14 +166,7 @@ Object.defineProperty(Module, 'wrapper', {
   }
 });
 
-let debuglog;
-function debug(...args) {
-  if (!debuglog) {
-    debuglog = require('internal/util/debuglog').debuglog('module');
-  }
-  debuglog(...args);
-}
-
+const debug = require('internal/util/debuglog').debuglog('module');
 Module._debug = deprecate(debug, 'Module._debug is deprecated.', 'DEP0077');
 
 // Given a module name, and a list of paths to test, returns the first

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -31,7 +31,7 @@ const kAfterAsyncWrite = Symbol('kAfterAsyncWrite');
 const kHandle = Symbol('kHandle');
 const kSession = Symbol('kSession');
 
-const debug = require('util').debuglog('stream');
+const debug = require('internal/util/debuglog').debuglog('stream');
 
 function handleWriteReq(req, data, encoding) {
   const { handle } = req;

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -107,13 +107,7 @@ const L = require('internal/linkedlist');
 const PriorityQueue = require('internal/priority_queue');
 
 const { inspect } = require('internal/util/inspect');
-let debuglog;
-function debug(...args) {
-  if (!debuglog) {
-    debuglog = require('internal/util/debuglog').debuglog('timer');
-  }
-  debuglog(...args);
-}
+const debug = require('internal/util/debuglog').debuglog('timer');
 
 // *Must* match Environment::ImmediateInfo::Fields in src/env.h.
 const kCount = 0;

--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -31,7 +31,7 @@ function emitWarningIfNeeded(set) {
   }
 }
 
-function debuglog(set) {
+function debuglogImpl(set) {
   set = set.toUpperCase();
   if (!debugs[set]) {
     if (debugEnvRegex.test(set)) {
@@ -46,6 +46,22 @@ function debuglog(set) {
     }
   }
   return debugs[set];
+}
+
+// debuglogImpl depends on process.pid and process.env.NODE_DEBUG,
+// so it needs to be called lazily in top scopes of internal modules
+// that may be loaded before these run time states are allowed to
+// be accessed.
+function debuglog(set) {
+  let debug;
+  return function(...args) {
+    if (!debug) {
+      // Only invokes debuglogImpl() when the debug function is
+      // called for the first time.
+      debug = debuglogImpl(set);
+    }
+    debug(...args);
+  };
 }
 
 module.exports = {

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -48,14 +48,7 @@ const kOnErrorMessage = Symbol('kOnErrorMessage');
 const kParentSideStdio = Symbol('kParentSideStdio');
 
 const SHARE_ENV = Symbol.for('nodejs.worker_threads.SHARE_ENV');
-
-let debuglog;
-function debug(...args) {
-  if (!debuglog) {
-    debuglog = require('internal/util/debuglog').debuglog('worker');
-  }
-  debuglog(...args);
-}
+const debug = require('internal/util/debuglog').debuglog('worker');
 
 class Worker extends EventEmitter {
   constructor(filename, options = {}) {

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -21,14 +21,7 @@ const {
 const { Readable, Writable } = require('stream');
 const EventEmitter = require('events');
 const { inspect } = require('internal/util/inspect');
-
-let debuglog;
-function debug(...args) {
-  if (!debuglog) {
-    debuglog = require('internal/util/debuglog').debuglog('worker');
-  }
-  debuglog(...args);
-}
+const debug = require('internal/util/debuglog').debuglog('worker');
 
 const kIncrementsPortRef = Symbol('kIncrementsPortRef');
 const kName = Symbol('kName');

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -50,14 +50,7 @@ const {
   deprecate
 } = require('internal/util');
 const { ERR_INVALID_CALLBACK } = require('internal/errors').codes;
-
-let debuglog;
-function debug(...args) {
-  if (!debuglog) {
-    debuglog = require('internal/util/debuglog').debuglog('timer');
-  }
-  debuglog(...args);
-}
+const debug = require('internal/util/debuglog').debuglog('timer');
 
 const {
   destroyHooksExist,


### PR DESCRIPTION
`debuglog()` depends on `process.pid` and `process.env.NODE_DEBUG`,
so it needs to be called lazily in top scopes of internal modules
that may be loaded before these run time states are allowed to
be accessed. This patch makes its implementation lazy by default,
the process states are only accessed when the returned debug
function is called for the first time.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
