### PR TITLE
dgram: append actual errors to ERR_SOCKET_CANNOT_SEND

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -504,7 +504,7 @@ function onListenSuccess() {
 function onListenError(err) {
   this.removeListener('listening', onListenSuccess);
   this[kStateSymbol].queue = undefined;
-  this.emit('error', new ERR_SOCKET_CANNOT_SEND());
+  this.emit('error', new ERR_SOCKET_CANNOT_SEND(err));
 }
 
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -610,6 +610,17 @@ function addNumericalSeparator(val) {
   return `${val.slice(0, i)}${res}`;
 }
 
+// Append `causedByError` to the `error`.
+function addCausedByError(error, message, causedByError) {
+  let msg = message;
+  if (causedByError) {
+    error.cause = causedByError;
+    if (typeof causedByError.message === 'string')
+      msg += ` (caused by: ${causedByError.message})`;
+  }
+  return msg;
+}
+
 module.exports = {
   addCodeToName, // Exported for NghttpError
   codes,
@@ -802,13 +813,7 @@ E('ERR_HTTP2_STATUS_101',
   'HTTP status code 101 (Switching Protocols) is forbidden in HTTP/2', Error);
 E('ERR_HTTP2_STATUS_INVALID', 'Invalid status code: %s', RangeError);
 E('ERR_HTTP2_STREAM_CANCEL', function(error) {
-  let msg = 'The pending stream has been canceled';
-  if (error) {
-    this.cause = error;
-    if (typeof error.message === 'string')
-      msg += ` (caused by: ${error.message})`;
-  }
-  return msg;
+  return addCausedByError(this, 'The pending stream has been canceled', error);
 }, Error);
 E('ERR_HTTP2_STREAM_ERROR', 'Stream closed with error code %s', Error);
 E('ERR_HTTP2_STREAM_SELF_DEPENDENCY',
@@ -1060,7 +1065,9 @@ E('ERR_SOCKET_BAD_TYPE',
 E('ERR_SOCKET_BUFFER_SIZE',
   'Could not get or set buffer size',
   SystemError);
-E('ERR_SOCKET_CANNOT_SEND', 'Unable to send data', Error);
+E('ERR_SOCKET_CANNOT_SEND', function(error) {
+  return addCausedByError(this, 'Unable to send data', error);
+}, Error);
 E('ERR_SOCKET_CLOSED', 'Socket is closed', Error);
 E('ERR_SOCKET_DGRAM_IS_CONNECTED', 'Already connected', Error);
 E('ERR_SOCKET_DGRAM_NOT_CONNECTED', 'Not connected', Error);

--- a/test/sequential/test-dgram-implicit-bind-failure.js
+++ b/test/sequential/test-dgram-implicit-bind-failure.js
@@ -21,7 +21,8 @@ process.on('exit', () => {
 });
 
 socket.on('error', (err) => {
-  if (/^Error: fake DNS$/.test(err)) {
+  const fakeDNSReg = /^Error: fake DNS$/;
+  if (fakeDNSReg.test(err)) {
     // The DNS lookup should fail since it is monkey patched. At that point in
     // time, the send queue should be populated with the send() operation. There
     // should also be two listeners - this function and the dgram internal one
@@ -39,6 +40,8 @@ socket.on('error', (err) => {
     sendFailures++;
     assert.strictEqual(socket[kStateSymbol].queue, undefined);
     assert.strictEqual(socket.listenerCount('error'), 1);
+    assert(err.cause instanceof Error);
+    assert(fakeDNSReg.test(err.cause));
     return;
   }
 


### PR DESCRIPTION
One of our apps has used up all available ports because of misuse and we have noticed some `ERR_SOCKET_CANNOT_SEND` errors in our logs indicating this. I think appending the actual errors to the `ERR_SOCKET_CANNOT_SEND` error would help with diagnosing.

This commit appends the actual error to the emitted `ERR_SOCKET_CANNOT_SEND`
error so that we could know the detailed reason why the `send()` operation
failed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
