### PR TITLE
doc: move DEP0129 to a runtime deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2436,12 +2436,15 @@ Node.js versions.
 ### DEP0129: ChildProcess._channel
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/27949
+    description: Runtime deprecation.
   - version: v11.14.0
     pr-url: https://github.com/nodejs/node/pull/26982
     description: Documentation-only.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 The `_channel` property of child process objects returned by `spawn()` and
 similar functions is not intended for public use. Use `ChildProcess.channel`

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -37,7 +37,7 @@ const { TTY } = internalBinding('tty_wrap');
 const { UDP } = internalBinding('udp_wrap');
 const SocketList = require('internal/socket_list');
 const { owner_symbol } = require('internal/async_hooks').symbols;
-const { convertToValidSignal } = require('internal/util');
+const { convertToValidSignal, deprecate } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 const spawn_sync = internalBinding('spawn_sync');
 const { kStateSymbol } = require('internal/dgram');
@@ -513,14 +513,21 @@ class Control extends EventEmitter {
   }
 }
 
+const channelDeprecationMsg = '_channel is deprecated. ' +
+                              'Use ChildProcess.channel instead.';
+
 function setupChannel(target, channel) {
   target.channel = channel;
 
-  // _channel can be deprecated in version 8
   Object.defineProperty(target, '_channel', {
-    get() { return target.channel; },
-    set(val) { target.channel = val; },
-    enumerable: true
+    get: deprecate(() => {
+      return target.channel;
+    }, channelDeprecationMsg, 'DEP0129'),
+    set: deprecate((val) => {
+      target.channel = val;
+    }, channelDeprecationMsg, 'DEP0129'),
+    configurable: true,
+    enumerable: false
   });
 
   target._handleQueue = null;


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
