### PR TITLE
tls: support `net.Server` options

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1436,6 +1436,10 @@ publicly trusted list of CAs as given in
 <!-- YAML
 added: v0.3.2
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/27665
+    description: The `options` parameter now supports `net.createServer()`
+                 options.
   - version: v9.3.0
     pr-url: https://github.com/nodejs/node/pull/14903
     description: The `options` parameter can now include `clientCertEngine`.
@@ -1486,6 +1490,7 @@ changes:
     data. See [Session Resumption][] for more information.
   * ...: Any [`tls.createSecureContext()`][] option can be provided. For
     servers, the identity options (`pfx` or `key`/`cert`) are usually required.
+  * ...: Any [`net.createServer()`][] option can be provided.
 * `secureConnectionListener` {Function}
 * Returns: {tls.Server}
 
@@ -1706,6 +1711,7 @@ where `secureSocket` has the same API as `pair.cleartext`.
 [`NODE_OPTIONS`]: cli.html#cli_node_options_options
 [`crypto.getCurves()`]: crypto.html#crypto_crypto_getcurves
 [`dns.lookup()`]: dns.html#dns_dns_lookup_hostname_options_callback
+[`net.createServer()`]: net.html#net_net_createserver_options_connectionlistener
 [`net.Server.address()`]: net.html#net_server_address
 [`net.Server`]: net.html#net_class_net_server
 [`net.Socket`]: net.html#net_class_net_socket

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1010,7 +1010,7 @@ function Server(options, listener) {
   }
 
   // constructor call
-  net.Server.call(this, tlsConnectionListener);
+  net.Server.call(this, options, tlsConnectionListener);
 
   if (listener) {
     this.on('secureConnection', listener);

--- a/test/parallel/test-tls-server-parent-constructor-options.js
+++ b/test/parallel/test-tls-server-parent-constructor-options.js
@@ -1,0 +1,63 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// Test that `tls.Server` constructor options are passed to the parent
+// constructor.
+
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const tls = require('tls');
+
+const options = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+};
+
+{
+  const server = tls.createServer(options, common.mustCall((socket) => {
+    assert.strictEqual(socket.allowHalfOpen, false);
+  }));
+
+  assert.strictEqual(server.allowHalfOpen, false);
+
+  server.listen(0, common.mustCall(() => {
+    const socket = tls.connect({
+      port: server.address().port,
+      rejectUnauthorized: false
+    }, common.mustCall(() => {
+      socket.end();
+    }));
+
+    socket.on('close', () => {
+      server.close();
+    });
+  }));
+}
+
+{
+  const server = tls.createServer({
+    allowHalfOpen: true,
+    ...options
+  }, common.mustCall((socket) => {
+    assert.strictEqual(socket.allowHalfOpen, true);
+    socket.on('end', socket.end);
+  }));
+
+  assert.strictEqual(server.allowHalfOpen, true);
+
+  server.listen(0, common.mustCall(() => {
+    const socket = tls.connect({
+      port: server.address().port,
+      rejectUnauthorized: false
+    }, common.mustCall(() => {
+      socket.end();
+    }));
+
+    socket.on('close', () => {
+      server.close();
+    });
+  }));
+}


### PR DESCRIPTION
Pass `tls.Server` constructor options to the parent constructor.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
