### PR TITLE
deps: V8: cherry-pick 5d0cf6b

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.16',
+    'v8_embedder_string': '-node.17',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/snapshot/code-serializer.cc
+++ b/deps/v8/src/snapshot/code-serializer.cc
@@ -258,11 +258,12 @@ MaybeHandle<SharedFunctionInfo> CodeSerializer::Deserialize(
     Script script = Script::cast(result->script());
     Handle<Script> script_handle(script, isolate);
     if (script->name()->IsString()) name = String::cast(script->name());
+    Handle<String> name_handle(name, isolate);
     if (FLAG_log_function_events) {
-      LOG(isolate,
-          FunctionEvent("deserialize", script->id(),
-                        timer.Elapsed().InMillisecondsF(),
-                        result->StartPosition(), result->EndPosition(), name));
+      LOG(isolate, FunctionEvent("deserialize", script->id(),
+                                 timer.Elapsed().InMillisecondsF(),
+                                 result->StartPosition(), result->EndPosition(),
+                                 *name_handle));
     }
     if (log_code_creation) {
       Script::InitLineEnds(Handle<Script>(script, isolate));
@@ -274,8 +275,8 @@ MaybeHandle<SharedFunctionInfo> CodeSerializer::Deserialize(
           int line_num = script->GetLineNumber(info->StartPosition()) + 1;
           int column_num = script->GetColumnNumber(info->StartPosition()) + 1;
           PROFILE(isolate, CodeCreateEvent(CodeEventListener::SCRIPT_TAG,
-                                           info->abstract_code(), info, name,
-                                           line_num, column_num));
+                                           info->abstract_code(), info,
+                                           *name_handle, line_num, column_num));
         }
       }
     }


### PR DESCRIPTION
Original commit message:

    [snapshot] Use Handle to track name in `CodeSerializer::Deserialize`

    The `Script::InitLineEnds(Handle<Script>(script, isolate));` line
    may lead to objects being moved around on the heap, so it’s necessary
    to use a `Handle` to track that.

    This was causing crashes in Node.js in Debug mode when using the
    code cache in combination with the CPU profiler.

    Refs: https://github.com/nodejs/node/issues/27307
    Change-Id: I392b4c00c6ebad44753f87fcbf2e3278ea7799a6
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1575698
    Reviewed-by: Jakob Gruber <jgruber@chromium.org>
    Reviewed-by: Peter Marshall <petermarshall@chromium.org>
    Commit-Queue: Peter Marshall <petermarshall@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#61036}

Refs: https://github.com/v8/v8/commit/5d0cf6bcd58aa63c86f2664c801538c4e731170b
Fixes: https://github.com/nodejs/node/issues/27307

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
