### PR TITLE
doc: document trace-events category for dns requests

### DIFF
--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -20,6 +20,7 @@ The available categories are:
 * `node.bootstrap` - Enables capture of Node.js bootstrap milestones.
 * `node.console` - Enables capture of `console.time()` and `console.count()`
   output.
+* `node.dns.native` - Enables capture of trace data for DNS queries.
 * `node.environment` - Enables capture of Node.js Environment milestones.
 * `node.fs.sync` - Enables capture of trace data for file system sync methods.
 * `node.perf` - Enables capture of [Performance API] measurements.


### PR DESCRIPTION
As implemented in https://github.com/nodejs/node/pull/21840, dns can
emit trace events when the category is enabled. This PR just add
it to the documentation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
