### PR TITLE
test: add coverage for sparse array maxArrayLength

### DIFF
--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -504,13 +504,6 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
   assert.strictEqual(util.inspect(a), "[ 'foo', 'bar', 'baz' ]");
   delete a[1];
   assert.strictEqual(util.inspect(a), "[ 'foo', <1 empty item>, 'baz' ]");
-  a.push('qux');
-  a.splice(3, 0, undefined);
-  delete a[3];
-  assert.strictEqual(util.inspect(a, {
-    maxArrayLength: 2
-  }), "[ 'foo', <1 empty item>, ... 3 more items ]");
-  a.splice(3, 2);
   assert.strictEqual(
     util.inspect(a, true),
     "[ 'foo', <1 empty item>, 'baz', [length]: 3 ]"
@@ -527,6 +520,10 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
     util.inspect(a, { maxArrayLength: 4 }),
     "[ 'foo', <1 empty item>, 'baz', <97 empty items>, ... 1 more item ]"
   );
+  // test 4 special case
+  assert.strictEqual(util.inspect(a, {
+    maxArrayLength: 2
+  }), "[ 'foo', <1 empty item>, ... 99 more items ]");
 }
 
 // Test for Array constructor in different context.

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -504,6 +504,13 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
   assert.strictEqual(util.inspect(a), "[ 'foo', 'bar', 'baz' ]");
   delete a[1];
   assert.strictEqual(util.inspect(a), "[ 'foo', <1 empty item>, 'baz' ]");
+  a.push('qux');
+  a.splice(3, 0, undefined);
+  delete a[3];
+  assert.strictEqual(util.inspect(a, {
+    maxArrayLength: 2
+  }), "[ 'foo', <1 empty item>, ... 3 more items ]");
+  a.splice(3, 2);
   assert.strictEqual(
     util.inspect(a, true),
     "[ 'foo', <1 empty item>, 'baz', [length]: 3 ]"


### PR DESCRIPTION
code and learn task for additional coverage for situation when
maxArrayLength option is passed to util.inspect for sparsed array
and is set to number lower than actual number of entries

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
