### PR TITLE
inspector: added --inspect-publish-uid

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -389,6 +389,13 @@ default) is not firewall-protected.**
 
 See the [debugging security implications][] section for more information.
 
+### `--inspect-publish-uid=stderr,http`
+
+Specify ways of the inspector web socket url exposure.
+
+By default inspector websocket url is available in stderr and under `/json/list`
+endpoint on `http://host:port/json/list`.
+
 ### `--loader=file`
 <!-- YAML
 added: v9.0.0
@@ -980,6 +987,7 @@ Node.js options that are allowed are:
 - `--inspect`
 - `--inspect-brk`
 - `--inspect-port`
+- `--inspect-publish-uid`
 - `--loader`
 - `--max-http-header-size`
 - `--napi-modules`

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -792,7 +792,10 @@ bool Agent::StartIoThread() {
 
   CHECK_NOT_NULL(client_);
 
-  io_ = InspectorIo::Start(client_->getThreadHandle(), path_, host_port_);
+  io_ = InspectorIo::Start(client_->getThreadHandle(),
+                           path_,
+                           host_port_,
+                           debug_options_.inspect_publish_uid);
   if (io_ == nullptr) {
     return false;
   }

--- a/src/inspector_io.h
+++ b/src/inspector_io.h
@@ -48,7 +48,8 @@ class InspectorIo {
   static std::unique_ptr<InspectorIo> Start(
       std::shared_ptr<MainThreadHandle> main_thread,
       const std::string& path,
-      std::shared_ptr<HostPort> host_port);
+      std::shared_ptr<HostPort> host_port,
+      const InspectPublishUid& inspect_publish_uid);
 
   // Will block till the transport thread shuts down
   ~InspectorIo();
@@ -61,7 +62,8 @@ class InspectorIo {
  private:
   InspectorIo(std::shared_ptr<MainThreadHandle> handle,
               const std::string& path,
-              std::shared_ptr<HostPort> host_port);
+              std::shared_ptr<HostPort> host_port,
+              const InspectPublishUid& inspect_publish_uid);
 
   // Wrapper for agent->ThreadMain()
   static void ThreadMain(void* agent);
@@ -76,6 +78,7 @@ class InspectorIo {
   // running
   std::shared_ptr<RequestQueue> request_queue_;
   std::shared_ptr<HostPort> host_port_;
+  InspectPublishUid inspect_publish_uid_;
 
   // The IO thread runs its own uv_loop to implement the TCP server off
   // the main thread.

--- a/src/inspector_socket_server.h
+++ b/src/inspector_socket_server.h
@@ -43,6 +43,7 @@ class InspectorSocketServer {
                         uv_loop_t* loop,
                         const std::string& host,
                         int port,
+                        const InspectPublishUid& inspect_publish_uid,
                         FILE* out = stderr);
   ~InspectorSocketServer();
 
@@ -88,6 +89,7 @@ class InspectorSocketServer {
   std::unique_ptr<SocketServerDelegate> delegate_;
   const std::string host_;
   int port_;
+  InspectPublishUid inspect_publish_uid_;
   std::vector<ServerSocketPtr> server_sockets_;
   std::map<int, std::pair<std::string, std::unique_ptr<SocketSession>>>
       connected_sessions_;

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -44,6 +44,21 @@ void DebugOptions::CheckOptions(std::vector<std::string>* errors) {
     errors->push_back("[DEP0062]: `node --inspect --debug-brk` is deprecated. "
                       "Please use `node --inspect-brk` instead.");
   }
+
+  std::vector<std::string> destinations =
+      SplitString(inspect_publish_uid_string, ',');
+  inspect_publish_uid.console = false;
+  inspect_publish_uid.http = false;
+  for (const std::string& destination : destinations) {
+    if (destination == "stderr") {
+      inspect_publish_uid.console = true;
+    } else if (destination == "http") {
+      inspect_publish_uid.http = true;
+    } else {
+      errors->push_back("--inspect-publish-uid destination can be "
+                        "stderr or http");
+    }
+  }
 }
 
 void PerProcessOptions::CheckOptions(std::vector<std::string>* errors) {
@@ -276,6 +291,12 @@ DebugOptionsParser::DebugOptionsParser() {
   AddOption("--debug-brk", "", &DebugOptions::break_first_line);
   Implies("--debug-brk", "--debug");
   AddAlias("--debug-brk=", { "--inspect-port", "--debug-brk" });
+
+  AddOption("--inspect-publish-uid",
+            "comma separated list of destinations for inspector uid"
+            "(default: stderr,http)",
+            &DebugOptions::inspect_publish_uid_string,
+            kAllowedInEnvironment);
 }
 
 EnvironmentOptionsParser::EnvironmentOptionsParser() {

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -50,6 +50,11 @@ class Options {
   virtual ~Options() = default;
 };
 
+struct InspectPublishUid {
+  bool console;
+  bool http;
+};
+
 // These options are currently essentially per-Environment, but it can be nice
 // to keep them separate since they are a group of options applying to a very
 // specific part of Node. It might also make more sense for them to be
@@ -70,6 +75,10 @@ class DebugOptions : public Options {
   bool break_first_line = false;
   // --inspect-brk-node
   bool break_node_first_line = false;
+  // --inspect-publish-uid
+  std::string inspect_publish_uid_string = "stderr,http";
+
+  InspectPublishUid inspect_publish_uid;
 
   enum { kDefaultInspectorPort = 9229 };
 

--- a/test/cctest/test_inspector_socket_server.cc
+++ b/test/cctest/test_inspector_socket_server.cc
@@ -1,6 +1,7 @@
 #include "inspector_socket_server.h"
 
 #include "node.h"
+#include "node_options.h"
 #include "util-inl.h"
 #include "gtest/gtest.h"
 
@@ -358,8 +359,11 @@ ServerHolder::ServerHolder(bool has_targets, uv_loop_t* loop,
     targets = { MAIN_TARGET_ID };
   std::unique_ptr<TestSocketServerDelegate> delegate(
       new TestSocketServerDelegate(this, targets));
+  node::InspectPublishUid inspect_publish_uid;
+  inspect_publish_uid.console = true;
+  inspect_publish_uid.http = true;
   server_ = std::make_unique<InspectorSocketServer>(
-      std::move(delegate), loop, host, port, out);
+      std::move(delegate), loop, host, port, inspect_publish_uid, out);
 }
 
 static void TestHttpRequest(int port, const std::string& path,

--- a/test/parallel/test-inspect-publish-uid.js
+++ b/test/parallel/test-inspect-publish-uid.js
@@ -1,0 +1,42 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+(async function test() {
+  await testArg('stderr');
+  await testArg('http');
+  await testArg('http,stderr');
+})();
+
+async function testArg(argValue) {
+  console.log('Checks ' + argValue + '..');
+  const hasHttp = argValue.split(',').includes('http');
+  const hasStderr = argValue.split(',').includes('stderr');
+
+  const nodeProcess = spawnSync(process.execPath, [
+    '--inspect=0',
+    `--inspect-publish-uid=${argValue}`,
+    '-e', `(${scriptMain.toString()})(${hasHttp ? 200 : 404})`
+  ]);
+  const hasWebSocketInStderr = checkStdError(
+    nodeProcess.stderr.toString('utf8'));
+  assert.strictEqual(hasWebSocketInStderr, hasStderr);
+
+  function checkStdError(data) {
+    const matches = data.toString('utf8').match(/ws:\/\/.+:(\d+)\/.+/);
+    return !!matches;
+  }
+
+  function scriptMain(code) {
+    const url = require('inspector').url();
+    const { host } = require('url').parse(url);
+    require('http').get('http://' + host + '/json/list', (response) => {
+      assert.strictEqual(response.statusCode, code);
+      response.destroy();
+    });
+  }
+}


### PR DESCRIPTION
This flag specifies how inspector websocket url should be exposed.
Supported options:
- stderr - reports websocket as a message to stderr,
- http - exposes /json/list endpoint that contains inspector websocket
  url,
- binding - `require('inspector').url()`.

Related discussion: https://github.com/nodejs/diagnostics/issues/303

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
