### PR TITLE
inspector: remove remainingCallbacks because code is synchronous

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -4,7 +4,6 @@ const { JSON } = primordials;
 
 const {
   ERR_INSPECTOR_ALREADY_CONNECTED,
-  ERR_INSPECTOR_CLOSED,
   ERR_INSPECTOR_COMMAND,
   ERR_INSPECTOR_NOT_AVAILABLE,
   ERR_INSPECTOR_NOT_CONNECTED,
@@ -100,11 +99,6 @@ class Session extends EventEmitter {
       return;
     this[connectionSymbol].disconnect();
     this[connectionSymbol] = null;
-    const remainingCallbacks = this[messageCallbacksSymbol].values();
-    for (const callback of remainingCallbacks) {
-      process.nextTick(callback, new ERR_INSPECTOR_CLOSED());
-    }
-    this[messageCallbacksSymbol].clear();
     this[nextIdSymbol] = 1;
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

I've tried to implement test coverage for this line [inspector.js L105](https://coverage.nodejs.org/coverage-7d5cf572f30d05b0/lib/inspector.js.html#L105)
But all callbacks passed to the `Session::post` are executed synchronously. The callback is added to `Map` and immediately gets removed from it because `onMessageSymbol` method is executed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
