### PR TITLE
src: move guessHandleType in the util binding

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -28,8 +28,8 @@ const {
   kStateSymbol,
   _createSocketHandle,
   newHandle,
-  guessHandleType,
 } = require('internal/dgram');
+const { guessHandleType } = internalBinding('util');
 const {
   isLegalPort,
 } = require('internal/net');

--- a/lib/internal/dgram.js
+++ b/lib/internal/dgram.js
@@ -1,8 +1,8 @@
 'use strict';
 const { codes } = require('internal/errors');
 const { UDP } = internalBinding('udp_wrap');
+const { guessHandleType } = internalBinding('util');
 const { isInt32 } = require('internal/validators');
-const TTYWrap = internalBinding('tty_wrap');
 const { UV_EINVAL } = internalBinding('uv');
 const { ERR_INVALID_ARG_TYPE, ERR_SOCKET_BAD_TYPE } = codes;
 const kStateSymbol = Symbol('state symbol');
@@ -17,10 +17,6 @@ function lookup4(lookup, address, callback) {
 function lookup6(lookup, address, callback) {
   return lookup(address || '::1', 6, callback);
 }
-
-
-const guessHandleType = TTYWrap.guessHandleType;
-
 
 function newHandle(type, lookup) {
   if (lookup === undefined) {
@@ -81,6 +77,5 @@ function _createSocketHandle(address, port, addressType, fd, flags) {
 module.exports = {
   kStateSymbol,
   _createSocketHandle,
-  newHandle,
-  guessHandleType,
+  newHandle
 };

--- a/lib/internal/process/stdio.js
+++ b/lib/internal/process/stdio.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { guessHandleType } = internalBinding('util');
 exports.getMainThreadStdio = getMainThreadStdio;
 
 function dummyDestroy(err, cb) {
@@ -48,10 +49,9 @@ function getMainThreadStdio() {
 
   function getStdin() {
     if (stdin) return stdin;
-    const tty_wrap = internalBinding('tty_wrap');
     const fd = 0;
 
-    switch (tty_wrap.guessHandleType(fd)) {
+    switch (guessHandleType(fd)) {
       case 'TTY':
         var tty = require('tty');
         stdin = new tty.ReadStream(fd, {
@@ -148,11 +148,8 @@ function getMainThreadStdio() {
 
 function createWritableStdioStream(fd) {
   var stream;
-  const tty_wrap = internalBinding('tty_wrap');
-
   // Note stream._type is used for test-module-load-list.js
-
-  switch (tty_wrap.guessHandleType(fd)) {
+  switch (guessHandleType(fd)) {
     case 'TTY':
       var tty = require('tty');
       stream = new tty.WriteStream(fd);

--- a/lib/net.js
+++ b/lib/net.js
@@ -43,7 +43,7 @@ const {
 } = internalBinding('uv');
 
 const { Buffer } = require('buffer');
-const TTYWrap = internalBinding('tty_wrap');
+const { guessHandleType } = internalBinding('util');
 const { ShutdownWrap } = internalBinding('stream_wrap');
 const {
   TCP,
@@ -111,7 +111,7 @@ function getFlags(ipv6Only) {
 
 function createHandle(fd, is_server) {
   validateInt32(fd, 'fd', 0);
-  const type = TTYWrap.guessHandleType(fd);
+  const type = guessHandleType(fd);
   if (type === 'PIPE') {
     return new Pipe(
       is_server ? PipeConstants.SERVER : PipeConstants.SOCKET

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -59,37 +59,12 @@ void TTYWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "setRawMode", SetRawMode);
 
   env->SetMethodNoSideEffect(target, "isTTY", IsTTY);
-  env->SetMethodNoSideEffect(target, "guessHandleType", GuessHandleType);
 
   Local<Value> func;
   if (t->GetFunction(env->context()).ToLocal(&func) &&
       target->Set(env->context(), ttyString, func).IsJust()) {
     env->set_tty_constructor_template(t);
   }
-}
-
-
-void TTYWrap::GuessHandleType(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  int fd;
-  if (!args[0]->Int32Value(env->context()).To(&fd)) return;
-  CHECK_GE(fd, 0);
-
-  uv_handle_type t = uv_guess_handle(fd);
-  const char* type = nullptr;
-
-  switch (t) {
-  case UV_TCP: type = "TCP"; break;
-  case UV_TTY: type = "TTY"; break;
-  case UV_UDP: type = "UDP"; break;
-  case UV_FILE: type = "FILE"; break;
-  case UV_NAMED_PIPE: type = "PIPE"; break;
-  case UV_UNKNOWN_HANDLE: type = "UNKNOWN"; break;
-  default:
-    ABORT();
-  }
-
-  args.GetReturnValue().Set(OneByteString(env->isolate(), type));
 }
 
 

--- a/src/tty_wrap.h
+++ b/src/tty_wrap.h
@@ -48,7 +48,6 @@ class TTYWrap : public LibuvStreamWrap {
           bool readable,
           int* init_err);
 
-  static void GuessHandleType(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void IsTTY(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetWindowSize(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetRawMode(const v8::FunctionCallbackInfo<v8::Value>& args);


### PR DESCRIPTION
It does not make too much sense to have modules unrelated to TTY
load the TTY binding just to use this method. Put this in the
util binding instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
