### PR TITLE
deps: histogram: unexport symbols

### DIFF
--- a/deps/histogram/histogram.gyp
+++ b/deps/histogram/histogram.gyp
@@ -3,6 +3,10 @@
     {
       'target_name': 'histogram',
       'type': 'static_library',
+      'cflags': ['-fvisibility=hidden'],
+      'xcode_settings': {
+        'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',  # -fvisibility=hidden
+      },
       'include_dirs': ['src'],
       'direct_dependent_settings': {
         'include_dirs': [ 'src' ]


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/27778
Fixes: https://github.com/nodejs/node-gyp/issues/1755