### PR TITLE
test: missing vtable in test when LTO is enabled

### DIFF
--- a/test/abort/test-addon-uv-handle-leak.js
+++ b/test/abort/test-addon-uv-handle-leak.js
@@ -79,7 +79,11 @@ if (process.argv[2] === 'child') {
         common.isAIX ||
         (common.isLinux && !isGlibc()) ||
         common.isWindows)) {
-    assert(stderr.includes('ExampleOwnerClass'), stderr);
+
+    // the vtable can get optimized away when LTO is enabled
+    if (common.isLinux && !process.config.variables.enable_lto)
+      assert(stderr.includes('ExampleOwnerClass'), stderr);
+
     assert(stderr.includes('CloseCallback'), stderr);
     assert(stderr.includes('example_instance'), stderr);
   }


### PR DESCRIPTION
Issue: https://github.com/nodejs/node/issues/28026

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
