### PR TITLE
test: add test case for checking typeof mgf1Hash

### DIFF
--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -987,3 +987,39 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     });
   }
 }
+{
+  // Test RSA-PSS.
+  common.expectsError(
+    () => {
+      generateKeyPair('rsa-pss', {
+        modulusLength: 512,
+        saltLength: 16,
+        hash: 'sha256',
+        mgf1Hash: undefined
+      });
+    },
+    {
+      type: TypeError,
+      code: 'ERR_INVALID_CALLBACK',
+      message: 'Callback must be a function. Received undefined'
+    }
+  );
+
+  for (const mgf1Hash of [null, 0, false, {}, []]) {
+    common.expectsError(
+      () => {
+        generateKeyPair('rsa-pss', {
+          modulusLength: 512,
+          saltLength: 16,
+          hash: 'sha256',
+          mgf1Hash
+        });
+      },
+      {
+        type: TypeError,
+        code: 'ERR_INVALID_OPT_VALUE',
+        message: `The value "${mgf1Hash}" is invalid for option "mgf1Hash"`
+      }
+    );
+  }
+}


### PR DESCRIPTION
add test case to cover uncovered test mgf1Hash param of generateKeyPair,
check typeof

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ x ] tests and/or benchmarks are included
