### PR TITLE
bootstrap: reorganize the bootstrap process

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -250,7 +250,7 @@ Environment* CreateEnvironment(IsolateData* isolate_data,
                                       Environment::kOwnsProcessState |
                                       Environment::kOwnsInspector));
   env->InitializeLibuv(per_process::v8_is_profiling);
-  if (RunBootstrapping(env).IsEmpty()) {
+  if (env->RunBootstrapping().IsEmpty()) {
     return nullptr;
   }
 

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -244,11 +244,12 @@ Environment* CreateEnvironment(IsolateData* isolate_data,
   Environment* env = new Environment(
       isolate_data,
       context,
+      args,
+      exec_args,
       static_cast<Environment::Flags>(Environment::kIsMainThread |
                                       Environment::kOwnsProcessState |
                                       Environment::kOwnsInspector));
   env->InitializeLibuv(per_process::v8_is_profiling);
-  env->ProcessCliArgs(args, exec_args);
   if (RunBootstrapping(env).IsEmpty()) {
     return nullptr;
   }

--- a/src/env.cc
+++ b/src/env.cc
@@ -236,6 +236,8 @@ uint64_t Environment::AllocateThreadId() {
 
 Environment::Environment(IsolateData* isolate_data,
                          Local<Context> context,
+                         const std::vector<std::string>& args,
+                         const std::vector<std::string>& exec_args,
                          Flags flags,
                          uint64_t thread_id)
     : isolate_(context->GetIsolate()),
@@ -243,6 +245,8 @@ Environment::Environment(IsolateData* isolate_data,
       immediate_info_(context->GetIsolate()),
       tick_info_(context->GetIsolate()),
       timer_base_(uv_now(isolate_data->event_loop())),
+      exec_argv_(exec_args),
+      argv_(args),
       should_abort_on_uncaught_toggle_(isolate_, 1),
       stream_base_state_(isolate_, StreamBase::kNumStreamBaseStateFields),
       flags_(flags),
@@ -305,6 +309,22 @@ Environment::Environment(IsolateData* isolate_data,
       performance::NODE_PERFORMANCE_MILESTONE_V8_START,
       performance::performance_v8_start);
 
+  if (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
+          TRACING_CATEGORY_NODE1(environment)) != 0) {
+    auto traced_value = tracing::TracedValue::Create();
+    traced_value->BeginArray("args");
+    for (const std::string& arg : args) traced_value->AppendString(arg);
+    traced_value->EndArray();
+    traced_value->BeginArray("exec_args");
+    for (const std::string& arg : exec_args) traced_value->AppendString(arg);
+    traced_value->EndArray();
+    TRACE_EVENT_NESTABLE_ASYNC_BEGIN1(TRACING_CATEGORY_NODE1(environment),
+                                      "Environment",
+                                      this,
+                                      "args",
+                                      std::move(traced_value));
+  }
+
   // By default, always abort when --abort-on-uncaught-exception was passed.
   should_abort_on_uncaught_toggle_[0] = 1;
 
@@ -317,6 +337,8 @@ Environment::Environment(IsolateData* isolate_data,
   if (options_->no_force_async_hooks_checks) {
     async_hooks_.no_force_checks();
   }
+
+  set_process_object(node::CreateProcessObject(this).ToLocalChecked());
 }
 
 CompileFnEntry::CompileFnEntry(Environment* env, uint32_t id)
@@ -431,35 +453,6 @@ void Environment::ExitEnv() {
   set_can_call_into_js(false);
   thread_stopper()->Stop();
   isolate_->TerminateExecution();
-}
-
-MaybeLocal<Object> Environment::ProcessCliArgs(
-    const std::vector<std::string>& args,
-    const std::vector<std::string>& exec_args) {
-  argv_ = args;
-  exec_argv_ = exec_args;
-
-  if (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
-          TRACING_CATEGORY_NODE1(environment)) != 0) {
-    auto traced_value = tracing::TracedValue::Create();
-    traced_value->BeginArray("args");
-    for (const std::string& arg : args) traced_value->AppendString(arg);
-    traced_value->EndArray();
-    traced_value->BeginArray("exec_args");
-    for (const std::string& arg : exec_args) traced_value->AppendString(arg);
-    traced_value->EndArray();
-    TRACE_EVENT_NESTABLE_ASYNC_BEGIN1(TRACING_CATEGORY_NODE1(environment),
-                                      "Environment",
-                                      this,
-                                      "args",
-                                      std::move(traced_value));
-  }
-
-  Local<Object> process_object =
-      node::CreateProcessObject(this, args, exec_args)
-          .FromMaybe(Local<Object>());
-  set_process_object(process_object);
-  return process_object;
 }
 
 void Environment::RegisterHandleCleanups() {

--- a/src/env.cc
+++ b/src/env.cc
@@ -234,6 +234,32 @@ uint64_t Environment::AllocateThreadId() {
   return next_thread_id++;
 }
 
+void Environment::CreateProperties() {
+  HandleScope handle_scope(isolate_);
+  Local<Context> ctx = context();
+  Local<FunctionTemplate> templ = FunctionTemplate::New(isolate());
+  templ->InstanceTemplate()->SetInternalFieldCount(1);
+  Local<Object> obj = templ->GetFunction(ctx)
+                          .ToLocalChecked()
+                          ->NewInstance(ctx)
+                          .ToLocalChecked();
+  obj->SetAlignedPointerInInternalField(0, this);
+  set_as_callback_data(obj);
+  set_as_callback_data_template(templ);
+
+  // Store primordials setup by the per-context script in the environment.
+  Local<Object> per_context_bindings =
+      GetPerContextExports(ctx).ToLocalChecked();
+  Local<Value> primordials =
+      per_context_bindings->Get(ctx, primordials_string()).ToLocalChecked();
+  CHECK(primordials->IsObject());
+  set_primordials(primordials.As<Object>());
+
+  Local<Object> process_object =
+      node::CreateProcessObject(this).FromMaybe(Local<Object>());
+  set_process_object(process_object);
+}
+
 Environment::Environment(IsolateData* isolate_data,
                          Local<Context> context,
                          const std::vector<std::string>& args,
@@ -257,16 +283,6 @@ Environment::Environment(IsolateData* isolate_data,
   // We'll be creating new objects so make sure we've entered the context.
   HandleScope handle_scope(isolate());
   Context::Scope context_scope(context);
-  {
-    Local<FunctionTemplate> templ = FunctionTemplate::New(isolate());
-    templ->InstanceTemplate()->SetInternalFieldCount(1);
-    Local<Object> obj =
-        templ->GetFunction(context).ToLocalChecked()->NewInstance(
-            context).ToLocalChecked();
-    obj->SetAlignedPointerInInternalField(0, this);
-    set_as_callback_data(obj);
-    set_as_callback_data_template(templ);
-  }
 
   set_env_vars(per_process::system_environment);
 
@@ -338,7 +354,9 @@ Environment::Environment(IsolateData* isolate_data,
     async_hooks_.no_force_checks();
   }
 
-  set_process_object(node::CreateProcessObject(this).ToLocalChecked());
+  // TODO(joyeecheung): deserialize when the snapshot cover the environment
+  // properties.
+  CreateProperties();
 }
 
 CompileFnEntry::CompileFnEntry(Environment* env, uint32_t id)

--- a/src/env.cc
+++ b/src/env.cc
@@ -348,8 +348,6 @@ Environment::Environment(IsolateData* isolate_data,
   credentials::SafeGetenv("NODE_DEBUG_NATIVE", &debug_cats, this);
   set_debug_categories(debug_cats, true);
 
-  isolate()->GetHeapProfiler()->AddBuildEmbedderGraphCallback(
-      BuildEmbedderGraph, this);
   if (options_->no_force_async_hooks_checks) {
     async_hooks_.no_force_checks();
   }

--- a/src/env.cc
+++ b/src/env.cc
@@ -352,7 +352,7 @@ Environment::Environment(IsolateData* isolate_data,
     async_hooks_.no_force_checks();
   }
 
-  // TODO(joyeecheung): deserialize when the snapshot cover the environment
+  // TODO(joyeecheung): deserialize when the snapshot covers the environment
   // properties.
   CreateProperties();
 }

--- a/src/env.h
+++ b/src/env.h
@@ -806,6 +806,10 @@ class Environment : public MemoryRetainer {
 #endif
   void InitializeDiagnostics();
 
+  v8::MaybeLocal<v8::Value> BootstrapInternalLoaders();
+  v8::MaybeLocal<v8::Value> BootstrapNode();
+  v8::MaybeLocal<v8::Value> RunBootstrapping();
+
   inline size_t async_callback_scope_depth() const;
   inline void PushAsyncCallbackScope();
   inline void PopAsyncCallbackScope();

--- a/src/env.h
+++ b/src/env.h
@@ -799,12 +799,13 @@ class Environment : public MemoryRetainer {
   void MemoryInfo(MemoryTracker* tracker) const override;
 
   void CreateProperties();
+  // Should be called before InitializeInspector()
+  void InitializeDiagnostics();
 #if HAVE_INSPECTOR && NODE_USE_V8_PLATFORM
   // If the environment is created for a worker, pass parent_handle and
   // the ownership if transferred into the Environment.
   int InitializeInspector(inspector::ParentInspectorHandle* parent_handle);
 #endif
-  void InitializeDiagnostics();
 
   v8::MaybeLocal<v8::Value> BootstrapInternalLoaders();
   v8::MaybeLocal<v8::Value> BootstrapNode();

--- a/src/env.h
+++ b/src/env.h
@@ -821,14 +821,13 @@ class Environment : public MemoryRetainer {
 
   Environment(IsolateData* isolate_data,
               v8::Local<v8::Context> context,
+              const std::vector<std::string>& args,
+              const std::vector<std::string>& exec_args,
               Flags flags = Flags(),
               uint64_t thread_id = kNoThreadId);
   ~Environment();
 
   void InitializeLibuv(bool start_profiler_idle_notifier);
-  v8::MaybeLocal<v8::Object> ProcessCliArgs(
-      const std::vector<std::string>& args,
-      const std::vector<std::string>& exec_args);
   inline const std::vector<std::string>& exec_argv();
   inline const std::vector<std::string>& argv();
 

--- a/src/env.h
+++ b/src/env.h
@@ -794,6 +794,8 @@ class Environment : public MemoryRetainer {
   bool IsRootNode() const override { return true; }
   void MemoryInfo(MemoryTracker* tracker) const override;
 
+  void CreateProperties();
+
   inline size_t async_callback_scope_depth() const;
   inline void PushAsyncCallbackScope();
   inline void PopAsyncCallbackScope();

--- a/src/env.h
+++ b/src/env.h
@@ -74,6 +74,10 @@ namespace profiler {
 class V8CoverageConnection;
 class V8CpuProfilerConnection;
 }  // namespace profiler
+
+namespace inspector {
+class ParentInspectorHandle;
+}
 #endif  // HAVE_INSPECTOR
 
 namespace worker {
@@ -795,6 +799,12 @@ class Environment : public MemoryRetainer {
   void MemoryInfo(MemoryTracker* tracker) const override;
 
   void CreateProperties();
+#if HAVE_INSPECTOR && NODE_USE_V8_PLATFORM
+  // If the environment is created for a worker, pass parent_handle and
+  // the ownership if transferred into the Environment.
+  int InitializeInspector(inspector::ParentInspectorHandle* parent_handle);
+#endif
+  void InitializeDiagnostics();
 
   inline size_t async_callback_scope_depth() const;
   inline void PushAsyncCallbackScope();

--- a/src/inspector/worker_inspector.h
+++ b/src/inspector/worker_inspector.h
@@ -60,6 +60,7 @@ class ParentInspectorHandle {
   bool WaitForConnect() {
     return wait_;
   }
+  const std::string& url() const { return url_; }
 
  private:
   int id_;

--- a/src/node.cc
+++ b/src/node.cc
@@ -261,17 +261,6 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
   global->Set(context, FIXED_ONE_BYTE_STRING(env->isolate(), "global"), global)
       .Check();
 
-  // Store primordials setup by the per-context script in the environment.
-  Local<Object> per_context_bindings;
-  Local<Value> primordials;
-  if (!GetPerContextExports(context).ToLocal(&per_context_bindings) ||
-      !per_context_bindings->Get(context, env->primordials_string())
-           .ToLocal(&primordials) ||
-      !primordials->IsObject()) {
-    return MaybeLocal<Value>();
-  }
-  env->set_primordials(primordials.As<Object>());
-
 #if HAVE_INSPECTOR
   if (env->options()->debug_options().break_node_first_line) {
     env->inspector_agent()->PauseOnNextJavascriptStatement(

--- a/src/node.cc
+++ b/src/node.cc
@@ -46,6 +46,7 @@
 #endif
 
 #if HAVE_INSPECTOR
+#include "inspector_agent.h"
 #include "inspector_io.h"
 #endif
 
@@ -57,6 +58,10 @@
 #include "libplatform/libplatform.h"
 #endif  // NODE_USE_V8_PLATFORM
 #include "v8-profiler.h"
+
+#if HAVE_INSPECTOR
+#include "inspector/worker_inspector.h"  // ParentInspectorHandle
+#endif
 
 #ifdef NODE_ENABLE_VTUNE_PROFILING
 #include "../deps/v8/src/third_party/vtune/v8-vtune.h"
@@ -135,7 +140,6 @@ using v8::Local;
 using v8::Maybe;
 using v8::MaybeLocal;
 using v8::Object;
-using v8::Script;
 using v8::String;
 using v8::Undefined;
 using v8::V8;
@@ -234,6 +238,50 @@ MaybeLocal<Value> ExecuteBootstrapper(Environment* env,
   return scope.EscapeMaybe(result);
 }
 
+#if HAVE_INSPECTOR && NODE_USE_V8_PLATFORM
+int Environment::InitializeInspector(
+    inspector::ParentInspectorHandle* parent_handle) {
+  std::string inspector_path;
+  if (parent_handle != nullptr) {
+    DCHECK(!is_main_thread());
+    inspector_path = parent_handle->url();
+    inspector_agent_->SetParentHandle(
+        std::unique_ptr<inspector::ParentInspectorHandle>(parent_handle));
+  } else {
+    inspector_path = argv_.size() > 1 ? argv_[1].c_str() : "";
+  }
+  CHECK(!inspector_agent_->IsListening());
+  // Inspector agent can't fail to start, but if it was configured to listen
+  // right away on the websocket port and fails to bind/etc, this will return
+  // false.
+  inspector_agent_->Start(inspector_path,
+                          options_->debug_options(),
+                          inspector_host_port(),
+                          is_main_thread());
+  if (options_->debug_options().inspector_enabled &&
+      !inspector_agent_->IsListening()) {
+    return 12;  // Signal internal error
+  }
+
+  profiler::StartProfilers(this);
+
+  if (options_->debug_options().break_node_first_line) {
+    inspector_agent_->PauseOnNextJavascriptStatement("Break at bootstrap");
+  }
+
+  return 0;
+}
+#endif  // HAVE_INSPECTOR && NODE_USE_V8_PLATFORM
+
+void Environment::InitializeDiagnostics() {
+  isolate_->GetHeapProfiler()->AddBuildEmbedderGraphCallback(
+      Environment::BuildEmbedderGraph, this);
+
+#if defined HAVE_DTRACE || defined HAVE_ETW
+  InitDTrace(this);
+#endif
+}
+
 MaybeLocal<Value> RunBootstrapping(Environment* env) {
   CHECK(!env->has_run_bootstrapping_code());
 
@@ -241,17 +289,9 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
   Isolate* isolate = env->isolate();
   Local<Context> context = env->context();
 
-#if HAVE_INSPECTOR
-  profiler::StartProfilers(env);
-#endif  // HAVE_INSPECTOR
 
   // Add a reference to the global object
   Local<Object> global = context->Global();
-
-#if defined HAVE_DTRACE || defined HAVE_ETW
-  InitDTrace(env);
-#endif
-
   Local<Object> process = env->process_object();
 
   // Setting global properties for the bootstrappers to use:
@@ -261,12 +301,6 @@ MaybeLocal<Value> RunBootstrapping(Environment* env) {
   global->Set(context, FIXED_ONE_BYTE_STRING(env->isolate(), "global"), global)
       .Check();
 
-#if HAVE_INSPECTOR
-  if (env->options()->debug_options().break_node_first_line) {
-    env->inspector_agent()->PauseOnNextJavascriptStatement(
-        "Break at bootstrap");
-  }
-#endif  // HAVE_INSPECTOR
 
   // Create binding loaders
   std::vector<Local<String>> loaders_params = {

--- a/src/node.cc
+++ b/src/node.cc
@@ -249,6 +249,7 @@ int Environment::InitializeInspector(
   } else {
     inspector_path = argv_.size() > 1 ? argv_[1].c_str() : "";
   }
+
   CHECK(!inspector_agent_->IsListening());
   // Inspector agent can't fail to start, but if it was configured to listen
   // right away on the websocket port and fails to bind/etc, this will return

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -296,7 +296,6 @@ void DefineZlibConstants(v8::Local<v8::Object> target);
 v8::Isolate* NewIsolate(v8::Isolate::CreateParams* params,
                         uv_loop_t* event_loop,
                         MultiIsolatePlatform* platform);
-v8::MaybeLocal<v8::Value> RunBootstrapping(Environment* env);
 v8::MaybeLocal<v8::Value> StartExecution(Environment* env,
                                          const char* main_script_id);
 v8::MaybeLocal<v8::Object> GetPerContextExports(v8::Local<v8::Context> context);

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -205,7 +205,7 @@ std::unique_ptr<Environment> NodeMainInstance::CreateMainEnvironment(
   }
 
   env->InitializeDiagnostics();
-  if (RunBootstrapping(env.get()).IsEmpty()) {
+  if (env->RunBootstrapping().IsEmpty()) {
     *exit_code = 1;
   }
 

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -188,11 +188,12 @@ std::unique_ptr<Environment> NodeMainInstance::CreateMainEnvironment(
   std::unique_ptr<Environment> env = std::make_unique<Environment>(
       isolate_data_.get(),
       context,
+      args_,
+      exec_args_,
       static_cast<Environment::Flags>(Environment::kIsMainThread |
                                       Environment::kOwnsProcessState |
                                       Environment::kOwnsInspector));
   env->InitializeLibuv(per_process::v8_is_profiling);
-  env->ProcessCliArgs(args_, exec_args_);
 
 #if HAVE_INSPECTOR && NODE_USE_V8_PLATFORM
   CHECK(!env->inspector_agent()->IsListening());

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -195,27 +195,16 @@ std::unique_ptr<Environment> NodeMainInstance::CreateMainEnvironment(
                                       Environment::kOwnsInspector));
   env->InitializeLibuv(per_process::v8_is_profiling);
 
+  // TODO(joyeecheung): when we snapshot the bootstrapped context,
+  // the inspector and diagnostics setup should after after deserialization.
 #if HAVE_INSPECTOR && NODE_USE_V8_PLATFORM
-  CHECK(!env->inspector_agent()->IsListening());
-  // Inspector agent can't fail to start, but if it was configured to listen
-  // right away on the websocket port and fails to bind/etc, this will return
-  // false.
-  env->inspector_agent()->Start(args_.size() > 1 ? args_[1].c_str() : "",
-                                env->options()->debug_options(),
-                                env->inspector_host_port(),
-                                true);
-  if (env->options()->debug_options().inspector_enabled &&
-      !env->inspector_agent()->IsListening()) {
-    *exit_code = 12;  // Signal internal error.
+  *exit_code = env->InitializeInspector(nullptr);
+#endif
+  if (*exit_code != 0) {
     return env;
   }
-#else
-  // inspector_enabled can't be true if !HAVE_INSPECTOR or
-  // !NODE_USE_V8_PLATFORM
-  // - the option parser should not allow that.
-  CHECK(!env->options()->debug_options().inspector_enabled);
-#endif  // HAVE_INSPECTOR && NODE_USE_V8_PLATFORM
 
+  env->InitializeDiagnostics();
   if (RunBootstrapping(env.get()).IsEmpty()) {
     *exit_code = 1;
   }

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -194,6 +194,7 @@ std::unique_ptr<Environment> NodeMainInstance::CreateMainEnvironment(
                                       Environment::kOwnsProcessState |
                                       Environment::kOwnsInspector));
   env->InitializeLibuv(per_process::v8_is_profiling);
+  env->InitializeDiagnostics();
 
   // TODO(joyeecheung): when we snapshot the bootstrapped context,
   // the inspector and diagnostics setup should after after deserialization.
@@ -204,7 +205,6 @@ std::unique_ptr<Environment> NodeMainInstance::CreateMainEnvironment(
     return env;
   }
 
-  env->InitializeDiagnostics();
   if (env->RunBootstrapping().IsEmpty()) {
     *exit_code = 1;
   }

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -31,10 +31,7 @@ v8::Maybe<bool> ProcessEmitDeprecationWarning(Environment* env,
                                               const char* warning,
                                               const char* deprecation_code);
 
-v8::MaybeLocal<v8::Object> CreateProcessObject(
-    Environment* env,
-    const std::vector<std::string>& args,
-    const std::vector<std::string>& exec_args);
+v8::MaybeLocal<v8::Object> CreateProcessObject(Environment* env);
 void PatchProcessObject(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 namespace task_queue {

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -68,10 +68,7 @@ static void GetParentProcessId(Local<Name> property,
   info.GetReturnValue().Set(uv_os_getppid());
 }
 
-MaybeLocal<Object> CreateProcessObject(
-    Environment* env,
-    const std::vector<std::string>& args,
-    const std::vector<std::string>& exec_args) {
+MaybeLocal<Object> CreateProcessObject(Environment* env) {
   Isolate* isolate = env->isolate();
   EscapableHandleScope scope(isolate);
   Local<Context> context = env->context();

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -271,7 +271,7 @@ void Worker::Run() {
         HandleScope handle_scope(isolate_);
         AsyncCallbackScope callback_scope(env_.get());
         env_->async_hooks()->push_async_ids(1, 0);
-        if (!RunBootstrapping(env_.get()).IsEmpty()) {
+        if (!env_->RunBootstrapping().IsEmpty()) {
           CreateEnvMessagePort(env_.get());
           if (is_stopped()) return;
           Debug(this, "Created message port for worker %llu", thread_id_);

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -58,7 +58,6 @@ Worker::Worker(Environment* env,
       per_isolate_opts_(per_isolate_opts),
       exec_argv_(exec_argv),
       platform_(env->isolate_data()->platform()),
-      // XXX(joyeecheung): should this be per_process::v8_is_profiling instead?
       start_profiler_idle_notifier_(env->profiler_idle_notifier_started()),
       thread_id_(Environment::AllocateThreadId()),
       env_vars_(env->env_vars()) {
@@ -263,11 +262,11 @@ void Worker::Run() {
       Debug(this, "Created Environment for worker with id %llu", thread_id_);
       if (is_stopped()) return;
       {
+        env_->InitializeDiagnostics();
 #if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
         env_->InitializeInspector(inspector_parent_handle_.release());
         inspector_started = true;
 #endif
-        env_->InitializeDiagnostics();
         HandleScope handle_scope(isolate_);
         AsyncCallbackScope callback_scope(env_.get());
         env_->async_hooks()->push_async_ids(1, 0);

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -255,6 +255,8 @@ void Worker::Run() {
         // public API.
         env_.reset(new Environment(data.isolate_data_.get(),
                                    context,
+                                   std::move(argv_),
+                                   std::move(exec_argv_),
                                    Environment::kNoFlags,
                                    thread_id_));
         CHECK_NOT_NULL(env_);
@@ -263,7 +265,6 @@ void Worker::Run() {
         env_->set_worker_context(this);
 
         env_->InitializeLibuv(profiler_idle_notifier_started_);
-        env_->ProcessCliArgs(std::move(argv_), std::move(exec_argv_));
       }
       {
         Mutex::ScopedLock lock(mutex_);

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -54,7 +54,6 @@ class Worker : public AsyncWrap {
  private:
   void OnThreadStopped();
   void CreateEnvMessagePort(Environment* env);
-  const std::string url_;
 
   std::shared_ptr<PerIsolateOptions> per_isolate_opts_;
   std::vector<std::string> exec_argv_;
@@ -62,7 +61,7 @@ class Worker : public AsyncWrap {
 
   MultiIsolatePlatform* platform_;
   v8::Isolate* isolate_ = nullptr;
-  bool profiler_idle_notifier_started_;
+  bool start_profiler_idle_notifier_;
   uv_thread_t tid_;
 
 #if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR


### PR DESCRIPTION
This patch reorganizes the bootstrap process so it's easier
to snapshot it incrementally.

#### src: inline ProcessCliArgs in the Environment constructor

Inline `ProcessCliArgs()` in the `Environment` constructor, and
emit the `Environment` creation trace events with the arguments
earlier. Remove the unused arguments passed to `CreateProcessObject()`
since these are now attached to process in `PatchProcessObject()`
during pre-execution instead.

#### src: create Environment properties in Environment::CreateProperties()

Move creation of `env->as_callback_data()`, `env->primordials()`
and `env->process()` into `Environment::CreateProperties()` and
call it in the `Environment` constructor - this can be replaced with
deserialization when we snapshot the per-environment properties
after the instantiation of `Environment`.

#### src: reorganize inspector and diagnostics initialization

- Split the initialization of the inspector and other diagnostics
  into `Environment::InitializeInspector()` and
  `Environment::InitializeDiagnostics()` - these need to be
  reinitialized separately after snapshot deserialization.
- Do not store worker url alongside the inspector parent handle,
  instead just get it from the handle.
- Rename `Worker::profiler_idle_notifier_started_` to
  `Worker::start_profiler_idle_notifier_` because it stores
  the state inherited from the parent env to use for initializing
  itself.

#### src: Split `RunBootstrapping()`

Split `RunBootstrapping()` into `BootstrapInternalLoaders()`
and `BootstrapNode()` from so the two can be snapshotted
incrementally.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
