### PR TITLE
src: move OnMessage to node_errors.cc

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -5,7 +5,6 @@
 #include "node_internals.h"
 #include "node_native_module_env.h"
 #include "node_platform.h"
-#include "node_process.h"
 #include "node_v8_platform-inl.h"
 #include "uv.h"
 
@@ -44,32 +43,6 @@ static bool ShouldAbortOnUncaughtException(Isolate* isolate) {
          (env->is_main_thread() || !env->is_stopping()) &&
          env->should_abort_on_uncaught_toggle()[0] &&
          !env->inside_should_not_abort_on_uncaught_scope();
-}
-
-static void OnMessage(Local<Message> message, Local<Value> error) {
-  Isolate* isolate = message->GetIsolate();
-  switch (message->ErrorLevel()) {
-    case Isolate::MessageErrorLevel::kMessageWarning: {
-      Environment* env = Environment::GetCurrent(isolate);
-      if (!env) {
-        break;
-      }
-      Utf8Value filename(isolate, message->GetScriptOrigin().ResourceName());
-      // (filename):(line) (message)
-      std::stringstream warning;
-      warning << *filename;
-      warning << ":";
-      warning << message->GetLineNumber(env->context()).FromMaybe(-1);
-      warning << " ";
-      v8::String::Utf8Value msg(isolate, message->Get());
-      warning << *msg;
-      USE(ProcessEmitWarningGeneric(env, warning.str().c_str(), "V8"));
-      break;
-    }
-    case Isolate::MessageErrorLevel::kMessageError:
-      FatalException(isolate, error, message);
-      break;
-  }
 }
 
 void* NodeArrayBufferAllocator::Allocate(size_t size) {
@@ -185,7 +158,7 @@ void SetIsolateCreateParamsForNode(Isolate::CreateParams* params) {
 
 void SetIsolateUpForNode(v8::Isolate* isolate) {
   isolate->AddMessageListenerWithErrorLevel(
-      OnMessage,
+      errors::PerIsolateMessageListener,
       Isolate::MessageErrorLevel::kMessageError |
           Isolate::MessageErrorLevel::kMessageWarning);
   isolate->SetAbortOnUncaughtExceptionCallback(ShouldAbortOnUncaughtException);

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -191,6 +191,8 @@ class TryCatchScope : public v8::TryCatch {
 };
 
 const char* errno_string(int errorno);
+void PerIsolateMessageListener(v8::Local<v8::Message> message,
+                               v8::Local<v8::Value> error);
 
 }  // namespace errors
 


### PR DESCRIPTION
Rename the per-isolate message listener to `PerIsolateMessageListener`
and move it to `node_errors.cc` since it's part of the error
handling process. It also creates an external reference so it needs
to be exposed in `node_errors.h` for a snapshot builder to know.

Refs: https://github.com/nodejs/node/issues/17058#issuecomment-484539429

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
