### PR TITLE
assert: stricter object comparison

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -123,7 +123,7 @@ the tty [getColorDepth()](tty.html#tty_writestream_getcolordepth_env) doc.
 
 ## Legacy mode
 
-Legacy mode uses the [Abstract Equality Comparison][] in:
+Legacy mode uses a variety of the [Abstract Equality Comparison][] in:
 
 * [`assert.deepEqual()`][]
 * [`assert.equal()`][]
@@ -137,13 +137,11 @@ const assert = require('assert');
 ```
 
 Whenever possible, use the [`strict` mode][] instead. Otherwise, the
-[Abstract Equality Comparison][] may cause surprising results. This is
-especially true for [`assert.deepEqual()`][], where the comparison rules are
-lax:
+[Abstract Equality Comparison][] may cause surprising results.
 
 ```js
 // WARNING: This does not throw an AssertionError!
-assert.deepEqual(/a/gi, new Date());
+assert.deepEqual('+00000000', false);
 ```
 
 ## assert(value\[, message\])
@@ -579,8 +577,9 @@ An alias of [`assert.strictEqual()`][].
 > Stability: 0 - Deprecated: Use [`assert.strictEqual()`][] instead.
 
 Tests shallow, coercive equality between the `actual` and `expected` parameters
-using the [Abstract Equality Comparison][] ( `==` ). `NaN` is special handled
-and treated as being identical in case both sides are `NaN`.
+using the [Abstract Equality Comparison][] ( `==` ) for primitive values and
+reference equality for objects. `NaN` is treated as being identical in case both
+sides are `NaN`.
 
 ```js
 const assert = require('assert');
@@ -593,9 +592,14 @@ assert.equal(NaN, NaN);
 // OK
 
 assert.equal(1, 2);
-// AssertionError: 1 == 2
+// AssertionError [ERR_ASSERTION]: Expected values to be loosely equal:
+// 1 should equal 2
 assert.equal({ a: { b: 1 } }, { a: { b: 1 } });
-// AssertionError: { a: { b: 1 } } == { a: { b: 1 } }
+// AssertionError [ERR_ASSERTION]: Expected values to be loosely equal:
+// { a: { b: 1 } } should equal { a: { b: 1 } }
+assert.equal(0, []);
+// AssertionError [ERR_ASSERTION]: Expected values to be loosely equal:
+// 0 should equal []
 ```
 
 If the values are not equal, an [`AssertionError`][] is thrown with a `message`
@@ -890,8 +894,8 @@ An alias of [`assert.notStrictEqual()`][].
 > Stability: 0 - Deprecated: Use [`assert.notStrictEqual()`][] instead.
 
 Tests shallow, coercive inequality with the [Abstract Equality Comparison][]
-(`!=` ). `NaN` is special handled and treated as being identical in case both
-sides are `NaN`.
+( `!=` ) for primitive values and reference equality for objects. `NaN` is
+treated as being identical in case both sides are `NaN`.
 
 ```js
 const assert = require('assert');
@@ -900,10 +904,11 @@ assert.notEqual(1, 2);
 // OK
 
 assert.notEqual(1, 1);
-// AssertionError: 1 != 1
-
+// AssertionError [ERR_ASSERTION]: Expected "actual" to be loosely unequal to:
+// 1
 assert.notEqual(1, '1');
-// AssertionError: 1 != '1'
+// AssertionError [ERR_ASSERTION]: Expected "actual" to be loosely unequal to:
+// 1
 ```
 
 If the values are equal, an [`AssertionError`][] is thrown with a `message`

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -99,6 +99,20 @@ function innerFail(obj) {
   throw new AssertionError(obj);
 }
 
+function looseEqual(a, b) {
+  if (a === b || (NumberIsNaN(actual) && NumberIsNaN(expected))) {
+    return true;
+  }
+  if (typeof a === 'object') {
+    return a === null && b === undefined;
+  }
+  if (typeof b === 'object') {
+    return b === null && a === undefined;
+  }
+  // eslint-disable-next-line eqeqeq
+  return a == b;
+}
+
 function fail(actual, expected, message, operator, stackStartFn) {
   const argsLen = arguments.length;
 
@@ -398,13 +412,12 @@ assert.equal = function equal(actual, expected, message) {
   if (arguments.length < 2) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
-  // eslint-disable-next-line eqeqeq
-  if (actual != expected && (!NumberIsNaN(actual) || !NumberIsNaN(expected))) {
+  if (!looseEqual(actual, expected)) {
     innerFail({
       actual,
       expected,
       message,
-      operator: '==',
+      operator: 'equal',
       stackStartFn: equal
     });
   }
@@ -416,13 +429,12 @@ assert.notEqual = function notEqual(actual, expected, message) {
   if (arguments.length < 2) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
-  // eslint-disable-next-line eqeqeq
-  if (actual == expected || (NumberIsNaN(actual) && NumberIsNaN(expected))) {
+  if (looseEqual(actual, expected)) {
     innerFail({
       actual,
       expected,
       message,
-      operator: '!=',
+      operator: 'notEqual',
       stackStartFn: notEqual
     });
   }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -72,6 +72,28 @@ a.equal(null, undefined);
 a.equal(true, true);
 a.equal(2, '2');
 a.notEqual(true, false);
+assert.throws(() => {
+  a.equal(0, []);
+}, {
+  actual: 0,
+  expected: [],
+  operator: 'equal',
+  generatedMessage: true
+});
+assert.throws(() => {
+  a.equal({ [Symbol.toPrimitive]() { return 5; } }, 5);
+}, {
+  operator: 'equal',
+  generatedMessage: true
+});
+assert.throws(() => {
+  a.notEqual(null, undefined);
+}, {
+  operator: 'notEqual',
+  actual: null,
+  expected: undefined,
+  generatedMessage: true
+});
 
 assert.throws(() => a.notEqual(true, true),
               a.AssertionError, 'notEqual(true, true)');


### PR DESCRIPTION
This changes the comparison for `assert.equal()` and
`assert.notEqual()` to compare objects by reference and not with the
abstract equality comparator. That prevents some mistakes that most
people would not anticipate as equal.

CITGM https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1840/
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
