### PR TITLE
benchmark: fix http bench-parser.js

### DIFF
--- a/benchmark/http/bench-parser.js
+++ b/benchmark/http/bench-parser.js
@@ -24,7 +24,7 @@ function main({ len, n }) {
     bench.start();
     for (var i = 0; i < n; i++) {
       parser.execute(header, 0, header.length);
-      parser.reinitialize(REQUEST, i > 0);
+      parser.initialize(REQUEST, header);
     }
     bench.end(n);
   }


### PR DESCRIPTION
The internal HTTParser `reinitialize()` function was removed in
ece507394a and replaced with an `initialize()` function. This broke
benchmark/http/bench-parser.js. This change updates the benchmark so
that it runs again.

/ping @nodejs/async_hooks @Drieger to make sure this is the correct change here.... If so, I would like to fast-track because this issue breaks the nightly benchmark tests on Jenkins.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
