### PR TITLE
report: add report versioning

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -22,6 +22,7 @@ is provided below for reference.
 ```json
 {
   "header": {
+    "reportVersion": 1,
     "event": "exception",
     "trigger": "Exception",
     "filename": "report.20181221.005011.8974.0.001.json",

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -24,6 +24,7 @@
 extern char** environ;
 #endif
 
+constexpr int NODE_REPORT_VERSION = 1;
 constexpr int NANOS_PER_SEC = 1000 * 1000 * 1000;
 constexpr double SEC_PER_MICROS = 1e-6;
 
@@ -172,7 +173,7 @@ static void WriteNodeReport(Isolate* isolate,
   JSONWriter writer(out);
   writer.json_start();
   writer.json_objectstart("header");
-
+  writer.json_keyvalue("reportVersion", NODE_REPORT_VERSION);
   writer.json_keyvalue("event", message);
   writer.json_keyvalue("trigger", trigger);
   if (!filename.empty())

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -63,8 +63,10 @@ function _validateContent(data) {
                         'nodejsVersion', 'wordSize', 'arch', 'platform',
                         'componentVersions', 'release', 'osName', 'osRelease',
                         'osVersion', 'osMachine', 'cpus', 'host',
-                        'glibcVersionRuntime', 'glibcVersionCompiler', 'cwd'];
+                        'glibcVersionRuntime', 'glibcVersionCompiler', 'cwd',
+                        'reportVersion'];
   checkForUnknownFields(header, headerFields);
+  assert.strictEqual(header.reportVersion, 1);  // Increment as needed.
   assert.strictEqual(typeof header.event, 'string');
   assert.strictEqual(typeof header.trigger, 'string');
   assert(typeof header.filename === 'string' || header.filename === null);


### PR DESCRIPTION
Marking as WIP, as this is still being discussed.

This commit adds a semver version to the diagnostic report feature.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
