### PR TITLE
test: skip fs-copyfile-respect-permission if root

### DIFF
--- a/test/parallel/test-fs-copyfile-respect-permissions.js
+++ b/test/parallel/test-fs-copyfile-respect-permissions.js
@@ -5,6 +5,9 @@
 
 const common = require('../common');
 
+if (process.getuid() === 0)
+  common.skip('as this test should not be run as `root`');
+
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 

--- a/test/parallel/test-fs-copyfile-respect-permissions.js
+++ b/test/parallel/test-fs-copyfile-respect-permissions.js
@@ -5,7 +5,7 @@
 
 const common = require('../common');
 
-if (process.getuid() === 0)
+if (!common.isWindows && process.getuid() === 0)
   common.skip('as this test should not be run as `root`');
 
 const tmpdir = require('../common/tmpdir');


### PR DESCRIPTION
Currently, if this test is run as the root user the following
failure will occur:
```console
=== release test-fs-copyfile-respect-permissions ===
Path: parallel/test-fs-copyfile-respect-permissions
assert.js:89
  throw new AssertionError(obj);
  ^
AssertionError [ERR_ASSERTION]: Missing expected exception (check).
    at Object.<anonymous>
      (/node/test/parallel/test-fs-copyfile-respect-permissions.js:38:10)
    at Module._compile (internal/modules/cjs/loader.js:759:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:770:10)
    at Module.load (internal/modules/cjs/loader.js:628:32)
    at Function.Module._load (internal/modules/cjs/loader.js:555:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:826:10)
    at internal/main/run_main_module.js:17:11
Command:
out/Release/node test/parallel/test-fs-copyfile-respect-permissions.js
[05:41|% 100|+ 2620|-   1]: Done
```
This commit adds a root user check and skips this test if running as the
user root.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
