### PR TITLE
tools,build: use the python interpreter running gyp througout the whole build process

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1608,7 +1608,7 @@ os.environ['PYTHON_EXECUTABLE'] = sys.executable
 
 write('config.mk', do_not_edit + config)
 
-gyp_args = ['--no-parallel', '-Dconfiguring_node=1', "-DPYTHON_EXECUTABLE=" + os.path.realpath(sys.executable)]
+gyp_args = ['--no-parallel', '-Dconfiguring_node=1', "-DPYTHON_EXECUTABLE=%s" % sys.executable]
 
 if options.use_ninja:
   gyp_args += ['-f', 'ninja']

--- a/configure.py
+++ b/configure.py
@@ -1604,8 +1604,6 @@ if options.prefix:
 
 config = '\n'.join(['='.join(item) for item in config.items()]) + '\n'
 
-
-sys.argv.append("-DPYTHON_EXECUTABLE=" + sys.executable)
 os.environ['PYTHON_EXECUTABLE'] = sys.executable
 
 write('config.mk', do_not_edit + config)

--- a/node.gyp
+++ b/node.gyp
@@ -838,7 +838,7 @@
               'outputs': ['<(SHARED_INTERMEDIATE_DIR)/openssl.def'],
               'process_outputs_as_sources': 1,
               'action': [
-                'python',
+                '<(PYTHON_EXECUTABLE)',
                 'tools/mkssldef.py',
                 '<@(mkssldef_flags)',
                 '-o',
@@ -873,7 +873,7 @@
             }]
           ],
           'action': [
-            'python', 'tools/js2c.py',
+            '<(PYTHON_EXECUTABLE)', 'tools/js2c.py',
             '<@(_outputs)',
             '<@(_inputs)',
           ],

--- a/src/inspector/node_inspector.gypi
+++ b/src/inspector/node_inspector.gypi
@@ -77,7 +77,7 @@
         '<(SHARED_INTERMEDIATE_DIR)/src/node_protocol.json',
       ],
       'action': [
-        'python',
+        '<(PYTHON_EXECUTABLE)',
         'tools/inspector_protocol/convert_protocol_to_json.py',
         '<@(_inputs)',
         '<@(_outputs)',
@@ -95,7 +95,7 @@
       ],
       'process_outputs_as_sources': 1,
       'action': [
-        'python',
+        '<(PYTHON_EXECUTABLE)',
         'tools/inspector_protocol/code_generator.py',
         '--jinja_dir', '<@(protocol_tool_path)',
         '--output_base', '<(SHARED_INTERMEDIATE_DIR)/src/',
@@ -113,7 +113,7 @@
         '<(SHARED_INTERMEDIATE_DIR)/concatenated_protocol.json',
       ],
       'action': [
-        'python',
+        '<(PYTHON_EXECUTABLE)',
         'tools/inspector_protocol/concatenate_protocols.py',
         '<@(_inputs)',
         '<@(_outputs)',
@@ -129,7 +129,7 @@
       ],
       'process_outputs_as_sources': 1,
       'action': [
-        'python',
+        '<(PYTHON_EXECUTABLE)',
         'tools/compress_json.py',
         '<@(_inputs)',
         '<@(_outputs)',

--- a/tools/gyp/gyp_main.py
+++ b/tools/gyp/gyp_main.py
@@ -10,8 +10,8 @@ import sys
 # Make sure we're using the version of pylib in this repo, not one installed
 # elsewhere on the system.
 sys.path.insert(0, os.path.join(os.path.dirname(sys.argv[0]), 'pylib'))
-sys.argv.append("-DPYTHON_EXECUTABLE=" + sys.executable)
-os.environ['PYTHON_EXECUTABLE'] = sys.executableimport gyp
+sys.argv.append("-DPYTHON_EXECUTABLE=" + os.path.realpath(sys.executable))
+os.environ['PYTHON_EXECUTABLE'] = os.path.realpath(sys.executable)
 import gyp
 
 if __name__ == '__main__':

--- a/tools/gyp/gyp_main.py
+++ b/tools/gyp/gyp_main.py
@@ -10,6 +10,8 @@ import sys
 # Make sure we're using the version of pylib in this repo, not one installed
 # elsewhere on the system.
 sys.path.insert(0, os.path.join(os.path.dirname(sys.argv[0]), 'pylib'))
+sys.argv.append("-DPYTHON_EXECUTABLE=" + sys.executable)
+os.environ['PYTHON_EXECUTABLE'] = sys.executableimport gyp
 import gyp
 
 if __name__ == '__main__':

--- a/tools/gyp/pylib/gyp/generator/xcode.py
+++ b/tools/gyp/pylib/gyp/generator/xcode.py
@@ -284,10 +284,10 @@ class XcodeProject(object):
         command_prefix = ''
         if serialize_all_tests:
           command_prefix = \
-"""python -c "import fcntl, subprocess, sys
+"""%s -c "import fcntl, subprocess, sys
 file = open('$TMPDIR/GYP_serialize_test_runs', 'a')
 fcntl.flock(file.fileno(), fcntl.LOCK_EX)
-sys.exit(subprocess.call(sys.argv[1:]))" """
+sys.exit(subprocess.call(sys.argv[1:]))" """ % (sys.executable)
 
         # If we were unable to exec for some reason, we want to exit
         # with an error, and fixup variable references to be shell

--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -240,7 +240,7 @@
                   'msvs_quote_cmd': 0,
                   'inputs': [ '<(icu_data_in)', 'icu_small.json' ],
                   'outputs': [ '<(SHARED_INTERMEDIATE_DIR)/icutmp/icudt<(icu_ver_major)<(icu_endianness).dat' ],
-                  'action': [ 'python',
+                  'action': [ '<(PYTHON_EXECUTABLE)',
                               'icutrim.py',
                               '-P', '<(PRODUCT_DIR)/.', # '.' suffix is a workaround against GYP assumptions :(
                               '-D', '<(icu_data_in)',
@@ -322,7 +322,7 @@
                   'action_name': 'icutrim',
                   'inputs': [ '<(icu_data_in)', 'icu_small.json' ],
                   'outputs': [ '<(SHARED_INTERMEDIATE_DIR)/icutmp/icudt<(icu_ver_major)<(icu_endianness).dat' ],
-                  'action': [ 'python',
+                  'action': [ '<(PYTHON_EXECUTABLE)',
                               'icutrim.py',
                               '-P', '<(PRODUCT_DIR)',
                               '-D', '<(icu_data_in)',

--- a/tools/v8_gypfiles/broken/shim_headers.gypi
+++ b/tools/v8_gypfiles/broken/shim_headers.gypi
@@ -62,7 +62,7 @@
       'outputs': [
         '<!@pymod_do_main(generate_shim_headers <@(generator_args) --outputs)',
       ],
-      'action': ['python',
+      'action': ['<(PYTHON_EXECUTABLE)',
                  '<(generator_path)',
                  '<@(generator_args)',
                  '--generate',

--- a/tools/v8_gypfiles/inspector.gypi
+++ b/tools/v8_gypfiles/inspector.gypi
@@ -99,7 +99,7 @@
         '<@(inspector_generated_output_root)/src/js_protocol.stamp',
       ],
       'action': [
-        'python',
+        '<(PYTHON_EXECUTABLE)',
         '<(inspector_protocol_path)/check_protocol_compatibility.py',
         '--stamp', '<@(_outputs)',
         '<@(_inputs)',
@@ -118,7 +118,7 @@
       ],
       'process_outputs_as_sources': 1,
       'action': [
-        'python',
+        '<(PYTHON_EXECUTABLE)',
         '<(inspector_protocol_path)/code_generator.py',
         '--jinja_dir', '<(V8_ROOT)/third_party',
         '--output_base', '<(inspector_generated_output_root)/src/inspector',

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -41,7 +41,7 @@
     'has_valgrind%': 0,
     'coverage%': 0,
     'v8_target_arch%': '<(target_arch)',
-    'v8_host_byteorder%': '<!(python -c "import sys; print(sys.byteorder)")',
+    'v8_host_byteorder%': '<!<(PYTHON_EXECUTABLE) -c "import sys; print sys.byteorder")',
     'force_dynamic_crt%': 0,
 
     # Setting 'v8_can_use_vfp32dregs' to 'true' will cause V8 to use the VFP

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -190,7 +190,7 @@
             }],
           ],
           'action': [
-            'python', '<(V8_ROOT)/tools/testrunner/utils/dump_build_config_gyp.py',
+            '<(PYTHON_EXECUTABLE)', '<(V8_ROOT)/tools/testrunner/utils/dump_build_config_gyp.py',
             '<@(v8_dump_build_config_args)',
           ],
         },
@@ -2633,7 +2633,7 @@
             '<(SHARED_INTERMEDIATE_DIR)/debug-support.cc',
           ],
           'action': [
-            'python',
+            '<(PYTHON_EXECUTABLE)',
             '<(V8_ROOT)/tools/gen-postmortem-metadata.py',
             '<@(_outputs)',
             '<@(heapobject_files)'
@@ -2702,7 +2702,7 @@
             '<(generate_bytecode_builtins_list_output)',
           ],
           'action': [
-            'python',
+            '<(PYTHON_EXECUTABLE)',
             '<(V8_ROOT)/tools/run.py',
             '<@(_inputs)',
             '<@(_outputs)',

--- a/tools/v8_gypfiles/v8_external_snapshot.gypi
+++ b/tools/v8_gypfiles/v8_external_snapshot.gypi
@@ -149,7 +149,7 @@
               ],
               'outputs': ['<(SHARED_INTERMEDIATE_DIR)/libraries-extras.bin'],
               'action': [
-                'python',
+                '<(PYTHON_EXECUTABLE)',
                 '<(V8_ROOT)/tools/js2c.py',
                 '<(SHARED_INTERMEDIATE_DIR)/extras-libraries.cc',
                 'EXTRAS',
@@ -172,14 +172,14 @@
                         '<(PRODUCT_DIR)/natives_blob_host.bin',
                       ],
                       'action': [
-                        'python', '<@(_inputs)', '<(PRODUCT_DIR)/natives_blob_host.bin'
+                        '<(PYTHON_EXECUTABLE)', '<@(_inputs)', '<(PRODUCT_DIR)/natives_blob_host.bin'
                       ],
                     }, {
                        'outputs': [
                          '<(PRODUCT_DIR)/natives_blob.bin',
                        ],
                        'action': [
-                         'python', '<@(_inputs)', '<(PRODUCT_DIR)/natives_blob.bin'
+                         '<(PYTHON_EXECUTABLE)', '<@(_inputs)', '<(PRODUCT_DIR)/natives_blob.bin'
                        ],
                      }],
                   ],
@@ -188,7 +188,7 @@
                      '<(PRODUCT_DIR)/natives_blob.bin',
                    ],
                    'action': [
-                     'python', '<@(_inputs)', '<(PRODUCT_DIR)/natives_blob.bin'
+                     '<(PYTHON_EXECUTABLE)', '<@(_inputs)', '<(PRODUCT_DIR)/natives_blob.bin'
                    ],
                  }],
               ],


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
