### PR TITLE
src: use RAII in setgroups implementation

### DIFF
--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -307,14 +307,13 @@ static void SetGroups(const FunctionCallbackInfo<Value>& args) {
 
   Local<Array> groups_list = args[0].As<Array>();
   size_t size = groups_list->Length();
-  gid_t* groups = new gid_t[size];
+  MaybeStackBuffer<gid_t, 64> groups(size);
 
   for (size_t i = 0; i < size; i++) {
     gid_t gid = gid_by_name(
         env->isolate(), groups_list->Get(env->context(), i).ToLocalChecked());
 
     if (gid == gid_not_found) {
-      delete[] groups;
       // Tells JS to throw ERR_INVALID_CREDENTIAL
       args.GetReturnValue().Set(static_cast<uint32_t>(i + 1));
       return;
@@ -323,8 +322,7 @@ static void SetGroups(const FunctionCallbackInfo<Value>& args) {
     groups[i] = gid;
   }
 
-  int rc = setgroups(size, groups);
-  delete[] groups;
+  int rc = setgroups(size, *groups);
 
   if (rc == -1) return env->ThrowErrnoException(errno, "setgroups");
 


### PR DESCRIPTION
Prefer `MaybeStackBuffer` over manual memory management.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
