### PR TITLE
child_process: only stop readable side of stream passed to process

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -384,12 +384,12 @@ ChildProcess.prototype.spawn = function(options) {
       continue;
     }
 
-    // The stream is already cloned and piped, thus close it.
+    // The stream is already cloned and piped, thus stop its readable side,
+    // otherwise we might attempt to read from the stream when at the same time
+    // the child process does.
     if (stream.type === 'wrap') {
-      stream.handle.close();
-      if (stream._stdio && stream._stdio instanceof EventEmitter) {
-        stream._stdio.emit('close');
-      }
+      stream.handle.readStop();
+      stream._stdio.pause();
       continue;
     }
 

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -388,8 +388,11 @@ ChildProcess.prototype.spawn = function(options) {
     // otherwise we might attempt to read from the stream when at the same time
     // the child process does.
     if (stream.type === 'wrap') {
+      stream.handle.reading = false;
       stream.handle.readStop();
       stream._stdio.pause();
+      stream._stdio.readableFlowing = false;
+      stream._stdio._readableState.reading = false;
       continue;
     }
 

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -63,6 +63,7 @@ let freeParser;
 let HTTPParser;
 
 const MAX_HANDLE_RETRANSMISSIONS = 3;
+const kIsUsedAsStdio = Symbol('kIsUsedAsStdio');
 
 // This object contain function to convert TCP objects to native handle objects
 // and back again.
@@ -278,8 +279,14 @@ function flushStdio(subprocess) {
 
   for (var i = 0; i < stdio.length; i++) {
     const stream = stdio[i];
-    if (!stream || !stream.readable || stream._readableState.readableListening)
+    // TODO(addaleax): This doesn't necessarily account for all the ways in
+    // which data can be read from a stream, e.g. being consumed on the
+    // native layer directly as a StreamBase.
+    if (!stream || !stream.readable ||
+        stream._readableState.readableListening ||
+        stream[kIsUsedAsStdio]) {
       continue;
+    }
     stream.resume();
   }
 }
@@ -393,6 +400,7 @@ ChildProcess.prototype.spawn = function(options) {
       stream._stdio.pause();
       stream._stdio.readableFlowing = false;
       stream._stdio._readableState.reading = false;
+      stream._stdio[kIsUsedAsStdio] = true;
       continue;
     }
 

--- a/test/parallel/test-child-process-pipe-dataflow.js
+++ b/test/parallel/test-child-process-pipe-dataflow.js
@@ -33,6 +33,10 @@ const MB = KB * KB;
   grep = spawn('grep', ['x'], { stdio: [cat.stdout, 'pipe', 'pipe'] });
   wc = spawn('wc', ['-c'], { stdio: [grep.stdout, 'pipe', 'pipe'] });
 
+  // Extra checks: We never try to start reading data ourselves.
+  cat.stdout._handle.readStart = common.mustNotCall();
+  grep.stdout._handle.readStart = common.mustNotCall();
+
   [cat, grep, wc].forEach((child, index) => {
     child.stderr.on('data', (d) => {
       // Don't want to assert here, as we might miss error code info.

--- a/test/parallel/test-child-process-server-close.js
+++ b/test/parallel/test-child-process-server-close.js
@@ -8,11 +8,11 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 const server = net.createServer((conn) => {
-  conn.on('close', common.mustCall());
-
   spawn(process.execPath, ['-v'], {
     stdio: ['ignore', conn, 'ignore']
-  }).on('close', common.mustCall());
+  }).on('close', common.mustCall(() => {
+    conn.end();
+  }));
 }).listen(common.PIPE, () => {
   const client = net.connect(common.PIPE, common.mustCall());
   client.on('data', () => {

--- a/test/parallel/test-child-process-stdio-merge-stdouts-into-cat.js
+++ b/test/parallel/test-child-process-stdio-merge-stdouts-into-cat.js
@@ -1,0 +1,30 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+// Regression test for https://github.com/nodejs/node/issues/27097.
+// Check that (cat [p1] ; cat [p2]) | cat [p3] works.
+
+const { spawn } = require('child_process');
+const p3 = spawn('cat', { stdio: ['pipe', 'pipe', process.stderr] });
+const p1 = spawn('cat', { stdio: ['pipe', p3.stdin, process.stderr] });
+const p2 = spawn('cat', { stdio: ['pipe', p3.stdin, process.stderr] });
+p3.stdout.setEncoding('utf8');
+
+// Write three different chunks:
+// - 'hello' from this process to p1 to p3 back to us
+// - 'world' from this process to p2 to p3 back to us
+// - 'foobar' from this process  to p3 back to us
+// Do so sequentially in order to avoid race conditions.
+p1.stdin.end('hello\n');
+p3.stdout.once('data', common.mustCall((chunk) => {
+  assert.strictEqual(chunk, 'hello\n');
+  p2.stdin.end('world\n');
+  p3.stdout.once('data', common.mustCall((chunk) => {
+    assert.strictEqual(chunk, 'world\n');
+    p3.stdin.end('foobar\n');
+    p3.stdout.once('data', common.mustCall((chunk) => {
+      assert.strictEqual(chunk, 'foobar\n');
+    }));
+  }));
+}));

--- a/test/parallel/test-child-process-stdio-merge-stdouts-into-cat.js
+++ b/test/parallel/test-child-process-stdio-merge-stdouts-into-cat.js
@@ -1,11 +1,11 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const { spawn } = require('child_process');
 
 // Regression test for https://github.com/nodejs/node/issues/27097.
 // Check that (cat [p1] ; cat [p2]) | cat [p3] works.
 
-const { spawn } = require('child_process');
 const p3 = spawn('cat', { stdio: ['pipe', 'pipe', process.stderr] });
 const p1 = spawn('cat', { stdio: ['pipe', p3.stdin, process.stderr] });
 const p2 = spawn('cat', { stdio: ['pipe', p3.stdin, process.stderr] });

--- a/test/parallel/test-child-process-stdio-merge-stdouts-into-cat.js
+++ b/test/parallel/test-child-process-stdio-merge-stdouts-into-cat.js
@@ -6,9 +6,9 @@ const { spawn } = require('child_process');
 // Regression test for https://github.com/nodejs/node/issues/27097.
 // Check that (cat [p1] ; cat [p2]) | cat [p3] works.
 
-const p3 = spawn('cat', { stdio: ['pipe', 'pipe', process.stderr] });
-const p1 = spawn('cat', { stdio: ['pipe', p3.stdin, process.stderr] });
-const p2 = spawn('cat', { stdio: ['pipe', p3.stdin, process.stderr] });
+const p3 = spawn('cat', { stdio: ['pipe', 'pipe', 'inherit'] });
+const p1 = spawn('cat', { stdio: ['pipe', p3.stdin, 'inherit'] });
+const p2 = spawn('cat', { stdio: ['pipe', p3.stdin, 'inherit'] });
 p3.stdout.setEncoding('utf8');
 
 // Write three different chunks:

--- a/test/parallel/test-child-process-stdio-reuse-readable-stdio.js
+++ b/test/parallel/test-child-process-stdio-reuse-readable-stdio.js
@@ -8,7 +8,7 @@ const { spawn } = require('child_process');
 // We simulate that using cat | (head -n1; ...)
 
 const p1 = spawn('cat', { stdio: ['pipe', 'pipe', 'inherit'] });
-const p2 = spawn('head', [ '-n1'], { stdio: [p1.stdout, 'pipe', 'inherit'] });
+const p2 = spawn('head', ['-n1'], { stdio: [p1.stdout, 'pipe', 'inherit'] });
 
 // First, write the line that gets passed through p2, making 'head' exit.
 p1.stdin.write('hello\n');
@@ -23,4 +23,5 @@ p2.on('exit', common.mustCall(() => {
   p1.stdout.on('data', common.mustCall((chunk) => {
     assert.strictEqual(chunk, 'world\n');
   }));
+  p1.stdout.resume();
 }));

--- a/test/parallel/test-child-process-stdio-reuse-readable-stdio.js
+++ b/test/parallel/test-child-process-stdio-reuse-readable-stdio.js
@@ -7,10 +7,8 @@ const { spawn } = require('child_process');
 // that the child had used as input.
 // We simulate that using cat | (head -n1; ...)
 
-const p1 = spawn('cat', { stdio: ['pipe', 'pipe', process.stderr] });
-const p2 = spawn('head', [ '-n1'], {
-  stdio: [p1.stdout, 'pipe', process.stderr]
-});
+const p1 = spawn('cat', { stdio: ['pipe', 'pipe', 'inherit'] });
+const p2 = spawn('head', [ '-n1'], { stdio: [p1.stdout, 'pipe', 'inherit'] });
 
 // First, write the line that gets passed through p2, making 'head' exit.
 p1.stdin.write('hello\n');

--- a/test/parallel/test-child-process-stdio-reuse-readable-stdio.js
+++ b/test/parallel/test-child-process-stdio-reuse-readable-stdio.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { spawn } = require('child_process');
+
+// Check that, once a child process has ended, it’s safe to read from a pipe
+// that the child had used as input.
+// We simulate that using cat | (head -n1; ...)
+
+const p1 = spawn('cat', { stdio: ['pipe', 'pipe', process.stderr] });
+const p2 = spawn('head', [ '-n1'], {
+  stdio: [p1.stdout, 'pipe', process.stderr]
+});
+
+// First, write the line that gets passed through p2, making 'head' exit.
+p1.stdin.write('hello\n');
+p2.stdout.setEncoding('utf8');
+p2.stdout.on('data', common.mustCall((chunk) => {
+  assert.strictEqual(chunk, 'hello\n');
+}));
+p2.on('exit', common.mustCall(() => {
+  // We can now use cat’s output, because 'head' is no longer reading from it.
+  p1.stdin.end('world\n');
+  p1.stdout.setEncoding('utf8');
+  p1.stdout.on('data', common.mustCall((chunk) => {
+    assert.strictEqual(chunk, 'world\n');
+  }));
+}));


### PR DESCRIPTION
Closing the underlying resource completely has the unwanted side effect
that the stream can no longer be used at all, including passing it
to other child processes.

What we want to avoid is accidentally reading from the stream;
accordingly, it should be sufficient to stop its readable side
manually, and otherwise leave the underlying resource intact.

Fixes: https://github.com/nodejs/node/issues/27097
Refs: https://github.com/nodejs/node/pull/21209

I’d love to get reviews from @gireeshpunathil, @arcanis, @elibarzilay and maybe @mcollina (esp. regarding the `pause()` vs `push(null)` choice?).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
