### PR TITLE
path: fix win32.relative() for some Unicode paths

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -437,14 +437,25 @@ const win32 = {
     if (from === to)
       return '';
 
-    const fromOrig = win32.resolve(from);
-    const toOrig = win32.resolve(to);
+    let fromOrig = win32.resolve(from);
+    let toOrig = win32.resolve(to);
 
     if (fromOrig === toOrig)
       return '';
 
     from = fromOrig.toLowerCase();
     to = toOrig.toLowerCase();
+
+    if (fromOrig.length !== from.length) {
+      fromOrig = fromOrig.normalize('NFD');
+      from = fromOrig.toLowerCase();
+    }
+    let toNormalized;
+    if (toOrig.length !== to.length) {
+      toNormalized = true;
+      toOrig = toOrig.normalize('NFD');
+      to = toOrig.toLowerCase();
+    }
 
     if (from === to)
       return '';
@@ -493,18 +504,24 @@ const win32 = {
     // return the original `to`.
     if (i !== length) {
       if (lastCommonSep === -1)
-        return toOrig;
+        return (toNormalized ? toOrig.normalize('NFC') : toOrig);
     } else {
       if (toLen > length) {
         if (to.charCodeAt(toStart + i) === CHAR_BACKWARD_SLASH) {
           // We get here if `from` is the exact base path for `to`.
           // For example: from='C:\\foo\\bar'; to='C:\\foo\\bar\\baz'
-          return toOrig.slice(toStart + i + 1);
+          return (
+            toNormalized ?
+              toOrig.slice(toStart + i + 1).normalize('NFC') :
+              toOrig.slice(toStart + i + 1));
         }
         if (i === 2) {
           // We get here if `from` is the device root.
           // For example: from='C:\\'; to='C:\\foo'
-          return toOrig.slice(toStart + i);
+          return (
+            toNormalized ?
+              toOrig.slice(toStart + i).normalize('NFC') :
+              toOrig.slice(toStart + i));
         }
       }
       if (fromLen > length) {
@@ -535,12 +552,20 @@ const win32 = {
 
     // Lastly, append the rest of the destination (`to`) path that comes after
     // the common path parts
-    if (out.length > 0)
-      return `${out}${toOrig.slice(toStart, toEnd)}`;
+    if (out.length > 0) {
+      const slice = (
+        toNormalized ?
+          toOrig.slice(toStart, toEnd).normalize('NFC') :
+          toOrig.slice(toStart, toEnd));
+      return `${out}${slice}`;
+    }
 
     if (toOrig.charCodeAt(toStart) === CHAR_BACKWARD_SLASH)
       ++toStart;
-    return toOrig.slice(toStart, toEnd);
+    return (
+      toNormalized ?
+        toOrig.slice(toStart, toEnd).normalize('NFC') :
+        toOrig.slice(toStart, toEnd));
   },
 
   toNamespacedPath(path) {

--- a/test/parallel/test-path-relative.js
+++ b/test/parallel/test-path-relative.js
@@ -31,7 +31,12 @@ const relativeTests = [
      ['\\\\foo\\baz-quux', '\\\\foo\\baz', '..\\baz'],
      ['\\\\foo\\baz', '\\\\foo\\baz-quux', '..\\baz-quux'],
      ['C:\\baz', '\\\\foo\\bar\\baz', '\\\\foo\\bar\\baz'],
-     ['\\\\foo\\bar\\baz', 'C:\\baz', 'C:\\baz']
+     ['\\\\foo\\bar\\baz', 'C:\\baz', 'C:\\baz'],
+     ['c:\\a\\İ', 'c:\\a\\İ\\test.txt', 'test.txt'],
+     ['c:\\İ\\a\\İ', 'c:\\İ\\b\\İ\\test.txt', '..\\..\\b\\İ\\test.txt'],
+     ['c:\\İ\\a\\i̇', 'c:\\İ\\b\\İ\\test.txt', '..\\..\\b\\İ\\test.txt'],
+     ['c:\\i̇\\a\\İ', 'c:\\İ\\b\\İ\\test.txt', '..\\..\\b\\İ\\test.txt'],
+     ['c:\\ß\\a\\ß', 'c:\\ß\\b\\ß\\test.txt', '..\\..\\b\\ß\\test.txt']
     ]
   ],
   [ path.posix.relative,


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/27534

This is an alternative to https://github.com/nodejs/node/pull/27644 that avoids any performance regressions in cases where lowercased versions of paths do not differ in length to the original.

The only minor issue (in practice it may not really matter) is that return values are *always* returned normalized using canonical composition if the lowercased version differed in length to the original, which may be unexpected if you passed in a path that was normalized using canonical decomposition for example.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
