### PR TITLE
[v8.x] deps: V8: backport d520ebb

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 6
 #define V8_MINOR_VERSION 2
 #define V8_BUILD_NUMBER 414
-#define V8_PATCH_LEVEL 77
+#define V8_PATCH_LEVEL 78
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/compiler/typed-optimization.cc
+++ b/deps/v8/src/compiler/typed-optimization.cc
@@ -244,12 +244,13 @@ Reduction TypedOptimization::ReduceNumberFloor(Node* node) {
       //
       //   NumberToUint32(NumberDivide(lhs, rhs))
       //
-      // and just smash the type of the {lhs} on the {node},
-      // as the truncated result must be in the same range as
-      // {lhs} since {rhs} cannot be less than 1 (due to the
+      // and just smash the type [0...lhs.Max] on the {node},
+      // as the truncated result must be loewr than {lhs}'s maximum
+      // value (note that {rhs} cannot be less than 1 due to the
       // plain-number type constraint on the {node}).
       NodeProperties::ChangeOp(node, simplified()->NumberToUint32());
-      NodeProperties::SetType(node, lhs_type);
+      NodeProperties::SetType(node,
+                              Type::Range(0, lhs_type->Max(), graph()->zone()));
       return Changed(node);
     }
   }

--- a/deps/v8/test/mjsunit/compiler/regress-841117.js
+++ b/deps/v8/test/mjsunit/compiler/regress-841117.js
@@ -1,0 +1,11 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+var v = 1e9;
+function f() { return Math.floor(v / 10); }
+assertEquals(1e8, f());
+%OptimizeFunctionOnNextCall(f);
+assertEquals(1e8, f());


### PR DESCRIPTION
Original commit message:

    [turbofan] Fix NumberFloor typing.

    Bug: chromium:841117
    Change-Id: I1e83dfc82f87d0b49d3cca96290ae1d738e37d20
    Reviewed-on: https://chromium-review.googlesource.com/1051228
    Reviewed-by: Benedikt Meurer <bmeurer@chromium.org>
    Commit-Queue: Jaroslav Sevcik <jarin@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#53083}

Refs: https://github.com/v8/v8/commit/d520ebb9a85b73b2a6505e133a7cc940c7d2adbd
Fixes: https://github.com/nodejs/node/issues/22810