### PR TITLE
http: fix test where aborted should not be emitted

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -24,11 +24,7 @@
 const { Math } = primordials;
 const { setImmediate } = require('timers');
 
-const { getOptionValue } = require('internal/options');
-
-const { methods, HTTPParser } =
-  getOptionValue('--http-parser') === 'legacy' ?
-    internalBinding('http_parser') : internalBinding('http_parser_llhttp');
+const { methods, HTTPParser } = internalBinding('http_parser');
 
 const FreeList = require('internal/freelist');
 const { ondrain } = require('internal/http');

--- a/test/parallel/test-http-response-no-headers.js
+++ b/test/parallel/test-http-response-no-headers.js
@@ -51,6 +51,7 @@ function test(httpVersion, callback) {
         body += data;
       });
 
+      res.on('aborted', common.mustNotCall());
       res.on('end', common.mustCall(function() {
         assert.strictEqual(body, expected[httpVersion]);
         server.close();

--- a/test/parallel/test-http-response-status-message.js
+++ b/test/parallel/test-http-response-status-message.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 const net = require('net');
@@ -71,6 +71,7 @@ function runTest(testCaseIndex) {
     console.log(`client: actual status message: ${response.statusMessage}`);
     assert.strictEqual(testCase.statusMessage, response.statusMessage);
 
+    response.on('aborted', common.mustNotCall());
     response.on('end', function() {
       countdown.dec();
       if (testCaseIndex + 1 < testCases.length) {


### PR DESCRIPTION
This fixes two http tests to properly catch a potential bug where `aborted` is incorrectly emitted.

I don't know how to fix the actual "bug". 

##### Checklist
- [x] commit message follows [commit guidelines]
