### PR TITLE
test: remove unneeded `--expose-internals`

### DIFF
--- a/test/wpt/test-timers.js
+++ b/test/wpt/test-timers.js
@@ -1,7 +1,5 @@
 'use strict';
 
-// Flags: --expose-internals
-
 require('../common');
 const { WPTRunner } = require('../common/wpt');
 


### PR DESCRIPTION
test/wpt/test-timers.js does not appear to need the `--expose-internals`
flag. Remove it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
