### PR TITLE
tls: disallow conflicting TLS protocol options

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -148,6 +148,11 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
     errors->push_back("invalid value for --unhandled-rejections");
   }
 
+  if (tls_min_v1_3 && tls_max_v1_2) {
+    errors->push_back("either --tls-min-v1.3 or --tls-max-v1.2 can be "
+                      "used, not both");
+  }
+
 #if HAVE_INSPECTOR
   if (!cpu_prof) {
     if (!cpu_prof_name.empty()) {

--- a/test/parallel/test-tls-cli-min-max-conflict.js
+++ b/test/parallel/test-tls-cli-min-max-conflict.js
@@ -1,0 +1,14 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto) common.skip('missing crypto');
+
+// Check that conflicting TLS protocol versions are not allowed
+
+const assert = require('assert');
+const child_process = require('child_process');
+
+const args = ['--tls-min-v1.3', '--tls-max-v1.2', '-p', 'process.version'];
+child_process.execFile(process.argv[0], args, (err) => {
+  assert(err);
+  assert(/not both/.test(err.message));
+});


### PR DESCRIPTION
Do not allow the minimum protocol level to be set higher than the max protocol level.

See: https://github.com/nodejs/node/pull/26951, 109c097797b

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
