### PR TITLE
Add documentation for Http2Stream#id property

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1077,7 +1077,7 @@ added: v8.4.0
 
 * {number}
 
-The numeric stream identifier of this `Http2Stream` instance. Set to undefined
+The numeric stream identifier of this `Http2Stream` instance. Set to `undefined`
 if the stream identifier has not yet been assigned.
 
 #### http2stream.pending

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1075,7 +1075,7 @@ and the readable side of the `Http2Stream` will be closed.
 added: v8.4.0
 -->
 
-* {number}
+* {number|undefined}
 
 The numeric stream identifier of this `Http2Stream` instance. Set to `undefined`
 if the stream identifier has not yet been assigned.

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1070,6 +1070,16 @@ Set the `true` if the `END_STREAM` flag was set in the request or response
 HEADERS frame received, indicating that no additional data should be received
 and the readable side of the `Http2Stream` will be closed.
 
+#### http2stream.id
+<!-- YAML
+added: v8.4.0
+-->
+
+* {number}
+
+The numeric stream identifier of this `Http2Stream` instance. Set to undefined
+if the stream identifier has not yet been assigned.
+
 #### http2stream.pending
 <!-- YAML
 added: v9.4.0


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added

This property is already mentioned in [this section](https://nodejs.org/api/http2.html#http2_creation) of the documentation. The implementation can be found [here](https://github.com/nodejs/node/blob/master/lib/internal/http2/core.js#L1693), and it was introduced in [the original commit for the http2 module](https://github.com/nodejs/node/commit/e71e71b5138c3dfee080f4215dd957dc7a6cbdaf)
