### PR TITLE
dgram: change 'this' to 'self' for 'isConnected'

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -519,7 +519,7 @@ function clearQueue() {
 
 function isConnected(self) {
   try {
-    this.remoteAddress();
+    self.remoteAddress();
     return true;
   } catch {
     return false;


### PR DESCRIPTION
The function 'isConnected' is directly called by many 'Socket' instance functions, so we shouldn't directly use 'this' because 'this' will be the self of function itself, and we should use 'self' as the instance of 'Socket' function.

---
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
