### PR TITLE
[10.x] http, http2: flag for overriding server timeout

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -119,6 +119,17 @@ added: v6.0.0
 Force FIPS-compliant crypto on startup. (Cannot be disabled from script code.)
 (Same requirements as `--enable-fips`.)
 
+### `--http-server-default-timeout=milliseconds`
+<!-- YAML
+added: REPLACEME
+-->
+
+Overrides the default value of `http`, `https` and `http2` server socket
+timeout. Setting the value to 0 disables server socket timeout. Unless
+provided, http server sockets timeout after 120s (2 minutes). Programmatic
+setting of the timeout takes precedence over the value set through this
+flag.
+
 ### `--icu-data-dir=file`
 <!-- YAML
 added: v0.11.15
@@ -590,6 +601,7 @@ Node.js options that are allowed are:
 - `--experimental-vm-modules`
 - `--experimental-worker`
 - `--force-fips`
+- `--http-server-default-timeout`
 - `--icu-data-dir`
 - `--inspect`
 - `--inspect-brk`

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1004,6 +1004,9 @@ By default, the Server's timeout value is 2 minutes, and sockets are
 destroyed automatically if they time out. However, if a callback is assigned
 to the Server's `'timeout'` event, timeouts must be handled explicitly.
 
+To change the default timeout use the [`--http-server-default-timeout`][]
+flag.
+
 ### server.timeout
 <!-- YAML
 added: v0.9.12
@@ -1018,6 +1021,9 @@ A value of `0` will disable the timeout behavior on incoming connections.
 
 The socket timeout logic is set up on connection, so changing this
 value only affects new connections to the server, not any existing connections.
+
+To change the default timeout use the [`--http-server-default-timeout`][]
+flag.
 
 ### server.keepAliveTimeout
 <!-- YAML
@@ -2113,6 +2119,7 @@ will be emitted in the following order:
 Note that setting the `timeout` option or using the `setTimeout()` function will
 not abort the request or do anything besides add a `'timeout'` event.
 
+[`--http-server-default-timeout`]: cli.html#cli_http_server_default_timeout_milliseconds
 [`--max-http-header-size`]: cli.html#cli_max_http_header_size_size
 [`'checkContinue'`]: #http_event_checkcontinue
 [`'request'`]: #http_event_request

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1723,6 +1723,9 @@ The `'timeout'` event is emitted when there is no activity on the Server for
 a given number of milliseconds set using `http2server.setTimeout()`.
 **Default:** 2 minutes.
 
+To change the default timeout use the [`--http-server-default-timeout`][]
+flag.
+
 #### server.close([callback])
 <!-- YAML
 added: v8.4.0
@@ -1752,6 +1755,9 @@ The given callback is registered as a listener on the `'timeout'` event.
 
 In case of no callback function were assigned, a new `ERR_INVALID_CALLBACK`
 error will be thrown.
+
+To change the default timeout use the [`--http-server-default-timeout`][]
+flag.
 
 ### Class: Http2SecureServer
 <!-- YAML
@@ -3411,6 +3417,7 @@ following additional properties:
 * `type` {string} Either `'server'` or `'client'` to identify the type of
   `Http2Session`.
 
+[`--http-server-default-timeout`]: cli.html#cli_http_server_default_timeout_milliseconds
 [ALPN Protocol ID]: https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
 [ALPN negotiation]: #http2_alpn_negotiation
 [Compatibility API]: #http2_compatibility_api

--- a/doc/node.1
+++ b/doc/node.1
@@ -109,6 +109,9 @@ Chooses an HTTP parser library. Available values are
 or
 .Sy legacy .
 .
+.It Fl -http-server-default-timeout Ns = Ns Ar milliseconds
+Overrides the default value for server socket timeout.
+.
 .It Fl -icu-data-dir Ns = Ns Ar file
 Specify ICU data load path.
 Overrides

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -50,8 +50,11 @@ const {
   ERR_INVALID_CHAR
 } = require('internal/errors').codes;
 const Buffer = require('buffer').Buffer;
+const { getOptionValue } = require('internal/options');
 
 const kServerResponse = Symbol('ServerResponse');
+const kDefaultHttpServerTimeout =
+  getOptionValue('--http-server-default-timeout');
 
 const STATUS_CODES = {
   100: 'Continue',
@@ -300,7 +303,7 @@ function Server(options, requestListener) {
 
   this.on('connection', connectionListener);
 
-  this.timeout = 2 * 60 * 1000;
+  this.timeout = kDefaultHttpServerTimeout;
   this.keepAliveTimeout = 5000;
   this.maxHeadersCount = null;
   this.headersTimeout = 40 * 1000; // 40 seconds

--- a/lib/https.js
+++ b/lib/https.js
@@ -39,6 +39,10 @@ const { urlToOptions, searchParamsSymbol } = require('internal/url');
 const { ERR_INVALID_DOMAIN_NAME } = require('internal/errors').codes;
 const { IncomingMessage, ServerResponse } = require('http');
 const { kIncomingMessage } = require('_http_common');
+const { getOptionValue } = require('internal/options');
+
+const kDefaultHttpServerTimeout =
+  getOptionValue('--http-server-default-timeout');
 
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
@@ -72,7 +76,7 @@ function Server(opts, requestListener) {
       conn.destroy(err);
   });
 
-  this.timeout = 2 * 60 * 1000;
+  this.timeout = kDefaultHttpServerTimeout;
   this.keepAliveTimeout = 5000;
   this.maxHeadersCount = null;
   this.headersTimeout = 40 * 1000; // 40 seconds

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -126,6 +126,7 @@ const { UV_EOF } = process.binding('uv');
 const { StreamPipe } = internalBinding('stream_pipe');
 const { _connectionListener: httpConnectionListener } = http;
 const debug = util.debuglog('http2');
+const { getOptionValue } = require('internal/options');
 
 const kMaxFrameSize = (2 ** 24) - 1;
 const kMaxInt = (2 ** 32) - 1;
@@ -162,7 +163,8 @@ const kState = Symbol('state');
 const kType = Symbol('type');
 const kWriteGeneric = Symbol('write-generic');
 
-const kDefaultSocketTimeout = 2 * 60 * 1000;
+const kDefaultHttpServerTimeout =
+  getOptionValue('--http-server-default-timeout');
 
 const {
   paddingBuffer,
@@ -2726,7 +2728,7 @@ class Http2SecureServer extends TLSServer {
     options = initializeTLSOptions(options);
     super(options, connectionListener);
     this[kOptions] = options;
-    this.timeout = kDefaultSocketTimeout;
+    this.timeout = kDefaultHttpServerTimeout;
     this.on('newListener', setupCompat);
     if (typeof requestListener === 'function')
       this.on('request', requestListener);
@@ -2748,7 +2750,7 @@ class Http2Server extends NETServer {
   constructor(options, requestListener) {
     super(connectionListener);
     this[kOptions] = initializeOptions(options);
-    this.timeout = kDefaultSocketTimeout;
+    this.timeout = kDefaultHttpServerTimeout;
     this.on('newListener', setupCompat);
     if (typeof requestListener === 'function')
       this.on('request', requestListener);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -102,6 +102,11 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::experimental_worker,
             kAllowedInEnvironment);
   AddOption("--expose-internals", "", &EnvironmentOptions::expose_internals);
+  AddOption("--http-server-default-timeout",
+            "Default http server socket timeout in ms "
+            "(default: 120000)",
+            &EnvironmentOptions::http_server_default_timeout,
+            kAllowedInEnvironment);
   AddOption("--loader",
             "(with --experimental-modules) use the specified file as a "
             "custom loader",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -72,6 +72,7 @@ class EnvironmentOptions : public Options {
   bool experimental_vm_modules = false;
   bool experimental_worker = false;
   bool expose_internals = false;
+  uint64_t http_server_default_timeout = 120000;
   bool no_deprecation = false;
   bool no_force_async_hooks_checks = false;
   bool no_warnings = false;

--- a/test/parallel/test-http-timeout-flag.js
+++ b/test/parallel/test-http-timeout-flag.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const fixtures = require('../common/fixtures');
+const http = require('http');
+const https = require('https');
+const http2 = require('http2');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+// Make sure the defaults are correct.
+const servers = [
+  http.createServer(),
+  https.createServer({
+    key: fixtures.readKey('agent1-key.pem'),
+    cert: fixtures.readKey('agent1-cert.pem')
+  }),
+  http2.createServer()
+];
+
+for (const server of servers) {
+  assert.strictEqual(server.timeout, 120000);
+  server.close();
+}
+
+// Ensure that command line flag overrides the default timeout.
+const child1 = spawnSync(process.execPath, ['--http-server-default-timeout=10',
+                                            '-p', 'http.createServer().timeout'
+]);
+assert.strictEqual(+child1.stdout.toString().trim(), 10);
+
+// Ensure that the flag is whitelisted for NODE_OPTIONS.
+const env = Object.assign({}, process.env, {
+  NODE_OPTIONS: '--http-server-default-timeout=10'
+});
+const child2 = spawnSync(process.execPath,
+                         [ '-p', 'http.createServer().timeout'], { env });
+assert.strictEqual(+child2.stdout.toString().trim(), 10);


### PR DESCRIPTION
This is the 10.x backport of #27704.

Make it possible to override the default http server timeout. Ideally
there should be no server timeout - as done on the master branch. This
is a non-breaking way to enable platform providers to override the
value.

PR-URL: https://github.com/nodejs/node/pull/27704
Refs: https://github.com/nodejs/node/pull/27558
Refs: https://github.com/nodejs/node/issues/27556
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Myles Borins <myles.borins@gmail.com>
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
