### PR TITLE
util: use Set to store deprecation codes

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -35,7 +35,7 @@ function isError(e) {
 
 // Keep a list of deprecation codes that have been warned on so we only warn on
 // each one once.
-const codesWarned = {};
+const codesWarned = new Set();
 
 // Mark that a method should not be used.
 // Returns a modified function which warns once by default.
@@ -53,9 +53,9 @@ function deprecate(fn, msg, code) {
     if (!warned) {
       warned = true;
       if (code !== undefined) {
-        if (!codesWarned[code]) {
+        if (!codesWarned.has(code)) {
           process.emitWarning(msg, 'DeprecationWarning', code, deprecated);
-          codesWarned[code] = true;
+          codesWarned.add(code);
         }
       } else {
         process.emitWarning(msg, 'DeprecationWarning', deprecated);


### PR DESCRIPTION
uses **Set** over **Object** to store deprecation codes.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
