### PR TITLE
Revert "Revert "console: use consolePropAttributes for k-bind propert…

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -177,15 +177,13 @@ Console.prototype[kBindProperties] = function(ignoreErrors, colorMode) {
       ...consolePropAttributes,
       value: Boolean(ignoreErrors)
     },
-    '_times': { ...consolePropAttributes, value: new Map() }
+    '_times': { ...consolePropAttributes, value: new Map() },
+    // Corresponds to https://console.spec.whatwg.org/#count-map
+    [kCounts]: { ...consolePropAttributes, value: new Map() },
+    [kColorMode]: { ...consolePropAttributes, value: colorMode },
+    [kIsConsole]: { ...consolePropAttributes, value: true },
+    [kGroupIndent]: { ...consolePropAttributes, value: '' }
   });
-
-  // TODO(joyeecheung): use consolePropAttributes for these
-  // Corresponds to https://console.spec.whatwg.org/#count-map
-  this[kCounts] = new Map();
-  this[kColorMode] = colorMode;
-  this[kIsConsole] = true;
-  this[kGroupIndent] = '';
 };
 
 // Make a function that can serve as the callback passed to `stream.write()`.


### PR DESCRIPTION
…ies in constructor""

This reverts commit a8eac78f8dbe778a2aef69d0989416e47c6c403e.

The revert turned out not to be the actual cause of the test failure. Random changes caused the test to constantly fail.

Refs: https://github.com/nodejs/node/issues/26401#issuecomment-479926045
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
