### PR TITLE
test: fs internal util preprocessSymlinkDestination() function

### DIFF
--- a/test/parallel/test-internal-fs.js
+++ b/test/parallel/test-internal-fs.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const common = require('../common');
+const assert = require('assert');
 const fs = require('internal/fs/utils');
 
 // Valid encodings and no args should not throw.
@@ -12,3 +13,41 @@ common.expectsError(
   () => fs.assertEncoding('foo'),
   { code: 'ERR_INVALID_OPT_VALUE_ENCODING', type: TypeError }
 );
+
+// Test junction symlinks
+{
+  const pathString = 'c:\\test1';
+  const linkPathString = '\\test2';
+
+  const preprocessSymlinkDestination = fs.preprocessSymlinkDestination(
+    pathString,
+    'junction',
+    linkPathString
+  );
+
+  if (process.platform === 'win32') {
+    assert.strictEqual(/^\\\\\?\\/.test(preprocessSymlinkDestination), true);
+  } else {
+    assert.strictEqual(preprocessSymlinkDestination, pathString);
+  }
+}
+
+// Test none junction symlinks
+{
+  const pathString = 'c:\\test1';
+  const linkPathString = '\\test2';
+
+  const preprocessSymlinkDestination = fs.preprocessSymlinkDestination(
+    pathString,
+    undefined,
+    linkPathString
+  );
+
+  if (process.platform === 'win32') {
+    // There should not be any forward slashes
+    assert.strictEqual(
+      /\//.test(preprocessSymlinkDestination), false);
+  } else {
+    assert.strictEqual(preprocessSymlinkDestination, pathString);
+  }
+}


### PR DESCRIPTION
Unit tests for `preprocessSymlinkDestination()` function in `'internal/fs/utils'`.
 These tests are without any monkey-patching for the platform.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
