### PR TITLE
stream: convert existing buffer when calling .setEncoding

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -321,9 +321,22 @@ Readable.prototype.isPaused = function() {
 Readable.prototype.setEncoding = function(enc) {
   if (!StringDecoder)
     StringDecoder = require('string_decoder').StringDecoder;
-  this._readableState.decoder = new StringDecoder(enc);
+  const decoder = new StringDecoder(enc);
+  this._readableState.decoder = decoder;
   // If setEncoding(null), decoder.encoding equals utf8
   this._readableState.encoding = this._readableState.decoder.encoding;
+
+  // Iterate over current buffer to convert already stored Buffers:
+  let p = this._readableState.buffer.head;
+  let content = '';
+  while (p !== null) {
+    content += decoder.write(p.data);
+    p = p.next;
+  }
+  this._readableState.buffer.clear();
+  if (content !== '')
+    this._readableState.buffer.push(content);
+  this._readableState.length = content.length;
   return this;
 };
 

--- a/test/parallel/test-stream-readable-setEncoding-existing-buffers.js
+++ b/test/parallel/test-stream-readable-setEncoding-existing-buffers.js
@@ -1,0 +1,60 @@
+'use strict';
+require('../common');
+const { Readable } = require('stream');
+const assert = require('assert');
+
+{
+  // Call .setEncoding() while there are bytes already in the buffer.
+  const r = new Readable({ read() {} });
+
+  r.push(Buffer.from('a'));
+  r.push(Buffer.from('b'));
+
+  r.setEncoding('utf8');
+  const chunks = [];
+  r.on('data', (chunk) => chunks.push(chunk));
+
+  process.nextTick(() => {
+    assert.deepStrictEqual(chunks, ['ab']);
+  });
+}
+
+{
+  // Call .setEncoding() while the buffer contains a complete,
+  // but chunked character.
+  const r = new Readable({ read() {} });
+
+  r.push(Buffer.from([0xf0]));
+  r.push(Buffer.from([0x9f]));
+  r.push(Buffer.from([0x8e]));
+  r.push(Buffer.from([0x89]));
+
+  r.setEncoding('utf8');
+  const chunks = [];
+  r.on('data', (chunk) => chunks.push(chunk));
+
+  process.nextTick(() => {
+    assert.deepStrictEqual(chunks, ['🎉']);
+  });
+}
+
+{
+  // Call .setEncoding() while the buffer contains an incomplete character,
+  // and finish the character later.
+  const r = new Readable({ read() {} });
+
+  r.push(Buffer.from([0xf0]));
+  r.push(Buffer.from([0x9f]));
+
+  r.setEncoding('utf8');
+
+  r.push(Buffer.from([0x8e]));
+  r.push(Buffer.from([0x89]));
+
+  const chunks = [];
+  r.on('data', (chunk) => chunks.push(chunk));
+
+  process.nextTick(() => {
+    assert.deepStrictEqual(chunks, ['🎉']);
+  });
+}


### PR DESCRIPTION
Convert already-stored chunks when `.setEncoding()` is called
so that subsequent `data` events will receive decoded strings,
as they expect.

Fixes: https://github.com/nodejs/node/issues/27932

@nodejs/streams

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
