### PR TITLE
build: unbreak --with-intl=system-icu build

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -628,18 +628,20 @@ def pkg_config(pkg):
   Returns ("-l flags", "-I flags", "-L flags", "version")
   otherwise (None, None, None, None)"""
   pkg_config = os.environ.get('PKG_CONFIG', 'pkg-config')
+  args = []  # Print pkg-config warnings on first round.
   retval = ()
   for flag in ['--libs-only-l', '--cflags-only-I',
                '--libs-only-L', '--modversion']:
+    args += [flag, pkg]
     try:
-      proc = subprocess.Popen(
-          shlex.split(pkg_config) + ['--silence-errors', flag, pkg],
-          stdout=subprocess.PIPE)
+      proc = subprocess.Popen(shlex.split(pkg_config) + args,
+                              stdout=subprocess.PIPE)
       val = proc.communicate()[0].strip()
     except OSError as e:
       if e.errno != errno.ENOENT: raise e  # Unexpected error.
       return (None, None, None, None)  # No pkg-config/pkgconf installed.
     retval += (val,)
+    args = ['--silence-errors']
   return retval
 
 

--- a/configure.py
+++ b/configure.py
@@ -1348,7 +1348,7 @@ def configure_intl(o):
     # ICU from pkg-config.
     o['variables']['v8_enable_i18n_support'] = 1
     pkgicu = pkg_config('icu-i18n')
-    if pkgicu[0] is None:
+    if not pkgicu[0]:
       error('''Could not load pkg-config data for "icu-i18n".
        See above errors or the README.md.''')
     (libs, cflags, libpath, icuversion) = pkgicu

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -393,13 +393,6 @@
             '<(icu_gyp_path):icui18n',
             '<(icu_gyp_path):icuuc',
           ],
-          'direct_dependent_settings': {
-            'include_dirs': [
-              '<(icu_path)/source/common',
-              '<(icu_path)/source/i18n',
-              '<(icu_path)/source/tools/toolutil',
-            ],
-          },
         }],
       ],
     },  # v8_maybe_icu


### PR DESCRIPTION
Include directories are configured by the tools/icu/icu-*.gyp files.
The v8.gyp file doesn't need to add them and in fact the way it did
that breaks when building against an external copy of ICU.

Fixes: #28052

CI: https://ci.nodejs.org/job/node-test-commit/29244/