### PR TITLE
test: cover util.inspect on boxed primitive with colors

### DIFF
--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -896,6 +896,10 @@ assert.strictEqual(
 // Test boxed primitives output the correct values.
 assert.strictEqual(util.inspect(new String('test')), "[String: 'test']");
 assert.strictEqual(
+  util.inspect(new String('test'), { colors: true }),
+  "\u001b[32m[String: 'test']\u001b[39m"
+);
+assert.strictEqual(
   util.inspect(Object(Symbol('test'))),
   '[Symbol: Symbol(test)]'
 );


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
This PR adds a coverage for `util.inspect`'s colored boxed primitive [test-util-inspect.js L868](https://coverage.nodejs.org/coverage-99268b1e996d13a0/lib/internal/util/inspect.js.html#L868)
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
