### PR TITLE
test: add mustCall to net-can-reset-timeout

### DIFF
--- a/test/parallel/test-net-can-reset-timeout.js
+++ b/test/parallel/test-net-can-reset-timeout.js
@@ -37,13 +37,13 @@ const server = net.createServer(common.mustCall(function(stream) {
     stream.write('WHAT.');
   }));
 
-  stream.on('end', function() {
+  stream.on('end', common.mustCall(function() {
     console.log('server side end');
     stream.end();
-  });
+  }));
 }));
 
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   const c = net.createConnection(this.address().port);
 
   c.on('data', function() {
@@ -54,4 +54,4 @@ server.listen(0, function() {
     console.log('client side end');
     server.close();
   });
-});
+}));


### PR DESCRIPTION
add mustCall to net-can-reset-timeout

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
