### PR TITLE
http: fix socketOnWrap edge cases

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -404,7 +404,7 @@ function connectionListenerInternal(server, socket) {
   socket.on('resume', onSocketResume);
   socket.on('pause', onSocketPause);
 
-  // Override on to unconsume on `data`, `readable` listeners
+  // Overrides to unconsume on `data`, `readable` listeners
   socket.on = generateSocketListenerWrapper('on');
   socket.addListener = generateSocketListenerWrapper('addListener');
   socket.prependListener = generateSocketListenerWrapper('prependListener');

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -405,8 +405,9 @@ function connectionListenerInternal(server, socket) {
   socket.on('pause', onSocketPause);
 
   // Override on to unconsume on `data`, `readable` listeners
-  socket.on = socketOnWrap;
-  socket.addListener = socket.on;
+  socket.on = generateSocketListenerWrapper('on');
+  socket.addListener = generateSocketListenerWrapper('addListener');
+  socket.prependListener = generateSocketListenerWrapper('prependListener');
 
   // We only consume the socket if it has never been consumed before.
   if (socket._handle && socket._handle.isStreamBase &&
@@ -754,19 +755,21 @@ function unconsume(parser, socket) {
   }
 }
 
-function socketOnWrap(ev, fn) {
-  const res = net.Socket.prototype.on.call(this, ev, fn);
-  if (!this.parser) {
-    this.prependListener = net.Socket.prototype.prependListener;
-    this.on = net.Socket.prototype.on;
-    this.addListener = this.on;
+function generateSocketListenerWrapper(originalFnName) {
+  return function socketListenerWrap(ev, fn) {
+    const res = net.Socket.prototype[originalFnName].call(this, ev, fn);
+    if (!this.parser) {
+      this.on = net.Socket.prototype.on;
+      this.addListener = net.Socket.prototype.addListener;
+      this.prependListener = net.Socket.prototype.prependListener;
+      return res;
+    }
+
+    if (ev === 'data' || ev === 'readable')
+      unconsume(this.parser, this);
+
     return res;
-  }
-
-  if (ev === 'data' || ev === 'readable')
-    unconsume(this.parser, this);
-
-  return res;
+  };
 }
 
 function resetHeadersTimeoutOnReqEnd() {

--- a/test/parallel/test-http-server-unconsume.js
+++ b/test/parallel/test-http-server-unconsume.js
@@ -1,34 +1,33 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 const net = require('net');
 
-let received = '';
+['on', 'addListener', 'prependListener'].forEach((testFn) => {
+  let received = '';
 
-const server = http.createServer(function(req, res) {
-  res.writeHead(200);
-  res.end();
+  const server = http.createServer(function(req, res) {
+    res.writeHead(200);
+    res.end();
 
-  req.socket.on('data', function(data) {
-    received += data;
-  });
+    req.socket[testFn]('data', function(data) {
+      received += data;
+    });
 
-  assert.strictEqual(req.socket.on, req.socket.addListener);
-  assert.strictEqual(req.socket.prependListener,
-                     net.Socket.prototype.prependListener);
+    server.close();
+  }).listen(0, function() {
+    const socket = net.connect(this.address().port, function() {
+      socket.write('PUT / HTTP/1.1\r\n\r\n');
 
-  server.close();
-}).listen(0, function() {
-  const socket = net.connect(this.address().port, function() {
-    socket.write('PUT / HTTP/1.1\r\n\r\n');
+      socket.once('data', function() {
+        socket.end('hello world');
+      });
 
-    socket.once('data', function() {
-      socket.end('hello world');
+      socket.on('end', common.mustCall(() => {
+        assert.strictEqual(received, 'hello world',
+                           `failed for socket.${testFn}`);
+      }));
     });
   });
-});
-
-process.on('exit', function() {
-  assert.strictEqual(received, 'hello world');
 });


### PR DESCRIPTION
Properly handle `prependListener` wrapping on http server socket, in addition to `on` and `addListener`. (A commit was made that was supposed to fix this last month but hadn't actually done so.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
