### PR TITLE
src: make UNREACHABLE variadic

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -181,8 +181,8 @@ void DumpBacktrace(FILE* fp);
 #endif
 
 
-#define UNREACHABLE(expr)                                                     \
-  ERROR_AND_ABORT("Unreachable code reached: " expr)
+#define UNREACHABLE(...)                                                      \
+  ERROR_AND_ABORT("Unreachable code reached" __VA_OPT__(": ") __VA_ARGS__)
 
 // TAILQ-style intrusive list node.
 template <typename T>


### PR DESCRIPTION
Eliminate warning C4003 (not enough arguments for function-like macro invocation 'UNREACHABLE') which is raised 101 times per build by MSVC.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
