### PR TITLE
doc: improve CCM example

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2883,11 +2883,10 @@ const receivedPlaintext = decipher.update(ciphertext, null, 'utf8');
 
 try {
   decipher.final();
+  console.log(receivedPlaintext);
 } catch (err) {
   console.error('Authentication failed!');
 }
-
-console.log(receivedPlaintext);
 ```
 
 ## Crypto Constants

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2883,10 +2883,12 @@ const receivedPlaintext = decipher.update(ciphertext, null, 'utf8');
 
 try {
   decipher.final();
-  console.log(receivedPlaintext);
 } catch (err) {
   console.error('Authentication failed!');
+  return;
 }
+
+console.log(receivedPlaintext);
 ```
 
 ## Crypto Constants


### PR DESCRIPTION
Applications should never attempt to use the deciphered message if authentication fails. In reality, this is usually not a problem since OpenSSL does not disclose the plaintext in this case, but it is still a design mistake and can lead to critical security problems in other cipher modes and implementations.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
