### PR TITLE
src: reduced env.h and env-inl.h include lines and added forward declarations of class Environment where necessary.

### DIFF
--- a/src/api/async_resource.cc
+++ b/src/api/async_resource.cc
@@ -1,6 +1,7 @@
 #include "node.h"
-#include "env-inl.h"
 
+
+class Environment;
 namespace node {
 
 using v8::Function;

--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -1,8 +1,8 @@
 #include "node.h"
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "v8.h"
 
+class Environment;
 namespace node {
 
 using v8::Context;

--- a/src/api/exceptions.cc
+++ b/src/api/exceptions.cc
@@ -1,6 +1,5 @@
 // This file contains implementation of error APIs exposed in node.h
 
-#include "env-inl.h"
 #include "node.h"
 #include "node_errors.h"
 #include "util-inl.h"
@@ -9,6 +8,7 @@
 
 #include <cstring>
 
+class Environment;
 namespace node {
 
 using v8::Exception;

--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -1,8 +1,8 @@
-#include "env-inl.h"
 #include "node_internals.h"
 #include "node_process.h"
 #include "async_wrap.h"
 
+class Environment;
 namespace node {
 
 using v8::Context;

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -21,7 +21,6 @@
 
 #include "async_wrap.h"  // NOLINT(build/include_inline)
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "node_errors.h"
 #include "tracing/traced_value.h"
 #include "util-inl.h"
@@ -58,6 +57,8 @@ using v8::WeakCallbackInfo;
 using v8::WeakCallbackType;
 
 using TryCatchScope = node::errors::TryCatchScope;
+
+class Environment;
 
 namespace node {
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -22,7 +22,6 @@
 #define CARES_STATICLIB
 #include "ares.h"
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "memory_tracker-inl.h"
 #include "node.h"
 #include "req_wrap-inl.h"
@@ -53,6 +52,7 @@
 # define AI_V4MAPPED 0
 #endif
 
+class Environment;
 namespace node {
 namespace cares_wrap {
 

--- a/src/connect_wrap.cc
+++ b/src/connect_wrap.cc
@@ -1,9 +1,9 @@
 #include "connect_wrap.h"
 
-#include "env-inl.h"
 #include "req_wrap-inl.h"
 #include "util-inl.h"
 
+class Environment;
 namespace node {
 
 using v8::Local;

--- a/src/connection_wrap.cc
+++ b/src/connection_wrap.cc
@@ -1,13 +1,13 @@
 #include "connection_wrap.h"
 
 #include "connect_wrap.h"
-#include "env-inl.h"
 #include "pipe_wrap.h"
 #include "stream_base-inl.h"
 #include "stream_wrap.h"
 #include "tcp_wrap.h"
 #include "util-inl.h"
 
+class Environment;
 namespace node {
 
 using v8::Boolean;

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -20,13 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "util-inl.h"
 #include "node.h"
 #include "handle_wrap.h"
 #include "string_bytes.h"
 
-
+class Environment;
 namespace node {
 
 using v8::Context;

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -21,10 +21,10 @@
 
 #include "handle_wrap.h"
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "util-inl.h"
 #include "node.h"
 
+class Environment;
 namespace node {
 
 using v8::Context;

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -1,5 +1,4 @@
 #include "diagnosticfilename-inl.h"
-#include "env-inl.h"
 #include "memory_tracker-inl.h"
 #include "stream_base-inl.h"
 #include "util-inl.h"
@@ -24,6 +23,7 @@ using v8::ObjectTemplate;
 using v8::String;
 using v8::Value;
 
+class Environment;
 namespace node {
 namespace heap {
 

--- a/src/inspector/tracing_agent.cc
+++ b/src/inspector/tracing_agent.cc
@@ -7,6 +7,7 @@
 #include <set>
 #include <sstream>
 
+class Environment;
 namespace node {
 namespace inspector {
 namespace protocol {

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -1,13 +1,13 @@
 #include "js_stream.h"
 
 #include "async_wrap.h"
-#include "env-inl.h"
 #include "node_buffer.h"
 #include "node_errors.h"
 #include "stream_base-inl.h"
 #include "util-inl.h"
 #include "v8.h"
 
+class Environment;
 namespace node {
 
 using errors::TryCatchScope;

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -24,7 +24,6 @@
 #include "node_errors.h"
 #include "node_internals.h"
 
-#include "env-inl.h"
 #include "string_bytes.h"
 #include "string_search.h"
 #include "util-inl.h"
@@ -34,6 +33,7 @@
 #include <cstring>
 #include <climits>
 
+class Environment;
 #define THROW_AND_RETURN_UNLESS_BUFFER(env, obj)                            \
   THROW_AND_RETURN_IF_NOT_BUFFER(env, obj, "argument")                      \
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -31,7 +31,6 @@
 
 #include "async_wrap-inl.h"
 #include "base_object-inl.h"
-#include "env-inl.h"
 #include "memory_tracker-inl.h"
 #include "string_bytes.h"
 #include "threadpoolwork-inl.h"
@@ -58,6 +57,8 @@
 #include <memory>
 #include <utility>
 #include <vector>
+
+class Environment;
 
 static const int X509_NAME_FLAGS = ASN1_STRFLGS_ESC_CTRL
                                  | ASN1_STRFLGS_UTF8_CONVERT

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -26,10 +26,10 @@
 
 #include "node_crypto.h"
 #include "openssl/bio.h"
-#include "env.h"
 #include "util.h"
 #include "v8.h"
 
+class Environment;
 namespace node {
 namespace crypto {
 

--- a/src/node_http_parser_impl.h
+++ b/src/node_http_parser_impl.h
@@ -29,7 +29,6 @@
 #include "util.h"
 
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "stream_base-inl.h"
 #include "v8.h"
 
@@ -50,7 +49,7 @@
 // No copying is performed when slicing the buffer, only small reference
 // allocations.
 
-
+class Environment;
 namespace node {
 namespace {  // NOLINT(build/namespaces)
 

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -67,6 +67,7 @@
 #include <unicode/uversion.h>
 #include <unicode/ustring.h>
 
+class Environment;
 #ifdef NODE_HAVE_SMALL_ICU
 /* if this is defined, we have a 'secondary' entry point.
    compare following to utypes.h defs for U_ICUDATA_ENTRY_POINT */

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -1,12 +1,12 @@
 #include "node_platform.h"
 #include "node_internals.h"
 
-#include "env-inl.h"
 #include "debug_utils.h"
 #include <algorithm>
 #include <cmath>
 #include <memory>
 
+class Environment;
 namespace node {
 
 using v8::Isolate;

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -1,5 +1,4 @@
 #include "base_object-inl.h"
-#include "env-inl.h"
 #include "node.h"
 #include "node_errors.h"
 #include "node_internals.h"
@@ -28,6 +27,7 @@ typedef int mode_t;
 #include <termios.h>  // tcgetattr, tcsetattr
 #endif
 
+class Environment;
 namespace node {
 
 using v8::Array;

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -1,4 +1,3 @@
-#include "env-inl.h"
 #include "node_internals.h"
 #include "node_options-inl.h"
 #include "node_metadata.h"
@@ -8,6 +7,7 @@
 
 #include <climits>  // PATH_MAX
 
+class Environment;
 namespace node {
 using v8::Context;
 using v8::DEFAULT;

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -1,4 +1,3 @@
-#include "env-inl.h"
 #include "node.h"
 #include "node_errors.h"
 #include "node_internals.h"
@@ -8,6 +7,7 @@
 
 #include <atomic>
 
+class Environment;
 namespace node {
 
 using v8::Array;

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -4,10 +4,9 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
-#include "env.h"
-
 #include <string>
 
+class Environment;
 namespace node {
 namespace url {
 

--- a/src/node_v8_platform-inl.h
+++ b/src/node_v8_platform-inl.h
@@ -5,7 +5,6 @@
 
 #include <memory>
 
-#include "env-inl.h"
 #include "node.h"
 #include "node_metadata.h"
 #include "node_options.h"
@@ -13,6 +12,7 @@
 #include "tracing/trace_event.h"
 #include "tracing/traced_value.h"
 
+class Environment;
 namespace node {
 
 // Ensures that __metadata trace events are only emitted

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -24,7 +24,6 @@
 #include "node_buffer.h"
 
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "threadpoolwork-inl.h"
 #include "util-inl.h"
 
@@ -41,6 +40,7 @@
 #include <cstring>
 #include <atomic>
 
+class Environment;
 namespace node {
 
 using v8::Array;

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -23,7 +23,6 @@
 
 #include "async_wrap.h"
 #include "connection_wrap.h"
-#include "env-inl.h"
 #include "handle_wrap.h"
 #include "node.h"
 #include "node_buffer.h"
@@ -32,6 +31,7 @@
 #include "stream_wrap.h"
 #include "util-inl.h"
 
+class Environment;
 namespace node {
 
 using v8::Context;

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -19,7 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "env-inl.h"
 #include "stream_base-inl.h"
 #include "stream_wrap.h"
 #include "util-inl.h"
@@ -27,6 +26,7 @@
 #include <cstring>
 #include <cstdlib>
 
+class Environment;
 namespace node {
 
 using v8::Array;

--- a/src/req_wrap-inl.h
+++ b/src/req_wrap-inl.h
@@ -7,6 +7,7 @@
 #include "async_wrap-inl.h"
 #include "uv.h"
 
+class Environment;
 namespace node {
 
 ReqWrapBase::ReqWrapBase(Environment* env) {

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -20,12 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "async_wrap-inl.h"
-#include "env-inl.h"
 #include "handle_wrap.h"
 #include "node_process.h"
 #include "util-inl.h"
 #include "v8.h"
 
+class Environment;
 namespace node {
 
 using v8::Context;

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -21,14 +21,13 @@
 
 #include "spawn_sync.h"
 #include "debug_utils.h"
-#include "env-inl.h"
 #include "node_internals.h"
 #include "string_bytes.h"
 #include "util-inl.h"
 
 #include <cstring>
 
-
+class Environment;
 namespace node {
 
 using v8::Array;

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -6,9 +6,9 @@
 #include "stream_base.h"
 
 #include "node.h"
-#include "env-inl.h"
 #include "v8.h"
 
+class Environment;
 namespace node {
 
 using v8::Signature;

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -5,7 +5,6 @@
 #include "node.h"
 #include "node_buffer.h"
 #include "node_errors.h"
-#include "env-inl.h"
 #include "js_stream.h"
 #include "string_bytes.h"
 #include "util-inl.h"
@@ -13,6 +12,7 @@
 
 #include <climits>  // INT_MAX
 
+class Environment;
 namespace node {
 
 using v8::Array;

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -22,7 +22,6 @@
 #include "stream_wrap.h"
 #include "stream_base-inl.h"
 
-#include "env-inl.h"
 #include "handle_wrap.h"
 #include "node_buffer.h"
 #include "pipe_wrap.h"
@@ -34,7 +33,7 @@
 #include <cstring>  // memcpy()
 #include <climits>  // INT_MAX
 
-
+class Environment;
 namespace node {
 
 using v8::Context;

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -22,7 +22,6 @@
 #include "string_bytes.h"
 
 #include "base64.h"
-#include "env-inl.h"
 #include "node_buffer.h"
 #include "node_errors.h"
 #include "util.h"
@@ -38,6 +37,7 @@
 // use external string resources.
 #define EXTERN_APEX 0xFBEE9
 
+class Environment;
 namespace node {
 
 using v8::HandleScope;

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -22,7 +22,6 @@
 #include "tcp_wrap.h"
 
 #include "connection_wrap.h"
-#include "env-inl.h"
 #include "handle_wrap.h"
 #include "node_buffer.h"
 #include "node_internals.h"
@@ -33,7 +32,7 @@
 
 #include <cstdlib>
 
-
+class Environment;
 namespace node {
 
 using v8::Boolean;

--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -4,8 +4,8 @@
 #include "trace_event.h"
 #include "tracing/node_trace_buffer.h"
 #include "debug_utils.h"
-#include "env-inl.h"
 
+class Environment;
 namespace node {
 namespace tracing {
 

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -21,13 +21,13 @@
 
 #include "tty_wrap.h"
 
-#include "env-inl.h"
 #include "handle_wrap.h"
 #include "node_buffer.h"
 #include "stream_base-inl.h"
 #include "stream_wrap.h"
 #include "util-inl.h"
 
+class Environment;
 namespace node {
 
 using v8::Array;

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -20,12 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "udp_wrap.h"
-#include "env-inl.h"
 #include "node_buffer.h"
 #include "handle_wrap.h"
 #include "req_wrap-inl.h"
 #include "util-inl.h"
 
+class Environment;
 namespace node {
 
 using v8::Array;


### PR DESCRIPTION
Reduces env.h and env-inl.h include lines and added forward declarations of class Environment.
Some files had references to Environment* types in the code but for those files, no include<env.h> or include<env-inl.h> files where present. In those cases I added a forward declaration of class Environment.

Running the vcbuild test on windows ran it successfully.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
