### PR TITLE
meta: move whitlockjc to Collaborator Emeriti list

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,8 +465,6 @@ For information about the governance of the Node.js project, see
 **Daijiro Wachi** &lt;daijiro.wachi@gmail.com&gt; (he/him)
 * [watson](https://github.com/watson) -
 **Thomas Watson** &lt;w@tson.dk&gt;
-* [whitlockjc](https://github.com/whitlockjc) -
-**Jeremy Whitlock** &lt;jwhitlock@apache.org&gt;
 * [XadillaX](https://github.com/XadillaX) -
 **Khaidi Chu** &lt;i@2333.moe&gt; (he/him)
 * [yhwang](https://github.com/yhwang) -
@@ -530,6 +528,8 @@ For information about the governance of the Node.js project, see
 **Mike Tunnicliffe** &lt;m.j.tunnicliffe@gmail.com&gt;
 * [vsemozhetbyt](https://github.com/vsemozhetbyt) -
 **Vse Mozhet Byt** &lt;vsemozhetbyt@gmail.com&gt; (he/him)
+* [whitlockjc](https://github.com/whitlockjc) -
+**Jeremy Whitlock** &lt;jwhitlock@apache.org&gt;
 
 Collaborators follow the [COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md) in
 maintaining the Node.js project.


### PR DESCRIPTION
Jeremy confirmed in email that it would be OK to move them to Emeritus
status.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
