### PR TITLE
update N-API docs

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1,6 +1,6 @@
 # N-API
 
-<!--introduced_in=v7.10.0-->
+<!--introduced_in=v8.0.0-->
 <!-- type=misc -->
 
 > Stability: 2 - Stable

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -152,6 +152,7 @@ available to the module code.
 | v9.x  | v9.0.0* | v9.3.0*  | v9.11.0* |          |
 | v10.x |         |          | v10.0.0  |          |
 | v11.x |         |          | v11.0.0  | v11.8.0  |
+| v12.x |         |          |          | v12.0.0  |
 
 \* Indicates that the N-API version was released as experimental
 


### PR DESCRIPTION
* doc,n-api: fix `introduced_in` metadata
Node.js v7.10.0 did not contain N-API. Update the `introduced_in`
metadata to prevent a broken 7.x "View another version" link in the
N-API docs.
* doc,n-api: update N-API version matrix for v12.x 

The first commit ("fix `introduced_in` metadata") fixes a 404 not found link
(https://nodejs.org/docs/latest-v7.x/api/n-api.html) which was disovered 
in https://github.com/nodejs/node/pull/27267 (https://travis-ci.com/nodejs/node/jobs/193473667#L1277).
![image](https://user-images.githubusercontent.com/5445507/57896167-3e046f80-7847-11e9-913f-b551d1ed3e4e.png)

As seen in the version matrix, N-API was backported to Node.js 6. I set 
`introduced_in` for v8.0.0 based on Node.js 6 being End-of-Life and 
setting to a 6.x release would still result in the broken link to 7.x due to 
the simplistic way the "View another version" links are generated:
https://github.com/nodejs/node/blob/f4572cc088bc3fd7e360983a579e95e768d200e9/tools/doc/html.js#L417-L423

For the version matrix the non-12.x rows of the N-API version 4 column
should be handled in https://github.com/nodejs/node/pull/27567 (raised by a first time contributor). 

cc @nodejs/n-api @nodejs/documentation 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
