### PR TITLE
inspector: supported NodeRuntime domain in worker

### DIFF
--- a/src/inspector/node_protocol.pdl
+++ b/src/inspector/node_protocol.pdl
@@ -71,6 +71,11 @@ experimental domain NodeWorker
   # Detaches from all running workers and disables attaching to new workers as they are started.
   command disable
 
+  # Detached from the worker with given sessionId.
+  command detach
+    parameters
+      SessionID sessionId
+
   # Issued when attached to a worker.
   event attachedToWorker
     parameters

--- a/src/inspector/runtime_agent.cc
+++ b/src/inspector/runtime_agent.cc
@@ -16,10 +16,6 @@ void RuntimeAgent::Wire(UberDispatcher* dispatcher) {
 }
 
 DispatchResponse RuntimeAgent::notifyWhenWaitingForDisconnect(bool enabled) {
-  if (!env_->owns_process_state()) {
-    return DispatchResponse::Error(
-        "NodeRuntime domain can only be used through main thread sessions");
-  }
   notify_when_waiting_for_disconnect_ = enabled;
   return DispatchResponse::OK();
 }

--- a/src/inspector/worker_agent.cc
+++ b/src/inspector/worker_agent.cc
@@ -115,6 +115,11 @@ DispatchResponse WorkerAgent::disable() {
   return DispatchResponse::OK();
 }
 
+DispatchResponse WorkerAgent::detach(const String& sessionId) {
+  workers_->Detached(sessionId);
+  return DispatchResponse::OK();
+}
+
 void NodeWorkers::WorkerCreated(const std::string& title,
                                 const std::string& url,
                                 bool waiting,

--- a/src/inspector/worker_agent.h
+++ b/src/inspector/worker_agent.h
@@ -25,6 +25,7 @@ class WorkerAgent : public NodeWorker::Backend {
 
   DispatchResponse enable(bool waitForDebuggerOnStart) override;
   DispatchResponse disable() override;
+  DispatchResponse detach(const String& sessionId) override;
 
  private:
   std::shared_ptr<NodeWorker::Frontend> frontend_;

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -464,8 +464,8 @@ class NodeInspectorClient : public V8InspectorClient {
     runMessageLoop();
   }
 
-  void waitForIoShutdown() {
-    waiting_for_io_shutdown_ = true;
+  void waitForSessionsDisconnect() {
+    waiting_for_sessions_disconnect_ = true;
     runMessageLoop();
   }
 
@@ -540,6 +540,8 @@ class NodeInspectorClient : public V8InspectorClient {
       }
       contextDestroyed(env_->context());
     }
+    if (waiting_for_sessions_disconnect_ && !is_main_)
+      waiting_for_sessions_disconnect_ = false;
   }
 
   void dispatchMessageFromFrontend(int session_id, const StringView& message) {
@@ -670,8 +672,9 @@ class NodeInspectorClient : public V8InspectorClient {
   bool shouldRunMessageLoop() {
     if (waiting_for_frontend_)
       return true;
-    if (waiting_for_io_shutdown_ || waiting_for_resume_)
+    if (waiting_for_sessions_disconnect_ || waiting_for_resume_) {
       return hasConnectedSessions();
+    }
     return false;
   }
 
@@ -715,7 +718,7 @@ class NodeInspectorClient : public V8InspectorClient {
   int next_session_id_ = 1;
   bool waiting_for_resume_ = false;
   bool waiting_for_frontend_ = false;
-  bool waiting_for_io_shutdown_ = false;
+  bool waiting_for_sessions_disconnect_ = false;
   // Allows accessing Inspector from non-main threads
   std::unique_ptr<MainThreadInterface> interface_;
   std::shared_ptr<WorkerManager> worker_manager_;
@@ -811,11 +814,14 @@ void Agent::WaitForDisconnect() {
     fprintf(stderr, "Waiting for the debugger to disconnect...\n");
     fflush(stderr);
   }
-  if (!client_->notifyWaitingForDisconnect())
+  if (!client_->notifyWaitingForDisconnect()) {
     client_->contextDestroyed(parent_env_->context());
+  } else if (is_worker) {
+    client_->waitForSessionsDisconnect();
+  }
   if (io_ != nullptr) {
     io_->StopAcceptingNewConnections();
-    client_->waitForIoShutdown();
+    client_->waitForSessionsDisconnect();
   }
 }
 


### PR DESCRIPTION
NodeRuntime domain was introduced to give inspector client way to
fetch captured information before Node process is gone. We need
similar capability for worker.

With current protocol inspector client can force worker to wait
on start by passing waitForDebuggerOnStart flag to NodeWorker.enable
method. So client has some time to setup environment, e.g. start
profiler. At the same time there is no way to prevent worker from
being terminated. So we can start capturing profile but we can not
reliably get captured data back.

This PR implemented NodeRuntime.notifyWhenWaitingForDisconnect
method for worker. When NodeRuntime.waitingForDisconnect notification
is enabled, worker will wait for explicit NodeWorker.detach call.

With this PR worker tooling story is nicely aligned with main thread
tooling story. The only difference is that main thread by default is
waiting for disconnect but worker thread is not waiting.

Issue: https://github.com/nodejs/node/issues/27677

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
