### PR TITLE
doc: add information to revoked deprecations

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -796,7 +796,9 @@ changes:
 
 Type: Deprecation revoked
 
-The [`fs.lchown(path, uid, gid, callback)`][] API is deprecated.
+The [`fs.lchown(path, uid, gid, callback)`][] API was deprecated. The
+deprecation was revoked because the requisite supporting APIs were added in
+libuv.
 
 <a id="DEP0038"></a>
 ### DEP0038: fs.lchownSync(path, uid, gid)
@@ -816,7 +818,8 @@ changes:
 
 Type: Deprecation revoked
 
-The [`fs.lchownSync(path, uid, gid)`][] API is deprecated.
+The [`fs.lchownSync(path, uid, gid)`][] API was deprecated. The deprecation was
+revoked because the requisite supporting APIs were added in libuv.
 
 <a id="DEP0039"></a>
 ### DEP0039: require.extensions


### PR DESCRIPTION
Revoked deprecations are supposed to have some sort of information explaining why the deprecation was reversed. This commit adds some information to the two existing revoked deprecations.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
