### PR TITLE
tools: DRY isString() in lint rules

### DIFF
--- a/tools/eslint-rules/no-duplicate-requires.js
+++ b/tools/eslint-rules/no-duplicate-requires.js
@@ -4,16 +4,12 @@
  */
 'use strict';
 
-const { isRequireCall } = require('./rules-utils.js');
+const { isRequireCall, isString } = require('./rules-utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-
-function isString(node) {
-  return node && node.type === 'Literal' && typeof node.value === 'string';
-}
 
 function isTopLevel(node) {
   do {

--- a/tools/eslint-rules/require-common-first.js
+++ b/tools/eslint-rules/require-common-first.js
@@ -4,7 +4,7 @@
 'use strict';
 
 const path = require('path');
-const { isRequireCall } = require('./rules-utils.js');
+const { isRequireCall, isString } = require('./rules-utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -14,15 +14,6 @@ module.exports = function(context) {
   const requiredModule = 'common';
   const isESM = context.parserOptions.sourceType === 'module';
   const foundModules = [];
-
-  /**
-   * Function to check if a node is a string literal.
-   * @param {ASTNode} node The node to check.
-   * @returns {boolean} If the node is a string literal.
-   */
-  function isString(node) {
-    return node && node.type === 'Literal' && typeof node.value === 'string';
-  }
 
   /**
    * Function to check if the path is a module and return its name.

--- a/tools/eslint-rules/required-modules.js
+++ b/tools/eslint-rules/required-modules.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-const { isRequireCall } = require('./rules-utils.js');
+const { isRequireCall, isString } = require('./rules-utils.js');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -23,15 +23,6 @@ module.exports = function(context) {
   // If no modules are required we don't need to check the CallExpressions
   if (requiredModules.length === 0) {
     return {};
-  }
-
-  /**
-   * Function to check if a node is a string literal.
-   * @param {ASTNode} node The node to check.
-   * @returns {boolean} If the node is a string literal.
-   */
-  function isString(node) {
-    return node && node.type === 'Literal' && typeof node.value === 'string';
   }
 
   /**

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -8,6 +8,10 @@ function isRequireCall(node) {
 }
 module.exports.isRequireCall = isRequireCall;
 
+module.exports.isString = function(node) {
+  return node && node.type === 'Literal' && typeof node.value === 'string';
+};
+
 module.exports.isDefiningError = function(node) {
   return node.expression &&
          node.expression.type === 'CallExpression' &&


### PR DESCRIPTION
This commit makes `isString()` a reusable utility function for core's custom ESLint rules.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
