### PR TITLE
build,win: create junction instead of symlink to `out\%config%`

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -328,8 +328,9 @@ if "%target%" == "Clean" goto exit
 :after-build
 rd %config%
 if errorlevel 1 echo "Old build output exists at 'out\%config%'. Please remove." & exit /B
-if EXIST out\%config% mklink /D %config% out\%config%
-if errorlevel 1 exit /B
+:: Use /J because /D (symlink) requires special permissions.
+if EXIST out\%config% mklink /J %config% out\%config%
+if errorlevel 1 echo "Could not create junction to 'out\%config%'." & exit /B
 
 :sign
 @rem Skip signing unless the `sign` option was specified.


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/27149#issuecomment-493168460

Create a junction to `out\%config%` instead of symlink, because symlinks need elevation or developer mode on Win10.

Background: https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/
H/T @yodurr
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
