### PR TITLE
util: add node.telemetry trace event category

### DIFF
--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -29,6 +29,7 @@ The available categories are:
     measurements.
 * `node.promises.rejections` - Enables capture of trace data tracking the number
   of unhandled Promise rejections and handled-after-rejections.
+* `node.telemetry` - Enables capture of targeted Node.js API usage data.
 * `node.vm.script` - Enables capture of trace data for the `vm` module's
   `runInNewContext()`, `runInContext()`, and `runInThisContext()` methods.
 * `v8` - The [V8] events are GC, compiling, and execution related.

--- a/lib/internal/util/telemetry.js
+++ b/lib/internal/util/telemetry.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const { format } = require('internal/util/inspect');
+const {
+  isTraceCategoryEnabled,
+  trace
+} = internalBinding('trace_events');
+const kTraceTelemetryCategory = 'node,node.telemetry';
+const kTraceInstant = 'n'.charCodeAt(0);
+
+function telemetry(set, ...args) {
+  if (!isTraceCategoryEnabled(kTraceTelemetryCategory))
+    return;
+  const msg = format(...args);
+  trace(kTraceInstant,
+        kTraceTelemetryCategory,
+        set.toUpperCase(), 0,
+        msg);
+}
+
+module.exports = {
+  telemetry,
+};

--- a/node.gyp
+++ b/node.gyp
@@ -187,6 +187,7 @@
       'lib/internal/util/debuglog.js',
       'lib/internal/util/inspect.js',
       'lib/internal/util/inspector.js',
+      'lib/internal/util/telemetry.js',
       'lib/internal/util/types.js',
       'lib/internal/http2/core.js',
       'lib/internal/http2/compat.js',

--- a/test/parallel/test-trace-telemetry.js
+++ b/test/parallel/test-trace-telemetry.js
@@ -1,0 +1,31 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const CODE =
+  'const { telemetry } = require(\'internal/util/telemetry\');' +
+  'telemetry(\'FOO\', \'%s %s %s\', 1, 2, 3);';
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const FILE_NAME = path.join(tmpdir.path, 'node_trace.1.log');
+
+const proc = cp.spawn(process.execPath,
+                      [ '--trace-event-categories', 'node.telemetry',
+                        '--expose-internals',
+                        '-e', CODE ],
+                      { cwd: tmpdir.path });
+proc.once('exit', common.mustCall(() => {
+  assert(fs.existsSync(FILE_NAME));
+  fs.readFile(FILE_NAME, common.mustCall((err, data) => {
+    const traces = JSON.parse(data.toString()).traceEvents
+      .filter((trace) => trace.cat === 'node,node.telemetry');
+    assert.strictEqual(traces.length, 1);
+    const trace = traces[0];
+    assert.strictEqual(trace.name, 'FOO');
+    assert.strictEqual(trace.args.data, '1 2 3');
+  }));
+}));


### PR DESCRIPTION
At the Collaborator Summit, during the session discussing deprecations,
the concept of adding a mechanism to optionally collect targeted
telemetry data was discussed. This PR introduces one possible way
of doing so while giving users complete opt-in control.

This adds a new `node.telemetry` trace event category and a new
internal `telemetry()` function that we can selectively place at
key locations within the code. When the `node.telemetry` trace
category is enabled, the `telemetry()` function will emit a
trace event, the key use of which shall just be to determine
how many times a particular code path is used.

For instance,

```js
const { telemetry } = require('util/internal/telemetry');

function someCoreFunction(arg) {
  telemetry('SOME_TRACE_ID', `Path used with arg: ${arg}`);
}
```

By running node.js with the `--trace-event-categories=node.telemetry`
flag, the trace event log will include the telemetry entries that
can then be optionally shared with the Node.js project.

The trace event is intentionally very simple.

/cc @addaleax @BridgeAR @Fishrock123 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
