### PR TITLE
lib: remove outdated optimizations

### DIFF
--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -92,9 +92,6 @@ function processTicksAndRejections() {
 
 class TickObject {
   constructor(callback, args, triggerAsyncId) {
-    // This must be set to null first to avoid function tracking
-    // on the hidden class, revisit in V8 versions after 6.2
-    this.callback = null;
     this.callback = callback;
     this.args = args;
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -207,9 +207,6 @@ const Immediate = class Immediate {
   constructor(callback, args) {
     this._idleNext = null;
     this._idlePrev = null;
-    // This must be set to null first to avoid function tracking
-    // on the hidden class, revisit in V8 versions after 6.2
-    this._onImmediate = null;
     this._onImmediate = callback;
     this._argv = args;
     this._destroyed = false;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

These two optimizations is outdated in current v8.

Benchmark results:
```
                                                confidence improvement accuracy (*)    (**)   (***)
 process/next-tick-breadth-args.js n=4000000                   -0.02 %      ±0.75% ±1.00% ±1.31%
 process/next-tick-breadth.js n=4000000                        -0.23 %      ±1.78% ±2.38% ±3.13%
 process/next-tick-depth-args.js n=12000000                    -0.34 %      ±0.69% ±0.93% ±1.21%
 process/next-tick-depth.js n=12000000                         -0.12 %      ±1.46% ±1.95% ±2.54%
 process/next-tick-exec-args.js n=5000000                       2.18 %      ±4.03% ±5.37% ±7.01%
 process/next-tick-exec.js n=5000000                            0.43 %      ±2.18% ±2.91% ±3.79%
 timers/immediate.js type='breadth' n=5000000                   0.39 %      ±1.85% ±2.46% ±3.22%
 timers/immediate.js type='breadth1' n=5000000                 -1.19 %      ±2.43% ±3.24% ±4.23%
 timers/immediate.js type='breadth4' n=5000000                 -2.37 %      ±3.80% ±5.06% ±6.60%
 timers/immediate.js type='clear' n=5000000                     0.36 %      ±1.93% ±2.57% ±3.35%
 timers/immediate.js type='depth' n=5000000                    -0.40 %      ±0.69% ±0.91% ±1.19%
 timers/immediate.js type='depth1' n=5000000                   -0.46 %      ±0.76% ±1.01% ±1.32%
 timers/set-immediate-breadth-args.js n=5000000                 3.25 %      ±3.84% ±5.11% ±6.65%
 timers/set-immediate-breadth.js n=10000000                     1.62 %      ±2.37% ±3.16% ±4.13%
 timers/set-immediate-depth-args.js n=5000000                   0.02 %      ±0.44% ±0.59% ±0.77%
```


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
