### PR TITLE
test: skip test-cpu-prof in debug builds with code cache

### DIFF
--- a/test/sequential/test-cpu-prof.js
+++ b/test/sequential/test-cpu-prof.js
@@ -3,6 +3,13 @@
 // This tests that --cpu-prof and --cpu-prof-path works.
 
 const common = require('../common');
+if (process.features.debug &&
+  process.config.variables.node_code_cache_path == 'yes') {
+  // FIXME(joyeecheung): the profiler crashes when code cache
+  // is enabled in debug builds.
+  common.skip('--prof does not work in debug builds with code cache');
+}
+
 const fixtures = require('../common/fixtures');
 common.skipIfInspectorDisabled();
 

--- a/test/sequential/test-cpu-prof.js
+++ b/test/sequential/test-cpu-prof.js
@@ -7,7 +7,7 @@ if (process.features.debug &&
   process.config.variables.node_code_cache_path === 'yes') {
   // FIXME(joyeecheung): the profiler crashes when code cache
   // is enabled in debug builds.
-  common.skip('--prof does not work in debug builds with code cache');
+  common.skip('--cpu-prof does not work in debug builds with code cache');
 }
 
 const fixtures = require('../common/fixtures');

--- a/test/sequential/test-cpu-prof.js
+++ b/test/sequential/test-cpu-prof.js
@@ -4,7 +4,7 @@
 
 const common = require('../common');
 if (process.features.debug &&
-  process.config.variables.node_code_cache_path == 'yes') {
+  process.config.variables.node_code_cache_path === 'yes') {
   // FIXME(joyeecheung): the profiler crashes when code cache
   // is enabled in debug builds.
   common.skip('--prof does not work in debug builds with code cache');


### PR DESCRIPTION
The CPU profiler crashes in debug builds when code cache is
enabled. Skip the test temporarily until it's fixed.

Refs: https://github.com/nodejs/node/issues/27307

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
