### PR TITLE
tools: fix node-core/required-modules eslint rule

### DIFF
--- a/test/es-module/test-esm-basic-imports.mjs
+++ b/test/es-module/test-esm-basic-imports.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 import assert from 'assert';
 import ok from '../fixtures/es-modules/test-esm-ok.mjs';

--- a/test/es-module/test-esm-cyclic-dynamic-import.mjs
+++ b/test/es-module/test-esm-cyclic-dynamic-import.mjs
@@ -1,4 +1,3 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 import('./test-esm-cyclic-dynamic-import.mjs');

--- a/test/es-module/test-esm-double-encoding.mjs
+++ b/test/es-module/test-esm-double-encoding.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 
 // Assert we can import files with `%` in their pathname.

--- a/test/es-module/test-esm-encoded-path.mjs
+++ b/test/es-module/test-esm-encoded-path.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 import assert from 'assert';
 // ./test-esm-ok.mjs

--- a/test/es-module/test-esm-forbidden-globals.mjs
+++ b/test/es-module/test-esm-forbidden-globals.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 
 // eslint-disable-next-line no-undef

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -1,6 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
-
 import '../common/index.mjs';
 import assert from 'assert';
 

--- a/test/es-module/test-esm-json-cache.mjs
+++ b/test/es-module/test-esm-json-cache.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules --experimental-json-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 
 import { strictEqual, deepStrictEqual } from 'assert';

--- a/test/es-module/test-esm-json.mjs
+++ b/test/es-module/test-esm-json.mjs
@@ -1,6 +1,4 @@
 // Flags: --experimental-modules --experimental-json-modules
-/* eslint-disable node-core/required-modules */
-
 import '../common/index.mjs';
 import { strictEqual } from 'assert';
 

--- a/test/es-module/test-esm-live-binding.mjs
+++ b/test/es-module/test-esm-live-binding.mjs
@@ -1,6 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
-
 import '../common/index.mjs';
 import assert from 'assert';
 

--- a/test/es-module/test-esm-loader-invalid-format.mjs
+++ b/test/es-module/test-esm-loader-invalid-format.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-invalid-format.mjs
-/* eslint-disable node-core/required-modules */
 import { expectsError, mustCall } from '../common/index.mjs';
 import assert from 'assert';
 

--- a/test/es-module/test-esm-loader-invalid-url.mjs
+++ b/test/es-module/test-esm-loader-invalid-url.mjs
@@ -1,6 +1,4 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-invalid-url.mjs
-/* eslint-disable node-core/required-modules */
-
 import { expectsError, mustCall } from '../common/index.mjs';
 import assert from 'assert';
 

--- a/test/es-module/test-esm-loader-missing-dynamic-instantiate-hook.mjs
+++ b/test/es-module/test-esm-loader-missing-dynamic-instantiate-hook.mjs
@@ -1,6 +1,4 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/missing-dynamic-instantiate-hook.mjs
-/* eslint-disable node-core/required-modules */
-
 import { expectsError } from '../common/index.mjs';
 
 import('test').catch(expectsError({

--- a/test/es-module/test-esm-main-lookup.mjs
+++ b/test/es-module/test-esm-main-lookup.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 import assert from 'assert';
 

--- a/test/es-module/test-esm-named-exports.mjs
+++ b/test/es-module/test-esm-named-exports.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 import { readFile } from 'fs';
 import assert from 'assert';

--- a/test/es-module/test-esm-namespace.mjs
+++ b/test/es-module/test-esm-namespace.mjs
@@ -1,6 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
-
 import '../common/index.mjs';
 import * as fs from 'fs';
 import assert from 'assert';

--- a/test/es-module/test-esm-process.mjs
+++ b/test/es-module/test-esm-process.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 import assert from 'assert';
 import process from 'process';

--- a/test/es-module/test-esm-require-cache.mjs
+++ b/test/es-module/test-esm-require-cache.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
 import { createRequire } from '../common/index.mjs';
 import assert from 'assert';
 //

--- a/test/es-module/test-esm-shared-loader-dep.mjs
+++ b/test/es-module/test-esm-shared-loader-dep.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-shared-dep.mjs
-/* eslint-disable node-core/required-modules */
 import { createRequire } from '../common/index.mjs';
 
 import assert from 'assert';

--- a/test/es-module/test-esm-shebang.mjs
+++ b/test/es-module/test-esm-shebang.mjs
@@ -1,6 +1,5 @@
 #! }]) // isn't js
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 
 const isJs = true;

--- a/test/es-module/test-esm-snapshot.mjs
+++ b/test/es-module/test-esm-snapshot.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 import '../fixtures/es-modules/esm-snapshot-mutator.js';
 import one from '../fixtures/es-modules/esm-snapshot.js';

--- a/test/es-module/test-esm-throw-undefined.mjs
+++ b/test/es-module/test-esm-throw-undefined.mjs
@@ -1,6 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
-
 import '../common/index.mjs';
 import assert from 'assert';
 

--- a/test/es-module/test-esm-type-flag.mjs
+++ b/test/es-module/test-esm-type-flag.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
 import cjs from '../fixtures/baz.js';
 import '../common/index.mjs';
 import { message } from '../fixtures/es-modules/message.mjs';

--- a/test/message/async_error_sync_esm.mjs
+++ b/test/message/async_error_sync_esm.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 import four from '../fixtures/async-error.js';
 

--- a/test/message/async_error_sync_esm.out
+++ b/test/message/async_error_sync_esm.out
@@ -4,4 +4,4 @@ Error: test
     at two (*fixtures*async-error.js:17:9)
     at async three (*fixtures*async-error.js:20:3)
     at async four (*fixtures*async-error.js:24:3)
-    at async main (*message*async_error_sync_esm.mjs:8:5)
+    at async main (*message*async_error_sync_esm.mjs:7:5)

--- a/test/message/esm_display_syntax_error_import.mjs
+++ b/test/message/esm_display_syntax_error_import.mjs
@@ -1,5 +1,5 @@
 // Flags:  --experimental-modules
-/* eslint-disable no-unused-vars, node-core/required-modules */
+/* eslint-disable no-unused-vars */
 import '../common/index.mjs';
 import {
   foo,

--- a/test/message/esm_display_syntax_error_import_module.mjs
+++ b/test/message/esm_display_syntax_error_import_module.mjs
@@ -1,4 +1,3 @@
 // Flags:  --experimental-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 import '../fixtures/es-module-loaders/syntax-error-import.mjs';

--- a/test/message/esm_display_syntax_error_module.mjs
+++ b/test/message/esm_display_syntax_error_module.mjs
@@ -1,4 +1,3 @@
 // Flags:  --experimental-modules
-/* eslint-disable node-core/required-modules */
 import '../common/index.mjs';
 import '../fixtures/es-module-loaders/syntax-error.mjs';

--- a/test/parallel/test-loaders-unknown-builtin-module.mjs
+++ b/test/parallel/test-loaders-unknown-builtin-module.mjs
@@ -1,5 +1,4 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-unknown-builtin-module.mjs
-/* eslint-disable node-core/required-modules */
 import { expectsError, mustCall } from '../common/index.mjs';
 import assert from 'assert';
 

--- a/tools/eslint-rules/required-modules.js
+++ b/tools/eslint-rules/required-modules.js
@@ -46,6 +46,10 @@ module.exports = function(context) {
    * @returns {undefined|String} required module name or undefined
    */
   function getRequiredModuleName(str) {
+    if (str === '../common/index.mjs') {
+      return 'common';
+    }
+
     const value = path.basename(str);
 
     // Check if value is in required modules array


### PR DESCRIPTION
Make the node-core/required-modules eslint rule smart enough
to recognize that `import '../common/index.mjs'` in ESM files
imports the mandatory 'common' module.