### PR TITLE
test: add test cases for cluster profiling

### DIFF
--- a/test/parallel/test-cluster-prof-and-logfile.js
+++ b/test/parallel/test-cluster-prof-and-logfile.js
@@ -6,9 +6,6 @@ const fs = require('fs');
 const assert = require('assert');
 const cluster = require('cluster');
 
-const TEST_TIMEOUT = 1000;
-
-const timeout = ms => new Promise(resolve => setTimeout(resolve, ms));
 const waitForEvent = (eventEmiter, event) => new Promise(resolve => eventEmiter.on(event, resolve));
 
 function findLogFileWithName(name, dir) {
@@ -36,10 +33,7 @@ async function shouldFillLogfileArg() {
   cluster.on('exit', handler);
 
   try {
-    await Promise.race([
-      timeout(TEST_TIMEOUT),
-      waitForEvent(cluster, 'exit')
-    ]);
+    await waitForEvent(cluster, 'exit');
   } finally {
     cluster.removeListener('exit', handler);
     tmpdir.refresh();
@@ -67,10 +61,7 @@ async function shouldCreateLogWithArgName() {
   cluster.on('exit', handler);
 
   try {
-    await Promise.race([
-      timeout(TEST_TIMEOUT),
-      waitForEvent(cluster, 'exit')
-    ]);
+    await waitForEvent(cluster, 'exit');
   } finally {
     cluster.removeListener('exit', handler);
     tmpdir.refresh();

--- a/test/parallel/test-cluster-prof-and-logfile.js
+++ b/test/parallel/test-cluster-prof-and-logfile.js
@@ -1,0 +1,85 @@
+'use strict';
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+
+const fs = require('fs');
+const assert = require('assert');
+const cluster = require('cluster');
+
+const TEST_TIMEOUT = 1000;
+
+const timeout = ms => new Promise(resolve => setTimeout(resolve, ms));
+const waitForEvent = (eventEmiter, event) => new Promise(resolve => eventEmiter.on(event, resolve));
+
+function findLogFileWithName(name, dir) {
+  const data = fs.readdirSync(dir, 'utf8');
+  return data.filter(file => file.includes(name));
+}
+
+async function shouldFillLogfileArg() {
+  tmpdir.refresh();
+
+  cluster.setupMaster({
+    exec: __dirname,
+    execArgv: ['--prof', '--logfile'],
+    cwd: tmpdir.path
+  });
+
+  cluster.fork();
+  
+  const handler = common.mustCall(worker => {
+    const EXPECTED_FILENAME = 'v8-' + worker.process.pid;
+    const reports = findLogFileWithName(EXPECTED_FILENAME, tmpdir.path);
+    assert.strictEqual(reports.length, 1);
+  });
+
+  cluster.on('exit', handler);
+
+  try {
+    await Promise.race([
+      timeout(TEST_TIMEOUT),
+      waitForEvent(cluster, 'exit')
+    ]);
+  } finally {
+    cluster.removeListener('exit', handler);
+    tmpdir.refresh();
+  }
+}
+
+async function shouldCreateLogWithArgName() {
+  tmpdir.refresh();
+
+  const EXPECTED_FILENAME = 'test';
+
+  cluster.setupMaster({
+    exec: __dirname,
+    execArgv: ['--prof', '--logfile=' + EXPECTED_FILENAME],
+    cwd: tmpdir.path
+  });
+
+  cluster.fork();
+
+  const handler = common.mustCall(worker => {
+    const reports = findLogFileWithName(EXPECTED_FILENAME, tmpdir.path);
+    assert.strictEqual(reports.length, 1);
+  });
+
+  cluster.on('exit', handler);
+
+  try {
+    await Promise.race([
+      timeout(TEST_TIMEOUT),
+      waitForEvent(cluster, 'exit')
+    ]);
+  } finally {
+    cluster.removeListener('exit', handler);
+    tmpdir.refresh();
+  }
+}
+
+if (cluster.isMaster) {
+  (async () => {
+    await shouldFillLogfileArg();
+    await shouldCreateLogWithArgName();
+  })()
+}

--- a/test/parallel/test-cluster-prof-and-logfile.js
+++ b/test/parallel/test-cluster-prof-and-logfile.js
@@ -6,11 +6,12 @@ const fs = require('fs');
 const assert = require('assert');
 const cluster = require('cluster');
 
-const waitForEvent = (eventEmiter, event) => new Promise(resolve => eventEmiter.on(event, resolve));
+const waitForEvent = (eventEmiter, event) =>
+  new Promise((resolve) => eventEmiter.on(event, resolve));
 
 function findLogFileWithName(name, dir) {
   const data = fs.readdirSync(dir, 'utf8');
-  return data.filter(file => file.includes(name));
+  return data.filter((file) => file.includes(name));
 }
 
 async function shouldFillLogfileArg() {
@@ -23,8 +24,8 @@ async function shouldFillLogfileArg() {
   });
 
   cluster.fork();
-  
-  const handler = common.mustCall(worker => {
+
+  const handler = common.mustCall((worker) => {
     const EXPECTED_FILENAME = 'v8-' + worker.process.pid;
     const reports = findLogFileWithName(EXPECTED_FILENAME, tmpdir.path);
     assert.strictEqual(reports.length, 1);
@@ -53,7 +54,7 @@ async function shouldCreateLogWithArgName() {
 
   cluster.fork();
 
-  const handler = common.mustCall(worker => {
+  const handler = common.mustCall((worker) => {
     const reports = findLogFileWithName(EXPECTED_FILENAME, tmpdir.path);
     assert.strictEqual(reports.length, 1);
   });
@@ -72,5 +73,5 @@ if (cluster.isMaster) {
   (async () => {
     await shouldFillLogfileArg();
     await shouldCreateLogWithArgName();
-  })()
+  })();
 }


### PR DESCRIPTION
Add test cases for `cluster` fork method with `--prof` and `--logfile`
arguments.

Refs: https://coverage.nodejs.org/coverage-a388f4d13aa29ddb/lib/internal/cluster/master.js.html#L64

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
