### PR TITLE
doc: add missing --experimental-wasm-modules docs

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -183,6 +183,13 @@ added: v9.6.0
 
 Enable experimental ES Module support in the `vm` module.
 
+### `--experimental-wasm-modules`
+<!-- YAML
+added: v12.3.0
+-->
+
+Enable experimental WebAssembly module support.
+
 ### `--force-fips`
 <!-- YAML
 added: v6.0.0
@@ -965,6 +972,7 @@ Node.js options that are allowed are:
 - `--experimental-repl-await`
 - `--experimental-report`
 - `--experimental-vm-modules`
+- `--experimental-wasm-modules`
 - `--force-fips`
 - `--frozen-intrinsics`
 - `--heapsnapshot-signal`

--- a/doc/node.1
+++ b/doc/node.1
@@ -127,6 +127,9 @@ feature.
 .It Fl -experimental-vm-modules
 Enable experimental ES module support in VM module.
 .
+.It Fl -experimental-wasm-modules
+Enable experimental WebAssembly module support.
+.
 .It Fl -force-fips
 Force FIPS-compliant crypto on startup
 (Cannot be disabled from script code).


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
