### PR TITLE
doc: edit reason-for-deprecation text

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -5,7 +5,7 @@
 
 Node.js may deprecate APIs for any of the following reasons:
 
-* Use of the API is considered to be unsafe.
+* Use of the API is unsafe.
 * An improved alternative API is available.
 * Breaking changes to the API are expected in a future major release.
 


### PR DESCRIPTION
It's not clear (to me, at least) how describing an API as  "considered
to be unsafe" differs from describing it as simply "unsafe". Use the
shorter, latter wording.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
