### PR TITLE
path: fix unicode path problems in path.relative

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -464,86 +464,67 @@ const win32 = {
            from.charCodeAt(fromEnd - 1) === CHAR_BACKWARD_SLASH) {
       fromEnd--;
     }
-    const fromLen = fromEnd - fromStart;
+    if (fromStart > 0 || fromEnd < from.length)
+      from = from.slice(fromStart, fromEnd);
 
     // Trim any leading backslashes
+    const toLenBeforeTrim = to.length;
     let toStart = 0;
-    while (toStart < to.length &&
+    while (toStart < toLenBeforeTrim &&
            to.charCodeAt(toStart) === CHAR_BACKWARD_SLASH) {
       toStart++;
     }
     // Trim trailing backslashes (applicable to UNC paths only)
-    let toEnd = to.length;
+    let toEnd = toLenBeforeTrim;
     while (toEnd - 1 > toStart &&
            to.charCodeAt(toEnd - 1) === CHAR_BACKWARD_SLASH) {
       toEnd--;
     }
-    const toLen = toEnd - toStart;
+    if (toStart > 0 || toEnd < toLenBeforeTrim)
+      to = to.slice(toStart, toEnd);
 
-    // Compare paths to find the longest common path from root
-    const length = fromLen < toLen ? fromLen : toLen;
-    let lastCommonSep = -1;
+    // Even the device roots are different. Return the original `to`.
+    if (from.charCodeAt(0) !== to.charCodeAt(0))
+      return toOrig;
+
+    // Split paths
+    const fromParts = from.split('\\');
+    const toParts = to.split('\\');
+
     let i = 0;
-    for (; i < length; i++) {
-      const fromCode = from.charCodeAt(fromStart + i);
-      if (fromCode !== to.charCodeAt(toStart + i))
-        break;
-      else if (fromCode === CHAR_BACKWARD_SLASH)
-        lastCommonSep = i;
-    }
+    const partLen = fromParts.length < toParts.length ?
+      fromParts.length :
+      toParts.length;
 
-    // We found a mismatch before the first common path separator was seen, so
-    // return the original `to`.
-    if (i !== length) {
-      if (lastCommonSep === -1)
-        return toOrig;
-    } else {
-      if (toLen > length) {
-        if (to.charCodeAt(toStart + i) === CHAR_BACKWARD_SLASH) {
-          // We get here if `from` is the exact base path for `to`.
-          // For example: from='C:\\foo\\bar'; to='C:\\foo\\bar\\baz'
-          return toOrig.slice(toStart + i + 1);
-        }
-        if (i === 2) {
-          // We get here if `from` is the device root.
-          // For example: from='C:\\'; to='C:\\foo'
-          return toOrig.slice(toStart + i);
-        }
-      }
-      if (fromLen > length) {
-        if (from.charCodeAt(fromStart + i) === CHAR_BACKWARD_SLASH) {
-          // We get here if `to` is the exact base path for `from`.
-          // For example: from='C:\\foo\\bar'; to='C:\\foo'
-          lastCommonSep = i;
-        } else if (i === 2) {
-          // We get here if `to` is the device root.
-          // For example: from='C:\\foo\\bar'; to='C:\\'
-          lastCommonSep = 3;
-        }
-      }
-      if (lastCommonSep === -1)
-        lastCommonSep = 0;
-    }
+    // Find the number of common ancestors
+    while (i < partLen && fromParts[i] === toParts[i])
+      i++;
 
+    const numOfCommonAncestors = i;
+    let numOfStepsToWalkUp = fromParts.length - numOfCommonAncestors;
     let out = '';
-    // Generate the relative path based on the path difference between `to` and
-    // `from`
-    for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
-      if (i === fromEnd || from.charCodeAt(i) === CHAR_BACKWARD_SLASH) {
-        out += out.length === 0 ? '..' : '\\..';
-      }
+
+    // Walk up the directory tree to get the nearest common ancestor (if any)
+    // and then append the "different" parts (if any)
+    while (numOfStepsToWalkUp-- > 0)
+      out += out.length === 0 ? '..' : '\\..';
+
+    let partIx = 0;
+
+    // Find the starting position of the remaining part
+    const toOrigEnd = toOrig.length - toLenBeforeTrim + toEnd;
+    for (i = toStart; partIx < numOfCommonAncestors && i <= toOrigEnd; i++)
+      if (toOrig.charCodeAt(i) === CHAR_BACKWARD_SLASH)
+        partIx++;
+
+    if (partIx > 0 && i <= toOrigEnd) {
+      if (out.length > 0)
+        out += '\\';
+
+      out += toOrig.slice(i, toOrigEnd);
     }
 
-    toStart += lastCommonSep;
-
-    // Lastly, append the rest of the destination (`to`) path that comes after
-    // the common path parts
-    if (out.length > 0)
-      return `${out}${toOrig.slice(toStart, toEnd)}`;
-
-    if (toOrig.charCodeAt(toStart) === CHAR_BACKWARD_SLASH)
-      ++toStart;
-    return toOrig.slice(toStart, toEnd);
+    return out;
   },
 
   toNamespacedPath(path) {

--- a/test/parallel/test-path-relative.js
+++ b/test/parallel/test-path-relative.js
@@ -31,7 +31,9 @@ const relativeTests = [
      ['\\\\foo\\baz-quux', '\\\\foo\\baz', '..\\baz'],
      ['\\\\foo\\baz', '\\\\foo\\baz-quux', '..\\baz-quux'],
      ['C:\\baz', '\\\\foo\\bar\\baz', '\\\\foo\\bar\\baz'],
-     ['\\\\foo\\bar\\baz', 'C:\\baz', 'C:\\baz']
+     ['\\\\foo\\bar\\baz', 'C:\\baz', 'C:\\baz'],
+     ['c:\\a\\İ', 'c:\\a\\İ\\test.txt', 'test.txt'],
+     ['c:\\İ\\a\\İ', 'c:\\İ\\b\\İ\\test.txt', '..\\..\\b\\İ\\test.txt']
     ]
   ],
   [ path.posix.relative,


### PR DESCRIPTION
This commit changes the way two paths are compared in path.relative:
Instead of comparing each char code in path strings one by one, which
causes problems when the number of char codes in lowercased path string
does not match the original one (e.g. path contains certain Unicode
characters like 'İ'), it now splits the path string by backslash and
compares the parts instead.

Fixes: https://github.com/nodejs/node/issues/27534

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
