### PR TITLE
readline: error on falsy values for callback

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -121,7 +121,7 @@ function Interface(input, output, completer, terminal) {
     input = input.input;
   }
 
-  if (completer && typeof completer !== 'function') {
+  if (completer !== undefined && typeof completer !== 'function') {
     throw new ERR_INVALID_OPT_VALUE('completer', completer);
   }
 

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -366,6 +366,26 @@ function isWarned(emitter) {
       type: TypeError,
       code: 'ERR_INVALID_OPT_VALUE'
     });
+
+    common.expectsError(function() {
+      readline.createInterface({
+        input: fi,
+        completer: ''
+      });
+    }, {
+      type: TypeError,
+      code: 'ERR_INVALID_OPT_VALUE'
+    });
+
+    common.expectsError(function() {
+      readline.createInterface({
+        input: fi,
+        completer: false
+      });
+    }, {
+      type: TypeError,
+      code: 'ERR_INVALID_OPT_VALUE'
+    });
   }
 
   // Constructor throws if historySize is not a positive number


### PR DESCRIPTION
It was intended, according to in-test comments and common behaviour,
that callbacks be either `undefined` or a function, but falsy values
were being accepted as meaning "no callback".


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
