### PR TITLE
inspector: added NodeRuntime domain

### DIFF
--- a/src/inspector/node_inspector.gypi
+++ b/src/inspector/node_inspector.gypi
@@ -9,6 +9,8 @@
       '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/NodeWorker.h',
       '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/NodeTracing.cpp',
       '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/NodeTracing.h',
+      '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/NodeRuntime.cpp',
+      '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/NodeRuntime.h',
     ],
     'node_protocol_files': [
       '<(protocol_tool_path)/lib/Allocator_h.template',
@@ -55,6 +57,8 @@
     '../../src/inspector/main_thread_interface.h',
     '../../src/inspector/node_string.cc',
     '../../src/inspector/node_string.h',
+    '../../src/inspector/runtime_agent.cc',
+    '../../src/inspector/runtime_agent.h',
     '../../src/inspector/tracing_agent.cc',
     '../../src/inspector/tracing_agent.h',
     '../../src/inspector/worker_agent.cc',

--- a/src/inspector/node_protocol.pdl
+++ b/src/inspector/node_protocol.pdl
@@ -92,3 +92,16 @@ experimental domain NodeWorker
       # Identifier of a session which sends a message.
       SessionID sessionId
       string message
+
+# Support for inspecting node process state.
+experimental domain NodeRuntime
+  # Enable the `NodeRuntime.waitingForDisconnect`.
+  command notifyWhenWaitingForDisconnect
+    parameters
+      boolean enabled
+
+  # This event is fired instead of `Runtime.executionContextDestroyed` when
+  # enabled.
+  # It is fired when the Node process finished all code execution and is
+  # waiting for all frontends to disconnect.
+  event waitingForDisconnect

--- a/src/inspector/runtime_agent.cc
+++ b/src/inspector/runtime_agent.cc
@@ -1,0 +1,36 @@
+#include "runtime_agent.h"
+
+#include "env-inl.h"
+#include "inspector_agent.h"
+
+namespace node {
+namespace inspector {
+namespace protocol {
+
+RuntimeAgent::RuntimeAgent(Environment* env)
+  : notify_when_waiting_for_disconnect_(false), env_(env) {}
+
+void RuntimeAgent::Wire(UberDispatcher* dispatcher) {
+  frontend_ = std::make_unique<NodeRuntime::Frontend>(dispatcher->channel());
+  NodeRuntime::Dispatcher::wire(dispatcher, this);
+}
+
+DispatchResponse RuntimeAgent::notifyWhenWaitingForDisconnect(bool enabled) {
+  if (!env_->owns_process_state()) {
+    return DispatchResponse::Error(
+        "NodeRuntime domain can only be used through main thread sessions");
+  }
+  notify_when_waiting_for_disconnect_ = enabled;
+  return DispatchResponse::OK();
+}
+
+bool RuntimeAgent::notifyWaitingForDisconnect() {
+  if (notify_when_waiting_for_disconnect_) {
+    frontend_->waitingForDisconnect();
+    return true;
+  }
+  return false;
+}
+}  // namespace protocol
+}  // namespace inspector
+}  // namespace node

--- a/src/inspector/runtime_agent.h
+++ b/src/inspector/runtime_agent.h
@@ -1,0 +1,32 @@
+#ifndef SRC_INSPECTOR_RUNTIME_AGENT_H_
+#define SRC_INSPECTOR_RUNTIME_AGENT_H_
+
+#include "node/inspector/protocol/NodeRuntime.h"
+#include "v8.h"
+
+namespace node {
+class Environment;
+
+namespace inspector {
+namespace protocol {
+
+class RuntimeAgent : public NodeRuntime::Backend {
+ public:
+  explicit RuntimeAgent(Environment* env);
+
+  void Wire(UberDispatcher* dispatcher);
+
+  DispatchResponse notifyWhenWaitingForDisconnect(bool enabled) override;
+
+  bool notifyWaitingForDisconnect();
+
+ private:
+  std::shared_ptr<NodeRuntime::Frontend> frontend_;
+  bool notify_when_waiting_for_disconnect_;
+  Environment* env_;
+};
+}  // namespace protocol
+}  // namespace inspector
+}  // namespace node
+
+#endif  // SRC_INSPECTOR_RUNTIME_AGENT_H_

--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -191,6 +191,10 @@ class InspectorSession {
     }
   }
 
+  unprocessedNotifications() {
+    return this._unprocessedNotifications;
+  }
+
   _sendMessage(message) {
     const msg = JSON.parse(JSON.stringify(message)); // Clone!
     msg.id = this._nextId++;

--- a/test/parallel/test-inspector-waiting-for-disconnect.js
+++ b/test/parallel/test-inspector-waiting-for-disconnect.js
@@ -1,0 +1,45 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { NodeInstance } = require('../common/inspector-helper.js');
+
+function mainContextDestroyed(notification) {
+  return notification.method === 'Runtime.executionContextDestroyed' &&
+      notification.params.executionContextId === 1;
+}
+
+async function runTest() {
+  const child = new NodeInstance(['--inspect-brk=0', '-e', 'process.exit(55)']);
+  const session = await child.connectInspectorSession();
+  const oldStyleSession = await child.connectInspectorSession();
+  await oldStyleSession.send([
+    { method: 'Runtime.enable' }]);
+  await session.send([
+    { method: 'Runtime.enable' },
+    { method: 'NodeRuntime.notifyWhenWaitingForDisconnect',
+      params: { enabled: true } },
+    { method: 'Runtime.runIfWaitingForDebugger' }]);
+  await session.waitForNotification((notification) => {
+    return notification.method === 'NodeRuntime.waitingForDisconnect';
+  });
+  const receivedExecutionContextDestroyed =
+    session.unprocessedNotifications().some(mainContextDestroyed);
+  if (receivedExecutionContextDestroyed) {
+    assert.fail('When NodeRuntime enabled, ' +
+      'Runtime.executionContextDestroyed should not be sent');
+  }
+  const { result: { value } } = await session.send({
+    method: 'Runtime.evaluate', params: { expression: '42' }
+  });
+  assert.strictEqual(value, 42);
+  await session.disconnect();
+  await oldStyleSession.waitForNotification(mainContextDestroyed);
+  await oldStyleSession.disconnect();
+  assert.strictEqual((await child.expectShutdown()).exitCode, 55);
+}
+
+runTest();


### PR DESCRIPTION
Historically Node process sends Runtime.executionContextDestroyed
with main context as argument when it is finished.
This approach has some disadvantages. V8 prevents running some
protocol command on destroyed contexts, e.g. Runtime.evaluate
will return an error or Debugger.enable won't return a list of
scripts.
Both command might be useful for different tools, e.g. tool runs
Profiler.startPreciseCoverage and at the end of node process it
would like to get list of all scripts to match data to source code.
Or some tooling frontend would like to provide capabilities to run
commands in console when node process is finished to allow user to
inspect state of the program at exit.
This PR adds new domain: NodeRuntime. This domain sends
`NodeRuntime.waitingForDisconnect` when this event is enabled.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
