### PR TITLE
util: support AsyncGeneratorFunction in .inspect

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -870,10 +870,11 @@ function getBoxedBase(value, ctx, keys, constructor, tag) {
 
 function getFunctionBase(value, constructor, tag) {
   let type = 'Function';
+  if (isGeneratorFunction(value)) {
+    type = `Generator${type}`;
+  }
   if (isAsyncFunction(value)) {
-    type = 'AsyncFunction';
-  } else if (isGeneratorFunction(value)) {
-    type = 'GeneratorFunction';
+    type = `Async${type}`;
   }
   let base = `[${type}`;
   if (constructor === null) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -48,6 +48,10 @@ assert.strictEqual(util.inspect(async () => {}), '[AsyncFunction (anonymous)]');
     util.inspect(fn),
     '[GeneratorFunction (anonymous)]'
   );
+  assert.strictEqual(
+    util.inspect(async function* abc() {}),
+    '[AsyncGeneratorFunction: abc]'
+  );
   Object.setPrototypeOf(fn, Object.getPrototypeOf(async () => {}));
   assert.strictEqual(
     util.inspect(fn),


### PR DESCRIPTION
This makes sure async generator functions are properly detected while
using `util.inspect`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
