### PR TITLE
assert: remove unreachable code

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -374,9 +374,9 @@ class AssertionError extends Error {
       } else {
         let res = inspectValue(actual);
         let other = inspectValue(expected);
-        const knownOperators = kReadableOperator[operator];
+        const knownOperator = kReadableOperator[operator];
         if (operator === 'notDeepEqual' && res === other) {
-          res = `${knownOperators}\n\n${res}`;
+          res = `${knownOperator}\n\n${res}`;
           if (res.length > 1024) {
             res = `${res.slice(0, 1021)}...`;
           }
@@ -389,8 +389,7 @@ class AssertionError extends Error {
             other = `${other.slice(0, 509)}...`;
           }
           if (operator === 'deepEqual') {
-            const eq = operator === 'deepEqual' ? 'deep-equal' : 'equal';
-            res = `${knownOperators}\n\n${res}\n\nshould loosely ${eq}\n\n`;
+            res = `${knownOperator}\n\n${res}\n\nshould loosely deep-equal\n\n`;
           } else {
             const newOperator = kReadableOperator[`${operator}Unequal`];
             if (newOperator) {


### PR DESCRIPTION
In lib/internal/assert/assertion_error.js, line 391 assures that
`operator` is 'deepEqual' so there is no need to check the value of
`operator` in a ternary on the next line (line 392). Remove the ternary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
