### PR TITLE
test: remove test-tty-wrap from status file

### DIFF
--- a/test/pseudo-tty/pseudo-tty.status
+++ b/test/pseudo-tty/pseudo-tty.status
@@ -1,8 +1,6 @@
 prefix pseudo-tty
 
 [$system==aix]
-# being investigated under https://github.com/nodejs/node/issues/9728
-test-tty-wrap              : FAIL, PASS
 
 [$system==solaris]
 # https://github.com/nodejs/node/pull/16225 - `ioctl(fd, TIOCGWINSZ)` seems


### PR DESCRIPTION
The test is believed to no longer be unreliable on AIX. Remove the flaky
designation from the appropriate status file.

Closes: https://github.com/nodejs/node/issues/9728

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
