### PR TITLE
assert: add compatibility for older Node.js versions

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -298,7 +298,9 @@ class AssertionError extends Error {
     const {
       message,
       operator,
-      stackStartFn
+      stackStartFn,
+      // Compatibility with older versions.
+      stackStartFunction
     } = options;
     let {
       actual,
@@ -418,7 +420,7 @@ class AssertionError extends Error {
     this.expected = expected;
     this.operator = operator;
     // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(this, stackStartFn);
+    Error.captureStackTrace(this, stackStartFn || stackStartFunction);
     // Create error message including the error code in the name.
     this.stack;
     // Reset the name.

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1203,3 +1203,21 @@ assert.throws(
   () => a.deepStrictEqual(),
   { code: 'ERR_MISSING_ARGS' }
 );
+
+// Verify that `stackStartFunction` works as alternative to `stackStartFn`.
+{
+  (function hidden() {
+    const err = new assert.AssertionError({
+      actual: 'foo',
+      operator: 'strictEqual',
+      stackStartFunction: hidden
+    });
+    const err2 = new assert.AssertionError({
+      actual: 'foo',
+      operator: 'strictEqual',
+      stackStartFn: hidden
+    });
+    assert(!err.stack.includes('hidden'));
+    assert(!err2.stack.includes('hidden'));
+  })();
+}


### PR DESCRIPTION
This makes sure the `AssertionError` still accepts the
`stackStartFunction` option as alternative to the `stackStartFn`.

Fixes: https://github.com/nodejs/node/issues/27671

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
