### PR TITLE
tools: disable no-use-before-define for class

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -249,7 +249,7 @@ module.exports = {
     'no-unused-labels': 'error',
     'no-unused-vars': ['error', { args: 'none', caughtErrors: 'all' }],
     'no-use-before-define': ['error', {
-      classes: true,
+      classes: false,
       functions: false,
       variables: false,
     }],

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* eslint-disable no-use-before-define */
-
 const { Math, Object, Reflect } = primordials;
 
 const {


### PR DESCRIPTION
When I am reviewing https://github.com/nodejs/quic/pull/25/files#diff-a70ceda4fa0f250275838b2662a4fe36R300 find it very confusing why have to add the `eslint disable`.
Then I did a little digging
https://github.com/nodejs/node/blob/de230555369087282213d337ecc1c315fbb74230/.eslintrc.js#L251-L254
The configuration for functions and variables is false while class is true.
I think maybe we can change the config for class too since our codebase is ES6 env.

Rule def: https://eslint.org/docs/rules/no-use-before-define.

cc @danbev @BridgeAR @Trott @richardlau 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
