### PR TITLE
test: add mustCall to net-connect-buffer test

### DIFF
--- a/test/parallel/test-net-connect-buffer.js
+++ b/test/parallel/test-net-connect-buffer.js
@@ -33,11 +33,11 @@ const tcp = net.Server(common.mustCall((s) => {
     buf += d;
   });
 
-  s.on('end', function() {
+  s.on('end', common.mustCall(function() {
     console.error('SERVER: end', buf);
     assert.strictEqual(buf, "L'État, c'est moi");
     s.end();
-  });
+  }));
 }));
 
 tcp.listen(0, common.mustCall(function() {


### PR DESCRIPTION
From code and learn: https://github.com/nodejs/code-and-learn/issues/94

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
