### PR TITLE
bootstrap: unfreeze console under --frozen-intrinsics

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -214,7 +214,7 @@ reference.
 **Code breakage is highly likely with this flag**, since redefining any
 builtin properties on a subclass will throw in strict mode due to the ECMA-262
 issue https://github.com/tc39/ecma262/pull/1307. This flag may still change
-or be removed in future.
+or be removed in the future.
 
 To avoid these cases any builtin function overrides should be defined upfront:
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -216,7 +216,7 @@ builtin properties on a subclass will throw in strict mode due to the ECMA-262
 issue https://github.com/tc39/ecma262/pull/1307. This flag may still change
 or be removed in the future.
 
-To avoid these cases any builtin function overrides should be defined upfront:
+To avoid these cases, any builtin function overrides should be defined upfront:
 
 <!-- eslint-disable no-redeclare -->
 ```js

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -211,11 +211,41 @@ Support is currently only provided for the root context and no guarantees are
 currently provided that `global.Array` is indeed the default intrinsic
 reference.
 
-**Code breakage is highly likely with this flag**, especially since limited
-support for subclassing builtins is provided currently due to ECMA-262 bug
-https://github.com/tc39/ecma262/pull/1320.
+**Code breakage is highly likely with this flag**, since redefining any
+builtin properties on a subclass will throw in strict mode due to the ECMA-262
+issue https://github.com/tc39/ecma262/pull/1307. This flag may still change
+or be removed in future.
 
-Both of the above may change in future updates, which will be breaking changes.
+To avoid these cases any builtin function overrides should be defined upfront:
+
+<!-- eslint-disable no-redeclare -->
+```js
+const o = {};
+// THROWS: Cannot assign read only property 'toString' of object
+o.toString = () => 'string';
+
+// OK
+const o = { toString: () => 'string' };
+
+class X {
+  constructor() {
+    this.toString = () => 'string';
+  }
+}
+// THROWS: Cannot assign read only property 'toString' of object
+new X();
+
+class X {
+  toString = undefined;
+  constructor() {
+    this.toString = () => 'string';
+  }
+}
+// OK
+new X();
+```
+
+
 
 ### `--heapsnapshot-signal=signal`
 <!-- YAML

--- a/lib/internal/freeze_intrinsics.js
+++ b/lib/internal/freeze_intrinsics.js
@@ -32,7 +32,6 @@ module.exports = function() {
     setInterval,
     setTimeout
   } = require('timers');
-  const console = require('internal/console/global');
 
   const intrinsics = [
     // Anonymous Intrinsics
@@ -136,7 +135,6 @@ module.exports = function() {
     setImmediate,
     setInterval,
     setTimeout,
-    console,
 
     // Other APIs
     BigInt,


### PR DESCRIPTION
This fixes the bug pointed out by @jdalton in https://github.com/nodejs/node/pull/25685#issuecomment-457971744.

I haven't included an explicit test, because for all intensive purposes we could be testing EVERY global that it works under this flag. Rather the fix is by exclusion.

At the same time I've also added some documentation on how to handle the common errors, which are really only these two cases.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
