### PR TITLE
build: disable custom v8 snapshot by default

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -421,6 +421,11 @@ parser.add_option('--with-ltcg',
     dest='with_ltcg',
     help='Use Link Time Code Generation. This feature is only available on Windows.')
 
+parser.add_option('--with-node-snapshot',
+    action='store_true',
+    dest='with_node_snapshot',
+    help='Turn on V8 snapshot integration. Currently experimental.')
+
 intl_optgroup.add_option('--download',
     action='store',
     dest='download_list',
@@ -927,6 +932,13 @@ def configure_node(o):
   want_snapshots = not options.without_snapshot
   o['variables']['want_separate_host_toolset'] = int(
       cross_compiling and want_snapshots)
+
+  if options.with_node_snapshot:
+    o['variables']['node_use_node_snapshot'] = 'true'
+  else:
+    # Default to false for now.
+    # TODO(joyeecheung): enable it once we fix the hashseed uniqueness
+    o['variables']['node_use_node_snapshot'] = 'false'
 
   if target_arch == 'arm':
     configure_arm(o)

--- a/node.gyp
+++ b/node.gyp
@@ -6,6 +6,7 @@
     'node_use_dtrace%': 'false',
     'node_use_etw%': 'false',
     'node_no_browser_globals%': 'false',
+    'node_use_node_snapshot%': 'false',
     'node_use_v8_platform%': 'true',
     'node_use_bundled_v8%': 'true',
     'node_shared%': 'false',
@@ -431,7 +432,7 @@
             'src/node_code_cache_stub.cc'
           ],
         }],
-        ['want_separate_host_toolset==0', {
+        ['node_use_node_snapshot=="true"', {
           'dependencies': [
             'node_mksnapshot',
           ],


### PR DESCRIPTION
This currently breaks `test/pummel/test-hash-seed.js`

Refs: https://github.com/nodejs/node/pull/27321

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
