### PR TITLE
doc: remove experimental status for JSON documentation

### DIFF
--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -58,7 +58,7 @@ added: v0.6.12
 -->
 
 Every `.html` document has a corresponding `.json` document. This is for IDEs
-and other utilities doing programmatic things with the documentation.
+and other utilities that consume the documentation.
 
 ## Syscalls and man pages
 

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -57,12 +57,8 @@ attaching a listener to the [`'warning'`][] event.
 added: v0.6.12
 -->
 
-> Stability: 1 - Experimental
-
-Every `.html` document has a corresponding `.json` document presenting
-the same information in a structured manner. This feature is
-experimental, and added for the benefit of IDEs and other utilities that
-wish to do programmatic things with the documentation.
+Every `.html` document has a corresponding `.json` document. This is for IDEs
+and other utilities doing programmatic things with the documentation.
 
 ## Syscalls and man pages
 


### PR DESCRIPTION
The JSON documentation is relied upon by some consumers. It has been in
Experimental status for a long time. Promote it to Stable.

Reword the JSON documentation overview for brevity and clarity.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
