### PR TITLE
deps: ignore deps/.cipd fetched by deps/v8/tools/node/fetch_deps.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,8 @@ _UpgradeReport_Files/
 /deps/uv/.github/
 /deps/uv/docs/code/
 /deps/uv/docs/src/guide/
+# Ignore dependencies fetched by deps/v8/tools/node/fetch_deps.py
+/deps/.cipd
 
 # === Global Rules ===
 # Keep last to avoid being excluded


### PR DESCRIPTION
This may show up when building and running v8 tests locally
with tools/make-v8.sh

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
