### PR TITLE
test: fix flaky test-https-agent-additional-options

### DIFF
--- a/test/parallel/test-https-agent-additional-options.js
+++ b/test/parallel/test-https-agent-additional-options.js
@@ -15,7 +15,7 @@ const options = {
   minVersion: 'TLSv1.1',
 };
 
-const server = https.Server(options, function(req, res) {
+const server = https.Server(options, (req, res) => {
   res.writeHead(200);
   res.end('hello world\n');
 });
@@ -45,9 +45,9 @@ function variations(iter, port, cb) {
     return common.mustCall(cb);
   } else {
     const [key, val] = value;
-    return common.mustCall(function(res) {
+    return common.mustCall((res) => {
       res.resume();
-      https.globalAgent.once('free', common.mustCall(function() {
+      https.globalAgent.once('free', common.mustCall(() => {
         https.get(
           Object.assign({}, getBaseOptions(port), { [key]: val }),
           variations(iter, port, cb)
@@ -57,16 +57,16 @@ function variations(iter, port, cb) {
   }
 }
 
-server.listen(0, common.mustCall(function() {
-  const port = this.address().port;
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
   const globalAgent = https.globalAgent;
   globalAgent.keepAlive = true;
   https.get(getBaseOptions(port), variations(
     updatedValues.entries(),
     port,
-    common.mustCall(function(res) {
+    common.mustCall((res) => {
       res.resume();
-      globalAgent.once('free', common.mustCall(function() {
+      globalAgent.once('free', common.mustCall(() => {
         // Verify that different keep-alived connections are created
         // for the base call and each variation
         const keys = Object.keys(globalAgent.freeSockets);

--- a/test/parallel/test-https-agent-additional-options.js
+++ b/test/parallel/test-https-agent-additional-options.js
@@ -1,4 +1,3 @@
-// Flags: --tls-min-v1.1
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto)
@@ -12,7 +11,8 @@ const fixtures = require('../common/fixtures');
 const options = {
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem'),
-  ca: fixtures.readKey('ca1-cert.pem')
+  ca: fixtures.readKey('ca1-cert.pem'),
+  minVersion: 'TLSv1.1',
 };
 
 const server = https.Server(options, function(req, res) {


### PR DESCRIPTION
    test: fix test-https-agent-additional-options
    
    test-https-agent-additional-options can occasionally fail if a socket
    closes before the checks near the end of the test. Modify the test to
    check the freeSockets pool after each request.
    
    Fixes: https://github.com/nodejs/node/issues/24449

---

    test: refactor test-https-agent-additional-options
    
    Move callback to location where it is less confusing.

---

    test: favor arrow functions for anonymous callbacks
    
    In test-https-agent-additional-options, use arrow functions for
    anonymous callbacks. Replace a use of `this` with the relevant constant.

---

    test: replace flag with option
    
    test-https-agent-additional-options is invoked with a command-line flag.
    However, there is an equivalent option that can be enabled within the
    code. Do that instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
