### PR TITLE
inspector: removing checking of non existent field in lib/inspector.js

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -37,12 +37,8 @@ class Session extends EventEmitter {
   connect() {
     if (this[connectionSymbol])
       throw new ERR_INSPECTOR_ALREADY_CONNECTED('The inspector session');
-    const connection =
+    this[connectionSymbol] =
       new Connection((message) => this[onMessageSymbol](message));
-    if (connection.sessionAttached) {
-      throw new ERR_INSPECTOR_ALREADY_CONNECTED('Another inspector session');
-    }
-    this[connectionSymbol] = connection;
   }
 
   [onMessageSymbol](message) {


### PR DESCRIPTION
Seems like sessionAttached doesn't exist and no more assigned anywhere

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
