### PR TITLE
doc: adjust TOC margins

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -353,8 +353,11 @@ hr {
 
 #toc h2 {
   margin-top: 0;
-  line-height: 0;
   margin: 1.5rem 0;
+}
+
+#toc p {
+  margin: 0;
 }
 
 #toc ul a {


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Adjusted the margins in the Documentation's TOC to be less weird and uniform within the elements of the TOC tree.

Before:
<img width="376" src="https://user-images.githubusercontent.com/115237/58977363-d4cea700-87c9-11e9-863a-a7082b84965c.png">

After:
<img width="376" src="https://user-images.githubusercontent.com/115237/58977376-dd26e200-87c9-11e9-8e8f-cfaf3926106f.png">

