### PR TITLE
lib: remove unnecessary bind

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -327,7 +327,7 @@ ClientRequest.prototype._implicitHeader = function _implicitHeader() {
 
 ClientRequest.prototype.abort = function abort() {
   if (!this.aborted) {
-    process.nextTick(emitAbortNT.bind(this));
+    process.nextTick(emitAbortNT, this);
   }
   this.aborted = true;
 
@@ -345,8 +345,8 @@ ClientRequest.prototype.abort = function abort() {
 };
 
 
-function emitAbortNT() {
-  this.emit('abort');
+function emitAbortNT(req) {
+  req.emit('abort');
 }
 
 function ondrain() {

--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -118,8 +118,8 @@ function shared(message, handle, indexesKey, cb) {
     send({ act: 'close', key });
     handles.delete(key);
     indexes.delete(indexesKey);
-    return close.apply(this, arguments);
-  }.bind(handle);
+    return close.apply(handle, arguments);
+  };
   assert(handles.has(key) === false);
   handles.set(key, handle);
   cb(message.errno, handle);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -121,7 +121,7 @@ class FileHandle {
     return writeFile(this, data, options);
   }
 
-  close() {
+  close = () => {
     return this[kHandle].close();
   }
 }
@@ -425,7 +425,7 @@ async function lchmod(path, mode) {
     throw new ERR_METHOD_NOT_IMPLEMENTED('lchmod()');
 
   const fd = await open(path, O_WRONLY | O_SYMLINK);
-  return fchmod(fd, mode).finally(fd.close.bind(fd));
+  return fchmod(fd, mode).finally(fd.close);
 }
 
 async function lchown(path, uid, gid) {
@@ -490,7 +490,7 @@ async function writeFile(path, data, options) {
     return writeFileHandle(path, data, options);
 
   const fd = await open(path, flag, options.mode);
-  return writeFileHandle(fd, data, options).finally(fd.close.bind(fd));
+  return writeFileHandle(fd, data, options).finally(fd.close);
 }
 
 async function appendFile(path, data, options) {
@@ -508,7 +508,7 @@ async function readFile(path, options) {
     return readFileHandle(path, options);
 
   const fd = await open(path, flag, 0o666);
-  return readFileHandle(fd, options).finally(fd.close.bind(fd));
+  return readFileHandle(fd, options).finally(fd.close);
 }
 
 module.exports = {

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -442,7 +442,7 @@ WriteStream.prototype.close = function(cb) {
   // If we are not autoClosing, we should call
   // destroy on 'finish'.
   if (!this.autoClose) {
-    this.on('finish', this.destroy.bind(this));
+    this.on('finish', this.destroy);
   }
 
   // We use end() instead of destroy() because of

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2152,10 +2152,14 @@ class Http2Stream extends Duplex {
         // By using setImmediate we allow pushStreams to make it through
         // before the stream is officially closed. This prevents a bug
         // in most browsers where those pushStreams would be rejected.
-        setImmediate(this.close.bind(this));
+        setImmediate(callStreamClose, this);
       }
     }
   }
+}
+
+function callStreamClose(stream) {
+  stream.close();
 }
 
 function processHeaders(oldHeaders) {

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -463,11 +463,14 @@ function getObserversList(type) {
   return list;
 }
 
-function doNotify() {
-  this[kQueued] = false;
-  this.runInAsyncScope(this[kCallback], this, this[kBuffer], this);
-  this[kBuffer][kEntries] = [];
-  L.init(this[kBuffer][kEntries]);
+function doNotify(observer) {
+  observer[kQueued] = false;
+  observer.runInAsyncScope(observer[kCallback],
+                           observer,
+                           observer[kBuffer],
+                           observer);
+  observer[kBuffer][kEntries] = [];
+  L.init(observer[kBuffer][kEntries]);
 }
 
 // Set up the callback used to receive PerformanceObserver notifications
@@ -493,11 +496,11 @@ function observersCallback(entry) {
         observer[kQueued] = true;
         // Use setImmediate instead of nextTick to give more time
         // for multiple entries to collect.
-        setImmediate(doNotify.bind(observer));
+        setImmediate(doNotify, observer);
       }
     } else {
       // If not buffering, notify immediately
-      doNotify.call(observer);
+      doNotify(observer);
     }
     current = current._idlePrev;
   }


### PR DESCRIPTION
There has been a lot of effort on the V8 side to optimize `bind` performance but nonetheless it's still unnecessary overhead in many cases. Removing it can also make the resulting code more readable as the implied scope isn't immediately apparent when reading certain functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
