### PR TITLE
tls: trace errors can show up as SSL errors

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -941,7 +941,8 @@ void TLSWrap::EnableTrace(
   if (wrap->ssl_) {
     wrap->bio_trace_.reset(BIO_new_fp(stderr,  BIO_NOCLOSE | BIO_FP_TEXT));
     SSL_set_msg_callback(wrap->ssl_.get(), [](int write_p, int version, int
-          content_type, const void* buf, size_t len, SSL* ssl, void* arg) void {
+          content_type, const void* buf, size_t len, SSL* ssl, void* arg)
+        -> void {
         // BIO_write(), etc., called by SSL_trace, may error. The error should
         // be ignored, trace is a "best effort", and its usually because stderr
         // is a non-blocking pipe, and its buffer has overflowed. Leaving errors

--- a/test/parallel/test-tls-enable-trace-cli.js
+++ b/test/parallel/test-tls-enable-trace-cli.js
@@ -36,8 +36,8 @@ child.on('close', common.mustCall((code, signal) => {
   assert.strictEqual(signal, null);
   assert.strictEqual(stdout.trim(), '');
   assert(/Warning: Enabling --trace-tls can expose sensitive/.test(stderr));
+  assert(/Sent Record/.test(stderr));
   assert(/Received Record/.test(stderr));
-  assert(/ClientHello/.test(stderr));
 }));
 
 function test() {
@@ -55,12 +55,14 @@ function test() {
       key: keys.agent6.key
     },
   }, common.mustCall((err, pair, cleanup) => {
-    if (err) {
-      console.error(err);
-      console.error(err.opensslErrorStack);
-      console.error(err.reason);
-      assert(err);
+    if (pair.server.err) {
+      console.trace('server', pair.server.err);
     }
+    if (pair.client.err) {
+      console.trace('client', pair.client.err);
+    }
+    assert.ifError(pair.server.err);
+    assert.ifError(pair.client.err);
 
     return cleanup();
   }));


### PR DESCRIPTION
Calls to TLS_trace might leave errors on the SSL error stack, which then
get reported as SSL errors instead of being ignored. Wrap TLS_trace to
keep the error stack unchanged.

Fixes: https://github.com/nodejs/node/issues/27636

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
