### PR TITLE
test: move the corresponding IPv4 and IPv6 tests

### DIFF
--- a/test/parallel/test-net-isip.js
+++ b/test/parallel/test-net-isip.js
@@ -53,7 +53,14 @@ const ip = [
   ['0', 0]
 ];
 
-ip.forEach(([ip, version]) => {
-  assert.strictEqual(net.isIP(ip), version);
-  assert.strictEqual(net.isIP({ toString: () => ip }), version);
-});
+const validateIsIP = ([ip, version]) => {
+  const errMessage = `\n\nnet.isIP('${ip}') !== ${version}\n`;
+  assert.strictEqual(net.isIP(ip), version, errMessage);
+  assert.strictEqual(
+    net.isIP({ toString: () => ip }),
+    version,
+    errMessage
+  );
+};
+
+ip.forEach(validateIsIP);

--- a/test/parallel/test-net-isip.js
+++ b/test/parallel/test-net-isip.js
@@ -24,70 +24,36 @@ require('../common');
 const assert = require('assert');
 const net = require('net');
 
-assert.strictEqual(net.isIP('127.0.0.1'), 4);
-assert.strictEqual(net.isIP('x127.0.0.1'), 0);
-assert.strictEqual(net.isIP('example.com'), 0);
-assert.strictEqual(net.isIP('0000:0000:0000:0000:0000:0000:0000:0000'), 6);
-assert.strictEqual(net.isIP('0000:0000:0000:0000:0000:0000:0000:0000::0000'),
-                   0);
-assert.strictEqual(net.isIP('1050:0:0:0:5:600:300c:326b'), 6);
-assert.strictEqual(net.isIP('2001:252:0:1::2008:6'), 6);
-assert.strictEqual(net.isIP('2001:dead:beef:1::2008:6'), 6);
-assert.strictEqual(net.isIP('2001::'), 6);
-assert.strictEqual(net.isIP('2001:dead::'), 6);
-assert.strictEqual(net.isIP('2001:dead:beef::'), 6);
-assert.strictEqual(net.isIP('2001:dead:beef:1::'), 6);
-assert.strictEqual(net.isIP('ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff'), 6);
-assert.strictEqual(net.isIP(':2001:252:0:1::2008:6:'), 0);
-assert.strictEqual(net.isIP(':2001:252:0:1::2008:6'), 0);
-assert.strictEqual(net.isIP('2001:252:0:1::2008:6:'), 0);
-assert.strictEqual(net.isIP('2001:252::1::2008:6'), 0);
-assert.strictEqual(net.isIP('::2001:252:1:2008:6'), 6);
-assert.strictEqual(net.isIP('::2001:252:1:1.1.1.1'), 6);
-assert.strictEqual(net.isIP('::2001:252:1:255.255.255.255'), 6);
-assert.strictEqual(net.isIP('::2001:252:1:255.255.255.255.76'), 0);
-assert.strictEqual(net.isIP('::anything'), 0);
-assert.strictEqual(net.isIP('::1'), 6);
-assert.strictEqual(net.isIP('::'), 6);
-assert.strictEqual(net.isIP('0000:0000:0000:0000:0000:0000:12345:0000'), 0);
-assert.strictEqual(net.isIP('0'), 0);
-assert.strictEqual(net.isIP(), 0);
-assert.strictEqual(net.isIP(''), 0);
-assert.strictEqual(net.isIP(null), 0);
-assert.strictEqual(net.isIP(123), 0);
-assert.strictEqual(net.isIP(true), 0);
-assert.strictEqual(net.isIP({}), 0);
-assert.strictEqual(net.isIP({ toString: () => '::2001:252:1:255.255.255.255' }),
-                   6);
-assert.strictEqual(net.isIP({ toString: () => '127.0.0.1' }), 4);
-assert.strictEqual(net.isIP({ toString: () => 'bla' }), 0);
+const ip = [
+  ['127.0.0.1', 4],
+  ['8.8.8.8', 4],
+  ['x127.0.0.1', 0],
+  ['example.com', 0],
+  ['0000:0000:0000:0000:0000:0000:0000:0000', 6],
+  ['0000:0000:0000:0000:0000:0000:0000:0000::0000', 0],
+  ['1050:0:0:0:5:600:300c:326b', 6],
+  ['2001:252:0:1::2008:6', 6],
+  ['2001::', 6],
+  ['2001:dead::', 6],
+  ['2001:dead:beef::', 6],
+  ['2001:dead:beef:1::', 6],
+  ['ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', 6],
+  [':2001:252:0:1::2008:6:', 0],
+  [':2001:252:0:1::2008:6', 0],
+  ['2001:252:0:1::2008:6:', 0],
+  ['2001:252::1::2008:6', 0],
+  ['::2001:252:1:2008:6', 6],
+  ['::2001:252:1:1.1.1.1', 6],
+  ['::2001:252:1:255.255.255.255', 6],
+  ['::2001:252:1:255.255.255.255.76', 0],
+  ['::anything', 0],
+  ['::1', 6],
+  ['::', 6],
+  ['0000:0000:0000:0000:0000:0000:12345:0000', 0],
+  ['0', 0]
+];
 
-assert.strictEqual(net.isIPv4('127.0.0.1'), true);
-assert.strictEqual(net.isIPv4('example.com'), false);
-assert.strictEqual(net.isIPv4('2001:252:0:1::2008:6'), false);
-assert.strictEqual(net.isIPv4(), false);
-assert.strictEqual(net.isIPv4(''), false);
-assert.strictEqual(net.isIPv4(null), false);
-assert.strictEqual(net.isIPv4(123), false);
-assert.strictEqual(net.isIPv4(true), false);
-assert.strictEqual(net.isIPv4({}), false);
-assert.strictEqual(net.isIPv4({
-  toString: () => '::2001:252:1:255.255.255.255'
-}), false);
-assert.strictEqual(net.isIPv4({ toString: () => '127.0.0.1' }), true);
-assert.strictEqual(net.isIPv4({ toString: () => 'bla' }), false);
-
-assert.strictEqual(net.isIPv6('127.0.0.1'), false);
-assert.strictEqual(net.isIPv6('example.com'), false);
-assert.strictEqual(net.isIPv6('2001:252:0:1::2008:6'), true);
-assert.strictEqual(net.isIPv6(), false);
-assert.strictEqual(net.isIPv6(''), false);
-assert.strictEqual(net.isIPv6(null), false);
-assert.strictEqual(net.isIPv6(123), false);
-assert.strictEqual(net.isIPv6(true), false);
-assert.strictEqual(net.isIPv6({}), false);
-assert.strictEqual(net.isIPv6({
-  toString: () => '::2001:252:1:255.255.255.255'
-}), true);
-assert.strictEqual(net.isIPv6({ toString: () => '127.0.0.1' }), false);
-assert.strictEqual(net.isIPv6({ toString: () => 'bla' }), false);
+ip.forEach(([ip, version]) => {
+  assert.strictEqual(net.isIP(ip), version);
+  assert.strictEqual(net.isIP({ toString: () => ip }), version);
+});

--- a/test/parallel/test-net-isipv4.js
+++ b/test/parallel/test-net-isipv4.js
@@ -39,8 +39,10 @@ const v4not = [
 
 v4.forEach((ip) => {
   assert.strictEqual(net.isIPv4(ip), true);
+  assert.strictEqual(net.isIPv4({ toString: () => ip }), true);
 });
 
 v4not.forEach((ip) => {
   assert.strictEqual(net.isIPv4(ip), false);
+  assert.strictEqual(net.isIPv4({ toString: () => ip }), false);
 });

--- a/test/parallel/test-net-isipv4.js
+++ b/test/parallel/test-net-isipv4.js
@@ -37,12 +37,16 @@ const v4not = [
   '192.168.0.2000000000'
 ];
 
-v4.forEach((ip) => {
-  assert.strictEqual(net.isIPv4(ip), true);
-  assert.strictEqual(net.isIPv4({ toString: () => ip }), true);
-});
+const validateIsIPv4 = (ip, expected) => {
+  const errMessage = `\n\nnet.isIPv4('${ip}') !== ${expected}\n`;
+  assert.strictEqual(net.isIPv4(ip), expected, errMessage);
+  assert.strictEqual(
+    net.isIPv4({ toString: () => ip }),
+    expected,
+    errMessage
+  );
+};
 
-v4not.forEach((ip) => {
-  assert.strictEqual(net.isIPv4(ip), false);
-  assert.strictEqual(net.isIPv4({ toString: () => ip }), false);
-});
+v4.forEach((ip) => validateIsIPv4(ip, true));
+
+v4not.forEach((ip) => validateIsIPv4(ip, false));

--- a/test/parallel/test-net-isipv6.js
+++ b/test/parallel/test-net-isipv6.js
@@ -235,12 +235,16 @@ const v6not = [
   '02001:0000:1234:0000:0000:C1C0:ABCD:0876'
 ];
 
-v6.forEach((ip) => {
-  assert.strictEqual(net.isIPv6(ip), true);
-  assert.strictEqual(net.isIPv6({ toString: () => ip }), true);
-});
+const validateIsIPv6 = (ip, expected) => {
+  const errMessage = `\n\nnet.isIPv6('${ip}') !== ${expected}\n`;
+  assert.strictEqual(net.isIPv6(ip), expected, errMessage);
+  assert.strictEqual(
+    net.isIPv6({ toString: () => ip }),
+    expected,
+    errMessage
+  );
+};
 
-v6not.forEach((ip) => {
-  assert.strictEqual(net.isIPv6(ip), false);
-  assert.strictEqual(net.isIPv6({ toString: () => ip }), false);
-});
+v6.forEach((ip) => validateIsIPv6(ip, true));
+
+v6not.forEach((ip) => validateIsIPv6(ip, false));

--- a/test/parallel/test-net-isipv6.js
+++ b/test/parallel/test-net-isipv6.js
@@ -237,8 +237,10 @@ const v6not = [
 
 v6.forEach((ip) => {
   assert.strictEqual(net.isIPv6(ip), true);
+  assert.strictEqual(net.isIPv6({ toString: () => ip }), true);
 });
 
 v6not.forEach((ip) => {
   assert.strictEqual(net.isIPv6(ip), false);
+  assert.strictEqual(net.isIPv6({ toString: () => ip }), false);
 });


### PR DESCRIPTION
Move the IPv4 and IPv6 test in the isIp file to the corresponding file,
and remove non-string tests(isIP test is only for string input).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
