### PR TITLE
doc: adds link to nightly code coverage report

### DIFF
--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -424,6 +424,9 @@ will depend on what is being tested if this is required or not.
 To generate a test coverage report, see the
 [Test Coverage section of the Building guide][].
 
+Nightly coverage reports for the Node.js master branch are available at
+https://coverage.nodejs.org/.
+
 [ASCII]: http://man7.org/linux/man-pages/man7/ascii.7.html
 [Google Test]: https://github.com/google/googletest
 [`common` module]: https://github.com/nodejs/node/blob/master/test/common/README.md


### PR DESCRIPTION
##### Description

The [writing-tests.md](https://github.com/nodejs/node/blob/master/doc/guides/writing-tests.md#test-coverage) file leads to documentation on generating a test code coverage report, but doesn't actually link to [the page](https://coverage.nodejs.org/) with the nightly code coverage report. (Actually, the Nightly Code Coverage Report doesn't seem to be linked anywhere in the project.) 

This PR adds a link to the Nightly Test Code Coverage Report in the writing-tests.md file (specifically, in the Test Coverage section).

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]