### PR TITLE
test: add "mustCall" to test-fs-readfile-unlink

### DIFF
--- a/test/parallel/test-fs-readfile-unlink.js
+++ b/test/parallel/test-fs-readfile-unlink.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 
 // Test that unlink succeeds immediately after readFile completes.
 
@@ -37,7 +37,7 @@ tmpdir.refresh();
 
 fs.writeFileSync(fileName, buf);
 
-fs.readFile(fileName, function(err, data) {
+fs.readFile(fileName, common.mustCall((err, data) => {
   assert.ifError(err);
   assert.strictEqual(data.length, buf.length);
   assert.strictEqual(buf[0], 42);
@@ -45,4 +45,4 @@ fs.readFile(fileName, function(err, data) {
   // Unlink should not throw. This is part of the test. It used to throw on
   // Windows due to a bug.
   fs.unlinkSync(fileName);
-});
+}));


### PR DESCRIPTION
Add common.mustCall to test-fs-readfile-unlink

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
