### PR TITLE
doc: remove superfluous filenaming convention

### DIFF
--- a/doc/api/synopsis.md
+++ b/doc/api/synopsis.md
@@ -55,10 +55,6 @@ Windows PowerShell:
 Next, create a new source file in the `projects`
  folder and call it `hello-world.js`.
 
-In Node.js it is considered good style to use
-hyphens (`-`) or underscores (`_`) to separate
- multiple words in filenames.
-
 Open `hello-world.js` in any preferred text editor and
 paste in the following content:
 


### PR DESCRIPTION
It is debatable whether "it is considered good style" in Node.js to use
hypens or underscores to separate words in file names. Node.js has
little to say about that. Remove that material as it is superfluous.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
