### PR TITLE
test: crypto internal library keys

### DIFF
--- a/test/parallel/test-internal-crypto-keys.js
+++ b/test/parallel/test-internal-crypto-keys.js
@@ -1,0 +1,53 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const keys = require('internal/crypto/keys');
+
+// This test ensures getKeyObjectHandle throws error for invalid key type
+{
+  const keyObject = new keys.KeyObject('private', {});
+  Object.defineProperty(keyObject, 'type', { get: () => 'test' });
+
+  assert.throws(
+    () => {
+      keys.preparePublicOrPrivateKey(keyObject);
+    },
+    {
+      name: 'TypeError',
+      message: 'Invalid key object type test, expected private or public.',
+      code: 'ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE'
+    }
+  );
+}
+
+// This test ensures KeyObject throws error for invalid key type
+// during the instantiation
+{
+  assert.throws(
+    () => {
+      new keys.KeyObject('someOther', {});
+    },
+    {
+      name: 'TypeError',
+      message: "The argument 'type' is invalid. Received 'someOther'",
+      code: 'ERR_INVALID_ARG_VALUE'
+    }
+  );
+}
+
+// This test ensures KeyObject throws error for invalid handler variable type
+// during the instantiation
+{
+  assert.throws(
+    () => {
+      new keys.KeyObject('private', 'notObject');
+    },
+    {
+      name: 'TypeError',
+      message:
+        'The "handle" argument must be of type string. Received type string',
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+}

--- a/test/parallel/test-internal-crypto-keys.js
+++ b/test/parallel/test-internal-crypto-keys.js
@@ -1,6 +1,6 @@
 // Flags: --expose-internals
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const keys = require('internal/crypto/keys');
 


### PR DESCRIPTION
Unit tests for internal library `'internal/crypto/keys'`.
These tests are for:
- `getKeyObjectHandle()` function when `key.type` is not `private` or `public`
- Create new `KeyObject` with in valid `type`
- Create new `KeyObject` with none object type `handler`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
