### PR TITLE
doc: corrected tlsSocket.getPeerCertificate response type

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -917,8 +917,8 @@ certificate.
    It is returned as a `:` separated hexadecimal string. Example:
    `'2A:7A:C2:DD:...'`.
 * `ext_key_usage` {Array} (Optional) The extended key usage, a set of OIDs.
-* `subjectaltname` {Array} (Optional) An array of names for the subject, an
-   alternative to the `subject` names.
+* `subjectaltname` {string} (Optional) A string containing concatenated names
+ for the subject, an alternative to the `subject` names.
 * `infoAccess` {Array} (Optional) An array describing the AuthorityInfoAccess,
    used with OCSP.
 * `issuerCertificate` {Object} (Optional) The issuer certificate object. For


### PR DESCRIPTION
Within tls.md, the documentation for the response of
tlsSocket.getPeerCertificate() included subjectaltname
documented as an array of values. However these values are
actually returned as a single string of concatenated values.
The documentation has been updated to reflect this.

Fixes: https://github.com/nodejs/node/issues/27721

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
