### PR TITLE
tools: fix use-after-free mkcodecache warning

### DIFF
--- a/tools/code_cache/mkcodecache.cc
+++ b/tools/code_cache/mkcodecache.cc
@@ -58,5 +58,6 @@ int main(int argc, char* argv[]) {
     out.close();
   }
 
+  v8::V8::ShutdownPlatform();
   return 0;
 }


### PR DESCRIPTION
Call `v8::Platform::ShutdownPlatform()` to fix a Coverity warning about
the `v8::Platform` instance being deleted when it's still in use.