### PR TITLE
OpenSSL dlloads node static linked executable

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -477,6 +477,18 @@
           '-Wl,--export-dynamic',
         ],
       }],
+      # if node is built as an executable, 
+      #      the openssl mechanism for keeping itself "dload"-ed to ensure proper 
+      #      atexit cleanup does not apply
+      ['node_shared_openssl!="true" and node_shared!="true"', {
+        'defines': [
+          # `OPENSSL_NO_PINSHARED` prevents openssl from dload 
+          #      current node executable, 
+          #      see https://github.com/nodejs/node/pull/21848 
+          #      or https://github.com/nodejs/node/issues/27925
+          'OPENSSL_NO_PINSHARED' 
+        ],
+      }],
       ['node_shared_openssl!="true"', {
         # `OPENSSL_THREADS` is defined via GYP for openSSL for all architectures.
         'defines': [


### PR DESCRIPTION
Fix: OpenSSL dlloads itself to prevent unloading, in case it might be dynamically loaded via dload. However when linked statically this will lead to dloading the main executable, which is not valid.


##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
(issues with test, see: https://github.com/nodejs/node/issues/27856)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

See more here: https://github.com/nodejs/node/pull/21848