### PR TITLE
assert,test: complete coverage for AssertionError

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -14,6 +14,8 @@ let white = '';
 
 const kReadableOperator = {
   deepStrictEqual: 'Expected values to be strictly deep-equal:',
+  equal: 'Expected values to be loosely equal:',
+  notEqualUnequal: 'Expected values not to be loosely equal:',
   strictEqual: 'Expected values to be strictly equal:',
   strictEqualObject: 'Expected "actual" to be reference-equal to "expected":',
   deepEqual: 'Expected values to be loosely deep-equal:',

--- a/test/parallel/test-assert-assertion-error.js
+++ b/test/parallel/test-assert-assertion-error.js
@@ -1,0 +1,27 @@
+'use strict';
+require('../common');
+
+// Test some edge cases for AssertionError that are not tested elsewhere.
+const assert = require('assert');
+
+{
+  const err = new assert.AssertionError({ operator: 'equal',
+                                          actual: 'come on',
+                                          expected: 'fhqwhgads',
+  });
+
+  assert.strictEqual(err.message,
+                     "Expected values to be loosely equal:\n\n'come on'\n\n" +
+                     "should loosely equal\n\n'fhqwhgads'");
+}
+
+{
+  const err = new assert.AssertionError({ operator: 'notEqual',
+                                          actual: 'come on',
+                                          expected: 'fhqwhgads',
+  });
+
+  assert.strictEqual(err.message,
+                     'Expected values not to be loosely equal:\n\n' +
+                     "'come on'\n\nshould not loosely equal\n\n'fhqwhgads'");
+}


### PR DESCRIPTION
There were two code branches in lib/internal/assert/assertion_error.js
that were not covered by tests. This adds a test to cover the
two uncovered branches. The test revealed that there was some missing
properties/functaionality in the AssertionError class. So this also adds
the missing material.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
