### PR TITLE
modules: explicitly initialize CJS loader

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -48,6 +48,7 @@ function prepareMainThreadExecution(expandArgv1 = false) {
 
   initializeDeprecations();
   initializeFrozenIntrinsics();
+  initializeCJSLoader();
   initializeESMLoader();
   loadPreloadModules();
 }
@@ -336,6 +337,10 @@ function initializePolicy() {
   }
 }
 
+function initializeCJSLoader() {
+  require('internal/modules/cjs/loader')._initPaths();
+}
+
 function initializeESMLoader() {
   const experimentalModules = getOptionValue('--experimental-modules');
   const experimentalVMModules = getOptionValue('--experimental-vm-modules');
@@ -397,5 +402,6 @@ module.exports = {
   loadPreloadModules,
   setupTraceCategoryState,
   setupInspectorHooks,
-  initializeReport
+  initializeReport,
+  initializeCJSLoader
 };

--- a/lib/internal/main/check_syntax.js
+++ b/lib/internal/main/check_syntax.js
@@ -18,6 +18,11 @@ const {
   stripShebang, stripBOM
 } = require('internal/modules/cjs/helpers');
 
+const {
+  _resolveFilename: resolveCJSModuleName,
+  wrap: wrapCJSModule
+} = require('internal/modules/cjs/loader');
+
 // TODO(joyeecheung): not every one of these are necessary
 prepareMainThreadExecution(true);
 
@@ -26,12 +31,8 @@ if (process.argv[1] && process.argv[1] !== '-') {
   const path = require('path');
   process.argv[1] = path.resolve(process.argv[1]);
 
-  // This has to be done after prepareMainThreadExecution because it
-  // relies on process.execPath
-  const CJSModule = require('internal/modules/cjs/loader');
-
   // Read the source.
-  const filename = CJSModule._resolveFilename(process.argv[1]);
+  const filename = resolveCJSModuleName(process.argv[1]);
 
   const fs = require('fs');
   const source = fs.readFileSync(filename, 'utf-8');
@@ -50,10 +51,6 @@ if (process.argv[1] && process.argv[1] !== '-') {
 function checkSyntax(source, filename) {
   // Remove Shebang.
   source = stripShebang(source);
-
-  // This has to be done after prepareMainThreadExecution because it
-  // relies on process.execPath
-  const CJSModule = require('internal/modules/cjs/loader');
 
   const { getOptionValue } = require('internal/options');
   const experimentalModules = getOptionValue('--experimental-modules');
@@ -76,7 +73,7 @@ function checkSyntax(source, filename) {
   // Remove BOM.
   source = stripBOM(source);
   // Wrap it.
-  source = CJSModule.wrap(source);
+  source = wrapCJSModule(source);
   // Compile the script, this will throw if it fails.
   new vm.Script(source, { displayErrors: true, filename });
 }

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -12,6 +12,7 @@ const {
   setupWarningHandler,
   setupDebugEnv,
   initializeDeprecations,
+  initializeCJSLoader,
   initializeESMLoader,
   initializeFrozenIntrinsics,
   initializeReport,
@@ -104,6 +105,7 @@ port.on('message', (message) => {
     }
     initializeDeprecations();
     initializeFrozenIntrinsics();
+    initializeCJSLoader();
     initializeESMLoader();
     loadPreloadModules();
     publicWorker.parentPort = publicPort;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -893,8 +893,6 @@ Module._preloadModules = function(requests) {
     parent.require(requests[n]);
 };
 
-Module._initPaths();
-
 // Backwards compatibility
 Module.Module = Module;
 


### PR DESCRIPTION
Explicitly initialize the CJS loader with `module._initPaths()`
instead of making it a side-effect of requiring
`internal/modules/cjs/loader` - that makes it harder to reason about
when it's safe to load `internal/modules/cjs/loader`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
