### PR TITLE
trace_events: respect inspect() depth

### DIFF
--- a/lib/trace_events.js
+++ b/lib/trace_events.js
@@ -61,6 +61,9 @@ class Tracing {
   }
 
   [customInspectSymbol](depth, opts) {
+    if (typeof depth === 'number' && depth < 0)
+      return this;
+
     const obj = {
       enabled: this.enabled,
       categories: this.categories

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2519,3 +2519,15 @@ assert.strictEqual(
     assert(i < 2 || line.startsWith('\u001b[90m'));
   });
 }
+
+{
+  // Tracing class respects inspect depth.
+  try {
+    const trace = require('trace_events').createTracing({ categories: ['fo'] });
+    const actual = util.inspect({ trace }, { depth: 0 });
+    assert.strictEqual(actual, '{ trace: [Tracing] }');
+  } catch (err) {
+    if (err.code !== 'ERR_TRACE_EVENTS_UNAVAILABLE')
+      throw err;
+  }
+}


### PR DESCRIPTION
This commit causes the `Tracing` class to account for `util.inspect()` depth.

Similar to #27983. After this commit, all of these cases in core are handled.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
