### PR TITLE
module: handle empty require.resolve() options

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -598,7 +598,9 @@ Module._resolveFilename = function(request, parent, isMain, options) {
           }
         }
       }
-    } else if (options.paths !== undefined) {
+    } else if (options.paths === undefined) {
+      paths = Module._resolveLookupPaths(request, parent);
+    } else {
       throw new ERR_INVALID_OPT_VALUE('options.paths', options.paths);
     }
   } else {

--- a/test/fixtures/require-resolve.js
+++ b/test/fixtures/require-resolve.js
@@ -92,3 +92,9 @@ common.expectsError(() => {
   code: 'ERR_INVALID_OPT_VALUE',
   type: TypeError,
 });
+
+// Verify that the default require.resolve() is used for empty options.
+assert.strictEqual(
+  require.resolve('./printA.js', {}),
+  require.resolve('./printA.js')
+);


### PR DESCRIPTION
If `require.resolve()` is passed an `options` object, but the `paths` option is not present, then use the default `require.resolve()` paths.

Fixes: https://github.com/nodejs/node/issues/28077

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
