### PR TITLE
doc: add note about AsyncResource for Worker pooling

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -48,6 +48,9 @@ if (isMainThread) {
 The above example spawns a Worker thread for each `parse()` call. In actual
 practice, use a pool of Workers instead for these kinds of tasks. Otherwise, the
 overhead of creating Workers would likely exceed their benefit.
+When implementing a worker pool, it is strongly recommended to use the
+[`AsyncResource`][] API to inform diagnostic tools (for e.g. asynchronous stack
+traces) about the correlation between tasks and their outcomes.
 
 ## worker.isMainThread
 <!-- YAML
@@ -653,6 +656,7 @@ active handle in the event system. If the worker is already `unref()`ed calling
 `unref()` again will have no effect.
 
 [`'close'` event]: #worker_threads_event_close
+[`AsyncResource`]: async_hooks.html#async_hooks_class_asyncresource
 [`Buffer`]: buffer.html
 [`EventEmitter`]: events.html
 [`EventTarget`]: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -48,9 +48,10 @@ if (isMainThread) {
 The above example spawns a Worker thread for each `parse()` call. In actual
 practice, use a pool of Workers instead for these kinds of tasks. Otherwise, the
 overhead of creating Workers would likely exceed their benefit.
-When implementing a worker pool, it is strongly recommended to use the
-[`AsyncResource`][] API to inform diagnostic tools (for e.g. asynchronous stack
-traces) about the correlation between tasks and their outcomes.
+
+When implementing a worker pool, use the [`AsyncResource`][] API to inform
+diagnostic tools (e.g. in order to provide asynchronous stack traces) about the
+correlation between tasks and their outcomes.
 
 ## worker.isMainThread
 <!-- YAML


### PR DESCRIPTION
When implementing a pool for Worker threads, the correlation between
posting tasks and getting their results may get lost, depending on
the implementation.

The `AsyncResource` API is the primary way to solve that issue,
so link it from the recommendation in the worker docs.

(This was brought up at the collaborator summit in Berlin.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
