### PR TITLE
deps: V8: cherry-pick cca9ae3c9a

### DIFF
--- a/deps/v8/src/compiler/property-access-builder.cc
+++ b/deps/v8/src/compiler/property-access-builder.cc
@@ -115,14 +115,6 @@ bool NeedsCheckHeapObject(Node* receiver) {
     case IrOpcode::kJSToString:
     case IrOpcode::kTypeOf:
       return false;
-    case IrOpcode::kPhi: {
-      Node* control = NodeProperties::GetControlInput(receiver);
-      if (control->opcode() != IrOpcode::kMerge) return true;
-      for (int i = 0; i < receiver->InputCount() - 1; ++i) {
-        if (NeedsCheckHeapObject(receiver->InputAt(i))) return true;
-      }
-      return false;
-    }
     default:
       return true;
   }


### PR DESCRIPTION
Original commit message:

    Remove recursion from NeedsCheckHeapObject.

    We use the predicate NeedsCheckHeapObject in the compiler frontend to
    determine whether we can skip introducing CheckHeapObject nodes. But
    this predicate would also walk up the graph in case of Phis, which can
    result in really long compilation times (on the main thread). In the
    report in https://github.com/nodejs/node/issues/27667, the compiler
    frontend alone took around 4-5mins of main thread time for a single
    function. With this patch the time goes down to 4-5ms.

    Bug: v8:9250
    Refs: nodejs/node#27667
    Change-Id: I231eb780ff04f949fa1669714f9af6ebfbcade05
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1612897
    Reviewed-by: Jaroslav Sevcik <jarin@chromium.org>
    Commit-Queue: Benedikt Meurer <bmeurer@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#61503}

Fixes: https://github.com/nodejs/node/issues/27667

Per the issue, this applies to v10.x-v12.x. v8.x is unaffected.