### PR TITLE
tls: add missing 'new'

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -169,7 +169,7 @@ exports.createSecureContext = function createSecureContext(options) {
   if (cipherSuites === '' && cipherList === '') {
     // Specifying empty cipher suites for both TLS1.2 and TLS1.3 is invalid, its
     // not possible to handshake with no suites.
-    throw ERR_INVALID_OPT_VALUE('ciphers', ciphers);
+    throw new ERR_INVALID_OPT_VALUE('ciphers', ciphers);
   }
 
   c.context.setCipherSuites(cipherSuites);

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -163,7 +163,8 @@ exports.createSecureContext = function createSecureContext(options) {
   // cipher suites all have a standard name format beginning with TLS_, so split
   // the ciphers and pass them to the appropriate API.
   const ciphers = (options.ciphers || tls.DEFAULT_CIPHERS).split(':');
-  const cipherList = ciphers.filter((_) => !_.match(/^TLS_/)).join(':');
+  const cipherList = ciphers.filter((_) => !_.match(/^TLS_/) &&
+                                    _.length > 0).join(':');
   const cipherSuites = ciphers.filter((_) => _.match(/^TLS_/)).join(':');
 
   if (cipherSuites === '' && cipherList === '') {

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -91,3 +91,13 @@ test('TLS_AES_128_CCM_8_SHA256', U,
 
 test('TLS_AES_128_CCM_8_SHA256', 'TLS_AES_128_CCM_8_SHA256',
      'TLS_AES_128_CCM_8_SHA256');
+
+// Invalid cipher values
+test(9, 'AES256-SHA', U, 'ERR_INVALID_ARG_TYPE', U);
+test('AES256-SHA', 9, U, U, 'ERR_INVALID_ARG_TYPE');
+test(':', 'AES256-SHA', U, 'ERR_INVALID_OPT_VALUE', U);
+test('AES256-SHA', ':', U, U, 'ERR_INVALID_OPT_VALUE');
+
+// Using '' is synonymous for "use default ciphers"
+test('TLS_AES_256_GCM_SHA384', '', 'TLS_AES_256_GCM_SHA384');
+test('', 'TLS_AES_256_GCM_SHA384', 'TLS_AES_256_GCM_SHA384');


### PR DESCRIPTION
`ERR_INVALID_OPT_VALUE` cannot be constructed without new.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
