### PR TITLE
deps: use nghttp2's config.h on all platforms

### DIFF
--- a/deps/nghttp2/lib/includes/config.h
+++ b/deps/nghttp2/lib/includes/config.h
@@ -54,7 +54,9 @@ typedef intptr_t ssize_t;
 /* #undef NOTHREADS */
 
 /* Define to 1 if you have the <arpa/inet.h> header file. */
-/* #undef HAVE_ARPA_INET_H */
+#ifndef _WIN32
+# define HAVE_ARPA_INET_H 1
+#endif
 
 /* Define to 1 if you have the <fcntl.h> header file. */
 #define HAVE_FCNTL_H 1

--- a/deps/nghttp2/nghttp2.gyp
+++ b/deps/nghttp2/nghttp2.gyp
@@ -12,13 +12,13 @@
       'defines': [
         'BUILDING_NGHTTP2',
         'NGHTTP2_STATICLIB',
+        'HAVE_CONFIG_H',
       ],
       'conditions': [
         ['OS=="win"', {
           'defines': [
             'WIN32',
             '_WINDOWS',
-            'HAVE_CONFIG_H',
           ],
           'msvs_settings': {
             'VCCLCompilerTool': {


### PR DESCRIPTION
Fix warnings about use of htonl(), etc. by including config.h for all
platforms, defining HAVE_ARPA_INET_H on non-Windows, and therefore
including <arpa/inet.h>, which defines the host to network byte order
conversion functions.

--

This works on Linux, I'll see what ci says about the other platforms.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
