### PR TITLE
[WIP] esm: basic wasm module env

### DIFF
--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -159,11 +159,25 @@ translators.set('wasm', async function(url) {
   }
 
   const imports =
-      WebAssembly.Module.imports(compiled).map(({ module }) => module);
+      WebAssembly.Module.imports(compiled).map(({ module }) => module).filter((module) => module != 'env');
   const exports = WebAssembly.Module.exports(compiled).map(({ name }) => name);
 
   return createDynamicModule(imports, exports, url, (reflect) => {
-    const { exports } = new WebAssembly.Instance(compiled, reflect.imports);
+    const env = {
+      __memory_base: 0,
+      memory: new WebAssembly.Memory({
+        initial: 512
+      }),
+      __table_base: 0,
+      table: new WebAssembly.Table({
+        initial: 0,
+        element: 'anyfunc'
+      })
+    };
+    const { exports } = new WebAssembly.Instance(compiled, {
+      ...reflect.imports,
+      env
+    });
     for (const expt of Object.keys(exports))
       reflect.exports[expt].set(exports[expt]);
   });


### PR DESCRIPTION
The current tests for Wasm modules is only testing modules that were compiled from Wast to Wasm.

When trying to get some basic functions working that were compiled via emscripten I quickly found that those modules were expecting a gloabal `env` that is generated for the .js wrapper.

Here's a link to the upstream source--> https://github.com/emscripten-core/emscripten/blob/incoming/src/preamble.js#L1117-L1158

This is a really naive PR tracking my work trying to get off the shelf wasm working as modules, it seems like there are lots of edge cases. I'm not 100% we want to ship this specific, and arguably internal, details of emscripten in core... hope to use this PR for a discussion in figuring out what makes the most sense.

@nodejs/modules