### PR TITLE
process: mark process.env as side-effect-free

### DIFF
--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -28,6 +28,7 @@ using v8::Nothing;
 using v8::Object;
 using v8::ObjectTemplate;
 using v8::PropertyCallbackInfo;
+using v8::PropertyHandlerFlags;
 using v8::String;
 using v8::Value;
 
@@ -377,7 +378,8 @@ MaybeLocal<Object> CreateEnvVarProxy(Local<Context> context,
   EscapableHandleScope scope(isolate);
   Local<ObjectTemplate> env_proxy_template = ObjectTemplate::New(isolate);
   env_proxy_template->SetHandler(NamedPropertyHandlerConfiguration(
-      EnvGetter, EnvSetter, EnvQuery, EnvDeleter, EnvEnumerator, data));
+      EnvGetter, EnvSetter, EnvQuery, EnvDeleter, EnvEnumerator, data,
+      PropertyHandlerFlags::kHasNoSideEffect));
   return scope.EscapeMaybe(env_proxy_template->NewInstance(context));
 }
 }  // namespace node

--- a/test/parallel/test-inspector-vm-global-accessors-sideeffects.js
+++ b/test/parallel/test-inspector-vm-global-accessors-sideeffects.js
@@ -19,7 +19,7 @@ session.post('Runtime.evaluate', {
   expression: 'a',
   throwOnSideEffect: true,
   contextId: 2 // context's id
-}, (error, res) => {
+}, common.mustCall((error, res) => {
   assert.ifError(error),
   assert.deepStrictEqual(res, {
     result: {
@@ -28,4 +28,4 @@ session.post('Runtime.evaluate', {
       description: '100'
     }
   });
-});
+}));

--- a/test/parallel/test-process-env-sideeffects.js
+++ b/test/parallel/test-process-env-sideeffects.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+// Test that read-only process.env access is considered to have no
+// side-effects by the insepctor.
+
+const assert = require('assert');
+const inspector = require('inspector');
+
+const session = new inspector.Session();
+session.connect();
+
+process.env.TESTVAR = 'foobar';
+
+session.post('Runtime.evaluate', {
+  expression: 'process.env.TESTVAR',
+  throwOnSideEffect: true
+}, (error, res) => {
+  assert.ifError(error);
+  assert.deepStrictEqual(res, {
+    result: { type: 'string', value: 'foobar' }
+  });
+});

--- a/test/parallel/test-process-env-sideeffects.js
+++ b/test/parallel/test-process-env-sideeffects.js
@@ -3,7 +3,7 @@ const common = require('../common');
 common.skipIfInspectorDisabled();
 
 // Test that read-only process.env access is considered to have no
-// side-effects by the insepctor.
+// side-effects by the inspector.
 
 const assert = require('assert');
 const inspector = require('inspector');


### PR DESCRIPTION
Read-only access to `process.env` does not have side effects.

Refs: https://github.com/nodejs/node/pull/27523

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
