### PR TITLE
build: expose napi_build_version

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -72,6 +72,9 @@
 
     ##### end V8 defaults #####
 
+    # This variable need to be updated when N-API version change
+    'napi_build_version': 4,
+
     'conditions': [
       ['target_arch=="arm64"', {
         # Disabled pending https://github.com/nodejs/node/issues/23913.

--- a/common.gypi
+++ b/common.gypi
@@ -72,7 +72,7 @@
 
     ##### end V8 defaults #####
 
-    # This variable need to be updated when N-API version change
+    # This variable needs to be updated when N-API version change
     'napi_build_version': 4,
 
     'conditions': [


### PR DESCRIPTION
build: expose `napi_build_version` to allow `node-gyp` to make it available for add-ons.
Fixes: https://github.com/nodejs/node-gyp/issues/1745
Refs: https://github.com/nodejs/abi-stable-node/issues/371

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines]
