### PR TITLE
test: switch actual value argument and expected in deepStrictEqual call

### DIFF
--- a/test/parallel/test-http-upgrade-client.js
+++ b/test/parallel/test-http-upgrade-client.js
@@ -31,6 +31,8 @@ const http = require('http');
 const net = require('net');
 const Countdown = require('../common/countdown');
 
+const expectedRecvData = 'nurtzo';
+
 // Create a TCP server
 const srv = net.createServer(function(c) {
   c.on('data', function(d) {
@@ -39,7 +41,7 @@ const srv = net.createServer(function(c) {
     c.write('connection: upgrade\r\n');
     c.write('upgrade: websocket\r\n');
     c.write('\r\n');
-    c.write('nurtzo');
+    c.write(expectedRecvData);
   });
 
   c.on('end', function() {
@@ -77,7 +79,7 @@ srv.listen(0, '127.0.0.1', common.mustCall(function() {
       });
 
       socket.on('close', common.mustCall(function() {
-        assert.strictEqual(recvData.toString(), 'nurtzo');
+        assert.strictEqual(recvData.toString(), expectedRecvData);
       }));
 
       console.log(res.headers);
@@ -86,8 +88,7 @@ srv.listen(0, '127.0.0.1', common.mustCall(function() {
         connection: 'upgrade',
         upgrade: 'websocket'
       };
-      assert.deepStrictEqual(expectedHeaders, res.headers);
-
+      assert.deepStrictEqual(res.headers, expectedHeaders);
       socket.end();
       countdown.dec();
     }));


### PR DESCRIPTION
Replace deepStrictEqual call to have actual value as the first argument
and the expected value as the second.

Change expectedRecvData definition in single place.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
