### PR TITLE
http2: do not override the allowHalfOpen option

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2643,7 +2643,6 @@ function connectionListener(socket) {
 function initializeOptions(options) {
   assertIsObject(options, 'options');
   options = { ...options };
-  options.allowHalfOpen = true;
   assertIsObject(options.settings, 'options.settings');
   options.settings = { ...options.settings };
 


### PR DESCRIPTION
The constructors of `tls.Server` and `Http2Server` call the super
constructors without options so the `allowHalfOpen` option is never used
regardless of its value.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
