### PR TITLE
test: detect missing postmortem metadata

### DIFF
--- a/test/v8-updates/test-postmortem-metadata.js
+++ b/test/v8-updates/test-postmortem-metadata.js
@@ -41,6 +41,9 @@ const symbols = nm.stdout.toString().split('\n').reduce((filtered, line) => {
 
   return filtered;
 }, []);
+
+assert.notStrictEqual(symbols.length, 0, 'No postmortem metadata detected');
+
 const missing = getExpectedSymbols().filter((symbol) => {
   return !symbols.includes(symbol);
 });


### PR DESCRIPTION
This commit updates test-postmortem-metadata to provide a more useful error message in the scenario where Node is compiled without postmortem support.

Refs: https://github.com/nodejs/node/pull/27375#issuecomment-494869011

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
