### PR TITLE
[v10.x]  tls: renegotiate should take care of its own state

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -573,6 +573,9 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
     this._requestCert = requestCert;
     this._rejectUnauthorized = rejectUnauthorized;
   }
+  // Ensure that we'll cycle through internal openssl's state
+  this.write('');
+
   if (!this._handle.renegotiate()) {
     if (callback) {
       process.nextTick(callback, new ERR_TLS_RENEGOTIATE());

--- a/test/parallel/test-tls-disable-renegotiation.js
+++ b/test/parallel/test-tls-disable-renegotiation.js
@@ -46,7 +46,6 @@ server.listen(0, common.mustCall(() => {
     port
   };
   const client = tls.connect(options, common.mustCall(() => {
-    client.write('');
     // Negotiation is still permitted for this first
     // attempt. This should succeed.
     let ok = client.renegotiate(options, common.mustCall((err) => {
@@ -56,7 +55,6 @@ server.listen(0, common.mustCall(() => {
       // data event on the server. After that data
       // is received, disableRenegotiation is called.
       client.write('data', common.mustCall(() => {
-        client.write('');
         // This second renegotiation attempt should fail
         // and the callback should never be invoked. The
         // server will simply drop the connection after


### PR DESCRIPTION
backport of https://github.com/nodejs/node/pull/25997