### PR TITLE
src: read break_node_first_line from the inspect options

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -254,7 +254,7 @@ int Environment::InitializeInspector(
 
   profiler::StartProfilers(this);
 
-  if (options_->debug_options().break_node_first_line) {
+  if (inspector_agent_->options().break_node_first_line) {
     inspector_agent_->PauseOnNextJavascriptStatement("Break at bootstrap");
   }
 


### PR DESCRIPTION
There are cases where the debug_options() on the env are different to the options that were passed into inspector::Agent.  This is particularly true in Electrons case where we pass the agent a real parsed `NodeOptions` but give the env an empty one.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
