### PR TITLE
module: increase code coverage of cjs loader

### DIFF
--- a/test/fixtures/cjs-module-wrap.js
+++ b/test/fixtures/cjs-module-wrap.js
@@ -1,3 +1,4 @@
+'use strict';
 const assert = require('assert');
 const m = require('module');
 

--- a/test/fixtures/cjs-module-wrapper.js
+++ b/test/fixtures/cjs-module-wrapper.js
@@ -1,0 +1,23 @@
+'use strict';
+const assert = require('assert');
+const m = require('module');
+
+global.mwc = 0;
+
+const originalWrapper = m.wrapper;
+const patchedWrapper = {...m.wrapper};
+
+patchedWrapper[0] += 'global.mwc = (global.mwc || 0 ) + 1';
+
+// Storing original version of wrapper function
+m.wrapper = patchedWrapper;
+
+require('./not-main-module.js');
+
+assert.strictEqual(mwc, 1);
+
+// Restoring original wrapper function
+m.wrapper = originalWrapper;
+// Cleaning require cache
+delete require.cache[require.resolve('./not-main-module.js')];
+delete global.mwc;

--- a/test/parallel/test-module-wrapper.js
+++ b/test/parallel/test-module-wrapper.js
@@ -3,7 +3,7 @@ require('../common');
 const fixtures = require('../common/fixtures');
 const { execFileSync } = require('child_process');
 
-const cjsModuleWrapTest = fixtures.path('cjs-module-wrap.js');
+const cjsModuleWrapTest = fixtures.path('cjs-module-wrapper.js');
 const node = process.execPath;
 
 execFileSync(node, [cjsModuleWrapTest], { stdio: 'pipe' });


### PR DESCRIPTION
Add test cases to cover uncovered wrap and wrapper getters.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)