### PR TITLE
module: improve resolve paths validation

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -53,6 +53,7 @@ const { compileFunction } = internalBinding('contextify');
 
 const {
   ERR_INVALID_ARG_VALUE,
+  ERR_INVALID_OPT_VALUE,
   ERR_REQUIRE_ESM
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
@@ -573,28 +574,33 @@ Module._resolveFilename = function(request, parent, isMain, options) {
 
   var paths;
 
-  if (typeof options === 'object' && options !== null &&
-      Array.isArray(options.paths)) {
-    const isRelative = request.startsWith('./') || request.startsWith('../') ||
-        (isWindows && request.startsWith('.\\') || request.startsWith('..\\'));
+  if (typeof options === 'object' && options !== null) {
+    if (Array.isArray(options.paths)) {
+      const isRelative = request.startsWith('./') ||
+          request.startsWith('../') ||
+          (isWindows && request.startsWith('.\\') ||
+          request.startsWith('..\\'));
 
-    if (isRelative) {
-      paths = options.paths;
-    } else {
-      const fakeParent = new Module('', null);
+      if (isRelative) {
+        paths = options.paths;
+      } else {
+        const fakeParent = new Module('', null);
 
-      paths = [];
+        paths = [];
 
-      for (var i = 0; i < options.paths.length; i++) {
-        const path = options.paths[i];
-        fakeParent.paths = Module._nodeModulePaths(path);
-        const lookupPaths = Module._resolveLookupPaths(request, fakeParent);
+        for (var i = 0; i < options.paths.length; i++) {
+          const path = options.paths[i];
+          fakeParent.paths = Module._nodeModulePaths(path);
+          const lookupPaths = Module._resolveLookupPaths(request, fakeParent);
 
-        for (var j = 0; j < lookupPaths.length; j++) {
-          if (!paths.includes(lookupPaths[j]))
-            paths.push(lookupPaths[j]);
+          for (var j = 0; j < lookupPaths.length; j++) {
+            if (!paths.includes(lookupPaths[j]))
+              paths.push(lookupPaths[j]);
+          }
         }
       }
+    } else if (options.paths !== undefined) {
+      throw new ERR_INVALID_OPT_VALUE('options.paths', options.paths);
     }
   } else {
     paths = Module._resolveLookupPaths(request, parent);

--- a/test/fixtures/require-resolve.js
+++ b/test/fixtures/require-resolve.js
@@ -84,3 +84,11 @@ assert.throws(() => {
     );
   }
 }
+
+// Test paths option validation
+common.expectsError(() => {
+  require.resolve('.\\three.js', { paths: 'foo' })
+}, {
+  code: 'ERR_INVALID_OPT_VALUE',
+  type: TypeError,
+});


### PR DESCRIPTION
~~The first commit is just #27598, which I've included here just to avoid conflicts later.~~

This PR adds input validation to `require.resolve()`'s `paths` option. Prior to this change, passing in a non-array value lead to a misleading 'module not found' error.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
