### PR TITLE
src: use predefined AliasedBuffer types in the code base

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -101,16 +101,15 @@ inline AsyncHooks::AsyncHooks()
   NODE_ASYNC_PROVIDER_TYPES(V)
 #undef V
 }
-
-inline AliasedBuffer<uint32_t, v8::Uint32Array>& AsyncHooks::fields() {
+inline AliasedUint32Array& AsyncHooks::fields() {
   return fields_;
 }
 
-inline AliasedBuffer<double, v8::Float64Array>& AsyncHooks::async_id_fields() {
+inline AliasedFloat64Array& AsyncHooks::async_id_fields() {
   return async_id_fields_;
 }
 
-inline AliasedBuffer<double, v8::Float64Array>& AsyncHooks::async_ids_stack() {
+inline AliasedFloat64Array& AsyncHooks::async_ids_stack() {
   return async_ids_stack_;
 }
 
@@ -235,8 +234,7 @@ inline void Environment::PopAsyncCallbackScope() {
 inline ImmediateInfo::ImmediateInfo(v8::Isolate* isolate)
     : fields_(isolate, kFieldsCount) {}
 
-inline AliasedBuffer<uint32_t, v8::Uint32Array>&
-    ImmediateInfo::fields() {
+inline AliasedUint32Array& ImmediateInfo::fields() {
   return fields_;
 }
 
@@ -271,7 +269,7 @@ inline void ImmediateInfo::ref_count_dec(uint32_t decrement) {
 inline TickInfo::TickInfo(v8::Isolate* isolate)
     : fields_(isolate, kFieldsCount) {}
 
-inline AliasedBuffer<uint8_t, v8::Uint8Array>& TickInfo::fields() {
+inline AliasedUint8Array& TickInfo::fields() {
   return fields_;
 }
 
@@ -478,13 +476,11 @@ inline void Environment::set_abort_on_uncaught_exception(bool value) {
   options_->abort_on_uncaught_exception = value;
 }
 
-inline AliasedBuffer<uint32_t, v8::Uint32Array>&
-Environment::should_abort_on_uncaught_toggle() {
+inline AliasedUint32Array& Environment::should_abort_on_uncaught_toggle() {
   return should_abort_on_uncaught_toggle_;
 }
 
-inline AliasedBuffer<int32_t, v8::Int32Array>&
-Environment::stream_base_state() {
+inline AliasedInt32Array& Environment::stream_base_state() {
   return stream_base_state_;
 }
 
@@ -614,13 +610,11 @@ void Environment::set_debug_enabled(DebugCategory category, bool enabled) {
   debug_enabled_[static_cast<int>(category)] = enabled;
 }
 
-inline AliasedBuffer<double, v8::Float64Array>*
-Environment::fs_stats_field_array() {
+inline AliasedFloat64Array* Environment::fs_stats_field_array() {
   return &fs_stats_field_array_;
 }
 
-inline AliasedBuffer<uint64_t, v8::BigUint64Array>*
-Environment::fs_stats_field_bigint_array() {
+inline AliasedBigUint64Array* Environment::fs_stats_field_bigint_array() {
   return &fs_stats_field_bigint_array_;
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -605,9 +605,9 @@ class AsyncHooks : public MemoryRetainer {
     kUidFieldsCount,
   };
 
-  inline AliasedBuffer<uint32_t, v8::Uint32Array>& fields();
-  inline AliasedBuffer<double, v8::Float64Array>& async_id_fields();
-  inline AliasedBuffer<double, v8::Float64Array>& async_ids_stack();
+  inline AliasedUint32Array& fields();
+  inline AliasedFloat64Array& async_id_fields();
+  inline AliasedFloat64Array& async_ids_stack();
 
   inline v8::Local<v8::String> provider_string(int idx);
 
@@ -646,12 +646,12 @@ class AsyncHooks : public MemoryRetainer {
   // Keep a list of all Persistent strings used for Provider types.
   std::array<v8::Eternal<v8::String>, AsyncWrap::PROVIDERS_LENGTH> providers_;
   // Stores the ids of the current execution context stack.
-  AliasedBuffer<double, v8::Float64Array> async_ids_stack_;
+  AliasedFloat64Array async_ids_stack_;
   // Attached to a Uint32Array that tracks the number of active hooks for
   // each type.
-  AliasedBuffer<uint32_t, v8::Uint32Array> fields_;
+  AliasedUint32Array fields_;
   // Attached to a Float64Array that tracks the state of async resources.
-  AliasedBuffer<double, v8::Float64Array> async_id_fields_;
+  AliasedFloat64Array async_id_fields_;
 
   void grow_async_ids_stack();
 };
@@ -670,7 +670,7 @@ class AsyncCallbackScope {
 
 class ImmediateInfo : public MemoryRetainer {
  public:
-  inline AliasedBuffer<uint32_t, v8::Uint32Array>& fields();
+  inline AliasedUint32Array& fields();
   inline uint32_t count() const;
   inline uint32_t ref_count() const;
   inline bool has_outstanding() const;
@@ -692,12 +692,12 @@ class ImmediateInfo : public MemoryRetainer {
 
   enum Fields { kCount, kRefCount, kHasOutstanding, kFieldsCount };
 
-  AliasedBuffer<uint32_t, v8::Uint32Array> fields_;
+  AliasedUint32Array fields_;
 };
 
 class TickInfo : public MemoryRetainer {
  public:
-  inline AliasedBuffer<uint8_t, v8::Uint8Array>& fields();
+  inline AliasedUint8Array& fields();
   inline bool has_tick_scheduled() const;
   inline bool has_rejection_to_warn() const;
 
@@ -714,7 +714,7 @@ class TickInfo : public MemoryRetainer {
 
   enum Fields { kHasTickScheduled = 0, kHasRejectionToWarn, kFieldsCount };
 
-  AliasedBuffer<uint8_t, v8::Uint8Array> fields_;
+  AliasedUint8Array fields_;
 };
 
 class TrackingTraceStateObserver :
@@ -902,10 +902,9 @@ class Environment : public MemoryRetainer {
   // This is a pseudo-boolean that keeps track of whether an uncaught exception
   // should abort the process or not if --abort-on-uncaught-exception was
   // passed to Node. If the flag was not passed, it is ignored.
-  inline AliasedBuffer<uint32_t, v8::Uint32Array>&
-  should_abort_on_uncaught_toggle();
+  inline AliasedUint32Array& should_abort_on_uncaught_toggle();
 
-  inline AliasedBuffer<int32_t, v8::Int32Array>& stream_base_state();
+  inline AliasedInt32Array& stream_base_state();
 
   // The necessary API for async_hooks.
   inline double new_async_id();
@@ -951,9 +950,8 @@ class Environment : public MemoryRetainer {
   inline void set_debug_enabled(DebugCategory category, bool enabled);
   void set_debug_categories(const std::string& cats, bool enabled);
 
-  inline AliasedBuffer<double, v8::Float64Array>* fs_stats_field_array();
-  inline AliasedBuffer<uint64_t, v8::BigUint64Array>*
-      fs_stats_field_bigint_array();
+  inline AliasedFloat64Array* fs_stats_field_array();
+  inline AliasedBigUint64Array* fs_stats_field_bigint_array();
 
   inline std::vector<std::unique_ptr<fs::FileHandleReadWrap>>&
       file_handle_read_wrap_freelist();
@@ -1192,12 +1190,12 @@ class Environment : public MemoryRetainer {
   uint32_t script_id_counter_ = 0;
   uint32_t function_id_counter_ = 0;
 
-  AliasedBuffer<uint32_t, v8::Uint32Array> should_abort_on_uncaught_toggle_;
+  AliasedUint32Array should_abort_on_uncaught_toggle_;
   int should_not_abort_scope_counter_ = 0;
 
   std::unique_ptr<TrackingTraceStateObserver> trace_state_observer_;
 
-  AliasedBuffer<int32_t, v8::Int32Array> stream_base_state_;
+  AliasedInt32Array stream_base_state_;
 
   std::unique_ptr<performance::performance_state> performance_state_;
   std::unordered_map<std::string, uint64_t> performance_marks_;
@@ -1240,8 +1238,8 @@ class Environment : public MemoryRetainer {
 
   bool debug_enabled_[static_cast<int>(DebugCategory::CATEGORY_COUNT)] = {0};
 
-  AliasedBuffer<double, v8::Float64Array> fs_stats_field_array_;
-  AliasedBuffer<uint64_t, v8::BigUint64Array> fs_stats_field_bigint_array_;
+  AliasedFloat64Array fs_stats_field_array_;
+  AliasedBigUint64Array fs_stats_field_bigint_array_;
 
   std::vector<std::unique_ptr<fs::FileHandleReadWrap>>
       file_handle_read_wrap_freelist_;

--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -226,7 +226,7 @@ void MemoryTracker::TrackField(const char* name,
 
 template <class NativeT, class V8T>
 void MemoryTracker::TrackField(const char* name,
-                               const AliasedBuffer<NativeT, V8T>& value,
+                               const AliasedBufferBase<NativeT, V8T>& value,
                                const char* node_name) {
   TrackField(name, value.GetJSArray(), "AliasedBuffer");
 }

--- a/src/memory_tracker.h
+++ b/src/memory_tracker.h
@@ -215,7 +215,7 @@ class MemoryTracker {
                          const char* node_name = nullptr);
   template <class NativeT, class V8T>
   inline void TrackField(const char* edge_name,
-                         const AliasedBuffer<NativeT, V8T>& value,
+                         const AliasedBufferBase<NativeT, V8T>& value,
                          const char* node_name = nullptr);
 
   // Put a memory container into the graph, create an edge from

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -756,9 +756,9 @@ inline FSReqBase* GetReqWrap(Environment* env, Local<Value> value,
     return Unwrap<FSReqBase>(value.As<Object>());
   } else if (value->StrictEquals(env->fs_use_promises_symbol())) {
     if (use_bigint) {
-      return FSReqPromise<uint64_t, BigUint64Array>::New(env, use_bigint);
+      return FSReqPromise<AliasedBigUint64Array>::New(env, use_bigint);
     } else {
-      return FSReqPromise<double, Float64Array>::New(env, use_bigint);
+      return FSReqPromise<AliasedFloat64Array>::New(env, use_bigint);
     }
   }
   return nullptr;

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -192,8 +192,9 @@ constexpr uint64_t ToNative(uv_timespec_t ts) {
 #undef constexpr  // end N3652 bug workaround
 
 template <typename NativeT, typename V8T>
-constexpr void FillStatsArray(AliasedBuffer<NativeT, V8T>* fields,
-                              const uv_stat_t* s, const size_t offset = 0) {
+constexpr void FillStatsArray(AliasedBufferBase<NativeT, V8T>* fields,
+                              const uv_stat_t* s,
+                              const size_t offset = 0) {
   fields->SetValue(offset + 0, static_cast<NativeT>(s->st_dev));
   fields->SetValue(offset + 1, static_cast<NativeT>(s->st_mode));
   fields->SetValue(offset + 2, static_cast<NativeT>(s->st_nlink));
@@ -227,7 +228,7 @@ inline Local<Value> FillGlobalStatsArray(Environment* env,
   }
 }
 
-template <typename NativeT = double, typename V8T = v8::Float64Array>
+template <typename AliasedBufferT>
 class FSReqPromise : public FSReqBase {
  public:
   static FSReqPromise* New(Environment* env, bool use_bigint) {
@@ -304,7 +305,7 @@ class FSReqPromise : public FSReqBase {
         stats_field_array_(env->isolate(), kFsStatsFieldsNumber) {}
 
   bool finished_ = false;
-  AliasedBuffer<NativeT, V8T> stats_field_array_;
+  AliasedBufferT stats_field_array_;
 };
 
 class FSReqAfterScope {

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -119,8 +119,7 @@ Http2Options::Http2Options(Environment* env, nghttp2_session_type type) {
     nghttp2_option_set_builtin_recv_extension_type(options_, NGHTTP2_ORIGIN);
   }
 
-  AliasedBuffer<uint32_t, Uint32Array>& buffer =
-      env->http2_state()->options_buffer;
+  AliasedUint32Array& buffer = env->http2_state()->options_buffer;
   uint32_t flags = buffer[IDX_OPTIONS_FLAGS];
 
   if (flags & (1 << IDX_OPTIONS_MAX_DEFLATE_DYNAMIC_TABLE_SIZE)) {
@@ -200,8 +199,7 @@ Http2Options::Http2Options(Environment* env, nghttp2_session_type type) {
 }
 
 void Http2Session::Http2Settings::Init() {
-  AliasedBuffer<uint32_t, Uint32Array>& buffer =
-      env()->http2_state()->settings_buffer;
+  AliasedUint32Array& buffer = env()->http2_state()->settings_buffer;
   uint32_t flags = buffer[IDX_SETTINGS_COUNT];
 
   size_t n = 0;
@@ -262,8 +260,7 @@ Local<Value> Http2Session::Http2Settings::Pack() {
 void Http2Session::Http2Settings::Update(Environment* env,
                                          Http2Session* session,
                                          get_setting fn) {
-  AliasedBuffer<uint32_t, Uint32Array>& buffer =
-      env->http2_state()->settings_buffer;
+  AliasedUint32Array& buffer = env->http2_state()->settings_buffer;
   buffer[IDX_SETTINGS_HEADER_TABLE_SIZE] =
       fn(**session, NGHTTP2_SETTINGS_HEADER_TABLE_SIZE);
   buffer[IDX_SETTINGS_MAX_CONCURRENT_STREAMS] =
@@ -282,8 +279,7 @@ void Http2Session::Http2Settings::Update(Environment* env,
 
 // Initializes the shared TypedArray with the default settings values.
 void Http2Session::Http2Settings::RefreshDefaults(Environment* env) {
-  AliasedBuffer<uint32_t, Uint32Array>& buffer =
-      env->http2_state()->settings_buffer;
+  AliasedUint32Array& buffer = env->http2_state()->settings_buffer;
 
   buffer[IDX_SETTINGS_HEADER_TABLE_SIZE] =
       DEFAULT_SETTINGS_HEADER_TABLE_SIZE;
@@ -648,8 +644,7 @@ std::string Http2Session::diagnostic_name() const {
 }
 
 inline bool HasHttp2Observer(Environment* env) {
-  AliasedBuffer<uint32_t, Uint32Array>& observers =
-      env->performance_state()->observers;
+  AliasedUint32Array& observers = env->performance_state()->observers;
   return observers[performance::NODE_PERFORMANCE_ENTRY_TYPE_HTTP2] != 0;
 }
 
@@ -665,8 +660,7 @@ void Http2Stream::EmitStatistics() {
     if (!HasHttp2Observer(env))
       return;
     HandleScope handle_scope(env->isolate());
-    AliasedBuffer<double, Float64Array>& buffer =
-        env->http2_state()->stream_stats_buffer;
+    AliasedFloat64Array& buffer = env->http2_state()->stream_stats_buffer;
     buffer[IDX_STREAM_STATS_ID] = entry->id();
     if (entry->first_byte() != 0) {
       buffer[IDX_STREAM_STATS_TIMETOFIRSTBYTE] =
@@ -705,8 +699,7 @@ void Http2Session::EmitStatistics() {
     if (!HasHttp2Observer(env))
       return;
     HandleScope handle_scope(env->isolate());
-    AliasedBuffer<double, Float64Array>& buffer =
-        env->http2_state()->session_stats_buffer;
+    AliasedFloat64Array& buffer = env->http2_state()->session_stats_buffer;
     buffer[IDX_SESSION_STATS_TYPE] = entry->type();
     buffer[IDX_SESSION_STATS_PINGRTT] = entry->ping_rtt() / 1e6;
     buffer[IDX_SESSION_STATS_FRAMESRECEIVED] = entry->frame_count();
@@ -839,8 +832,7 @@ ssize_t Http2Session::OnCallbackPadding(size_t frameLen,
   Local<Context> context = env()->context();
   Context::Scope context_scope(context);
 
-  AliasedBuffer<uint32_t, Uint32Array>& buffer =
-      env()->http2_state()->padding_buffer;
+  AliasedUint32Array& buffer = env()->http2_state()->padding_buffer;
   buffer[PADDING_BUF_FRAME_LENGTH] = frameLen;
   buffer[PADDING_BUF_MAX_PAYLOAD_LENGTH] = maxPayloadLen;
   buffer[PADDING_BUF_RETURN_VALUE] = frameLen;
@@ -2387,8 +2379,7 @@ void Http2Session::RefreshState(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
   Debug(session, "refreshing state");
 
-  AliasedBuffer<double, Float64Array>& buffer =
-      env->http2_state()->session_state_buffer;
+  AliasedFloat64Array& buffer = env->http2_state()->session_state_buffer;
 
   nghttp2_session* s = **session;
 
@@ -2670,8 +2661,7 @@ void Http2Stream::RefreshState(const FunctionCallbackInfo<Value>& args) {
 
   Debug(stream, "refreshing state");
 
-  AliasedBuffer<double, Float64Array>& buffer =
-      env->http2_state()->stream_state_buffer;
+  AliasedFloat64Array& buffer = env->http2_state()->stream_state_buffer;
 
   nghttp2_stream* str = **stream;
   nghttp2_session* s = **(stream->session());

--- a/src/node_http2_state.h
+++ b/src/node_http2_state.h
@@ -128,14 +128,14 @@ class Http2State {
       root_buffer) {
   }
 
-  AliasedBuffer<uint8_t, v8::Uint8Array> root_buffer;
-  AliasedBuffer<double, v8::Float64Array> session_state_buffer;
-  AliasedBuffer<double, v8::Float64Array> stream_state_buffer;
-  AliasedBuffer<double, v8::Float64Array> stream_stats_buffer;
-  AliasedBuffer<double, v8::Float64Array> session_stats_buffer;
-  AliasedBuffer<uint32_t, v8::Uint32Array> padding_buffer;
-  AliasedBuffer<uint32_t, v8::Uint32Array> options_buffer;
-  AliasedBuffer<uint32_t, v8::Uint32Array> settings_buffer;
+  AliasedUint8Array root_buffer;
+  AliasedFloat64Array session_state_buffer;
+  AliasedFloat64Array stream_state_buffer;
+  AliasedFloat64Array stream_stats_buffer;
+  AliasedFloat64Array session_stats_buffer;
+  AliasedUint32Array padding_buffer;
+  AliasedUint32Array options_buffer;
+  AliasedUint32Array settings_buffer;
 
  private:
   struct http2_state_internal {

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -114,8 +114,7 @@ void PerformanceEntry::Notify(Environment* env,
                               PerformanceEntryType type,
                               Local<Value> object) {
   Context::Scope scope(env->context());
-  AliasedBuffer<uint32_t, Uint32Array>& observers =
-      env->performance_state()->observers;
+  AliasedUint32Array& observers = env->performance_state()->observers;
   if (type != NODE_PERFORMANCE_ENTRY_TYPE_INVALID &&
       observers[type]) {
     node::MakeCallback(env->isolate(),
@@ -173,8 +172,7 @@ void Measure(const FunctionCallbackInfo<Value>& args) {
   Utf8Value startMark(env->isolate(), args[1]);
   Utf8Value endMark(env->isolate(), args[2]);
 
-  AliasedBuffer<double, v8::Float64Array>& milestones =
-      env->performance_state()->milestones;
+  AliasedFloat64Array& milestones = env->performance_state()->milestones;
 
   uint64_t startTimestamp = timeOrigin;
   uint64_t start = GetPerformanceMark(env, *startMark);
@@ -235,8 +233,7 @@ void PerformanceGCCallback(Environment* env, void* ptr) {
   HandleScope scope(env->isolate());
   Local<Context> context = env->context();
 
-  AliasedBuffer<uint32_t, Uint32Array>& observers =
-      env->performance_state()->observers;
+  AliasedUint32Array& observers = env->performance_state()->observers;
   if (observers[NODE_PERFORMANCE_ENTRY_TYPE_GC]) {
     Local<Object> obj;
     if (!entry->ToObject().ToLocal(&obj)) return;
@@ -342,8 +339,7 @@ void TimerFunctionCall(const FunctionCallbackInfo<Value>& args) {
     return;
   args.GetReturnValue().Set(ret.ToLocalChecked());
 
-  AliasedBuffer<uint32_t, Uint32Array>& observers =
-      env->performance_state()->observers;
+  AliasedUint32Array& observers = env->performance_state()->observers;
   if (!observers[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION])
     return;
 

--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -71,9 +71,9 @@ class performance_state {
       milestones[i] = -1.;
   }
 
-  AliasedBuffer<uint8_t, v8::Uint8Array> root;
-  AliasedBuffer<double, v8::Float64Array> milestones;
-  AliasedBuffer<uint32_t, v8::Uint32Array> observers;
+  AliasedUint8Array root;
+  AliasedFloat64Array milestones;
+  AliasedUint32Array observers;
 
   uint64_t performance_last_gc_start_mark = 0;
 

--- a/test/cctest/test_aliased_buffer.cc
+++ b/test/cctest/test_aliased_buffer.cc
@@ -3,7 +3,7 @@
 #include "aliased_buffer.h"
 #include "node_test_fixture.h"
 
-using node::AliasedBuffer;
+using node::AliasedBufferBase;
 
 class AliasBufferTest : public NodeTestFixture {};
 
@@ -15,7 +15,7 @@ void CreateOracleValues(std::vector<NativeT>* buf) {
 }
 
 template <class NativeT, class V8T>
-void WriteViaOperator(AliasedBuffer<NativeT, V8T>* aliasedBuffer,
+void WriteViaOperator(AliasedBufferBase<NativeT, V8T>* aliasedBuffer,
                       const std::vector<NativeT>& oracle) {
   // write through the API
   for (size_t i = 0; i < oracle.size(); i++) {
@@ -24,7 +24,7 @@ void WriteViaOperator(AliasedBuffer<NativeT, V8T>* aliasedBuffer,
 }
 
 template <class NativeT, class V8T>
-void WriteViaSetValue(AliasedBuffer<NativeT, V8T>* aliasedBuffer,
+void WriteViaSetValue(AliasedBufferBase<NativeT, V8T>* aliasedBuffer,
                       const std::vector<NativeT>& oracle) {
   // write through the API
   for (size_t i = 0; i < oracle.size(); i++) {
@@ -35,7 +35,7 @@ void WriteViaSetValue(AliasedBuffer<NativeT, V8T>* aliasedBuffer,
 template <class NativeT, class V8T>
 void ReadAndValidate(v8::Isolate* isolate,
                      v8::Local<v8::Context> context,
-                     AliasedBuffer<NativeT, V8T>* aliasedBuffer,
+                     AliasedBufferBase<NativeT, V8T>* aliasedBuffer,
                      const std::vector<NativeT>& oracle) {
   // read through the API
   for (size_t i = 0; i < oracle.size(); i++) {
@@ -76,7 +76,7 @@ void ReadWriteTest(v8::Isolate* isolate) {
   v8::Context::Scope context_scope(context);
 
   const size_t size = 100;
-  AliasedBuffer<NativeT, V8T> ab(isolate, size);
+  AliasedBufferBase<NativeT, V8T> ab(isolate, size);
   std::vector<NativeT> oracle(size);
   CreateOracleValues(&oracle);
   WriteViaOperator(&ab, oracle);
@@ -86,7 +86,7 @@ void ReadWriteTest(v8::Isolate* isolate) {
 
   // validate copy constructor
   {
-    AliasedBuffer<NativeT, V8T> ab2(ab);
+    AliasedBufferBase<NativeT, V8T> ab2(ab);
     ReadAndValidate(isolate, context, &ab2, oracle);
   }
   ReadAndValidate(isolate, context, &ab, oracle);
@@ -110,13 +110,12 @@ void SharedBufferTest(
   size_t sizeInBytes_B = count_B * sizeof(NativeT_B);
   size_t sizeInBytes_C = count_C * sizeof(NativeT_C);
 
-  AliasedBuffer<uint8_t, v8::Uint8Array> rootBuffer(
+  AliasedBufferBase<uint8_t, v8::Uint8Array> rootBuffer(
       isolate, sizeInBytes_A + sizeInBytes_B + sizeInBytes_C);
-  AliasedBuffer<NativeT_A, V8T_A> ab_A(
-      isolate, 0, count_A, rootBuffer);
-  AliasedBuffer<NativeT_B, V8T_B> ab_B(
+  AliasedBufferBase<NativeT_A, V8T_A> ab_A(isolate, 0, count_A, rootBuffer);
+  AliasedBufferBase<NativeT_B, V8T_B> ab_B(
       isolate, sizeInBytes_A, count_B, rootBuffer);
-  AliasedBuffer<NativeT_C, V8T_C> ab_C(
+  AliasedBufferBase<NativeT_C, V8T_C> ab_C(
       isolate, sizeInBytes_A + sizeInBytes_B, count_C, rootBuffer);
 
   std::vector<NativeT_A> oracle_A(count_A);
@@ -209,7 +208,7 @@ TEST_F(AliasBufferTest, OperatorOverloads) {
   v8::Local<v8::Context> context = v8::Context::New(isolate_);
   v8::Context::Scope context_scope(context);
   const size_t size = 10;
-  AliasedBuffer<uint32_t, v8::Uint32Array> ab{isolate_, size};
+  AliasedBufferBase<uint32_t, v8::Uint32Array> ab{isolate_, size};
 
   EXPECT_EQ(static_cast<uint32_t>(1), ab[0] = 1);
   EXPECT_EQ(static_cast<uint32_t>(4), ab[0] += 3);
@@ -222,8 +221,8 @@ TEST_F(AliasBufferTest, OperatorOverloadsRefs) {
   v8::HandleScope handle_scope(isolate_);
   v8::Local<v8::Context> context = v8::Context::New(isolate_);
   v8::Context::Scope context_scope(context);
-  AliasedBuffer<uint32_t, v8::Uint32Array> ab{isolate_, 2};
-  using Reference = AliasedBuffer<uint32_t, v8::Uint32Array>::Reference;
+  AliasedBufferBase<uint32_t, v8::Uint32Array> ab{isolate_, 2};
+  using Reference = AliasedBufferBase<uint32_t, v8::Uint32Array>::Reference;
   Reference ref = ab[0];
   Reference ref_value = ab[1] = 2;
 


### PR DESCRIPTION
Instead of allowing the callers to instantiate the template
with any numeric types (such as aliasing a Uint8Array to double[]),
predefine types that make sense and use those instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
