### PR TITLE
console: don't attach unnecessary error handlers

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -231,7 +231,8 @@ Console.prototype[kWriteToConsole] = function(streamSymbol, string) {
   // handle both situations.
   try {
     // Add and later remove a noop error handler to catch synchronous errors.
-    stream.once('error', noop);
+    if (stream.listenerCount('error') === 0)
+      stream.once('error', noop);
 
     stream.write(string, errorHandler);
   } catch (e) {

--- a/test/parallel/test-worker-console-listeners.js
+++ b/test/parallel/test-worker-console-listeners.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../common');
+const { Worker, isMainThread } = require('worker_threads');
+const EventEmitter = require('events');
+
+if (isMainThread) {
+  process.on('warning', common.mustNotCall('unexpected warning'));
+
+  for (let i = 0; i < EventEmitter.defaultMaxListeners; ++i) {
+    const worker = new Worker(__filename);
+
+    worker.on('exit', common.mustCall(() => {
+      console.log('a'); // This console.log() is part of the test.
+    }));
+  }
+}


### PR DESCRIPTION
A noop error handler is attached to the console's stream on write. The handler is then immediately removed after the write. This commit skips adding the error handler if one already exists.

Fixes: https://github.com/nodejs/node/issues/27687

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
