### PR TITLE
http2: support net.Server options

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1912,6 +1912,10 @@ error will be thrown.
 <!-- YAML
 added: v8.4.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/27782
+    description: The `options` parameter now supports `net.createServer()`
+                 options.
   - version: v8.9.3
     pr-url: https://github.com/nodejs/node/pull/17105
     description: Added the `maxOutstandingPings` option with a default limit of
@@ -1987,6 +1991,7 @@ changes:
     `Http2ServerResponse` class to use.
     Useful for extending the original `Http2ServerResponse`.
     **Default:** `Http2ServerResponse`.
+  * ...: Any [`net.createServer()`][] option can be provided.
 * `onRequestHandler` {Function} See [Compatibility API][]
 * Returns: {Http2Server}
 
@@ -3466,6 +3471,7 @@ following additional properties:
 [`http2.createServer()`]: #http2_http2_createserver_options_onrequesthandler
 [`http2session.close()`]: #http2_http2session_close_callback
 [`http2stream.pushStream()`]: #http2_http2stream_pushstream_headers_options_callback
+[`net.createServer()`]: net.html#net_net_createserver_options_connectionlistener
 [`net.Server.close()`]: net.html#net_server_close_callback
 [`net.Socket.bufferSize`]: net.html#net_socket_buffersize
 [`net.Socket.prototype.ref()`]: net.html#net_socket_ref

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2697,8 +2697,9 @@ class Http2SecureServer extends TLSServer {
 
 class Http2Server extends NETServer {
   constructor(options, requestListener) {
-    super(connectionListener);
-    this[kOptions] = initializeOptions(options);
+    options = initializeOptions(options);
+    super(options, connectionListener);
+    this[kOptions] = options;
     this.timeout = 0;
     this.on('newListener', setupCompat);
     if (typeof requestListener === 'function')

--- a/test/parallel/test-http2-server-startup.js
+++ b/test/parallel/test-http2-server-startup.js
@@ -10,6 +10,7 @@ const commonFixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const assert = require('assert');
 const http2 = require('http2');
 const tls = require('tls');
 const net = require('net');
@@ -48,6 +49,25 @@ server.on('error', common.mustNotCall());
   }));
 }
 
+// Test that `http2.createServer()` supports `net.Server` options.
+{
+  const server = http2.createServer({ allowHalfOpen: true });
+
+  server.on('connection', common.mustCall((socket) => {
+    assert.strictEqual(socket.allowHalfOpen, true);
+    socket.end();
+    server.close();
+  }));
+
+  assert.strictEqual(server.allowHalfOpen, true);
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    const socket = net.connect(port, common.mustCall());
+    socket.resume();
+  }));
+}
+
 // Test the secure server socket timeout.
 {
   let client;
@@ -65,5 +85,31 @@ server.on('error', common.mustNotCall());
       rejectUnauthorized: false,
       ALPNProtocols: ['h2']
     }, common.mustCall());
+  }));
+}
+
+// Test that `http2.createSecureServer()` supports `net.Server` options.
+{
+  const server = http2.createSecureServer({
+    allowHalfOpen: true,
+    ...options
+  });
+
+  server.on('secureConnection', common.mustCall((socket) => {
+    assert.strictEqual(socket.allowHalfOpen, true);
+    socket.end();
+    server.close();
+  }));
+
+  assert.strictEqual(server.allowHalfOpen, true);
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    const socket = tls.connect({
+      port: port,
+      rejectUnauthorized: false,
+      ALPNProtocols: ['h2']
+    }, common.mustCall());
+    socket.resume();
   }));
 }


### PR DESCRIPTION
Make `http2.createServer()` support `net.Server` options.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
