### PR TITLE
lib: remove useless type check on fs

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -749,8 +749,6 @@ function mkdir(path, options, callback) {
   path = toPathIfFileURL(path);
 
   validatePath(path);
-  if (typeof recursive !== 'boolean')
-    throw new ERR_INVALID_ARG_TYPE('recursive', 'boolean', recursive);
 
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -769,8 +767,6 @@ function mkdirSync(path, options) {
   } = options || {};
 
   validatePath(path);
-  if (typeof recursive !== 'boolean')
-    throw new ERR_INVALID_ARG_TYPE('recursive', 'boolean', recursive);
 
   const ctx = { path };
   binding.mkdir(pathModule.toNamespacedPath(path),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

`recursive` always is the type `boolean`

for an example

https://github.com/nodejs/node/blob/eca71e5a0c4b5e4357d8e871a5dc46b10e9bd1f1/lib/fs.js#L766-L773

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
