### PR TITLE
repl: fix global object in repl

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -109,6 +109,19 @@ const kContextId = Symbol('contextId');
 
 let addedNewListener = false;
 
+const GLOBAL_OBJECT_PROPERTIES = [
+  'NaN', 'Infinity', 'undefined', 'eval', 'parseInt', 'parseFloat', 'isNaN',
+  'isFinite', 'decodeURI', 'decodeURIComponent', 'encodeURI',
+  'encodeURIComponent', 'Object', 'Function', 'Array', 'String', 'Boolean',
+  'Number', 'Date', 'RegExp', 'Error', 'EvalError', 'RangeError',
+  'ReferenceError', 'SyntaxError', 'TypeError', 'URIError', 'Math', 'JSON'
+];
+const GLOBAL_OBJECT_PROPERTY_MAP = {};
+for (var n = 0; n < GLOBAL_OBJECT_PROPERTIES.length; n++) {
+  GLOBAL_OBJECT_PROPERTY_MAP[GLOBAL_OBJECT_PROPERTIES[n]] =
+    GLOBAL_OBJECT_PROPERTIES[n];
+}
+
 try {
   // Hack for require.resolve("./relative") to work properly.
   module.filename = path.resolve('repl');
@@ -874,10 +887,6 @@ REPLServer.prototype.createContext = function() {
     }, () => {
       context = vm.createContext();
     });
-    for (const name of Object.getOwnPropertyNames(global)) {
-      Object.defineProperty(context, name,
-                            Object.getOwnPropertyDescriptor(global, name));
-    }
     context.global = context;
     const _console = new Console(this.outputStream);
     Object.defineProperty(context, 'console', {
@@ -885,6 +894,15 @@ REPLServer.prototype.createContext = function() {
       writable: true,
       value: _console
     });
+
+    for (const name of Object.getOwnPropertyNames(global)) {
+      if (name === 'console' || name === 'global')
+        continue;
+      if (GLOBAL_OBJECT_PROPERTY_MAP[name] === undefined) {
+        Object.defineProperty(context, name,
+                              Object.getOwnPropertyDescriptor(global, name));
+      }
+    }
   }
 
   const module = new CJSModule('<repl>');
@@ -1455,6 +1473,10 @@ function _memory(cmd) {
 }
 
 function addCommonWords(completionGroups) {
+  // Global object properties
+  // (http://www.ecma-international.org/publications/standards/Ecma-262.htm)
+  completionGroups.push(GLOBAL_OBJECT_PROPERTIES);
+
   // Only words which do not yet exist as global property should be added to
   // this list.
   completionGroups.push([

--- a/test/parallel/test-repl-context.js
+++ b/test/parallel/test-repl-context.js
@@ -21,6 +21,7 @@ const stream = new ArrayStream();
 
   // Ensure that the repl console instance is not the global one.
   assert.notStrictEqual(r.context.console, console);
+  assert.notStrictEqual(r.context.Object, Object);
 
   const context = r.createContext();
   // Ensure that the repl context gets its own "console" instance.

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -496,7 +496,7 @@ const testNonGlobal = repl.start({
   useGlobal: false
 });
 
-const builtins = [['Infinity', 'Int16Array', 'Int32Array',
+const builtins = [['Infinity', '', 'Int16Array', 'Int32Array',
                    'Int8Array'], 'I'];
 
 if (common.hasIntl) {


### PR DESCRIPTION
The global object in repl conetxt is copied from main context, which breaks the behavior of `instanceof`.

This change reverts https://github.com/nodejs/node/pull/25731. cc @BridgeAR 

Fixes: https://github.com/nodejs/node/issues/27859
Refs: https://github.com/nodejs/node/pull/25731

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
