### PR TITLE
test: make test-worker-esm-missing-main more robust

### DIFF
--- a/test/parallel/test-worker-esm-missing-main.js
+++ b/test/parallel/test-worker-esm-missing-main.js
@@ -1,11 +1,14 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const path = require('path');
 const { Worker } = require('worker_threads');
 
-const worker = new Worker('./does-not-exist.js', {
-  execArgv: ['--experimental-modules'],
-});
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const missing = path.join(tmpdir.path, 'does-not-exist.js');
+
+const worker = new Worker(missing, { execArgv: ['--experimental-modules'] });
 
 worker.on('error', common.mustCall((err) => {
   // eslint-disable-next-line node-core/no-unescaped-regexp-dot


### PR DESCRIPTION
test-worker-esm-missing-main failed in CI recently in a way that
suggests that maybe the `does-not-exist.js` file did in fact exist.
Maybe that isn't what happened at all, but let's rule it out by changing
the use of `does-not-exist.js` from a file expected to be missing from
the current working directory to a file in the temp directory, which the
test will remove and recreate at the outset.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
