### PR TITLE
esm: JSON modules no longer experimental

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -148,13 +148,6 @@ the ability to import a directory that has an index file.
 
 Please see [customizing esm specifier resolution][] for example usage.
 
-### `--experimental-json-modules`
-<!-- YAML
-added: v12.0.0
--->
-
-Enable experimental JSON support for the ES Module loader.
-
 ### `--experimental-modules`
 <!-- YAML
 added: v8.5.0

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -409,18 +409,11 @@ fs.readFileSync = () => Buffer.from('Hello, ESM');
 fs.readFileSync === readFileSync;
 ```
 
-## Experimental JSON Modules
+## JSON Modules
 
-**Note: This API is still being designed and is subject to change.**
+JSON modules follow the [WHATWG JSON modules specification][].
 
-Currently importing JSON modules are only supported in the `commonjs` mode
-and are loaded using the CJS loader. [WHATWG JSON modules][] are currently
-being standardized, and are experimentally supported by including the
-additional flag `--experimental-json-modules` when running Node.js.
-
-When the `--experimental-json-modules` flag is included both the
-`commonjs` and `module` mode will use the new experimental JSON
-loader. The imported JSON only exposes a `default`, there is no
+The imported JSON only exposes a `default`. There is no
 support for named exports. A cache entry is created in the CommonJS
 cache, to avoid duplication. The same object will be returned in
 CommonJS if the JSON module has already been imported from the
@@ -431,14 +424,6 @@ Assuming an `index.mjs` with
 <!-- eslint-skip -->
 ```js
 import packageConfig from './package.json';
-```
-
-The `--experimental-json-modules` flag is needed for the module
-to work.
-
-```bash
-node --experimental-modules index.mjs # fails
-node --experimental-modules --experimental-json-modules index.mjs # works
 ```
 
 ## Experimental Wasm Modules
@@ -763,7 +748,7 @@ success!
 [CommonJS]: modules.html
 [ECMAScript-modules implementation]: https://github.com/nodejs/modules/blob/master/doc/plan-for-new-modules-implementation.md
 [Node.js EP for ES Modules]: https://github.com/nodejs/node-eps/blob/master/002-es-modules.md
-[WHATWG JSON modules]: https://github.com/whatwg/html/issues/4315
+[WHATWG JSON modules specification]: https://html.spec.whatwg.org/#creating-a-json-module-script
 [ES Module Integration Proposal for Web Assembly]: https://github.com/webassembly/esm-integration
 [dynamic instantiate hook]: #esm_dynamic_instantiate_hook
 [the official standard format]: https://tc39.github.io/ecma262/#sec-modules

--- a/doc/node.1
+++ b/doc/node.1
@@ -108,9 +108,6 @@ Requires Node.js to be built with
 .It Fl -es-module-specifier-resolution
 Select extension resolution algorithm for ES Modules; either 'explicit' (default) or 'node'
 .
-.It Fl -experimental-json-modules
-Enable experimental JSON interop support for the ES Module loader.
-.
 .It Fl -experimental-modules
 Enable experimental ES module support and caching modules.
 .

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -8,7 +8,6 @@ const { getOptionValue } = require('internal/options');
 
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
-const experimentalJsonModules = getOptionValue('--experimental-json-modules');
 const typeFlag = getOptionValue('--input-type');
 const experimentalWasmModules = getOptionValue('--experimental-wasm-modules');
 const { resolve: moduleWrapResolve,
@@ -29,6 +28,7 @@ const extensionFormatMap = {
   '__proto__': null,
   '.cjs': 'commonjs',
   '.js': 'module',
+  '.json': 'json',
   '.mjs': 'module'
 };
 
@@ -36,16 +36,13 @@ const legacyExtensionFormatMap = {
   '__proto__': null,
   '.cjs': 'commonjs',
   '.js': 'commonjs',
-  '.json': 'commonjs',
+  '.json': 'json',
   '.mjs': 'module',
   '.node': 'commonjs'
 };
 
 if (experimentalWasmModules)
   extensionFormatMap['.wasm'] = legacyExtensionFormatMap['.wasm'] = 'wasm';
-
-if (experimentalJsonModules)
-  extensionFormatMap['.json'] = legacyExtensionFormatMap['.json'] = 'json';
 
 function resolve(specifier, parentURL) {
   if (NativeModule.canBeRequiredByUsers(specifier)) {

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -117,11 +117,6 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
     }
   }
 
-  if (experimental_json_modules && !experimental_modules) {
-    errors->push_back("--experimental-json-modules requires "
-                      "--experimental-modules be enabled");
-  }
-
   if (experimental_wasm_modules && !experimental_modules) {
     errors->push_back("--experimental-wasm-modules requires "
                       "--experimental-modules be enabled");
@@ -271,10 +266,6 @@ DebugOptionsParser::DebugOptionsParser() {
 }
 
 EnvironmentOptionsParser::EnvironmentOptionsParser() {
-  AddOption("--experimental-json-modules",
-            "experimental JSON interop support for the ES Module loader",
-            &EnvironmentOptions::experimental_json_modules,
-            kAllowedInEnvironment);
   AddOption("--experimental-modules",
             "experimental ES Module support and caching modules",
             &EnvironmentOptions::experimental_modules,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -91,7 +91,6 @@ class DebugOptions : public Options {
 class EnvironmentOptions : public Options {
  public:
   bool abort_on_uncaught_exception = false;
-  bool experimental_json_modules = false;
   bool experimental_modules = false;
   std::string es_module_specifier_resolution;
   bool experimental_wasm_modules = false;

--- a/test/es-module/test-esm-json-cache.mjs
+++ b/test/es-module/test-esm-json-cache.mjs
@@ -1,4 +1,4 @@
-// Flags: --experimental-modules --experimental-json-modules
+// Flags: --experimental-modules
 import '../common/index.mjs';
 
 import { strictEqual, deepStrictEqual } from 'assert';

--- a/test/es-module/test-esm-json.mjs
+++ b/test/es-module/test-esm-json.mjs
@@ -1,4 +1,5 @@
-// Flags: --experimental-modules --experimental-json-modules
+// Flags: --experimental-modules
+
 import '../common/index.mjs';
 import { strictEqual } from 'assert';
 


### PR DESCRIPTION
The HTML spec has officially landed JSON Modules and as such I think
we can move them out of the "experimental" status. They will still
be behind the `--experimental-modules` flag until the entire esm
implementation moves out of experimental.

Refs: https://html.spec.whatwg.org/#creating-a-json-module-script

/cc @domenic and @littledan to confirm that this respects the spec
/cc @nodejs/modules