### PR TITLE
src: move DiagnosticFilename inlines into a -inl.h

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -1,4 +1,3 @@
-#include "env-inl.h"
 #include "node.h"
 #include "node_context_data.h"
 #include "node_errors.h"

--- a/src/api/utils.cc
+++ b/src/api/utils.cc
@@ -1,4 +1,3 @@
-#include "env-inl.h"
 #include "node.h"
 #include "node_internals.h"
 #include "util-inl.h"

--- a/src/diagnosticfilename-inl.h
+++ b/src/diagnosticfilename-inl.h
@@ -1,0 +1,33 @@
+#ifndef SRC_DIAGNOSTICFILENAME_INL_H_
+#define SRC_DIAGNOSTICFILENAME_INL_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include "node_internals.h"
+#include "env-inl.h"
+
+namespace node {
+
+inline DiagnosticFilename::DiagnosticFilename(
+    Environment* env,
+    const char* prefix,
+    const char* ext) :
+  filename_(MakeFilename(env->thread_id(), prefix, ext)) {
+}
+
+inline DiagnosticFilename::DiagnosticFilename(
+    uint64_t thread_id,
+    const char* prefix,
+    const char* ext) :
+  filename_(MakeFilename(thread_id, prefix, ext)) {
+}
+
+inline const char* DiagnosticFilename::operator*() const {
+  return filename_.c_str();
+}
+
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_DIAGNOSTICFILENAME_INL_H_

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -1,3 +1,4 @@
+#include "diagnosticfilename-inl.h"
 #include "env-inl.h"
 #include "memory_tracker-inl.h"
 #include "stream_base-inl.h"

--- a/src/inspector/tracing_agent.cc
+++ b/src/inspector/tracing_agent.cc
@@ -2,9 +2,6 @@
 #include "main_thread_interface.h"
 #include "node_internals.h"
 #include "node_v8_platform-inl.h"
-
-#include "env-inl.h"
-#include "util-inl.h"
 #include "v8.h"
 
 #include <set>

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -4,7 +4,6 @@
 #include "inspector/main_thread_interface.h"
 #include "inspector/node_string.h"
 #include "base_object-inl.h"
-#include "env-inl.h"
 #include "debug_utils.h"
 #include "node.h"
 #include "node_crypto.h"

--- a/src/inspector_profiler.cc
+++ b/src/inspector_profiler.cc
@@ -2,6 +2,7 @@
 #include <sstream>
 #include "base_object-inl.h"
 #include "debug_utils.h"
+#include "diagnosticfilename-inl.h"
 #include "memory_tracker-inl.h"
 #include "node_file.h"
 #include "node_internals.h"

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1,9 +1,9 @@
-#include <node_buffer.h>
 #include "env-inl.h"
 #define NAPI_EXPERIMENTAL
 #include "js_native_api_v8.h"
 #include "node_api.h"
 #include "node_binding.h"
+#include "node_buffer.h"
 #include "node_errors.h"
 #include "node_internals.h"
 #include "threadpoolwork-inl.h"

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -45,7 +45,6 @@
 #if defined(NODE_HAVE_I18N_SUPPORT)
 
 #include "base_object-inl.h"
-#include "env-inl.h"
 #include "node.h"
 #include "node_buffer.h"
 #include "node_errors.h"

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -321,17 +321,15 @@ class DiagnosticFilename {
  public:
   static void LocalTime(TIME_TYPE* tm_struct);
 
-  DiagnosticFilename(Environment* env,
-                     const char* prefix,
-                     const char* ext) :
-      filename_(MakeFilename(env->thread_id(), prefix, ext)) {}
+  inline DiagnosticFilename(Environment* env,
+                            const char* prefix,
+                            const char* ext);
 
-  DiagnosticFilename(uint64_t thread_id,
-                     const char* prefix,
-                     const char* ext) :
-      filename_(MakeFilename(thread_id, prefix, ext)) {}
+  inline DiagnosticFilename(uint64_t thread_id,
+                            const char* prefix,
+                            const char* ext);
 
-  const char* operator*() const { return filename_.c_str(); }
+  inline const char* operator*() const;
 
  private:
   static std::string MakeFilename(

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -1,6 +1,7 @@
 #include "env-inl.h"
 #include "node_report.h"
 #include "debug_utils.h"
+#include "diagnosticfilename-inl.h"
 #include "node_internals.h"
 #include "node_metadata.h"
 #include "util.h"

--- a/src/node_report_utils.cc
+++ b/src/node_report_utils.cc
@@ -1,4 +1,3 @@
-#include "env-inl.h"
 #include "node_internals.h"
 #include "node_report.h"
 #include "util-inl.h"

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -1,5 +1,5 @@
 #include "base_object-inl.h"
-#include "env.h"
+#include "env-inl.h"
 #include "memory_tracker-inl.h"
 #include "node.h"
 #include "node_internals.h"

--- a/tools/snapshot/node_mksnapshot.cc
+++ b/tools/snapshot/node_mksnapshot.cc
@@ -5,7 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "env-inl.h"
 #include "libplatform/libplatform.h"
 #include "node_internals.h"
 #include "snapshot_builder.h"

--- a/tools/snapshot/snapshot_builder.cc
+++ b/tools/snapshot/snapshot_builder.cc
@@ -1,7 +1,6 @@
 #include "snapshot_builder.h"
 #include <iostream>
 #include <sstream>
-#include "env-inl.h"
 #include "node_internals.h"
 #include "node_main_instance.h"
 #include "node_v8_platform-inl.h"


### PR DESCRIPTION
DiagnosticFilename's constructor default values use inlines from
env-inl.h, causing the many users of node_internals.h to include
env-inl.h, even if they never use DiagnosticFilename.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
