### PR TITLE
test: Covering destroying when worker already disconnected

### DIFF
--- a/test/parallel/test-cluster-call-and-destroy.js
+++ b/test/parallel/test-cluster-call-and-destroy.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+const cluster = require('cluster');
+const assert = require('assert');
+
+if (cluster.isMaster) {
+  const worker = cluster.fork();
+  worker.on('disconnect', common.mustCall(() => {
+    assert.strictEqual(worker.isConnected(), false);
+    worker.destroy();
+  }));
+} else {
+  assert.strictEqual(cluster.worker.isConnected(), true);
+  cluster.worker.disconnect();
+}


### PR DESCRIPTION
 
This test covers 374 line in lib/internal/cluster/master that was uncovered by previous tests

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
