### PR TITLE
doc: reorganized "Contributing to Node.js"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ The Node.js project uses an [open governance model](./GOVERNANCE.md). The
   * [Verifying Binaries](#verifying-binaries)
 * [Building Node.js](#building-nodejs)
 * [Security](#security)
+* [Contributing to Node.js](#contributing-to-nodejs)
 * [Current Project Team Members](#current-project-team-members)
   * [TSC (Technical Steering Committee)](#tsc-technical-steering-committee)
   * [Collaborators](#collaborators)
   * [Release Keys](#release-keys)
-* [Contributing to Node.js](#contributing-to-nodejs)
+
 
 ## Support
 
@@ -159,6 +160,12 @@ source and a list of supported platforms.
 
 For information on reporting security vulnerabilities in Node.js, see
 [SECURITY.md](./SECURITY.md).
+
+## Contributing to Node.js
+
+* [Contributing to the project][]
+* [Working Groups][]
+* [Strategic Initiatives][]
 
 ## Current Project Team Members
 
@@ -593,11 +600,6 @@ Other keys used to sign some previous releases:
 * **Timothy J Fontaine** &lt;tjfontaine@gmail.com&gt;
 `7937DFD2AB06298B2293C3187D33FF9D0246406D`
 
-## Contributing to Node.js
-
-* [Contributing to the project][]
-* [Working Groups][]
-* [Strategic Initiatives][]
 
 [Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
 [Contributing to the project]: CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ The Node.js project uses an [open governance model](./GOVERNANCE.md). The
   * [Collaborators](#collaborators)
   * [Release Keys](#release-keys)
 
-
 ## Support
 
 Node.js contributors have limited availability to address general support

--- a/doc/guides/contributing/issues.md
+++ b/doc/guides/contributing/issues.md
@@ -22,7 +22,7 @@ contribute:
 
 For for those that are new to node:
 
-1. You can view our issues page filtered by "[good first issue](https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)." 
+1. You can view our issues page filtered by "[good first issue](https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)" 
 2. By helping to triage the issue: This can be done either by providing
    supporting details (a test case that demonstrates a bug), or providing
    suggestions on how to address the issue.

--- a/doc/guides/contributing/issues.md
+++ b/doc/guides/contributing/issues.md
@@ -20,7 +20,7 @@ contribute:
 
 ## New to Node.js
 
-1. You can view our issues page filtered by "[good first issue](https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)" 
+1. View the issues page filtered by the [good first issue](https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) label.
 2. By helping to triage the issue: This can be done either by providing
    supporting details (a test case that demonstrates a bug), or providing
    suggestions on how to address the issue.

--- a/doc/guides/contributing/issues.md
+++ b/doc/guides/contributing/issues.md
@@ -1,6 +1,7 @@
 # Issues
 
 * [How to Contribute in Issues](#how-to-contribute-in-issues)
+* [New to Node](#new-to-node)
 * [Asking for General Help](#asking-for-general-help)
 * [Discussing non-technical topics](#discussing-non-technical-topics)
 * [Submitting a Bug Report](#submitting-a-bug-report)

--- a/doc/guides/contributing/issues.md
+++ b/doc/guides/contributing/issues.md
@@ -15,13 +15,16 @@ contribute:
 1. By opening the issue for discussion: For instance, if you believe that you
    have uncovered a bug in Node.js, creating a new issue in the `nodejs/node`
    issue tracker is the way to report it.
+2. We also have a  #node-dev channel on freenode.net if you have questions.
+
+## New to Node
+
+For for those that are new to node:
+
+1. You can view our issues page filtered by "[good first issue](https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)." 
 2. By helping to triage the issue: This can be done either by providing
    supporting details (a test case that demonstrates a bug), or providing
    suggestions on how to address the issue.
-3. By helping to resolve the issue: Typically this is done either in the form
-   of demonstrating that the issue reported is not a problem after all, or more
-   often, by opening a Pull Request that changes some bit of something in
-   `nodejs/node` in a concrete and reviewable manner.
 
 ## Asking for General Help
 

--- a/doc/guides/contributing/issues.md
+++ b/doc/guides/contributing/issues.md
@@ -18,9 +18,7 @@ contribute:
    issue tracker is the way to report it.
 2. We also have a  #node-dev channel on freenode.net if you have questions.
 
-## New to Node
-
-For for those that are new to node:
+## New to Node.js
 
 1. You can view our issues page filtered by "[good first issue](https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)" 
 2. By helping to triage the issue: This can be done either by providing


### PR DESCRIPTION
Updated the "Contributing to Node.js" section of the README.md to be 
more welcoming to potential FOSS contributors. Moved the contribution
section above the current project team in both the table of contents
and sections below.

Updated the "issues.md" section of the contributing section to be 
more welcoming to potential FOSS contributors. Added a "new
to Node" section and a link to good first issues


##### Checklist
<!-- Remove items that do not apply. 
For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]
(https://github.com/nodejs/node/blob/master/doc/
guides/contributing/pull-requests.md#commit-message-guidelines)
