### PR TITLE
test: deflake test-tls-js-stream

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -23,8 +23,6 @@ test-http2-client-upload-reject: PASS,FLAKY
 [$system==linux]
 
 [$system==macos]
-# https://github.com/nodejs/node/issues/26938
-test-tls-js-stream: PASS,FLAKY
 
 [$arch==arm || $arch==arm64]
 # https://github.com/nodejs/node/issues/26610

--- a/test/parallel/test-tls-js-stream.js
+++ b/test/parallel/test-tls-js-stream.js
@@ -6,24 +6,19 @@ if (!common.hasCrypto)
 
 const fixtures = require('../common/fixtures');
 
-const assert = require('assert');
 const net = require('net');
 const stream = require('stream');
 const tls = require('tls');
 
-const connected = {
-  client: 0,
-  server: 0
-};
-
 const server = tls.createServer({
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem')
-}, function(c) {
+}, common.mustCall(function(c) {
   console.log('new client');
-  connected.server++;
+
+  c.resume();
   c.end('ohai');
-}).listen(0, function() {
+})).listen(0, common.mustCall(function() {
   const raw = net.connect(this.address().port);
 
   let pending = false;
@@ -53,23 +48,15 @@ const server = tls.createServer({
   const socket = tls.connect({
     socket: p,
     rejectUnauthorized: false
-  }, function() {
+  }, common.mustCall(function() {
     console.log('client secure');
 
-    connected.client++;
-
-    socket.end('hello');
     socket.resume();
-    socket.destroy();
-  });
+    socket.end('hello');
+  }));
 
   socket.once('close', function() {
     console.log('client close');
     server.close();
   });
-});
-
-process.once('exit', function() {
-  assert.strictEqual(connected.client, 1);
-  assert.strictEqual(connected.server, 1);
-});
+}));

--- a/test/parallel/test-tls-js-stream.js
+++ b/test/parallel/test-tls-js-stream.js
@@ -27,6 +27,10 @@ const server = tls.createServer({
       p._read();
   });
 
+  raw.on('end', function() {
+    p.push(null);
+  });
+
   const p = new stream.Duplex({
     read: function read() {
       pending = false;


### PR DESCRIPTION
`socket.destroy()` can destory the stream before the chunk to write
with `socket.end()` is actually sent. Furthermore `socket.destroy()`
destroys `p` and not the actual raw socket. As a result it is possible
that the connection is left open.

Remove `socket.destroy()` to ensure that the chunk is sent. Also use
`common.mustCall()` to ensure that the `'secureConnection'` and
`'secureConnect'` events are emitted exactly once.

Fixes: https://github.com/nodejs/node/issues/26938

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
