### PR TITLE
doc: clarify weak keys text

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2807,8 +2807,8 @@ it can be used to put the ECDH key pair into an inconsistent state.
 
 The `crypto` module still supports some algorithms which are already
 compromised and are not currently recommended for use. The API also allows
-the use of ciphers and hashes with a small key size that are considered to be
-too weak for safe use.
+the use of ciphers and hashes with a small key size that are too weak for safe
+use.
 
 Users should take full responsibility for selecting the crypto
 algorithm and key size according to their security requirements.


### PR DESCRIPTION
Describe small key sizes as "too weak for safe use" rather than
"considered to be too weak for safe use".

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
