### PR TITLE
lib: add an alias at addListener on Server connection socket

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -394,6 +394,7 @@ function connectionListenerInternal(server, socket) {
 
   // Override on to unconsume on `data`, `readable` listeners
   socket.on = socketOnWrap;
+  socket.addListener = socket.on;
 
   // We only consume the socket if it has never been consumed before.
   if (socket._handle && socket._handle.isStreamBase &&
@@ -744,7 +745,9 @@ function unconsume(parser, socket) {
 function socketOnWrap(ev, fn) {
   const res = net.Socket.prototype.on.call(this, ev, fn);
   if (!this.parser) {
+    this.prependListener = net.Socket.prototype.prependListener;
     this.on = net.Socket.prototype.on;
+    this.addListener = this.on;
     return res;
   }
 

--- a/test/parallel/test-http-server-unconsume.js
+++ b/test/parallel/test-http-server-unconsume.js
@@ -14,6 +14,10 @@ const server = http.createServer(function(req, res) {
     received += data;
   });
 
+  assert.strictEqual(req.socket.on, req.socket.addListener);
+  assert.strictEqual(req.socket.prependListener,
+                     net.Socket.prototype.prependListener);
+
   server.close();
 }).listen(0, function() {
   const socket = net.connect(this.address().port, function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

about #27199

`socket.addListener` should be the same behavior with `socket.on`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
