### PR TITLE
doc,test: clarify that Http2Stream is destroyed after data is read

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -907,8 +907,9 @@ the value is `undefined`, the stream is not yet ready for use.
 
 All [`Http2Stream`][] instances are destroyed either when:
 
-* An `RST_STREAM` frame for the stream is received by the connected peer.
-* The `http2stream.close()` method is called.
+* An `RST_STREAM` frame for the stream is received by the connected peer,
+  and pending data has been read.
+* The `http2stream.close()` method is called, and pending data has been read.
 * The `http2stream.destroy()` or `http2session.destroy()` methods are called.
 
 When an `Http2Stream` instance is destroyed, an attempt will be made to send an

--- a/test/parallel/test-http2-large-write-destroy.js
+++ b/test/parallel/test-http2-large-write-destroy.js
@@ -32,6 +32,7 @@ server.listen(0, common.mustCall(() => {
 
   const req = client.request({ ':path': '/' });
   req.end();
+  req.resume(); // Otherwise close won't be emitted if there's pending data
 
   req.on('close', common.mustCall(() => {
     client.close();

--- a/test/parallel/test-http2-large-write-destroy.js
+++ b/test/parallel/test-http2-large-write-destroy.js
@@ -32,7 +32,7 @@ server.listen(0, common.mustCall(() => {
 
   const req = client.request({ ':path': '/' });
   req.end();
-  req.resume(); // Otherwise close won't be emitted if there's pending data
+  req.resume(); // Otherwise close won't be emitted if there's pending data.
 
   req.on('close', common.mustCall(() => {
     client.close();


### PR DESCRIPTION
Correct docs to clarify that behaviour,
and fix a race condition in `test-http2-large-write-destroy.js`.

Fixes: https://github.com/nodejs/node/issues/27863

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
