### PR TITLE
os: assume UTF-8 for hostname

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -49,6 +49,7 @@ using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
+using v8::NewStringType;
 using v8::Null;
 using v8::Number;
 using v8::Object;
@@ -69,7 +70,9 @@ static void GetHostname(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().SetUndefined();
   }
 
-  args.GetReturnValue().Set(OneByteString(env->isolate(), buf));
+  args.GetReturnValue().Set(
+      String::NewFromUtf8(env->isolate(), buf, NewStringType::kNormal)
+          .ToLocalChecked());
 }
 
 
@@ -84,7 +87,9 @@ static void GetOSType(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().SetUndefined();
   }
 
-  args.GetReturnValue().Set(OneByteString(env->isolate(), info.sysname));
+  args.GetReturnValue().Set(
+      String::NewFromUtf8(env->isolate(), info.sysname, NewStringType::kNormal)
+          .ToLocalChecked());
 }
 
 
@@ -99,7 +104,9 @@ static void GetOSRelease(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().SetUndefined();
   }
 
-  args.GetReturnValue().Set(OneByteString(env->isolate(), info.release));
+  args.GetReturnValue().Set(
+      String::NewFromUtf8(env->isolate(), info.release, NewStringType::kNormal)
+          .ToLocalChecked());
 }
 
 


### PR DESCRIPTION
os: assume UTF-8 for hostname

Do not assume Latin-1, but rather UTF-8 for the result of getting the
OS hostname.

While in 99 % of cases these strings are stored in ASCII, the OS does
not enforce an encoding on its own, and apparently the hostname is
sometimes set to non-ASCII data (despite at least some versions of
hostname(1) rejecting such input, making it even harder to write a
test for this which would already require root privileges).

In any case, these are short strings, so assuming UTF-8 comes
with no significant overhead.

Fixes: https://github.com/nodejs/node/issues/27848


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
