### PR TITLE
doc,meta: codify security release commit message

### DIFF
--- a/doc/releases.md
+++ b/doc/releases.md
@@ -345,6 +345,21 @@ Notable changes:
 * Copy the notable changes list here, reformatted for plain-text
 ```
 
+For security releases, begin the commit message with the phrase
+`This is a security release.` to allow the
+[distribution indexer](https://github.com/nodejs/nodejs-dist-indexer) to
+identify it as such:
+
+```txt
+YYYY-MM-DD, Version x.y.z (Release Type)
+
+This is a security release.
+
+Notable changes:
+
+* Copy the notable changes list here, reformatted for plain-text
+```
+
 ### 6. Propose Release on GitHub
 
 Push the release branch to `nodejs/node`, not to your own fork. This allows


### PR DESCRIPTION
The release commit message for security releases have conventionally
started with the phrase `This is a security release.`. Codify this
as part of the release process so that the distribution indexer can
use this to detect and mark releases as security releases.

Fixes: https://github.com/nodejs/Release/issues/437
Refs: https://github.com/nodejs/node/pull/27612#issuecomment-490698922
Refs: https://github.com/nodejs/nodejs-dist-indexer/pull/9

cc @nodejs/security-wg (as the requirement came out of one of their meetings) 
@nodejs/security-release (this should just be a case of writing down what already happens)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
