### PR TITLE
stream: add bytesRead to Readable

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -474,6 +474,15 @@ process.nextTick(() => {
 
 See also: [`writable.cork()`][].
 
+##### writable.bytesWritten
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+Number of bytes written through [`writable.write()`], or `null` in `objectMode`.
+
 ##### writable.writable
 <!-- YAML
 added: v11.4.0
@@ -1102,6 +1111,15 @@ added: v12.3.0
 -->
 
 Getter for the property `objectMode` of a given `Readable` stream.
+
+##### readable.bytesRead
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+Number of bytes read, or `null` in `objectMode`.
 
 ##### readable.resume()
 <!-- YAML

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -103,6 +103,7 @@ function ReadableState(options, stream, isDuplex) {
   this.ended = false;
   this.endEmitted = false;
   this.reading = false;
+  this.bytesRead = this.objectMode ? null : 0;
 
   // A flag to be able to tell if the event 'readable'/'data' is emitted
   // immediately, or on a later tick.  We set this to true at first, because
@@ -171,6 +172,17 @@ function Readable(options) {
 
   Stream.call(this);
 }
+
+Object.defineProperty(Readable.prototype, 'bytesRead', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get() {
+    return this._readableState && this._readableState.bytesRead;
+  }
+});
+
 
 Object.defineProperty(Readable.prototype, 'destroyed', {
   // Making it explicit this property is not enumerable
@@ -287,6 +299,9 @@ function readableAddChunk(stream, chunk, encoding, addToFront, skipChunkCheck) {
 function addChunk(stream, state, chunk, addToFront) {
   if (state.flowing && state.length === 0 && !state.sync) {
     state.awaitDrain = 0;
+    if (!state.objectMode) {
+      state.bytesRead += chunk.length;
+    }
     stream.emit('data', chunk);
   } else {
     // Update the buffer info.
@@ -500,8 +515,12 @@ Readable.prototype.read = function(n) {
       endReadable(this);
   }
 
-  if (ret !== null)
+  if (ret !== null) {
+    if (!state.objectMode) {
+      state.bytesRead += ret.length;
+    }
     this.emit('data', ret);
+  }
 
   return ret;
 };

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -92,6 +92,8 @@ function WritableState(options, stream, isDuplex) {
   // Has it been destroyed
   this.destroyed = false;
 
+  this.bytesWritten = this.objectMode ? null : 0;
+
   // Should we decode strings into buffers before passing to _write?
   // this is here so that some node-core streams can optimize string
   // handling at a lower level.
@@ -342,6 +344,16 @@ Object.defineProperty(Writable.prototype, 'writableBuffer', {
   }
 });
 
+Object.defineProperty(Writable.prototype, 'bytesWritten', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get() {
+    return this._writableState && this._writableState.bytesWritten;
+  }
+});
+
 function decodeChunk(state, chunk, encoding) {
   if (!state.objectMode &&
       state.decodeStrings !== false &&
@@ -376,6 +388,10 @@ function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
   const len = state.objectMode ? 1 : chunk.length;
 
   state.length += len;
+
+  if (!state.objectMode) {
+    state.bytesWritten += len;
+  }
 
   const ret = state.length < state.highWaterMark;
   // We must ensure that previous needDrain will not be reset to false.


### PR DESCRIPTION
It's a somewhat common scenario to be able to keep track of number of bytes that has been read from a stream. The only way to achieve this in user land will cause either complexity or performance overhead.

Adding it into core would be somewhat untrivial both in terms of complexity and performance.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
