### PR TITLE
deps: V8: cherry-pick 94c87fe

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.17',
+    'v8_embedder_string': '-node.18',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/code-stub-assembler.h
+++ b/deps/v8/src/code-stub-assembler.h
@@ -3095,7 +3095,14 @@ class V8_EXPORT_PRIVATE CodeStubAssembler
   // ECMA#sec-samevalue
   // Similar to StrictEqual except that NaNs are treated as equal and minus zero
   // differs from positive zero.
-  void BranchIfSameValue(Node* lhs, Node* rhs, Label* if_true, Label* if_false);
+  enum class SameValueMode { kNumbersOnly, kFull };
+  void BranchIfSameValue(Node* lhs, Node* rhs, Label* if_true, Label* if_false,
+                         SameValueMode mode = SameValueMode::kFull);
+  // A part of BranchIfSameValue() that handles two double values.
+  // Treats NaN == NaN and +0 != -0.
+  void BranchIfSameNumberValue(TNode<Float64T> lhs_value,
+                               TNode<Float64T> rhs_value, Label* if_true,
+                               Label* if_false);
 
   enum HasPropertyLookupMode { kHasProperty, kForInHasProperty };
 

--- a/deps/v8/src/lookup.cc
+++ b/deps/v8/src/lookup.cc
@@ -934,10 +934,14 @@ bool LookupIterator::IsConstFieldValueEqualTo(Object value) const {
       // Uninitialized double field.
       return true;
     }
-    return bit_cast<double>(bits) == value->Number();
+    return Object::SameNumberValue(bit_cast<double>(bits), value->Number());
   } else {
     Object current_value = holder->RawFastPropertyAt(field_index);
-    return current_value->IsUninitialized(isolate()) || current_value == value;
+    if (current_value->IsUninitialized(isolate()) || current_value == value) {
+      return true;
+    }
+    return current_value->IsNumber() && value->IsNumber() &&
+           Object::SameNumberValue(current_value->Number(), value->Number());
   }
 }
 

--- a/deps/v8/src/objects-inl.h
+++ b/deps/v8/src/objects-inl.h
@@ -383,6 +383,16 @@ double Object::Number() const {
                  : HeapNumber::unchecked_cast(*this)->value();
 }
 
+// static
+bool Object::SameNumberValue(double value1, double value2) {
+  // SameNumberValue(NaN, NaN) is true.
+  if (value1 != value2) {
+    return std::isnan(value1) && std::isnan(value2);
+  }
+  // SameNumberValue(0.0, -0.0) is false.
+  return (std::signbit(value1) == std::signbit(value2));
+}
+
 bool Object::IsNaN() const {
   return this->IsHeapNumber() && std::isnan(HeapNumber::cast(*this)->value());
 }

--- a/deps/v8/src/objects.cc
+++ b/deps/v8/src/objects.cc
@@ -594,7 +594,7 @@ namespace {
 
 // TODO(bmeurer): Maybe we should introduce a marker interface Number,
 // where we put all these methods at some point?
-ComparisonResult NumberCompare(double x, double y) {
+ComparisonResult StrictNumberCompare(double x, double y) {
   if (std::isnan(x) || std::isnan(y)) {
     return ComparisonResult::kUndefined;
   } else if (x < y) {
@@ -606,19 +606,20 @@ ComparisonResult NumberCompare(double x, double y) {
   }
 }
 
-bool NumberEquals(double x, double y) {
+// See Number case of ES6#sec-strict-equality-comparison
+// Returns false if x or y is NaN, treats -0.0 as equal to 0.0.
+bool StrictNumberEquals(double x, double y) {
   // Must check explicitly for NaN's on Windows, but -0 works fine.
-  if (std::isnan(x)) return false;
-  if (std::isnan(y)) return false;
+  if (std::isnan(x) || std::isnan(y)) return false;
   return x == y;
 }
 
-bool NumberEquals(const Object x, const Object y) {
-  return NumberEquals(x->Number(), y->Number());
+bool StrictNumberEquals(const Object x, const Object y) {
+  return StrictNumberEquals(x->Number(), y->Number());
 }
 
-bool NumberEquals(Handle<Object> x, Handle<Object> y) {
-  return NumberEquals(*x, *y);
+bool StrictNumberEquals(Handle<Object> x, Handle<Object> y) {
+  return StrictNumberEquals(*x, *y);
 }
 
 ComparisonResult Reverse(ComparisonResult result) {
@@ -663,7 +664,7 @@ Maybe<ComparisonResult> Object::Compare(Isolate* isolate, Handle<Object> x,
   bool x_is_number = x->IsNumber();
   bool y_is_number = y->IsNumber();
   if (x_is_number && y_is_number) {
-    return Just(NumberCompare(x->Number(), y->Number()));
+    return Just(StrictNumberCompare(x->Number(), y->Number()));
   } else if (!x_is_number && !y_is_number) {
     return Just(BigInt::CompareToBigInt(Handle<BigInt>::cast(x),
                                         Handle<BigInt>::cast(y)));
@@ -683,11 +684,12 @@ Maybe<bool> Object::Equals(Isolate* isolate, Handle<Object> x,
   while (true) {
     if (x->IsNumber()) {
       if (y->IsNumber()) {
-        return Just(NumberEquals(x, y));
+        return Just(StrictNumberEquals(x, y));
       } else if (y->IsBoolean()) {
-        return Just(NumberEquals(*x, Handle<Oddball>::cast(y)->to_number()));
+        return Just(
+            StrictNumberEquals(*x, Handle<Oddball>::cast(y)->to_number()));
       } else if (y->IsString()) {
-        return Just(NumberEquals(
+        return Just(StrictNumberEquals(
             x, String::ToNumber(isolate, Handle<String>::cast(y))));
       } else if (y->IsBigInt()) {
         return Just(BigInt::EqualToNumber(Handle<BigInt>::cast(y), x));
@@ -705,10 +707,11 @@ Maybe<bool> Object::Equals(Isolate* isolate, Handle<Object> x,
                                    Handle<String>::cast(y)));
       } else if (y->IsNumber()) {
         x = String::ToNumber(isolate, Handle<String>::cast(x));
-        return Just(NumberEquals(x, y));
+        return Just(StrictNumberEquals(x, y));
       } else if (y->IsBoolean()) {
         x = String::ToNumber(isolate, Handle<String>::cast(x));
-        return Just(NumberEquals(*x, Handle<Oddball>::cast(y)->to_number()));
+        return Just(
+            StrictNumberEquals(*x, Handle<Oddball>::cast(y)->to_number()));
       } else if (y->IsBigInt()) {
         return Just(BigInt::EqualToString(isolate, Handle<BigInt>::cast(y),
                                           Handle<String>::cast(x)));
@@ -724,10 +727,12 @@ Maybe<bool> Object::Equals(Isolate* isolate, Handle<Object> x,
       if (y->IsOddball()) {
         return Just(x.is_identical_to(y));
       } else if (y->IsNumber()) {
-        return Just(NumberEquals(Handle<Oddball>::cast(x)->to_number(), *y));
+        return Just(
+            StrictNumberEquals(Handle<Oddball>::cast(x)->to_number(), *y));
       } else if (y->IsString()) {
         y = String::ToNumber(isolate, Handle<String>::cast(y));
-        return Just(NumberEquals(Handle<Oddball>::cast(x)->to_number(), *y));
+        return Just(
+            StrictNumberEquals(Handle<Oddball>::cast(x)->to_number(), *y));
       } else if (y->IsBigInt()) {
         x = Oddball::ToNumber(isolate, Handle<Oddball>::cast(x));
         return Just(BigInt::EqualToNumber(Handle<BigInt>::cast(y), x));
@@ -776,7 +781,7 @@ Maybe<bool> Object::Equals(Isolate* isolate, Handle<Object> x,
 bool Object::StrictEquals(Object that) {
   if (this->IsNumber()) {
     if (!that->IsNumber()) return false;
-    return NumberEquals(*this, that);
+    return StrictNumberEquals(*this, that);
   } else if (this->IsString()) {
     if (!that->IsString()) return false;
     return String::cast(*this)->Equals(String::cast(that));
@@ -1624,14 +1629,7 @@ bool Object::SameValue(Object other) {
   if (other == *this) return true;
 
   if (IsNumber() && other->IsNumber()) {
-    double this_value = Number();
-    double other_value = other->Number();
-    // SameValue(NaN, NaN) is true.
-    if (this_value != other_value) {
-      return std::isnan(this_value) && std::isnan(other_value);
-    }
-    // SameValue(0.0, -0.0) is false.
-    return (std::signbit(this_value) == std::signbit(other_value));
+    return SameNumberValue(Number(), other->Number());
   }
   if (IsString() && other->IsString()) {
     return String::cast(*this)->Equals(String::cast(other));

--- a/deps/v8/src/objects.h
+++ b/deps/v8/src/objects.h
@@ -854,6 +854,10 @@ class Object {
   // to implement the Object.is function.
   V8_EXPORT_PRIVATE bool SameValue(Object other);
 
+  // A part of SameValue which handles Number vs. Number case.
+  // Treats NaN == NaN and +0 != -0.
+  inline static bool SameNumberValue(double number1, double number2);
+
   // Checks whether this object has the same value as the given one.
   // +0 and -0 are treated equal. Everything else is the same as SameValue.
   // This function is implemented according to ES6, section 7.2.4 and is used

--- a/deps/v8/test/mjsunit/regress/regress-crbug-950747.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-950747.js
@@ -1,0 +1,11 @@
+// Copyright 2019 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+let o = {};
+Reflect.set(o, "a", 0.1);
+
+let o1 = {};
+o1.a = {};
+
+Reflect.set(o, "a", 0.1);


### PR DESCRIPTION
Original commit message:

    [ic] Fix handling of +0/-0 when constant field tracking is enabled

    ... and ensure that runtime behaviour is in sync with the IC code.

    Bug: chromium:950747, v8:9113
    Change-Id: Ied66c9514cbe3a4d75fc71d4fc3b19ea1538f9b2
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1561319
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Commit-Queue: Igor Sheludko <ishell@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#60768}

Refs: https://github.com/v8/v8/commit/94c87fe0746fc95618ae091351f2f8c342212917

Fixes: https://github.com/nodejs/node/issues/27784