### PR TITLE
test: fix flaky test-tls-multiple-cas-as-string

### DIFF
--- a/test/parallel/test-tls-multiple-cas-as-string.js
+++ b/test/parallel/test-tls-multiple-cas-as-string.js
@@ -15,26 +15,29 @@ const ca2 = fixtures.readKey('ca2-cert.pem', 'utf8');
 const cert = fixtures.readKey('agent3-cert.pem', 'utf8');
 const key = fixtures.readKey('agent3-key.pem', 'utf8');
 
-function test(ca, next) {
-  const server = tls.createServer({ ca, cert, key }, function(conn) {
-    this.close();
-    conn.end();
-  });
+function test(ca) {
+  const server = tls.createServer({ ca, cert, key });
 
   server.addContext('agent3', { ca, cert, key });
 
   const host = common.localhostIPv4;
-  server.listen(0, host, function() {
-    tls.connect({ servername: 'agent3', host, port: this.address().port, ca });
-  });
+  server.listen(0, host, common.mustCall(() => {
+    const socket = tls.connect({
+      servername: 'agent3',
+      host,
+      port: server.address().port,
+      ca
+    }, common.mustCall(() => {
+      socket.end();
+    }));
 
-  if (next) {
-    server.once('close', next);
-  }
+    socket.on('close', () => {
+      server.close();
+    });
+  }));
 }
 
 // `ca1` is not actually necessary for the certificate validation -- maybe
 // the fixtures should be written in a way that requires it?
-const array = [ca1, ca2];
-const string = `${ca1}\n${ca2}`;
-test(array, common.mustCall(() => test(string)));
+test([ca1, ca2]);
+test(`${ca1}\n${ca2}`);


### PR DESCRIPTION
The following error is emitted in a nondeterministic way on the server
side socket on macOS:

```
events.js:173
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:183:27)
Emitted 'error' event at:
    at emitErrorNT (internal/streams/destroy.js:91:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at processTicksAndRejections (internal/process/task_queues.js:84:9)
```

Prevent the error from being emitted by moving the `socket.end()` call
to the client. Also, run tests in parallel and use `common.mustCall()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
