### PR TITLE
lib: remove Reflect.apply where appropriate

### DIFF
--- a/benchmark/timers/timers-breadth-args.js
+++ b/benchmark/timers/timers-breadth-args.js
@@ -1,0 +1,42 @@
+'use strict';
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  n: [1e6],
+});
+
+function main({ n }) {
+  var j = 0;
+  function cb1(arg1) {
+    j++;
+    if (j === n)
+      bench.end(n);
+  }
+  function cb2(arg1, arg2) {
+    j++;
+    if (j === n)
+      bench.end(n);
+  }
+  function cb3(arg1, arg2, arg3) {
+    j++;
+    if (j === n)
+      bench.end(n);
+  }
+  function cb4(arg1, arg2, arg3, arg4) {
+    j++;
+    if (j === n)
+      bench.end(n);
+  }
+
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    if (i % 4 === 0)
+      setTimeout(cb4, 1, 3.14, 1024, true, false);
+    else if (i % 3 === 0)
+      setTimeout(cb3, 1, 512, true, null);
+    else if (i % 2 === 0)
+      setTimeout(cb2, 1, false, 5.1);
+    else
+      setTimeout(cb1, 1, 0);
+  }
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -24,7 +24,7 @@
 
 'use strict';
 
-const { Math, Object, Reflect } = primordials;
+const { Math, Object } = primordials;
 
 const { fs: constants } = internalBinding('constants');
 const {
@@ -149,9 +149,7 @@ function makeCallback(cb) {
     throw new ERR_INVALID_CALLBACK(cb);
   }
 
-  return (...args) => {
-    return Reflect.apply(cb, undefined, args);
-  };
+  return (...args) => cb(...args);
 }
 
 // Special case of `makeCallback()` that is specific to async `*stat()` calls as

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { FunctionPrototype, Object, Reflect } = primordials;
+const { FunctionPrototype, Object } = primordials;
 
 const {
   ERR_ASYNC_TYPE,
@@ -278,14 +278,14 @@ function clearDefaultTriggerAsyncId() {
 
 function defaultTriggerAsyncIdScope(triggerAsyncId, block, ...args) {
   if (triggerAsyncId === undefined)
-    return Reflect.apply(block, null, args);
+    return block(...args);
   // CHECK(Number.isSafeInteger(triggerAsyncId))
   // CHECK(triggerAsyncId > 0)
   const oldDefaultTriggerAsyncId = async_id_fields[kDefaultTriggerAsyncId];
   async_id_fields[kDefaultTriggerAsyncId] = triggerAsyncId;
 
   try {
-    return Reflect.apply(block, null, args);
+    return block(...args);
   } finally {
     async_id_fields[kDefaultTriggerAsyncId] = oldDefaultTriggerAsyncId;
   }

--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { FunctionPrototype, Reflect } = primordials;
+const { FunctionPrototype } = primordials;
 
 const {
   // For easy access to the nextTick state in the C++ land,
@@ -80,7 +80,7 @@ function processTicksAndRejections() {
       if (tock.args === undefined)
         callback();
       else
-        Reflect.apply(callback, undefined, tock.args);
+        callback(...tock.args);
 
       emitAfter(asyncId);
     }

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -72,7 +72,7 @@
 // timers within (or creation of a new list). However, these operations combined
 // have shown to be trivial in comparison to other timers architectures.
 
-const { Math, Object, Reflect } = primordials;
+const { Math, Object } = primordials;
 
 const {
   scheduleTimer,
@@ -438,7 +438,7 @@ function getTimerCallbacks(runNextTicks) {
         if (!argv)
           immediate._onImmediate();
         else
-          Reflect.apply(immediate._onImmediate, immediate, argv);
+          immediate._onImmediate(...argv);
       } finally {
         immediate._onImmediate = null;
 
@@ -530,7 +530,7 @@ function getTimerCallbacks(runNextTicks) {
         if (args === undefined)
           timer._onTimeout();
         else
-          Reflect.apply(timer._onTimeout, timer, args);
+          timer._onTimeout(...args);
       } finally {
         if (timer._repeat && timer._idleTimeout !== -1) {
           timer._idleTimeout = timer._repeat;


### PR DESCRIPTION
Using Reflect.apply where the callback context does not need to change is unnecessary and less performant.

CI: https://ci.nodejs.org/job/node-test-pull-request/22638/
Benchmarks: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/354/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
