### PR TITLE
test: converting NghttpError to string in HTTP2 module

### DIFF
--- a/test/parallel/test-http2-util-nghttp2error.js
+++ b/test/parallel/test-http2-util-nghttp2error.js
@@ -14,3 +14,9 @@ common.expectsError(() => {
   type: NghttpError,
   message: 'Invalid argument'
 });
+
+// Should convert the NghttpError object to string properly
+{
+  const err = new NghttpError(401);
+  strictEqual(err.toString(), 'Error [ERR_HTTP2_ERROR]: Unknown error code');
+}


### PR DESCRIPTION
This unit test is for converting `NghttpError` instance to string using `toString()` function in `NghttpError` class

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
