### PR TITLE
doc: mark Node.js 11 as EOL in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Select a Node.js version below to view the changelog history:
 
 * [Node.js 12](doc/changelogs/CHANGELOG_V12.md) - **Current**
-* [Node.js 11](doc/changelogs/CHANGELOG_V11.md) - Current
+* [Node.js 11](doc/changelogs/CHANGELOG_V11.md) - End-of-Life
 * [Node.js 10](doc/changelogs/CHANGELOG_V10.md) — **Long Term Support**
 * [Node.js 9](doc/changelogs/CHANGELOG_V9.md) — End-of-Life
 * [Node.js 8](doc/changelogs/CHANGELOG_V8.md) — Long Term Support
@@ -23,7 +23,6 @@ release.
 <table>
 <tr>
   <th title="Current"><a href="doc/changelogs/CHANGELOG_V12.md">12</a><sup>Current</sup></th>
-  <th title="Current"><a href="doc/changelogs/CHANGELOG_V11.md">11</a><sup>Current</sup></th>
   <th title="LTS Until 2021-04"><a href="doc/changelogs/CHANGELOG_V10.md">10</a><sup>LTS</sup></th>
   <th title="LTS Until 2019-12"><a href="doc/changelogs/CHANGELOG_V8.md">8</a><sup>LTS</sup></th>
 </tr>
@@ -35,25 +34,6 @@ release.
 <a href="doc/changelogs/CHANGELOG_V12.md#12.2.0">12.2.0</a><br/>
 <a href="doc/changelogs/CHANGELOG_V12.md#12.1.0">12.1.0</a><br/>
 <a href="doc/changelogs/CHANGELOG_V12.md#12.0.0">12.0.0</a><br/>
-    </td>
-    <td valign="top">
-<b><a href="doc/changelogs/CHANGELOG_V11.md#11.15.0">11.15.0</a></b><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.14.0">11.14.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.13.0">11.13.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.12.0">11.12.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.11.0">11.11.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.10.1">11.10.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.10.0">11.10.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.9.0">11.9.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.8.0">11.8.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.7.0">11.7.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.6.0">11.6.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.5.0">11.5.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.4.0">11.4.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.3.0">11.3.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.2.0">11.2.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.1.0">11.1.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V11.md#11.0.0">11.0.0</a><br/>
     </td>
     <td valign="top">
 <b><a href="doc/changelogs/CHANGELOG_V10.md#10.16.0">10.16.0</a></b><br/>


### PR DESCRIPTION
Update the changelog to mark Node.js 11 as End-of-Life. Remove the
column for Node.js 11 changelog entries from the table.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
