### PR TITLE
esm: use correct error arguments

### DIFF
--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -91,8 +91,7 @@ function resolve(specifier, parentURL) {
     if (isMain)
       format = type === TYPE_MODULE ? 'module' : 'commonjs';
     else
-      throw new ERR_UNKNOWN_FILE_EXTENSION(fileURLToPath(url),
-                                           fileURLToPath(parentURL));
+      throw new ERR_UNKNOWN_FILE_EXTENSION(fileURLToPath(url));
   }
   return { url: `${url}`, format };
 }

--- a/test/es-module/test-esm-invalid-extension.js
+++ b/test/es-module/test-esm-invalid-extension.js
@@ -1,0 +1,13 @@
+'use strict';
+require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fixture = fixtures.path('/es-modules/import-invalid-ext.mjs');
+const child = spawnSync(process.execPath, ['--experimental-modules', fixture]);
+const errMsg = 'TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension';
+
+assert.strictEqual(child.status, 1);
+assert.strictEqual(child.signal, null);
+assert.strictEqual(child.stdout.toString().trim(), '');
+assert(child.stderr.toString().includes(errMsg));

--- a/test/fixtures/es-modules/import-invalid-ext.mjs
+++ b/test/fixtures/es-modules/import-invalid-ext.mjs
@@ -1,0 +1,1 @@
+import './simple.wat';


### PR DESCRIPTION
ERR_UNKNOWN_FILE_EXTENSION expects a single argument. This
commit fixes the argument count.

Fixes: https://github.com/nodejs/node/issues/27761

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
