### PR TITLE
lib: bind functions on EventEmitter

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -266,6 +266,9 @@ function _addListener(target, type, listener, prepend) {
   return target;
 }
 
+bindEventEmitterFunction('addListener', '_addListener');
+bindEventEmitterFunction('on', '_addListener');
+
 EventEmitter.prototype.addListener = function addListener(type, listener) {
   return _addListener(this, type, listener, false);
 };
@@ -307,6 +310,9 @@ EventEmitter.prototype.prependOnceListener =
       this.prependListener(type, _onceWrap(this, type, listener));
       return this;
     };
+
+bindEventEmitterFunction('removeListener', '_removeListener');
+bindEventEmitterFunction('off', '_removeListener');
 
 // Emits a 'removeListener' event if and only if the listener was removed.
 EventEmitter.prototype.removeListener =
@@ -506,5 +512,18 @@ function once(emitter, name) {
     }
 
     emitter.once(name, eventListener);
+  });
+}
+
+function bindEventEmitterFunction(name, target) {
+  Object.defineProperty(EventEmitter.prototype, name, {
+    configurable: true,
+    enumerable: true,
+    set: function(newVal) {
+      this[target] = newVal;
+    },
+    get: function() {
+      return this[target];
+    }
   });
 }

--- a/test/parallel/test-event-emitter-check-bind-functions.js
+++ b/test/parallel/test-event-emitter-check-bind-functions.js
@@ -1,0 +1,43 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const events = require('events');
+
+{
+  const E = events.EventEmitter.prototype;
+
+  assert.strictEqual(E.on, E.addListener);
+  assert.strictEqual(E.off, E.removeListener);
+
+  E.on = function() {};
+  assert.strictEqual(E.on, E.addListener);
+
+  E.addListener = function() {};
+  assert.strictEqual(E.on, E.addListener);
+
+  E.off = function() {};
+  assert.strictEqual(E.off, E.removeListener);
+
+  E.removeListener = function() {};
+  assert.strictEqual(E.off, E.removeListener);
+}
+
+{
+  const EventEmitter = events.EventEmitter;
+
+  const ee = new EventEmitter();
+
+  assert.strictEqual(ee.on, ee.addListener);
+
+  ee.on = function() {};
+  assert.strictEqual(ee.on, ee.addListener);
+
+  ee.addListener = function() {};
+  assert.strictEqual(ee.on, ee.addListener);
+
+  ee.off = function() {};
+  assert.strictEqual(ee.off, ee.removeListener);
+
+  ee.removeListener = function() {};
+  assert.strictEqual(ee.off, ee.removeListener);
+}

--- a/test/parallel/test-event-emitter-method-names.js
+++ b/test/parallel/test-event-emitter-method-names.js
@@ -29,7 +29,9 @@ assert.strictEqual(E.constructor.name, 'EventEmitter');
 assert.strictEqual(E.on, E.addListener);  // Same method.
 assert.strictEqual(E.off, E.removeListener);  // Same method.
 Object.getOwnPropertyNames(E).forEach(function(name) {
-  if (name === 'constructor' || name === 'on' || name === 'off') return;
+  if (name === 'constructor' || name === 'on' || name === 'off' ||
+      name === '_addListener' || name === '_removeListener')
+    return;
   if (typeof E[name] !== 'function') return;
   assert.strictEqual(E[name].name, name);
 });


### PR DESCRIPTION
Further modifications from #27325

bind some functions on `EventEmitter` so that we no need to change two functions at the same time.

for example:

before
```js
Socket.prototype.on = function(){};
Socket.prototype.addListener = Socket.prototype.on;
```

now only need to code one line
```js
Socket.prototype.on = function(){};
// or
Socket.prototype.addListener = function(){};
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
