### PR TITLE
test: better assertion for async hook tests

### DIFF
--- a/test/async-hooks/verify-graph.js
+++ b/test/async-hooks/verify-graph.js
@@ -108,7 +108,8 @@ module.exports = function verifyGraph(hooks, graph) {
 
   for (const type in expTypes) {
     assert.strictEqual(typeSeen[type], expTypes[type],
-                       `Expecting type '${type}' in graph`);
+                       `Type '${type}': expecting: ${expTypes[type]} ` +
+                       `found ${typeSeen[type]}`);
   }
 };
 


### PR DESCRIPTION
The existing assertion was misleading to whether there were too few or
too many events of a particular type. Improve the assertion message.

Related: https://github.com/nodejs/node/pull/27558


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
