### PR TITLE
src: fix unused private field warning

### DIFF
--- a/src/inspector/runtime_agent.cc
+++ b/src/inspector/runtime_agent.cc
@@ -7,8 +7,8 @@ namespace node {
 namespace inspector {
 namespace protocol {
 
-RuntimeAgent::RuntimeAgent(Environment* env)
-  : notify_when_waiting_for_disconnect_(false), env_(env) {}
+RuntimeAgent::RuntimeAgent()
+  : notify_when_waiting_for_disconnect_(false) {}
 
 void RuntimeAgent::Wire(UberDispatcher* dispatcher) {
   frontend_ = std::make_unique<NodeRuntime::Frontend>(dispatcher->channel());

--- a/src/inspector/runtime_agent.h
+++ b/src/inspector/runtime_agent.h
@@ -12,7 +12,7 @@ namespace protocol {
 
 class RuntimeAgent : public NodeRuntime::Backend {
  public:
-  explicit RuntimeAgent(Environment* env);
+  RuntimeAgent();
 
   void Wire(UberDispatcher* dispatcher);
 
@@ -23,7 +23,6 @@ class RuntimeAgent : public NodeRuntime::Backend {
  private:
   std::shared_ptr<NodeRuntime::Frontend> frontend_;
   bool notify_when_waiting_for_disconnect_;
-  Environment* env_;
 };
 }  // namespace protocol
 }  // namespace inspector

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -239,7 +239,7 @@ class ChannelImpl final : public v8_inspector::V8Inspector::Channel,
     tracing_agent_->Wire(node_dispatcher_.get());
     worker_agent_ = std::make_unique<protocol::WorkerAgent>(worker_manager);
     worker_agent_->Wire(node_dispatcher_.get());
-    runtime_agent_ = std::make_unique<protocol::RuntimeAgent>(env);
+    runtime_agent_ = std::make_unique<protocol::RuntimeAgent>();
     runtime_agent_->Wire(node_dispatcher_.get());
   }
 


### PR DESCRIPTION
This fixes the following warning (and subsequent warnings that occurred from fixing the original warning):

```
../src/inspector/runtime_agent.h:26:16: warning: private field 'env_' is not used [-Wunused-private-field]
  Environment* env_;
               ^
1 warning generated.
```

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
