### PR TITLE
tty: add color support for iterm2

### DIFF
--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -49,6 +49,7 @@ const TERM_ENVS = {
   'dtterm': COLORS_16,
   'gnome': COLORS_16,
   'hurd': COLORS_16,
+  'iterm2': COLORS_256,
   'jfbterm': COLORS_16,
   'konsole': COLORS_16,
   'kterm': COLORS_16,
@@ -58,8 +59,7 @@ const TERM_ENVS = {
   // https://github.com/da-x/rxvt-unicode/tree/v9.22-with-24bit-color
   'rxvt-unicode-24bit': COLORS_16m,
   // https://gist.github.com/XVilka/8346728#gistcomment-2823421
-  'terminator': COLORS_16m,
-  'iterm2': COLORS_256
+  'terminator': COLORS_16m
 };
 
 const TERM_ENVS_REG_EXP = [

--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -58,7 +58,8 @@ const TERM_ENVS = {
   // https://github.com/da-x/rxvt-unicode/tree/v9.22-with-24bit-color
   'rxvt-unicode-24bit': COLORS_16m,
   // https://gist.github.com/XVilka/8346728#gistcomment-2823421
-  'terminator': COLORS_16m
+  'terminator': COLORS_16m,
+  'iterm2': COLORS_256
 };
 
 const TERM_ENVS_REG_EXP = [


### PR DESCRIPTION
Added iterm2 to the tty.js file for terminal color support #27609 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
