### PR TITLE
test: try to reduce flakes on Windows

### DIFF
--- a/test/async-hooks/test-pipeconnectwrap.js
+++ b/test/async-hooks/test-pipeconnectwrap.js
@@ -5,11 +5,11 @@ const assert = require('assert');
 const tick = require('../common/tick');
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');
-
+const tmpdir = require('../common/tmpdir');
 const net = require('net');
 
-const tmpdir = require('../common/tmpdir');
-tmpdir.refresh();
+// Spawning messes up `async_hooks` state.
+tmpdir.refresh({ spawn: false });
 
 const hooks = initHooks();
 hooks.enable();

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -852,7 +852,11 @@ The `tmpdir` module supports the use of a temporary directory for testing.
 
 The realpath of the testing temporary directory.
 
-### refresh()
+### refresh([opts])
+
+* `opts` [&lt;Object>] (optional) Extra options.
+  * `spawn` [&lt;boolean>] (default: `true`) Indicates that `refresh` is allowed
+    to optionally spawn a subprocess.
 
 Deletes and recreates the testing temporary directory.
 

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -89,11 +89,7 @@ const testRoot = process.env.NODE_TEST_DIR ?
 
 // Using a `.` prefixed name, which is the convention for "hidden" on POSIX,
 // gets tools to ignore it by default or by simple rules, especially eslint.
-let tmpdirName = '.tmp';
-if (process.env.TEST_THREAD_ID) {
-  tmpdirName += `.${process.env.TEST_THREAD_ID}`;
-}
-
+const tmpdirName = '.tmp.' + (process.env.TEST_THREAD_ID || '0');
 const tmpPath = path.join(testRoot, tmpdirName);
 
 function refresh(opts = {}) {

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -17,6 +17,8 @@ test-worker-memory: PASS,FLAKY
 # https://github.com/nodejs/node/issues/20750
 test-http2-client-upload: PASS,FLAKY
 test-http2-client-upload-reject: PASS,FLAKY
+# https://github.com/nodejs/node/issues/28106
+test-worker-debug: PASS,FLAKY
 
 [$system==linux]
 


### PR DESCRIPTION
* __test: always suffix `tmpdir`__
This makes temp dir names consistent whether we run in stand-alone mode,
via `test.py` in single process, or in multi-process.
* __test: shell out to `rmdir` first on Windows__
cmd's `rmdir` is hardened to deal with Windows edge cases, like
lingering processes, indexing, and AV checks. So we give it a try first.
* __test: regression test `tmpdir`__



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
