### PR TITLE
doc: add code sample for WriteStream

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1569,6 +1569,16 @@ should be passed to [`net.Socket`][].
 
 If `options` is a string, then it specifies the encoding.
 
+```js
+// Create a stream of file copy functions
+const fs = require('fs');
+
+const rs = fs.createReadStream('./out.txt');
+const ws = fs.createWriteStream('./input.txt', { flags: 'a' });
+
+rs.pipe(ws); // Out.txt content pipe to input.txt
+```
+
 ## fs.exists(path, callback)
 <!-- YAML
 added: v0.0.2


### PR DESCRIPTION
Add a code example for WriteStream(alse explaining `ws
and `rs`) to compare and briefly explain with ReadStream.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
