### PR TITLE
module: throw on require('./path.mjs');

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -132,6 +132,13 @@ variable. Since the module lookups using `node_modules` folders are all
 relative, and based on the real path of the files making the calls to
 `require()`, the packages themselves can be anywhere.
 
+## Addenda: The .mjs extension
+
+It is not possible to `require()` files that have the `.mjs` extension.
+Attempting to do so will throw [an error][]. The `.mjs` extension is
+reserved for [ECMAScript Modules][] which cannot be loaded via `require()`.
+See [ECMAScript Modules][] for more details.
+
 ## All Together...
 
 <!-- type=misc -->
@@ -928,6 +935,8 @@ requireUtil('./some-tool');
 [`__filename`]: #modules_filename
 [`module` object]: #modules_the_module_object
 [`path.dirname()`]: path.html#path_path_dirname_path
+[ECMAScript Modules]: esm.html
+[an error]: errors.html#errors_err_require_esm
 [exports shortcut]: #modules_exports_shortcut
 [module resolution]: #modules_all_together
 [module wrapper]: #modules_the_module_wrapper

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -800,11 +800,9 @@ Module._extensions['.node'] = function(module, filename) {
   return process.dlopen(module, path.toNamespacedPath(filename));
 };
 
-if (experimentalModules) {
-  Module._extensions['.mjs'] = function(module, filename) {
-    throw new ERR_REQUIRE_ESM(filename);
-  };
-}
+Module._extensions['.mjs'] = function(module, filename) {
+  throw new ERR_REQUIRE_ESM(filename);
+};
 
 // Bootstrap main module.
 Module.runMain = function() {

--- a/test/parallel/test-require-mjs.js
+++ b/test/parallel/test-require-mjs.js
@@ -1,0 +1,11 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+assert.throws(
+  () => require('../fixtures/es-modules/test-esm-ok.mjs'),
+  {
+    message: /Must use import to load ES Module/,
+    code: 'ERR_REQUIRE_ESM'
+  }
+);


### PR DESCRIPTION
This is an extremely important part of the ESM implementation
that should have been unflagged as a breaking change in v12.0.0
to allow us to unflag ESM in Node.js 12.x before LTS. Assuming we
can get consensus on this behavior I would argue that this Semver-Major
behavior change could be viewed as a Semver-Patch fix in v12.0.1

Thoughts?

/cc @nodejs/modules @nodejs/tsc