### PR TITLE
Cleanup old ssl code

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5564,12 +5564,6 @@ void DiffieHellman::SetPublicKey(const FunctionCallbackInfo<Value>& args) {
 }
 
 void DiffieHellman::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-    OPENSSL_VERSION_NUMBER < 0x10100070L
-// Older versions of OpenSSL 1.1.0 have a DH_set0_key which does not work for
-// Node. See https://github.com/openssl/openssl/pull/4384.
-#error "OpenSSL 1.1.0 revisions before 1.1.0g are not supported"
-#endif
   SetKey(args,
          [](DH* dh, BIGNUM* num) { return DH_set0_key(dh, nullptr, num); },
          "Private key");

--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -30,16 +30,6 @@
 namespace node {
 namespace crypto {
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#define BIO_set_data(bio, data) bio->ptr = data
-#define BIO_get_data(bio) bio->ptr
-#define BIO_set_shutdown(bio, shutdown_) bio->shutdown = shutdown_
-#define BIO_get_shutdown(bio) bio->shutdown
-#define BIO_set_init(bio, init_) bio->init = init_
-#define BIO_get_init(bio) bio->init
-#endif
-
-
 BIOPointer NodeBIO::New(Environment* env) {
   BIOPointer bio(BIO_new(GetMethod()));
   if (bio && env != nullptr)
@@ -231,22 +221,6 @@ long NodeBIO::Ctrl(BIO* bio, int cmd, long num,  // NOLINT(runtime/int)
 
 
 const BIO_METHOD* NodeBIO::GetMethod() {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-  static const BIO_METHOD method = {
-    BIO_TYPE_MEM,
-    "node.js SSL buffer",
-    Write,
-    Read,
-    Puts,
-    Gets,
-    Ctrl,
-    New,
-    Free,
-    nullptr
-  };
-
-  return &method;
-#else
   // This is called from InitCryptoOnce() to avoid race conditions during
   // initialization.
   static BIO_METHOD* method = nullptr;
@@ -263,7 +237,6 @@ const BIO_METHOD* NodeBIO::GetMethod() {
   }
 
   return method;
-#endif
 }
 
 

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -7,10 +7,8 @@ const { readKey } = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const assert = require('assert');
 const https = require('https');
-const { OPENSSL_VERSION_NUMBER, SSL_OP_NO_TICKET } =
-    require('crypto').constants;
+const { SSL_OP_NO_TICKET } = require('crypto').constants;
 
 const options = {
   key: readKey('agent1-key.pem'),
@@ -60,38 +58,12 @@ function second(server, session) {
     res.resume();
   });
 
-  if (OPENSSL_VERSION_NUMBER >= 0x10100000) {
-    // Although we have a TLS 1.2 session to offer to the TLS 1.0 server,
-    // connection to the TLS 1.0 server should work.
-    req.on('response', common.mustCall(function(res) {
-      // The test is now complete for OpenSSL 1.1.0.
-      server.close();
-    }));
-  } else {
-    // OpenSSL 1.0.x mistakenly locked versions based on the session it was
-    // offering. This causes this sequent request to fail. Let it fail, but
-    // test that this is mitigated on the next try by invalidating the session.
-    req.on('error', common.mustCall(function(err) {
-      assert(/wrong version number/.test(err.message));
-
-      req.on('close', function() {
-        third(server);
-      });
-    }));
-  }
-  req.end();
-}
-
-// Try one more time - session should be evicted!
-function third(server) {
-  const req = https.request({
-    port: server.address().port,
-    rejectUnauthorized: false
-  }, function(res) {
-    res.resume();
-    assert(!req.socket.isSessionReused());
+  // Although we have a TLS 1.2 session to offer to the TLS 1.0 server,
+  // connection to the TLS 1.0 server should work.
+  req.on('response', common.mustCall(function(res) {
+    // The test is now complete for OpenSSL 1.1.0.
     server.close();
-  });
-  req.on('error', common.mustNotCall());
+  }));
+
   req.end();
 }


### PR DESCRIPTION
    test: remove workaround for unsupported OpenSSLs
    
    Workaround added in d9b9229d98afb4b is no longer needed, since OpenSSL
    versions lower than 1.1.1 are unsupported.
and

    src: remove TLS code for unsupported OpenSSLs
    
    Versions of OpenSSL lower than 1.1.1 are no longer supported, so remove
    ifdefs for previous versions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
