### PR TITLE
module: add test for cjs loader with esm flag

### DIFF
--- a/test/known_issues/test-esm-loader-cache-clearing.js
+++ b/test/known_issues/test-esm-loader-cache-clearing.js
@@ -1,0 +1,11 @@
+// Flags: --experimental-modules
+'use strict';
+require('../common');
+
+const { cache } = require;
+
+Object.keys(cache).forEach((key) => {
+  delete cache[key];
+});
+// Require the same module again triggers the crash
+require('../common');


### PR DESCRIPTION
When using the `--experimental-modules` flag with node, the CJS loader crashes sometime aas described in the related issue. I don' t have sufficient background to understand the module loading, but I have managed to isolate the bug and right a test, hoping that would encourages someone with a better background to tackle the issue.

I have observed the bug to be triggered by [stealthy-require](https://github.com/analog-nico/stealthy-require) module, but only when the `--experimental-modules` flag is specified, even if no `.mjs` are imported. This is going to be a problem when we remove the esm flag as the module has more than 4M weekly download on npm.

Refs: https://github.com/nodejs/node/issues/25482

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
