### PR TITLE
stream: use readableObjectMode public api for js stream

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -502,6 +502,13 @@ This property contains the number of bytes (or objects) in the queue
 ready to be written. The value provides introspection data regarding
 the status of the `highWaterMark`.
 
+##### writable.writableObjectMode
+<!-- YAML
+added: REPLACEME
+-->
+
+Getter for the property `objectMode` of a given `Writable` stream.
+
 ##### writable.write(chunk[, encoding][, callback])
 <!-- YAML
 added: v0.9.4
@@ -1088,6 +1095,13 @@ added: v9.4.0
 This property contains the number of bytes (or objects) in the queue
 ready to be read. The value provides introspection data regarding
 the status of the `highWaterMark`.
+
+##### readable.readableObjectMode
+<!-- YAML
+added: REPLACEME
+-->
+
+Getter for the property `objectMode` of a given `Readable` stream.
 
 ##### readable.resume()
 <!-- YAML

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1081,6 +1081,13 @@ Object.defineProperty(Readable.prototype, 'readableLength', {
   }
 });
 
+Object.defineProperty(Readable.prototype, 'readableObjectMode', {
+  enumerable: false,
+  get() {
+    return this._readableState ? this._readableState.objectMode : false;
+  }
+});
+
 // Pluck off n bytes from an array of buffers.
 // Length is the combined lengths of all the buffers in the list.
 // This function is designed to be inlinable, so please take care when making

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -707,6 +707,13 @@ Object.defineProperty(Writable.prototype, 'destroyed', {
   }
 });
 
+Object.defineProperty(Writable.prototype, 'writableObjectMode', {
+  enumerable: false,
+  get() {
+    return this._writableState ? this._writableState.objectMode : false;
+  }
+});
+
 Writable.prototype.destroy = destroyImpl.destroy;
 Writable.prototype._undestroy = destroyImpl.undestroy;
 Writable.prototype._destroy = function(err, cb) {

--- a/lib/internal/js_stream_socket.js
+++ b/lib/internal/js_stream_socket.js
@@ -50,7 +50,7 @@ class JSStreamSocket extends Socket {
     stream.on('error', (err) => this.emit('error', err));
     const ondata = (chunk) => {
       if (typeof chunk === 'string' ||
-          stream._readableState.objectMode === true) {
+          stream.readableObjectMode === true) {
         // Make sure that no further `data` events will happen.
         stream.pause();
         stream.removeListener('data', ondata);

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -23,6 +23,7 @@
 
 const common = require('../common');
 const R = require('_stream_readable');
+const W = require('_stream_writable');
 const assert = require('assert');
 
 const EE = require('events').EventEmitter;
@@ -419,4 +420,16 @@ class TestWriter extends EE {
   r._read = common.mustCall();
   const r2 = r.setEncoding('utf8').pause().resume().pause();
   assert.strictEqual(r, r2);
+}
+
+{
+  // Verify readableObjectMode property
+  const r = new R({ objectMode: true });
+  assert.strictEqual(r.readableObjectMode, true);
+}
+
+{
+  // Verify writableObjectMode property
+  const w = new W({ objectMode: true });
+  assert.strictEqual(w.writableObjectMode, true);
 }


### PR DESCRIPTION
Added `readableObjectMode` and `writableObjectMode` to stream, so that we can remove instances like `_readableState.*` in code.

Refs: https://github.com/nodejs/node/issues/445

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
