### PR TITLE
test: increase debugging information on failure

### DIFF
--- a/test/parallel/test-child-process-pipe-dataflow.js
+++ b/test/parallel/test-child-process-pipe-dataflow.js
@@ -38,16 +38,19 @@ const MB = KB * KB;
   grep.stdout._handle.readStart = common.mustNotCall();
 
   [cat, grep, wc].forEach((child, index) => {
-    child.stderr.on('data', (d) => {
+    const errorHandler = (thing, type) => {
       // Don't want to assert here, as we might miss error code info.
-      console.error(`got unexpected data from child #${index}:\n${d}`);
-    });
-    child.on('exit', common.mustCall(function(code) {
-      assert.strictEqual(code, 0);
+      console.error(`unexpected ${type} from child #${index}:\n${thing}`);
+    };
+
+    child.stderr.on('data', (d) => { errorHandler(d, 'data'); });
+    child.on('error', (err) => { errorHandler(err, 'error'); });
+    child.on('exit', common.mustCall((code) => {
+      assert.strictEqual(code, 0, `child ${index} exited with code ${code}`);
     }));
   });
 
-  wc.stdout.on('data', common.mustCall(function(data) {
+  wc.stdout.on('data', common.mustCall((data) => {
     assert.strictEqual(data.toString().trim(), MB.toString());
   }));
 }


### PR DESCRIPTION
Increase the information displayed when
test-child-process-pipe-dataflow.js fails.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
