### PR TITLE
process: disallow some uses of Object.defineProperty() on process.env

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1921,7 +1921,7 @@ specifier.
 
 <a id="ERR_INVALID_OBJECT_DEFINE_PROPERTY"></a>
 
-### ERR\_INVALID\_OBJECT\_DEFINE\_PROPERTY
+### `ERR_INVALID_OBJECT_DEFINE_PROPERTY`
 
 An error occurred while setting an invalid attribute on the property of
 an object.

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1920,7 +1920,8 @@ The imported module string is an invalid URL, package name, or package subpath
 specifier.
 
 <a id="ERR_INVALID_OBJECT_DEFINE_PROPERTY"></a>
-### ERR_INVALID_OBJECT_DEFINE_PROPERTY
+
+### ERR\_INVALID\_OBJECT\_DEFINE\_PROPERTY
 
 An error occurred while setting an invalid attribute on the property of
 an object.

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1919,6 +1919,12 @@ valid.
 The imported module string is an invalid URL, package name, or package subpath
 specifier.
 
+<a id="ERR_INVALID_OBJECT_DEFINE_PROPERTY"></a>
+### ERR_INVALID_OBJECT_DEFINE_PROPERTY
+
+An error occurred while setting an invalid attribute on the property of
+an object.
+
 <a id="ERR_INVALID_PACKAGE_CONFIG"></a>
 
 ### `ERR_INVALID_PACKAGE_CONFIG`

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -408,12 +408,16 @@ static void EnvDefiner(Local<Name> property,
       THROW_ERR_INVALID_OBJECT_DEFINE_PROPERTY(env,
                                                "'process.env' only accepts a "
                                                "configurable, writable,"
-                                               " and enumerable data descriptor");
-    } else if (!desc.configurable() || !desc.enumerable() || !desc.writable()) {
+                                               " and enumerable "
+                                               "data descriptor");
+    } else if (!desc.configurable() ||
+               !desc.enumerable() ||
+               !desc.writable()) {
       THROW_ERR_INVALID_OBJECT_DEFINE_PROPERTY(env,
                                                "'process.env' only accepts a "
                                                "configurable, writable,"
-                                               " and enumerable data descriptor");
+                                               " and enumerable "
+                                               "data descriptor");
     } else {
       return EnvSetter(property, desc.value(), info);
     }
@@ -421,12 +425,14 @@ static void EnvDefiner(Local<Name> property,
     // we don't accept a getter/setter in 'process.env'
     THROW_ERR_INVALID_OBJECT_DEFINE_PROPERTY(env,
                              "'process.env' does not accept an"
-                                             "accessor(getter/setter) descriptor");
+                                             "accessor(getter/setter)"
+                                             " descriptor");
   } else {
     THROW_ERR_INVALID_OBJECT_DEFINE_PROPERTY(env,
                                              "'process.env' only accepts a "
                                              "configurable, writable,"
-                                             " and enumerable data descriptor");
+                                             " and enumerable "
+                                             "data descriptor");
   }
 }
 

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -64,6 +64,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_INVALID_ARG_VALUE, TypeError)                                          \
   V(ERR_OSSL_EVP_INVALID_DIGEST, Error)                                        \
   V(ERR_INVALID_ARG_TYPE, TypeError)                                           \
+  V(ERR_INVALID_OBJECT_DEFINE_PROPERTY, TypeError)                             \
   V(ERR_INVALID_MODULE, Error)                                                 \
   V(ERR_INVALID_THIS, TypeError)                                               \
   V(ERR_INVALID_TRANSFER_OBJECT, TypeError)                                    \

--- a/test/parallel/test-process-env-delete.js
+++ b/test/parallel/test-process-env-delete.js
@@ -1,0 +1,13 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+process.env.foo = 'foo';
+assert.strictEqual(process.env.foo, 'foo');
+process.env.foo = undefined;
+assert.strictEqual(process.env.foo, 'undefined');
+
+process.env.foo = 'foo';
+assert.strictEqual(process.env.foo, 'foo');
+delete process.env.foo;
+assert.strictEqual(process.env.foo, undefined);

--- a/test/parallel/test-process-env-ignore-getter-setter.js
+++ b/test/parallel/test-process-env-ignore-getter-setter.js
@@ -1,0 +1,65 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+assert.throws(
+  () => {
+    Object.defineProperty(process.env, 'foo', {
+      value: 'foo1'
+    });
+  },
+  {
+    code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
+    name: 'TypeError',
+    message: 'Must set all attributes with true to \'value\' ' +
+             'in \'process.env\''
+  }
+);
+
+assert.strictEqual(process.env.foo, undefined);
+process.env.foo = 'foo2';
+assert.strictEqual(process.env.foo, 'foo2');
+
+assert.throws(
+  () => {
+    Object.defineProperty(process.env, 'goo', {
+      get() {
+        return 'goo';
+      },
+      set() {}
+    });
+  },
+  {
+    code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
+    name: 'TypeError',
+    message: 'Cannot set attributes other than \'value\' ' +
+             'for properties in \'process.env\''
+  }
+);
+
+const attributes = ['configurable', 'writable', 'enumerable'];
+
+attributes.forEach((attribute) => {
+  assert.throws(
+    () => {
+      Object.defineProperty(process.env, 'goo', {
+        [attribute]: false
+      });
+    },
+    {
+      code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
+      name: 'TypeError',
+      message: 'Cannot set attributes other than \'value\' ' +
+               'for properties in \'process.env\''
+    }
+  );
+});
+
+assert.strictEqual(process.env.goo, undefined);
+Object.defineProperty(process.env, 'goo', {
+  value: 'goo',
+  configurable: true,
+  writable: true,
+  enumerable: true
+});
+assert.strictEqual(process.env.goo, 'goo');

--- a/test/parallel/test-process-env-ignore-getter-setter.js
+++ b/test/parallel/test-process-env-ignore-getter-setter.js
@@ -11,8 +11,9 @@ assert.throws(
   {
     code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
     name: 'TypeError',
-    message: 'Must set all attributes with true to \'value\' ' +
-             'in \'process.env\''
+    message: '\'process.env\' only accepts a ' +
+        'configurable, writable,' +
+        ' and enumerable data descriptor'
   }
 );
 
@@ -32,8 +33,8 @@ assert.throws(
   {
     code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
     name: 'TypeError',
-    message: 'Cannot set attributes other than \'value\' ' +
-             'for properties in \'process.env\''
+    message: '\'process.env\' does not accept an' +
+        'accessor(getter/setter) descriptor'
   }
 );
 
@@ -49,8 +50,9 @@ attributes.forEach((attribute) => {
     {
       code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
       name: 'TypeError',
-      message: 'Cannot set attributes other than \'value\' ' +
-               'for properties in \'process.env\''
+      message: '\'process.env\' only accepts a ' +
+          'configurable, writable,' +
+          ' and enumerable data descriptor'
     }
   );
 });

--- a/test/parallel/test-worker-process-env.js
+++ b/test/parallel/test-worker-process-env.js
@@ -39,8 +39,20 @@ if (!workerData && process.argv[2] !== 'child') {
   process.env.SET_IN_WORKER = 'set';
   assert.strictEqual(process.env.SET_IN_WORKER, 'set');
 
-  Object.defineProperty(process.env, 'DEFINED_IN_WORKER', { value: 42 });
-  assert.strictEqual(process.env.DEFINED_IN_WORKER, '42');
+  assert.throws(
+    () => {
+      Object.defineProperty(process.env, 'DEFINED_IN_WORKER', {
+        value: 42
+      });
+    },
+    {
+      code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
+      name: 'TypeError',
+      message: 'Must set all attributes with true to \'value\' ' +
+               'in \'process.env\''
+    }
+  );
+
 
   const { stderr } =
     child_process.spawnSync(process.execPath, [__filename, 'child']);

--- a/test/parallel/test-worker-process-env.js
+++ b/test/parallel/test-worker-process-env.js
@@ -48,8 +48,8 @@ if (!workerData && process.argv[2] !== 'child') {
     {
       code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
       name: 'TypeError',
-      message: 'Must set all attributes with true to \'value\' ' +
-               'in \'process.env\''
+      message: '\'process.env\' only accepts a configurable, ' +
+          'writable, and enumerable data descriptor'
     }
   );
 


### PR DESCRIPTION
try to fix #27990 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
