### PR TITLE
tty: add color support for hyper terminal

### DIFF
--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -49,6 +49,7 @@ const TERM_ENVS = {
   'dtterm': COLORS_16,
   'gnome': COLORS_16,
   'hurd': COLORS_16,
+  'hyper': COLORS_256,
   'jfbterm': COLORS_16,
   'konsole': COLORS_16,
   'kterm': COLORS_16,


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines]
