### PR TITLE
buffer: throw on new Buffer

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -660,6 +660,16 @@ instance is to create a normal `Uint8Array`, which only differs in the
 prototype of the resulting object. `Uint8Array`s are generally accepted in all
 Node.js core APIs where `Buffer`s are; they are available in all Contexts.
 
+<a id="ERR_BUFFER_NEW_NOT_SUPPORTED"></a>
+### ERR_BUFFER_NEW_NOT_SUPPORTED
+
+Use of `new Buffer` is not supported. It has been deprecated since 10.x,
+and now throws an error. The deprecation can be reverted, if absolutely
+necessary, by using `--security-revert=`.
+
+See [DEP0005](deprecations.html#deprecations_dep0005_buffer_constructor) for
+more information.
+
 <a id="ERR_BUFFER_OUT_OF_BOUNDS"></a>
 ### ERR_BUFFER_OUT_OF_BOUNDS
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -64,6 +64,7 @@ const {
 
 const {
   codes: {
+    ERR_BUFFER_NEW_NOT_SUPPORTED,
     ERR_BUFFER_OUT_OF_BOUNDS,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
@@ -168,6 +169,9 @@ function showFlaggedDeprecation() {
  * Deprecation Code: DEP0005
  */
 function Buffer(arg, encodingOrOffset, length) {
+  if (!process.REVERT_CVE_2018_7166)
+    throw new ERR_BUFFER_NEW_NOT_SUPPORTED();
+
   showFlaggedDeprecation();
   // Common case.
   if (typeof arg === 'number') {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -612,6 +612,7 @@ E('ERR_ASSERTION', '%s', Error);
 E('ERR_ASYNC_CALLBACK', '%s must be a function', TypeError);
 E('ERR_ASYNC_TYPE', 'Invalid name for async "type": %s', TypeError);
 E('ERR_BROTLI_INVALID_PARAM', '%s is not a valid Brotli parameter', RangeError);
+E('ERR_BUFFER_NEW_NOT_SUPPORTED', 'Use of new Buffer not supported', Error);
 E('ERR_BUFFER_OUT_OF_BOUNDS',
   // Using a default argument here is important so the argument is not counted
   // towards `Function#length`.

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -513,7 +513,8 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             &PerProcessOptions::debug_arraybuffer_allocations,
             kAllowedInEnvironment);
 
-  AddOption("--security-reverts", "", &PerProcessOptions::security_reverts);
+  AddOption("--security-reverts", "", &PerProcessOptions::security_reverts,
+      kAllowedInEnvironment);
   AddOption("--completion-bash",
             "print source-able bash completion script",
             &PerProcessOptions::print_bash_completion);

--- a/src/node_revert.h
+++ b/src/node_revert.h
@@ -15,8 +15,9 @@
  **/
 namespace node {
 
-#define SECURITY_REVERSIONS(XX)
-//  XX(CVE_2016_PEND, "CVE-2016-PEND", "Vulnerability Title")
+#define SECURITY_REVERSIONS(XX) \
+  XX(CVE_2018_7166, "CVE-2018-7166", \
+      "Buffer constructor exposes uninitialized memory")
 
 enum reversion {
 #define V(code, ...) SECURITY_REVERT_##code,


### PR DESCRIPTION
It's been deprecated a long time, time to start throwing. The throw can
be reverted via a CLI option, directly or in the NODE_OPTIONS
environment variable.

See: https://github.com/nodejs/security-wg/issues/505

----

Usage of `new Buffer` is not decreasing in the ecosystem. The run-time deprecation warning appears to have have done all it will do.

This is a WIP to gauge interest,the docs would need more comprehensive updating. @nodejs/security-wg @nodejs/security-wg @nodejs/package-maintenance 

If this lands at all, I see it landing in 13.0.0, so it increases the pressure during that non-LTS cycle in a version that the most stable and conservative node users won't be using, this gives some time before 14.x for packages to update. Then perhaps in 15.x we can make reverting it impossible,  though throwing an error without CLI intervention is going to make most packages update, I expect (if they are maintained).

I know this isn't how the revert flag is usually used, but it seems an appropriate use to me. Of course, a new CLI flag specific to this use would also be possible.

Other options:
- Remove the check that prevents the deprecation warning is for dependencies. It made sense to only show the warning to people who wrote the code in question, but showing to everyone will increase the pressure, just as npm's warnings about vulnerabilities in sub-sub-deps causes issues to be opened and users to ask for updates (not always politely, which is unfortunate).
- Do nothing, its fertile ground for sec researchers.
- ... I'm not sure, perhaps there is a plan for this already?

Example with and without the revert:

```
core/node (master *$% u=) % NODE_OPTIONS=--security-reverts=CVE-2018-7166 ./out/Release/node -p 'const Buffer = require("buffer").Buffer; new Buffer(4)'                     
SECURITY WARNING: Reverting CVE-2018-7166: Buffer constructor exposes uninitialized memory                                                                                   
SECURITY WARNING: Reverting CVE-2018-7166: Buffer constructor exposes uninitialized memory                                                                                   
<Buffer 00 00 00 00>
(node:12796) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from()
methods instead.

core/node (new-buffer-throws $% u=) % ./out/Release/node -p 'const Buffer = require("buffer").Buffer; new Buffer(4)'                                                         
buffer.js:173
    throw new ERR_BUFFER_NEW_NOT_SUPPORTED();
    ^

Error [ERR_BUFFER_NEW_NOT_SUPPORTED]: Use of new Buffer not supported
    at new Buffer (buffer.js:173:11)
    at [eval]:1:42
    at Script.runInThisContext (vm.js:123:20)
    at Object.runInThisContext (vm.js:313:38)
    at Object.<anonymous> ([eval]-wrapper:9:26)
    at Module._compile (internal/modules/cjs/loader.js:766:30)
    at evalScript (internal/process/execution.js:81:25)
    at internal/main/eval_string.js:20:3
```



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
