### PR TITLE
src: export v8.GetHeapCodeAndMetadataStatistics()

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -166,6 +166,28 @@ being non-zero indicates a potential memory leak.
 }
 ```
 
+## v8.getHeapCodeStatistics()
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Object}
+
+Returns an object with the following properties:
+
+* `code_and_metadata_size` {number}
+* `bytecode_and_metadata_size` {number}
+* `external_script_source_size` {number}
+
+<!-- eslint-skip -->
+```js
+{
+  code_and_metadata_size: 212208,
+  bytecode_and_metadata_size: 161368,
+  external_script_source_size: 1410794
+}
+```
+
 ## v8.setFlagsFromString(flags)
 <!-- YAML
 added: v1.0.0

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -91,10 +91,12 @@ const {
   setFlagsFromString: _setFlagsFromString,
   heapStatisticsArrayBuffer,
   heapSpaceStatisticsArrayBuffer,
+  heapCodeStatisticsArrayBuffer,
   updateHeapStatisticsArrayBuffer,
   updateHeapSpaceStatisticsArrayBuffer,
+  updateHeapCodeStatisticsArrayBuffer,
 
-  // Properties for heap and heap space statistics buffer extraction.
+  // Properties for heap statistics buffer extraction.
   kTotalHeapSizeIndex,
   kTotalHeapSizeExecutableIndex,
   kTotalPhysicalSizeIndex,
@@ -104,14 +106,21 @@ const {
   kDoesZapGarbageIndex,
   kMallocedMemoryIndex,
   kPeakMallocedMemoryIndex,
+  kNumberOfNativeContextsIndex,
+  kNumberOfDetachedContextsIndex,
+
+  // Properties for heap spaces statistics buffer extraction.
   kHeapSpaces,
   kHeapSpaceStatisticsPropertiesCount,
   kSpaceSizeIndex,
   kSpaceUsedSizeIndex,
   kSpaceAvailableSizeIndex,
   kPhysicalSpaceSizeIndex,
-  kNumberOfNativeContextsIndex,
-  kNumberOfDetachedContextsIndex
+
+  // Properties for heap code statistics buffer extraction.
+  kCodeAndMetadataSizeIndex,
+  kBytecodeAndMetadataSizeIndex,
+  kExternalScriptSourceSizeIndex
 } = internalBinding('v8');
 
 const kNumberOfHeapSpaces = kHeapSpaces.length;
@@ -121,6 +130,9 @@ const heapStatisticsBuffer =
 
 const heapSpaceStatisticsBuffer =
     new Float64Array(heapSpaceStatisticsArrayBuffer);
+
+const heapCodeStatisticsBuffer =
+    new Float64Array(heapCodeStatisticsArrayBuffer);
 
 function setFlagsFromString(flags) {
   validateString(flags, 'flags');
@@ -164,6 +176,17 @@ function getHeapSpaceStatistics() {
   }
 
   return heapSpaceStatistics;
+}
+
+function getHeapCodeStatistics() {
+  const buffer = heapCodeStatisticsBuffer;
+
+  updateHeapCodeStatisticsArrayBuffer();
+  return {
+    'code_and_metadata_size': buffer[kCodeAndMetadataSizeIndex],
+    'bytecode_and_metadata_size': buffer[kBytecodeAndMetadataSizeIndex],
+    'external_script_source_size': buffer[kExternalScriptSourceSizeIndex]
+  };
 }
 
 /* V8 serialization API */
@@ -272,6 +295,7 @@ module.exports = {
   getHeapSnapshot,
   getHeapStatistics,
   getHeapSpaceStatistics,
+  getHeapCodeStatistics,
   setFlagsFromString,
   Serializer,
   Deserializer,

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -569,6 +569,16 @@ inline void Environment::set_heap_space_statistics_buffer(double* pointer) {
   heap_space_statistics_buffer_ = pointer;
 }
 
+inline double* Environment::heap_code_statistics_buffer() const {
+  CHECK_NOT_NULL(heap_code_statistics_buffer_);
+  return heap_code_statistics_buffer_;
+}
+
+inline void Environment::set_heap_code_statistics_buffer(double* pointer) {
+  CHECK_NULL(heap_code_statistics_buffer_);  // Should be set only once.
+  heap_code_statistics_buffer_ = pointer;
+}
+
 inline char* Environment::http_parser_buffer() const {
   return http_parser_buffer_;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -398,6 +398,7 @@ Environment::~Environment() {
   delete[] heap_statistics_buffer_;
   delete[] heap_space_statistics_buffer_;
   delete[] http_parser_buffer_;
+  delete[] heap_code_statistics_buffer_;
 
   TRACE_EVENT_NESTABLE_ASYNC_END0(
     TRACING_CATEGORY_NODE1(environment), "Environment", this);

--- a/src/env.h
+++ b/src/env.h
@@ -963,6 +963,9 @@ class Environment : public MemoryRetainer {
   inline double* heap_space_statistics_buffer() const;
   inline void set_heap_space_statistics_buffer(double* pointer);
 
+  inline double* heap_code_statistics_buffer() const;
+  inline void set_heap_code_statistics_buffer(double* pointer);
+
   inline char* http_parser_buffer() const;
   inline void set_http_parser_buffer(char* buffer);
   inline bool http_parser_buffer_in_use() const;
@@ -1284,6 +1287,7 @@ class Environment : public MemoryRetainer {
 
   double* heap_statistics_buffer_ = nullptr;
   double* heap_space_statistics_buffer_ = nullptr;
+  double* heap_code_statistics_buffer_ = nullptr;
 
   char* http_parser_buffer_ = nullptr;
   bool http_parser_buffer_in_use_ = false;

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -22,6 +22,18 @@ keys.forEach(function(key) {
 });
 
 
+const heapCodeStatistics = v8.getHeapCodeStatistics();
+const heapCodeStatisticsKeys = [
+  'bytecode_and_metadata_size',
+  'code_and_metadata_size',
+  'external_script_source_size'];
+assert.deepStrictEqual(Object.keys(heapCodeStatistics).sort(),
+                       heapCodeStatisticsKeys);
+heapCodeStatisticsKeys.forEach(function(key) {
+  assert.strictEqual(typeof heapCodeStatistics[key], 'number');
+});
+
+
 const expectedHeapSpaces = [
   'code_large_object_space',
   'code_space',


### PR DESCRIPTION
Export statistic provided by V8 through HeapCodeStatistics class and
and GetHeapCodeAndMetadataStatistics function to v8 Node.js module

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x ] tests and/or benchmarks are included
- [x ] documentation is changed or added
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
