### PR TITLE
http: `servername === false` should disable SNI

### DIFF
--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -28,11 +28,11 @@ An [`Agent`][] object for HTTPS similar to [`http.Agent`][]. See
 * `options` {Object} Set of configurable options to set on the agent.
   Can have the same fields as for [`http.Agent(options)`][], and
   * `maxCachedSessions` {number} maximum number of TLS cached sessions.
-    Use `0` to disable TLS session caching. **Default:** `100`
+    Use `0` to disable TLS session caching. **Default:** `100`.
   * `servername` {string | boolean} the value of
     [Server Name Indication extension](https://en.wikipedia.org/wiki/Server_Name_Indication)
     to be sent to the server. Use `false` to disable sending the extension.
-    **Default:** hostname or ip address of the target server
+    **Default:** hostname or IP address of the target server.
 
     See [`Session Resumption`][] for infomation about TLS session reuse.
 

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -29,9 +29,9 @@ An [`Agent`][] object for HTTPS similar to [`http.Agent`][]. See
   Can have the same fields as for [`http.Agent(options)`][], and
   * `maxCachedSessions` {number} maximum number of TLS cached sessions.
     Use `0` to disable TLS session caching. **Default:** `100`.
-  * `servername` {string | boolean} the value of
+  * `servername` {string} the value of
     [Server Name Indication extension][sni wiki] to be sent to the server. Use
-    `false` to disable sending the extension.
+    empty string `''` to disable sending the extension.
     **Default:** hostname or IP address of the target server.
 
     See [`Session Resumption`][] for infomation about TLS session reuse.

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -28,7 +28,11 @@ An [`Agent`][] object for HTTPS similar to [`http.Agent`][]. See
 * `options` {Object} Set of configurable options to set on the agent.
   Can have the same fields as for [`http.Agent(options)`][], and
   * `maxCachedSessions` {number} maximum number of TLS cached sessions.
-    Use `0` to disable TLS session caching. **Default:** `100`.
+    Use `0` to disable TLS session caching. **Default:** `100`
+  * `servername` {string | boolean} the value of
+    [Server Name Indication extension](https://en.wikipedia.org/wiki/Server_Name_Indication)
+    to be sent to the server. Use `false` to disable sending the extension.
+    **Default:** hostname or ip address of the target server
 
     See [`Session Resumption`][] for infomation about TLS session reuse.
 

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -30,8 +30,8 @@ An [`Agent`][] object for HTTPS similar to [`http.Agent`][]. See
   * `maxCachedSessions` {number} maximum number of TLS cached sessions.
     Use `0` to disable TLS session caching. **Default:** `100`.
   * `servername` {string | boolean} the value of
-    [Server Name Indication extension](https://en.wikipedia.org/wiki/Server_Name_Indication)
-    to be sent to the server. Use `false` to disable sending the extension.
+    [Server Name Indication extension][sni wiki] to be sent to the server. Use
+    `false` to disable sending the extension.
     **Default:** hostname or IP address of the target server.
 
     See [`Session Resumption`][] for infomation about TLS session reuse.
@@ -410,3 +410,4 @@ headers: max-age=0; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; p
 [`tls.createSecureContext()`]: tls.html#tls_tls_createsecurecontext_options
 [`tls.createServer()`]: tls.html#tls_tls_createserver_options_secureconnectionlistener
 [`Session Resumption`]: tls.html#tls_session_resumption
+[sni wiki]: https://en.wikipedia.org/wiki/Server_Name_Indication

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -151,7 +151,7 @@ Agent.prototype.addRequest = function addRequest(req, options, port/* legacy */,
   if (options.socketPath)
     options.path = options.socketPath;
 
-  if (!options.servername)
+  if (!options.servername && options.servername !== false)
     options.servername = calculateServerName(options, req);
 
   const name = this.getName(options);
@@ -198,7 +198,7 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
   if (options.socketPath)
     options.path = options.socketPath;
 
-  if (!options.servername)
+  if (!options.servername && options.servername !== false)
     options.servername = calculateServerName(options, req);
 
   const name = this.getName(options);

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -151,7 +151,7 @@ Agent.prototype.addRequest = function addRequest(req, options, port/* legacy */,
   if (options.socketPath)
     options.path = options.socketPath;
 
-  if (!options.servername && options.servername !== false)
+  if (!options.servername && options.servername !== '')
     options.servername = calculateServerName(options, req);
 
   const name = this.getName(options);
@@ -198,7 +198,7 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
   if (options.socketPath)
     options.path = options.socketPath;
 
-  if (!options.servername && options.servername !== false)
+  if (!options.servername && options.servername !== '')
     options.servername = calculateServerName(options, req);
 
   const name = this.getName(options);

--- a/test/parallel/test-https-agent-sni.js
+++ b/test/parallel/test-https-agent-sni.js
@@ -18,9 +18,12 @@ let waiting = TOTAL;
 const server = https.Server(options, function(req, res) {
   if (--waiting === 0) server.close();
 
-  res.writeHead(200, {
-    'x-sni': req.socket.servername
-  });
+  const servername = req.socket.servername;
+
+  if (servername !== false) {
+    res.setHeader('x-sni', servername);
+  }
+
   res.end('hello world');
 });
 
@@ -28,7 +31,8 @@ server.listen(0, function() {
   function expectResponse(id) {
     return common.mustCall(function(res) {
       res.resume();
-      assert.strictEqual(res.headers['x-sni'], `sni.${id}`);
+      assert.strictEqual(res.headers['x-sni'],
+        id === false ? undefined : `sni.${id}`);
     });
   }
 
@@ -46,4 +50,13 @@ server.listen(0, function() {
       rejectUnauthorized: false
     }, expectResponse(j));
   }
+  https.get({
+    agent: agent,
+
+    path: '/',
+    port: this.address().port,
+    host: '127.0.0.1',
+    servername: false,
+    rejectUnauthorized: false
+  }, expectResponse(false));
 });

--- a/test/parallel/test-https-agent-sni.js
+++ b/test/parallel/test-https-agent-sni.js
@@ -32,7 +32,7 @@ server.listen(0, function() {
     return common.mustCall(function(res) {
       res.resume();
       assert.strictEqual(res.headers['x-sni'],
-        id === false ? undefined : `sni.${id}`);
+                         id === false ? undefined : `sni.${id}`);
     });
   }
 

--- a/test/parallel/test-https-agent-sni.js
+++ b/test/parallel/test-https-agent-sni.js
@@ -56,7 +56,7 @@ server.listen(0, function() {
     path: '/',
     port: this.address().port,
     host: '127.0.0.1',
-    servername: false,
+    servername: '',
     rejectUnauthorized: false
   }, expectResponse(false));
 });


### PR DESCRIPTION
There is no way to disable SNI extension when sending a request to HTTPS
server. Setting `options.servername` to a falsy value would make Node.js
core override it with either hostname or ip address.

This change introduces a way to disable SNI completely if this is
required for user's application. Setting `options.servername` to `false`
in `https.request` would disable overrides and thus disable the
extension.
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
