### PR TITLE
tty: add color support for mosh

### DIFF
--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -53,7 +53,7 @@ const TERM_ENVS = {
   'konsole': COLORS_16,
   'kterm': COLORS_16,
   'mlterm': COLORS_16,
-  'mosh': COLORS_16,
+  'mosh': COLORS_16m,
   'putty': COLORS_16,
   'st': COLORS_16,
   // https://github.com/da-x/rxvt-unicode/tree/v9.22-with-24bit-color

--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -53,7 +53,7 @@ const TERM_ENVS = {
   'konsole': COLORS_16,
   'kterm': COLORS_16,
   'mlterm': COLORS_16,
-  'mosh' : COLORS_256
+  'mosh' : COLORS_256,
   'putty': COLORS_16,
   'st': COLORS_16,
   // https://github.com/da-x/rxvt-unicode/tree/v9.22-with-24bit-color

--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -53,6 +53,7 @@ const TERM_ENVS = {
   'konsole': COLORS_16,
   'kterm': COLORS_16,
   'mlterm': COLORS_16,
+  'mosh' : COLORS_256
   'putty': COLORS_16,
   'st': COLORS_16,
   // https://github.com/da-x/rxvt-unicode/tree/v9.22-with-24bit-color

--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -53,7 +53,7 @@ const TERM_ENVS = {
   'konsole': COLORS_16,
   'kterm': COLORS_16,
   'mlterm': COLORS_16,
-  'mosh' : COLORS_256,
+  'mosh': COLORS_256,
   'putty': COLORS_16,
   'st': COLORS_16,
   // https://github.com/da-x/rxvt-unicode/tree/v9.22-with-24bit-color

--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -53,7 +53,7 @@ const TERM_ENVS = {
   'konsole': COLORS_16,
   'kterm': COLORS_16,
   'mlterm': COLORS_16,
-  'mosh': COLORS_256,
+  'mosh': COLORS_16,
   'putty': COLORS_16,
   'st': COLORS_16,
   // https://github.com/da-x/rxvt-unicode/tree/v9.22-with-24bit-color


### PR DESCRIPTION
Added mosh to the tty.js file for terminal color support #27609