### PR TITLE
worker: prevent event loop starvation through MessagePorts

### DIFF
--- a/test/parallel/test-worker-message-port-infinite-message-loop.js
+++ b/test/parallel/test-worker-message-port-infinite-message-loop.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const { MessageChannel } = require('worker_threads');
+
+// Make sure that an infinite asynchronous .on('message')/postMessage loop
+// does not lead to a stack overflow and does not starve the event loop.
+// We schedule timeouts both from before the the .on('message') handler and
+// inside of it, which both should run.
+
+const { port1, port2 } = new MessageChannel();
+let count = 0;
+port1.on('message', () => {
+  if (count === 0) {
+    setTimeout(common.mustCall(() => {
+      port1.close();
+    }), 0);
+  }
+
+  port2.postMessage(0);
+  assert(count++ < 10000, `hit ${count} loop iterations`);
+});
+
+port2.postMessage(0);
+
+setTimeout(common.mustCall(), 0);


### PR DESCRIPTION
Limit the number of messages processed without interruption on a
given `MessagePort` to prevent event loop starvation.

This aligns the behaviour better with the web.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
