### PR TITLE
test: add a test case for the path.posix.resolve

### DIFF
--- a/test/parallel/test-path-resolve.js
+++ b/test/parallel/test-path-resolve.js
@@ -69,3 +69,12 @@ if (common.isWindows) {
   const resolvedPath = spawnResult.stdout.toString().trim();
   assert.strictEqual(resolvedPath.toLowerCase(), process.cwd().toLowerCase());
 }
+
+if (!common.isWindows) {
+  // Test handling relative paths to be safe when process.cwd() fails.
+  process.cwd = () => '';
+  assert.strictEqual(process.cwd(), '');
+  const resolved = path.resolve();
+  const expected = '.';
+  assert.strictEqual(resolved, expected);
+}


### PR DESCRIPTION
In posix path.resolve should handle relative paths to be safe even if process.cwd fails.

At `lib/path.js#999`:
```
    return resolvedPath.length > 0 ? resolvedPath : '.';
```
Else branch wasn't covered.

Add a test case to cover this.

### Checklist
- [x]  `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x]  commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
