### PR TITLE
[v10.x] doc,n-api: update matrix for N-API version 4

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -150,7 +150,7 @@ available to the module code.
 | v6.x  |         |          | v6.14.2* |          |
 | v8.x  | v8.0.0* | v8.10.0* | v8.11.2  |          |
 | v9.x  | v9.0.0* | v9.3.0*  | v9.11.0* |          |
-| v10.x |         |          | v10.0.0  |          |
+| v10.x |         |          | v10.0.0  | REPLACEME |
 | v11.x |         |          | v11.0.0  | v11.8.0  |
 
 \* Indicates that the N-API version was released as experimental


### PR DESCRIPTION
The N-API version was bumped to 4 for Node.js 10 in
https://github.com/nodejs/node/pull/25633

Refs: https://github.com/nodejs/node/pull/25633

This should land in the release with the above referenced PR.

cc @nodejs/lts @nodejs/n-api 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
