### PR TITLE
Crypto key object constructor coverage and message fix

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -44,7 +44,7 @@ class KeyObject {
     if (type !== 'secret' && type !== 'public' && type !== 'private')
       throw new ERR_INVALID_ARG_VALUE('type', type);
     if (typeof handle !== 'object')
-      throw new ERR_INVALID_ARG_TYPE('handle', 'string', handle);
+      throw new ERR_INVALID_ARG_TYPE('handle', 'object', handle);
 
     this[kKeyType] = type;
 

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -52,6 +52,16 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
 }
 
 {
+  // Attempting to create a key with non-object handle should throw
+  common.expectsError(() => new KeyObject('secret', ''), {
+    type: TypeError,
+    code: 'ERR_INVALID_ARG_TYPE',
+    message:
+      'The "handle" argument must be of type object. Received type string'
+  });
+}
+
+{
   const keybuf = randomBytes(32);
   const key = createSecretKey(keybuf);
   assert.strictEqual(key.type, 'secret');

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -13,6 +13,7 @@ const {
   createSecretKey,
   createPublicKey,
   createPrivateKey,
+  KeyObject,
   randomBytes,
   publicEncrypt,
   privateDecrypt
@@ -36,6 +37,17 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
     code: 'ERR_OUT_OF_RANGE',
     message: 'The value of "key.byteLength" is out of range. ' +
              'It must be > 0. Received 0'
+  });
+}
+
+{
+  // Attempting to create a key of a wrong type should throw
+  const TYPE = 'wrong_type';
+
+  common.expectsError(() => new KeyObject(TYPE), {
+    type: TypeError,
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: `The argument 'type' is invalid. Received '${TYPE}'`
   });
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
PR is targeted to cover [keys.js L45](https://coverage.nodejs.org/coverage-99268b1e996d13a0/lib/internal/crypto/keys.js.html#L45) and [keys.js L47](https://coverage.nodejs.org/coverage-99268b1e996d13a0/lib/internal/crypto/keys.js.html#L47).
When I covered L47 I found and fixed a bug with the exception message.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
