### PR TITLE
build: more portable Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1214,11 +1214,11 @@ lint-js:
 jslint: lint-js
 	$(info Please use lint-js instead of jslint)
 
-# For CI use local compiled 'node', and output in xUnit (junit) format.
+# For CI use local compiled 'node', and output in TAP format.
 .PHONY: lint-js-ci
 lint-js-ci:
 	$(info Running JS linter...)
-	./node tools/lint-js.js $(PARALLEL_ARGS) -f junit -o test-eslint.xml $(LINT_JS_TARGETS)
+	./node tools/lint-js.js $(PARALLEL_ARGS) -f tap -o test-eslint.tap $(LINT_JS_TARGETS)
 
 jslint-ci: lint-js-ci
 	$(info Please use lint-js-ci instead of jslint-ci)

--- a/Makefile
+++ b/Makefile
@@ -692,7 +692,7 @@ tools/doc/node_modules: tools/doc/package.json
 	@if [ "$(shell $(node_use_openssl))" != "true" ]; then \
 		echo "Skipping tools/doc/node_modules (no crypto)"; \
 	else \
-		cd tools/doc && $(call available-node,$(run-npm-ci)) \
+		cd tools/doc && $(call available-node,$(run-npm-ci)); \
 	fi
 
 .PHONY: doc-only
@@ -1211,7 +1211,7 @@ lint-js:
 		echo "Skipping $@ (no crypto)"; \
 	else \
 		echo "Running JS linter..."; \
-		$(call available-node,$(run-lint-js)) \
+		$(call available-node,$(run-lint-js)); \
 	fi
 
 jslint: lint-js


### PR DESCRIPTION
* Make some `$(shell)` calls lazy
* `$(wildcard)` instead of `ls`
* `$(info)` instead of `echo`
* `$?` instead of duplicated file lists

Biggest benefit: smoother experience with MSYS `make` (can be added to "Git Bash", or vendored)

/CC @nodejs/build-files @nodejs/platform-windows 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
