### PR TITLE
assert: loose deep equal should not compare symbol properties

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -37,7 +37,8 @@ const {
 const {
   getOwnNonIndexProperties,
   propertyFilter: {
-    ONLY_ENUMERABLE
+    ONLY_ENUMERABLE,
+    SKIP_SYMBOLS
   }
 } = internalBinding('util');
 
@@ -163,8 +164,9 @@ function innerDeepEqual(val1, val2, strict, memos) {
     if (val1.length !== val2.length) {
       return false;
     }
-    const keys1 = getOwnNonIndexProperties(val1, ONLY_ENUMERABLE);
-    const keys2 = getOwnNonIndexProperties(val2, ONLY_ENUMERABLE);
+    const filter = strict ? ONLY_ENUMERABLE : ONLY_ENUMERABLE | SKIP_SYMBOLS;
+    const keys1 = getOwnNonIndexProperties(val1, filter);
+    const keys2 = getOwnNonIndexProperties(val2, filter);
     if (keys1.length !== keys2.length) {
       return false;
     }
@@ -198,8 +200,9 @@ function innerDeepEqual(val1, val2, strict, memos) {
     // Buffer.compare returns true, so val1.length === val2.length. If they both
     // only contain numeric keys, we don't need to exam further than checking
     // the symbols.
-    const keys1 = getOwnNonIndexProperties(val1, ONLY_ENUMERABLE);
-    const keys2 = getOwnNonIndexProperties(val2, ONLY_ENUMERABLE);
+    const filter = strict ? ONLY_ENUMERABLE : ONLY_ENUMERABLE | SKIP_SYMBOLS;
+    const keys1 = getOwnNonIndexProperties(val1, filter);
+    const keys2 = getOwnNonIndexProperties(val2, filter);
     if (keys1.length !== keys2.length) {
       return false;
     }

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -639,7 +639,7 @@ assertDeepAndStrictEqual(-0, -0);
   const b = new Uint8Array(4);
   a[symbol1] = true;
   b[symbol1] = false;
-  assertNotDeepOrStrict(a, b);
+  assertOnlyDeepEqual(a, b);
   b[symbol1] = true;
   assertDeepAndStrictEqual(a, b);
   // The same as TypedArrays is valid for boxed primitives
@@ -649,6 +649,13 @@ assertDeepAndStrictEqual(-0, -0);
   assertOnlyDeepEqual(boxedStringA, boxedStringB);
   boxedStringA[symbol1] = true;
   assertDeepAndStrictEqual(a, b);
+  // Loose equal arrays should not compare symbols.
+  const arr = [1];
+  const arr2 = [1];
+  arr[symbol1] = true;
+  assertOnlyDeepEqual(arr, arr2);
+  arr2[symbol1] = false;
+  assertOnlyDeepEqual(arr, arr2);
 }
 
 assert.throws(


### PR DESCRIPTION
This is the way it's currently documented and that seems appropriate
for loose equal assertions. The change was not intentional.

Fixes: https://github.com/nodejs/node/issues/27652

// cc @nodejs/assert 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
