### PR TITLE
src: remove util-inl.h include in node.h

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -103,14 +103,6 @@
 # endif
 #endif
 
-#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
-// Internally, do not include util-inl.h into files unless they need it's
-// inline definitions.
-#else
-// Externally, it must be included for backwards API compatibility.
-#  include <util-inl.h>
-#endif
-
 // Forward-declare libuv loop
 struct uv_loop_s;
 


### PR DESCRIPTION
`node.h` may only include public APIs, which `util-inl.h` is not.
There does not seem to be any reason for including it, so remove it,
because otherwise native addon compilation is broken due to us not
shipping the `util-inl.h` header.

Refs: https://github.com/nodejs/node/pull/27631
Fixes: https://github.com/nodejs/node/issues/27803

@bridgear It would be awesome if you could push out 12.3.1 with that soon, it completely breaks non-N-API addon compilation.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
