### PR TITLE
worker: add typechecking for postMessage transfer list

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -712,9 +712,11 @@ void MessagePort::PostMessage(const FunctionCallbackInfo<Value>& args) {
                                        "MessagePort.postMessage");
   }
   if (!args[1]->IsNullOrUndefined() && !args[1]->IsObject()) {
-    // Browsers also do not throw on `null` or objects, although it really
-    // should be an array or undefined, thus the mismatch between the checks
-    // above and the actual error message.
+    // Browsers ignore null or undefined, and otherwise accept an array or an
+    // options object.
+    // TODO(addaleax): Add support for an options object and generic sequence
+    // support.
+    // Refs: https://github.com/nodejs/node/pull/28033#discussion_r289964991
     return THROW_ERR_INVALID_ARG_TYPE(env,
         "Optional transferList argument must be an array");
   }

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -711,6 +711,13 @@ void MessagePort::PostMessage(const FunctionCallbackInfo<Value>& args) {
     return THROW_ERR_MISSING_ARGS(env, "Not enough arguments to "
                                        "MessagePort.postMessage");
   }
+  if (!args[1]->IsNullOrUndefined() && !args[1]->IsObject()) {
+    // Browsers also do not throw on `null` or objects, although it really
+    // should be an array or undefined, thus the mismatch between the checks
+    // above and the actual error message.
+    return THROW_ERR_INVALID_ARG_TYPE(env,
+        "Transfer list argument must be array or missing");
+  }
 
   MessagePort* port = Unwrap<MessagePort>(args.This());
   // Even if the backing MessagePort object has already been deleted, we still

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -716,7 +716,7 @@ void MessagePort::PostMessage(const FunctionCallbackInfo<Value>& args) {
     // should be an array or undefined, thus the mismatch between the checks
     // above and the actual error message.
     return THROW_ERR_INVALID_ARG_TYPE(env,
-        "Transfer list argument must be array or missing");
+        "Optional transferList argument must be an array");
   }
 
   MessagePort* port = Unwrap<MessagePort>(args.This());

--- a/test/parallel/test-worker-message-port.js
+++ b/test/parallel/test-worker-message-port.js
@@ -81,13 +81,14 @@ const { MessageChannel, MessagePort } = require('worker_threads');
   const err = {
     constructor: TypeError,
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'Transfer list argument must be array or missing'
+    message: 'Optional transferList argument must be an array'
   };
 
   assert.throws(() => port1.postMessage(5, 0), err);
   assert.throws(() => port1.postMessage(5, false), err);
   assert.throws(() => port1.postMessage(5, 'X'), err);
   assert.throws(() => port1.postMessage(5, Symbol('X')), err);
+  port1.close();
 }
 
 {

--- a/test/parallel/test-worker-message-port.js
+++ b/test/parallel/test-worker-message-port.js
@@ -71,6 +71,26 @@ const { MessageChannel, MessagePort } = require('worker_threads');
 }
 
 {
+  const { port1, port2 } = new MessageChannel();
+  port2.on('message', common.mustCall(4));
+  port1.postMessage(1, null);
+  port1.postMessage(2, undefined);
+  port1.postMessage(3, []);
+  port1.postMessage(4, {});
+
+  const err = {
+    constructor: TypeError,
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'Transfer list argument must be array or missing'
+  };
+
+  assert.throws(() => port1.postMessage(5, 0), err);
+  assert.throws(() => port1.postMessage(5, false), err);
+  assert.throws(() => port1.postMessage(5, 'X'), err);
+  assert.throws(() => port1.postMessage(5, Symbol('X')), err);
+}
+
+{
   assert.deepStrictEqual(
     Object.getOwnPropertyNames(MessagePort.prototype).sort(),
     [


### PR DESCRIPTION
If the transfer list argument is present, it should be an array.
This commit adds typechecking to that effect. This aligns behaviour
with browsers.

I’m also more than happy to label this semver-major.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
