### PR TITLE
build: expose napi_build_version variable to native addons

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -72,9 +72,6 @@
 
     ##### end V8 defaults #####
 
-    # This variable needs to be updated when N-API version change
-    'napi_build_version': 4,
-
     'conditions': [
       ['target_arch=="arm64"', {
         # Disabled pending https://github.com/nodejs/node/issues/23913.

--- a/common.gypi
+++ b/common.gypi
@@ -72,6 +72,9 @@
 
     ##### end V8 defaults #####
 
+    # This variable needs to be updated when N-API version change
+    'napi_build_version': 4,
+
     'conditions': [
       ['target_arch=="arm64"', {
         # Disabled pending https://github.com/nodejs/node/issues/23913.

--- a/configure.py
+++ b/configure.py
@@ -1099,7 +1099,8 @@ def configure_node(o):
     o['variables']['node_target_type'] = 'executable'
 
 def configure_napi(output):
-  output['variables']['napi_build_version'] = getnapibuildversion.get_napi_version()
+  version = getnapibuildversion.get_napi_version()
+  output['variables']['napi_build_version'] = version
 
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib

--- a/configure.py
+++ b/configure.py
@@ -34,6 +34,7 @@ import nodedownload
 # imports in tools/
 sys.path.insert(0, 'tools')
 import getmoduleversion
+import getnapibuildversion
 from gyp_node import run_gyp
 
 # imports in deps/v8/tools/node
@@ -1097,6 +1098,9 @@ def configure_node(o):
   else:
     o['variables']['node_target_type'] = 'executable'
 
+def configure_napi(output):
+  output['variables']['napi_build_version'] = getnapibuildversion.get_napi_version()
+
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib
   output['variables']['node_' + shared_lib] = b(getattr(options, shared_lib))
@@ -1576,6 +1580,7 @@ if (options.dest_os):
 flavor = GetFlavor(flavor_params)
 
 configure_node(output)
+configure_napi(output)
 configure_library('zlib', output)
 configure_library('http_parser', output)
 configure_library('libuv', output)

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -666,6 +666,7 @@ An example of the possible output looks like:
   variables:
    {
      host_arch: 'x64',
+     napi_build_version: 4,
      node_install_npm: 'true',
      node_prefix: '',
      node_shared_cares: 'false',

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -16,7 +16,7 @@
 // The NAPI_VERSION controls which version will be used by default when
 // compilling a native addon. If the addon developer specifically wants to use
 // functions available in a new version of N-API that is not yet ported in all
-// LTS version, they can set NAPI_VERSION knowing that they have specifically
+// LTS versions, they can set NAPI_VERSION knowing that they have specifically
 // depended on that version.
 #define NAPI_VERSION 4
 #endif

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -12,7 +12,12 @@
 #ifdef NAPI_EXPERIMENTAL
 #define NAPI_VERSION NAPI_VERSION_EXPERIMENTAL
 #else
-// The baseline version for N-API
+// The baseline version for N-API.
+// The NAPI_VERSION controls which version will be used by default when
+// compilling a native addon. If the addon developer specifically wants to use
+// functions available in a new version of N-API that is not yet ported in all
+// LTS version, they can set NAPI_VERSION knowing that they have specifically
+// depended on that version.
 #define NAPI_VERSION 4
 #endif
 #endif

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -91,7 +91,8 @@
  */
 #define NODE_MODULE_VERSION 72
 
-// the NAPI_VERSION provided by this version of the runtime
+// The NAPI_VERSION provided by this version of the runtime. This is the version
+// which the Node binary being built supports.
 #define NAPI_VERSION  4
 
 #endif  // SRC_NODE_VERSION_H_

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -45,3 +45,6 @@ for (let i = 0; i < expected_keys.length; i++) {
   const descriptor = Object.getOwnPropertyDescriptor(process.versions, key);
   assert.strictEqual(descriptor.writable, false);
 }
+
+assert.strictEqual(process.config.variables.napi_build_version,
+  process.versions.napi);

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -47,4 +47,4 @@ for (let i = 0; i < expected_keys.length; i++) {
 }
 
 assert.strictEqual(process.config.variables.napi_build_version,
-  process.versions.napi);
+                   process.versions.napi);

--- a/tools/getnapibuildversion.py
+++ b/tools/getnapibuildversion.py
@@ -8,11 +8,11 @@ def get_napi_version():
     os.path.dirname(__file__),
     '..',
     'src',
-    'js_native_api.h')
+    'node_version.h')
 
   f = open(napi_version_h)
 
-  regex = '^#define NAPI_VERSION [0-9]+'
+  regex = '^#define NAPI_VERSION'
 
   for line in f:
     if re.match(regex, line):

--- a/tools/getnapibuildversion.py
+++ b/tools/getnapibuildversion.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+import os
+import re
+
+
+def get_napi_version():
+  napi_version_h = os.path.join(
+    os.path.dirname(__file__),
+    '..',
+    'src',
+    'js_native_api.h')
+
+  f = open(napi_version_h)
+
+  regex = '^#define NAPI_VERSION [0-9]+'
+
+  for line in f:
+    if re.match(regex, line):
+      napi_version = line.split()[2]
+      return napi_version
+
+  raise Exception('Could not find pattern matching %s' % regex)
+
+
+if __name__ == '__main__':
+  print(get_napi_version())


### PR DESCRIPTION
Expose `napi_build_version` to allow `node-gyp` to make it
available for addons.
Fixes: https://github.com/nodejs/node-gyp/issues/1745
Refs: https://github.com/nodejs/abi-stable-node/issues/371
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
