### PR TITLE
modules: prevent race condition while combining import and require

### DIFF
--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -123,6 +123,16 @@ translators.set('json', async function jsonStrategy(url) {
     });
   }
   const content = await readFileAsync(pathname, 'utf-8');
+  // A require call could have been called on the same file during loading and
+  // that resolves synchronously. To make sure we always return the identical
+  // export, we have to check again if the module already exists or not.
+  module = CJSModule._cache[modulePath];
+  if (module && module.loaded) {
+    const exports = module.exports;
+    return createDynamicModule(['default'], url, (reflect) => {
+      reflect.exports.default.set(exports);
+    });
+  }
   try {
     const exports = JsonParse(stripBOM(content));
     module = {


### PR DESCRIPTION
This switches the async file read to the sync version to prevent
the file potentially being read multiple times during the actual
loading phase (that could happen if the translator is called multiple
times on the same file while the file read is not complete).

This is not critical (reading the files multiple times should be fine)
but it came up by eslint using the `require-atomic-updates` rule.

An alternative would be to use a map with all currently loading
files and each entry contains a promise that is resolved as soon as
the module is fully loaded. That way it could be awaited and the async
file read would still be fine. I have no strong opinion about either
solution @nodejs/modules-active-members.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
