### PR TITLE
http2,doc: minor fixes

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -913,8 +913,9 @@ the value is `undefined`, the stream is not yet ready for use.
 All [`Http2Stream`][] instances are destroyed either when:
 
 * An `RST_STREAM` frame for the stream is received by the connected peer,
-  and pending data has been read.
-* The `http2stream.close()` method is called, and pending data has been read.
+  and (for client streams only) pending data has been read.
+* The `http2stream.close()` method is called, and (for client streams only)
+  pending data has been read.
 * The `http2stream.destroy()` or `http2session.destroy()` methods are called.
 
 When an `Http2Stream` instance is destroyed, an attempt will be made to send an

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2309,7 +2309,7 @@ ssize_t Http2Stream::Provider::Stream::OnRead(nghttp2_session* handle,
     return NGHTTP2_ERR_DEFERRED;
   }
 
-  if (stream->queue_.empty() && !stream->is_writable()) {
+  if (stream->available_outbound_length_ == 0 && !stream->is_writable()) {
     Debug(session, "no more data for stream %d", id);
     *flags |= NGHTTP2_DATA_FLAG_EOF;
     if (stream->has_trailers()) {


### PR DESCRIPTION
Some small fixes on HTTP/2 and its documentation:

 - ~~Fix server side example: start data flow when receiving a stream~~
   Add a note that, on server streams, it's not necessary to start data flow.

 - Set EOF flag if we have marked all data for sending: there's no need to wait until the queue is actually empty (and send a separate, empty DATA).

   (Note that, even with this change, an empty DATA frame will always be sent, because the streams layer waits until data has been flushed before queueing EOF)

 - Fix debug message

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
