### PR TITLE
src: move SIGINT watchdog utils to the contextify binding

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -87,10 +87,13 @@ const {
   propertyFilter: {
     ALL_PROPERTIES,
     SKIP_SYMBOLS
-  },
+  }
+} = internalBinding('util');
+const {
   startSigintWatchdog,
   stopSigintWatchdog
-} = internalBinding('util');
+} = internalBinding('contextify');
+
 const history = require('internal/repl/history');
 
 // Lazy-loaded.

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1141,6 +1141,20 @@ void ContextifyContext::CompileFunction(
   args.GetReturnValue().Set(fn);
 }
 
+static void StartSigintWatchdog(const FunctionCallbackInfo<Value>& args) {
+  int ret = SigintWatchdogHelper::GetInstance()->Start();
+  args.GetReturnValue().Set(ret == 0);
+}
+
+static void StopSigintWatchdog(const FunctionCallbackInfo<Value>& args) {
+  bool had_pending_signals = SigintWatchdogHelper::GetInstance()->Stop();
+  args.GetReturnValue().Set(had_pending_signals);
+}
+
+static void WatchdogHasPendingSigint(const FunctionCallbackInfo<Value>& args) {
+  bool ret = SigintWatchdogHelper::GetInstance()->HasPendingSignal();
+  args.GetReturnValue().Set(ret);
+}
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
@@ -1149,6 +1163,12 @@ void Initialize(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
   ContextifyContext::Init(env, target);
   ContextifyScript::Init(env, target);
+
+  env->SetMethod(target, "startSigintWatchdog", StartSigintWatchdog);
+  env->SetMethod(target, "stopSigintWatchdog", StopSigintWatchdog);
+  // Used in tests.
+  env->SetMethodNoSideEffect(
+      target, "watchdogHasPendingSigint", WatchdogHasPendingSigint);
 }
 
 }  // namespace contextify

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -1,5 +1,4 @@
 #include "node_errors.h"
-#include "node_watchdog.h"
 #include "util.h"
 #include "base_object-inl.h"
 
@@ -157,24 +156,6 @@ static void SetHiddenValue(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(maybe_value.FromJust());
 }
 
-
-void StartSigintWatchdog(const FunctionCallbackInfo<Value>& args) {
-  int ret = SigintWatchdogHelper::GetInstance()->Start();
-  args.GetReturnValue().Set(ret == 0);
-}
-
-
-void StopSigintWatchdog(const FunctionCallbackInfo<Value>& args) {
-  bool had_pending_signals = SigintWatchdogHelper::GetInstance()->Stop();
-  args.GetReturnValue().Set(had_pending_signals);
-}
-
-
-void WatchdogHasPendingSigint(const FunctionCallbackInfo<Value>& args) {
-  bool ret = SigintWatchdogHelper::GetInstance()->HasPendingSignal();
-  args.GetReturnValue().Set(ret);
-}
-
 void ArrayBufferViewHasBuffer(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsArrayBufferView());
   args.GetReturnValue().Set(args[0].As<ArrayBufferView>()->HasBuffer());
@@ -245,11 +226,6 @@ void Initialize(Local<Object> target,
   env->SetMethodNoSideEffect(target, "previewEntries", PreviewEntries);
   env->SetMethodNoSideEffect(target, "getOwnNonIndexProperties",
                                      GetOwnNonIndexProperties);
-
-  env->SetMethod(target, "startSigintWatchdog", StartSigintWatchdog);
-  env->SetMethod(target, "stopSigintWatchdog", StopSigintWatchdog);
-  env->SetMethodNoSideEffect(target, "watchdogHasPendingSigint",
-                             WatchdogHasPendingSigint);
 
   env->SetMethod(target, "arrayBufferViewHasBuffer", ArrayBufferViewHasBuffer);
   Local<Object> constants = Object::New(env->isolate());

--- a/test/parallel/test-util-sigint-watchdog.js
+++ b/test/parallel/test-util-sigint-watchdog.js
@@ -8,7 +8,7 @@ if (common.isWindows) {
 
 const assert = require('assert');
 const { internalBinding } = require('internal/test/binding');
-const binding = internalBinding('util');
+const binding = internalBinding('contextify');
 
 [(next) => {
   // Test with no signal observed.


### PR DESCRIPTION
These are used when evaluating scripts so it makes more sense
to put them in the contextify binding whose other methods are
going to be used together.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
