### PR TITLE
tools: DRY isRequireCall() in lint rules

### DIFF
--- a/tools/eslint-rules/no-duplicate-requires.js
+++ b/tools/eslint-rules/no-duplicate-requires.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const { isRequireCall } = require('./rules-utils.js');
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -11,10 +13,6 @@
 
 function isString(node) {
   return node && node.type === 'Literal' && typeof node.value === 'string';
-}
-
-function isRequireCall(node) {
-  return node.callee.type === 'Identifier' && node.callee.name === 'require';
 }
 
 function isTopLevel(node) {

--- a/tools/eslint-rules/require-common-first.js
+++ b/tools/eslint-rules/require-common-first.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const path = require('path');
+const { isRequireCall } = require('./rules-utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -21,15 +22,6 @@ module.exports = function(context) {
    */
   function isString(node) {
     return node && node.type === 'Literal' && typeof node.value === 'string';
-  }
-
-  /**
-   * Function to check if a node is a require call.
-   * @param {ASTNode} node The node to check.
-   * @returns {boolean} If the node is a require call.
-   */
-  function isRequireCall(node) {
-    return node.callee.type === 'Identifier' && node.callee.name === 'require';
   }
 
   /**

--- a/tools/eslint-rules/required-modules.js
+++ b/tools/eslint-rules/required-modules.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const { isRequireCall } = require('./rules-utils.js');
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -30,15 +32,6 @@ module.exports = function(context) {
    */
   function isString(node) {
     return node && node.type === 'Literal' && typeof node.value === 'string';
-  }
-
-  /**
-   * Function to check if a node is a require call.
-   * @param {ASTNode} node The node to check.
-   * @returns {boolean} If the node is a require call.
-   */
-  function isRequireCall(node) {
-    return node.callee.type === 'Identifier' && node.callee.name === 'require';
   }
 
   /**

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -3,6 +3,11 @@
  */
 'use strict';
 
+function isRequireCall(node) {
+  return node.callee.type === 'Identifier' && node.callee.name === 'require';
+}
+module.exports.isRequireCall = isRequireCall;
+
 module.exports.isDefiningError = function(node) {
   return node.expression &&
          node.expression.type === 'CallExpression' &&
@@ -16,7 +21,7 @@ module.exports.isDefiningError = function(node) {
  * require calls.
  */
 module.exports.isRequired = function(node, modules) {
-  return node.callee.name === 'require' && node.arguments.length !== 0 &&
+  return isRequireCall(node) && node.arguments.length !== 0 &&
     modules.includes(node.arguments[0].value);
 };
 
@@ -26,7 +31,7 @@ module.exports.isRequired = function(node, modules) {
 */
 const commonModuleRegExp = new RegExp(/^(\.\.\/)*common(\.js)?$/);
 module.exports.isCommonModule = function(node) {
-  return node.callee.name === 'require' &&
+  return isRequireCall(node) &&
          node.arguments.length !== 0 &&
          commonModuleRegExp.test(node.arguments[0].value);
 };


### PR DESCRIPTION
This commit makes `isRequireCall()` a reusable utility function for core's custom ESLint rules.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
