### PR TITLE
doc: move DEP0130 to a runtime deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2461,7 +2461,8 @@ changes:
 
 Type: Runtime
 
-Module.createRequireFromPath() is deprecated. Please use [`module.createRequire()`][] instead.
+Module.createRequireFromPath() is deprecated. Please use
+[`module.createRequire()`][] instead.
 
 <a id="DEP0131"></a>
 ### DEP0131: Legacy HTTP parser

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2451,12 +2451,15 @@ instead.
 ### DEP0130: Module.createRequireFromPath()
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/27951
+    description: Runtime deprecation.
   - version: v12.2.0
     pr-url: https://github.com/nodejs/node/pull/27405
     description: Documentation-only.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 Module.createRequireFromPath() is deprecated. Please use [`module.createRequire()`][] instead.
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -860,7 +860,12 @@ function createRequireFromPath(filename) {
   return makeRequireFunction(m);
 }
 
-Module.createRequireFromPath = createRequireFromPath;
+Module.createRequireFromPath = deprecate(
+  createRequireFromPath,
+  'Module.createRequireFromPath() is deprecated. ' +
+  'Use Module.createRequire() instead.',
+  'DEP0130'
+);
 
 const createRequireError = 'must be a file URL object, file URL string, or ' +
   'absolute path string';

--- a/test/message/async_error_sync_esm.out
+++ b/test/message/async_error_sync_esm.out
@@ -5,3 +5,4 @@ Error: test
     at async three (*fixtures*async-error.js:20:3)
     at async four (*fixtures*async-error.js:24:3)
     at async main (*message*async_error_sync_esm.mjs:7:5)
+(node:*) [DEP0130] DeprecationWarning: Module.createRequireFromPath() is deprecated. Use Module.createRequire() instead.


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
