### PR TITLE
util: special handle `maxArrayLength` while grouping arrays

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -970,12 +970,17 @@ function groupArrayElements(ctx, output) {
   let totalLength = 0;
   let maxLength = 0;
   let i = 0;
+  let outputLength = output.length;
+  if (ctx.maxArrayLength < output.length) {
+    // This makes sure the "... n more items" part is not taken into account.
+    outputLength--;
+  }
   const separatorSpace = 2; // Add 1 for the space and 1 for the separator.
-  const dataLen = new Array(output.length);
+  const dataLen = new Array(outputLength);
   // Calculate the total length of all output entries and the individual max
   // entries length of all output entries. We have to remove colors first,
   // otherwise the length would not be calculated properly.
-  for (; i < output.length; i++) {
+  for (; i < outputLength; i++) {
     const len = ctx.colors ? removeColors(output[i]).length : output[i].length;
     dataLen[i] = len;
     totalLength += len + separatorSpace;
@@ -1003,7 +1008,7 @@ function groupArrayElements(ctx, output) {
       // The added bias slightly increases the columns for short entries.
       Math.round(
         Math.sqrt(
-          approxCharHeights * (actualMax - bias) * output.length
+          approxCharHeights * (actualMax - bias) * outputLength
         ) / (actualMax - bias)
       ),
       // Do not exceed the breakLength.
@@ -1027,19 +1032,22 @@ function groupArrayElements(ctx, output) {
         firstLineMaxLength = dataLen[i];
     }
     // Each iteration creates a single line of grouped entries.
-    for (i = 0; i < output.length; i += columns) {
+    for (i = 0; i < outputLength; i += columns) {
       // Calculate extra color padding in case it's active. This has to be done
       // line by line as some lines might contain more colors than others.
       let colorPadding = output[i].length - dataLen[i];
       // Add padding to the first column of the output.
       let str = output[i].padStart(firstLineMaxLength + colorPadding, ' ');
       // The last lines may contain less entries than columns.
-      const max = Math.min(i + columns, output.length);
+      const max = Math.min(i + columns, outputLength);
       for (var j = i + 1; j < max; j++) {
         colorPadding = output[j].length - dataLen[j];
         str += `, ${output[j].padStart(maxLength + colorPadding, ' ')}`;
       }
       tmp.push(str);
+    }
+    if (ctx.maxArrayLength < output.length) {
+      tmp.push(output[outputLength]);
     }
     output = tmp;
   }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2193,7 +2193,7 @@ assert.strictEqual(
       [ 1, 2, { a: 1, b: 2, c: 3 } ]
     ],
     c: ['foo', 4, 444444],
-    d: Array.from({ length: 100 }).map((e, i) => {
+    d: Array.from({ length: 101 }).map((e, i) => {
       return i % 2 === 0 ? i * i : i;
     }),
     e: Array(6).fill('foobar'),
@@ -2242,7 +2242,8 @@ assert.strictEqual(
     '      77, 6084,   79, 6400,   81, 6724,   83,',
     '    7056,   85, 7396,   87, 7744,   89, 8100,',
     '      91, 8464,   93, 8836,   95, 9216,   97,',
-    '    9604,   99',
+    '    9604,   99,',
+    '    ... 1 more item',
     '  ],',
     '  e: [',
     "    'foobar',",


### PR DESCRIPTION
This makes sure that large arrays with lots of small entries ignore
the `... n more item(s)` part since it often resulted in output that
users did not expect.

Now that part is printed on a separate line to indicate extra entries.

Now: 
![image](https://user-images.githubusercontent.com/8822573/58899151-80112a80-86fc-11e9-8e6b-b608440833f2.png)

Before:

![image](https://user-images.githubusercontent.com/8822573/58899184-90c1a080-86fc-11e9-8c59-71bcdce82e05.png)

Refs: #27690

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
