### PR TITLE
doc: add Buffer#subarray() and add note about Uint8Array#slice()

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1977,7 +1977,9 @@ offset and cropped by the `start` and `end` indices.
 
 This is the same behavior as `buf.subarray()`.
 
-Note that this method is not compatible with the `Uint8Array#slice()`, which is a superclass of `Buffer`. If a copy of slice is needed, use `Uint8Array.prototype.slice` directly.
+Note that this method is not compatible with the `Uint8Array.prototype.slice()`,
+which is a superclass of `Buffer`. If a copy of the slice is needed, use
+`Uint8Array.prototype.slice` directly.
 
 ```js
 const buf = Buffer.from('buffer');

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1981,7 +1981,7 @@ offset and cropped by the `start` and `end` indices.
 This is the same behavior as `buf.subarray()`.
 
 This method is not compatible with the `Uint8Array.prototype.slice()`,
-which is a superclass of `Buffer`. If a copy of the slice is needed, use
+which is a superclass of `Buffer`. To copy the slice, use
 `Uint8Array.prototype.slice()`.
 
 ```js

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1980,7 +1980,7 @@ offset and cropped by the `start` and `end` indices.
 
 This is the same behavior as `buf.subarray()`.
 
-Note that this method is not compatible with the `Uint8Array.prototype.slice()`,
+This method is not compatible with the `Uint8Array.prototype.slice()`,
 which is a superclass of `Buffer`. If a copy of the slice is needed, use
 `Uint8Array.prototype.slice()`.
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1982,7 +1982,7 @@ This is the same behavior as `buf.subarray()`.
 
 Note that this method is not compatible with the `Uint8Array.prototype.slice()`,
 which is a superclass of `Buffer`. If a copy of the slice is needed, use
-`Uint8Array.prototype.slice` directly.
+`Uint8Array.prototype.slice()`.
 
 ```js
 const buf = Buffer.from('buffer');

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1897,6 +1897,9 @@ console.log(buf.readUIntBE(1, 6).toString(16));
 ```
 
 ### buf.subarray([start[, end]])
+<!-- YAML
+added: v3.0.0
+-->
 
 * `start` {integer} Where the new `Buffer` will start. **Default:** `0`.
 * `end` {integer} Where the new `Buffer` will end (not inclusive).

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1896,19 +1896,7 @@ console.log(buf.readUIntBE(1, 6).toString(16));
 // Throws ERR_OUT_OF_RANGE.
 ```
 
-### buf.slice([start[, end]])
-<!-- YAML
-added: v0.3.0
-changes:
-  - version: v7.1.0, v6.9.2
-    pr-url: https://github.com/nodejs/node/pull/9341
-    description: Coercing the offsets to integers now handles values outside
-                 the 32-bit integer range properly.
-  - version: v7.0.0
-    pr-url: https://github.com/nodejs/node/pull/9101
-    description: All offsets are now coerced to integers before doing any
-                 calculations with them.
--->
+### buf.subarray([start[, end]])
 
 * `start` {integer} Where the new `Buffer` will start. **Default:** `0`.
 * `end` {integer} Where the new `Buffer` will end (not inclusive).
@@ -1935,7 +1923,7 @@ for (let i = 0; i < 26; i++) {
   buf1[i] = i + 97;
 }
 
-const buf2 = buf1.slice(0, 3);
+const buf2 = buf1.subarray(0, 3);
 
 console.log(buf2.toString('ascii', 0, buf2.length));
 // Prints: abc
@@ -1952,17 +1940,55 @@ end of `buf` rather than the beginning.
 ```js
 const buf = Buffer.from('buffer');
 
-console.log(buf.slice(-6, -1).toString());
+console.log(buf.subarray(-6, -1).toString());
 // Prints: buffe
-// (Equivalent to buf.slice(0, 5).)
+// (Equivalent to buf.subarray(0, 5).)
 
-console.log(buf.slice(-6, -2).toString());
+console.log(buf.subarray(-6, -2).toString());
 // Prints: buff
-// (Equivalent to buf.slice(0, 4).)
+// (Equivalent to buf.subarray(0, 4).)
 
-console.log(buf.slice(-5, -2).toString());
+console.log(buf.subarray(-5, -2).toString());
 // Prints: uff
-// (Equivalent to buf.slice(1, 4).)
+// (Equivalent to buf.subarray(1, 4).)
+```
+
+### buf.slice([start[, end]])
+<!-- YAML
+added: v0.3.0
+changes:
+  - version: v7.1.0, v6.9.2
+    pr-url: https://github.com/nodejs/node/pull/9341
+    description: Coercing the offsets to integers now handles values outside
+                 the 32-bit integer range properly.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/9101
+    description: All offsets are now coerced to integers before doing any
+                 calculations with them.
+-->
+
+* `start` {integer} Where the new `Buffer` will start. **Default:** `0`.
+* `end` {integer} Where the new `Buffer` will end (not inclusive).
+  **Default:** [`buf.length`][].
+* Returns: {Buffer}
+
+Returns a new `Buffer` that references the same memory as the original, but
+offset and cropped by the `start` and `end` indices.
+
+This is the same behavior as `buf.subarray()`.
+
+Note that this method is not compatible with the `Uint8Array#slice()`, which is a superclass of `Buffer`. If a copy of slice is needed, use `Uint8Array.prototype.slice` directly.
+
+```js
+const buf = Buffer.from('buffer');
+
+const copiedBuf = Uint8Array.prototype.slice.call(buf);
+copiedBuf[0]++;
+console.log(copiedBuf.toString());
+// Prints: cuffer
+
+console.log(buf.toString());
+// Prints: buffer
 ```
 
 ### buf.swap16()


### PR DESCRIPTION
refs: https://github.com/nodejs/node/issues/28087

* Added document for `Buffer#subarray()`; its content is just copied from `#slice()`
* Changed document for `Buffer#slice()` because of its incompatibility with its superclass's method, and also added how to use `Uint8Array.prototype.slice()` to get a copy of slice

##### Checklist

- <del>[ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes</del>
- <del>[ ] tests and/or benchmarks are included</del>
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
