### PR TITLE
test: pass null params to napi_xxx_property()

### DIFF
--- a/test/js-native-api/test_object/test.js
+++ b/test/js-native-api/test_object/test.js
@@ -225,3 +225,30 @@ assert.strictEqual(newObject.test_string, 'test string');
   assert.deepStrictEqual(test_object.GetPropertyNames(object),
                          ['5', 'normal', 'inherited']);
 }
+
+// Verify that passing NULL to napi_set_property() results in the correct
+// error.
+assert.deepStrictEqual(test_object.TestSetProperty(), {
+  envIsNull: 'pass',
+  objectIsNull: 'pass',
+  keyIsNull: 'pass',
+  valueIsNull: 'pass'
+});
+
+// Verify that passing NULL to napi_has_property() results in the correct
+// error.
+assert.deepStrictEqual(test_object.TestHasProperty(), {
+  envIsNull: 'pass',
+  objectIsNull: 'pass',
+  keyIsNull: 'pass',
+  resultIsNull: 'pass'
+});
+
+// Verify that passing NULL to napi_get_property() results in the correct
+// error.
+assert.deepStrictEqual(test_object.TestGetProperty(), {
+  envIsNull: 'pass',
+  objectIsNull: 'pass',
+  keyIsNull: 'pass',
+  resultIsNull: 'pass'
+});

--- a/test/js-native-api/test_object/test_object.c
+++ b/test/js-native-api/test_object/test_object.c
@@ -339,6 +339,191 @@ static napi_value Unwrap(napi_env env, napi_callback_info info) {
   return result;
 }
 
+static napi_value TestSetProperty(napi_env env,
+                                  napi_callback_info info) {
+  napi_status ret[4];
+  napi_value object, key, value, prop_value;
+
+  NAPI_CALL(env, napi_create_object(env, &object));
+
+  NAPI_CALL(env, napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &key));
+
+  NAPI_CALL(env, napi_create_object(env, &value));
+
+  ret[0] = napi_set_property(NULL, object, key, value);
+
+  ret[1] = napi_set_property(env, NULL, key, value);
+
+  ret[2] = napi_set_property(env, object, NULL, value);
+
+  ret[3] = napi_set_property(env, object, key, NULL);
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[0] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_value));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         object,
+                                         "envIsNull",
+                                         prop_value));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[1] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_value));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         object,
+                                         "objectIsNull",
+                                         prop_value));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[2] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_value));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         object,
+                                         "keyIsNull",
+                                         prop_value));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[3] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_value));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         object,
+                                         "valueIsNull",
+                                         prop_value));
+
+  return object;
+}
+
+static napi_value TestHasProperty(napi_env env,
+                                  napi_callback_info info) {
+  napi_status ret[4];
+  napi_value object, key, prop_result;
+  bool result;
+
+  NAPI_CALL(env, napi_create_object(env, &object));
+
+  NAPI_CALL(env, napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &key));
+
+  ret[0] = napi_has_property(NULL, object, key, &result);
+
+  ret[1] = napi_has_property(env, NULL, key, &result);
+
+  ret[2] = napi_has_property(env, object, NULL, &result);
+
+  ret[3] = napi_has_property(env, object, key, NULL);
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[0] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_result));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         object,
+                                         "envIsNull",
+                                         prop_result));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[1] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_result));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         object,
+                                         "objectIsNull",
+                                         prop_result));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[2] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_result));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         object,
+                                         "keyIsNull",
+                                         prop_result));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[3] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_result));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         object,
+                                         "resultIsNull",
+                                         prop_result));
+
+  return object;
+}
+
+static napi_value TestGetProperty(napi_env env,
+                                  napi_callback_info info) {
+  napi_status ret[4];
+  napi_value object, key, result, prop_result;
+
+  NAPI_CALL(env, napi_create_object(env, &object));
+
+  NAPI_CALL(env, napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &key));
+
+  NAPI_CALL(env, napi_create_object(env, &result));
+
+  ret[0] = napi_get_property(NULL, object, key, &result);
+
+  ret[1] = napi_get_property(env, NULL, key, &result);
+
+  ret[2] = napi_get_property(env, object, NULL, &result);
+
+  ret[3] = napi_get_property(env, object, key, NULL);
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[0] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_result));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         object,
+                                         "envIsNull",
+                                         prop_result));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[1] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_result));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         object,
+                                         "objectIsNull",
+                                         prop_result));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[2] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_result));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         object,
+                                         "keyIsNull",
+                                         prop_result));
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (ret[3] == napi_invalid_arg ?
+                                             "pass" : "fail"),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_result));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         object,
+                                         "resultIsNull",
+                                         prop_result));
+
+  return object;
+}
+
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
@@ -355,6 +540,9 @@ napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NAPI_PROPERTY("Inflate", Inflate),
     DECLARE_NAPI_PROPERTY("Wrap", Wrap),
     DECLARE_NAPI_PROPERTY("Unwrap", Unwrap),
+    DECLARE_NAPI_PROPERTY("TestSetProperty", TestSetProperty),
+    DECLARE_NAPI_PROPERTY("TestHasProperty", TestHasProperty),
+    DECLARE_NAPI_PROPERTY("TestGetProperty", TestGetProperty),
   };
 
   NAPI_CALL(env, napi_define_properties(


### PR DESCRIPTION
    For napi_set_property(), each one of the following arguments is checked:
      napi_env env,
      napi_value object,
      napi_value key,
      napi_value* value.

    For napi_has_property(), each one of the following arguments is checked:

      napi_env env,
      napi_value object,
      napi_value key,
      bool* result

    For napi_get_property, each one of the following arguments is checked:

      napi_env env,
      napi_value object,
      napi_value key,
      napi_value* result

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
