### PR TITLE
test: move dgram invalid host test to internet tests

### DIFF
--- a/test/internet/test-dgram-connect.js
+++ b/test/internet/test-dgram-connect.js
@@ -5,17 +5,15 @@ const { addresses } = require('../common/internet');
 const assert = require('assert');
 const dgram = require('dgram');
 
-const PORT = 12345;
-
 const client = dgram.createSocket('udp4');
-client.connect(PORT, addresses.INVALID_HOST, common.mustCall((err) => {
+client.connect(common.PORT, addresses.INVALID_HOST, common.mustCall((err) => {
   assert.ok(err.code === 'ENOTFOUND' || err.code === 'EAI_AGAIN');
 
   client.once('error', common.mustCall((err) => {
     assert.ok(err.code === 'ENOTFOUND' || err.code === 'EAI_AGAIN');
     client.once('connect', common.mustCall(() => client.close()));
-    client.connect(PORT);
+    client.connect(common.PORT);
   }));
 
-  client.connect(PORT, addresses.INVALID_HOST);
+  client.connect(common.PORT, addresses.INVALID_HOST);
 }));

--- a/test/internet/test-dgram-connect.js
+++ b/test/internet/test-dgram-connect.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const { addresses } = require('../common/internet');
+const assert = require('assert');
+const dgram = require('dgram');
+
+const PORT = 12345;
+
+const client = dgram.createSocket('udp4');
+client.connect(PORT, addresses.INVALID_HOST, common.mustCall((err) => {
+  assert.ok(err.code === 'ENOTFOUND' || err.code === 'EAI_AGAIN');
+
+  client.once('error', common.mustCall((err) => {
+    assert.ok(err.code === 'ENOTFOUND' || err.code === 'EAI_AGAIN');
+    client.once('connect', common.mustCall(() => client.close()));
+    client.connect(PORT);
+  }));
+
+  client.connect(PORT, addresses.INVALID_HOST);
+}));

--- a/test/parallel/test-dgram-connect.js
+++ b/test/parallel/test-dgram-connect.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const { addresses } = require('../common/internet');
 const assert = require('assert');
 const dgram = require('dgram');
 
@@ -36,17 +35,8 @@ client.connect(PORT, common.mustCall(() => {
     code: 'ERR_SOCKET_DGRAM_NOT_CONNECTED'
   });
 
-  client.connect(PORT, addresses.INVALID_HOST, common.mustCall((err) => {
-    assert.ok(err.code === 'ENOTFOUND' || err.code === 'EAI_AGAIN');
-
-    client.once('error', common.mustCall((err) => {
-      assert.ok(err.code === 'ENOTFOUND' || err.code === 'EAI_AGAIN');
-      client.once('connect', common.mustCall(() => client.close()));
-      client.connect(PORT);
-    }));
-
-    client.connect(PORT, addresses.INVALID_HOST);
-  }));
+  client.once('connect', common.mustCall(() => client.close()));
+  client.connect(PORT);
 }));
 
 assert.throws(() => {


### PR DESCRIPTION
This moves a dgram test from `parallel` to `internet` because it relies
on a DNS request.
In certain cases, ISPs hijack invalid IETF-reserved invalid names which
causes a false negative failure.

Fixes: https://github.com/nodejs/node/issues/27341

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
