### PR TITLE
test: relax check in verify-graph

### DIFF
--- a/test/async-hooks/verify-graph.js
+++ b/test/async-hooks/verify-graph.js
@@ -99,7 +99,7 @@ module.exports = function verifyGraph(hooks, graph) {
   }
   assert.strictEqual(errors.length, 0);
 
-  // Verify that all expected types are present
+  // Verify that all expected types are present (but more/others are allowed)
   const expTypes = Object.create(null);
   for (let i = 0; i < graph.length; i++) {
     if (expTypes[graph[i].type] == null) expTypes[graph[i].type] = 0;
@@ -107,9 +107,9 @@ module.exports = function verifyGraph(hooks, graph) {
   }
 
   for (const type in expTypes) {
-    assert.strictEqual(typeSeen[type], expTypes[type],
-                       `Type '${type}': expecting: ${expTypes[type]} ` +
-                       `found ${typeSeen[type]}`);
+    assert.ok(typeSeen[type] >= expTypes[type],
+              `Type '${type}': expecting: ${expTypes[type]} ` +
+              `found: ${typeSeen[type]}`);
   }
 };
 


### PR DESCRIPTION
Relax the check regarding presence of async resources in graph to
allow extra events. Before this change events not mentioned in
reference graph were allowed but that one specified must match
exactly in count. Now it's allowed to have more events of this
type.

Refs: https://github.com/nodejs/node/pull/27477
Fixes: https://github.com/nodejs/node/issues/27617

fyi @ofrobots 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
