### PR TITLE
src: remove memory_tracker-inl.h from header files

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -1,4 +1,4 @@
-#include "env.h"
+#include "env-inl.h"
 #include "node.h"
 #include "node_context_data.h"
 #include "node_errors.h"

--- a/src/api/utils.cc
+++ b/src/api/utils.cc
@@ -1,3 +1,4 @@
+#include "env-inl.h"
 #include "node.h"
 #include "node_internals.h"
 #include "util-inl.h"

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -24,7 +24,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "memory_tracker-inl.h"
+#include "memory_tracker.h"
 #include "v8.h"
 #include <type_traits>  // std::remove_reference
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -23,6 +23,7 @@
 #include "ares.h"
 #include "async_wrap-inl.h"
 #include "env-inl.h"
+#include "memory_tracker-inl.h"
 #include "node.h"
 #include "req_wrap-inl.h"
 #include "util-inl.h"

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -1,4 +1,5 @@
 #include "debug_utils.h"
+#include "env-inl.h"
 #include "util-inl.h"
 
 #ifdef __POSIX__

--- a/src/debug_utils.h
+++ b/src/debug_utils.h
@@ -4,7 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "async_wrap.h"
-#include "env-inl.h"
+#include "env.h"
 
 #include <sstream>
 #include <string>

--- a/src/env.cc
+++ b/src/env.cc
@@ -1,6 +1,7 @@
 #include "env.h"
 
 #include "async_wrap.h"
+#include "memory_tracker-inl.h"
 #include "node_buffer.h"
 #include "node_context_data.h"
 #include "node_errors.h"

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -1,4 +1,5 @@
 #include "env-inl.h"
+#include "memory_tracker-inl.h"
 #include "stream_base-inl.h"
 #include "util-inl.h"
 

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -1,5 +1,6 @@
 #include "inspector_agent.h"
 
+#include "env-inl.h"
 #include "inspector/main_thread_interface.h"
 #include "inspector/node_string.h"
 #include "inspector/runtime_agent.h"

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -1,6 +1,7 @@
 #include "base_object-inl.h"
 #include "inspector_agent.h"
 #include "inspector_io.h"
+#include "memory_tracker-inl.h"
 #include "util-inl.h"
 #include "v8.h"
 #include "v8-inspector.h"

--- a/src/inspector_profiler.cc
+++ b/src/inspector_profiler.cc
@@ -2,6 +2,7 @@
 #include <sstream>
 #include "base_object-inl.h"
 #include "debug_utils.h"
+#include "memory_tracker-inl.h"
 #include "node_file.h"
 #include "node_internals.h"
 #include "v8-inspector.h"

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <algorithm>
 #define NAPI_EXPERIMENTAL
+#include "env-inl.h"
 #include "js_native_api_v8.h"
 #include "js_native_api.h"
 #include "util-inl.h"

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -1,6 +1,7 @@
 #include "module_wrap.h"
 
 #include "env.h"
+#include "memory_tracker-inl.h"
 #include "node_errors.h"
 #include "node_url.h"
 #include "util-inl.h"

--- a/src/node.cc
+++ b/src/node.cc
@@ -25,6 +25,7 @@
 
 #include "debug_utils.h"
 #include "env-inl.h"
+#include "memory_tracker-inl.h"
 #include "node_binding.h"
 #include "node_internals.h"
 #include "node_main_instance.h"

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -6,6 +6,7 @@
 #include "node_binding.h"
 #include "node_errors.h"
 #include "node_internals.h"
+#include "threadpoolwork-inl.h"
 #include "util-inl.h"
 
 #include <memory>

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1,5 +1,5 @@
 #include <node_buffer.h>
-#include "env.h"
+#include "env-inl.h"
 #define NAPI_EXPERIMENTAL
 #include "js_native_api_v8.h"
 #include "node_api.h"

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -1,4 +1,5 @@
 #include "env-inl.h"
+#include "memory_tracker.h"
 #include "node.h"
 #include "node_i18n.h"
 #include "node_native_module_env.h"

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -19,6 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#include "env-inl.h"
 #include "node_constants.h"
 #include "node_internals.h"
 #include "util-inl.h"

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -21,6 +21,7 @@
 
 #include "node_contextify.h"
 
+#include "memory_tracker-inl.h"
 #include "node_internals.h"
 #include "node_watchdog.h"
 #include "base_object-inl.h"

--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -1,3 +1,4 @@
+#include "env-inl.h"
 #include "node_internals.h"
 #include "util-inl.h"
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -33,6 +33,7 @@
 #include "base_object-inl.h"
 #include "env-inl.h"
 #include "string_bytes.h"
+#include "threadpoolwork-inl.h"
 #include "util-inl.h"
 #include "v8.h"
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -32,6 +32,7 @@
 #include "async_wrap-inl.h"
 #include "base_object-inl.h"
 #include "env-inl.h"
+#include "memory_tracker-inl.h"
 #include "string_bytes.h"
 #include "threadpoolwork-inl.h"
 #include "util-inl.h"

--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -20,6 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "base_object-inl.h"
+#include "memory_tracker-inl.h"
 #include "node_crypto_bio.h"
 #include "openssl/bio.h"
 #include "util-inl.h"

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -21,6 +21,7 @@
 
 #include "node_file.h"
 #include "aliased_buffer.h"
+#include "memory_tracker-inl.h"
 #include "node_buffer.h"
 #include "node_process.h"
 #include "node_stat_watcher.h"

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1,5 +1,6 @@
 #include "aliased_buffer.h"
 #include "debug_utils.h"
+#include "memory_tracker-inl.h"
 #include "node.h"
 #include "node_buffer.h"
 #include "node_http2.h"

--- a/src/node_http_parser_llhttp.cc
+++ b/src/node_http_parser_llhttp.cc
@@ -1,6 +1,7 @@
 #define NODE_EXPERIMENTAL_HTTP 1
 
 #include "node_http_parser_impl.h"
+#include "memory_tracker-inl.h"
 #include "node_metadata.h"
 #include "util-inl.h"
 

--- a/src/node_http_parser_traditional.cc
+++ b/src/node_http_parser_traditional.cc
@@ -2,6 +2,7 @@
 #undef NODE_EXPERIMENTAL_HTTP
 #endif
 
+#include "memory_tracker-inl.h"
 #include "node_http_parser_impl.h"
 #include "node_metadata.h"
 #include "util-inl.h"

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -24,7 +24,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "env-inl.h"
+#include "env.h"
 #include "node.h"
 #include "node_binding.h"
 #include "node_mutex.h"

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -252,27 +252,6 @@ class ThreadPoolWork {
   uv_work_t work_req_;
 };
 
-void ThreadPoolWork::ScheduleWork() {
-  env_->IncreaseWaitingRequestCounter();
-  int status = uv_queue_work(
-      env_->event_loop(),
-      &work_req_,
-      [](uv_work_t* req) {
-        ThreadPoolWork* self = ContainerOf(&ThreadPoolWork::work_req_, req);
-        self->DoThreadPoolWork();
-      },
-      [](uv_work_t* req, int status) {
-        ThreadPoolWork* self = ContainerOf(&ThreadPoolWork::work_req_, req);
-        self->env_->DecreaseWaitingRequestCounter();
-        self->AfterThreadPoolWork(status);
-      });
-  CHECK_EQ(status, 0);
-}
-
-int ThreadPoolWork::CancelWork() {
-  return uv_cancel(reinterpret_cast<uv_req_t*>(&work_req_));
-}
-
 #define TRACING_CATEGORY_NODE "node"
 #define TRACING_CATEGORY_NODE1(one)                                           \
     TRACING_CATEGORY_NODE ","                                                 \

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -2,6 +2,7 @@
 
 #include "async_wrap-inl.h"
 #include "debug_utils.h"
+#include "memory_tracker-inl.h"
 #include "node_contextify.h"
 #include "node_buffer.h"
 #include "node_errors.h"

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -1,4 +1,5 @@
 #include "aliased_buffer.h"
+#include "memory_tracker-inl.h"
 #include "node_internals.h"
 #include "node_perf.h"
 #include "node_buffer.h"

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -1,3 +1,4 @@
+#include "env-inl.h"
 #include "node_report.h"
 #include "debug_utils.h"
 #include "node_internals.h"

--- a/src/node_report_utils.cc
+++ b/src/node_report_utils.cc
@@ -1,3 +1,4 @@
+#include "env-inl.h"
 #include "node_internals.h"
 #include "node_report.h"
 #include "util-inl.h"

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -19,6 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memory_tracker-inl.h"
 #include "node_stat_watcher.h"
 #include "async_wrap-inl.h"
 #include "env.h"

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -1,5 +1,6 @@
 #include "base_object-inl.h"
 #include "env.h"
+#include "memory_tracker-inl.h"
 #include "node.h"
 #include "node_internals.h"
 #include "node_v8_platform-inl.h"

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -4,7 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
-#include "env-inl.h"
+#include "env.h"
 
 #include <string>
 

--- a/src/node_watchdog.cc
+++ b/src/node_watchdog.cc
@@ -19,11 +19,13 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "node_watchdog.h"
 #include <algorithm>
+
 #include "debug_utils.h"
+#include "env-inl.h"
 #include "node_errors.h"
 #include "node_internals.h"
+#include "node_watchdog.h"
 #include "util-inl.h"
 
 namespace node {

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -1,5 +1,6 @@
 #include "node_worker.h"
 #include "debug_utils.h"
+#include "memory_tracker-inl.h"
 #include "node_errors.h"
 #include "node_buffer.h"
 #include "node_options-inl.h"

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -19,6 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memory_tracker-inl.h"
 #include "node.h"
 #include "node_buffer.h"
 

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -24,6 +24,7 @@
 
 #include "async_wrap-inl.h"
 #include "env-inl.h"
+#include "threadpoolwork-inl.h"
 #include "util-inl.h"
 
 #include "v8.h"

--- a/src/threadpoolwork-inl.h
+++ b/src/threadpoolwork-inl.h
@@ -1,0 +1,57 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SRC_THREADPOOLWORK_INL_H_
+#define SRC_THREADPOOLWORK_INL_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include "util-inl.h"
+#include "node_internals.h"
+
+namespace node {
+
+void ThreadPoolWork::ScheduleWork() {
+  env_->IncreaseWaitingRequestCounter();
+  int status = uv_queue_work(
+      env_->event_loop(),
+      &work_req_,
+      [](uv_work_t* req) {
+        ThreadPoolWork* self = ContainerOf(&ThreadPoolWork::work_req_, req);
+        self->DoThreadPoolWork();
+      },
+      [](uv_work_t* req, int status) {
+        ThreadPoolWork* self = ContainerOf(&ThreadPoolWork::work_req_, req);
+        self->env_->DecreaseWaitingRequestCounter();
+        self->AfterThreadPoolWork(status);
+      });
+  CHECK_EQ(status, 0);
+}
+
+int ThreadPoolWork::CancelWork() {
+  return uv_cancel(reinterpret_cast<uv_req_t*>(&work_req_));
+}
+
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_THREADPOOLWORK_INL_H_

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -22,6 +22,7 @@
 #include "tls_wrap.h"
 #include "async_wrap-inl.h"
 #include "debug_utils.h"
+#include "memory_tracker-inl.h"
 #include "node_buffer.h"  // Buffer
 #include "node_crypto.h"  // SecureContext
 #include "node_crypto_bio.h"  // NodeBIO

--- a/src/util.cc
+++ b/src/util.cc
@@ -22,6 +22,7 @@
 #include "util.h"  // NOLINT(build/include_inline)
 #include "util-inl.h"
 
+#include "env-inl.h"
 #include "node_buffer.h"
 #include "node_errors.h"
 #include "node_internals.h"

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -7,7 +7,7 @@
 #include "node.h"
 #include "node_platform.h"
 #include "node_internals.h"
-#include "env.h"
+#include "env-inl.h"
 #include "util-inl.h"
 #include "v8.h"
 #include "libplatform/libplatform.h"

--- a/test/cctest/test_aliased_buffer.cc
+++ b/test/cctest/test_aliased_buffer.cc
@@ -1,4 +1,3 @@
-
 #include "v8.h"
 #include "aliased_buffer.h"
 #include "node_test_fixture.h"

--- a/test/cctest/test_url.cc
+++ b/test/cctest/test_url.cc
@@ -1,5 +1,6 @@
 #include "node_url.h"
 #include "node_i18n.h"
+#include "util-inl.h"
 
 #include "gtest/gtest.h"
 

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -177,6 +177,7 @@ def ReadMacros(macro_files):
 
 
 TEMPLATE = """
+#include "env-inl.h"
 #include "node_native_module.h"
 #include "node_internals.h"
 

--- a/tools/snapshot/node_mksnapshot.cc
+++ b/tools/snapshot/node_mksnapshot.cc
@@ -5,9 +5,11 @@
 #include <string>
 #include <vector>
 
+#include "env-inl.h"
 #include "libplatform/libplatform.h"
 #include "node_internals.h"
 #include "snapshot_builder.h"
+#include "util-inl.h"
 #include "v8.h"
 
 #ifdef _WIN32


### PR DESCRIPTION
Inline headers should only be included into the .cc files that use them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
