### PR TITLE
test: allow EAI_FAIL in test-http-dns-error.js

### DIFF
--- a/test/parallel/test-http-dns-error.js
+++ b/test/parallel/test-http-dns-error.js
@@ -32,9 +32,7 @@ const https = require('https');
 const host = '*'.repeat(64);
 const MAX_TRIES = 5;
 
-let errCode = 'ENOTFOUND';
-if (common.isOpenBSD)
-  errCode = 'EAI_FAIL';
+const errCodes = ['ENOTFOUND', 'EAI_FAIL'];
 
 function tryGet(mod, tries) {
   // Bad host name should not throw an uncatchable exception.
@@ -45,7 +43,7 @@ function tryGet(mod, tries) {
       tryGet(mod, ++tries);
       return;
     }
-    assert.strictEqual(err.code, errCode);
+    assert(errCodes.includes(err.code), err);
   }));
   // http.get() called req1.end() for us
 }
@@ -61,7 +59,7 @@ function tryRequest(mod, tries) {
       tryRequest(mod, ++tries);
       return;
     }
-    assert.strictEqual(err.code, errCode);
+    assert(errCodes.includes(err.code), err);
   }));
   req.end();
 }


### PR DESCRIPTION
`EAI_FAIL` is expected on OpenBSD, and has been observed on platforms such as FreeBSD and Windows. This commit makes `EAI_FAIL` an acceptable error code on all platforms.

Fixes: https://github.com/nodejs/node/issues/27487

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
