### PR TITLE
tools: fix js2c regression

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -1094,6 +1094,7 @@
         'test/cctest/test_node_postmortem_metadata.cc',
         'test/cctest/test_environment.cc',
         'test/cctest/test_linked_binding.cc',
+        'test/cctest/test_per_process.cc',
         'test/cctest/test_platform.cc',
         'test/cctest/test_report_util.cc',
         'test/cctest/test_traced_value.cc',

--- a/src/node_native_module.h
+++ b/src/node_native_module.h
@@ -11,6 +11,9 @@
 #include "node_union_bytes.h"
 #include "v8.h"
 
+// Forward declare test fixture for `friend` declaration.
+class PerProcessTest;
+
 namespace node {
 namespace native_module {
 
@@ -82,6 +85,8 @@ class NativeModuleLoader {
 
   // Used to synchronize access to the code cache map
   Mutex code_cache_mutex_;
+
+  friend class ::PerProcessTest;
 };
 }  // namespace native_module
 

--- a/test/cctest/test_per_process.cc
+++ b/test/cctest/test_per_process.cc
@@ -1,0 +1,34 @@
+#include "node_native_module.h"
+
+#include "gtest/gtest.h"
+#include "node_test_fixture.h"
+
+#include <string>
+
+
+using node::native_module::NativeModuleLoader;
+using node::native_module::NativeModuleRecordMap;
+
+class PerProcessTest : public ::testing::Test {
+ protected:
+  static const NativeModuleRecordMap get_sources_for_test() {
+    return NativeModuleLoader::instance_.source_;
+  }
+};
+
+namespace {
+
+TEST_F(PerProcessTest, EmbeddedSources) {
+  const auto& sources = PerProcessTest::get_sources_for_test();
+  ASSERT_TRUE(
+    std::any_of(sources.cbegin(), sources.cend(),
+                [](auto p){ return p.second.is_one_byte(); }))
+      << "NativeModuleLoader::source_ should have some 8bit items";
+
+  ASSERT_TRUE(
+    std::any_of(sources.cbegin(), sources.cend(),
+                [](auto p){ return !p.second.is_one_byte(); }))
+      << "NativeModuleLoader::source_ should have some 16bit items";
+}
+
+}  // end namespace

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -227,7 +227,10 @@ def GetDefinition(var, source, step=30):
     template = TWO_BYTE_STRING
     # Treat non-ASCII as UTF-8 and encode as UTF-16 Little Endian.
     encoded_source = bytearray(source, 'utf-16le')
-    code_points = [encoded_source[i] + (encoded_source[i + 1] * 256) for i in range(0, len(encoded_source), 2)]
+    code_points = [
+      encoded_source[i] + (encoded_source[i + 1] * 256)
+      for i in range(0, len(encoded_source), 2)
+    ]
 
   # For easier debugging, align to the common 3 char for code-points.
   elements_s = ['%3s' % x for x in code_points]


### PR DESCRIPTION
Fix a regression that was introduced in #25518 and causes the binary to bloat by ~10%.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
