### PR TITLE
doc: improve DEP0090 text

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1809,10 +1809,10 @@ changes:
 Type: End-of-Life
 
 Node.js used to support all GCM authentication tag lengths which are accepted by
-OpenSSL when calling [`decipher.setAuthTag()`][]. Beginning with node v11.0.0,
-only authentication tag lengths of 128, 120, 112, 104, 96, 64, and 32 bits are
-allowed. Authentication tags whose length is not included in this list are
-considered invalid in compliance with [NIST SP 800-38D][].
+OpenSSL when calling [`decipher.setAuthTag()`][]. Beginning with Node.js
+v11.0.0, only authentication tag lengths of 128, 120, 112, 104, 96, 64, and 32
+bits are allowed. Authentication tags of other lengths are invalid per
+[NIST SP 800-38D][].
 
 <a id="DEP0091"></a>
 ### DEP0091: crypto.DEFAULT_ENCODING


### PR DESCRIPTION
Edit text for "DEP0090: Invalid GCM authentication tag lengths" for
clarity and branding. Invalid langths are "invalid" rather than
"considered invalid". Refer to "Node.js v11.0.0" rather than "node
v11.0.0".

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
