### PR TITLE
tools: enable block-scoped-var eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,6 +60,7 @@ module.exports = {
     'arrow-parens': ['error', 'always'],
     'arrow-spacing': ['error', { before: true, after: true }],
     'block-spacing': 'error',
+    'block-scoped-var': 'error',
     'brace-style': ['error', '1tbs', { allowSingleLine: true }],
     'capitalized-comments': ['error', 'always', {
       line: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,8 +59,8 @@ module.exports = {
     'array-callback-return': 'error',
     'arrow-parens': ['error', 'always'],
     'arrow-spacing': ['error', { before: true, after: true }],
-    'block-spacing': 'error',
     'block-scoped-var': 'error',
+    'block-spacing': 'error',
     'brace-style': ['error', '1tbs', { allowSingleLine: true }],
     'capitalized-comments': ['error', 'always', {
       line: {

--- a/benchmark/fixtures/simple-http-server.js
+++ b/benchmark/fixtures/simple-http-server.js
@@ -10,8 +10,9 @@ const storedUnicode = Object.create(null);
 const useDomains = process.env.NODE_USE_DOMAINS;
 
 // Set up one global domain.
+let domain;
 if (useDomains) {
-  var domain = require('domain');
+  domain = require('domain');
   const gdom = domain.create();
   gdom.on('error', (er) => {
     console.error('Error on global domain', er);

--- a/benchmark/http/_chunky_http_client.js
+++ b/benchmark/http/_chunky_http_client.js
@@ -16,7 +16,7 @@ function main({ len, n }) {
   const headers = [];
   // Chose 7 because 9 showed "Connection error" / "Connection closed"
   // An odd number could result in a better length dispersion.
-  for (var i = 7; i <= 7 * 7 * 7; i *= 7)
+  for (let i = 7; i <= 7 * 7 * 7; i *= 7)
     headers.push('o'.repeat(i));
 
   function WriteHTTPHeaders(channel, has_keep_alive, extra_header_count) {
@@ -31,7 +31,7 @@ function main({ len, n }) {
               'Chrome/39.0.2171.71 Safari/537.36');
     todo.push('Accept-Encoding: gzip, deflate, sdch');
     todo.push('Accept-Language: en-US,en;q=0.8');
-    for (var i = 0; i < extra_header_count; i++) {
+    for (let i = 0; i < extra_header_count; i++) {
       // Utilize first three powers of a small integer for an odd cycle and
       // because the fourth power of some integers overloads the server.
       todo.push(`X-Header-${i}: ${headers[i % 3]}`);
@@ -41,7 +41,7 @@ function main({ len, n }) {
     todo = todo.join('\r\n');
     // Using odd numbers in many places may increase length coverage.
     const chunksize = 37;
-    for (i = 0; i < todo.length; i += chunksize) {
+    for (let i = 0; i < todo.length; i += chunksize) {
       const cur = todo.slice(i, i + chunksize);
       channel.write(cur);
     }

--- a/benchmark/http/cluster.js
+++ b/benchmark/http/cluster.js
@@ -3,8 +3,9 @@ const common = require('../common.js');
 const PORT = common.PORT;
 
 const cluster = require('cluster');
+let bench;
 if (cluster.isMaster) {
-  var bench = common.createBenchmark(main, {
+  bench = common.createBenchmark(main, {
     // Unicode confuses ab on os x.
     type: ['bytes', 'buffer'],
     len: [4, 1024, 102400],

--- a/benchmark/napi/function_call/index.js
+++ b/benchmark/napi/function_call/index.js
@@ -11,8 +11,9 @@ const common = require('../../common.js');
 // which is quite common for benchmarks.  so in that case, just
 // abort quietly.
 
+let binding;
 try {
-  var binding = require(`./build/${common.buildType}/binding`);
+  binding = require(`./build/${common.buildType}/binding`);
 } catch {
   console.error('misc/function_call.js Binding failed to load');
   process.exit(0);

--- a/benchmark/util/priority-queue.js
+++ b/benchmark/util/priority-queue.js
@@ -10,9 +10,9 @@ function main({ n, type }) {
   const PriorityQueue = require('internal/priority_queue');
   const queue = new PriorityQueue();
   bench.start();
-  for (var i = 0; i < n; i++)
+  for (let i = 0; i < n; i++)
     queue.insert(Math.random() * 1e7 | 0);
-  for (i = 0; i < n; i++)
+  for (let i = 0; i < n; i++)
     queue.shift();
   bench.end(n);
 }

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -91,8 +91,9 @@ function Socket(type, listener) {
   let recvBufferSize;
   let sendBufferSize;
 
+  let options;
   if (type !== null && typeof type === 'object') {
-    var options = type;
+    options = type;
     type = options.type;
     lookup = options.lookup;
     recvBufferSize = options.recvBufferSize;

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -693,6 +693,8 @@ function setupChannel(target, channel) {
       options = { swallowErrors: options };
     }
 
+    let obj;
+
     // Package messages with a handle object
     if (handle) {
       // This message will be handled by an internalMessage event handler
@@ -727,7 +729,7 @@ function setupChannel(target, channel) {
         return this._handleQueue.length === 1;
       }
 
-      var obj = handleConversion[message.type];
+      obj = handleConversion[message.type];
 
       // convert TCP object to native handle object
       handle = handleConversion[message.type].send.call(target,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -316,8 +316,8 @@ promisify.custom = kCustomPromisifiedSymbol;
 function join(output, separator) {
   let str = '';
   if (output.length !== 0) {
-    let i;
-    for (i = 0; i < output.length - 1; i++) {
+    let i = 0;
+    for (; i < output.length - 1; i++) {
       // It is faster not to use a template string here
       str += output[i];
       str += separator;

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -316,7 +316,8 @@ promisify.custom = kCustomPromisifiedSymbol;
 function join(output, separator) {
   let str = '';
   if (output.length !== 0) {
-    for (var i = 0; i < output.length - 1; i++) {
+    let i;
+    for (i = 0; i < output.length - 1; i++) {
       // It is faster not to use a template string here
       str += output[i];
       str += separator;

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -316,12 +316,13 @@ promisify.custom = kCustomPromisifiedSymbol;
 function join(output, separator) {
   let str = '';
   if (output.length !== 0) {
-    for (let i = 0; i < output.length - 1; i++) {
+    const lastIndex = output.length - 1;
+    for (let i = 0; i < lastIndex; i++) {
       // It is faster not to use a template string here
       str += output[i];
       str += separator;
     }
-    str += output[output.length - 1];
+    str += output[lastIndex];
   }
   return str;
 }

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -316,13 +316,12 @@ promisify.custom = kCustomPromisifiedSymbol;
 function join(output, separator) {
   let str = '';
   if (output.length !== 0) {
-    let i = 0;
-    for (; i < output.length - 1; i++) {
+    for (let i = 0; i < output.length - 1; i++) {
       // It is faster not to use a template string here
       str += output[i];
       str += separator;
     }
-    str += output[i];
+    str += output[output.length - 1];
   }
   return str;
 }

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -312,8 +312,8 @@ function strEscape(str) {
 
   let result = '';
   let last = 0;
-  let i;
-  for (i = 0; i < str.length; i++) {
+  let i = 0;
+  for (; i < str.length; i++) {
     const point = str.charCodeAt(i);
     if (point === singleQuote || point === 92 || point < 32) {
       if (last === i) {
@@ -1062,8 +1062,8 @@ function formatPrimitive(fn, value, ctx) {
       if (matches.length > 1) {
         const indent = ' '.repeat(ctx.indentationLvl);
         let res = `${fn(strEscape(matches[0]), 'string')} +\n`;
-        let i;
-        for (i = 1; i < matches.length - 1; i++) {
+        let i = 1;
+        for (; i < matches.length - 1; i++) {
           res += `${indent}  ${fn(strEscape(matches[i]), 'string')} +\n`;
         }
         res += `${indent}  ${fn(strEscape(matches[i]), 'string')}`;
@@ -1189,8 +1189,8 @@ function formatTypedArray(ctx, value, recurseTimes) {
   const elementFormatter = value.length > 0 && typeof value[0] === 'number' ?
     formatNumber :
     formatBigInt;
-  let i;
-  for (i = 0; i < maxLength; ++i)
+  let i = 0;
+  for (; i < maxLength; ++i)
     output[i] = elementFormatter(ctx.stylize, value[i]);
   if (remaining > 0) {
     output[i] = `... ${remaining} more item${remaining > 1 ? 's' : ''}`;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -312,7 +312,8 @@ function strEscape(str) {
 
   let result = '';
   let last = 0;
-  for (var i = 0; i < str.length; i++) {
+  let i;
+  for (i = 0; i < str.length; i++) {
     const point = str.charCodeAt(i);
     if (point === singleQuote || point === 92 || point < 32) {
       if (last === i) {
@@ -1061,7 +1062,8 @@ function formatPrimitive(fn, value, ctx) {
       if (matches.length > 1) {
         const indent = ' '.repeat(ctx.indentationLvl);
         let res = `${fn(strEscape(matches[0]), 'string')} +\n`;
-        for (var i = 1; i < matches.length - 1; i++) {
+        let i;
+        for (i = 1; i < matches.length - 1; i++) {
           res += `${indent}  ${fn(strEscape(matches[i]), 'string')} +\n`;
         }
         res += `${indent}  ${fn(strEscape(matches[i]), 'string')}`;
@@ -1187,7 +1189,8 @@ function formatTypedArray(ctx, value, recurseTimes) {
   const elementFormatter = value.length > 0 && typeof value[0] === 'number' ?
     formatNumber :
     formatBigInt;
-  for (var i = 0; i < maxLength; ++i)
+  let i;
+  for (i = 0; i < maxLength; ++i)
     output[i] = elementFormatter(ctx.stylize, value[i]);
   if (remaining > 0) {
     output[i] = `... ${remaining} more item${remaining > 1 ? 's' : ''}`;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -312,8 +312,7 @@ function strEscape(str) {
 
   let result = '';
   let last = 0;
-  let i = 0;
-  for (; i < str.length; i++) {
+  for (let i = 0; i < str.length; i++) {
     const point = str.charCodeAt(i);
     if (point === singleQuote || point === 92 || point < 32) {
       if (last === i) {
@@ -325,7 +324,7 @@ function strEscape(str) {
     }
   }
 
-  if (last !== i) {
+  if (last !== str.length) {
     result += str.slice(last);
   }
   return addQuotes(result, singleQuote);
@@ -1062,11 +1061,11 @@ function formatPrimitive(fn, value, ctx) {
       if (matches.length > 1) {
         const indent = ' '.repeat(ctx.indentationLvl);
         let res = `${fn(strEscape(matches[0]), 'string')} +\n`;
-        let i = 1;
-        for (; i < matches.length - 1; i++) {
+        const lastIndex = matches.length - 1;
+        for (let i = 1; i < lastIndex; i++) {
           res += `${indent}  ${fn(strEscape(matches[i]), 'string')} +\n`;
         }
-        res += `${indent}  ${fn(strEscape(matches[i]), 'string')}`;
+        res += `${indent}  ${fn(strEscape(matches[lastIndex]), 'string')}`;
         return res;
       }
     }
@@ -1189,11 +1188,10 @@ function formatTypedArray(ctx, value, recurseTimes) {
   const elementFormatter = value.length > 0 && typeof value[0] === 'number' ?
     formatNumber :
     formatBigInt;
-  let i = 0;
-  for (; i < maxLength; ++i)
+  for (let i = 0; i < maxLength; ++i)
     output[i] = elementFormatter(ctx.stylize, value[i]);
   if (remaining > 0) {
-    output[i] = `... ${remaining} more item${remaining > 1 ? 's' : ''}`;
+    output[maxLength] = `... ${remaining} more item${remaining > 1 ? 's' : ''}`;
   }
   if (ctx.showHidden) {
     // .buffer goes last, it's not a primitive like the others.

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -312,7 +312,8 @@ function strEscape(str) {
 
   let result = '';
   let last = 0;
-  for (let i = 0; i < str.length; i++) {
+  const lastIndex = str.length;
+  for (let i = 0; i < lastIndex; i++) {
     const point = str.charCodeAt(i);
     if (point === singleQuote || point === 92 || point < 32) {
       if (last === i) {
@@ -324,7 +325,7 @@ function strEscape(str) {
     }
   }
 
-  if (last !== str.length) {
+  if (last !== lastIndex) {
     result += str.slice(last);
   }
   return addQuotes(result, singleQuote);

--- a/lib/url.js
+++ b/lib/url.js
@@ -267,9 +267,10 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
   // user@server is *always* interpreted as a hostname, and url
   // resolution will treat //foo/bar as host=foo,path=bar because that's
   // how the browser resolves relative URLs.
+  let slashes;
   if (slashesDenoteHost || proto || hostPattern.test(rest)) {
-    var slashes = rest.charCodeAt(0) === CHAR_FORWARD_SLASH &&
-                  rest.charCodeAt(1) === CHAR_FORWARD_SLASH;
+    slashes = rest.charCodeAt(0) === CHAR_FORWARD_SLASH &&
+              rest.charCodeAt(1) === CHAR_FORWARD_SLASH;
     if (slashes && !(proto && hostlessProtocol.has(lowerProto))) {
       rest = rest.slice(2);
       this.slashes = true;


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This enables the [block-scoped-var](https://eslint.org/docs/rules/block-scoped-var) eslint rule and fixes discovered issues. Code that does not rely on the hoisting properties of `var` is easier to read and understand.