### PR TITLE
deps: Update node-inspect to v1.11.6

### DIFF
--- a/deps/node-inspect/CHANGELOG.md
+++ b/deps/node-inspect/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 1.11.6
+
+* fix: replace the deprecated "repl.cli" with "repl" - **[@oyyd](https://github.com/oyyd)** [#66](https://github.com/nodejs/node-inspect/pull/66)
+  - [`5c1d771`](https://github.com/nodejs/node-inspect/commit/5c1d7716523b73e26f98f4f594ee34b7daa920a0) **fix:** replace the deprecated "repl.cli" with "repl" - see: [26260](Refs: https://github.com/nodejs/node/pull/26260)
+* Address regressions due to changes in node - **[@jkrems](https://github.com/jkrems)** [#67](https://github.com/nodejs/node-inspect/pull/67)
+  - [`5b3511e`](https://github.com/nodejs/node-inspect/commit/5b3511ef21d0eba8304d8b2fed33f33aae22f308) **fix:** Address regressions due to changes in node
+
+
 ### 1.11.5
 
 * Fix eslint issues - **[@jkrems](https://github.com/jkrems)** [#63](https://github.com/nodejs/node-inspect/pull/63)

--- a/deps/node-inspect/lib/_inspect.js
+++ b/deps/node-inspect/lib/_inspect.js
@@ -198,7 +198,7 @@ class NodeInspector {
 
   suspendReplWhile(fn) {
     if (this.repl) {
-      this.repl.rli.pause();
+      this.repl.pause();
     }
     this.stdin.pause();
     this.paused = true;
@@ -207,7 +207,7 @@ class NodeInspector {
     }).then(() => {
       this.paused = false;
       if (this.repl) {
-        this.repl.rli.resume();
+        this.repl.resume();
         this.repl.displayPrompt();
       }
       this.stdin.resume();

--- a/deps/node-inspect/package.json
+++ b/deps/node-inspect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-inspect",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "description": "Node Inspect",
   "license": "MIT",
   "main": "lib/_inspect.js",

--- a/deps/node-inspect/test/cli/break.test.js
+++ b/deps/node-inspect/test/cli/break.test.js
@@ -18,12 +18,12 @@ test('stepping through breakpoints', (t) => {
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(
-        cli.output,
-        `break in ${script}:1`,
+        cli.breakInfo,
+        { filename: script, line: 1 },
         'pauses in the first line of the script');
       t.match(
         cli.output,
-        /> 1 \(function \([^)]+\) \{ const x = 10;/,
+        /> 1 (?:\(function \([^)]+\) \{ )?const x = 10;/,
         'shows the source and marks the current line');
     })
     .then(() => cli.stepCommand('n'))

--- a/deps/node-inspect/test/cli/exceptions.test.js
+++ b/deps/node-inspect/test/cli/exceptions.test.js
@@ -17,7 +17,7 @@ test('break on (uncaught) exceptions', (t) => {
   return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.breakInfo, { filename: script, line: 1 });
     })
     // making sure it will die by default:
     .then(() => cli.command('c'))
@@ -28,7 +28,7 @@ test('break on (uncaught) exceptions', (t) => {
     .then(() => cli.stepCommand('r'))
     .then(() => cli.waitForInitialBreak())
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.breakInfo, { filename: script, line: 1 });
     })
     .then(() => cli.command('breakOnException'))
     .then(() => cli.stepCommand('c'))
@@ -45,7 +45,7 @@ test('break on (uncaught) exceptions', (t) => {
     .then(() => cli.stepCommand('r')) // also, the setting survives the restart
     .then(() => cli.waitForInitialBreak())
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.breakInfo, { filename: script, line: 1 });
     })
     .then(() => cli.stepCommand('c'))
     .then(() => {
@@ -57,7 +57,7 @@ test('break on (uncaught) exceptions', (t) => {
     .then(() => cli.stepCommand('r'))
     .then(() => cli.waitForInitialBreak())
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.breakInfo, { filename: script, line: 1 });
     })
     .then(() => cli.command('c'))
     // TODO: Remove FATAL ERROR once node doesn't show a FATAL ERROR anymore

--- a/deps/node-inspect/test/cli/launch.test.js
+++ b/deps/node-inspect/test/cli/launch.test.js
@@ -137,23 +137,23 @@ test('run after quit / restart', (t) => {
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(
-        cli.output,
-        `break in ${script}:1`,
+        cli.breakInfo,
+        { filename: script, line: 1 },
         'is back at the beginning');
     })
     .then(() => cli.stepCommand('n'))
     .then(() => {
       t.match(
-        cli.output,
-        `break in ${script}:2`,
+        cli.breakInfo,
+        { filename: script, line: 2 },
         'steps to the 2nd line');
     })
     .then(() => cli.stepCommand('restart'))
     .then(() => cli.waitForInitialBreak())
     .then(() => {
       t.match(
-        cli.output,
-        `break in ${script}:1`,
+        cli.breakInfo,
+        { filename: script, line: 1 },
         'is back at the beginning');
     })
     .then(() => cli.command('kill'))
@@ -167,8 +167,8 @@ test('run after quit / restart', (t) => {
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(
-        cli.output,
-        `break in ${script}:1`,
+        cli.breakInfo,
+        { filename: script, line: 1 },
         'is back at the beginning');
     })
     .then(() => cli.quit())

--- a/deps/node-inspect/test/cli/low-level.test.js
+++ b/deps/node-inspect/test/cli/low-level.test.js
@@ -24,7 +24,7 @@ test('Debugger agent direct access', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        /scriptSource: '\(function \(/);
+        /scriptSource:[ \n]*'(?:\(function \(|let x = 1)/);
       t.match(
         cli.output,
         /let x = 1;/);

--- a/deps/node-inspect/test/cli/preserve-breaks.test.js
+++ b/deps/node-inspect/test/cli/preserve-breaks.test.js
@@ -30,20 +30,20 @@ test('run after quit / restart', (t) => {
     .then(() => cli.stepCommand('c')) // hit line 2
     .then(() => cli.stepCommand('c')) // hit line 3
     .then(() => {
-      t.match(cli.output, `break in ${script}:3`);
+      t.match(cli.breakInfo, { filename: script, line: 3 });
     })
     .then(() => cli.command('restart'))
     .then(() => cli.waitForInitialBreak())
     .then(() => {
-      t.match(cli.output, `break in ${script}:1`);
+      t.match(cli.breakInfo, { filename: script, line: 1 });
     })
     .then(() => cli.stepCommand('c'))
     .then(() => {
-      t.match(cli.output, `break in ${script}:2`);
+      t.match(cli.breakInfo, { filename: script, line: 2 });
     })
     .then(() => cli.stepCommand('c'))
     .then(() => {
-      t.match(cli.output, `break in ${script}:3`);
+      t.match(cli.breakInfo, { filename: script, line: 3 });
     })
     .then(() => cli.command('breakpoints'))
     .then(() => {

--- a/deps/node-inspect/test/cli/scripts.test.js
+++ b/deps/node-inspect/test/cli/scripts.test.js
@@ -24,7 +24,7 @@ test('list scripts', (t) => {
         'lists the user script');
       t.notMatch(
         cli.output,
-        /\d+: module\.js <native>/,
+        /\d+: buffer\.js <native>/,
         'omits node-internal scripts');
     })
     .then(() => cli.command('scripts(true)'))
@@ -35,7 +35,7 @@ test('list scripts', (t) => {
         'lists the user script');
       t.match(
         cli.output,
-        /\d+: module\.js <native>/,
+        /\d+: buffer\.js <native>/,
         'includes node-internal scripts');
     })
     .then(() => cli.quit())

--- a/deps/node-inspect/test/cli/use-strict.test.js
+++ b/deps/node-inspect/test/cli/use-strict.test.js
@@ -17,9 +17,10 @@ test('for whiles that starts with strict directive', (t) => {
   return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
+      const brk = cli.breakInfo;
       t.match(
-        cli.output,
-        /break in [^:]+:(?:1|2)[^\d]/,
+        `${brk.line}`,
+        /^(1|2)$/,
         'pauses either on strict directive or first "real" line');
     })
     .then(() => cli.quit())


### PR DESCRIPTION
#### Highlights

* The `node-inspect` test suite passes against latest master.
* Removes use of deprecated `repl.rli`.

Compare: https://github.com/nodejs/node-inspect/compare/v1.11.5...v1.11.6

Generated via:

```bash
rm -rf deps/node-inspect node-inspect-* && curl -sSL "https://github.com/nodejs/node-inspect/archive/v1.11.6.tar.gz" | tar -xzvf - && mv node-inspect-* deps/node-inspect
```

#### Rendered Changelog

> ### 1.11.6
> 
> * fix: replace the deprecated "repl.cli" with "repl" - **[@oyyd](https://github.com/oyyd)** [#66](https://github.com/nodejs/node-inspect/pull/66)
>   - [`5c1d771`](https://github.com/nodejs/node-inspect/commit/5c1d7716523b73e26f98f4f594ee34b7daa920a0) **fix:** replace the deprecated "repl.cli" with "repl" - see: [26260](Refs: https://github.com/nodejs/node/pull/26260)
> * Address regressions due to changes in node - **[@jkrems](https://github.com/jkrems)** [#67](https://github.com/nodejs/node-inspect/pull/67)
>   - [`5b3511e`](https://github.com/nodejs/node-inspect/commit/5b3511ef21d0eba8304d8b2fed33f33aae22f308) **fix:** Address regressions due to changes in node

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-node-inspect` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
