### PR TITLE
lib: use console.log for TTY on Windows

### DIFF
--- a/lib/internal/util/print.js
+++ b/lib/internal/util/print.js
@@ -41,7 +41,12 @@ function getColors() {
 function print(fd, obj, ignoreErrors = true) {
   switch (getFdType(fd)) {
     case 'TTY':
-      formatAndWrite(fd, obj, ignoreErrors, getColors());
+      // Fallback to console.log to handle ANSI codes on Windows.
+      if (process.platform === 'win32') {
+        log(obj);
+      } else {
+        formatAndWrite(fd, obj, ignoreErrors, getColors());
+      }
       break;
     case 'FILE':
       formatAndWrite(fd, obj, ignoreErrors);


### PR DESCRIPTION
ANSI sequences are emulated on Windows, so use `console.log()` for
TTY's on Windows instead of directly writing to the filedescriptor.

Fixes: https://github.com/nodejs/node/issues/27819

This is an alternative to https://github.com/nodejs/node/pull/27823,
which is a full revert.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
