### PR TITLE
[v10.x] async_hooks: avoid double-destroy HTTPParser

### DIFF
--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -108,9 +108,11 @@ class AsyncWrap : public BaseObject {
   AsyncWrap(Environment* env,
             v8::Local<v8::Object> object,
             ProviderType provider,
-            double execution_async_id = -1);
+            double execution_async_id = kInvalidAsyncId);
 
   virtual ~AsyncWrap();
+
+  static constexpr double kInvalidAsyncId = -1;
 
   static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
       Environment* env);
@@ -137,6 +139,8 @@ class AsyncWrap : public BaseObject {
   static void EmitAfter(Environment* env, double async_id);
   static void EmitPromiseResolve(Environment* env, double async_id);
 
+  void EmitDestroy();
+
   void EmitTraceEventBefore();
   static void EmitTraceEventAfter(ProviderType type, double async_id);
   void EmitTraceEventDestroy();
@@ -149,7 +153,8 @@ class AsyncWrap : public BaseObject {
 
   inline double get_trigger_async_id() const;
 
-  void AsyncReset(double execution_async_id = -1, bool silent = false);
+  void AsyncReset(double execution_async_id = kInvalidAsyncId,
+                  bool silent = false);
 
   // Only call these within a valid HandleScope.
   v8::MaybeLocal<v8::Value> MakeCallback(const v8::Local<v8::Function> cb,
@@ -202,7 +207,7 @@ class AsyncWrap : public BaseObject {
   inline AsyncWrap();
   const ProviderType provider_type_;
   // Because the values may be Reset(), cannot be made const.
-  double async_id_ = -1;
+  double async_id_ = kInvalidAsyncId;
   double trigger_async_id_;
 };
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -383,14 +383,13 @@ class Parser : public AsyncWrap, public StreamListener {
 
 
   static void Free(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args);
     Parser* parser;
     ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
 
     // Since the Parser destructor isn't going to run the destroy() callbacks
     // it needs to be triggered manually.
     parser->EmitTraceEventDestroy();
-    parser->EmitDestroy(env, parser->get_async_id());
+    parser->EmitDestroy();
   }
 
 

--- a/test/parallel/test-async-hooks-http-parser-nodouble-destroy.js
+++ b/test/parallel/test-async-hooks-http-parser-nodouble-destroy.js
@@ -1,0 +1,53 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { createHook } = require('async_hooks');
+const http = require('http');
+
+// Regression test for https://github.com/nodejs/node/issues/19859.
+// Checks that matching destroys are emitted when creating new/reusing old http
+// parser instances.
+
+const httpParsers = [];
+const dupDestroys = [];
+const destroyed = [];
+
+createHook({
+  init(asyncId, type, triggerAsyncId, resource) {
+    if (type === 'HTTPPARSER') {
+      httpParsers.push(asyncId);
+    }
+  },
+  destroy(asyncId) {
+    if (destroyed.includes(asyncId)) {
+      dupDestroys.push(asyncId);
+    } else {
+      destroyed.push(asyncId);
+    }
+  }
+}).enable();
+
+const server = http.createServer((req, res) => {
+  res.end();
+});
+
+server.listen(common.mustCall(() => {
+  http.get({ port: server.address().port }, common.mustCall(() => {
+    server.close(common.mustCall(() => {
+      server.listen(common.mustCall(() => {
+        http.get({ port: server.address().port }, common.mustCall(() => {
+          server.close(common.mustCall(() => {
+            setTimeout(common.mustCall(verify), 200);
+          }));
+        }));
+      }));
+    }));
+  }));
+}));
+
+function verify() {
+  assert.strictEqual(httpParsers.length, 4);
+
+  assert.strictEqual(dupDestroys.length, 0);
+  httpParsers.forEach((id) => assert.ok(destroyed.includes(id)));
+}


### PR DESCRIPTION
Avoid that destroy hook is invoked twice - once via `Parser::Free()` and once again via `Parser::Reinitialize()` by clearing the async_id in `EmitDestroy()`.

Partial backport of https://github.com/nodejs/node/pull/27477, a full backport would require also https://github.com/nodejs/node/pull/25094 which has a dont-land-on-v10.x label on it.

Fixes: https://github.com/nodejs/node/issues/26961

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
