### PR TITLE
src: use cgroups to get memory limits

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -179,7 +179,10 @@ void FreeArrayBufferAllocator(ArrayBufferAllocator* allocator) {
 }
 
 void SetIsolateCreateParamsForNode(Isolate::CreateParams* params) {
-  const uint64_t total_memory = uv_get_total_memory();
+  const uint64_t constrained_memory = uv_get_constrained_memory();
+  const uint64_t total_memory = constrained_memory > 0 ?
+      std::min(uv_get_total_memory(), constrained_memory) :
+      uv_get_total_memory();
   if (total_memory > 0) {
     // V8 defaults to 700MB or 1.4GB on 32 and 64 bit platforms respectively.
     // This default is based on browser use-cases. Tell V8 to configure the


### PR DESCRIPTION
This PR improves the way we set the memory ceiling for a Node.js process. Previously we would use the physical memory size (from libuv) to estimate the necessary V8 heap sizes. The physical memory size is not necessarily the correct limit, e.g. if the process is running inside a docker container or is otherwise constrained.

This change adds the ability to get a memory limit set by linux cgroups, which is used by [docker containers to set resource constraints](https://docs.docker.com/config/containers/resource_constraints/).

I've created a "resource limits" namespace/class that maybe should be the interface through which all resource constraint parameters are retrieved. So far that is just the memory limit but this could be expanded to other cgroups controller params. Also, this functionality is not necessarily specific to linux, so it's possible to have other implementations for other platforms (though this change is primarily motivated by the docker use case). Currently, behavior for other platforms besides linux is unchanged.

See also [this article about support for cgroups in Java](https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits).

cc/ @ofrobots

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
