### PR TITLE
doc: clarify N-API version Matrix.

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -145,9 +145,9 @@ available to the module code.
 
 ## N-API Version Matrix
 
-N-API versions are additive and versioned independantly from Node.js. Version 4 is an extension
-to version 3 in that it has all of the APIs from version 3 with
-some additions. This means that you
+N-API versions are additive and versioned independantly from Node.js.
+Version 4 is an extension to version 3 in that it has all of the APIs
+from version 3 with some additions. This means that you
 do not need to recompile for new versions of Node.js which are
 listed as supporting a later version.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -145,7 +145,7 @@ available to the module code.
 
 ## N-API Version Matrix
 
-N-API versions are additive NOT SemVer. Version 4 is an extension
+N-API versions are additive, not SemVer. Version 4 is an extension
 to version 3 in that is has all of the APIs from version 3 with
 some additions. This means that you
 do NOT need to recompile for new versions of Node.js which are

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -145,6 +145,12 @@ available to the module code.
 
 ## N-API Version Matrix
 
+N-API versions are additive NOT SemVer. Version 4 is an extension
+to version 3 in that is has all of the APIs from version 3 with
+some additions. This means that you
+do NOT need to recompile for new versions of Node.js which are
+listed as supporting a later version.
+
 |       | 1       | 2        | 3        | 4        |
 |:-----:|:-------:|:--------:|:--------:|:--------:|
 | v6.x  |         |          | v6.14.2* |          |

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -145,7 +145,7 @@ available to the module code.
 
 ## N-API Version Matrix
 
-N-API versions are additive, not SemVer. Version 4 is an extension
+N-API versions are additive and versioned independantly from Node.js. Version 4 is an extension
 to version 3 in that it has all of the APIs from version 3 with
 some additions. This means that you
 do not need to recompile for new versions of Node.js which are

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -148,7 +148,7 @@ available to the module code.
 N-API versions are additive, not SemVer. Version 4 is an extension
 to version 3 in that it has all of the APIs from version 3 with
 some additions. This means that you
-do NOT need to recompile for new versions of Node.js which are
+do not need to recompile for new versions of Node.js which are
 listed as supporting a later version.
 
 |       | 1       | 2        | 3        | 4        |

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -146,7 +146,7 @@ available to the module code.
 ## N-API Version Matrix
 
 N-API versions are additive, not SemVer. Version 4 is an extension
-to version 3 in that is has all of the APIs from version 3 with
+to version 3 in that it has all of the APIs from version 3 with
 some additions. This means that you
 do NOT need to recompile for new versions of Node.js which are
 listed as supporting a later version.


### PR DESCRIPTION
I was asked by a community member if they needed to
recompile for v12.x based on the version matrix. Add
additional context to help ensure it is clear that this
is not the case.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
