### PR TITLE
doc:  add missing `--trace` in man page

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -282,6 +282,9 @@ or servers.
 Set default minVersion to 'TLSv1.3'. Use to disable support for TLSv1.2 in
 favour of TLSv1.3, which is more secure.
 .
+.It Fl -trace
+Print the default trace on standard output.
+.
 .It Fl -trace-deprecation
 Print stack traces for deprecations.
 .


### PR DESCRIPTION
This is a documentation pull-request to improve the man page.