### PR TITLE
tls: set tlsSocket.servername as early as possible

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -774,6 +774,7 @@ TLSSocket.prototype._finishInit = function() {
     return;
 
   this.alpnProtocol = this._handle.getALPNNegotiatedProtocol();
+  // The servername could be set by TLSWrap.
   this.servername = this._handle.getServername();
 
   debug('%s _finishInit',

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -774,8 +774,10 @@ TLSSocket.prototype._finishInit = function() {
     return;
 
   this.alpnProtocol = this._handle.getALPNNegotiatedProtocol();
-  // The servername could be set by TLSWrap.
-  this.servername = this._handle.getServername();
+  // The servername could be set by TLSWrap::SelectSNIContextCallback().
+  if (this.servername === null) {
+    this.servername = this._handle.getServername();
+  }
 
   debug('%s _finishInit',
         this._tlsOptions.isServer ? 'server' : 'client',

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -1033,6 +1033,11 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
   Local<Object> object = p->object();
   Local<Value> ctx;
 
+  // Set the servername as early as possible
+  Local<Object> owner = p->GetOwner();
+  USE(owner->Set(env->context(), env->servername_string(),
+      OneByteString(env->isolate(), servername)));
+
   if (!object->Get(env->context(), env->sni_context_string()).ToLocal(&ctx))
     return SSL_TLSEXT_ERR_NOACK;
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -1035,8 +1035,11 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
 
   // Set the servername as early as possible
   Local<Object> owner = p->GetOwner();
-  USE(owner->Set(env->context(), env->servername_string(),
-      OneByteString(env->isolate(), servername)));
+  if (!owner->Set(env->context(),
+                  env->servername_string(),
+                  OneByteString(env->isolate(), servername)).FromMaybe(false)) {
+    return SSL_TLSEXT_ERR_NOACK;
+  }
 
   if (!object->Get(env->context(), env->sni_context_string()).ToLocal(&ctx))
     return SSL_TLSEXT_ERR_NOACK;

--- a/test/parallel/test-tls-sni-servername.js
+++ b/test/parallel/test-tls-sni-servername.js
@@ -1,0 +1,56 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+
+// We could get the `tlsSocket.servername` even if the event of "tlsClientError"
+// is emitted.
+
+const serverOptions = {
+  requestCert: true,
+  rejectUnauthorized: false,
+  SNICallback: function(servername, callback) {
+    if (servername === 'c.another.com') {
+      callback(null, {});
+    } else {
+      callback(new Error('Invalid SNI context'), null);
+    }
+  }
+};
+
+function test(options) {
+  const server = tls.createServer(serverOptions, common.mustNotCall());
+
+  server.on('tlsClientError', common.mustCall((err, socket) => {
+    assert.strictEqual(err.message, 'Invalid SNI context');
+    // The `servername` should match.
+    assert.strictEqual(socket.servername, options.servername);
+  }));
+
+  server.listen(0, () => {
+    options.port = server.address().port;
+    const client = tls.connect(options, common.mustNotCall());
+
+    client.on('error', common.mustCall((err) => {
+      assert.strictEqual(err.message, 'Client network socket' +
+      ' disconnected before secure TLS connection was established');
+    }));
+
+    client.on('close', common.mustCall(() => server.close()));
+  });
+}
+
+test({
+  port: undefined,
+  servername: 'c.another.com',
+  rejectUnauthorized: false
+});
+
+test({
+  port: undefined,
+  servername: 'c.wrong.com',
+  rejectUnauthorized: false
+});


### PR DESCRIPTION
This commit makes `TLSSocket` set the `servername` property on
`SSL_CTX_set_tlsext_servername_callback` so that we could get it
later even if errors happen.

Fixes: https://github.com/nodejs/node/issues/27699

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
