### PR TITLE
src: remove freebsd SA_RESETHAND workaround

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -191,13 +191,6 @@ void WaitForInspectorDisconnect(Environment* env) {
 #ifdef __POSIX__
 void SignalExit(int signo, siginfo_t* info, void* ucontext) {
   uv_tty_reset_mode();
-#ifdef __FreeBSD__
-  // FreeBSD has a nasty bug, see RegisterSignalHandler for details
-  struct sigaction sa;
-  memset(&sa, 0, sizeof(sa));
-  sa.sa_handler = SIG_DFL;
-  CHECK_EQ(sigaction(signo, &sa, nullptr), 0);
-#endif
   raise(signo);
 }
 #endif  // __POSIX__
@@ -480,12 +473,7 @@ void RegisterSignalHandler(int signal,
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_sigaction = handler;
-#ifndef __FreeBSD__
-  // FreeBSD has a nasty bug with SA_RESETHAND reseting the SA_SIGINFO, that is
-  // in turn set for a libthr wrapper. This leads to a crash.
-  // Work around the issue by manually setting SIG_DFL in the signal handler
   sa.sa_flags = reset_handler ? SA_RESETHAND : 0;
-#endif
   sigfillset(&sa.sa_mask);
   CHECK_EQ(sigaction(signal, &sa, nullptr), 0);
 }


### PR DESCRIPTION
This workaround should no longer be necessary with supported versions
of FreeSBD.

Originall introduced in commit b64983d77c ("src: reset signal handler to
SIG_DFL on FreeBSD") from March 2015.

Fixes: https://github.com/nodejs/node/issues/27515
Refs: https://github.com/nodejs/node/pull/27246#discussion_r279636813

CI: https://ci.nodejs.org/job/node-test-pull-request/23227/