### PR TITLE
test: add github refs to flaky tests

### DIFF
--- a/test/known_issues/known_issues.status
+++ b/test/known_issues/known_issues.status
@@ -9,6 +9,8 @@ prefix known_issues
 [$system==win32]
 
 [$system==linux]
+# https://github.com/nodejs/node/pull/23743
+# https://github.com/nodejs/node/issues/3020
 test-vm-timeout-escape-promise: PASS,FLAKY
 
 [$system==macos]

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -11,11 +11,13 @@ test-net-connect-options-port: PASS,FLAKY
 test-worker-prof: PASS,FLAKY
 
 [$system==win32]
+# https://github.com/nodejs/node/issues/20750
 test-http2-pipe: PASS,FLAKY
 # https://github.com/nodejs/node/issues/23277
 test-worker-memory: PASS,FLAKY
 # https://github.com/nodejs/node/issues/20750
 test-http2-client-upload: PASS,FLAKY
+# https://github.com/nodejs/node/issues/20750
 test-http2-client-upload-reject: PASS,FLAKY
 # https://github.com/nodejs/node/issues/28106
 test-worker-debug: PASS,FLAKY

--- a/test/pseudo-tty/pseudo-tty.status
+++ b/test/pseudo-tty/pseudo-tty.status
@@ -1,7 +1,7 @@
 prefix pseudo-tty
 
 [$system==aix]
-# being investigated under https://github.com/nodejs/node/issues/9728
+# https://github.com/nodejs/node/issues/9728
 test-tty-wrap              : FAIL, PASS
 
 [$system==solaris]


### PR DESCRIPTION
See https://github.com/nodejs/reliability/issues/1, I'm trying to get the info on flakes correct.

I also adjusted platform labels for the issues, though that can't be seen in this PR, and added a platform label for Linux, since one was missing and  there were some Linux flakes.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
