### PR TITLE
test: unhardcode server port

### DIFF
--- a/test/parallel/test-http-server-delete-parser.js
+++ b/test/parallel/test-http-server-delete-parser.js
@@ -12,13 +12,13 @@ const server = http.createServer(common.mustCall((req, res) => {
   res.end();
 }));
 
-server.listen(1337, '127.0.0.1');
+server.listen(0, '127.0.0.1', common.mustCall(() => {
+  const req = http.request({
+    port: server.address().port,
+    host: '127.0.0.1',
+    method: 'GET',
+  });
+  req.end();
+}));
+
 server.unref();
-
-const req = http.request({
-  port: 1337,
-  host: '127.0.0.1',
-  method: 'GET',
-});
-
-req.end();


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
