### PR TITLE
test: update WPT encoding tests and run WPT in subdirectories

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -94,7 +94,7 @@ class StatusRule {
    * @returns {RegExp}
    */
   transformPattern(pattern) {
-    const result = pattern.replace(/[-/\\^$+?.()|[\]{}]/g, '\\$&');
+    const result = path.normalize(pattern).replace(/[-/\\^$+?.()|[\]{}]/g, '\\$&');
     return new RegExp(result.replace('*', '.*'));
   }
 }

--- a/test/fixtures/wpt/README.md
+++ b/test/fixtures/wpt/README.md
@@ -11,7 +11,7 @@ See [test/wpt](../../wpt/README.md) for information on how these tests are run.
 Last update:
 
 - console: https://github.com/web-platform-tests/wpt/tree/9786a4b131/console
-- encoding: https://github.com/web-platform-tests/wpt/tree/a093a659ed/encoding
+- encoding: https://github.com/web-platform-tests/wpt/tree/7287608f90/encoding
 - url: https://github.com/web-platform-tests/wpt/tree/418f7fabeb/url
 - resources: https://github.com/web-platform-tests/wpt/tree/e1fddfbf80/resources
 - interfaces: https://github.com/web-platform-tests/wpt/tree/712c9f275e/interfaces

--- a/test/fixtures/wpt/encoding/encodeInto.any.js
+++ b/test/fixtures/wpt/encoding/encodeInto.any.js
@@ -1,0 +1,149 @@
+[
+  {
+    "input": "Hi",
+    "read": 0,
+    "destinationLength": 0,
+    "written": []
+  },
+  {
+    "input": "A",
+    "read": 1,
+    "destinationLength": 10,
+    "written": [0x41]
+  },
+  {
+    "input": "\u{1D306}", // "\uD834\uDF06"
+    "read": 2,
+    "destinationLength": 4,
+    "written": [0xF0, 0x9D, 0x8C, 0x86]
+  },
+  {
+    "input": "\u{1D306}A",
+    "read": 0,
+    "destinationLength": 3,
+    "written": []
+  },
+  {
+    "input": "\uD834A\uDF06A¥Hi",
+    "read": 5,
+    "destinationLength": 10,
+    "written": [0xEF, 0xBF, 0xBD, 0x41, 0xEF, 0xBF, 0xBD, 0x41, 0xC2, 0xA5]
+  },
+  {
+    "input": "A\uDF06",
+    "read": 2,
+    "destinationLength": 4,
+    "written": [0x41, 0xEF, 0xBF, 0xBD]
+  },
+  {
+    "input": "¥¥",
+    "read": 2,
+    "destinationLength": 4,
+    "written": [0xC2, 0xA5, 0xC2, 0xA5]
+  }
+].forEach(testData => {
+  [
+    {
+      "bufferIncrease": 0,
+      "destinationOffset": 0,
+      "filler": 0
+    },
+    {
+      "bufferIncrease": 10,
+      "destinationOffset": 4,
+      "filler": 0
+    },
+    {
+      "bufferIncrease": 0,
+      "destinationOffset": 0,
+      "filler": 0x80
+    },
+    {
+      "bufferIncrease": 10,
+      "destinationOffset": 4,
+      "filler": 0x80
+    },
+    {
+      "bufferIncrease": 0,
+      "destinationOffset": 0,
+      "filler": "random"
+    },
+    {
+      "bufferIncrease": 10,
+      "destinationOffset": 4,
+      "filler": "random"
+    }
+  ].forEach(destinationData => {
+    test(() => {
+      // Setup
+      const bufferLength = testData.destinationLength + destinationData.bufferIncrease,
+            destinationOffset = destinationData.destinationOffset,
+            destinationLength = testData.destinationLength,
+            destinationFiller = destinationData.filler,
+            encoder = new TextEncoder(),
+            buffer = new ArrayBuffer(bufferLength),
+            view = new Uint8Array(buffer, destinationOffset, destinationLength),
+            fullView = new Uint8Array(buffer),
+            control = new Array(bufferLength);
+      let byte = destinationFiller;
+      for (let i = 0; i < bufferLength; i++) {
+        if (destinationFiller === "random") {
+          byte = Math.floor(Math.random() * 256);
+        }
+        control[i] = byte;
+        fullView[i] = byte;
+      }
+
+      // It's happening
+      const result = encoder.encodeInto(testData.input, view);
+
+      // Basics
+      assert_equals(view.byteLength, destinationLength);
+      assert_equals(view.length, destinationLength);
+
+      // Remainder
+      assert_equals(result.read, testData.read);
+      assert_equals(result.written, testData.written.length);
+      for (let i = 0; i < bufferLength; i++) {
+        if (i < destinationOffset || i >= (destinationOffset + testData.written.length)) {
+          assert_equals(fullView[i], control[i]);
+        } else {
+          assert_equals(fullView[i], testData.written[i - destinationOffset]);
+        }
+      }
+    }, "encodeInto() with " + testData.input + " and destination length " + testData.destinationLength + ", offset " + destinationData.destinationOffset + ", filler " + destinationData.filler);
+  });
+});
+
+[DataView,
+ Int8Array,
+ Int16Array,
+ Int32Array,
+ Uint16Array,
+ Uint32Array,
+ Uint8ClampedArray,
+ Float32Array,
+ Float64Array].forEach(view => {
+  test(() => {
+    assert_throws(new TypeError(), () => new TextEncoder().encodeInto("", new view(new ArrayBuffer(0))));
+  }, "Invalid encodeInto() destination: " + view);
+ });
+
+test(() => {
+  assert_throws(new TypeError(), () => new TextEncoder().encodeInto("", new ArrayBuffer(10)));
+}, "Invalid encodeInto() destination: ArrayBuffer");
+
+test(() => {
+  const buffer = new ArrayBuffer(10),
+        view = new Uint8Array(buffer);
+  let { read, written } = new TextEncoder().encodeInto("", view);
+  assert_equals(read, 0);
+  assert_equals(written, 0);
+  new MessageChannel().port1.postMessage(buffer, [buffer]);
+  ({ read, written } = new TextEncoder().encodeInto("", view));
+  assert_equals(read, 0);
+  assert_equals(written, 0);
+  ({ read, written } = new TextEncoder().encodeInto("test", view));
+  assert_equals(read, 0);
+  assert_equals(written, 0);
+}, "encodeInto() and a detached output buffer");

--- a/test/fixtures/wpt/encoding/streams/decode-bad-chunks.any.js
+++ b/test/fixtures/wpt/encoding/streams/decode-bad-chunks.any.js
@@ -24,26 +24,6 @@ const badChunks = [
     value: [65]
   },
   {
-    name: 'detached ArrayBufferView',
-    value: (() => {
-      const u8 = new Uint8Array([65]);
-      const ab = u8.buffer;
-      const mc = new MessageChannel();
-      mc.port1.postMessage(ab, [ab]);
-      return u8;
-    })()
-  },
-  {
-    name: 'detached ArrayBuffer',
-    value: (() => {
-      const u8 = new Uint8Array([65]);
-      const ab = u8.buffer;
-      const mc = new MessageChannel();
-      mc.port1.postMessage(ab, [ab]);
-      return ab;
-    })()
-  },
-  {
     name: 'SharedArrayBuffer',
     // Use a getter to postpone construction so that all tests don't fail where
     // SharedArrayBuffer is not yet implemented.

--- a/test/fixtures/wpt/encoding/streams/decode-utf8.any.js
+++ b/test/fixtures/wpt/encoding/streams/decode-utf8.any.js
@@ -39,3 +39,23 @@ promise_test(async () => {
   assert_array_equals(array, [expectedOutputString],
                       'the output should be in one chunk');
 }, 'a trailing empty chunk should be ignored');
+
+promise_test(async () => {
+  const buffer = new ArrayBuffer(3);
+  const view = new Uint8Array(buffer, 1, 1);
+  view[0] = 65;
+  new MessageChannel().port1.postMessage(buffer, [buffer]);
+  const input = readableStreamFromArray([view]);
+  const output = input.pipeThrough(new TextDecoderStream());
+  const array = await readableStreamToArray(output);
+  assert_array_equals(array, [], 'no chunks should be output');
+}, 'decoding a transferred Uint8Array chunk should give no output');
+
+promise_test(async () => {
+  const buffer = new ArrayBuffer(1);
+  new MessageChannel().port1.postMessage(buffer, [buffer]);
+  const input = readableStreamFromArray([buffer]);
+  const output = input.pipeThrough(new TextDecoderStream());
+  const array = await readableStreamToArray(output);
+  assert_array_equals(array, [], 'no chunks should be output');
+}, 'decoding a transferred ArrayBuffer chunk should give no output');

--- a/test/fixtures/wpt/encoding/textdecoder-fatal-single-byte.any.js
+++ b/test/fixtures/wpt/encoding/textdecoder-fatal-single-byte.any.js
@@ -1,4 +1,6 @@
+// META: timeout=long
 // META: title=Encoding API: Fatal flag for single byte encodings
+// META: timeout=long
 
 var singleByteEncodings = [
      {encoding: 'IBM866', bad: []},

--- a/test/fixtures/wpt/versions.json
+++ b/test/fixtures/wpt/versions.json
@@ -4,7 +4,7 @@
     "path": "console"
   },
   "encoding": {
-    "commit": "a093a659ed118112138f8a1ffba97a66c1ea8235",
+    "commit": "7287608f90f6b9530635d10086fd2ab386faab38",
     "path": "encoding"
   },
   "url": {

--- a/test/wpt/status/encoding.json
+++ b/test/wpt/status/encoding.json
@@ -47,5 +47,8 @@
   },
   "unsupported-encodings.any.js": {
     "skip": "decoding-helpers.js needs XMLHttpRequest"
+  },
+  "streams/*.js": {
+    "fail": "No implementation of TextDecoderStream and TextEncoderStream"
   }
 }

--- a/test/wpt/status/encoding.json
+++ b/test/wpt/status/encoding.json
@@ -50,5 +50,8 @@
   },
   "streams/*.js": {
     "fail": "No implementation of TextDecoderStream and TextEncoderStream"
+  },
+  "encodeInto.any.js": {
+    "fail": "TextEncoder.prototype.encodeInto not implemented"
   }
 }


### PR DESCRIPTION
#### test: expect wpt/encoding/streams to fail

Since we do not implement TextDecoderStream or TextEncoderStream.

#### test: run WPT in subdirectories

For a directory like this:

- wpt
  - encoding
    - streams
      - backpressure.any.js
    - api-basics.any.js

Previously we only run `api-basics.any.js`, now we also run
`backpressure.any.js` (and any tests in more deeply nested
directories). This enables us to run more of WPT since not
every module put their tests at the top level directory.

#### test: update wpt/encoding to 7287608f90

Using `git node wpt encoding`

#### test: expect wpt/encoding/encodeInto.any.js to fail

Since we do not implement TextEncoder.prototype.encodeInto

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
