### PR TITLE
http: bytesWritten for http/1 and compat

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -892,8 +892,10 @@ Fires immediately after `'open'`.
 added: v0.4.7
 -->
 
-The number of bytes written so far. Does not include data that is still queued
-for writing.
+{integer}
+
+Integer value that indicates how many bytes has been written to
+the response body (not the amount flushed).
 
 ### writeStream.path
 <!-- YAML

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1166,6 +1166,16 @@ response.end();
 Attempting to set a header field name or value that contains invalid characters
 will result in a [`TypeError`][] being thrown.
 
+### response.bytesWritten
+<!-- YAML
+added: CHANGEME
+-->
+
+* {integer}
+
+Integer value that indicates how many bytes has been written to
+the response body (not the amount flushed).
+
 ### response.connection
 <!-- YAML
 added: v0.3.0

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2977,6 +2977,16 @@ message) to the response.
 Attempting to set a header field name or value that contains invalid characters
 will result in a [`TypeError`][] being thrown.
 
+#### response.bytesWritten
+<!-- YAML
+added: CHANGEME
+-->
+
+* {integer}
+
+Integer value that indicates how many bytes has been written to
+the response body (not the amount flushed).
+
 #### response.connection
 <!-- YAML
 added: v8.4.0

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -348,6 +348,16 @@ writer.on('unpipe', (src) => {
 reader.pipe(writer);
 reader.unpipe(writer);
 ```
+##### writable.bytesWritten
+<!-- YAML
+added: CHANGEME
+-->
+
+* {integer}
+
+Integer value that indicates how many bytes has been written to
+the stream (not the amount flushed). In `objectMode` this
+value represents the number of objects written.
 
 ##### writable.cork()
 <!-- YAML

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -83,6 +83,8 @@ function OutgoingMessage() {
   // TCP socket and HTTP Parser and thus handle the backpressure.
   this.outputSize = 0;
 
+  this.bytesWritten = 0;
+
   this.writable = true;
 
   this._last = false;
@@ -646,8 +648,11 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
     msg._send(chunk, encoding, null);
     ret = msg._send(crlf_buf, null, callback);
   } else {
+    len = chunk.length;
     ret = msg._send(chunk, encoding, callback);
   }
+
+  msg.bytesWritten += len;
 
   debug('write ret = ' + ret);
   return ret;

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -118,6 +118,16 @@ Object.defineProperty(Duplex.prototype, 'writableEnded', {
   }
 });
 
+Object.defineProperty(Duplex.prototype, 'bytesWritten', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get() {
+    return this._writableState ? this._writableState.written : null;
+  }
+});
+
 // The no-half-open enforcer
 function onend() {
   // If the writable side ended, then we're ok.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -132,6 +132,9 @@ function WritableState(options, stream, isDuplex) {
   // The callback that the user supplies to write(chunk,encoding,cb)
   this.writecb = null;
 
+  // The amount that has been written.
+  this.written = 0;
+
   // The amount that is being written when _write is called.
   this.writelen = 0;
 
@@ -373,6 +376,16 @@ Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
   }
 });
 
+Object.defineProperty(Writable.prototype, 'bytesWritten', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get: function() {
+    return this._writableState.written;
+  }
+});
+
 // If we're already writing something, then just put this
 // in the queue, and wait our turn.  Otherwise, call _write
 // If we return false, then we need a drain event, so set that flag.
@@ -388,6 +401,7 @@ function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
   const len = state.objectMode ? 1 : chunk.length;
 
   state.length += len;
+  state.written += len;
 
   const ret = state.length < state.highWaterMark;
   // We must ensure that previous needDrain will not be reset to false.

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -250,7 +250,6 @@ function WriteStream(path, options) {
   this.start = options.start;
   this.autoClose = options.autoClose === undefined ? true : !!options.autoClose;
   this.pos = undefined;
-  this.bytesWritten = 0;
   this.closed = false;
 
   if (this.start !== undefined) {
@@ -312,7 +311,6 @@ WriteStream.prototype._write = function(data, encoding, cb) {
       }
       return cb(er);
     }
-    this.bytesWritten += bytes;
     cb();
   });
 
@@ -345,7 +343,6 @@ WriteStream.prototype._writev = function(data, cb) {
       self.destroy();
       return cb(er);
     }
-    self.bytesWritten += bytes;
     cb();
   });
 

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -454,6 +454,11 @@ class Http2ServerResponse extends Stream {
     return this.headersSent;
   }
 
+  get bytesWritten () {
+    const stream = this[kStream];
+    return stream.bytesWritten;
+  }
+
   get writableEnded() {
     const state = this[kState];
     return state.ending;

--- a/test/parallel/test-http-outgoing-bytes-written.js
+++ b/test/parallel/test-http-outgoing-bytes-written.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(common.mustCall(function(req, res) {
+  res.setHeader('test-header', 'header');
+  assert.strictEqual(res.bytesWritten, 0);
+  res.write('hello');
+  assert.strictEqual(res.bytesWritten, 5);
+  res.end('world');
+  assert.strictEqual(res.bytesWritten, 10);
+  server.close();
+}));
+
+server.listen(0);
+
+server.on('listening', common.mustCall(function() {
+  const clientRequest = http.request({
+    port: server.address().port,
+    method: 'GET',
+    path: '/'
+  });
+  clientRequest.end();
+}));

--- a/test/parallel/test-http2-compat-serverresponse-bytes-written.js
+++ b/test/parallel/test-http2-compat-serverresponse-bytes-written.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+const server = h2.createServer(common.mustCall(function(req, res) {
+  res.setHeader('test-header', 'header');
+  assert.strictEqual(res.bytesWritten, 0);
+  res.write('hello');
+  assert.strictEqual(res.bytesWritten, 5);
+  res.end('world');
+  assert.strictEqual(res.bytesWritten, 10);
+  server.close();
+}));
+
+server.listen(0);
+
+server.on('listening', common.mustCall(function() {
+  const url = `http://localhost:${server.address().port}`;
+  const client = h2.connect(url, common.mustCall(() => {
+    const request = client.request();
+    request.end();
+  }));
+}));

--- a/test/parallel/test-stream-writable-bytes-written.js
+++ b/test/parallel/test-stream-writable-bytes-written.js
@@ -1,0 +1,31 @@
+'use strict';
+const common = require('../common');
+const { Writable } = require('stream');
+const assert = require('assert');
+
+{
+  const writable = new Writable({
+    write: (buf, enc, cb) => {
+      cb();
+    }
+  });
+  assert.strictEqual(writable.bytesWritten, 0);
+  writable.write('hello');
+  assert.strictEqual(writable.bytesWritten, 5);
+  writable.end('world');
+  assert.strictEqual(writable.bytesWritten, 10);
+}
+
+{
+  const writable = new Writable({
+    objectMode: true,
+    write: (buf, enc, cb) => {
+      cb();
+    }
+  });
+  assert.strictEqual(writable.bytesWritten, 0);
+  writable.write({});
+  assert.strictEqual(writable.bytesWritten, 1);
+  writable.end({});
+  assert.strictEqual(writable.bytesWritten, 2);
+}


### PR DESCRIPTION
Adds `bytesWritten` helper to http/1 & compat response.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
