### PR TITLE
test:add common.mustCall in test-http-abort-client.js

### DIFF
--- a/test/parallel/test-http-abort-client.js
+++ b/test/parallel/test-http-abort-client.js
@@ -24,11 +24,11 @@ const common = require('../common');
 const http = require('http');
 
 let serverRes;
-const server = http.Server((req, res) => {
+const server = http.Server(common.mustCall((req, res) => {
   serverRes = res;
   res.writeHead(200);
   res.write('Part of my res.');
-});
+}));
 
 server.listen(0, common.mustCall(() => {
   http.get({


### PR DESCRIPTION
refactor test-http-abort-client to use common.mustCall (from: code-and-learn)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
