### PR TITLE
Revert "test: skip test-cpu-prof in debug builds with code cache"

### DIFF
--- a/test/sequential/test-cpu-prof.js
+++ b/test/sequential/test-cpu-prof.js
@@ -3,12 +3,6 @@
 // This tests that --cpu-prof, --cpu-prof-dir and --cpu-prof-name works.
 
 const common = require('../common');
-if (process.features.debug && process.features.cached_builtins) {
-  // FIXME(joyeecheung): the profiler crashes when code cache
-  // is enabled in debug builds.
-  common.skip('--cpu-prof does not work in debug builds with code cache');
-}
-
 const fixtures = require('../common/fixtures');
 common.skipIfInspectorDisabled();
 


### PR DESCRIPTION
Skipping the test is not needed now that the underlying cause
has been addressed in V8.

This reverts commit b66f01d9037a120a8aad624c57e769fb418ccd9c.

Refs: https://github.com/nodejs/node/pull/27423

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
