### PR TITLE
inspector: allow whitelisting inspector domain

### DIFF
--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -196,7 +196,7 @@ class ThreadSafeDelegate : public InspectorSessionDelegate {
  public:
   ThreadSafeDelegate(std::shared_ptr<MainThreadHandle> thread,
                      int object_id,
-                     int is_trusted)
+                     bool is_trusted)
       : thread_(thread),
         delegate_(thread, object_id),
         is_trusted_(is_trusted) {}

--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -197,8 +197,9 @@ class ThreadSafeDelegate : public InspectorSessionDelegate {
   ThreadSafeDelegate(std::shared_ptr<MainThreadHandle> thread,
                      int object_id,
                      int is_trusted)
-                     : thread_(thread), delegate_(thread, object_id),
-                       is_trusted_(is_trusted) {}
+      : thread_(thread),
+        delegate_(thread, object_id),
+        is_trusted_(is_trusted) {}
 
   void SendMessageToFrontend(const v8_inspector::StringView& message) override {
     delegate_.Call(

--- a/src/inspector/worker_agent.h
+++ b/src/inspector/worker_agent.h
@@ -15,7 +15,8 @@ class NodeWorkers;
 
 class WorkerAgent : public NodeWorker::Backend {
  public:
-  explicit WorkerAgent(std::weak_ptr<WorkerManager> manager);
+  explicit WorkerAgent(std::weak_ptr<WorkerManager> manager,
+                       bool is_session_trusted);
   ~WorkerAgent() override = default;
 
   void Wire(UberDispatcher* dispatcher);
@@ -31,6 +32,7 @@ class WorkerAgent : public NodeWorker::Backend {
   std::weak_ptr<WorkerManager> manager_;
   std::unique_ptr<WorkerManagerEventHandle> event_handle_;
   std::shared_ptr<NodeWorkers> workers_;
+  bool is_session_trusted_;
 };
 }  // namespace protocol
 }  // namespace inspector

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -38,6 +38,7 @@ class InspectorSessionDelegate {
   virtual ~InspectorSessionDelegate() = default;
   virtual void SendMessageToFrontend(const v8_inspector::StringView& message)
                                      = 0;
+  virtual bool IsSessionTrusted() = 0;
 };
 
 class Agent {

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -203,6 +203,10 @@ class IoSessionDelegate : public InspectorSessionDelegate {
                          StringBuffer::create(message));
   }
 
+  bool IsSessionTrusted() override {
+    return false;
+  }
+
  private:
   std::shared_ptr<RequestQueue> request_queue_;
   int id_;

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -58,6 +58,10 @@ class JSBindingsConnection : public AsyncWrap {
       connection_->OnMessage(argument);
     }
 
+    bool IsSessionTrusted() override {
+      return true;
+    }
+
    private:
     Environment* env_;
     JSBindingsConnection* connection_;

--- a/src/inspector_profiler.h
+++ b/src/inspector_profiler.h
@@ -26,6 +26,10 @@ class V8ProfilerConnection {
     void SendMessageToFrontend(
         const v8_inspector::StringView& message) override;
 
+    bool IsSessionTrusted() override {
+      return true;
+    }
+
    private:
     V8ProfilerConnection* connection_;
   };

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -263,6 +263,10 @@ DebugOptionsParser::DebugOptionsParser() {
   AddOption("--debug-brk", "", &DebugOptions::break_first_line);
   Implies("--debug-brk", "--debug");
   AddAlias("--debug-brk=", { "--inspect-port", "--debug-brk" });
+
+  AddOption("--inspector-domain-whitelist",
+            "Comma-separated list of enabled Inspector protocol domains",
+            &DebugOptions::domain_whitelist);
 }
 
 EnvironmentOptionsParser::EnvironmentOptionsParser() {

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -70,6 +70,8 @@ class DebugOptions : public Options {
   bool break_first_line = false;
   // --inspect-brk-node
   bool break_node_first_line = false;
+  // --inspector-domain-whitelist
+  std::string domain_whitelist;
 
   enum { kDefaultInspectorPort = 9229 };
 

--- a/test/parallel/test-inspector-domain-whitelist.js
+++ b/test/parallel/test-inspector-domain-whitelist.js
@@ -1,0 +1,40 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { NodeInstance } = require('../common/inspector-helper.js');
+const script = `
+const session = new (require('inspector').Session)();
+session.connect();
+session.post('Debugger.enable', (error, res) => {
+  if (!error) {
+    process.exit(42);
+  }
+});`;
+
+/**
+ * This test verifies that it is possible to disable built-in V8 inpsector
+ * domains by providing a domains whitelist from the command line.
+ * Disabled domains are still available for "trusted" sessions (ones that are
+ * not accepting arbitrary commands from external clients)
+ */
+async function runTest() {
+  const child = new NodeInstance([
+    '--inspect-brk=0', '--inspector-domain-whitelist=Runtime', '-e', script
+  ]);
+  const session = await child.connectInspectorSession();
+  await session.send({ method: 'Runtime.runIfWaitingForDebugger' });
+  try {
+    const response = await session.send({ method: 'Debugger.enable' });
+    assert.fail(JSON.stringify(response));
+  } catch (e) {
+    console.log(`Expected error ${JSON.stringify(e)} was recieved`);
+  }
+  await session.disconnect();
+  assert.strictEqual((await child.expectShutdown()).exitCode, 42);
+}
+
+runTest();


### PR DESCRIPTION
This change introduces an "--inspector-domain-whitelist" that can be used to
provide a comma-separated list of enabled Inspector domains. This will allow
to limit exposure of the Node instances to applications that may connect to
the inspector socket. E.g. this allows hiding unsafe methods like
"Runtime.evaluate" that allow executing arbitrary code.

  1. Runtime.runIfWaitingForDebugger will always be available. This is essential
     for tools that rely on --inspect-brk flag to connect before the code execution
     starts.
  2. All domains are still available through the Inspector JS APIs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
