### PR TITLE
test: add mustCall for parallel/test-net-connect-paused-connection

### DIFF
--- a/test/parallel/test-net-connect-paused-connection.js
+++ b/test/parallel/test-net-connect-paused-connection.js
@@ -26,8 +26,8 @@ const net = require('net');
 
 net.createServer(function(conn) {
   conn.unref();
-}).listen(0, function() {
+}).listen(0, common.mustCall(function() {
   net.connect(this.address().port, 'localhost').pause();
 
   setTimeout(common.mustNotCall('expected to exit'), 1000).unref();
-}).unref();
+})).unref();


### PR DESCRIPTION
Add common.mustCall test on net.createServer callback and listen
callback in the parallel/test-net-connect-paused-connection

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
