### PR TITLE
test: only assert on first lines of TLS trace

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -9,8 +9,6 @@ prefix parallel
 test-net-connect-options-port: PASS,FLAKY
 # https://github.com/nodejs/node/issues/26401
 test-worker-prof: PASS,FLAKY
-# https://github.com/nodejs/node/issues/27553
-test-tls-enable-trace-cli: PASS,FLAKY
 
 [$system==win32]
 test-http2-pipe: PASS,FLAKY

--- a/test/parallel/test-tls-enable-trace-cli.js
+++ b/test/parallel/test-tls-enable-trace-cli.js
@@ -37,7 +37,6 @@ child.on('close', common.mustCall((code, signal) => {
   assert.strictEqual(stdout.trim(), '');
   assert(/Warning: Enabling --trace-tls can expose sensitive/.test(stderr));
   assert(/Sent Record/.test(stderr));
-  assert(/Received Record/.test(stderr));
 }));
 
 function test() {


### PR DESCRIPTION
The TLS trace data is best-effort, and enough can be dropped from pipe
buffers that only the start of the trace is detected. Only assert on the
first line of the trace, it should not get dropped, and it's enough to
check that trace was enabled via CLI.

Fixes: https://github.com/nodejs/node/issues/27636

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
