### PR TITLE
Remove the unsupported Python 2.6 from configure

### DIFF
--- a/configure
+++ b/configure
@@ -14,7 +14,7 @@ del _
 import sys
 from distutils.spawn import find_executable as which
 if sys.version_info[:2] != (2, 7):
-  sys.stderr.write('Please use either Python 2.7')
+  sys.stderr.write('Please use Python 2.7')
 
   python2 = which('python2') or which('python2.7')
 

--- a/configure
+++ b/configure
@@ -13,10 +13,10 @@ del _
 
 import sys
 from distutils.spawn import find_executable as which
-if sys.version_info[0] != 2 or sys.version_info[1] not in (6, 7):
-  sys.stderr.write('Please use either Python 2.6 or 2.7')
+if sys.version_info[:2] != (2, 7):
+  sys.stderr.write('Please use either Python 2.7')
 
-  python2 = which('python2') or which('python2.6') or which('python2.7')
+  python2 = which('python2') or which('python2.7')
 
   if python2:
     sys.stderr.write(':\n\n')


### PR DESCRIPTION
A precursor to #25878

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
