### PR TITLE
doc,tools: get altDocs versions from CHANGELOG.md

### DIFF
--- a/test/internet/test-doctool-versions.js
+++ b/test/internet/test-doctool-versions.js
@@ -1,0 +1,59 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const util = require('util');
+const { versions } = require('../../tools/doc/versions.js');
+
+// At the time of writing these are the minimum expected versions.
+// New versions of Node.js do not have to be explicitly added here.
+const expected = [
+  '12.x',
+  '11.x',
+  '10.x',
+  '9.x',
+  '8.x',
+  '7.x',
+  '6.x',
+  '5.x',
+  '4.x',
+  '0.12.x',
+  '0.10.x',
+];
+
+async function test() {
+  const vers = await versions();
+  // Coherence checks for each returned version.
+  for (const version of vers) {
+    const tested = util.inspect(version);
+    const parts = version.num.split('.');
+    const expectedLength = parts[0] === '0' ? 3 : 2;
+    assert.strictEqual(parts.length, expectedLength,
+                       `'num' from ${tested} should be '<major>.x'.`);
+    assert.strictEqual(parts[parts.length - 1], 'x',
+                       `'num' from ${tested} doesn't end in '.x'.`);
+    const isEvenRelease = Number.parseInt(parts[expectedLength - 2]) % 2 === 0;
+    const hasLtsProperty = version.hasOwnProperty('lts');
+    if (hasLtsProperty) {
+      // Odd-numbered versions of Node.js are never LTS.
+      assert.ok(isEvenRelease, `${tested} should not be an 'lts' release.`);
+      assert.ok(version.lts, `'lts' from ${tested} should 'true'.`);
+    }
+  }
+
+  // Check that the minimum number of versions were returned.
+  // Later versions are allowed, but not checked for here (they were checked
+  // above).
+  // Also check for the previous semver major -- From master this will be the
+  // most recent major release.
+  const thisMajor = Number.parseInt(process.versions.node.split('.')[0]);
+  const prevMajorString = `${thisMajor - 1}.x`;
+  if (!expected.includes(prevMajorString)) {
+    expected.unshift(prevMajorString);
+  }
+  for (const version of expected) {
+    assert.ok(vers.find((x) => x.num === version),
+              `Did not find entry for '${version}' in ${util.inspect(vers)}`);
+  }
+}
+test();

--- a/tools/doc/versions.js
+++ b/tools/doc/versions.js
@@ -1,0 +1,45 @@
+'use strict';
+
+let _versions;
+
+const getUrl = (url) => {
+  return new Promise((resolve, reject) => {
+    const https = require('https');
+    const request = https.get(url, (response) => {
+      if (response.statusCode !== 200) {
+        reject(new Error(
+          `Failed to get ${url}, status code ${response.statusCode}`));
+      }
+      response.setEncoding('utf8');
+      let body = '';
+      response.on('data', (data) => body += data);
+      response.on('end', () => resolve(body));
+    });
+    request.on('error', (err) => reject(err));
+  });
+};
+
+module.exports = {
+  async versions() {
+    if (_versions) {
+      return _versions;
+    }
+
+    // The CHANGELOG.md on release branches may not reference newer semver
+    // majors of Node.js so fetch and parse the version from the master branch.
+    const githubContentUrl = 'https://raw.githubusercontent.com/nodejs/node/';
+    const changelog = await getUrl(`${githubContentUrl}/master/CHANGELOG.md`);
+    const ltsRE = /Long Term Support/i;
+    const versionRE = /\* \[Node\.js ([0-9.]+)\][^-—]+[-—]\s*(.*)\n/g;
+    _versions = [];
+    let match;
+    while ((match = versionRE.exec(changelog)) != null) {
+      const entry = { num: `${match[1]}.x` };
+      if (ltsRE.test(match[2])) {
+        entry.lts = true;
+      }
+      _versions.push(entry);
+    }
+    return _versions;
+  }
+};


### PR DESCRIPTION
Parse `CHANGELOG.md` for versions of Node.js used by the documentation
feature `View another version` so that we don't have to manually update
the list when we cut a new version or transition a release to LTS.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
