### PR TITLE
test: remove test-gc-http-client from status file

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -5,8 +5,6 @@ prefix sequential
 # sample-test                       : PASS,FLAKY
 
 [true] # This section applies to all platforms
-# https://github.com/nodejs/node/issues/22336
-test-gc-http-client: PASS,FLAKY
 
 [$system==win32]
 # https://github.com/nodejs/node/issues/22327


### PR DESCRIPTION
test-gc-http-client is no longer believed to be unreliable. Remove it's
entry indicating it's flaky from the status file.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
