### PR TITLE
test: add missing line breaks to keep-alive header of slow headers test

### DIFF
--- a/test/parallel/test-http-slow-headers-keepalive.js
+++ b/test/parallel/test-http-slow-headers-keepalive.js
@@ -8,7 +8,7 @@ const { finished } = require('stream');
 const headers =
   'GET / HTTP/1.1\r\n' +
   'Host: localhost\r\n' +
-  'Connection: keep-alive' +
+  'Connection: keep-alive\r\n' +
   'Agent: node\r\n';
 
 let sendCharEvery = 1000;


### PR DESCRIPTION
`\r\n` is missing in the HTTP header in the slow headers test with keep-alive, and `Connection` and `Agent` headers are not effectively sent to the server. However, it shouldn't affect the behavior of the test because HTTP 1.1 uses persistent connection by default even if `Connection: keep-alive` is not specified.

This PR fixes it just for the sake of correctness.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
