### PR TITLE
src: export number_of_native_contexts and number_of_detached_contexts

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -147,7 +147,7 @@ a memory leak.
 
 `number_of_detached_contexts` The value of detached_context is the number
 of contexts that were detached and not yet garbage collected. This number
-being non-zero indicates potential memory leak.
+being non-zero indicates a potential memory leak.
 
 <!-- eslint-skip -->
 ```js

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -142,7 +142,7 @@ because it continuously touches all heap pages and that makes them less likely
 to get swapped out by the operating system.
 
 `number_of_native_contexts` The value of native_context is the number of the
-top-level contexts created. Increase of this number over time indicates
+top-level contexts currently active. Increase of this number over time indicates
 a memory leak.
 
 `number_of_detached_contexts` The value of detached_context is the number

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -131,12 +131,23 @@ Returns an object with the following properties:
 * `malloced_memory` {number}
 * `peak_malloced_memory` {number}
 * `does_zap_garbage` {number}
+* `number_of_native_contexts` {number}
+* `number_of_detached_contexts` {number}
+
 
 `does_zap_garbage` is a 0/1 boolean, which signifies whether the
 `--zap_code_space` option is enabled or not. This makes V8 overwrite heap
 garbage with a bit pattern. The RSS footprint (resident memory set) gets bigger
 because it continuously touches all heap pages and that makes them less likely
 to get swapped out by the operating system.
+
+`number_of_native_contexts` The value of native_context is the number of the
+top-level contexts created. Increase of this number over time indicates
+a memory leak.
+
+`number_of_detached_contexts` The value of detached_context is the number
+of contexts that were detached and not yet garbage collected. This number
+being non-zero indicates potential memory leak.
 
 <!-- eslint-skip -->
 ```js
@@ -149,7 +160,9 @@ to get swapped out by the operating system.
   heap_size_limit: 1535115264,
   malloced_memory: 16384,
   peak_malloced_memory: 1127496,
-  does_zap_garbage: 0
+  does_zap_garbage: 0,
+  number_of_native_contexts: 1,
+  number_of_detached_contexts: 0
 }
 ```
 

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -109,7 +109,9 @@ const {
   kSpaceSizeIndex,
   kSpaceUsedSizeIndex,
   kSpaceAvailableSizeIndex,
-  kPhysicalSpaceSizeIndex
+  kPhysicalSpaceSizeIndex,
+  kNumberOfNativeContextsIndex,
+  kNumberOfDetachedContextsIndex
 } = internalBinding('v8');
 
 const kNumberOfHeapSpaces = kHeapSpaces.length;
@@ -139,7 +141,9 @@ function getHeapStatistics() {
     'heap_size_limit': buffer[kHeapSizeLimitIndex],
     'malloced_memory': buffer[kMallocedMemoryIndex],
     'peak_malloced_memory': buffer[kPeakMallocedMemoryIndex],
-    'does_zap_garbage': buffer[kDoesZapGarbageIndex]
+    'does_zap_garbage': buffer[kDoesZapGarbageIndex],
+    'number_of_native_contexts': buffer[kNumberOfNativeContextsIndex],
+    'number_of_detached_contexts': buffer[kNumberOfDetachedContextsIndex]
   };
 }
 

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -52,7 +52,9 @@ using v8::Value;
   V(5, heap_size_limit, kHeapSizeLimitIndex)                                  \
   V(6, malloced_memory, kMallocedMemoryIndex)                                 \
   V(7, peak_malloced_memory, kPeakMallocedMemoryIndex)                        \
-  V(8, does_zap_garbage, kDoesZapGarbageIndex)
+  V(8, does_zap_garbage, kDoesZapGarbageIndex)                                \
+  V(9, number_of_native_contexts, kNumberOfNativeContextsIndex)               \
+  V(10, number_of_detached_contexts, kNumberOfDetachedContextsIndex)
 
 #define V(a, b, c) +1
 static const size_t kHeapStatisticsPropertiesCount =

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -8,6 +8,8 @@ const keys = [
   'does_zap_garbage',
   'heap_size_limit',
   'malloced_memory',
+  'number_of_detached_contexts',
+  'number_of_native_contexts',
   'peak_malloced_memory',
   'total_available_size',
   'total_heap_size',


### PR DESCRIPTION
export number_of_native_contexts and number_of_detached_contexts as
part of v8.getHeapStatistics()

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ x] tests and/or benchmarks are included
- [x ] documentation is changed or added
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
