### PR TITLE
Added promise support to `rl.question` in the readline module.

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -29,6 +29,16 @@ rl.question('What do you think of Node.js? ', (answer) => {
 });
 ```
 
+`rl.question` can also be used with `async`/`await` and `.then`
+
+```js
+async function askQuestion(question) {
+  const answer = await rl.question(question);
+  console.log(`Thank you for your valuable feedback: ${answer}`);
+  rl.close();
+}
+```
+
 Once this code is invoked, the Node.js application will not terminate until the
 `readline.Interface` is closed because the interface waits for data to be
 received on the `input` stream.

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -291,7 +291,7 @@ Interface.prototype.prompt = function(preserveCursor) {
 
 
 Interface.prototype.question = function(query, cb) {
-  const self = this
+  const self = this;
 
   if (typeof cb === 'function') {
     if (this._questionCallback) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -301,6 +301,11 @@ Interface.prototype.question = function(query, cb) {
       this.prompt();
     }
   }
+
+  return new Promise((resolve, reject) => {
+    self._resolveQuestionPromise = resolve;
+    self._rejectQuestionPromise = reject;
+  });
 };
 
 
@@ -312,6 +317,10 @@ Interface.prototype._onLine = function(line) {
     cb(line);
   } else {
     this.emit('line', line);
+  }
+
+  if (this._resolveQuestionPromise) {
+    this._resolveQuestionPromise(line);
   }
 };
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -291,6 +291,8 @@ Interface.prototype.prompt = function(preserveCursor) {
 
 
 Interface.prototype.question = function(query, cb) {
+  const self = this
+
   if (typeof cb === 'function') {
     if (this._questionCallback) {
       this.prompt();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

As described in the first commit: added a promise as the return value to the `Interface.prototype.question` function in the readline module. Inside that promise I placed the resolve and reject functions on the `_resolveQuestionPromise` and `_rejectQuestionPromise` properties respectively. Ran the  `_resolveQuestionPromise` in the `Interface.prototype._onLine` function if the `_resolveQuestionPromise` function existed, the argument being the `line` argument passed into the `Interface.prototype._onLine` function. 

I made a simple documentation change explaining that `rl.question` can now be used with `async`/`await` or `.then` syntax:

`rl.question` can also be used with `async`/`await` and `.then`

```js
async function askQuestion(question) {
  const answer = await rl.question(question);
  console.log(`Thank you for your valuable feedback: ${answer}`);
  rl.close();
}
```

The other commits were me experimenting with my forked repo and deleting and auto generated file and are not additional features or changes.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
