### PR TITLE
tools: enable camelcase linting in tools

### DIFF
--- a/tools/.eslintrc.yaml
+++ b/tools/.eslintrc.yaml
@@ -3,6 +3,11 @@ env:
   es6: true
 
 rules:
+  camelcase:
+    - error
+    - properties: 'never'
+      ignoreDestructuring: true
+      allow: ['child_process']
   comma-dangle:
     - error
     - arrays: 'always-multiline'

--- a/tools/doc/apilinks.js
+++ b/tools/doc/apilinks.js
@@ -36,10 +36,10 @@ function execSync(command) {
 }
 
 // Determine origin repo and tag (or hash) of the most recent commit.
-const local_branch = execSync('git name-rev --name-only HEAD');
-const tracking_remote = execSync(`git config branch.${local_branch}.remote`);
-const remote_url = execSync(`git config remote.${tracking_remote}.url`);
-const repo = (remote_url.match(/(\w+\/\w+)\.git\r?\n?$/) ||
+const localBranch = execSync('git name-rev --name-only HEAD');
+const trackingRemote = execSync(`git config branch.${localBranch}.remote`);
+const remoteUrl = execSync(`git config remote.${trackingRemote}.url`);
+const repo = (remoteUrl.match(/(\w+\/\w+)\.git\r?\n?$/) ||
              ['', 'nodejs/node'])[1];
 
 const hash = execSync('git log -1 --pretty=%H') || 'master';


### PR DESCRIPTION
Use camelcasing in tools/doc/apilinks.js and enable linting rule.



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
