### PR TITLE
esm: refactor createDynamicModule()

### DIFF
--- a/lib/internal/modules/esm/create_dynamic_module.js
+++ b/lib/internal/modules/esm/create_dynamic_module.js
@@ -4,24 +4,27 @@ const { ArrayPrototype, JSON, Object } = primordials;
 
 const debug = require('internal/util/debuglog').debuglog('esm');
 
-const createDynamicModule = (imports, exports, url = '', evaluate) => {
-  debug('creating ESM facade for %s with exports: %j', url, exports);
-  const names = ArrayPrototype.map(exports, (name) => `${name}`);
-
-  const source = `
-${ArrayPrototype.join(ArrayPrototype.map(imports, (impt, index) =>
-    `import * as $import_${index} from ${JSON.stringify(impt)};
-import.meta.imports[${JSON.stringify(impt)}] = $import_${index};`), '\n')
+function createImport(impt, index) {
+  const imptPath = JSON.stringify(impt);
+  return `import * as $import_${index} from ${imptPath};
+import.meta.imports[${imptPath}] = $import_${index};`;
 }
-${ArrayPrototype.join(ArrayPrototype.map(names, (name) =>
-    `let $${name};
+
+function createExport(expt) {
+  const name = `${expt}`;
+  return `let $${name};
 export { $${name} as ${name} };
 import.meta.exports.${name} = {
   get: () => $${name},
   set: (v) => $${name} = v,
-};`), '\n')
+};`;
 }
 
+const createDynamicModule = (imports, exports, url = '', evaluate) => {
+  debug('creating ESM facade for %s with exports: %j', url, exports);
+  const source = `
+${ArrayPrototype.join(ArrayPrototype.map(imports, createImport), '\n')}
+${ArrayPrototype.join(ArrayPrototype.map(exports, createExport), '\n')}
 import.meta.done();
 `;
   const { ModuleWrap, callbackMap } = internalBinding('module_wrap');


### PR DESCRIPTION
This commit refactors `createDynamicModule()` for readability:

- The `map()` callback functions are named and moved to a higher scope.
- The two export `map()` loops are combined.
- `JSON.stringify()` is only called once per import.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
