### PR TITLE
doc: correct parameter type on 'subprocess.kill([signal])'

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1022,7 +1022,7 @@ within the child process to close the IPC channel as well.
 added: v0.1.90
 -->
 
-* `signal` {string}
+* `signal` {number|string}
 
 The `subprocess.kill()` method sends a signal to the child process. If no
 argument is given, the process will be sent the `'SIGTERM'` signal. See


### PR DESCRIPTION
see #27750

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
