### PR TITLE
deps: make VC-WIN config generation deterministic

### DIFF
--- a/deps/openssl/config/Makefile_VC-WIN32
+++ b/deps/openssl/config/Makefile_VC-WIN32
@@ -5678,8 +5678,10 @@ engines/padlock-dso-e_padlock.obj: engines/padlock-dso-e_padlock.d
 engines/padlock.def: util/engines.num  util/mkdef.pl
 	$(PERL) util/mkdef.pl --ordinals util/engines.num --name padlock --OS windows > engines/padlock.def
 
-distclean:
+clean:
+	$(RM) $(GENERATED_MANDATORY)
 	$(RM) $(GENERATED)
+distclean:
 	$(RM) configdata.pm
 	$(RM) makefile
 	$(RM) NUL

--- a/deps/openssl/config/Makefile_VC-WIN64-ARM
+++ b/deps/openssl/config/Makefile_VC-WIN64-ARM
@@ -17,6 +17,7 @@ MINOR=1.1
 SHLIB_VERSION_NUMBER=1.1
 
 GENERATED_MANDATORY=crypto/include/internal/bn_conf.h crypto/include/internal/dso_conf.h include/openssl/opensslconf.h
+GENERATED=crypto/buildinf.h apps/progs.h
 
 INSTALL_LIBS="libcrypto.lib" "libssl.lib"
 INSTALL_SHLIBS="libcrypto-1_1-arm64.dll" "libssl-1_1-arm64.dll"
@@ -141,7 +142,9 @@ include/openssl/opensslconf.h:
 	"$(PERL)" "-I$(BLDDIR)" -Mconfigdata "util/dofile.pl" \
 	    "-omakefile" "include/openssl/opensslconf.h.in" > $@
 
-distclean:
+clean:
+	$(RM) $(GENERATED_MANDATORY)
 	$(RM) $(GENERATED)
+distclean:
 	$(RM) /Q /F configdata.pm
 	$(RM) /Q /F makefile

--- a/deps/openssl/config/Makefile_VC-WIN64A
+++ b/deps/openssl/config/Makefile_VC-WIN64A
@@ -2950,7 +2950,9 @@ engines/e_padlock.d: "engines/e_padlock.c"
 engines/e_padlock.obj: engines/e_padlock.d
 	$(CC)  $(DSO_CFLAGS) /I "include" $(DSO_CPPFLAGS) -c $(COUTFLAG)$@ "engines/e_padlock.c"
 
-distclean:
+clean:
+	$(RM) $(GENERATED_MANDATORY)
 	$(RM) $(GENERATED)
+distclean:
 	$(RM) /Q /F configdata.pm
 	$(RM) /Q /F makefile

--- a/deps/openssl/config/generate_gypi.pl
+++ b/deps/openssl/config/generate_gypi.pl
@@ -46,7 +46,7 @@ my $makefile = $is_win ? "../config/Makefile_$arch": "Makefile";
 # Generate arch dependent header files with Makefile
 my $buildinf = "crypto/buildinf.h";
 my $progs = "apps/progs.h";
-my $cmd1 = "cd ../openssl; make -f $makefile build_generated $buildinf $progs;";
+my $cmd1 = "cd ../openssl; make -f $makefile clean build_generated $buildinf $progs;";
 system($cmd1) == 0 or die "Error in system($cmd1)";
 
 # Copy and move all arch dependent header files into config/archs


### PR DESCRIPTION
This change adds a clean target to the VC-WIN* Makefiles, then adjusts
the config generation script to call it before config file generation
as well as after. This prevents files from previous configurations from
causing make to incorrectly assume the files are up to date.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
