### PR TITLE
http: call write callback even if there is no message body

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -573,6 +573,7 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
   if (!msg._hasBody) {
     debug('This type of response MUST NOT have a body. ' +
           'Ignoring write() calls.');
+    if (callback) process.nextTick(callback);
     return true;
   }
 

--- a/test/parallel/test-http-outgoing-message-write-callback.js
+++ b/test/parallel/test-http-outgoing-message-write-callback.js
@@ -3,35 +3,37 @@
 const common = require('../common');
 
 // This test ensures that the callback of `OutgoingMessage.prototype.write()` is
-// called also when writing empty chunks.
+// called also when writing empty chunks or when the message has no body.
 
 const assert = require('assert');
 const http = require('http');
 const stream = require('stream');
 
-const expected = ['a', 'b', '', Buffer.alloc(0), 'c'];
-const results = [];
+for (const method of ['GET, HEAD']) {
+  const expected = ['a', 'b', '', Buffer.alloc(0), 'c'];
+  const results = [];
 
-const writable = new stream.Writable({
-  write(chunk, encoding, callback) {
-    setImmediate(callback);
-  }
-});
-
-const res = new http.ServerResponse({
-  method: 'GET',
-  httpVersionMajor: 1,
-  httpVersionMinor: 1
-});
-
-res.assignSocket(writable);
-
-for (const chunk of expected) {
-  res.write(chunk, () => {
-    results.push(chunk);
+  const writable = new stream.Writable({
+    write(chunk, encoding, callback) {
+      callback();
+    }
   });
-}
 
-res.end(common.mustCall(() => {
-  assert.deepStrictEqual(results, expected);
-}));
+  const res = new http.ServerResponse({
+    method: method,
+    httpVersionMajor: 1,
+    httpVersionMinor: 1
+  });
+
+  res.assignSocket(writable);
+
+  for (const chunk of expected) {
+    res.write(chunk, () => {
+      results.push(chunk);
+    });
+  }
+
+  res.end(common.mustCall(() => {
+    assert.deepStrictEqual(results, expected);
+  }));
+}


### PR DESCRIPTION
Ensure that the callback of `OutgoingMessage.prototype.write()` is
called when `outgoingMessage._hasBody` is `false` (HEAD method, 204
status code, etc.).

Refs: https://github.com/nodejs/node/pull/27709

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
