### PR TITLE
n-api: defer Buffer finalizer with SetImmediate

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -641,6 +641,11 @@ void Environment::RunAndClearNativeImmediates() {
           if (!try_catch.HasTerminated())
             FatalException(isolate(), try_catch);
 
+          // We are done with the current callback. Increase the counter so that
+          // the steps below make everything *after* the current item part of
+          // the new list.
+          it++;
+
           // Bail out, remove the already executed callbacks from list
           // and set up a new TryCatch for the other pending callbacks.
           std::move_backward(it, list.end(), list.begin() + (list.end() - it));

--- a/test/node-api/test_buffer/test.js
+++ b/test/node-api/test_buffer/test.js
@@ -4,18 +4,25 @@
 const common = require('../../common');
 const binding = require(`./build/${common.buildType}/test_buffer`);
 const assert = require('assert');
+const setImmediatePromise = require('util').promisify(setImmediate);
 
-assert.strictEqual(binding.newBuffer().toString(), binding.theText);
-assert.strictEqual(binding.newExternalBuffer().toString(), binding.theText);
-console.log('gc1');
-global.gc();
-assert.strictEqual(binding.getDeleterCallCount(), 1);
-assert.strictEqual(binding.copyBuffer().toString(), binding.theText);
+(async function() {
+  assert.strictEqual(binding.newBuffer().toString(), binding.theText);
+  assert.strictEqual(binding.newExternalBuffer().toString(), binding.theText);
+  console.log('gc1');
+  global.gc();
+  assert.strictEqual(binding.getDeleterCallCount(), 0);
+  await setImmediatePromise();
+  assert.strictEqual(binding.getDeleterCallCount(), 1);
+  assert.strictEqual(binding.copyBuffer().toString(), binding.theText);
 
-let buffer = binding.staticBuffer();
-assert.strictEqual(binding.bufferHasInstance(buffer), true);
-assert.strictEqual(binding.bufferInfo(buffer), true);
-buffer = null;
-global.gc();
-console.log('gc2');
-assert.strictEqual(binding.getDeleterCallCount(), 2);
+  let buffer = binding.staticBuffer();
+  assert.strictEqual(binding.bufferHasInstance(buffer), true);
+  assert.strictEqual(binding.bufferInfo(buffer), true);
+  buffer = null;
+  global.gc();
+  assert.strictEqual(binding.getDeleterCallCount(), 1);
+  await setImmediatePromise();
+  console.log('gc2');
+  assert.strictEqual(binding.getDeleterCallCount(), 2);
+})().then(common.mustCall());

--- a/test/node-api/test_exception/test.js
+++ b/test/node-api/test_exception/test.js
@@ -9,7 +9,10 @@ const test_exception = require(`./build/${common.buildType}/test_exception`);
 function testFinalize(binding) {
   let x = test_exception[binding]();
   x = null;
-  assert.throws(() => { global.gc(); }, /Error during Finalize/);
+  global.gc();
+  process.on('uncaughtException', (err) => {
+    assert.strictEqual(err.message, 'Error during Finalize');
+  });
 
   // To assuage the linter's concerns.
   (function() {})(x);


### PR DESCRIPTION
##### src: fix off-by-one error in native SetImmediate

Previously, the throwing callback would have been re-executed in case
of an exception. This patch corrects the calculation to exclude the
callback.

##### n-api: defer Buffer finalizer with SetImmediate

We have a test that verifies that JS execution from the Buffer
finalizer is accepted, and that errors thrown are passed
down synchronously.

However, since the finalizer executes during GC, this is behaviour is
fundamentally invalid and, for good reasons, disallowed by the
JS engine. This leaves us with the options of either finding a way
to allow JS execution from the callback, or explicitly forbidding it on
the N-API side as well.

This commit implements the former option, since it is the more
backwards-compatible one, in the sense that the current situation
sometimes appears to work as well and we should not break that
behaviour if we don’t have to, but rather try to actually make it
work reliably.

Since GC timing is largely unobservable anyway, this commit moves
the callback into a `SetImmediate()`, as we do elsewhere in the code,
and a second pass callback is not an easily implemented option,
as the API is supposed to wrap around Node’s `Buffer` API.
In this case, exceptions are handled like other uncaught exceptions.

Two tests have to be adjusted to account for the timing difference.
This is unfortunate, but unavoidable if we want to conform to the
JS engine API contract and keep all tests.

Fixes: https://github.com/nodejs/node/issues/26754 (as far as the non-build part is concerned)

@nodejs/n-api

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
