### PR TITLE
src: reduce env.h & env-inl.h include lines

### DIFF
--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -356,7 +356,6 @@ would be placed in `test/cctest/test_env.cc`:
 ```c++
 #include "gtest/gtest.h"
 #include "node_test_fixture.h"
-#include "env.h"
 #include "node.h"
 #include "v8.h"
 

--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -1,6 +1,5 @@
 #include "node.h"
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "v8.h"
 
 namespace node {

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -1,4 +1,3 @@
-#include "env.h"
 #include "node.h"
 #include "node_context_data.h"
 #include "node_errors.h"

--- a/src/api/exceptions.cc
+++ b/src/api/exceptions.cc
@@ -1,6 +1,5 @@
 // This file contains implementation of error APIs exposed in node.h
 
-#include "env-inl.h"
 #include "node.h"
 #include "node_errors.h"
 #include "util-inl.h"

--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -1,4 +1,3 @@
-#include "env-inl.h"
 #include "node_internals.h"
 #include "node_process.h"
 #include "async_wrap.h"

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -21,7 +21,6 @@
 
 #include "async_wrap.h"  // NOLINT(build/include_inline)
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "node_errors.h"
 #include "tracing/traced_value.h"
 #include "util-inl.h"

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -22,7 +22,6 @@
 #define CARES_STATICLIB
 #include "ares.h"
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "node.h"
 #include "req_wrap-inl.h"
 #include "util-inl.h"

--- a/src/connect_wrap.cc
+++ b/src/connect_wrap.cc
@@ -1,6 +1,5 @@
 #include "connect_wrap.h"
 
-#include "env-inl.h"
 #include "req_wrap-inl.h"
 #include "util-inl.h"
 

--- a/src/connect_wrap.h
+++ b/src/connect_wrap.h
@@ -3,7 +3,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "env.h"
 #include "req_wrap-inl.h"
 #include "async_wrap.h"
 #include "v8.h"

--- a/src/connection_wrap.cc
+++ b/src/connection_wrap.cc
@@ -1,7 +1,6 @@
 #include "connection_wrap.h"
 
 #include "connect_wrap.h"
-#include "env-inl.h"
 #include "pipe_wrap.h"
 #include "stream_base-inl.h"
 #include "stream_wrap.h"

--- a/src/connection_wrap.h
+++ b/src/connection_wrap.h
@@ -3,7 +3,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "env.h"
 #include "stream_wrap.h"
 #include "v8.h"
 

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -20,7 +20,6 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "util-inl.h"
 #include "node.h"
 #include "handle_wrap.h"

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -21,7 +21,6 @@
 
 #include "handle_wrap.h"
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "util-inl.h"
 #include "node.h"
 

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -1,4 +1,3 @@
-#include "env-inl.h"
 #include "stream_base-inl.h"
 
 using v8::Array;

--- a/src/inspector/main_thread_interface.h
+++ b/src/inspector/main_thread_interface.h
@@ -5,7 +5,6 @@
 #error("This header can only be used when inspector is enabled")
 #endif
 
-#include "env.h"
 #include "inspector_agent.h"
 #include "node_mutex.h"
 

--- a/src/inspector/tracing_agent.cc
+++ b/src/inspector/tracing_agent.cc
@@ -3,7 +3,6 @@
 #include "node_internals.h"
 #include "node_v8_platform-inl.h"
 
-#include "env-inl.h"
 #include "v8.h"
 
 #include <set>

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -4,7 +4,6 @@
 #include "inspector/main_thread_interface.h"
 #include "inspector/node_string.h"
 #include "base_object-inl.h"
-#include "env-inl.h"
 #include "debug_utils.h"
 #include "node.h"
 #include "node_crypto.h"

--- a/src/inspector_profiler.h
+++ b/src/inspector_profiler.h
@@ -7,7 +7,6 @@
 #error("This header can only be used when inspector is enabled")
 #endif
 
-#include "env.h"
 #include "inspector_agent.h"
 
 namespace node {

--- a/src/js_native_api_v8_internals.h
+++ b/src/js_native_api_v8_internals.h
@@ -14,7 +14,6 @@
 // included below, defines `NAPI_VERSION`.
 
 #include "node_version.h"
-#include "env.h"
 #include "node_internals.h"
 
 #define NAPI_ARRAYSIZE(array) \

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -1,7 +1,6 @@
 #include "js_stream.h"
 
 #include "async_wrap.h"
-#include "env-inl.h"
 #include "node_buffer.h"
 #include "node_errors.h"
 #include "stream_base-inl.h"

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -4,7 +4,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "async_wrap.h"
-#include "env.h"
 #include "stream_base.h"
 #include "v8.h"
 

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -1,6 +1,5 @@
 #include "module_wrap.h"
 
-#include "env.h"
 #include "node_errors.h"
 #include "node_url.h"
 #include "util-inl.h"

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1,5 +1,4 @@
 #include <node_buffer.h>
-#include "env.h"
 #define NAPI_EXPERIMENTAL
 #include "js_native_api_v8.h"
 #include "node_api.h"

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -24,7 +24,6 @@
 #include "node_errors.h"
 #include "node_internals.h"
 
-#include "env-inl.h"
 #include "string_bytes.h"
 #include "string_search.h"
 #include "util-inl.h"

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -31,7 +31,6 @@
 
 #include "async_wrap-inl.h"
 #include "base_object-inl.h"
-#include "env-inl.h"
 #include "string_bytes.h"
 #include "util-inl.h"
 #include "v8.h"

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -26,7 +26,6 @@
 
 #include "node_crypto.h"
 #include "openssl/bio.h"
-#include "env-inl.h"
 #include "util-inl.h"
 #include "v8.h"
 

--- a/src/node_http_parser_impl.h
+++ b/src/node_http_parser_impl.h
@@ -29,7 +29,6 @@
 #include "util.h"
 
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "stream_base-inl.h"
 #include "v8.h"
 

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -45,7 +45,6 @@
 #if defined(NODE_HAVE_I18N_SUPPORT)
 
 #include "base_object-inl.h"
-#include "env-inl.h"
 #include "node.h"
 #include "node_buffer.h"
 #include "node_errors.h"

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -5,7 +5,6 @@
 
 #include "node.h"
 #include "node_perf_common.h"
-#include "env.h"
 #include "base_object-inl.h"
 #include "histogram-inl.h"
 

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -1,7 +1,6 @@
 #include "node_platform.h"
 #include "node_internals.h"
 
-#include "env-inl.h"
 #include "debug_utils.h"
 #include "util.h"
 #include <algorithm>

--- a/src/node_postmortem_metadata.cc
+++ b/src/node_postmortem_metadata.cc
@@ -1,4 +1,3 @@
-#include "env.h"
 #include "base_object-inl.h"
 #include "handle_wrap.h"
 #include "util-inl.h"

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -1,5 +1,4 @@
 #include "base_object-inl.h"
-#include "env-inl.h"
 #include "node.h"
 #include "node_errors.h"
 #include "node_internals.h"

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -1,4 +1,3 @@
-#include "env-inl.h"
 #include "node_internals.h"
 #include "node_options-inl.h"
 #include "node_metadata.h"

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -1,4 +1,3 @@
-#include "env.h"
 #include "node_errors.h"
 #include "node_internals.h"
 #include "node_options.h"

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -21,7 +21,6 @@
 
 #include "node_stat_watcher.h"
 #include "async_wrap-inl.h"
-#include "env.h"
 #include "node_file.h"
 #include "util.h"
 

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -26,7 +26,6 @@
 
 #include "node.h"
 #include "handle_wrap.h"
-#include "env.h"
 #include "uv.h"
 #include "v8.h"
 

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -1,4 +1,3 @@
-#include "env-inl.h"
 #include "node.h"
 #include "node_errors.h"
 #include "node_internals.h"

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -1,5 +1,4 @@
 #include "base_object-inl.h"
-#include "env.h"
 #include "node.h"
 #include "node_internals.h"
 #include "node_v8_platform-inl.h"

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -4,7 +4,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
-#include "env-inl.h"
 
 #include <string>
 

--- a/src/node_v8_platform-inl.h
+++ b/src/node_v8_platform-inl.h
@@ -5,7 +5,6 @@
 
 #include <memory>
 
-#include "env-inl.h"
 #include "node.h"
 #include "node_metadata.h"
 #include "node_options.h"

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -23,7 +23,6 @@
 #include "node_buffer.h"
 
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "util-inl.h"
 
 #include "v8.h"

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -23,7 +23,6 @@
 
 #include "async_wrap.h"
 #include "connection_wrap.h"
-#include "env-inl.h"
 #include "handle_wrap.h"
 #include "node.h"
 #include "node_buffer.h"

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -26,7 +26,6 @@
 
 #include "async_wrap.h"
 #include "connection_wrap.h"
-#include "env.h"
 
 namespace node {
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -19,7 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "env-inl.h"
 #include "stream_base-inl.h"
 #include "stream_wrap.h"
 #include "util-inl.h"

--- a/src/req_wrap-inl.h
+++ b/src/req_wrap-inl.h
@@ -5,7 +5,6 @@
 
 #include "req_wrap.h"
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "util-inl.h"
 #include "uv.h"
 

--- a/src/req_wrap.h
+++ b/src/req_wrap.h
@@ -4,7 +4,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "async_wrap.h"
-#include "env.h"
 #include "util.h"
 #include "v8.h"
 

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -20,7 +20,6 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "handle_wrap.h"
 #include "node_process.h"
 #include "util-inl.h"

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -21,7 +21,6 @@
 
 #include "spawn_sync.h"
 #include "debug_utils.h"
-#include "env-inl.h"
 #include "node_internals.h"
 #include "string_bytes.h"
 

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -6,7 +6,6 @@
 #include "stream_base.h"
 
 #include "node.h"
-#include "env-inl.h"
 #include "v8.h"
 
 namespace node {

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -5,7 +5,6 @@
 #include "node.h"
 #include "node_buffer.h"
 #include "node_errors.h"
-#include "env-inl.h"
 #include "js_stream.h"
 #include "string_bytes.h"
 #include "util-inl.h"

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -3,7 +3,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "env.h"
 #include "async_wrap-inl.h"
 #include "node.h"
 #include "util.h"

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -22,7 +22,6 @@
 #include "stream_wrap.h"
 #include "stream_base-inl.h"
 
-#include "env-inl.h"
 #include "handle_wrap.h"
 #include "node_buffer.h"
 #include "pipe_wrap.h"

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -26,7 +26,6 @@
 
 #include "stream_base.h"
 
-#include "env.h"
 #include "handle_wrap.h"
 #include "string_bytes.h"
 #include "v8.h"

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -22,7 +22,6 @@
 #include "string_bytes.h"
 
 #include "base64.h"
-#include "env-inl.h"
 #include "node_buffer.h"
 #include "node_errors.h"
 #include "util.h"

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -22,7 +22,6 @@
 #include "tcp_wrap.h"
 
 #include "connection_wrap.h"
-#include "env-inl.h"
 #include "handle_wrap.h"
 #include "node_buffer.h"
 #include "node_internals.h"

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -25,7 +25,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "async_wrap.h"
-#include "env.h"
 #include "connection_wrap.h"
 
 namespace node {

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -27,7 +27,6 @@
 #include "node_crypto.h"  // SSLWrap
 
 #include "async_wrap.h"
-#include "env.h"
 #include "stream_wrap.h"
 #include "v8.h"
 

--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -4,7 +4,6 @@
 #include "trace_event.h"
 #include "tracing/node_trace_buffer.h"
 #include "debug_utils.h"
-#include "env-inl.h"
 
 namespace node {
 namespace tracing {

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -21,7 +21,6 @@
 
 #include "tty_wrap.h"
 
-#include "env-inl.h"
 #include "handle_wrap.h"
 #include "node_buffer.h"
 #include "stream_base-inl.h"

--- a/src/tty_wrap.h
+++ b/src/tty_wrap.h
@@ -24,7 +24,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "env.h"
 #include "uv.h"
 #include "stream_wrap.h"
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -20,7 +20,6 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "udp_wrap.h"
-#include "env-inl.h"
 #include "node_buffer.h"
 #include "handle_wrap.h"
 #include "req_wrap-inl.h"

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -25,7 +25,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "async_wrap.h"
-#include "env.h"
 #include "handle_wrap.h"
 #include "uv.h"
 #include "v8.h"

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -7,7 +7,6 @@
 #include "node.h"
 #include "node_platform.h"
 #include "node_internals.h"
-#include "env.h"
 #include "v8.h"
 #include "libplatform/libplatform.h"
 

--- a/tools/msvs/pch/node_pch.h
+++ b/tools/msvs/pch/node_pch.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "aliased_buffer.h"
 #include "base_object-inl.h"
-#include "env-inl.h"
 #include "node_internals.h"
 #include "util-inl.h"
 #include "uv.h"

--- a/tools/snapshot/snapshot_builder.cc
+++ b/tools/snapshot/snapshot_builder.cc
@@ -1,7 +1,6 @@
 #include "snapshot_builder.h"
 #include <iostream>
 #include <sstream>
-#include "env-inl.h"
 #include "node_internals.h"
 #include "node_main_instance.h"
 #include "node_v8_platform-inl.h"


### PR DESCRIPTION
Try this PR to resolve #27531:

- confirm the forward declaration to support `Environment*` in "env.h":

https://github.com/nodejs/node/blob/3b48ce6ccfb39b72a446fad06b56d29dabe09b05/src/env.h#L414

- remove the include lines of `env.h` & `env-inl.h` in `src/`, while pass `make -j4 test`
  - list of files that I couldn't remove (could use advice if any suggest to update further)
    - `env.h`: 
      - node_crypto.h, node_dtrace.h, node_messaging.h, string_bytes.h
    - `env-inl.h`:
      - base_object-inl.h, debug_utils.h, node_binding.cc, node_config.cc, node_domain.cc, node_errors.h, node_internals.h, node_native_module_env.cc, node_options.cc, node_os.cc, node_process_events.cc, node_symbols.cc, node_types.cc, node_v8.cc, string_decoder.cc, timers.cc, uv.cc, async_resource.cc, encoding.cc

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)