### PR TITLE
src: fix segfault handling/RegisterSignalHandler

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -487,6 +487,12 @@ void TrapWebAssemblyOrContinue(int signo, siginfo_t* info, void* ucontext) {
     if (prev != nullptr) {
       prev(signo, info, ucontext);
     } else {
+      // Reset to the default signal handler, i.e. cause a hard crash.
+      struct sigaction sa;
+      memset(&sa, 0, sizeof(sa));
+      sa.sa_handler = SIG_DFL;
+      CHECK_EQ(sigaction(signo, &sa, nullptr), 0);
+
       ResetStdio();
       raise(signo);
     }

--- a/src/node.h
+++ b/src/node.h
@@ -66,9 +66,11 @@
 
 #include <memory>
 
-#ifdef __POSIX__
+// We cannot use __POSIX__ in this header because that's only defined when
+// building Node.js.
+#ifndef _WIN32
 #include <signal.h>
-#endif  // __POSIX__
+#endif  // _WIN32
 
 #define NODE_MAKE_VERSION(major, minor, patch)                                \
   ((major) * 0x1000 + (minor) * 0x100 + (patch))
@@ -812,7 +814,7 @@ class NODE_EXTERN AsyncResource {
   async_context async_context_;
 };
 
-#ifdef __POSIX__
+#ifndef _WIN32
 // Register a signal handler without interrupting
 // any handlers that node itself needs.
 NODE_EXTERN
@@ -821,7 +823,7 @@ void RegisterSignalHandler(int signal,
                                            siginfo_t* info,
                                            void* ucontext),
                            bool reset_handler = false);
-#endif  // __POSIX__
+#endif  // _WIN32
 
 }  // namespace node
 

--- a/src/node.h
+++ b/src/node.h
@@ -815,8 +815,12 @@ class NODE_EXTERN AsyncResource {
 };
 
 #ifndef _WIN32
-// Register a signal handler without interrupting
-// any handlers that node itself needs.
+// Register a signal handler without interrupting any handlers that node
+// itself needs. This does override handlers registered through
+// process.on('SIG...', function() { ... }). The `reset_handler` flag indicates
+// whether the signal handler for the given signal should be reset to its
+// default value before executing the handler (i.e. it works like SA_RESETHAND).
+// The `reset_handler` flag is invalid when `signal` is SIGSEGV.
 NODE_EXTERN
 void RegisterSignalHandler(int signal,
                            void (*handler)(int signal,

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -63,6 +63,12 @@ static void Abort(const FunctionCallbackInfo<Value>& args) {
   Abort();
 }
 
+// For internal testing only, not exposed to userland.
+static void CauseSegfault(const FunctionCallbackInfo<Value>& args) {
+  // This should crash hard all platforms.
+  *static_cast<void**>(nullptr) = nullptr;
+}
+
 static void Chdir(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   CHECK(env->owns_process_state());
@@ -405,6 +411,7 @@ static void InitializeProcessMethods(Local<Object> target,
     env->SetMethod(target, "_debugProcess", DebugProcess);
     env->SetMethod(target, "_debugEnd", DebugEnd);
     env->SetMethod(target, "abort", Abort);
+    env->SetMethod(target, "causeSegfault", CauseSegfault);
     env->SetMethod(target, "chdir", Chdir);
   }
 

--- a/test/abort/test-addon-register-signal-handler.js
+++ b/test/abort/test-addon-register-signal-handler.js
@@ -1,0 +1,7 @@
+'use strict';
+require('../common');
+
+// This is a sibling test to test/addons/register-signal-handler/
+
+process.env.ALLOW_CRASHES = true;
+require('../addons/register-signal-handler/test');

--- a/test/abort/test-signal-handler.js
+++ b/test/abort/test-signal-handler.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+if (common.isWindows)
+  common.skip('No signals on Window');
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+// Test that a hard crash does not cause an endless loop.
+
+if (process.argv[2] === 'child') {
+  const { internalBinding } = require('internal/test/binding');
+  const { causeSegfault } = internalBinding('process_methods');
+
+  causeSegfault();
+} else {
+  const child = spawnSync(process.execPath,
+                          ['--expose-internals', __filename, 'child'],
+                          { stdio: 'inherit' });
+  // FreeBSD and macOS use SIGILL for the kind of crash we're causing here.
+  assert(child.signal === 'SIGSEGV' || child.signal === 'SIGILL',
+         `child.signal = ${child.signal}`);
+}

--- a/test/addons/register-signal-handler/binding.cc
+++ b/test/addons/register-signal-handler/binding.cc
@@ -1,0 +1,36 @@
+#ifndef _WIN32
+#include <node.h>
+#include <v8.h>
+#include <uv.h>
+#include <assert.h>
+#include <unistd.h>
+
+using v8::Boolean;
+using v8::FunctionCallbackInfo;
+using v8::Int32;
+using v8::Value;
+
+void Handler(int signo, siginfo_t* siginfo, void* ucontext) {
+  char signo_char = signo;
+  int written;
+  do {
+    written = write(1, &signo_char, 1);  // write() is signal-safe.
+  } while (written == -1 && errno == EINTR);
+  assert(written == 1);
+}
+
+void RegisterSignalHandler(const FunctionCallbackInfo<Value>& args) {
+  assert(args[0]->IsInt32());
+  assert(args[1]->IsBoolean());
+
+  int32_t signo = args[0].As<Int32>()->Value();
+  bool reset_handler = args[1].As<Boolean>()->Value();
+
+  node::RegisterSignalHandler(signo, Handler, reset_handler);
+}
+
+NODE_MODULE_INIT() {
+  NODE_SET_METHOD(exports, "registerSignalHandler", RegisterSignalHandler);
+}
+
+#endif  // _WIN32

--- a/test/addons/register-signal-handler/binding.gyp
+++ b/test/addons/register-signal-handler/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ],
+      'includes': ['../common.gypi'],
+    }
+  ]
+}

--- a/test/addons/register-signal-handler/test.js
+++ b/test/addons/register-signal-handler/test.js
@@ -1,0 +1,56 @@
+'use strict';
+const common = require('../../common');
+if (common.isWindows)
+  common.skip('No RegisterSignalHandler() on Windows');
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { signals } = require('os').constants;
+const { spawnSync } = require('child_process');
+
+const bindingPath = path.resolve(
+  __dirname, 'build', common.buildType, 'binding.node');
+
+if (!fs.existsSync(bindingPath))
+  common.skip('binding not built yet');
+
+const binding = require(bindingPath);
+
+if (process.argv[2] === 'child') {
+  const signo = +process.argv[3];
+  const reset = process.argv[4] === 'reset';
+  const count = +process.argv[5];
+
+  binding.registerSignalHandler(signo, reset);
+  for (let i = 0; i < count; i++)
+    process.kill(process.pid, signo);
+  return;
+}
+
+for (const raiseSignal of [ 'SIGABRT', 'SIGSEGV' ]) {
+  const signo = signals[raiseSignal];
+  for (const { reset, count, stderr, code, signal } of [
+    { reset: true, count: 1, stderr: [signo], code: 0, signal: null },
+    { reset: true, count: 2, stderr: [signo], code: null, signal: raiseSignal },
+    { reset: false, count: 1, stderr: [signo], code: 0, signal: null },
+    { reset: false, count: 2, stderr: [signo, signo], code: 0, signal: null }
+  ]) {
+    // We do not want to generate core files when running this test as an
+    // addon test. We require this file as an abort test as well, though,
+    // with ALLOW_CRASHES set.
+    if (signal !== null && !process.env.ALLOW_CRASHES)
+      continue;
+    // reset_handler does not work with SIGSEGV.
+    if (reset && signo === signals.SIGSEGV)
+      continue;
+
+    const args = [__filename, 'child', signo, reset ? 'reset' : '', count];
+    console.log(`Running: node ${args.join(' ')}`);
+    const result = spawnSync(
+      process.execPath, args, { stdio: ['inherit', 'pipe', 'inherit'] });
+    assert.strictEqual(result.status, code);
+    assert.strictEqual(result.signal, signal);
+    assert.deepStrictEqual([...result.stdout], stderr);
+  }
+}


### PR DESCRIPTION
##### src: do not use posix feature macro in node.h

This macro is only defined when building Node.js, so addons cannot
use it as a way of detecting feature availability.

##### src: reset SIGSEGV handler before crashing

Without this, we would re-enter the signal handler immediately
after re-raising the signal, leading to an infinite loop.

~~##### src: implement reset_handler for SIGSEGV handling~~

~~Otherwise, this makes `RegisterSignalHandler()` behave differently
for `SIGSEGV` than it does for all other signals.~~

~~Encoding the `reset_handler` bit as part of the function pointer value
is a bit of a hack, and may not work on all platforms.~~

~~(This commit can be left out, if people feel like it should be. It can also be replaced by not making the `reset_handler` argument part of the public API.)~~

##### src: forbid reset_handler for SIGSEGV handling

This is not easily implementable, and should be explicitly disallowed.

##### test: add addon tests for `RegisterSignalHandler()`

Ensure coverage for the different combinations of arguments.

Refs: https://github.com/nodejs/node/pull/27246

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
