### PR TITLE
http2: use getter replace use directly _witableState.finished

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -502,6 +502,16 @@ This property contains the number of bytes (or objects) in the queue
 ready to be written. The value provides introspection data regarding
 the status of the `highWaterMark`.
 
+##### writable.writableFinished
+<!-- YAML
+added: v12.4.0
+-->
+
+* {boolean}
+
+Is `true` if all data has been flushed to the underlying system. After
+the [`'finish'`][] event has been emitted.
+
 ##### writable.writableObjectMode
 <!-- YAML
 added: v12.3.0

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -98,6 +98,16 @@ Object.defineProperty(Duplex.prototype, 'writableLength', {
   }
 });
 
+Object.defineProperty(Duplex.prototype, 'writableFinished', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get() {
+    return this._writableState.finished;
+  }
+});
+
 // The no-half-open enforcer
 function onend() {
   // If the writable side ended, then we're ok.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -714,6 +714,16 @@ Object.defineProperty(Writable.prototype, 'writableObjectMode', {
   }
 });
 
+Object.defineProperty(Writable.prototype, 'writableFinished', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get() {
+    return this._writableState.finished;
+  }
+});
+
 Writable.prototype.destroy = destroyImpl.destroy;
 Writable.prototype._undestroy = destroyImpl.undestroy;
 Writable.prototype._destroy = function(err, cb) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1556,7 +1556,7 @@ function closeStream(stream, code, rstStreamStatus = kSubmitRstStream) {
   stream.setTimeout(0);
   stream.removeAllListeners('timeout');
 
-  const { ending, finished } = stream._writableState;
+  const { ending } = stream._writableState;
 
   if (!ending) {
     // If the writable side of the Http2Stream is still open, emit the
@@ -1572,7 +1572,7 @@ function closeStream(stream, code, rstStreamStatus = kSubmitRstStream) {
 
   if (rstStreamStatus !== kNoRstStream) {
     const finishFn = finishCloseStream.bind(stream, code);
-    if (!ending || finished || code !== NGHTTP2_NO_ERROR ||
+    if (!ending || stream.writableFinished || code !== NGHTTP2_NO_ERROR ||
         rstStreamStatus === kForceRstStream)
       finishFn();
     else
@@ -1982,8 +1982,7 @@ class Http2Stream extends Duplex {
       return;
     }
 
-    // TODO(mcollina): remove usage of _*State properties
-    if (this._writableState.finished) {
+    if (this.writableFinished) {
       if (!this.readable && this.closed) {
         this.destroy();
         return;

--- a/test/parallel/test-stream-duplex-writable-finished.js
+++ b/test/parallel/test-stream-duplex-writable-finished.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const common = require('../common');
+const { Duplex } = require('stream');
+const assert = require('assert');
+
+// basic
+{
+  // Find it on Duplex.prototype
+  assert(Duplex.prototype.hasOwnProperty('writableFinished'));
+}
+
+// event
+{
+  const duplex = new Duplex();
+
+  duplex._write = (chunk, encoding, cb) => {
+    // The state finished should start in false.
+    assert.strictEqual(duplex.writableFinished, false);
+    cb();
+  };
+
+  duplex.on('finish', common.mustCall(() => {
+    assert.strictEqual(duplex.writableFinished, true);
+  }));
+
+  duplex.end('testing finished state', common.mustCall(() => {
+    assert.strictEqual(duplex.writableFinished, true);
+  }));
+}

--- a/test/parallel/test-stream-writable-finished.js
+++ b/test/parallel/test-stream-writable-finished.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const common = require('../common');
+const { Writable } = require('stream');
+const assert = require('assert');
+
+// basic
+{
+  // Find it on Writable.prototype
+  assert(Writable.prototype.hasOwnProperty('writableFinished'));
+}
+
+// event
+{
+  const writable = new Writable();
+
+  writable._write = (chunk, encoding, cb) => {
+    // The state finished should start in false.
+    assert.strictEqual(writable.writableFinished, false);
+    cb();
+  };
+
+  writable.on('finish', common.mustCall(() => {
+    assert.strictEqual(writable.writableFinished, true);
+  }));
+
+  writable.end('testing finished state', common.mustCall(() => {
+    assert.strictEqual(writable.writableFinished, true);
+  }));
+}


### PR DESCRIPTION
add a new getter to duplex stream to replace the property `this
.writableState.finished` of the object that inherited duplex.

Refs: https://github.com/nodejs/node/issues/445

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
