### PR TITLE
docs: fs: stat.isDirectory: added clarification

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -809,7 +809,11 @@ added: v0.1.10
 
 Returns `true` if the `fs.Stats` object describes a file system directory.
 
-### `stats.isFIFO()`
+If the `fs.Stats` object was obtained from [`fs.lstat()`][], this method will
+always return `false`. This is because [`fs.lstat()`][] returns information
+about a symbolic link itself and not the path it resolves to.
+
+### stats.isFIFO()
 <!-- YAML
 added: v0.1.10
 -->

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -813,7 +813,7 @@ If the `fs.Stats` object was obtained from [`fs.lstat()`][], this method will
 always return `false`. This is because [`fs.lstat()`][] returns information
 about a symbolic link itself and not the path it resolves to.
 
-### stats.isFIFO()
+### `stats.isFIFO()`
 <!-- YAML
 added: v0.1.10
 -->


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Added clarification to documentation, similar to one describes [stat.isSymbolicLink](https://nodejs.org/dist/latest-v12.x/docs/api/fs.html#fs_stats_issymboliclink) which tells that
This method is only valid when using `fs.lstat()`.

When use `fs.lstat` for a symbolic link to a directory it will return `stat` which `isDirectory ` will always be `false`. This is not really obvious, and because of this both methods `stat` and `lstat` should be called to get true information about symbolic link to a directory.

Let's create symbolic link to root directory.
```sh
ln -s / 123
node
```

And then run in `REPL`:
```js
> fs.statSync('123').isDirectory()
true
> fs.statSync('123').isSymbolicLink()
false
> fs.lstatSync('123').isDirectory()
false
> fs.lstatSync('123').isSymbolicLink()
true
```
