### PR TITLE
test: improve test-tls-passphrase

### DIFF
--- a/test/parallel/test-tls-passphrase.js
+++ b/test/parallel/test-tls-passphrase.js
@@ -49,177 +49,195 @@ const server = tls.Server({
 });
 
 server.listen(0, common.mustCall(function() {
-  // Buffer
-  tls.connect({
-    port: this.address().port,
-    key: passKey,
-    passphrase: 'passphrase',
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
+  function test(options) {
+    const next = testCases.pop();
+    if (next) {
+      test(next);
+    } else {
+      server.close();
+    }
+  }
 
-  tls.connect({
-    port: this.address().port,
-    key: rawKey,
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
+  const port = server.address().port;
 
-  tls.connect({
-    port: this.address().port,
-    key: rawKey,
-    passphrase: 'ignored',
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
+  const testCases = [
+    {
+      port: port,
+      key: passKey,
+      passphrase: 'passphrase',
+      cert: cert,
+      rejectUnauthorized: false
+    },
 
-  // Buffer[]
-  tls.connect({
-    port: this.address().port,
-    key: [passKey],
-    passphrase: 'passphrase',
-    cert: [cert],
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: rawKey,
+      cert: cert,
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [rawKey],
-    cert: [cert],
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: rawKey,
+      passphrase: 'ignored',
+      cert: cert,
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [rawKey],
-    passphrase: 'ignored',
-    cert: [cert],
-    rejectUnauthorized: false
-  }, common.mustCall());
+    // Buffer[]
+    {
+      port: port,
+      key: [passKey],
+      passphrase: 'passphrase',
+      cert: [cert],
+      rejectUnauthorized: false
+    },
 
-  // string
-  tls.connect({
-    port: this.address().port,
-    key: passKey.toString(),
-    passphrase: 'passphrase',
-    cert: cert.toString(),
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: [rawKey],
+      cert: [cert],
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: rawKey.toString(),
-    cert: cert.toString(),
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: [rawKey],
+      passphrase: 'ignored',
+      cert: [cert],
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: rawKey.toString(),
-    passphrase: 'ignored',
-    cert: cert.toString(),
-    rejectUnauthorized: false
-  }, common.mustCall());
+    // string
+    {
+      port: port,
+      key: passKey.toString(),
+      passphrase: 'passphrase',
+      cert: cert.toString(),
+      rejectUnauthorized: false
+    },
 
-  // String[]
-  tls.connect({
-    port: this.address().port,
-    key: [passKey.toString()],
-    passphrase: 'passphrase',
-    cert: [cert.toString()],
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: rawKey.toString(),
+      cert: cert.toString(),
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [rawKey.toString()],
-    cert: [cert.toString()],
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: rawKey.toString(),
+      passphrase: 'ignored',
+      cert: cert.toString(),
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [rawKey.toString()],
-    passphrase: 'ignored',
-    cert: [cert.toString()],
-    rejectUnauthorized: false
-  }, common.mustCall());
+    // String[]
+    {
+      port: port,
+      key: [passKey.toString()],
+      passphrase: 'passphrase',
+      cert: [cert.toString()],
+      rejectUnauthorized: false
+    },
 
-  // Object[]
-  tls.connect({
-    port: this.address().port,
-    key: [{ pem: passKey, passphrase: 'passphrase' }],
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: [rawKey.toString()],
+      cert: [cert.toString()],
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [{ pem: passKey, passphrase: 'passphrase' }],
-    passphrase: 'ignored',
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: [rawKey.toString()],
+      passphrase: 'ignored',
+      cert: [cert.toString()],
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [{ pem: passKey }],
-    passphrase: 'passphrase',
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
+    // Object[]
+    {
+      port: port,
+      key: [{ pem: passKey, passphrase: 'passphrase' }],
+      cert: cert,
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [{ pem: passKey.toString(), passphrase: 'passphrase' }],
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: [{ pem: passKey, passphrase: 'passphrase' }],
+      passphrase: 'ignored',
+      cert: cert,
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [{ pem: rawKey, passphrase: 'ignored' }],
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: [{ pem: passKey }],
+      passphrase: 'passphrase',
+      cert: cert,
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [{ pem: rawKey.toString(), passphrase: 'ignored' }],
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: [{ pem: passKey.toString(), passphrase: 'passphrase' }],
+      cert: cert,
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [{ pem: rawKey }],
-    passphrase: 'ignored',
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: [{ pem: rawKey, passphrase: 'ignored' }],
+      cert: cert,
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [{ pem: rawKey.toString() }],
-    passphrase: 'ignored',
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: [{ pem: rawKey.toString(), passphrase: 'ignored' }],
+      cert: cert,
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [{ pem: rawKey }],
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
+    {
+      port: port,
+      key: [{ pem: rawKey }],
+      passphrase: 'ignored',
+      cert: cert,
+      rejectUnauthorized: false
+    },
 
-  tls.connect({
-    port: this.address().port,
-    key: [{ pem: rawKey.toString() }],
-    cert: cert,
-    rejectUnauthorized: false
-  }, common.mustCall());
-})).unref();
+    {
+      port: port,
+      key: [{ pem: rawKey.toString() }],
+      passphrase: 'ignored',
+      cert: cert,
+      rejectUnauthorized: false
+    },
+
+    {
+      port: port,
+      key: [{ pem: rawKey }],
+      cert: cert,
+      rejectUnauthorized: false
+    },
+
+    {
+      port: port,
+      key: [{ pem: rawKey.toString() }],
+      cert: cert,
+      rejectUnauthorized: false
+    },
+  ];
+
+  process.on('exit', () => {
+    assert.deepStrictEqual(testCases, []);
+  });
+
+  test(testCases.pop());
+}));
 
 const errMessagePassword = /bad decrypt/;
 


### PR DESCRIPTION
test-tls-passphrase is unreliable on some systems (such as my local
laptop) when run in a highly parallel way because it opens more than 20
connections to a TLS server simultaneously. Run enough of those with
other tests also opening lots of connections, and ECONNRESET starts to
show up:

```
$ tools/test.py -j 96 --repeat 192 test/parallel/test-tls-passphrase.js
...
=== release test-tls-passphrase ===
Path: parallel/test-tls-passphrase
events.js:173
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:183:27)
Emitted 'error' event at:
    at emitErrorNT (internal/streams/destroy.js:91:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at processTicksAndRejections (internal/process/task_queues.js:84:9)
...
[00:21|% 100|+ 137|-  55]: Done
```

This change runs all the connections in sequence. This results in a much
more reliable test:

```
$ tools/test.py -j 96 --repeat 192 test/parallel/test-tls-passphrase.js
[00:08|% 100|+ 192|-   0]: Done
$
```

Notice that the test run is also much faster this way (8 seconds instead
of 21 seconds). This is true even for single test runs, at least on my
machine (and I suspect on any typical setup). Current master:

```
$ time ./node test/parallel/test-tls-passphrase.js

real	0m0.249s
user	0m0.203s
sys	0m0.036s
$
```

This commit:

```
$ time ./node test/parallel/test-tls-passphrase.js

real	0m0.093s
user	0m0.075s
sys	0m0.014s
$
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
