### PR TITLE
process: improve nextTick performance

### DIFF
--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { FunctionPrototype, Reflect } = primordials;
+const { FunctionPrototype } = primordials;
 
 const {
   // For easy access to the nextTick state in the C++ land,
@@ -62,25 +62,24 @@ function processTicksAndRejections() {
   let tock;
   do {
     while (tock = queue.shift()) {
-      const asyncId = tock[async_id_symbol];
-      emitBefore(asyncId, tock[trigger_async_id_symbol]);
-      // emitDestroy() places the async_id_symbol into an asynchronous queue
-      // that calls the destroy callback in the future. It's called before
-      // calling tock.callback so destroy will be called even if the callback
-      // throws an exception that is handled by 'uncaughtException' or a
-      // domain.
-      // TODO(trevnorris): This is a bit of a hack. It relies on the fact
-      // that nextTick() doesn't allow the event loop to proceed, but if
-      // any async hooks are enabled during the callback's execution then
-      // this tock's after hook will be called, but not its destroy hook.
-      if (destroyHooksExist())
-        emitDestroy(asyncId);
+      const {
+        [async_id_symbol]: asyncId,
+        [trigger_async_id_symbol]: triggerAsyncId,
+        callback,
+        args
+      } = tock;
 
-      const callback = tock.callback;
-      if (tock.args === undefined)
-        callback();
-      else
-        Reflect.apply(callback, undefined, tock.args);
+      emitBefore(asyncId, triggerAsyncId);
+
+      try {
+        if (args === undefined)
+          callback();
+        else
+          callback(...args);
+      } finally {
+        if (destroyHooksExist())
+          emitDestroy(asyncId);
+      }
 
       emitAfter(asyncId);
     }
@@ -91,23 +90,18 @@ function processTicksAndRejections() {
 }
 
 class TickObject {
-  constructor(callback, args, triggerAsyncId) {
+  constructor(callback, args, asyncId, triggerAsyncId) {
     // This must be set to null first to avoid function tracking
-    // on the hidden class, revisit in V8 versions after 6.2
+    // on the hidden class, revisit in V8 versions after 7.4
     this.callback = null;
     this.callback = callback;
     this.args = args;
 
-    const asyncId = newAsyncId();
     this[async_id_symbol] = asyncId;
     this[trigger_async_id_symbol] = triggerAsyncId;
 
-    if (initHooksExist()) {
-      emitInit(asyncId,
-               'TickObject',
-               triggerAsyncId,
-               this);
-    }
+    if (initHooksExist())
+      emitInit(asyncId, 'TickObject', triggerAsyncId, this);
   }
 }
 
@@ -117,10 +111,7 @@ function nextTick(callback) {
   if (typeof callback !== 'function')
     throw new ERR_INVALID_CALLBACK(callback);
 
-  if (process._exiting)
-    return;
-
-  var args;
+  let args;
   switch (arguments.length) {
     case 1: break;
     case 2: args = [arguments[1]]; break;
@@ -128,13 +119,17 @@ function nextTick(callback) {
     case 4: args = [arguments[1], arguments[2], arguments[3]]; break;
     default:
       args = new Array(arguments.length - 1);
-      for (var i = 1; i < arguments.length; i++)
+      for (let i = 1; i < arguments.length; i++)
         args[i - 1] = arguments[i];
   }
 
-  if (queue.isEmpty())
+  if (queue.isEmpty() && !process._exiting)
     setHasTickScheduled(true);
-  queue.push(new TickObject(callback, args, getDefaultTriggerAsyncId()));
+
+  queue.push(new TickObject(callback,
+                            args,
+                            newAsyncId(),
+                            getDefaultTriggerAsyncId()));
 }
 
 let AsyncResource;


### PR DESCRIPTION
- No longer use symbols for asyncId & triggerAsyncId. This borrows from the seemingly abandoned PR at https://github.com/nodejs/node/pull/25461 by @mscdex. (Credit provided in the commit but happy to also remove this portion of the code.)
- No longer check `process.exiting` on each tick add.
- Cleaner `emitDestroy` with try/finally.
- No longer use `Reflect.apply` since it's slower.

CI: https://ci.nodejs.org/job/node-test-pull-request/22633/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
