### PR TITLE
worker: add ability to unshift message from MessagePort

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -125,6 +125,34 @@ if (isMainThread) {
 }
 ```
 
+## worker.receiveMessageOnPort(port)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `port` {MessagePort}
+
+* Returns: {Object|undefined}
+
+Receive a single message from a given `MessagePort`. If no message is available,
+`undefined` is returned, otherwise an object with a single `message` property
+that contains the message payload, corresponding to the oldest message in the
+`MessagePort`’s queue.
+
+```js
+const { MessageChannel, receiveMessageOnPort } = require('worker_threads');
+const { port1, port2 } = new MessageChannel();
+port1.postMessage({ hello: 'world' });
+
+console.log(receiveMessageOnPort(port2));
+// Prints: { message: { hello: 'world' } }
+console.log(receiveMessageOnPort(port2));
+// Prints: undefined
+```
+
+When this function is used, no `'message'` event will be emitted and the
+`onmessage` listener will not be invoked.
+
 ## worker.SHARE_ENV
 <!-- YAML
 added: v11.14.0

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -4,13 +4,15 @@ const { Object } = primordials;
 
 const {
   handle_onclose: handleOnCloseSymbol,
-  oninit: onInitSymbol
+  oninit: onInitSymbol,
+  no_message_symbol: noMessageSymbol
 } = internalBinding('symbols');
 const {
   MessagePort,
   MessageChannel,
   drainMessagePort,
   moveMessagePortToContext,
+  receiveMessageOnPort: receiveMessageOnPort_,
   stopMessagePort
 } = internalBinding('messaging');
 const {
@@ -235,6 +237,12 @@ function createWorkerStdio() {
   };
 }
 
+function receiveMessageOnPort(port) {
+  const message = receiveMessageOnPort_(port);
+  if (message === noMessageSymbol) return undefined;
+  return { message };
+}
+
 module.exports = {
   drainMessagePort,
   messageTypes,
@@ -245,6 +253,7 @@ module.exports = {
   moveMessagePortToContext,
   MessagePort,
   MessageChannel,
+  receiveMessageOnPort,
   setupPortReferencing,
   ReadableWorkerStdio,
   WritableWorkerStdio,

--- a/lib/worker_threads.js
+++ b/lib/worker_threads.js
@@ -11,6 +11,7 @@ const {
   MessagePort,
   MessageChannel,
   moveMessagePortToContext,
+  receiveMessageOnPort
 } = require('internal/worker/io');
 
 module.exports = {
@@ -18,6 +19,7 @@ module.exports = {
   MessagePort,
   MessageChannel,
   moveMessagePortToContext,
+  receiveMessageOnPort,
   threadId,
   SHARE_ENV,
   Worker,

--- a/src/env.h
+++ b/src/env.h
@@ -130,6 +130,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
 // for the sake of convenience.
 #define PER_ISOLATE_SYMBOL_PROPERTIES(V)                                      \
   V(handle_onclose_symbol, "handle_onclose")                                  \
+  V(no_message_symbol, "no_message_symbol")                                   \
   V(oninit_symbol, "oninit")                                                  \
   V(owner_symbol, "owner")                                                    \
 

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -163,6 +163,7 @@ class MessagePort : public HandleWrap {
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Stop(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Drain(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void ReceiveMessage(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   /* static */
   static void MoveToContext(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -200,6 +201,8 @@ class MessagePort : public HandleWrap {
   void OnClose() override;
   void OnMessage();
   void TriggerAsync();
+  v8::MaybeLocal<v8::Value> ReceiveMessage(v8::Local<v8::Context> context,
+                                           bool only_if_receiving);
 
   std::unique_ptr<MessagePortData> data_ = nullptr;
   bool receiving_messages_ = false;

--- a/test/parallel/test-worker-message-port-receive-message.js
+++ b/test/parallel/test-worker-message-port-receive-message.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { MessageChannel, receiveMessageOnPort } = require('worker_threads');
+
+const { port1, port2 } = new MessageChannel();
+
+const message1 = { hello: 'world' };
+const message2 = { foo: 'bar' };
+
+// Make sure receiveMessageOnPort() works in a FIFO way, the same way it does
+// when we’re using events.
+assert.deepStrictEqual(receiveMessageOnPort(port2), undefined);
+port1.postMessage(message1);
+port1.postMessage(message2);
+assert.deepStrictEqual(receiveMessageOnPort(port2), { message: message1 });
+assert.deepStrictEqual(receiveMessageOnPort(port2), { message: message2 });
+assert.deepStrictEqual(receiveMessageOnPort(port2), undefined);
+assert.deepStrictEqual(receiveMessageOnPort(port2), undefined);
+
+// Make sure message handlers aren’t called.
+port2.on('message', common.mustNotCall());
+port1.postMessage(message1);
+assert.deepStrictEqual(receiveMessageOnPort(port2), { message: message1 });
+port1.close();


### PR DESCRIPTION
##### ~worker: move `receiving_messages_` field to `MessagePort`~ (landed as part of #27705)

~This is a property of the native object associated with the
`MessagePort`, not something that should be set on the
conceptual `MessagePort` that may be transferred around.~

~(This is just cleanup that’s not directly related to the next commit except
for merge conflicts.)~

##### worker: add ability to unshift message from MessagePort

In combination with Atomics, this makes it possible to implement
generic synchronous functionality, e.g. `importScript()`, in Workers
purely by communicating with other threads.

This is a continuation of https://github.com/nodejs/node/pull/26686,
where a preference for a solution was voiced that allowed reading
individual messages, rather than emitting all messages through events.

(/cc @devsnek, @BridgeAR, @nodejs/workers)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
