### PR TITLE
module: resolve the filename in `createRequireFromPath()`

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -829,9 +829,9 @@ Module.runMain = function() {
 };
 
 Module.createRequireFromPath = (filename) => {
-  const m = new Module(filename);
+  const m = new Module(path.resolve(filename));
   m.filename = filename;
-  m.paths = Module._nodeModulePaths(path.dirname(filename));
+  m.paths = Module._nodeModulePaths(m.path);
   return makeRequireFunction(m);
 };
 

--- a/test/parallel/test-module-create-require.js
+++ b/test/parallel/test-module-create-require.js
@@ -4,9 +4,23 @@ require('../common');
 const assert = require('assert');
 const path = require('path');
 
+const util = require('util');
+util.inspect.defaultOptions.depth = 4;
+
 const { createRequireFromPath } = require('module');
 
-const p = path.resolve(__dirname, '..', 'fixtures', 'fake.js');
+const p = path.join(process.cwd(), 'test/fixtures/fake.js');
+const p2 = './test/fixtures/fake.js';
+const p3 = './fixtures/fake.js';
 
 const req = createRequireFromPath(p);
+const req2 = createRequireFromPath(p2);
+const req3 = createRequireFromPath(p3);
+process.chdir('./test/');
+const req4 = createRequireFromPath(p3);
+
 assert.strictEqual(req('./baz'), 'perhaps I work');
+assert.strictEqual(req2('./baz'), 'perhaps I work');
+// TODO: req3('./baz') should throw an error. There's some caching involved.
+assert.strictEqual(req3('./baz'), 'perhaps I work');
+assert.strictEqual(req4('./baz'), 'perhaps I work');


### PR DESCRIPTION
This makes sure the filename passed to `createRequireFromPath()` is
actually resolved. That makes sure the current working directory is
taken into account. Otherwise a directory change would not be noticed
by relative paths passed to `createRequireFromPath()`.

I am not certain semver-wise because this also changes the `filename` property.

I could set that to the actual input but it would be pretty weird to have two modules that officially have the identical filename while not resolving the same paths.

Fixes: #27401

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
