### PR TITLE
repl: do not run --eval code if there is none

### DIFF
--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -46,10 +46,9 @@ cliRepl.createInternalRepl(process.env, (err, repl) => {
 
 // If user passed '-e' or '--eval' along with `-i` or `--interactive`,
 // evaluate the code in the current context.
-const source = getOptionValue('--eval');
-if (source != null) {
+if (getOptionValue('[has_eval_string]')) {
   evalScript('[eval]',
-             source,
+             getOptionValue('--eval'),
              getOptionValue('--inspect-brk'),
              getOptionValue('--print'));
 }

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -55,6 +55,7 @@ function evalScript(name, body, breakFirstLine, printResult) {
   const { kVmBreakFirstLineSymbol } = require('internal/util');
 
   const cwd = tryGetCwd();
+  const origModule = global.module;  // Set e.g. when called from the REPL.
 
   const module = new CJSModule(name);
   module.filename = path.join(cwd, name);
@@ -79,6 +80,9 @@ function evalScript(name, body, breakFirstLine, printResult) {
     const { kStdout, print } = require('internal/util/print');
     print(kStdout, result);
   }
+
+  if (origModule !== undefined)
+    global.module = origModule;
 }
 
 const exceptionHandlerState = { captureFn: null };

--- a/test/parallel/test-repl-cli-eval.js
+++ b/test/parallel/test-repl-cli-eval.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+const child_process = require('child_process');
+const assert = require('assert');
+
+// Regression test for https://github.com/nodejs/node/issues/27575:
+// module.id === '<repl>' in the REPL.
+
+for (const extraFlags of [[], ['-e', '42']]) {
+  const flags = ['--interactive', ...extraFlags];
+  const proc = child_process.spawn(process.execPath, flags, {
+    stdio: ['pipe', 'pipe', 'inherit']
+  });
+  proc.stdin.write('module.id\n.exit\n');
+
+  let stdout = '';
+  proc.stdout.setEncoding('utf8');
+  proc.stdout.on('data', (chunk) => stdout += chunk);
+  proc.stdout.on('end', common.mustCall(() => {
+    assert(stdout.includes('<repl>'), `stdout: ${stdout}`);
+  }));
+}


### PR DESCRIPTION
`getOptionValue('--eval')` always returns a string, so it is never
loose-equal to `null`. Running eval makes some modifications to the
global object, including setting `module` to a different value, which
we want to avoid if possible.

Refs: https://github.com/nodejs/node/pull/27278
Fixes: https://github.com/nodejs/node/issues/27575

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
