### PR TITLE
doc: fix explanation of package.json "type" field

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -59,9 +59,9 @@ or when referenced by `import` statements within ES module code:
 
 ### `package.json` `"type"` field
 
-Files ending with `.js` or `.mjs`, or lacking any extension,
-will be loaded as ES modules when the nearest parent `package.json` file
-contains a top-level field `"type"` with a value of `"module"`.
+Files ending with `.js` or lacking any extension will be loaded as ES modules
+when the nearest parent `package.json` file contains a top-level field `"type"`
+with a value of `"module"`.
 
 The nearest parent `package.json` is defined as the first `package.json` found
 when searching in the current folder, that folder’s parent, and so on up

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -101,6 +101,9 @@ future-proof the package in case the default type of Node.js ever changes, and
 it will also make things easier for build tools and loaders to determine how the
 files in the package should be interpreted.
 
+Regardless of the value of the `"type"` field, `.mjs` files are always treated
+as ES modules and `.cjs` files are always treated as CommonJS modules.
+
 ### Package Scope and File Extensions
 
 A folder containing a `package.json` file, and all subfolders below that

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -102,7 +102,7 @@ it will also make things easier for build tools and loaders to determine how the
 files in the package should be interpreted.
 
 Regardless of the value of the `"type"` field, `.mjs` files are always treated
-as ES modules and `.cjs` files are always treated as CommonJS modules.
+as ES modules and `.cjs` files are always treated as CommonJS.
 
 ### Package Scope and File Extensions
 


### PR DESCRIPTION
Remove erroneous reference to files with `.mjs` extension, which are not affected by the "type" field.

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
