### PR TITLE
process: improve queueMicrotask performance

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Reflect } = primordials;
+const ReflectApply = Reflect.apply;
 
 const {
   ERR_ASYNC_CALLBACK,
@@ -134,15 +135,16 @@ class AsyncResource {
   constructor(type, opts = {}) {
     validateString(type, 'type');
 
-    if (typeof opts === 'number') {
-      opts = { triggerAsyncId: opts, requireManualDestroy: false };
-    } else if (opts.triggerAsyncId === undefined) {
-      opts.triggerAsyncId = getDefaultTriggerAsyncId();
+    let triggerAsyncId = opts;
+    let requireManualDestroy = false;
+    if (typeof opts !== 'number') {
+      triggerAsyncId = opts.triggerAsyncId === undefined ?
+        getDefaultTriggerAsyncId() : opts.triggerAsyncId;
+      requireManualDestroy = !!opts.requireManualDestroy;
     }
 
     // Unlike emitInitScript, AsyncResource doesn't supports null as the
     // triggerAsyncId.
-    const triggerAsyncId = opts.triggerAsyncId;
     if (!Number.isSafeInteger(triggerAsyncId) || triggerAsyncId < -1) {
       throw new ERR_INVALID_ASYNC_ID('triggerAsyncId', triggerAsyncId);
     }
@@ -151,15 +153,14 @@ class AsyncResource {
     this[async_id_symbol] = asyncId;
     this[trigger_async_id_symbol] = triggerAsyncId;
 
-    // This prop name (destroyed) has to be synchronized with C++
-    const destroyed = { destroyed: false };
-    this[destroyedSymbol] = destroyed;
-
     if (initHooksExist()) {
       emitInit(asyncId, type, triggerAsyncId, this);
     }
 
-    if (!opts.requireManualDestroy) {
+    if (!requireManualDestroy) {
+      // This prop name (destroyed) has to be synchronized with C++
+      const destroyed = { destroyed: false };
+      this[destroyedSymbol] = destroyed;
       registerDestroyHook(this, asyncId, destroyed);
     }
   }
@@ -168,14 +169,16 @@ class AsyncResource {
     const asyncId = this[async_id_symbol];
     emitBefore(asyncId, this[trigger_async_id_symbol]);
     try {
-      return Reflect.apply(fn, thisArg, args);
+      return ReflectApply(fn, thisArg, args);
     } finally {
       emitAfter(asyncId);
     }
   }
 
   emitDestroy() {
-    this[destroyedSymbol].destroyed = true;
+    if (this[destroyedSymbol] !== undefined) {
+      this[destroyedSymbol].destroyed = true;
+    }
     emitDestroy(this[async_id_symbol]);
     return this;
   }

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { Reflect } = primordials;
-const ReflectApply = Reflect.apply;
 
 const {
   ERR_ASYNC_CALLBACK,
@@ -169,7 +168,9 @@ class AsyncResource {
     const asyncId = this[async_id_symbol];
     emitBefore(asyncId, this[trigger_async_id_symbol]);
     try {
-      return ReflectApply(fn, thisArg, args);
+      if (thisArg === undefined)
+        return fn(...args);
+      return Reflect.apply(fn, thisArg, args);
     } finally {
       emitAfter(asyncId);
     }

--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { FunctionPrototype } = primordials;
+const FunctionPrototypeBind = FunctionPrototype.bind;
 
 const {
   // For easy access to the nextTick state in the C++ land,
@@ -136,15 +137,13 @@ function nextTick(callback) {
 }
 
 let AsyncResource;
+const defaultMicrotaskResourceOpts = { requireManualDestroy: true };
 function createMicrotaskResource() {
   // Lazy load the async_hooks module
-  if (!AsyncResource) {
+  if (AsyncResource === undefined) {
     AsyncResource = require('async_hooks').AsyncResource;
   }
-  return new AsyncResource('Microtask', {
-    triggerAsyncId: getDefaultTriggerAsyncId(),
-    requireManualDestroy: true,
-  });
+  return new AsyncResource('Microtask', defaultMicrotaskResourceOpts);
 }
 
 function runMicrotask() {
@@ -172,7 +171,7 @@ function queueMicrotask(callback) {
   const asyncResource = createMicrotaskResource();
   asyncResource.callback = callback;
 
-  enqueueMicrotask(FunctionPrototype.bind(runMicrotask, asyncResource));
+  enqueueMicrotask(FunctionPrototypeBind(runMicrotask, asyncResource));
 }
 
 module.exports = {

--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { FunctionPrototype } = primordials;
-const FunctionPrototypeBind = FunctionPrototype.bind;
 
 const {
   // For easy access to the nextTick state in the C++ land,
@@ -171,7 +170,7 @@ function queueMicrotask(callback) {
   const asyncResource = createMicrotaskResource();
   asyncResource.callback = callback;
 
-  enqueueMicrotask(FunctionPrototypeBind(runMicrotask, asyncResource));
+  enqueueMicrotask(FunctionPrototype.bind(runMicrotask, asyncResource));
 }
 
 module.exports = {


### PR DESCRIPTION
Optimize the hot code paths of queueMicrotask by not creating unnecessary objects, not looking up properties on frozen primordials, etc.

Benchmark: https://ci.nodejs.org/job/benchmark-node-micro-benchmarks/389/

```
                                            confidence improvement accuracy (*)   (**)  (***)
process/queue-microtask-breadth.js n=400000        ***      3.91 %       ±1.28% ±1.69% ±2.17%
process/queue-microtask-depth.js n=1200000         ***     16.19 %       ±0.84% ±1.11% ±1.42%
```

That said, this is what I get locally so I figure the system makes a difference:

```
                                             confidence improvement accuracy (*)   (**)  (***)
 process/queue-microtask-breadth.js n=400000        ***     49.12 %       ±2.95% ±3.93% ±5.12%
 process/queue-microtask-depth.js n=1200000         ***     18.32 %       ±1.47% ±1.96% ±2.55%
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
