### PR TITLE
test: improve test-async-hooks-http-parser-destroy

### DIFF
--- a/test/parallel/test-async-hooks-http-parser-destroy.js
+++ b/test/parallel/test-async-hooks-http-parser-destroy.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const Countdown = require('../common/countdown');
 const assert = require('assert');
 const async_hooks = require('async_hooks');
@@ -15,11 +15,11 @@ const KEEP_ALIVE = 100;
 const createdIds = [];
 const destroyedIds = [];
 async_hooks.createHook({
-  init: common.mustCallAtLeast((asyncId, type) => {
+  init: (asyncId, type) => {
     if (type === 'HTTPINCOMINGMESSAGE' || type === 'HTTPCLIENTREQUEST') {
       createdIds.push(asyncId);
     }
-  }),
+  },
   destroy: (asyncId) => {
     if (createdIds.includes(asyncId)) {
       destroyedIds.push(asyncId);

--- a/test/parallel/test-async-hooks-http-parser-destroy.js
+++ b/test/parallel/test-async-hooks-http-parser-destroy.js
@@ -58,8 +58,9 @@ function checkOnExit() {
 }
 
 process.on('SIGTERM', () => {
-  console.error('Test timed out. Runing checks to see how far we got.');
-  checkOnExit();
+  // Catching SIGTERM and calling `process.exit(1)`  so that the `exit` event
+  // is triggered and the assertions are checked. This can be useful for
+  // troubleshooting this test if it times out.
   process.exit(1);
 });
 


### PR DESCRIPTION
Improve reporting in test-async-hooks-http-parser-destroy when failing.

Before, failures looked like this (edited slightly to conform to our
commit message 72-char line length restriction):

    The expression evaluated to a falsy value:
    assert.ok(destroyedIds.indexOf(createdAsyncId) >= 0)

Now, you get a slightly better idea of what's up. (Is it missing one ID?
More than one? All of them?):

    AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
    + actual - expected ... Lines skipped

      [
        156,
    ...
        757,
    -   761,
        765
      ]

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
