### PR TITLE
util: reconstruct constructor in more cases

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -727,12 +727,20 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
         braces = getIteratorBraces('Set', tag);
         formatter = formatIterator;
       // Handle other regular objects again.
-      } else if (keys.length === 0) {
-        if (isExternal(value))
-          return ctx.stylize('[External]', 'special');
-        return `${getPrefix(constructor, tag, 'Object')}{}`;
       } else {
-        braces[0] = `${getPrefix(constructor, tag, 'Object')}{`;
+        let fallback = '';
+        if (constructor === null) {
+          fallback = internalGetConstructorName(value);
+          if (fallback === tag) {
+            fallback = 'Object';
+          }
+        }
+        if (keys.length === 0) {
+          if (isExternal(value))
+            return ctx.stylize('[External]', 'special');
+          return `${getPrefix(constructor, tag, fallback)}{}`;
+        }
+        braces[0] = `${getPrefix(constructor, tag, fallback)}{`;
       }
     }
   }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1156,6 +1156,10 @@ if (typeof Symbol !== 'undefined') {
     util.inspect({ a: { b: new ArraySubclass([1, [2], 3]) } }, { depth: 1 }),
     '{ a: { b: [ArraySubclass] } }'
   );
+  assert.strictEqual(
+    util.inspect(Object.setPrototypeOf(x, null)),
+    '[ObjectSubclass: null prototype] { foo: 42 }'
+  );
 }
 
 // Empty and circular before depth.


### PR DESCRIPTION
This makes sure the constructor is reconstructed in cases where we
otherwise would not be able to detect the actual constructor anymore.

That way some `util.inspect` output is improved.

// cc @nodejs/util 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
