### PR TITLE
src: move NAPI_AUTO_LEN from define to static const

### DIFF
--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -27,8 +27,6 @@
   #endif
 #endif
 
-#define NAPI_AUTO_LENGTH SIZE_MAX
-
 #ifdef __cplusplus
 #define EXTERN_C_START extern "C" {
 #define EXTERN_C_END }
@@ -38,6 +36,8 @@
 #endif
 
 EXTERN_C_START
+
+static const size_t NAPI_AUTO_LENGTH = SIZE_MAX;
 
 NAPI_EXTERN napi_status
 napi_get_last_error_info(napi_env env,


### PR DESCRIPTION
This allows tools like rust's bindgen to access this value

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
