### PR TITLE
src: only run preloadModules if the preload array is not empty

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -385,7 +385,7 @@ function initializeFrozenIntrinsics() {
 function loadPreloadModules() {
   // For user code, we preload modules if `-r` is passed
   const preloadModules = getOptionValue('--require');
-  if (preloadModules) {
+  if (preloadModules && preloadModules.length > 0) {
     const {
       Module: {
         _preloadModules


### PR DESCRIPTION
Noticed this while doing some performance work on Electrons start-up time, it looks like the `getOptionValue` call here always returns a truthy value even when it is an empty array.  When it's empty we can shortcut a `require` call here saving a few ms 👍 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
