### PR TITLE
test: vm module error thrown when breakOnSigint is not a boolean evaluate()

### DIFF
--- a/test/parallel/test-vm-module-errors.js
+++ b/test/parallel/test-vm-module-errors.js
@@ -250,6 +250,20 @@ async function checkExecution() {
   })();
 }
 
+// Check for error thrown when breakOnSigint is not a boolean for evaluate()
+async function checkInvalidOptionForEvaluate() {
+  await assert.rejects(async () => {
+    const m = new SourceTextModule('export const a = 1; export var b = 2');
+    await m.evaluate({ breakOnSigint: 'a-string' });
+  }, {
+    name: 'TypeError',
+    message:
+      'The "options.breakOnSigint" property must be of type boolean. \
+Received type string',
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+}
+
 const finished = common.mustCall();
 
 (async function main() {
@@ -257,5 +271,6 @@ const finished = common.mustCall();
   await checkModuleState();
   await checkLinking();
   await checkExecution();
+  await checkInvalidOptionForEvaluate();
   finished();
 })();

--- a/test/parallel/test-vm-module-errors.js
+++ b/test/parallel/test-vm-module-errors.js
@@ -258,8 +258,8 @@ async function checkInvalidOptionForEvaluate() {
   }, {
     name: 'TypeError',
     message:
-      'The "options.breakOnSigint" property must be of type boolean. \
-Received type string',
+      'The "options.breakOnSigint" property must be of type boolean. ' +
+      'Received type string',
     code: 'ERR_INVALID_ARG_TYPE'
   });
 }


### PR DESCRIPTION
This unit test is to assert the error thrown when `none boolean` value passed as `breakOnSigint` attribute to the `evaluate()` function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
