### PR TITLE
crypto: add debug info to client emit secureConnect

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1335,12 +1335,14 @@ function onConnectSecure() {
       this.destroy(verifyError);
       return;
     } else {
-      debug('client emit secureConnect');
+      debug('client emit secureConnect. rejectUnauthorized: %s, ' +
+            'authorizationError: %s', options.rejectUnauthorized,
+            this.authorizationError);
       this.emit('secureConnect');
     }
   } else {
     this.authorized = true;
-    debug('client emit secureConnect');
+    debug('client emit secureConnect. authorized:', this.authorized);
     this.emit('secureConnect');
   }
 


### PR DESCRIPTION
Currently, when debugging a TLS connection there might be multiple debug
statements `client emit secureConnect` for the 'secureConnect' event
when using `NODE_DEBUG='tls'`. While it is possible to step through this
with a debugger that is not always the fastest/easiest to do if debugging
remote code.

This commit adds some additional information to the debug statements to
make it easier to distinguish where the debug statements are coming
from.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
