### PR TITLE
util: improve symbol to string tag

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -574,8 +574,15 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
 
   const constructor = getConstructorName(value, ctx);
   let tag = value[Symbol.toStringTag];
-  if (typeof tag !== 'string')
+  // Only list the tag in case it's non-enumerable / not an own property.
+  // Otherwise we'd print this twice.
+  if (typeof tag !== 'string' ||
+      tag !== '' &&
+      (ctx.showHidden ? hasOwnProperty : propertyIsEnumerable)(
+        value, Symbol.toStringTag
+      )) {
     tag = '';
+  }
   let base = '';
   let formatter = getEmptyFormatArray;
   let braces;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -560,15 +560,6 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
   return formatRaw(ctx, value, recurseTimes, typedArray);
 }
 
-function setIteratorBraces(type, tag) {
-  if (tag !== `${type} Iterator`) {
-    if (tag !== '')
-      tag += '] [';
-    tag += `${type} Iterator`;
-  }
-  return [`[${tag}] {`, '}'];
-}
-
 function formatRaw(ctx, value, recurseTimes, typedArray) {
   let keys;
 
@@ -630,11 +621,11 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
       extrasType = kArrayExtrasType;
     } else if (isMapIterator(value)) {
       keys = getKeys(value, ctx.showHidden);
-      braces = setIteratorBraces('Map', tag);
+      braces = getIteratorBraces('Map', tag);
       formatter = formatIterator;
     } else if (isSetIterator(value)) {
       keys = getKeys(value, ctx.showHidden);
-      braces = setIteratorBraces('Set', tag);
+      braces = getIteratorBraces('Set', tag);
       formatter = formatIterator;
     } else {
       noIterator = true;
@@ -754,10 +745,10 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
         }
       }
       if (isMapIterator(value)) {
-        braces = setIteratorBraces('Map', tag);
+        braces = getIteratorBraces('Map', tag);
         formatter = formatIterator;
       } else if (isSetIterator(value)) {
-        braces = setIteratorBraces('Set', tag);
+        braces = getIteratorBraces('Set', tag);
         formatter = formatIterator;
       // Handle other regular objects again.
       } else if (keys.length === 0) {
@@ -816,6 +807,15 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
     ctx.stop = true;
   }
   return res;
+}
+
+function getIteratorBraces(type, tag) {
+  if (tag !== `${type} Iterator`) {
+    if (tag !== '')
+      tag += '] [';
+    tag += `${type} Iterator`;
+  }
+  return [`[${tag}] {`, '}'];
 }
 
 function formatError(err, constructor, tag, ctx) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1264,8 +1264,20 @@ util.inspect(process);
 
 {
   // @@toStringTag
-  assert.strictEqual(util.inspect({ [Symbol.toStringTag]: 'a' }),
-                     "Object [a] { [Symbol(Symbol.toStringTag)]: 'a' }");
+  const obj = { [Symbol.toStringTag]: 'a' };
+  assert.strictEqual(
+    util.inspect(obj),
+    "{ [Symbol(Symbol.toStringTag)]: 'a' }"
+  );
+  Object.defineProperty(obj, Symbol.toStringTag, {
+    value: 'a',
+    enumerable: false
+  });
+  assert.strictEqual(util.inspect(obj), 'Object [a] {}');
+  assert.strictEqual(
+    util.inspect(obj, { showHidden: true }),
+    "{ [Symbol(Symbol.toStringTag)]: 'a' }"
+  );
 
   class Foo {
     constructor() {


### PR DESCRIPTION
To reduce redundancy use the `Symbol.toStringTag` only if otherwise not visible.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
