### PR TITLE
src: expose DOMException to internalBinding('message') for testing

### DIFF
--- a/test/wpt/test-url.js
+++ b/test/wpt/test-url.js
@@ -3,29 +3,16 @@
 // Flags: --expose-internals
 
 require('../common');
-const assert = require('assert');
 const { WPTRunner } = require('../common/wpt');
-
+const { internalBinding } = require('internal/test/binding');
+const { DOMException } = internalBinding('messaging');
 const runner = new WPTRunner('url');
 
 // Copy global descriptors from the global object
 runner.copyGlobalsFromObject(global, ['URL', 'URLSearchParams']);
 // Needed by urlsearchparams-constructor.any.js
-let DOMException;
 runner.defineGlobal('DOMException', {
   get() {
-    // A 'hack' to get the DOMException constructor since we don't have it
-    // on the global object.
-    if (DOMException === undefined) {
-      const port = new (require('worker_threads').MessagePort)();
-      const ab = new ArrayBuffer(1);
-      try {
-        port.postMessage(ab, [ab, ab]);
-      } catch (err) {
-        DOMException = err.constructor;
-      }
-      assert.strictEqual(DOMException.name, 'DOMException');
-    }
     return DOMException;
   }
 });


### PR DESCRIPTION
Instead of using a hack to get it in the test.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
