### PR TITLE
http2: do no throw in writeHead if state.closed

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -589,13 +589,10 @@ class Http2ServerResponse extends Stream {
   writeHead(statusCode, statusMessage, headers) {
     const state = this[kState];
 
-    if (state.closed)
-      throw new ERR_HTTP2_INVALID_STREAM();
+    if (state.closed || this.stream.destroyed)
+      return this;
     if (this[kStream].headersSent)
       throw new ERR_HTTP2_HEADERS_SENT();
-
-    if (this.stream.destroyed)
-      return this;
 
     if (typeof statusMessage === 'string')
       statusMessageWarn();

--- a/test/parallel/test-http2-compat-serverresponse-writehead.js
+++ b/test/parallel/test-http2-compat-serverresponse-writehead.js
@@ -26,9 +26,9 @@ server.listen(0, common.mustCall(function() {
     response.on('finish', common.mustCall(function() {
       server.close();
       process.nextTick(common.mustCall(() => {
-        common.expectsError(() => { response.writeHead(300); }, {
-          code: 'ERR_HTTP2_INVALID_STREAM'
-        });
+        // The stream is invalid at this point,
+        // and this line verifies this does not throw.
+        response.writeHead(300);
       }));
     }));
     response.end();


### PR DESCRIPTION
The http1 implementation does not throw if the connection is down.
The http2 compat implementation should do the same.

See: https://github.com/fastify/fastify-http-proxy/issues/51.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
