### PR TITLE
inspector: introduced --inspect-store option

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -747,7 +747,10 @@ bool Agent::StartIoThread() {
 
   CHECK_NOT_NULL(client_);
 
-  io_ = InspectorIo::Start(client_->getThreadHandle(), path_, host_port_);
+  io_ = InspectorIo::Start(client_->getThreadHandle(),
+                           path_,
+                           host_port_,
+                           debug_options_.inspect_store);
   if (io_ == nullptr) {
     return false;
   }

--- a/src/inspector_io.h
+++ b/src/inspector_io.h
@@ -48,7 +48,8 @@ class InspectorIo {
   static std::unique_ptr<InspectorIo> Start(
       std::shared_ptr<MainThreadHandle> main_thread,
       const std::string& path,
-      std::shared_ptr<HostPort> host_port);
+      std::shared_ptr<HostPort> host_port,
+      const std::string& inspector_store);
 
   // Will block till the transport thread shuts down
   ~InspectorIo();
@@ -61,7 +62,8 @@ class InspectorIo {
  private:
   InspectorIo(std::shared_ptr<MainThreadHandle> handle,
               const std::string& path,
-              std::shared_ptr<HostPort> host_port);
+              std::shared_ptr<HostPort> host_port,
+              const std::string& inspector_store);
 
   // Wrapper for agent->ThreadMain()
   static void ThreadMain(void* agent);
@@ -85,6 +87,7 @@ class InspectorIo {
   Mutex thread_start_lock_;
   ConditionVariable thread_start_condition_;
   std::string script_name_;
+  std::string inspector_store_;
   // May be accessed from any thread
   const std::string id_;
 };

--- a/src/inspector_socket_server.h
+++ b/src/inspector_socket_server.h
@@ -43,6 +43,7 @@ class InspectorSocketServer {
                         uv_loop_t* loop,
                         const std::string& host,
                         int port,
+                        const std::string& inspector_store,
                         FILE* out = stderr);
   ~InspectorSocketServer();
 
@@ -79,6 +80,7 @@ class InspectorSocketServer {
  private:
   void SendListResponse(InspectorSocket* socket, const std::string& host,
                         SocketSession* session);
+  std::string GetListResponse(const std::string& host);
   std::string GetFrontendURL(bool is_compat,
                              const std::string &formatted_address);
   bool TargetExists(const std::string& id);
@@ -88,6 +90,7 @@ class InspectorSocketServer {
   std::unique_ptr<SocketServerDelegate> delegate_;
   const std::string host_;
   int port_;
+  std::string inspector_store_;
   std::vector<ServerSocketPtr> server_sockets_;
   std::map<int, std::pair<std::string, std::unique_ptr<SocketSession>>>
       connected_sessions_;

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -260,6 +260,13 @@ DebugOptionsParser::DebugOptionsParser() {
   Implies("--inspect-brk-node", "--inspect");
   AddAlias("--inspect-brk-node=", { "--inspect-port", "--inspect-brk-node" });
 
+  AddOption("--inspect-store",
+            "experimental force inspector to put information available on /json/list "
+            "to file inside given folder",
+            &DebugOptions::inspect_store,
+            kAllowedInEnvironment);
+  Implies("--inspect-store", "--inspect");
+
   AddOption("--debug-brk", "", &DebugOptions::break_first_line);
   Implies("--debug-brk", "--debug");
   AddAlias("--debug-brk=", { "--inspect-port", "--debug-brk" });

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -70,6 +70,8 @@ class DebugOptions : public Options {
   bool break_first_line = false;
   // --inspect-brk-node
   bool break_node_first_line = false;
+  // --inspect-store
+  std::string inspect_store;
 
   enum { kDefaultInspectorPort = 9229 };
 

--- a/test/cctest/test_inspector_socket_server.cc
+++ b/test/cctest/test_inspector_socket_server.cc
@@ -358,7 +358,7 @@ ServerHolder::ServerHolder(bool has_targets, uv_loop_t* loop,
   std::unique_ptr<TestSocketServerDelegate> delegate(
       new TestSocketServerDelegate(this, targets));
   server_ = std::make_unique<InspectorSocketServer>(
-      std::move(delegate), loop, host, port, out);
+      std::move(delegate), loop, host, port, std::string(), out);
 }
 
 static void TestHttpRequest(int port, const std::string& path,


### PR DESCRIPTION
This option takes folder name as argument. When it is passed,
inspector will dump content of /json/list endpoint to file with
random name inside of passed folder, inspector will try to cleanup
this file as well at finish but without strict guarantees.

This option is useful when we need to have node targets discovery
with child processes or without child processes. Current solution is
setting --inspect-brk=0 using environment to force each node process
to open inspector socket and listenning for stderr for started
process. This approach has a lot of flows, e.g. it requires stderr
parsing, it does not help with discovering node processes which are
started independently.

With new flag if we need to discover and debug node processes
using inspector:
1. create folder ahead of time,
2. pass this folder with new --inspect-store flag with
   --inspect-brk=0 or --inspect=0 using environment,
3. listen to files created inside this folder using any external
   tool, e.g. another nodes script with fs.watch.
4. as soon as new file created - try to connect,
5. be ready for stale store files,
6. remove store folder later.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
