### PR TITLE
assert: remove unused code

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -373,8 +373,7 @@ class AssertionError extends Error {
         let res = inspectValue(actual);
         let other = inspectValue(expected);
         const knownOperators = kReadableOperator[operator];
-        if ((operator === 'notDeepEqual' || operator === 'notEqual') &&
-            res === other) {
+        if (operator === 'notDeepEqual' && res === other) {
           res = `${knownOperators}\n\n${res}`;
           if (res.length > 1024) {
             res = `${res.slice(0, 1021)}...`;
@@ -387,7 +386,7 @@ class AssertionError extends Error {
           if (other.length > 512) {
             other = `${other.slice(0, 509)}...`;
           }
-          if (operator === 'deepEqual' || operator === 'equal') {
+          if (operator === 'deepEqual') {
             const eq = operator === 'deepEqual' ? 'deep-equal' : 'equal';
             res = `${knownOperators}\n\n${res}\n\nshould loosely ${eq}\n\n`;
           } else {


### PR DESCRIPTION
Those two operators are not used.

This is an alternative to #27635. @Trott 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
