### PR TITLE
http2: respect inspect() depth

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1069,6 +1069,9 @@ class Http2Session extends EventEmitter {
   }
 
   [kInspect](depth, opts) {
+    if (typeof depth === 'number' && depth < 0)
+      return this;
+
     const obj = {
       type: this[kType],
       closed: this.closed,
@@ -1645,6 +1648,9 @@ class Http2Stream extends Duplex {
   }
 
   [kInspect](depth, opts) {
+    if (typeof depth === 'number' && depth < 0)
+      return this;
+
     const obj = {
       id: this[kID] || '<pending>',
       closed: this.closed,


### PR DESCRIPTION
This commit causes `Http2Stream` and `Http2Session` to account for `inspect()` depth.

Fixes: https://github.com/nodejs/node/issues/27976

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
