### PR TITLE
worker: use special message as MessagePort close command

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -588,9 +588,9 @@ void MessagePort::OnMessage() {
       Mutex::ScopedLock lock(data_->mutex_);
 
       Debug(this, "MessagePort has message, receiving = %d",
-            static_cast<int>(data_->receiving_messages_));
+            static_cast<int>(receiving_messages_));
 
-      if (!data_->receiving_messages_)
+      if (!receiving_messages_)
         break;
       if (data_->incoming_messages_.empty())
         break;
@@ -722,17 +722,16 @@ void MessagePort::PostMessage(const FunctionCallbackInfo<Value>& args) {
 }
 
 void MessagePort::Start() {
-  Mutex::ScopedLock lock(data_->mutex_);
   Debug(this, "Start receiving messages");
-  data_->receiving_messages_ = true;
+  receiving_messages_ = true;
+  Mutex::ScopedLock lock(data_->mutex_);
   if (!data_->incoming_messages_.empty())
     TriggerAsync();
 }
 
 void MessagePort::Stop() {
-  Mutex::ScopedLock lock(data_->mutex_);
   Debug(this, "Stop receiving messages");
-  data_->receiving_messages_ = false;
+  receiving_messages_ = false;
 }
 
 void MessagePort::Start(const FunctionCallbackInfo<Value>& args) {

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -116,7 +116,6 @@ class MessagePortData : public MemoryRetainer {
   // This mutex protects all fields below it, with the exception of
   // sibling_.
   mutable Mutex mutex_;
-  bool receiving_messages_ = false;
   std::list<Message> incoming_messages_;
   MessagePort* owner_ = nullptr;
   // This mutex protects the sibling_ field and is shared between two entangled
@@ -205,6 +204,7 @@ class MessagePort : public HandleWrap {
   void TriggerAsync();
 
   std::unique_ptr<MessagePortData> data_ = nullptr;
+  bool receiving_messages_ = false;
   uv_async_t async_;
 
   friend class MessagePortData;

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -14,8 +14,6 @@ test-tls-enable-trace-cli: PASS,FLAKY
 
 [$system==win32]
 test-http2-pipe: PASS,FLAKY
-test-worker-syntax-error: PASS,FLAKY
-test-worker-syntax-error-file: PASS,FLAKY
 # https://github.com/nodejs/node/issues/23277
 test-worker-memory: PASS,FLAKY
 # https://github.com/nodejs/node/issues/20750

--- a/test/parallel/test-worker-message-port-message-before-close.js
+++ b/test/parallel/test-worker-message-port-message-before-close.js
@@ -1,0 +1,38 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { once } = require('events');
+const { Worker, MessageChannel } = require('worker_threads');
+
+// This is a regression test for the race condition underlying
+// https://github.com/nodejs/node/issues/22762.
+// It ensures that all messages send before a MessagePort#close() call are
+// received. Previously, what could happen was a race condition like this:
+// - Thread 1 sends message A
+// - Thread 2 begins receiving/emitting message A
+// - Thread 1 sends message B
+// - Thread 1 closes its side of the channel
+// - Thread 2 finishes receiving/emitting message A
+// - Thread 2 sees that the port should be closed
+// - Thread 2 closes the port, discarding message B in the process.
+
+async function test() {
+  const worker = new Worker(`
+  require('worker_threads').parentPort.on('message', ({ port }) => {
+    port.postMessage('firstMessage');
+    port.postMessage('lastMessage');
+    port.close();
+  });
+  `, { eval: true });
+
+  for (let i = 0; i < 10000; i++) {
+    const { port1, port2 } = new MessageChannel();
+    worker.postMessage({ port: port2 }, [ port2 ]);
+    await once(port1, 'message');  // 'complexObject'
+    assert.deepStrictEqual(await once(port1, 'message'), ['lastMessage']);
+  }
+
+  worker.terminate();
+}
+
+test().then(common.mustCall());


### PR DESCRIPTION
(The first commit is cleanup from https://github.com/nodejs/node/pull/27294, with which this is going to have conflicts anyway…)

When a `MessagePort` connected to another `MessagePort` closes, the
latter `MessagePort` will be closed as well. Until now, this is done
by testing whether the ports are still entangled after processing
messages. This leaves open a race condition window in which messages
sent just before the closure can be lost when timing is unfortunate.
(A description of the timing is in the test file.)

This can be addressed by using a special message instead, which is
the last message received by a `MessagePort`. This way, all previously
sent messages are processed first.

Fixes: https://github.com/nodejs/node/issues/22762

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
