### PR TITLE
module: handle relative paths in resolve paths

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -575,18 +575,25 @@ Module._resolveFilename = function(request, parent, isMain, options) {
 
   if (typeof options === 'object' && options !== null &&
       Array.isArray(options.paths)) {
-    const fakeParent = new Module('', null);
+    const isRelative = request.startsWith('./') || request.startsWith('../') ||
+        (isWindows && request.startsWith('.\\') || request.startsWith('..\\'));
 
-    paths = [];
+    if (isRelative) {
+      paths = options.paths;
+    } else {
+      const fakeParent = new Module('', null);
 
-    for (var i = 0; i < options.paths.length; i++) {
-      const path = options.paths[i];
-      fakeParent.paths = Module._nodeModulePaths(path);
-      const lookupPaths = Module._resolveLookupPaths(request, fakeParent);
+      paths = [];
 
-      for (var j = 0; j < lookupPaths.length; j++) {
-        if (!paths.includes(lookupPaths[j]))
-          paths.push(lookupPaths[j]);
+      for (var i = 0; i < options.paths.length; i++) {
+        const path = options.paths[i];
+        fakeParent.paths = Module._nodeModulePaths(path);
+        const lookupPaths = Module._resolveLookupPaths(request, fakeParent);
+
+        for (var j = 0; j < lookupPaths.length; j++) {
+          if (!paths.includes(lookupPaths[j]))
+            paths.push(lookupPaths[j]);
+        }
       }
     }
   } else {

--- a/test/fixtures/require-resolve.js
+++ b/test/fixtures/require-resolve.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const nodeModules = path.join(__dirname, 'node_modules');
@@ -53,4 +53,34 @@ assert.throws(() => {
     require.resolve('bar', { paths }),
     path.join(nodeModules, 'bar.js')
   );
+}
+
+// Verify that relative request paths work properly.
+{
+  const searchIn = './' + path.relative(process.cwd(), nestedIndex);
+
+  // Search in relative paths.
+  assert.strictEqual(
+    require.resolve('./three.js', { paths: [searchIn] }),
+    path.join(nestedIndex, 'three.js')
+  );
+
+  // Search in absolute paths.
+  assert.strictEqual(
+    require.resolve('./three.js', { paths: [nestedIndex] }),
+    path.join(nestedIndex, 'three.js')
+  );
+
+  // Repeat the same tests with Windows slashes in the request path.
+  if (common.isWindows) {
+    assert.strictEqual(
+      require.resolve('.\\three.js', { paths: [searchIn] }),
+      path.join(nestedIndex, 'three.js')
+    );
+
+    assert.strictEqual(
+      require.resolve('.\\three.js', { paths: [nestedIndex] }),
+      path.join(nestedIndex, 'three.js')
+    );
+  }
 }


### PR DESCRIPTION
This commit adds support for relative paths in `require.resolve()`'s `paths` option.

Fixes: https://github.com/nodejs/node/issues/27583

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
