### PR TITLE
lib: removed unnecessary fs.realpath `options` arg check + tests

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1533,11 +1533,9 @@ realpathSync.native = (path, options) => {
 
 function realpath(p, options, callback) {
   callback = typeof options === 'function' ? options : maybeCallback(callback);
-  if (!options)
-    options = emptyObj;
-  else
-    options = getOptions(options, emptyObj);
+  options = getOptions(options, {});
   p = toPathIfFileURL(p);
+
   if (typeof p !== 'string') {
     p += '';
   }


### PR DESCRIPTION
Removed duplicated check for options argument of fs.realpath.

Added some tests which covering the cases for passing options arg
as null.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
