### PR TITLE
tls: rename validateKeyCert in _tls_common.js

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -75,7 +75,7 @@ function SecureContext(secureProtocol, secureOptions, minVersion, maxVersion) {
   if (secureOptions) this.context.setOptions(secureOptions);
 }
 
-function validateKeyCertArg(name, value) {
+function validateKeyOrCertOption(name, value) {
   if (typeof value !== 'string' && !isArrayBufferView(value)) {
     throw new ERR_INVALID_ARG_TYPE(
       `options.${name}`,
@@ -107,11 +107,11 @@ exports.createSecureContext = function createSecureContext(options) {
     if (Array.isArray(ca)) {
       for (i = 0; i < ca.length; ++i) {
         val = ca[i];
-        validateKeyCertArg('ca', val);
+        validateKeyOrCertOption('ca', val);
         c.context.addCACert(val);
       }
     } else {
-      validateKeyCertArg('ca', ca);
+      validateKeyOrCertOption('ca', ca);
       c.context.addCACert(ca);
     }
   } else {
@@ -123,11 +123,11 @@ exports.createSecureContext = function createSecureContext(options) {
     if (Array.isArray(cert)) {
       for (i = 0; i < cert.length; ++i) {
         val = cert[i];
-        validateKeyCertArg('cert', val);
+        validateKeyOrCertOption('cert', val);
         c.context.setCert(val);
       }
     } else {
-      validateKeyCertArg('cert', cert);
+      validateKeyOrCertOption('cert', cert);
       c.context.setCert(cert);
     }
   }
@@ -144,11 +144,11 @@ exports.createSecureContext = function createSecureContext(options) {
         val = key[i];
         // eslint-disable-next-line eqeqeq
         const pem = (val != undefined && val.pem !== undefined ? val.pem : val);
-        validateKeyCertArg('key', pem);
+        validateKeyOrCertOption('key', pem);
         c.context.setKey(pem, val.passphrase || passphrase);
       }
     } else {
-      validateKeyCertArg('key', key);
+      validateKeyOrCertOption('key', key);
       c.context.setKey(key, passphrase);
     }
   }

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -75,7 +75,7 @@ function SecureContext(secureProtocol, secureOptions, minVersion, maxVersion) {
   if (secureOptions) this.context.setOptions(secureOptions);
 }
 
-function validateKeyCert(name, value) {
+function validateKeyCertArg(name, value) {
   if (typeof value !== 'string' && !isArrayBufferView(value)) {
     throw new ERR_INVALID_ARG_TYPE(
       `options.${name}`,
@@ -107,11 +107,11 @@ exports.createSecureContext = function createSecureContext(options) {
     if (Array.isArray(ca)) {
       for (i = 0; i < ca.length; ++i) {
         val = ca[i];
-        validateKeyCert('ca', val);
+        validateKeyCertArg('ca', val);
         c.context.addCACert(val);
       }
     } else {
-      validateKeyCert('ca', ca);
+      validateKeyCertArg('ca', ca);
       c.context.addCACert(ca);
     }
   } else {
@@ -123,11 +123,11 @@ exports.createSecureContext = function createSecureContext(options) {
     if (Array.isArray(cert)) {
       for (i = 0; i < cert.length; ++i) {
         val = cert[i];
-        validateKeyCert('cert', val);
+        validateKeyCertArg('cert', val);
         c.context.setCert(val);
       }
     } else {
-      validateKeyCert('cert', cert);
+      validateKeyCertArg('cert', cert);
       c.context.setCert(cert);
     }
   }
@@ -144,11 +144,11 @@ exports.createSecureContext = function createSecureContext(options) {
         val = key[i];
         // eslint-disable-next-line eqeqeq
         const pem = (val != undefined && val.pem !== undefined ? val.pem : val);
-        validateKeyCert('key', pem);
+        validateKeyCertArg('key', pem);
         c.context.setKey(pem, val.passphrase || passphrase);
       }
     } else {
-      validateKeyCert('key', key);
+      validateKeyCertArg('key', key);
       c.context.setKey(key, passphrase);
     }
   }


### PR DESCRIPTION
This commit renames validateKeyCert to validateKeyCertArg to avoid
confusing this with something that would validate the actual key or
certificate.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
