### PR TITLE
src: refactor deprecated UVException usage in pipe-wrap.cc

### DIFF
--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -41,6 +41,7 @@ using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Int32;
+using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
 using v8::Object;
@@ -216,8 +217,9 @@ void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
   int err = uv_pipe_open(&wrap->handle_, fd);
   wrap->set_fd(fd);
 
+  Isolate* isolate = env->isolate();
   if (err != 0)
-    env->isolate()->ThrowException(UVException(err, "uv_pipe_open"));
+    isolate->ThrowException(UVException(isolate, err, "uv_pipe_open"));
 }
 
 


### PR DESCRIPTION


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
