### PR TITLE
tools: add Release and Debug symlinks to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,9 @@ coverage/
 
 # various stuff that VC++ produces/uses and is not in /out
 /Debug/
+/Debug
 /Release/
+/Release
 !doc/blog/**
 *.sln
 !nodemsi.sln

--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,7 @@ coverage/
 /out
 
 # various stuff that VC++ produces/uses and is not in /out
-/Debug/
 /Debug
-/Release/
 /Release
 !doc/blog/**
 *.sln


### PR DESCRIPTION
Seems at least some windows versions interpret symlinks not as folders
therefore .gitignore needs some extra entries.

@refack I think this is related to your PR

Refs: #27149

##### Checklist
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
