### PR TITLE
src: remove util-inl.h from header files

### DIFF
--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -4,7 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include <cinttypes>
-#include "util-inl.h"
+#include "util.h"
 #include "v8.h"
 
 namespace node {

--- a/src/api/utils.cc
+++ b/src/api/utils.cc
@@ -1,5 +1,6 @@
 #include "node.h"
 #include "node_internals.h"
+#include "util-inl.h"
 
 #include <csignal>
 

--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -26,7 +26,7 @@
 
 #include "base_object.h"
 #include "env-inl.h"
-#include "util-inl.h"
+#include "util.h"
 #include "v8.h"
 
 namespace node {

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -1,4 +1,5 @@
 #include "debug_utils.h"
+#include "util-inl.h"
 
 #ifdef __POSIX__
 #if defined(__linux__)

--- a/src/env.cc
+++ b/src/env.cc
@@ -13,6 +13,7 @@
 #include "node_worker.h"
 #include "tracing/agent.h"
 #include "tracing/traced_value.h"
+#include "util-inl.h"
 #include "v8-profiler.h"
 
 #include <algorithm>

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -1,5 +1,6 @@
 #include "env-inl.h"
 #include "stream_base-inl.h"
+#include "util-inl.h"
 
 using v8::Array;
 using v8::Boolean;

--- a/src/inspector/tracing_agent.cc
+++ b/src/inspector/tracing_agent.cc
@@ -4,6 +4,7 @@
 #include "node_v8_platform-inl.h"
 
 #include "env-inl.h"
+#include "util-inl.h"
 #include "v8.h"
 
 #include <set>

--- a/src/inspector/worker_inspector.cc
+++ b/src/inspector/worker_inspector.cc
@@ -1,5 +1,6 @@
 #include "worker_inspector.h"
 #include "main_thread_interface.h"
+#include "util-inl.h"
 
 #include <memory>
 

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -12,6 +12,7 @@
 #include "node_options-inl.h"
 #include "node_process.h"
 #include "node_url.h"
+#include "util-inl.h"
 #include "v8-inspector.h"
 #include "v8-platform.h"
 

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -11,7 +11,7 @@
 #include "node_internals.h"
 #include "node_mutex.h"
 #include "v8-inspector.h"
-#include "util.h"
+#include "util-inl.h"
 #include "zlib.h"
 
 #include <deque>

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -1,6 +1,7 @@
 #include "base_object-inl.h"
 #include "inspector_agent.h"
 #include "inspector_io.h"
+#include "util-inl.h"
 #include "v8.h"
 #include "v8-inspector.h"
 

--- a/src/inspector_profiler.cc
+++ b/src/inspector_profiler.cc
@@ -5,7 +5,7 @@
 #include "node_file.h"
 #include "node_internals.h"
 #include "v8-inspector.h"
-#include "util.h"
+#include "util-inl.h"
 
 namespace node {
 namespace profiler {

--- a/src/inspector_socket.h
+++ b/src/inspector_socket.h
@@ -3,7 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "util-inl.h"
+#include "util.h"
 #include "uv.h"
 
 #include <string>

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -1,6 +1,7 @@
 #include "inspector_socket_server.h"
 
 #include "node.h"
+#include "util-inl.h"
 #include "uv.h"
 #include "zlib.h"
 

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -4,6 +4,7 @@
 #define NAPI_EXPERIMENTAL
 #include "js_native_api_v8.h"
 #include "js_native_api.h"
+#include "util-inl.h"
 
 #define CHECK_MAYBE_NOTHING(env, maybe, status) \
   RETURN_STATUS_IF_FALSE((env), !((maybe).IsNothing()), (status))

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -150,7 +150,7 @@ inline napi_value JsValueFromV8LocalValue(v8::Local<v8::Value> local) {
 
 inline v8::Local<v8::Value> V8LocalValueFromJsValue(napi_value v) {
   v8::Local<v8::Value> local;
-  memcpy(&local, &v, sizeof(v));
+  memcpy(static_cast<void*>(&local), &v, sizeof(v));
   return local;
 }
 

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -5,6 +5,7 @@
 #include "node_buffer.h"
 #include "node_errors.h"
 #include "stream_base-inl.h"
+#include "util-inl.h"
 #include "v8.h"
 
 namespace node {

--- a/src/node.cc
+++ b/src/node.cc
@@ -24,6 +24,7 @@
 // ========== local headers ==========
 
 #include "debug_utils.h"
+#include "env-inl.h"
 #include "node_binding.h"
 #include "node_internals.h"
 #include "node_main_instance.h"

--- a/src/node.h
+++ b/src/node.h
@@ -99,6 +99,14 @@
 # endif
 #endif
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+// Internally, do not include util-inl.h into files unless they need it's
+// inline definitions.
+#else
+// Externally, it must be included for backwards API compatibility.
+#  include <util-inl.h>
+#endif
+
 // Forward-declare libuv loop
 struct uv_loop_s;
 

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -6,6 +6,7 @@
 #include "node_binding.h"
 #include "node_errors.h"
 #include "node_internals.h"
+#include "util-inl.h"
 
 #include <memory>
 

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -21,7 +21,8 @@ using v8::Value;
 
 static void Initialize(Local<Object> target,
                        Local<Value> unused,
-                       Local<Context> context) {
+                       Local<Context> context,
+                       void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
 

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -21,6 +21,7 @@
 
 #include "node_constants.h"
 #include "node_internals.h"
+#include "util-inl.h"
 
 #include "zlib.h"
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -27,6 +27,7 @@
 #include "node_context_data.h"
 #include "node_errors.h"
 #include "module_wrap.h"
+#include "util-inl.h"
 
 namespace node {
 namespace contextify {

--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -1,4 +1,5 @@
 #include "node_internals.h"
+#include "util-inl.h"
 
 #ifdef NODE_IMPLEMENTS_POSIX_CREDENTIALS
 #include <grp.h>  // getgrnam()

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -26,8 +26,8 @@
 
 #include "node_crypto.h"
 #include "openssl/bio.h"
-#include "env-inl.h"
-#include "util-inl.h"
+#include "env.h"
+#include "util.h"
 #include "v8.h"
 
 namespace node {

--- a/src/node_crypto_clienthello-inl.h
+++ b/src/node_crypto_clienthello-inl.h
@@ -25,7 +25,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node_crypto_clienthello.h"
-#include "util-inl.h"
+#include "util.h"
 
 namespace node {
 namespace crypto {

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -42,6 +42,7 @@
 #define NODE_GC_DONE(arg0, arg1, arg2)
 #endif
 
+#include "env-inl.h"
 #include "node_errors.h"
 
 #include <cstring>

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -1,6 +1,6 @@
+#include "env-inl.h"
 #include "node_errors.h"
 #include "node_process.h"
-#include "util.h"
 
 #ifdef __APPLE__
 #include <crt_externs.h>

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -8,6 +8,7 @@
 #endif
 #include "node_process.h"
 #include "node_v8_platform-inl.h"
+#include "util-inl.h"
 
 namespace node {
 

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -4,8 +4,8 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
-#include "util-inl.h"
-#include "env-inl.h"
+#include "util.h"
+#include "env.h"
 #include "v8.h"
 
 // Use ostringstream to print exact-width integer types

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -24,7 +24,7 @@
 #include "node_buffer.h"
 #include "node_process.h"
 #include "node_stat_watcher.h"
-#include "util.h"
+#include "util-inl.h"
 
 #include "tracing/trace_event.h"
 

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -5,7 +5,7 @@
 #include "node_http2.h"
 #include "node_http2_state.h"
 #include "node_perf.h"
-#include "util.h"
+#include "util-inl.h"
 
 #include <algorithm>
 

--- a/src/node_http_parser_llhttp.cc
+++ b/src/node_http_parser_llhttp.cc
@@ -2,6 +2,7 @@
 
 #include "node_http_parser_impl.h"
 #include "node_metadata.h"
+#include "util-inl.h"
 
 namespace node {
 

--- a/src/node_http_parser_traditional.cc
+++ b/src/node_http_parser_traditional.cc
@@ -4,6 +4,7 @@
 
 #include "node_http_parser_impl.h"
 #include "node_metadata.h"
+#include "util-inl.h"
 
 namespace node {
 namespace per_process {

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -29,7 +29,7 @@
 #include "node_binding.h"
 #include "node_mutex.h"
 #include "tracing/trace_event.h"
-#include "util-inl.h"
+#include "util.h"
 #include "uv.h"
 #include "v8.h"
 

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -2,6 +2,7 @@
 #include "node_internals.h"
 #include "node_options-inl.h"
 #include "node_v8_platform-inl.h"
+#include "util-inl.h"
 
 namespace node {
 

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -6,7 +6,7 @@
 #include "node_buffer.h"
 #include "node_errors.h"
 #include "node_process.h"
-#include "util.h"
+#include "util-inl.h"
 
 using node::contextify::ContextifyContext;
 using v8::Array;

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -21,7 +21,6 @@
 
 #include "env-inl.h"
 #include "string_bytes.h"
-#include "util.h"
 
 #ifdef __MINGW32__
 # include <io.h>

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -3,6 +3,7 @@
 #include "node_perf.h"
 #include "node_buffer.h"
 #include "node_process.h"
+#include "util-inl.h"
 
 #include <cinttypes>
 

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -3,7 +3,6 @@
 
 #include "env-inl.h"
 #include "debug_utils.h"
-#include "util.h"
 #include <algorithm>
 #include <cmath>
 #include <memory>

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -3,7 +3,7 @@
 #include "node_internals.h"
 #include "node_options.h"
 #include "node_report.h"
-#include "util.h"
+#include "util-inl.h"
 
 #include "handle_wrap.h"
 #include "node_buffer.h"

--- a/src/node_report_utils.cc
+++ b/src/node_report_utils.cc
@@ -1,5 +1,6 @@
 #include "node_internals.h"
 #include "node_report.h"
+#include "util-inl.h"
 
 namespace report {
 

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -1,6 +1,7 @@
 #include "node_internals.h"
 #include "node_buffer.h"
 #include "node_errors.h"
+#include "util-inl.h"
 #include "base_object-inl.h"
 
 namespace node {

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -23,7 +23,7 @@
 #include "async_wrap-inl.h"
 #include "env.h"
 #include "node_file.h"
-#include "util.h"
+#include "util-inl.h"
 
 #include <cstring>
 #include <cstdlib>

--- a/src/node_symbols.cc
+++ b/src/node_symbols.cc
@@ -1,5 +1,6 @@
 #include "env-inl.h"
 #include "node_binding.h"
+#include "util.h"
 
 namespace node {
 

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -3,6 +3,7 @@
 #include "node_errors.h"
 #include "node_internals.h"
 #include "node_process.h"
+#include "util-inl.h"
 #include "v8.h"
 
 #include <atomic>

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -4,6 +4,7 @@
 #include "node_internals.h"
 #include "node_v8_platform-inl.h"
 #include "tracing/agent.h"
+#include "util-inl.h"
 
 #include <set>
 #include <string>

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -2,7 +2,7 @@
 #include "base_object-inl.h"
 #include "node_errors.h"
 #include "node_i18n.h"
-#include "util.h"
+#include "util-inl.h"
 
 #include <cmath>
 #include <cstdio>

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -1,5 +1,5 @@
 #include "node_errors.h"
-#include "util.h"
+#include "util-inl.h"
 #include "base_object-inl.h"
 
 namespace node {

--- a/src/node_watchdog.cc
+++ b/src/node_watchdog.cc
@@ -24,6 +24,7 @@
 #include "debug_utils.h"
 #include "node_errors.h"
 #include "node_internals.h"
+#include "util-inl.h"
 
 namespace node {
 

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -4,7 +4,7 @@
 #include "node_buffer.h"
 #include "node_options-inl.h"
 #include "node_perf.h"
-#include "util.h"
+#include "util-inl.h"
 #include "async_wrap-inl.h"
 
 #if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR

--- a/src/req_wrap-inl.h
+++ b/src/req_wrap-inl.h
@@ -5,8 +5,6 @@
 
 #include "req_wrap.h"
 #include "async_wrap-inl.h"
-#include "env-inl.h"
-#include "util-inl.h"
 #include "uv.h"
 
 namespace node {

--- a/src/sharedarraybuffer_metadata.cc
+++ b/src/sharedarraybuffer_metadata.cc
@@ -2,6 +2,7 @@
 
 #include "base_object-inl.h"
 #include "node_errors.h"
+#include "util-inl.h"
 
 #include <utility>
 

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -24,6 +24,7 @@
 #include "env-inl.h"
 #include "node_internals.h"
 #include "string_bytes.h"
+#include "util-inl.h"
 
 #include <cstring>
 

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -1,6 +1,7 @@
 #include "stream_pipe.h"
 #include "stream_base-inl.h"
 #include "node_buffer.h"
+#include "util-inl.h"
 
 using v8::Context;
 using v8::Function;

--- a/src/string_decoder.cc
+++ b/src/string_decoder.cc
@@ -4,6 +4,7 @@
 #include "env-inl.h"
 #include "node_buffer.h"
 #include "string_bytes.h"
+#include "util.h"
 
 using v8::Array;
 using v8::ArrayBufferView;

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -1,5 +1,5 @@
 #include "env-inl.h"
-#include "util.h"
+#include "util-inl.h"
 #include "v8.h"
 
 #include <cstdint>

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -27,6 +27,18 @@
 #include <cstring>
 #include "util.h"
 
+// These are defined by <sys/byteorder.h> or <netinet/in.h> on some systems.
+// To avoid warnings, undefine them before redefining them.
+#ifdef BSWAP_2
+# undef BSWAP_2
+#endif
+#ifdef BSWAP_4
+# undef BSWAP_4
+#endif
+#ifdef BSWAP_8
+# undef BSWAP_8
+#endif
+
 #if defined(_MSC_VER)
 #include <intrin.h>
 #define BSWAP_2(x) _byteswap_ushort(x)

--- a/src/util.cc
+++ b/src/util.cc
@@ -19,7 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "util.h"
+#include "util.h"  // NOLINT(build/include_inline)
+#include "util-inl.h"
 
 #include "node_buffer.h"
 #include "node_errors.h"

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -23,7 +23,6 @@
 #include "env-inl.h"
 #include "node.h"
 #include "node_process.h"
-#include "util.h"
 
 namespace node {
 

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -8,6 +8,7 @@
 #include "node_platform.h"
 #include "node_internals.h"
 #include "env.h"
+#include "util-inl.h"
 #include "v8.h"
 #include "libplatform/libplatform.h"
 

--- a/test/cctest/test_inspector_socket.cc
+++ b/test/cctest/test_inspector_socket.cc
@@ -1,4 +1,5 @@
 #include "inspector_socket.h"
+#include "util-inl.h"
 #include "gtest/gtest.h"
 
 #include <queue>

--- a/test/cctest/test_inspector_socket_server.cc
+++ b/test/cctest/test_inspector_socket_server.cc
@@ -1,6 +1,7 @@
 #include "inspector_socket_server.h"
 
 #include "node.h"
+#include "util-inl.h"
 #include "gtest/gtest.h"
 
 #include <algorithm>

--- a/test/cctest/test_linked_binding.cc
+++ b/test/cctest/test_linked_binding.cc
@@ -3,7 +3,8 @@
 
 void InitializeBinding(v8::Local<v8::Object> exports,
                        v8::Local<v8::Value> module,
-                       v8::Local<v8::Context> context) {
+                       v8::Local<v8::Context> context,
+                       void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
   exports->Set(
       context,


### PR DESCRIPTION
    Its intended that *-inl.h header files are only included into the src
    files that call the inline methods. Explicitly include it into the files
    that need it.

Also, declared an unused priv argument for Initialize, so it doesn't warn on signature mismatch.




<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Related to https://github.com/nodejs/node/issues/27531