### PR TITLE
completed secure-pair performance test with clear connections

### DIFF
--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -6,7 +6,7 @@ const net = require('net');
 const PORT = common.PORT;
 
 const bench = common.createBenchmark(main, {
-  len: [64, 102400, 1024 * 1024 * 16],
+  len: [2, 64, 102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5],
 });

--- a/benchmark/tls/secure-pair.js
+++ b/benchmark/tls/secure-pair.js
@@ -2,8 +2,8 @@
 const common = require('../common.js');
 const bench = common.createBenchmark(main, {
   dur: [5],
-  securing: ['SecurePair', 'TLSSocket'],
-  size: [2, 1024, 1024 * 1024]
+  securing: ['SecurePair', 'TLSSocket', 'clear'],
+  size: [2, 100, 1024, 1024 * 1024]
 });
 
 const fs = require('fs');
@@ -39,7 +39,8 @@ function main({ dur, size, securing }) {
         isServer: false,
         rejectUnauthorized: false,
       };
-      const conn = tls.connect(clientOptions, () => {
+      const network = securing === 'clear' ? net : tls;
+      const conn = network.connect(clientOptions, () => {
         setTimeout(() => {
           const mbits = (received * 8) / (1024 * 1024);
           bench.end(mbits);
@@ -70,6 +71,9 @@ function main({ dur, size, securing }) {
           break;
         case 'TLSSocket':
           secureTLSSocket(conn, client);
+          break;
+        case 'clear':
+          conn.pipe(client);
           break;
         default:
           throw new Error('Invalid securing method');


### PR DESCRIPTION
A very simple patch to the existing secure-pair benchmark  in order to include clear connections in the test and expose [this issue](https://github.com/nodejs/node/issues/27970)
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
