### PR TITLE
events: improve max listeners warning

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -31,6 +31,10 @@ const {
   ERR_UNHANDLED_ERROR
 } = require('internal/errors').codes;
 
+const {
+  inspect
+} = require('internal/util/inspect');
+
 function EventEmitter() {
   EventEmitter.init.call(this);
 }
@@ -253,8 +257,8 @@ function _addListener(target, type, listener, prepend) {
       // eslint-disable-next-line no-restricted-syntax
       const w = new Error('Possible EventEmitter memory leak detected. ' +
                           `${existing.length} ${String(type)} listeners ` +
-                          'added. Use emitter.setMaxListeners() to ' +
-                          'increase limit');
+                          `added to ${inspect(target, { depth: -1 })}. Use ` +
+                          'emitter.setMaxListeners() to increase limit');
       w.name = 'MaxListenersExceededWarning';
       w.emitter = target;
       w.type = type;

--- a/test/parallel/test-event-emitter-max-listeners-warning-for-null.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning-for-null.js
@@ -15,7 +15,8 @@ process.on('warning', common.mustCall((warning) => {
   assert.strictEqual(warning.emitter, e);
   assert.strictEqual(warning.count, 2);
   assert.strictEqual(warning.type, null);
-  assert.ok(warning.message.includes('2 null listeners added.'));
+  assert.ok(warning.message.includes(
+    '2 null listeners added to [EventEmitter].'));
 }));
 
 e.on(null, () => {});

--- a/test/parallel/test-event-emitter-max-listeners-warning-for-symbol.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning-for-symbol.js
@@ -17,7 +17,8 @@ process.on('warning', common.mustCall((warning) => {
   assert.strictEqual(warning.emitter, e);
   assert.strictEqual(warning.count, 2);
   assert.strictEqual(warning.type, symbol);
-  assert.ok(warning.message.includes('2 Symbol(symbol) listeners added.'));
+  assert.ok(warning.message.includes(
+    '2 Symbol(symbol) listeners added to [EventEmitter].'));
 }));
 
 e.on(symbol, () => {});

--- a/test/parallel/test-event-emitter-max-listeners-warning.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning.js
@@ -6,7 +6,14 @@ const common = require('../common');
 const events = require('events');
 const assert = require('assert');
 
-const e = new events.EventEmitter();
+class FakeInput extends events.EventEmitter {
+  resume() {}
+  pause() {}
+  write() {}
+  end() {}
+}
+
+const e = new FakeInput();
 e.setMaxListeners(1);
 
 process.on('warning', common.mustCall((warning) => {
@@ -15,7 +22,8 @@ process.on('warning', common.mustCall((warning) => {
   assert.strictEqual(warning.emitter, e);
   assert.strictEqual(warning.count, 2);
   assert.strictEqual(warning.type, 'event-type');
-  assert.ok(warning.message.includes('2 event-type listeners added.'));
+  assert.ok(warning.message.includes(
+    '2 event-type listeners added to [FakeInput].'));
 }));
 
 e.on('event-type', () => {});


### PR DESCRIPTION
This adds the constructor name of the event target to the emitted
warning. Right now it's difficult to identify where the leak is
actually coming from and having some further information about the
source will likely help to identify the source.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
