### PR TITLE
test: deflake test-tls-sni-option

### DIFF
--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -69,114 +69,106 @@ const SNIContexts = {
   }
 };
 
-const clientsOptions = [{
+test({
   port: undefined,
   key: loadPEM('agent1-key'),
   cert: loadPEM('agent1-cert'),
   ca: [loadPEM('ca1-cert')],
   servername: 'a.example.com',
   rejectUnauthorized: false
-}, {
+},
+     true,
+     { sni: 'a.example.com', authorized: false },
+     null,
+     null);
+
+test({
   port: undefined,
   key: loadPEM('agent4-key'),
   cert: loadPEM('agent4-cert'),
   ca: [loadPEM('ca1-cert')],
   servername: 'a.example.com',
   rejectUnauthorized: false
-}, {
+},
+     true,
+     { sni: 'a.example.com', authorized: true },
+     null,
+     null);
+
+test({
   port: undefined,
   key: loadPEM('agent2-key'),
   cert: loadPEM('agent2-cert'),
   ca: [loadPEM('ca2-cert')],
   servername: 'b.example.com',
   rejectUnauthorized: false
-}, {
+},
+     true,
+     { sni: 'b.example.com', authorized: false },
+     null,
+     null);
+
+test({
   port: undefined,
   key: loadPEM('agent3-key'),
   cert: loadPEM('agent3-cert'),
   ca: [loadPEM('ca1-cert')],
   servername: 'c.wrong.com',
   rejectUnauthorized: false
-}, {
+},
+     false,
+     { sni: 'c.wrong.com', authorized: false },
+     null,
+     null);
+
+test({
   port: undefined,
   key: loadPEM('agent3-key'),
   cert: loadPEM('agent3-cert'),
   ca: [loadPEM('ca1-cert')],
   servername: 'c.another.com',
   rejectUnauthorized: false
-}];
+},
+     false,
+     null,
+     'Client network socket disconnected before secure TLS ' +
+       'connection was established',
+     'Invalid SNI context');
 
-const serverResults = [];
-const clientResults = [];
-const serverErrors = [];
-const clientErrors = [];
-let serverError;
-let clientError;
+function test(options, clientResult, serverResult, clientError, serverError) {
+  const server = tls.createServer(serverOptions, (c) => {
+    assert.deepStrictEqual(
+      { sni: c.servername, authorized: c.authorized },
+      serverResult
+    );
+  });
 
-const server = tls.createServer(serverOptions, function(c) {
-  serverResults.push({ sni: c.servername, authorized: c.authorized });
-  c.end();
-});
-
-server.on('tlsClientError', function(err) {
-  serverResults.push(null);
-  serverError = err.message;
-});
-
-server.listen(0, startTest);
-
-function startTest() {
-  function connectClient(i, callback) {
-    const options = clientsOptions[i];
-    clientError = null;
-    serverError = null;
-
-    options.port = server.address().port;
-    const client = tls.connect(options, function() {
-      clientResults.push(
-        client.authorizationError &&
-         (client.authorizationError === 'ERR_TLS_CERT_ALTNAME_INVALID'));
-
-      next();
-    });
-
-    client.on('error', function(err) {
-      clientResults.push(false);
-      clientError = err.message;
-      next();
-    });
-
-    function next() {
-      clientErrors.push(clientError);
-      serverErrors.push(serverError);
-
-      if (i === clientsOptions.length - 1)
-        callback();
-      else
-        connectClient(i + 1, callback);
-    }
+  if (serverResult) {
+    assert(!serverError);
+    server.on('tlsClientError', common.mustNotCall());
+  } else {
+    assert(serverError);
+    server.on('tlsClientError', common.mustCall((err) => {
+      assert.strictEqual(err.message, serverError);
+    }));
   }
 
-  connectClient(0, function() {
-    server.close();
+  server.listen(0, () => {
+    options.port = server.address().port;
+    const client = tls.connect(options, () => {
+      const result = client.authorizationError &&
+        (client.authorizationError === 'ERR_TLS_CERT_ALTNAME_INVALID');
+      assert.strictEqual(result, clientResult);
+      client.end();
+    });
+
+    client.on('close', common.mustCall(() => server.close()));
+
+    if (clientError)
+      client.on('error', common.mustCall((err) => {
+        assert.strictEqual(err.message, clientError);
+      }));
+    else
+      client.on('error', common.mustNotCall());
   });
 }
-
-process.on('exit', function() {
-  assert.deepStrictEqual(serverResults, [
-    { sni: 'a.example.com', authorized: false },
-    { sni: 'a.example.com', authorized: true },
-    { sni: 'b.example.com', authorized: false },
-    { sni: 'c.wrong.com', authorized: false },
-    null
-  ]);
-  assert.deepStrictEqual(clientResults, [true, true, true, false, false]);
-  assert.deepStrictEqual(clientErrors, [
-    null, null, null, null,
-    'Client network socket disconnected before secure TLS ' +
-    'connection was established'
-  ]);
-  assert.deepStrictEqual(serverErrors, [
-    null, null, null, null, 'Invalid SNI context'
-  ]);
-});


### PR DESCRIPTION
Might fix https://github.com/nodejs/node/issues/26910, though I haven't reproed the failure yet.

Basically, I pull next() out so that the testcase isn't complete until the client and server have finished. TLS1.2 and 1.3 complete on client and server in different orders, this might be an issue here.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
