### PR TITLE
errors: create internal connResetException

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -40,13 +40,14 @@ const { Buffer } = require('buffer');
 const { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
 const { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
 const { outHeadersKey, ondrain } = require('internal/http');
+const { connResetException, codes } = require('internal/errors');
 const {
   ERR_HTTP_HEADERS_SENT,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_HTTP_TOKEN,
   ERR_INVALID_PROTOCOL,
   ERR_UNESCAPED_CHARACTERS
-} = require('internal/errors').codes;
+} = codes;
 const { getTimerDuration } = require('internal/timers');
 const {
   DTRACE_HTTP_CLIENT_REQUEST,
@@ -337,15 +338,6 @@ function emitAbortNT() {
   this.emit('abort');
 }
 
-
-function createHangUpError() {
-  // eslint-disable-next-line no-restricted-syntax
-  const error = new Error('socket hang up');
-  error.code = 'ECONNRESET';
-  return error;
-}
-
-
 function socketCloseListener() {
   const socket = this;
   const req = socket._httpMessage;
@@ -381,7 +373,7 @@ function socketCloseListener() {
       // receive a response. The error needs to
       // fire on the request.
       req.socket._hadError = true;
-      req.emit('error', createHangUpError());
+      req.emit('error', connResetException('socket hang up'));
     }
     req.emit('close');
   }
@@ -441,7 +433,7 @@ function socketOnEnd() {
     // If we don't have a response then we know that the socket
     // ended prematurely and we need to emit an error on the request.
     req.socket._hadError = true;
-    req.emit('error', createHangUpError());
+    req.emit('error', connResetException('socket hang up'));
   }
   if (parser) {
     parser.finish();

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -44,6 +44,7 @@ const tls_wrap = internalBinding('tls_wrap');
 const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');
 const { owner_symbol } = require('internal/async_hooks').symbols;
 const { SecureContext: NativeSecureContext } = internalBinding('crypto');
+const { connResetException, codes } = require('internal/errors');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_CALLBACK,
@@ -55,7 +56,7 @@ const {
   ERR_TLS_REQUIRED_SERVER_NAME,
   ERR_TLS_SESSION_ATTACK,
   ERR_TLS_SNI_FROM_SERVER
-} = require('internal/errors').codes;
+} = codes;
 const { getOptionValue } = require('internal/options');
 const { validateString } = require('internal/validators');
 const traceTls = getOptionValue('--trace-tls');
@@ -442,7 +443,7 @@ const proxiedMethods = [
   'setSimultaneousAccepts', 'setBlocking',
 
   // PipeWrap
-  'setPendingInstances'
+  'setPendingInstances',
 ];
 
 // Proxy HandleWrap, PipeWrap and TCPWrap methods
@@ -908,9 +909,7 @@ function onSocketClose(err) {
   // Emit ECONNRESET
   if (!this._controlReleased && !this[kErrorEmitted]) {
     this[kErrorEmitted] = true;
-    // eslint-disable-next-line no-restricted-syntax
-    const connReset = new Error('socket hang up');
-    connReset.code = 'ECONNRESET';
+    const connReset = connResetException('socket hang up');
     this._tlsOptions.server.emit('tlsClientError', connReset, this);
   }
 }
@@ -1353,10 +1352,9 @@ function onConnectEnd() {
   if (!this._hadError) {
     const options = this[kConnectOptions];
     this._hadError = true;
-    // eslint-disable-next-line no-restricted-syntax
-    const error = new Error('Client network socket disconnected before ' +
-                            'secure TLS connection was established');
-    error.code = 'ECONNRESET';
+    const error = connResetException('Client network socket disconnected ' +
+                                     'before secure TLS connection was ' +
+                                     'established');
     error.path = options.path;
     error.host = options.host;
     error.port = options.port;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -554,6 +554,13 @@ function dnsException(code, syscall, hostname) {
   return ex;
 }
 
+function connResetException(msg) {
+  // eslint-disable-next-line no-restricted-syntax
+  const ex = new Error(msg);
+  ex.code = 'ECONNRESET';
+  return ex;
+}
+
 let maxStack_ErrorName;
 let maxStack_ErrorMessage;
 /**
@@ -619,6 +626,7 @@ module.exports = {
   getMessage,
   hideStackFrames,
   isStackOverflowError,
+  connResetException,
   uvException,
   uvExceptionWithHostPort,
   SystemError,


### PR DESCRIPTION
Replace various instances of errors that use code ECONNRESET with a
single centralized factory function to create the errors.

(While making changes to _tls_wrap.js, this also takes the opportunity
to make trailing commas consistent on multi-line arrays. One had a
trailing comma and one didn't. This adds a traiiling comma to the one
that didn't.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
