### PR TITLE
test: remove flaky designation for test-cli-node-options

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -25,8 +25,6 @@ test-http2-client-upload-reject: PASS,FLAKY
 [$system==macos]
 
 [$arch==arm || $arch==arm64]
-# https://github.com/nodejs/node/issues/25028
-test-cli-node-options: PASS,FLAKY
 # https://github.com/nodejs/node/issues/26610
 test-async-hooks-http-parser-destroy: PASS,FLAKY
 


### PR DESCRIPTION
The test failure is not platform-specific and is the result of
manual/human error. Some improvements may be possible, but there is
nothing fundamentally unsound about the test insofar as when it fails in
CI, there is a problem on the host that needs to be addressed and not an
inherent issue with the test.

Refs: https://github.com/nodejs/node/issues/25028#issuecomment-479554080
Closes: https://github.com/nodejs/node/issues/25028

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
