### PR TITLE
tools: force common be required before any other modules

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -22,6 +22,7 @@ rules:
   node-core/number-isnan: error
   ## common module is mandatory in tests
   node-core/required-modules: [error, common]
+  node-core/require-common-first: error
   node-core/no-duplicate-requires: off
 
 # Global scoped methods and vars

--- a/test/async-hooks/hook-checks.js
+++ b/test/async-hooks/hook-checks.js
@@ -1,6 +1,6 @@
 'use strict';
-const assert = require('assert');
 require('../common');
+const assert = require('assert');
 
 /**
  * Checks the expected invocations against the invocations that actually

--- a/test/async-hooks/verify-graph.js
+++ b/test/async-hooks/verify-graph.js
@@ -1,8 +1,8 @@
 'use strict';
 
+require('../common');
 const assert = require('assert');
 const util = require('util');
-require('../common');
 
 function findInGraph(graph, type, n) {
   let found = 0;

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -386,7 +386,7 @@ thread.
 The `ArrayStream` module provides a simple `Stream` that pushes elements from
 a given array.
 
-<!-- eslint-disable no-undef, node-core/required-modules -->
+<!-- eslint-disable no-undef, node-core/require-common-first, node-core/required-modules -->
 ```js
 const ArrayStream = require('../common/arraystream');
 const stream = new ArrayStream();
@@ -402,7 +402,7 @@ require a particular action to be taken after a given number of completed
 tasks (for instance, shutting down an HTTP server after a specific number of
 requests). The Countdown will fail the test if the remainder did not reach 0.
 
-<!-- eslint-disable strict, node-core/required-modules -->
+<!-- eslint-disable strict, node-core/require-common-first, node-core/required-modules -->
 ```js
 const Countdown = require('../common/countdown');
 
@@ -574,7 +574,7 @@ one listed below. (`heap.validateSnapshotNodes(...)` is a shortcut for
 
 Create a heap dump and an embedder graph copy and validate occurrences.
 
-<!-- eslint-disable no-undef, node-core/required-modules -->
+<!-- eslint-disable no-undef, node-core/require-common-first, node-core/required-modules -->
 ```js
 validateSnapshotNodes('TLSWRAP', [
   {
@@ -592,7 +592,7 @@ validateSnapshotNodes('TLSWRAP', [
 The `hijackstdio` module provides utility functions for temporarily redirecting
 `stdout` and `stderr` output.
 
-<!-- eslint-disable no-undef, node-core/required-modules -->
+<!-- eslint-disable no-undef, node-core/require-common-first, node-core/required-modules -->
 ```js
 const { hijackStdout, restoreStdout } = require('../common/hijackstdio');
 
@@ -638,7 +638,7 @@ original state after calling [`hijackstdio.hijackStdOut()`][].
 The http2.js module provides a handful of utilities for creating mock HTTP/2
 frames for testing of HTTP/2 endpoints
 
-<!-- eslint-disable no-unused-vars, node-core/required-modules -->
+<!-- eslint-disable no-unused-vars, node-core/require-common-first, node-core/required-modules -->
 ```js
 const http2 = require('../common/http2');
 ```
@@ -648,7 +648,7 @@ const http2 = require('../common/http2');
 The `http2.Frame` is a base class that creates a `Buffer` containing a
 serialized HTTP/2 frame header.
 
-<!-- eslint-disable no-undef, node-core/required-modules -->
+<!-- eslint-disable no-undef, node-core/require-common-first, node-core/required-modules -->
 ```js
 // length is a 24-bit unsigned integer
 // type is an 8-bit unsigned integer identifying the frame type
@@ -667,7 +667,7 @@ The serialized `Buffer` may be retrieved using the `frame.data` property.
 The `http2.DataFrame` is a subclass of `http2.Frame` that serializes a `DATA`
 frame.
 
-<!-- eslint-disable no-undef, node-core/required-modules -->
+<!-- eslint-disable no-undef, node-core/require-common-first, node-core/required-modules -->
 ```js
 // id is the 32-bit stream identifier
 // payload is a Buffer containing the DATA payload
@@ -684,7 +684,7 @@ socket.write(frame.data);
 The `http2.HeadersFrame` is a subclass of `http2.Frame` that serializes a
 `HEADERS` frame.
 
-<!-- eslint-disable no-undef, node-core/required-modules -->
+<!-- eslint-disable no-undef, node-core/require-common-first, node-core/required-modules -->
 ```js
 // id is the 32-bit stream identifier
 // payload is a Buffer containing the HEADERS payload (see either
@@ -702,7 +702,7 @@ socket.write(frame.data);
 The `http2.SettingsFrame` is a subclass of `http2.Frame` that serializes an
 empty `SETTINGS` frame.
 
-<!-- eslint-disable no-undef, node-core/required-modules -->
+<!-- eslint-disable no-undef, node-core/require-common-first, node-core/required-modules -->
 ```js
 // ack is a boolean indicating whether or not to set the ACK flag.
 const frame = new http2.SettingsFrame(ack);
@@ -715,7 +715,7 @@ socket.write(frame.data);
 Set to a `Buffer` instance that contains a minimal set of serialized HTTP/2
 request headers to be used as the payload of a `http2.HeadersFrame`.
 
-<!-- eslint-disable no-undef, node-core/required-modules -->
+<!-- eslint-disable no-undef, node-core/require-common-first, node-core/required-modules -->
 ```js
 const frame = new http2.HeadersFrame(1, http2.kFakeRequestHeaders, 0, true);
 
@@ -727,7 +727,7 @@ socket.write(frame.data);
 Set to a `Buffer` instance that contains a minimal set of serialized HTTP/2
 response headers to be used as the payload a `http2.HeadersFrame`.
 
-<!-- eslint-disable no-undef, node-core/required-modules -->
+<!-- eslint-disable no-undef, node-core/require-common-first, node-core/required-modules -->
 ```js
 const frame = new http2.HeadersFrame(1, http2.kFakeResponseHeaders, 0, true);
 
@@ -739,7 +739,7 @@ socket.write(frame.data);
 Set to a `Buffer` containing the preamble bytes an HTTP/2 client must send
 upon initial establishment of a connection.
 
-<!-- eslint-disable no-undef, node-core/required-modules -->
+<!-- eslint-disable no-undef, node-core/require-common-first, node-core/required-modules -->
 ```js
 socket.write(http2.kClientMagic);
 ```

--- a/test/common/arraystream.js
+++ b/test/common/arraystream.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 const { Stream } = require('stream');

--- a/test/common/benchmark.js
+++ b/test/common/benchmark.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 
 'use strict';
 

--- a/test/common/countdown.js
+++ b/test/common/countdown.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 
 'use strict';
 

--- a/test/common/dns.js
+++ b/test/common/dns.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 const assert = require('assert');

--- a/test/common/duplexpair.js
+++ b/test/common/duplexpair.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 const { Duplex } = require('stream');
 const assert = require('assert');

--- a/test/common/fixtures.js
+++ b/test/common/fixtures.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 const path = require('path');

--- a/test/common/heap.js
+++ b/test/common/heap.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 const assert = require('assert');
 const util = require('util');

--- a/test/common/hijackstdio.js
+++ b/test/common/hijackstdio.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 // Hijack stdout and stderr

--- a/test/common/http2.js
+++ b/test/common/http2.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 // An HTTP/2 testing tool used to create mock frames for direct testing

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -19,7 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/* eslint-disable node-core/required-modules, node-core/crypto-check */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
+/* eslint-disable node-core/crypto-check */
 'use strict';
 const process = global.process;  // Some tests tamper with the process global.
 const path = require('path');

--- a/test/common/index.mjs
+++ b/test/common/index.mjs
@@ -1,5 +1,5 @@
 // Flags: --experimental-modules
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 
 import { createRequireFromPath } from 'module';
 import { fileURLToPath as toPath } from 'url';

--- a/test/common/internet.js
+++ b/test/common/internet.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 // Utilities for internet-related tests

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 const assert = require('assert');
 const fs = require('fs');

--- a/test/common/tls.js
+++ b/test/common/tls.js
@@ -1,4 +1,5 @@
-/* eslint-disable node-core/required-modules, node-core/crypto-check */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
+/* eslint-disable node-core/crypto-check */
 
 'use strict';
 const crypto = require('crypto');

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 const fs = require('fs');

--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 const assert = require('assert');

--- a/test/es-module/test-esm-example-loader.js
+++ b/test/es-module/test-esm-example-loader.js
@@ -1,5 +1,5 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/example-loader.mjs
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 import assert from 'assert';
 import ok from '../fixtures/es-modules/test-esm-ok.mjs';
 

--- a/test/es-module/test-esm-loader-dependency.mjs
+++ b/test/es-module/test-esm-loader-dependency.mjs
@@ -1,5 +1,5 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-with-dep.mjs
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 import '../fixtures/es-modules/test-esm-ok.mjs';
 
 // We just test that this module doesn't fail loading

--- a/test/es-module/test-esm-preserve-symlinks-not-found-plain.mjs
+++ b/test/es-module/test-esm-preserve-symlinks-not-found-plain.mjs
@@ -1,3 +1,3 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/not-found-assert-loader.mjs
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 import './not-found.js';

--- a/test/es-module/test-esm-preserve-symlinks-not-found.mjs
+++ b/test/es-module/test-esm-preserve-symlinks-not-found.mjs
@@ -1,3 +1,3 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/not-found-assert-loader.mjs
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 import './not-found.mjs';

--- a/test/es-module/test-esm-resolve-hook.mjs
+++ b/test/es-module/test-esm-resolve-hook.mjs
@@ -1,5 +1,5 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/js-loader.mjs
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 import { namedExport } from '../fixtures/es-module-loaders/js-as-esm.js';
 import assert from 'assert';
 import ok from '../fixtures/es-modules/test-esm-ok.mjs';

--- a/test/es-module/test-esm-type-flag.mjs
+++ b/test/es-module/test-esm-type-flag.mjs
@@ -1,6 +1,6 @@
 // Flags: --experimental-modules
-import cjs from '../fixtures/baz.js';
 import '../common/index.mjs';
+import cjs from '../fixtures/baz.js';
 import { message } from '../fixtures/es-modules/message.mjs';
 import assert from 'assert';
 

--- a/test/js-native-api/test_general/testInstanceOf.js
+++ b/test/js-native-api/test_general/testInstanceOf.js
@@ -1,7 +1,6 @@
 'use strict';
-const fs = require('fs');
-
 const common = require('../../common');
+const fs = require('fs');
 const assert = require('assert');
 
 // Addon is referenced through the eval expression in testFile

--- a/test/parallel/test-buffer-constructor-node-modules-paths.js
+++ b/test/parallel/test-buffer-constructor-node-modules-paths.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const common = require('../common');
 const child_process = require('child_process');
 const assert = require('assert');
-const common = require('../common');
 
 if (process.env.NODE_PENDING_DEPRECATION)
   common.skip('test does not work when NODE_PENDING_DEPRECATION is set');

--- a/test/parallel/test-buffer-constructor-outside-node-modules.js
+++ b/test/parallel/test-buffer-constructor-outside-node-modules.js
@@ -1,9 +1,9 @@
 // Flags: --no-warnings
 'use strict';
 
+const common = require('../common');
 const vm = require('vm');
 const assert = require('assert');
-const common = require('../common');
 
 if (new Error().stack.includes('node_modules'))
   common.skip('test does not work when inside `node_modules` directory');

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -1,6 +1,6 @@
 'use strict';
-const assert = require('assert');
 const common = require('../common');
+const assert = require('assert');
 
 const b = Buffer.from('abcdef');
 const buf_a = Buffer.from('a');

--- a/test/parallel/test-child-process-spawn-args.js
+++ b/test/parallel/test-child-process-spawn-args.js
@@ -6,11 +6,11 @@
 // caused the third argument (`options`) to be ignored.
 // See https://github.com/nodejs/node/issues/24912.
 
-const assert = require('assert');
-const { spawn } = require('child_process');
-
 const common = require('../common');
 const tmpdir = require('../common/tmpdir');
+
+const assert = require('assert');
+const { spawn } = require('child_process');
 
 tmpdir.refresh();
 

--- a/test/parallel/test-child-process-spawnsync-args.js
+++ b/test/parallel/test-child-process-spawnsync-args.js
@@ -6,11 +6,11 @@
 // caused the third argument (`options`) to be ignored.
 // See https://github.com/nodejs/node/issues/24912.
 
-const assert = require('assert');
-const { spawnSync } = require('child_process');
-
 const common = require('../common');
 const tmpdir = require('../common/tmpdir');
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
 
 const command = common.isWindows ? 'cd' : 'pwd';
 const options = { cwd: tmpdir.path };

--- a/test/parallel/test-dgram-deprecation-error.js
+++ b/test/parallel/test-dgram-deprecation-error.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const assert = require('assert');
 const common = require('../common');
+const assert = require('assert');
 const dgram = require('dgram');
 const fork = require('child_process').fork;
 

--- a/test/parallel/test-eslint-require-common-first.js
+++ b/test/parallel/test-eslint-require-common-first.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+common.skipIfEslintMissing();
+
+const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
+const rule = require('../../tools/eslint-rules/require-common-first');
+
+new RuleTester().run('require-common-first', rule, {
+  valid: [
+    {
+      code: 'require("common")\n' +
+            'require("assert")'
+    }
+  ],
+  invalid: [
+    {
+      code: 'require("assert")\n' +
+            'require("common")',
+      errors: [{ message: 'Mandatory module "common" must be loaded ' +
+                          'before any other modules.' }]
+    }
+  ]
+});

--- a/test/parallel/test-global-console-exists.js
+++ b/test/parallel/test-global-console-exists.js
@@ -1,4 +1,4 @@
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 
 'use strict';
 

--- a/test/parallel/test-http-client-req-error-dont-double-fire.js
+++ b/test/parallel/test-http-client-req-error-dont-double-fire.js
@@ -4,11 +4,12 @@
 // not get fired again when the 'error' event handler throws
 // an error.
 
-const assert = require('assert');
-const http = require('http');
 const common = require('../common');
 const { addresses } = require('../common/internet');
 const { errorLookupMock } = require('../common/dns');
+
+const assert = require('assert');
+const http = require('http');
 
 const host = addresses.INVALID_HOST;
 

--- a/test/parallel/test-http-header-overflow.js
+++ b/test/parallel/test-http-header-overflow.js
@@ -1,8 +1,8 @@
 'use strict';
+const { expectsError, mustCall } = require('../common');
 const assert = require('assert');
 const { createServer, maxHeaderSize } = require('http');
 const { createConnection } = require('net');
-const { expectsError, mustCall } = require('../common');
 
 const CRLF = '\r\n';
 const DUMMY_HEADER_NAME = 'Cookie: ';

--- a/test/parallel/test-http-parser-lazy-loaded.js
+++ b/test/parallel/test-http-parser-lazy-loaded.js
@@ -1,7 +1,7 @@
 // Flags: --expose-internals
 
 'use strict';
-
+const common = require('../common');
 const { internalBinding } = require('internal/test/binding');
 const { getOptionValue } = require('internal/options');
 
@@ -21,7 +21,6 @@ const binding =
     internalBinding('http_parser') : internalBinding('http_parser_llhttp');
 binding.HTTPParser = DummyParser;
 
-const common = require('../common');
 const assert = require('assert');
 const { spawn } = require('child_process');
 const { parsers } = require('_http_common');

--- a/test/parallel/test-http2-client-write-empty-string.js
+++ b/test/parallel/test-http2-client-write-empty-string.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const assert = require('assert');
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const assert = require('assert');
 const http2 = require('http2');
 
 for (const chunkSequence of [

--- a/test/parallel/test-icu-data-dir.js
+++ b/test/parallel/test-icu-data-dir.js
@@ -1,7 +1,7 @@
 // Flags: --expose-internals
 'use strict';
-const { internalBinding } = require('internal/test/binding');
 const common = require('../common');
+const { internalBinding } = require('internal/test/binding');
 const os = require('os');
 
 const { hasSmallICU } = internalBinding('config');

--- a/test/parallel/test-os-checked-function.js
+++ b/test/parallel/test-os-checked-function.js
@@ -1,3 +1,4 @@
+/* eslint-disable node-core/require-common-first */
 'use strict';
 // Flags: --expose_internals
 

--- a/test/parallel/test-process-env-allowed-flags.js
+++ b/test/parallel/test-process-env-allowed-flags.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const assert = require('assert');
 require('../common');
+const assert = require('assert');
 
 // Assert legit flags are allowed, and bogus flags are disallowed
 {

--- a/test/parallel/test-readline-position.js
+++ b/test/parallel/test-readline-position.js
@@ -1,7 +1,7 @@
 // Flags: --expose-internals
 'use strict';
-const { internalBinding } = require('internal/test/binding');
 require('../common');
+const { internalBinding } = require('internal/test/binding');
 const { PassThrough } = require('stream');
 const readline = require('readline');
 const assert = require('assert');

--- a/test/parallel/test-regression-object-prototype.js
+++ b/test/parallel/test-regression-object-prototype.js
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 Object.prototype.xadsadsdasasdxx = function() {

--- a/test/parallel/test-stream-readable-pause-and-resume.js
+++ b/test/parallel/test-stream-readable-pause-and-resume.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { Readable } = require('stream');
 const common = require('../common');
+const { Readable } = require('stream');
 
 let ticks = 18;
 let expectedData = 19;

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -2,9 +2,9 @@
 
 'use strict';
 
-const { internalBinding } = require('internal/test/binding');
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+const { internalBinding } = require('internal/test/binding');
 const assert = require('assert');
 const v8 = require('v8');
 const os = require('os');

--- a/test/parallel/test-worker-parent-port-ref.js
+++ b/test/parallel/test-worker-parent-port-ref.js
@@ -1,6 +1,6 @@
 'use strict';
-const assert = require('assert');
 const common = require('../common');
+const assert = require('assert');
 const { isMainThread, parentPort, Worker } = require('worker_threads');
 
 // This test makes sure that we manipulate the references of

--- a/test/parallel/test-worker-process-cwd.js
+++ b/test/parallel/test-worker-process-cwd.js
@@ -1,6 +1,6 @@
 'use strict';
-const assert = require('assert');
 const common = require('../common');
+const assert = require('assert');
 const { Worker, isMainThread, parentPort } = require('worker_threads');
 
 // Do not use isMainThread directly, otherwise the test would time out in case

--- a/test/parallel/test-worker-relative-path-double-dot.js
+++ b/test/parallel/test-worker-relative-path-double-dot.js
@@ -1,7 +1,7 @@
 'use strict';
+const common = require('../common');
 const path = require('path');
 const assert = require('assert');
-const common = require('../common');
 const { Worker, isMainThread, parentPort } = require('worker_threads');
 
 if (isMainThread) {

--- a/test/parallel/test-worker-relative-path.js
+++ b/test/parallel/test-worker-relative-path.js
@@ -1,7 +1,7 @@
 'use strict';
+const common = require('../common');
 const path = require('path');
 const assert = require('assert');
-const common = require('../common');
 const { Worker, isMainThread, parentPort } = require('worker_threads');
 
 if (isMainThread) {

--- a/test/parallel/test-worker-unsupported-path.js
+++ b/test/parallel/test-worker-unsupported-path.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const path = require('path');
 const common = require('../common');
+const path = require('path');
 const assert = require('assert');
 const { Worker } = require('worker_threads');
 

--- a/tools/eslint-rules/require-common-first.js
+++ b/tools/eslint-rules/require-common-first.js
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview Require `common` module first in our tests.
+ */
+'use strict';
+
+const path = require('path');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+  const requiredModule = 'common';
+  const isESM = context.parserOptions.sourceType === 'module';
+  const foundModules = [];
+
+  /**
+   * Function to check if a node is a string literal.
+   * @param {ASTNode} node The node to check.
+   * @returns {boolean} If the node is a string literal.
+   */
+  function isString(node) {
+    return node && node.type === 'Literal' && typeof node.value === 'string';
+  }
+
+  /**
+   * Function to check if a node is a require call.
+   * @param {ASTNode} node The node to check.
+   * @returns {boolean} If the node is a require call.
+   */
+  function isRequireCall(node) {
+    return node.callee.type === 'Identifier' && node.callee.name === 'require';
+  }
+
+  /**
+   * Function to check if the path is a required module and return its name.
+   * @param {String} str The path to check
+   * @returns {String} required module name
+   */
+  function getRequiredModuleName(str) {
+    if (str === '../common/index.mjs') {
+      return 'common';
+    }
+
+    return path.basename(str);
+  }
+
+  /**
+   * Function to check if a node has an argument that is a required module and
+   * return its name.
+   * @param {ASTNode} node The node to check
+   * @returns {undefined|String} required module name or undefined
+   */
+  function getRequiredModuleNameFromCall(node) {
+    // Node has arguments and first argument is string
+    if (node.arguments.length && isString(node.arguments[0])) {
+      return getRequiredModuleName(node.arguments[0].value.trim());
+    }
+
+    return undefined;
+  }
+
+  const rules = {
+    'Program:exit'(node) {
+      // The common module should be loaded in the first place.
+      const notLoadedFirst = foundModules.indexOf(requiredModule) !== 0;
+      if (notLoadedFirst) {
+        context.report(
+          node,
+          'Mandatory module "{{moduleName}}" must be loaded ' +
+          'before any other modules.',
+          { moduleName: requiredModule }
+        );
+      }
+    }
+  };
+
+  if (isESM) {
+    rules.ImportDeclaration = (node) => {
+      const requiredModuleName = getRequiredModuleName(node.source.value);
+      if (requiredModuleName) {
+        foundModules.push(requiredModuleName);
+      }
+    };
+  } else {
+    rules.CallExpression = (node) => {
+      if (isRequireCall(node)) {
+        const requiredModuleName = getRequiredModuleNameFromCall(node);
+
+        if (requiredModuleName) {
+          foundModules.push(requiredModuleName);
+        }
+      }
+    };
+  }
+
+  return rules;
+};

--- a/tools/eslint-rules/require-common-first.js
+++ b/tools/eslint-rules/require-common-first.js
@@ -33,11 +33,11 @@ module.exports = function(context) {
   }
 
   /**
-   * Function to check if the path is a required module and return its name.
+   * Function to check if the path is a module and return its name.
    * @param {String} str The path to check
-   * @returns {String} required module name
+   * @returns {String} module name
    */
-  function getRequiredModuleName(str) {
+  function getModuleName(str) {
     if (str === '../common/index.mjs') {
       return 'common';
     }
@@ -46,15 +46,15 @@ module.exports = function(context) {
   }
 
   /**
-   * Function to check if a node has an argument that is a required module and
+   * Function to check if a node has an argument that is a module and
    * return its name.
    * @param {ASTNode} node The node to check
-   * @returns {undefined|String} required module name or undefined
+   * @returns {undefined|String} module name or undefined
    */
-  function getRequiredModuleNameFromCall(node) {
+  function getModuleNameFromCall(node) {
     // Node has arguments and first argument is string
     if (node.arguments.length && isString(node.arguments[0])) {
-      return getRequiredModuleName(node.arguments[0].value.trim());
+      return getModuleName(node.arguments[0].value.trim());
     }
 
     return undefined;
@@ -77,18 +77,18 @@ module.exports = function(context) {
 
   if (isESM) {
     rules.ImportDeclaration = (node) => {
-      const requiredModuleName = getRequiredModuleName(node.source.value);
-      if (requiredModuleName) {
-        foundModules.push(requiredModuleName);
+      const moduleName = getModuleName(node.source.value);
+      if (moduleName) {
+        foundModules.push(moduleName);
       }
     };
   } else {
     rules.CallExpression = (node) => {
       if (isRequireCall(node)) {
-        const requiredModuleName = getRequiredModuleNameFromCall(node);
+        const moduleName = getModuleNameFromCall(node);
 
-        if (requiredModuleName) {
-          foundModules.push(requiredModuleName);
+        if (moduleName) {
+          foundModules.push(moduleName);
         }
       }
     };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Add a new eslint rule `require-common-first` to enforce `common` be loaded in tests before any other modules.

> The `common` module should be required in tests before any other module: https://github.com/nodejs/node/blob/master/doc/guides/writing-tests.md#lines-1-3

Refs: https://github.com/nodejs/node/pull/27455#discussion_r279222145

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
