### PR TITLE
module: fix createRequireFromPath() slash logic

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -838,7 +838,7 @@ Module.runMain = function() {
 function createRequireFromPath(filename) {
   // Allow a directory to be passed as the filename
   const trailingSlash =
-    filename.endsWith(path.sep) || path.sep !== '/' && filename.endsWith('\\');
+    filename.endsWith('/') || (isWindows && filename.endsWith('\\'));
 
   const proxyPath = trailingSlash ?
     path.join(filename, 'noop.js') :


### PR DESCRIPTION
The trailing slash detection logic in `createRequireFromPath()` seemed slightly incorrect. This commit reworks the logic.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
