### PR TITLE
Reposition "How to Contribute" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ the file's signature.
 See [BUILDING.md](BUILDING.md) for instructions on how to build Node.js from
 source and a list of supported platforms.
 
+## Contributing to Node.js
+
+* [Contributing to the project][]
+* [Working Groups][]
+* [Strategic Initiatives][]
+
 ## Security
 
 For information on reporting security vulnerabilities in Node.js, see
@@ -592,12 +598,6 @@ Other keys used to sign some previous releases:
 `114F43EE0176B71C7BC219DD50A3051F888C628D`
 * **Timothy J Fontaine** &lt;tjfontaine@gmail.com&gt;
 `7937DFD2AB06298B2293C3187D33FF9D0246406D`
-
-## Contributing to Node.js
-
-* [Contributing to the project][]
-* [Working Groups][]
-* [Strategic Initiatives][]
 
 [Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
 [Contributing to the project]: CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ The Node.js project uses an [open governance model](./GOVERNANCE.md). The
     * [API Documentation](#api-documentation)
   * [Verifying Binaries](#verifying-binaries)
 * [Building Node.js](#building-nodejs)
+* [Contributing to Node.js](#contributing-to-nodejs)
 * [Security](#security)
 * [Current Project Team Members](#current-project-team-members)
   * [TSC (Technical Steering Committee)](#tsc-technical-steering-committee)
   * [Collaborators](#collaborators)
   * [Release Keys](#release-keys)
-* [Contributing to Node.js](#contributing-to-nodejs)
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The Node.js project uses an [open governance model](./GOVERNANCE.md). The
     * [API Documentation](#api-documentation)
   * [Verifying Binaries](#verifying-binaries)
 * [Building Node.js](#building-nodejs)
-* [Contributing to Node.js](#contributing-to-nodejs)
 * [Security](#security)
+* [Contributing to Node.js](#contributing-to-nodejs)
 * [Current Project Team Members](#current-project-team-members)
   * [TSC (Technical Steering Committee)](#tsc-technical-steering-committee)
   * [Collaborators](#collaborators)
@@ -155,16 +155,16 @@ the file's signature.
 See [BUILDING.md](BUILDING.md) for instructions on how to build Node.js from
 source and a list of supported platforms.
 
+## Security
+
+For information on reporting security vulnerabilities in Node.js, see
+[SECURITY.md](./SECURITY.md).
+
 ## Contributing to Node.js
 
 * [Contributing to the project][]
 * [Working Groups][]
 * [Strategic Initiatives][]
-
-## Security
-
-For information on reporting security vulnerabilities in Node.js, see
-[SECURITY.md](./SECURITY.md).
 
 ## Current Project Team Members
 


### PR DESCRIPTION
doc: reposition "How to Contribute" section

Moving this section makes it easier to jump to contributing rather than scrolling to a larger list of information where this section is stashed away.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
