### PR TITLE
test: refactor test-tls-enable-trace-cli.js

### DIFF
--- a/test/parallel/test-tls-enable-trace-cli.js
+++ b/test/parallel/test-tls-enable-trace-cli.js
@@ -55,7 +55,13 @@ function test() {
       key: keys.agent6.key
     },
   }, common.mustCall((err, pair, cleanup) => {
-    assert.ifError(err);
+    if (err) {
+      console.error(err);
+      console.error(err.opensslErrorStack);
+      console.error(err.reason);
+      assert(err);
+    }
+
     return cleanup();
   }));
 }

--- a/test/parallel/test-tls-enable-trace-cli.js
+++ b/test/parallel/test-tls-enable-trace-cli.js
@@ -55,6 +55,7 @@ function test() {
       key: keys.agent6.key
     },
   }, common.mustCall((err, pair, cleanup) => {
+    assert.ifError(err);
     return cleanup();
   }));
 }

--- a/test/parallel/test-tls-enable-trace-cli.js
+++ b/test/parallel/test-tls-enable-trace-cli.js
@@ -22,21 +22,22 @@ const child = fork(__filename, ['test'], {
   execArgv: ['--trace-tls']
 });
 
+let stdout = '';
 let stderr = '';
+child.stdout.setEncoding('utf8');
 child.stderr.setEncoding('utf8');
+child.stdout.on('data', (data) => stdout += data);
 child.stderr.on('data', (data) => stderr += data);
-child.on('close', common.mustCall(() => {
+child.on('close', common.mustCall((code, signal) => {
+  // For debugging and observation of actual trace output.
+  console.log(stderr);
+
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+  assert.strictEqual(stdout.trim(), '');
   assert(/Warning: Enabling --trace-tls can expose sensitive/.test(stderr));
   assert(/Received Record/.test(stderr));
   assert(/ClientHello/.test(stderr));
-}));
-
-// For debugging and observation of actual trace output.
-child.stderr.pipe(process.stderr);
-child.stdout.pipe(process.stdout);
-
-child.on('exit', common.mustCall((code) => {
-  assert.strictEqual(code, 0);
 }));
 
 function test() {


### PR DESCRIPTION
This test appears to be flakey on Unix. I'm not entirely sure why, but I think it may be related to the additional piping of the child process stderr (although this test is mostly a copy of another test that isn't exhibiting problems). This commit simplifies the test a bit.

Some preliminary testing seems promising:

- node-test-commit: https://ci.nodejs.org/job/node-test-commit/28351/
- Re-run on Linux, even though no failures were seen on the previous run: https://ci.nodejs.org/job/node-test-commit-linux/27396/
- Stress test: https://ci.nodejs.org/job/node-stress-single-test/2205/

If the stress test comes back green, I'd recommend fast tracking this.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
