### PR TITLE
util: inspect constructor closer

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -28,6 +28,7 @@ const {
   kPending,
   kRejected,
   previewEntries,
+  getConstructorName: internalGetConstructorName,
   propertyFilter: {
     ALL_PROPERTIES,
     ONLY_ENUMERABLE
@@ -349,6 +350,7 @@ function getEmptyFormatArray() {
 
 function getConstructorName(obj, ctx) {
   let firstProto;
+  const tmp = obj;
   while (obj) {
     const descriptor = Object.getOwnPropertyDescriptor(obj, 'constructor');
     if (descriptor !== undefined &&
@@ -367,7 +369,7 @@ function getConstructorName(obj, ctx) {
     return null;
   }
 
-  return `<${inspect(firstProto, {
+  return `${internalGetConstructorName(tmp)} <${inspect(firstProto, {
     ...ctx,
     customInspect: false
   })}>`;

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -58,6 +58,16 @@ static void GetOwnNonIndexProperties(
   args.GetReturnValue().Set(properties);
 }
 
+static void GetConstructorName(
+    const FunctionCallbackInfo<Value>& args) {
+  CHECK(args[0]->IsObject());
+
+  Local<Object> object = args[0].As<Object>();
+  Local<String> name = object->GetConstructorName();
+
+  args.GetReturnValue().Set(name);
+}
+
 static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
   // Return undefined if it's not a Promise.
   if (!args[0]->IsPromise())
@@ -262,6 +272,7 @@ void Initialize(Local<Object> target,
   env->SetMethodNoSideEffect(target, "previewEntries", PreviewEntries);
   env->SetMethodNoSideEffect(target, "getOwnNonIndexProperties",
                                      GetOwnNonIndexProperties);
+  env->SetMethodNoSideEffect(target, "getConstructorName", GetConstructorName);
 
   env->SetMethod(target, "arrayBufferViewHasBuffer", ArrayBufferViewHasBuffer);
   Local<Object> constants = Object::New(env->isolate());

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2003,11 +2003,11 @@ assert.strictEqual(
   Object.setPrototypeOf(obj, value);
   assert.strictEqual(
     util.inspect(obj),
-    '<[Function (null prototype) (anonymous)]> { a: true }'
+    'Object <[Function (null prototype) (anonymous)]> { a: true }'
   );
   assert.strictEqual(
     util.inspect(obj, { colors: true }),
-    '<\u001b[36m[Function (null prototype) (anonymous)]\u001b[39m> ' +
+    'Object <\u001b[36m[Function (null prototype) (anonymous)]\u001b[39m> ' +
       '{ a: \u001b[33mtrue\u001b[39m }'
   );
 
@@ -2017,14 +2017,14 @@ assert.strictEqual(
   Object.setPrototypeOf(obj, value);
   assert.strictEqual(
     util.inspect(obj),
-    '<[Array: null prototype] []> { a: true }'
+    'Object <[Array: null prototype] []> { a: true }'
   );
 
   function StorageObject() {}
   StorageObject.prototype = Object.create(null);
   assert.strictEqual(
     util.inspect(new StorageObject()),
-    '<[Object: null prototype] {}> {}'
+    'StorageObject <[Object: null prototype] {}> {}'
   );
 
   obj = [1, 2, 3];
@@ -2034,7 +2034,7 @@ assert.strictEqual(
   Object.setPrototypeOf(obj, Object.create(null));
   assert.strictEqual(
     inspect(obj),
-    "<[Object: null prototype] {}> { '0': 1, '1': 2, '2': 3 }"
+    "Array <[Object: null prototype] {}> { '0': 1, '1': 2, '2': 3 }"
   );
 }
 


### PR DESCRIPTION
This adds an extra check to `util.inspect` to closer inspect object
constructors in case there's not much other information about the
constructor.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
