### PR TITLE
worker: make MessagePort constructor non-callable

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -703,6 +703,14 @@ non-writable `stdout` or `stderr` stream.
 
 A constructor for a class was called without `new`.
 
+<a id="ERR_CONSTRUCT_CALL_INVALID"></a>
+### ERR_CONSTRUCT_CALL_INVALID
+<!--
+added: REPLACEME
+-->
+
+A class constructor was called that is not callable.
+
 <a id="ERR_CPU_USAGE"></a>
 ### ERR_CPU_USAGE
 

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -54,7 +54,8 @@ void FatalException(v8::Isolate* isolate,
   V(ERR_BUFFER_CONTEXT_NOT_AVAILABLE, Error)                                 \
   V(ERR_BUFFER_OUT_OF_BOUNDS, RangeError)                                    \
   V(ERR_BUFFER_TOO_LARGE, Error)                                             \
-  V(ERR_CONSTRUCT_CALL_REQUIRED, Error)                                      \
+  V(ERR_CONSTRUCT_CALL_REQUIRED, TypeError)                                  \
+  V(ERR_CONSTRUCT_CALL_INVALID, TypeError)                                   \
   V(ERR_INVALID_ARG_VALUE, TypeError)                                        \
   V(ERR_INVALID_ARG_TYPE, TypeError)                                         \
   V(ERR_INVALID_MODULE_SPECIFIER, TypeError)                                 \
@@ -99,6 +100,7 @@ void FatalException(v8::Isolate* isolate,
 #define PREDEFINED_ERROR_MESSAGES(V)                                         \
   V(ERR_BUFFER_CONTEXT_NOT_AVAILABLE,                                        \
     "Buffer is not available for the current Context")                       \
+  V(ERR_CONSTRUCT_CALL_INVALID, "Constructor cannot be called")              \
   V(ERR_CONSTRUCT_CALL_REQUIRED, "Cannot call constructor without `new`")    \
   V(ERR_INVALID_TRANSFER_OBJECT, "Found invalid object in transferList")     \
   V(ERR_MEMORY_ALLOCATION_FAILED, "Failed to allocate memory")               \

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -211,8 +211,8 @@ class MessagePort : public HandleWrap {
   friend class MessagePortData;
 };
 
-v8::MaybeLocal<v8::Function> GetMessagePortConstructor(
-    Environment* env, v8::Local<v8::Context> context);
+v8::Local<v8::FunctionTemplate> GetMessagePortConstructorTemplate(
+    Environment* env);
 
 }  // namespace worker
 }  // namespace node

--- a/test/parallel/test-worker-message-port-constructor.js
+++ b/test/parallel/test-worker-message-port-constructor.js
@@ -1,0 +1,27 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const { MessageChannel, MessagePort } = require('worker_threads');
+
+// Make sure that `MessagePort` is the constructor for MessagePort instances,
+// but not callable.
+const { port1 } = new MessageChannel();
+
+assert(port1 instanceof MessagePort);
+assert.strictEqual(port1.constructor, MessagePort);
+
+assert.throws(() => MessagePort(), {
+  constructor: TypeError,
+  code: 'ERR_CONSTRUCT_CALL_INVALID'
+});
+
+assert.throws(() => new MessagePort(), {
+  constructor: TypeError,
+  code: 'ERR_CONSTRUCT_CALL_INVALID'
+});
+
+assert.throws(() => MessageChannel(), {
+  constructor: TypeError,
+  code: 'ERR_CONSTRUCT_CALL_REQUIRED'
+});

--- a/test/parallel/test-worker-message-port-move.js
+++ b/test/parallel/test-worker-message-port-move.js
@@ -53,13 +53,6 @@ vm.runInContext('(' + function() {
     }
     assert(threw);
   }
-
-  {
-    const newDummyPort = new (port.constructor)();
-    assert(!(newDummyPort instanceof MessagePort));
-    assert(newDummyPort.close instanceof Function);
-    newDummyPort.close();
-  }
 } + ')()', context);
 
 port2.on('message', common.mustCall((msg) => {


### PR DESCRIPTION
Refactor the C++ code for creating `MessagePort`s to skip calling the
constructor and instead directly instantiating the `InstanceTemplate`,
and always throw an error from the `MessagePort` constructor.

This aligns behaviour with the web, and creating single `MessagePort`s
does not make sense anyway.

This is technically a breaking change and I’d be happy to split out the added throw into a separate PR out of caution, if anybody considers that a good idea.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
