### PR TITLE
assert: remove unreachable code

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -391,10 +391,9 @@ class AssertionError extends Error {
           if (operator === 'deepEqual') {
             res = `${knownOperator}\n\n${res}\n\nshould loosely deep-equal\n\n`;
           } else {
-            const newOperator = kReadableOperator[`${operator}Unequal`];
-            if (newOperator) {
-              const eq = operator === 'notDeepEqual' ? 'deep-equal' : 'equal';
-              res = `${newOperator}\n\n${res}\n\nshould not loosely ${eq}\n\n`;
+            const newOp = kReadableOperator[`${operator}Unequal`];
+            if (newOp) {
+              res = `${newOp}\n\n${res}\n\nshould not loosely deep-equal\n\n`;
             } else {
               other = ` ${operator} ${other}`;
             }


### PR DESCRIPTION
There is only one entry in `kReadableOperator` that ends in `Unequal`. So
the value assigned on line 392 can only be truthy if `operator` is
`notDeepEqual`. Therefore, the ternary condition on line 394 is always
true. Remove the ternary. Coverage reports confirm that the removed code
is unused.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
