### PR TITLE
net: make writeAfterFIN() return false

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -410,6 +410,8 @@ function writeAfterFIN(chunk, encoding, cb) {
   if (typeof cb === 'function') {
     defaultTriggerAsyncIdScope(this[async_id_symbol], process.nextTick, cb, er);
   }
+
+  return false;
 }
 
 Socket.prototype.setTimeout = setStreamTimeout;


### PR DESCRIPTION
If `false` is not returned a readable stream piped into the socket
might continue reading indefinitely until the process goes out of
memory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
