### PR TITLE
test: roll WPT update for URL and harness

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -336,7 +336,6 @@ class WPTRunner {
       fetch(file) {
         return resource.fetch(file);
       },
-      location: {},
       GLOBAL: {
         isWindow() { return false; }
       },
@@ -375,8 +374,6 @@ class WPTRunner {
     // TODO(joyeecheung): we are not a window - work with the upstream to
     // add a new scope for us.
 
-    const { Worker } = require('worker_threads');
-    sandbox.DedicatedWorker = Worker;  // Pretend we are a Worker
     return context;
   }
 

--- a/test/fixtures/wpt/LICENSE.md
+++ b/test/fixtures/wpt/LICENSE.md
@@ -1,33 +1,11 @@
-# Dual-License for W3C Test Suites
+# The 3-Clause BSD License
 
-All documents in this Repository are licensed by contributors to be distributed under both the [W3C Test Suite License](#w3c-test-suite-license) and the [W3C 3-clause BSD License](#w3c-3-clause-bsd-license), reproduced below. The choice of license is up to the licensee. For more information, see [Licenses for W3C Test Suites](https://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html)
-
-# W3C Test Suite License
-
-This document, Test Suites and other documents that link to this statement are provided by the copyright holders under the following license: By using and/or copying this document, or the W3C document from which this statement is linked, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions:
-
-Permission to copy, and distribute the contents of this document, or the W3C document from which this statement is linked, in any medium for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the document, or portions thereof, that you use:
-
-*    A link or URL to the original W3C document.
-*    The pre-existing copyright notice of the original author, or if it doesn't exist, a notice (hypertext is preferred, but a textual representation is permitted) of the form: "Copyright © [$date-of-document] World Wide Web Consortium, (MIT, ERCIM, Keio, Beihang) and others. All Rights Reserved. http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html"
-*    If it exists, the STATUS of the W3C document.
-
-When space permits, inclusion of the full text of this NOTICE should be provided. We request that authorship attribution be provided in any software, documents, or other items or products that you create pursuant to the implementation of the contents of this document, or any portion thereof.
-
-No right to create modifications or derivatives of W3C documents is granted pursuant to this license. However, if additional requirements (documented in the Copyright FAQ) are satisfied, the right to create modifications or derivatives is sometimes granted by the W3C to individuals complying with those requirements.
-
-If a Test Suite distinguishes the test harness (or, framework for navigation) and the actual tests, permission is given to remove or alter the harness or navigation if the Test Suite in question allows to do so. The tests themselves shall NOT be changed in any way.
-
-The name and trademarks of W3C and other copyright holders may NOT be used in advertising or publicity pertaining to this document or other documents that link to this statement without specific, written prior permission. Title to copyright in this document will at all times remain with copyright holders. Permission is given to use the trademarked string "W3C" within claims of performance concerning W3C Specifications or features described therein, and there only, if the test suite so authorizes.
-
-THIS WORK IS PROVIDED BY W3C, MIT, ERCIM, KEIO, BEIHANG, THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL W3C, MIT, ERCIM, KEIO, BEIHANG, THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# W3C 3-clause BSD License
+Copyright 2019 web-platform-tests contributors
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
-*    Redistributions of works must retain the original copyright notice, this list of conditions and the following disclaimer.
-*    Redistributions in binary form must reproduce the original copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-*    Neither the name of the W3C nor the names of its contributors may be used to endorse or promote products derived from this work without specific prior written permission.
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/fixtures/wpt/LICENSE.md
+++ b/test/fixtures/wpt/LICENSE.md
@@ -1,11 +1,33 @@
-# The 3-Clause BSD License
+# Dual-License for W3C Test Suites
 
-Copyright 2019 web-platform-tests contributors
+All documents in this Repository are licensed by contributors to be distributed under both the [W3C Test Suite License](#w3c-test-suite-license) and the [W3C 3-clause BSD License](#w3c-3-clause-bsd-license), reproduced below. The choice of license is up to the licensee. For more information, see [Licenses for W3C Test Suites](https://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html)
+
+# W3C Test Suite License
+
+This document, Test Suites and other documents that link to this statement are provided by the copyright holders under the following license: By using and/or copying this document, or the W3C document from which this statement is linked, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions:
+
+Permission to copy, and distribute the contents of this document, or the W3C document from which this statement is linked, in any medium for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the document, or portions thereof, that you use:
+
+*    A link or URL to the original W3C document.
+*    The pre-existing copyright notice of the original author, or if it doesn't exist, a notice (hypertext is preferred, but a textual representation is permitted) of the form: "Copyright © [$date-of-document] World Wide Web Consortium, (MIT, ERCIM, Keio, Beihang) and others. All Rights Reserved. http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html"
+*    If it exists, the STATUS of the W3C document.
+
+When space permits, inclusion of the full text of this NOTICE should be provided. We request that authorship attribution be provided in any software, documents, or other items or products that you create pursuant to the implementation of the contents of this document, or any portion thereof.
+
+No right to create modifications or derivatives of W3C documents is granted pursuant to this license. However, if additional requirements (documented in the Copyright FAQ) are satisfied, the right to create modifications or derivatives is sometimes granted by the W3C to individuals complying with those requirements.
+
+If a Test Suite distinguishes the test harness (or, framework for navigation) and the actual tests, permission is given to remove or alter the harness or navigation if the Test Suite in question allows to do so. The tests themselves shall NOT be changed in any way.
+
+The name and trademarks of W3C and other copyright holders may NOT be used in advertising or publicity pertaining to this document or other documents that link to this statement without specific, written prior permission. Title to copyright in this document will at all times remain with copyright holders. Permission is given to use the trademarked string "W3C" within claims of performance concerning W3C Specifications or features described therein, and there only, if the test suite so authorizes.
+
+THIS WORK IS PROVIDED BY W3C, MIT, ERCIM, KEIO, BEIHANG, THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL W3C, MIT, ERCIM, KEIO, BEIHANG, THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# W3C 3-clause BSD License
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+*    Redistributions of works must retain the original copyright notice, this list of conditions and the following disclaimer.
+*    Redistributions in binary form must reproduce the original copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+*    Neither the name of the W3C nor the names of its contributors may be used to endorse or promote products derived from this work without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/fixtures/wpt/README.md
+++ b/test/fixtures/wpt/README.md
@@ -13,7 +13,7 @@ Last update:
 - console: https://github.com/web-platform-tests/wpt/tree/9786a4b131/console
 - encoding: https://github.com/web-platform-tests/wpt/tree/a093a659ed/encoding
 - url: https://github.com/web-platform-tests/wpt/tree/75b0f336c5/url
-- resources: https://github.com/web-platform-tests/wpt/tree/679a364421/resources
+- resources: https://github.com/web-platform-tests/wpt/tree/e1fddfbf80/resources
 - interfaces: https://github.com/web-platform-tests/wpt/tree/712c9f275e/interfaces
 - html/webappapis/microtask-queuing: https://github.com/web-platform-tests/wpt/tree/0c3bed38df/html/webappapis/microtask-queuing
 - html/webappapis/timers: https://github.com/web-platform-tests/wpt/tree/ddfe9c089b/html/webappapis/timers

--- a/test/fixtures/wpt/README.md
+++ b/test/fixtures/wpt/README.md
@@ -12,7 +12,7 @@ Last update:
 
 - console: https://github.com/web-platform-tests/wpt/tree/9786a4b131/console
 - encoding: https://github.com/web-platform-tests/wpt/tree/a093a659ed/encoding
-- url: https://github.com/web-platform-tests/wpt/tree/75b0f336c5/url
+- url: https://github.com/web-platform-tests/wpt/tree/418f7fabeb/url
 - resources: https://github.com/web-platform-tests/wpt/tree/e1fddfbf80/resources
 - interfaces: https://github.com/web-platform-tests/wpt/tree/712c9f275e/interfaces
 - html/webappapis/microtask-queuing: https://github.com/web-platform-tests/wpt/tree/0c3bed38df/html/webappapis/microtask-queuing

--- a/test/fixtures/wpt/resources/idlharness.js
+++ b/test/fixtures/wpt/resources/idlharness.js
@@ -298,7 +298,9 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
         }.bind(this));
 
         deps.forEach(function(name) {
-            new_options.only.push(name);
+            if (!new_options.only.includes(name)) {
+                new_options.only.push(name);
+            }
 
             const follow_up = new Set();
             for (const dep_type of ["inheritance", "implements", "includes"]) {
@@ -306,13 +308,19 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
                     const inheriting = parsed[dep_type];
                     const inheritor = parsed.name || parsed.target;
                     const deps = [inheriting];
-                    // For A includes B, we can ignore A unless B is being tested.
+                    // For A includes B, we can ignore A, unless B (or some of its
+                    // members) is being tested.
                     if (dep_type !== "includes"
-                        || (inheriting in this.members && !this.members[inheriting].untested)) {
+                        || inheriting in this.members && !this.members[inheriting].untested
+                        || this.partials.some(function(p) {
+                                return p.name === inheriting;
+                            })) {
                         deps.push(inheritor);
                     }
                     for (const dep of deps) {
-                        new_options.only.push(dep);
+                        if (!new_options.only.includes(dep)) {
+                            new_options.only.push(dep);
+                        }
                         all_deps.add(dep);
                         follow_up.add(dep);
                     }
@@ -717,9 +725,6 @@ function exposed_in(globals) {
     if ('ServiceWorkerGlobalScope' in self &&
         self instanceof ServiceWorkerGlobalScope) {
         return globals.has("ServiceWorker");
-    }
-    if ('NodeScope' in self) {
-        return true;
     }
     throw new IdlHarnessError("Unexpected global object");
 }
@@ -1669,7 +1674,122 @@ IdlInterface.prototype.test_self = function()
 
         }.bind(this), this.name + " interface: legacy window alias");
     }
-    // TODO: Test named constructors if I find any interfaces that have them.
+
+    if (this.has_extended_attribute("NamedConstructor")) {
+        var constructors = this.extAttrs
+            .filter(function(attr) { return attr.name == "NamedConstructor"; });
+        if (constructors.length !== 1) {
+            throw new IdlHarnessError("Internal error: missing support for multiple NamedConstructor extended attributes");
+        }
+        var constructor = constructors[0];
+        var min_length = minOverloadLength([constructor]);
+
+        subsetTestByKey(this.name, test, function()
+        {
+            // This function tests WebIDL as of 2019-01-14.
+
+            // "for every [NamedConstructor] extended attribute on an exposed
+            // interface, a corresponding property must exist on the ECMAScript
+            // global object. The name of the property is the
+            // [NamedConstructor]'s identifier, and its value is an object
+            // called a named constructor, ... . The property has the attributes
+            // { [[Writable]]: true, [[Enumerable]]: false,
+            // [[Configurable]]: true }."
+            var name = constructor.rhs.value;
+            assert_own_property(self, name);
+            var desc = Object.getOwnPropertyDescriptor(self, name);
+            assert_equals(desc.value, self[name], "wrong value in " + name + " property descriptor");
+            assert_true(desc.writable, name + " should be writable");
+            assert_false(desc.enumerable, name + " should not be enumerable");
+            assert_true(desc.configurable, name + " should be configurable");
+            assert_false("get" in desc, name + " should not have a getter");
+            assert_false("set" in desc, name + " should not have a setter");
+        }.bind(this), this.name + " interface: named constructor");
+
+        subsetTestByKey(this.name, test, function()
+        {
+            // This function tests WebIDL as of 2019-01-14.
+
+            // "2. Let F be ! CreateBuiltinFunction(realm, steps,
+            //     realm.[[Intrinsics]].[[%FunctionPrototype%]])."
+            var name = constructor.rhs.value;
+            var value = self[name];
+            assert_equals(typeof value, "function", "type of value in " + name + " property descriptor");
+            assert_not_equals(value, this.get_interface_object(), "wrong value in " + name + " property descriptor");
+            assert_equals(Object.getPrototypeOf(value), Function.prototype, "wrong value for " + name + "'s prototype");
+        }.bind(this), this.name + " interface: named constructor object");
+
+        subsetTestByKey(this.name, test, function()
+        {
+            // This function tests WebIDL as of 2019-01-14.
+
+            // "7. Let proto be the interface prototype object of interface I
+            //     in realm.
+            // "8. Perform ! DefinePropertyOrThrow(F, "prototype",
+            //     PropertyDescriptor{
+            //         [[Value]]: proto, [[Writable]]: false,
+            //         [[Enumerable]]: false, [[Configurable]]: false
+            //     })."
+            var name = constructor.rhs.value;
+            var expected = this.get_interface_object().prototype;
+            var desc = Object.getOwnPropertyDescriptor(self[name], "prototype");
+            assert_equals(desc.value, expected, "wrong value for " + name + ".prototype");
+            assert_false(desc.writable, "prototype should not be writable");
+            assert_false(desc.enumerable, "prototype should not be enumerable");
+            assert_false(desc.configurable, "prototype should not be configurable");
+            assert_false("get" in desc, "prototype should not have a getter");
+            assert_false("set" in desc, "prototype should not have a setter");
+        }.bind(this), this.name + " interface: named constructor prototype property");
+
+        subsetTestByKey(this.name, test, function()
+        {
+            // This function tests WebIDL as of 2019-01-14.
+
+            // "3. Perform ! SetFunctionName(F, id)."
+            var name = constructor.rhs.value;
+            var desc = Object.getOwnPropertyDescriptor(self[name], "name");
+            assert_equals(desc.value, name, "wrong value for " + name + ".name");
+            assert_false(desc.writable, "name should not be writable");
+            assert_false(desc.enumerable, "name should not be enumerable");
+            assert_true(desc.configurable, "name should be configurable");
+            assert_false("get" in desc, "name should not have a getter");
+            assert_false("set" in desc, "name should not have a setter");
+        }.bind(this), this.name + " interface: named constructor name");
+
+        subsetTestByKey(this.name, test, function()
+        {
+            // This function tests WebIDL as of 2019-01-14.
+
+            // "4. Initialize S to the effective overload set for constructors
+            //     with identifier id on interface I and with argument count 0.
+            // "5. Let length be the length of the shortest argument list of
+            //     the entries in S.
+            // "6. Perform ! SetFunctionLength(F, length)."
+            var name = constructor.rhs.value;
+            var desc = Object.getOwnPropertyDescriptor(self[name], "length");
+            assert_equals(desc.value, min_length, "wrong value for " + name + ".length");
+            assert_false(desc.writable, "length should not be writable");
+            assert_false(desc.enumerable, "length should not be enumerable");
+            assert_true(desc.configurable, "length should be configurable");
+            assert_false("get" in desc, "length should not have a getter");
+            assert_false("set" in desc, "length should not have a setter");
+        }.bind(this), this.name + " interface: named constructor length");
+
+        subsetTestByKey(this.name, test, function()
+        {
+            // This function tests WebIDL as of 2019-01-14.
+
+            // "1. Let steps be the following steps:
+            // "    1. If NewTarget is undefined, then throw a TypeError."
+            var name = constructor.rhs.value;
+            var args = constructor.arguments.map(function(arg) {
+                return create_suitable_object(arg.idlType);
+            });
+            assert_throws(new TypeError(), function() {
+                self[name](...args);
+            }.bind(this));
+        }.bind(this), this.name + " interface: named constructor without 'new'");
+    }
 
     subsetTestByKey(this.name, test, function()
     {
@@ -2304,22 +2424,7 @@ IdlInterface.prototype.do_member_operation_asserts = function(memberHolderObject
     }
 }
 
-IdlInterface.prototype.add_iterable_members = function(member)
-{
-    this.members.push(new IdlInterfaceMember(
-        { type: "operation", name: "entries", idlType: "iterator", arguments: []}));
-    this.members.push(new IdlInterfaceMember(
-        { type: "operation", name: "keys", idlType: "iterator", arguments: []}));
-    this.members.push(new IdlInterfaceMember(
-        { type: "operation", name: "values", idlType: "iterator", arguments: []}));
-    this.members.push(new IdlInterfaceMember(
-        { type: "operation", name: "forEach", idlType: "void",
-          arguments:
-          [{ name: "callback", idlType: {idlType: "function"}},
-           { name: "thisValue", idlType: {idlType: "any"}, optional: true}]}));
-};
-
-IdlInterface.prototype.test_to_json_operation = function(memberHolderObject, member) {
+IdlInterface.prototype.test_to_json_operation = function(desc, memberHolderObject, member) {
     var instanceName = memberHolderObject && memberHolderObject.constructor.name
         || member.name + " object";
     if (member.has_extended_attribute("Default")) {
@@ -2335,38 +2440,40 @@ IdlInterface.prototype.test_to_json_operation = function(memberHolderObject, mem
                 this.array.assert_type_is(json[k], type);
                 delete json[k];
             }, this);
-        }.bind(this), "Test default toJSON operation of " + instanceName);
+        }.bind(this), this.name + " interface: default toJSON operation on " + desc);
     } else {
         subsetTestByKey(this.name, test, function() {
             assert_true(this.array.is_json_type(member.idlType), JSON.stringify(member.idlType) + " is not an appropriate return value for the toJSON operation of " + instanceName);
             this.array.assert_type_is(memberHolderObject.toJSON(), member.idlType);
-        }.bind(this), "Test toJSON operation of " + instanceName);
+        }.bind(this), this.name + " interface: toJSON operation on " + desc);
     }
 };
 
 IdlInterface.prototype.test_member_iterable = function(member)
 {
-    var isPairIterator = member.idlType.length === 2;
     subsetTestByKey(this.name, test, function()
     {
-        var descriptor = Object.getOwnPropertyDescriptor(this.get_interface_object().prototype, Symbol.iterator);
-        assert_true(descriptor.writable, "property should be writable");
-        assert_true(descriptor.configurable, "property should be configurable");
-        assert_false(descriptor.enumerable, "property should not be enumerable");
-        assert_equals(this.get_interface_object().prototype[Symbol.iterator].name, isPairIterator ? "entries" : "values", "@@iterator function does not have the right name");
-    }.bind(this), "Testing Symbol.iterator property of iterable interface " + this.name);
+        var isPairIterator = member.idlType.length === 2;
+        var proto = this.get_interface_object().prototype;
+        var descriptor = Object.getOwnPropertyDescriptor(proto, Symbol.iterator);
 
-    if (isPairIterator) {
-        subsetTestByKey(this.name, test, function() {
-            assert_equals(this.get_interface_object().prototype[Symbol.iterator], this.get_interface_object().prototype["entries"], "entries method is not the same as @@iterator");
-        }.bind(this), "Testing pair iterable interface " + this.name);
-    } else {
-        subsetTestByKey(this.name, test, function() {
-            ["entries", "keys", "values", "forEach", Symbol.Iterator].forEach(function(property) {
-                assert_equals(this.get_interface_object().prototype[property], Array.prototype[property], property + " function is not the same as Array one");
+        assert_true(descriptor.writable, "@@iterator property should be writable");
+        assert_true(descriptor.configurable, "@@iterator property should be configurable");
+        assert_false(descriptor.enumerable, "@@iterator property should not be enumerable");
+        assert_equals(typeof descriptor.value, "function", "@@iterator property should be a function");
+        assert_equals(descriptor.value.length, 0, "@@iterator function object length should be 0");
+        assert_equals(descriptor.value.name, isPairIterator ? "entries" : "values", "@@iterator function object should have the right name");
+
+        if (isPairIterator) {
+            assert_equals(proto["entries"], proto[Symbol.iterator], "entries method should be the same as @@iterator method");
+        } else {
+            assert_equals(proto[Symbol.iterator], Array.prototype[Symbol.iterator], "@@iterator method should be the same as Array prototype's");
+            ["entries", "keys", "values", "forEach", Symbol.iterator].forEach(function(property) {
+                var propertyName = property === Symbol.iterator ? "@@iterator" : property;
+                assert_equals(proto[property], Array.prototype[property], propertyName + " method should be the same as Array prototype's");
             }.bind(this));
-        }.bind(this), "Testing value iterable interface " + this.name);
-    }
+        }
+    }.bind(this), this.name + " interface: iterable<" + member.idlType.map(function(t) { return t.idlType; }).join(", ") + ">");
 };
 
 IdlInterface.prototype.test_member_stringifier = function(member)
@@ -2432,19 +2539,6 @@ IdlInterface.prototype.test_member_stringifier = function(member)
 
 IdlInterface.prototype.test_members = function()
 {
-    for (var i = 0; i < this.members.length; i++)
-    {
-        var member = this.members[i];
-        switch (member.type) {
-        case "iterable":
-            this.add_iterable_members(member);
-            break;
-        // TODO: add setlike and maplike handling.
-        default:
-            break;
-        }
-    }
-
     for (var i = 0; i < this.members.length; i++)
     {
         var member = this.members[i];
@@ -2743,7 +2837,7 @@ IdlInterface.prototype.test_interface_of = function(desc, obj, exception, expect
         }
 
         if (member.is_to_json_regular_operation()) {
-            this.test_to_json_operation(obj, member);
+            this.test_to_json_operation(desc, obj, member);
         }
     }
 };

--- a/test/fixtures/wpt/resources/sriharness.js
+++ b/test/fixtures/wpt/resources/sriharness.js
@@ -97,3 +97,4 @@ SRIStyleTest.prototype.execute = function() {
     container.appendChild(e);
     this.customCallback(e, container);
 };
+

--- a/test/fixtures/wpt/resources/testdriver-actions.js
+++ b/test/fixtures/wpt/resources/testdriver-actions.js
@@ -7,7 +7,7 @@
   function Actions() {
     this.sourceTypes = new Map([["key", KeySource],
                                 ["pointer", PointerSource],
-                                ["general", GeneralSource]]);
+                                ["none", GeneralSource]]);
     this.sources = new Map();
     this.sourceOrder = [];
     for (let sourceType of this.sourceTypes.keys()) {
@@ -17,11 +17,19 @@
     for (let sourceType of this.sourceTypes.keys()) {
       this.currentSources.set(sourceType, null);
     }
-    this.createSource("general");
+    this.createSource("none");
     this.tickIdx = 0;
   }
 
   Actions.prototype = {
+    ButtonType: {
+      LEFT: 0,
+      MIDDLE: 1,
+      RIGHT: 2,
+      BACK: 3,
+      FORWARD: 4,
+    },
+
     /**
      * Generate the action sequence suitable for passing to
      * test_driver.action_sequence
@@ -62,7 +70,7 @@
      * If no name is passed, a new source with the given type is
      * created.
      *
-     * @param {String} type - Source type ('general', 'key', or 'pointer')
+     * @param {String} type - Source type ('none', 'key', or 'pointer')
      * @param {String?} name - Name of the source
      * @returns {Source} Source object for that source.
      */
@@ -98,7 +106,7 @@
      * @returns {Actions}
      */
     addKeyboard: function(name, set=true) {
-      this.createSource("key", name, true);
+      this.createSource("key", name);
       if (set) {
         this.setKeyboard(name);
       }
@@ -125,7 +133,7 @@
      * @returns {Actions}
      */
     addPointer: function(name, pointerType="mouse", set=true) {
-      this.createSource("pointer", name, true, {pointerType: pointerType});
+      this.createSource("pointer", name, {pointerType: pointerType});
       if (set) {
         this.setPointer(name);
       }
@@ -187,7 +195,7 @@
      * @returns {Actions}
      */
     pause: function(duration) {
-      this.getSource("general").addPause(this, duration);
+      this.getSource("none").addPause(this, duration);
       return this;
     },
 
@@ -225,7 +233,7 @@
      *                               pointer source
      * @returns {Actions}
      */
-    pointerDown: function({button=0, sourceName=null}={}) {
+    pointerDown: function({button=this.ButtonType.LEFT, sourceName=null}={}) {
       let source = this.getSource("pointer", sourceName);
       source.pointerDown(this, button);
       return this;
@@ -239,7 +247,7 @@
      *                               source
      * @returns {Actions}
      */
-    pointerUp: function({button=0, sourceName=null}={}) {
+    pointerUp: function({button=this.ButtonType.LEFT, sourceName=null}={}) {
       let source = this.getSource("pointer", sourceName);
       source.pointerUp(this, button);
       return this;

--- a/test/fixtures/wpt/url/META.yml
+++ b/test/fixtures/wpt/url/META.yml
@@ -2,7 +2,6 @@ spec: https://url.spec.whatwg.org/
 suggested_reviewers:
   - mikewest
   - domenic
-  - Sebmaster
   - annevk
   - GPHemsley
   - TimothyGu

--- a/test/fixtures/wpt/url/historical.any.js
+++ b/test/fixtures/wpt/url/historical.any.js
@@ -1,7 +1,9 @@
-test(function() {
-  assert_false("searchParams" in self.location,
-               "location object should not have a searchParams attribute");
-}, "searchParams on location object");
+if (self.location) {
+  test(function() {
+    assert_false("searchParams" in self.location,
+                "location object should not have a searchParams attribute");
+  }, "searchParams on location object");
+}
 
 if(self.GLOBAL.isWindow()) {
   test(() => {

--- a/test/fixtures/wpt/url/resources/urltestdata.json
+++ b/test/fixtures/wpt/url/resources/urltestdata.json
@@ -4633,6 +4633,22 @@
     "search": "",
     "hash": ""
   },
+  "# unknown scheme with non-URL characters in the path",
+  {
+    "input": "wow:\uFFFF",
+    "base": "about:blank",
+    "href": "wow:%EF%BF%BF",
+    "origin": "null",
+    "protocol": "wow:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "%EF%BF%BF",
+    "search": "",
+    "hash": ""
+  },
   "# Hosts and percent-encoding",
   {
     "input": "ftp://example.com%80/",

--- a/test/fixtures/wpt/url/urlsearchparams-constructor.any.js
+++ b/test/fixtures/wpt/url/urlsearchparams-constructor.any.js
@@ -14,6 +14,11 @@ test(function() {
     assert_equals(params.toString(), "")
 }, "URLSearchParams constructor, no arguments")
 
+test(function () {
+    var params = new URLSearchParams("?a=b")
+    assert_equals(params.toString(), "a=b")
+}, 'URLSearchParams constructor, remove leading "?"')
+
 test(() => {
     var params = new URLSearchParams(DOMException);
     assert_equals(params.toString(), "INDEX_SIZE_ERR=1&DOMSTRING_SIZE_ERR=2&HIERARCHY_REQUEST_ERR=3&WRONG_DOCUMENT_ERR=4&INVALID_CHARACTER_ERR=5&NO_DATA_ALLOWED_ERR=6&NO_MODIFICATION_ALLOWED_ERR=7&NOT_FOUND_ERR=8&NOT_SUPPORTED_ERR=9&INUSE_ATTRIBUTE_ERR=10&INVALID_STATE_ERR=11&SYNTAX_ERR=12&INVALID_MODIFICATION_ERR=13&NAMESPACE_ERR=14&INVALID_ACCESS_ERR=15&VALIDATION_ERR=16&TYPE_MISMATCH_ERR=17&SECURITY_ERR=18&NETWORK_ERR=19&ABORT_ERR=20&URL_MISMATCH_ERR=21&QUOTA_EXCEEDED_ERR=22&TIMEOUT_ERR=23&INVALID_NODE_TYPE_ERR=24&DATA_CLONE_ERR=25")

--- a/test/fixtures/wpt/versions.json
+++ b/test/fixtures/wpt/versions.json
@@ -8,7 +8,7 @@
     "path": "encoding"
   },
   "url": {
-    "commit": "75b0f336c50105c6fea47ad253d57219dfa744d3",
+    "commit": "418f7fabebeeb642e79e05b48ffde1a601c7e058",
     "path": "url"
   },
   "resources": {

--- a/test/fixtures/wpt/versions.json
+++ b/test/fixtures/wpt/versions.json
@@ -12,7 +12,7 @@
     "path": "url"
   },
   "resources": {
-    "commit": "679a364421ce3704289df21e1ff985c14b360981",
+    "commit": "e1fddfbf801e7cce9cac5645e992194e4059ef56",
     "path": "resources"
   },
   "interfaces": {


### PR DESCRIPTION
I have another batch of patches for encoding tests, but would like to update the URL tests first to keep the PR small.

#### test: update wpt/resources to e1fddfbf80

Using `git node wpt resources`

#### test: use ShellTestEnvironment in WPT

So we no longer need to hack the global.location and pretend
that we are in a worker anymore.

#### test: update wpt/url to 418f7fabeb

Using `git node wpt url`


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
