### PR TITLE
inspector: more conservative minimum stack size

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -25,6 +25,7 @@
 #include <climits>  // PTHREAD_STACK_MIN
 #endif  // __POSIX__
 
+#include <algorithm>
 #include <cstring>
 #include <sstream>
 #include <unordered_map>
@@ -111,12 +112,17 @@ static int StartDebugSignalHandler() {
   CHECK_EQ(0, uv_sem_init(&start_io_thread_semaphore, 0));
   pthread_attr_t attr;
   CHECK_EQ(0, pthread_attr_init(&attr));
-  // Don't shrink the thread's stack on FreeBSD.  Said platform decided to
-  // follow the pthreads specification to the letter rather than in spirit:
-  // https://lists.freebsd.org/pipermail/freebsd-current/2014-March/048885.html
 #ifndef __FreeBSD__
-  CHECK_EQ(0, pthread_attr_setstacksize(&attr, PTHREAD_STACK_MIN));
-#endif  // __FreeBSD__
+  // PTHREAD_STACK_MIN is 2 KB with musl libc, which is too small to safely
+  // receive signals. PTHREAD_STACK_MIN + MINSIGSTKSZ is 8 KB on arm64, which
+  // is the musl architecture with the biggest MINSIGSTKSZ so let's use that
+  // as a lower bound and let's quadruple it just in case. The goal is to avoid
+  // creating a big 2 or 4 MB address space gap (problematic on 32 bits
+  // because of fragmentation), not squeeze out every last byte.
+  const size_t stack_size = std::max(static_cast<size_t>(4 * 8192),
+                                     static_cast<size_t>(PTHREAD_STACK_MIN));
+  CHECK_EQ(0, pthread_attr_setstacksize(&attr, stack_size));
+#endif  // !__FreeBSD__
   CHECK_EQ(0, pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED));
   sigset_t sigmask;
   // Mask all signals.


### PR DESCRIPTION
PTHREAD_STACK_MIN is 2 KB with musl, which is too small to safely
receive signals. PTHREAD_STACK_MIN + MINSIGSTKSZ is 8 KB on arm64,
which is the musl architecture with the biggest MINSIGSTKSZ so let's
use that as a lower bound and let's quadruple it just in case.

This coincidentally also lets us remove a FreeBSD-specific workaround.