### PR TITLE
os: add constrainedmem()

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -49,6 +49,18 @@ Returns an object containing commonly used operating system specific constants
 for error codes, process signals, and so on. The specific constants currently
 defined are described in [OS Constants](#os_os_constants_1).
 
+## os.constrainedmem()
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {integer}
+
+The `os.constrainedmem()` method returns the an integer that represents the
+amount of memory available to the process (in bytes) based on limits imposed by
+the operating system. If there is no such constraint, or the constraint is
+unknown, `0` is returned.
+
 ## os.cpus()
 <!-- YAML
 added: v0.3.3

--- a/lib/os.js
+++ b/lib/os.js
@@ -46,6 +46,7 @@ const {
   getOSRelease: _getOSRelease,
   getOSType: _getOSType,
   getPriority: _getPriority,
+  getConstrainedMem,
   getTotalMem,
   getUserInfo,
   getUptime,
@@ -77,6 +78,7 @@ getOSRelease[Symbol.toPrimitive] = () => getOSRelease();
 getOSType[Symbol.toPrimitive] = () => getOSType();
 getTotalMem[Symbol.toPrimitive] = () => getTotalMem();
 getUptime[Symbol.toPrimitive] = () => getUptime();
+getConstrainedMem[Symbol.toPrimitive] = () => getConstrainedMem();
 
 const kEndianness = isBigEndian ? 'BE' : 'LE';
 
@@ -266,6 +268,7 @@ function userInfo(options) {
 
 module.exports = {
   arch,
+  constrainedmem: getConstrainedMem,
   cpus,
   endianness,
   freemem: getFreeMem,

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -151,6 +151,14 @@ static void GetTotalMemory(const FunctionCallbackInfo<Value>& args) {
 }
 
 
+static void GetConstrainedMemory(const FunctionCallbackInfo<Value>& args) {
+  double amount = uv_get_constrained_memory();
+  if (amount < 0)
+    return;
+  args.GetReturnValue().Set(amount);
+}
+
+
 static void GetUptime(const FunctionCallbackInfo<Value>& args) {
   double uptime;
   int err = uv_uptime(&uptime);
@@ -390,6 +398,7 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "getUptime", GetUptime);
   env->SetMethod(target, "getTotalMem", GetTotalMemory);
   env->SetMethod(target, "getFreeMem", GetFreeMemory);
+  env->SetMethod(target, "getConstrainedMem", GetConstrainedMemory);
   env->SetMethod(target, "getCPUs", GetCPUInfo);
   env->SetMethod(target, "getOSType", GetOSType);
   env->SetMethod(target, "getOSRelease", GetOSRelease);

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -126,6 +126,7 @@ if (!common.isSunOS) {
   assert.ok(os.loadavg().length > 0);
   assert.ok(os.freemem() > 0);
   assert.ok(os.totalmem() > 0);
+  assert.ok(os.constrainedmem() >= 0);
 }
 
 const interfaces = os.networkInterfaces();
@@ -249,3 +250,6 @@ is.number(os.uptime(), 'uptime');
 
 is.number(+os.freemem, 'freemem');
 is.number(os.freemem(), 'freemem');
+
+is.number(+os.constrainedmem, 'constrainedmem');
+is.number(os.constrainedmem(), 'constrainedmem');


### PR DESCRIPTION
This exposes libuv's [uv_get_constrained_memory()](https://github.com/libuv/libuv/pull/2289) that was recently added.
It is useful when running inside a container.

Also, 👋. It's been a while.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
