### PR TITLE
 http2: Prevent unnecessary listeners from being registered

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -160,6 +160,7 @@ const kLocalSettings = Symbol('local-settings');
 const kOptions = Symbol('options');
 const kOwner = owner_symbol;
 const kOrigin = Symbol('origin');
+const kPendingRequestCalls = Symbol('pending-request-calls');
 const kProceed = Symbol('proceed');
 const kProtocol = Symbol('protocol');
 const kRemoteSettings = Symbol('remote-settings');
@@ -1479,13 +1480,13 @@ class ClientHttp2Session extends Http2Session {
 
     const onConnect = requestOnConnect.bind(stream, headersList, options);
     if (this.connecting) {
-      if (this._pendingRequestCalls) {
-        this._pendingRequestCalls.push(onConnect);
+      if (this[kPendingRequestCalls]) {
+        this[kPendingRequestCalls].push(onConnect);
       } else {
-        this._pendingRequestCalls = [onConnect];
+        this[kPendingRequestCalls] = [onConnect];
         this.once('connect', () => {
-          this._pendingRequestCalls.forEach(f => f());
-          delete this._pendingRequestCalls;
+          this[kPendingRequestCalls].forEach(f => f());
+          delete this[kPendingRequestCalls];
         });
       }
     } else {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1485,7 +1485,7 @@ class ClientHttp2Session extends Http2Session {
       } else {
         this[kPendingRequestCalls] = [onConnect];
         this.once('connect', () => {
-          this[kPendingRequestCalls].forEach(f => f());
+          this[kPendingRequestCalls].forEach((f) => f());
           delete this[kPendingRequestCalls];
         });
       }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1479,7 +1479,15 @@ class ClientHttp2Session extends Http2Session {
 
     const onConnect = requestOnConnect.bind(stream, headersList, options);
     if (this.connecting) {
-      this.once('connect', onConnect);
+      if (this._pendingRequestCalls) {
+        this._pendingRequestCalls.push(onConnect);
+      } else {
+        this._pendingRequestCalls = [onConnect];
+        this.once('connect', () => {
+          this._pendingRequestCalls.forEach(f => f());
+          delete this._pendingRequestCalls;
+        });
+      }
     } else {
       onConnect();
     }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -160,7 +160,7 @@ const kLocalSettings = Symbol('local-settings');
 const kOptions = Symbol('options');
 const kOwner = owner_symbol;
 const kOrigin = Symbol('origin');
-const kPendingRequestCalls = Symbol('pending-request-calls');
+const kPendingRequestCalls = Symbol('kPendingRequestCalls');
 const kProceed = Symbol('proceed');
 const kProtocol = Symbol('protocol');
 const kRemoteSettings = Symbol('remote-settings');
@@ -1411,6 +1411,7 @@ class ServerHttp2Session extends Http2Session {
 class ClientHttp2Session extends Http2Session {
   constructor(options, socket) {
     super(NGHTTP2_SESSION_CLIENT, options, socket);
+    this[kPendingRequestCalls] = null;
   }
 
   // Submits a new HTTP2 request to the connected peer. Returns the
@@ -1480,13 +1481,13 @@ class ClientHttp2Session extends Http2Session {
 
     const onConnect = requestOnConnect.bind(stream, headersList, options);
     if (this.connecting) {
-      if (this[kPendingRequestCalls]) {
+      if (this[kPendingRequestCalls] !== null) {
         this[kPendingRequestCalls].push(onConnect);
       } else {
         this[kPendingRequestCalls] = [onConnect];
         this.once('connect', () => {
           this[kPendingRequestCalls].forEach((f) => f());
-          delete this[kPendingRequestCalls];
+          this[kPendingRequestCalls] = null;
         });
       }
     } else {

--- a/test/parallel/test-http2-client-request-listeners-warning.js
+++ b/test/parallel/test-http2-client-request-listeners-warning.js
@@ -12,7 +12,7 @@ const EventEmitter = require('events');
 process.on('warning', common.mustNotCall('A warning was emitted'));
 
 const server = http2.createServer();
-server.on('stream', stream => {
+server.on('stream', (stream) => {
   stream.respond();
   stream.end();
 });
@@ -23,7 +23,7 @@ server.listen(common.mustCall(() => {
   function request() {
     return new Promise((resolve, reject) => {
       const stream = client.request();
-      stream.on('error', reject)
+      stream.on('error', reject);
       stream.on('response', resolve);
       stream.end();
     });

--- a/test/parallel/test-http2-client-request-listeners-warning.js
+++ b/test/parallel/test-http2-client-request-listeners-warning.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+const EventEmitter = require('events');
+
+// This test ensures that a MaxListenersExceededWarning isn't emitted if
+// more than EventEmitter.defaultMaxListeners requests are started on a
+// ClientHttp2Session before it has finished connecting.
+
+process.on('warning', common.mustNotCall('A warning was emitted'));
+
+const server = http2.createServer();
+server.on('stream', stream => {
+  stream.respond();
+  stream.end();
+});
+
+server.listen(common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  function request() {
+    return new Promise((resolve, reject) => {
+      const stream = client.request();
+      stream.on('error', reject)
+      stream.on('response', resolve);
+      stream.end();
+    });
+  }
+
+  const requests = [];
+  for (let i = 0; i < EventEmitter.defaultMaxListeners + 1; i++) {
+    requests.push(request());
+  }
+
+  Promise.all(requests).then(common.mustCall()).finally(common.mustCall(() => {
+    server.close();
+    client.close();
+  }));
+}));


### PR DESCRIPTION
When multiple requests are started on a client HTTP/2 session while it it still connecting, a warning might get emitted: `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 connect listeners added to Http2Session`

This PR modifies the offending code so that only one event listener is registered, no matter how many requests are started. A test for the fix is included.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
