### PR TITLE
doc: warn about relying on fs gc close behavior

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3735,7 +3735,7 @@ A `FileHandle` object is a wrapper for a numeric file descriptor.
 Instances of `FileHandle` are distinct from numeric file descriptors
 in that they provide an object oriented API for working with files.
 
-If a `FileHandle` is not explicitly closed using the
+If a `FileHandle` is not closed using the
 `filehandle.close()` method, they might automatically close the file descriptor
 and will emit a process warning, thereby helping to prevent memory leaks.
 Please do not rely on this behavior in your code because it is unreliable and

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3736,7 +3736,7 @@ Instances of `FileHandle` are distinct from numeric file descriptors
 in that they provide an object oriented API for working with files.
 
 If a `FileHandle` is not closed using the
-`filehandle.close()` method, they might automatically close the file descriptor
+`filehandle.close()` method, it might automatically close the file descriptor
 and will emit a process warning, thereby helping to prevent memory leaks.
 Please do not rely on this behavior in your code because it is unreliable and
 your file may not be closed. Instead, always explicitly close `FileHandle`s.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3733,9 +3733,14 @@ added: v10.0.0
 
 A `FileHandle` object is a wrapper for a numeric file descriptor.
 Instances of `FileHandle` are distinct from numeric file descriptors
-in that, if the `FileHandle` is not explicitly closed using the
-`filehandle.close()` method, they will automatically close the file descriptor
+in that they provide an object oriented API for working with files.
+
+If a `FileHandle` is not explicitly closed using the
+`filehandle.close()` method, they might automatically close the file descriptor
 and will emit a process warning, thereby helping to prevent memory leaks.
+Please do not rely on this behavior in your code because it is unreliable and
+your file may not be closed. Instead, always explicitly close `FileHandle`s.
+Node.js may change this behavior in the future.
 
 Instances of the `FileHandle` object are created internally by the
 `fsPromises.open()` method.


### PR DESCRIPTION
Warn about using the bahavior where file handles are closed automatically when the file is closed.

ping @jasnell @littledan


- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
