### PR TITLE
dgram: fix abort on bad args

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -561,16 +561,19 @@ Socket.prototype.send = function(buffer,
       port = offset;
       address = length;
     }
-  } else if (typeof length === 'number') {
-    buffer = sliceBuffer(buffer, offset, length);
-    if (typeof port === 'function') {
-      callback = port;
-      port = null;
-    } else if (port || address) {
-      throw new ERR_SOCKET_DGRAM_IS_CONNECTED();
-    }
   } else {
-    callback = offset;
+    if (typeof length === 'number') {
+      buffer = sliceBuffer(buffer, offset, length);
+      if (typeof port === 'function') {
+        callback = port;
+        port = null;
+      }
+    } else {
+      callback = offset;
+    }
+
+    if (port || address)
+      throw new ERR_SOCKET_DGRAM_IS_CONNECTED();
   }
 
   if (!Array.isArray(buffer)) {

--- a/test/parallel/test-dgram-send-bad-arguments.js
+++ b/test/parallel/test-dgram-send-bad-arguments.js
@@ -68,6 +68,15 @@ function checkArgs(connected) {
         message: 'Already connected'
       }
     );
+
+    common.expectsError(
+      () => { sock.send(buf, 1234, '127.0.0.1', common.mustNotCall()); },
+      {
+        code: 'ERR_SOCKET_DGRAM_IS_CONNECTED',
+        type: Error,
+        message: 'Already connected'
+      }
+    );
   } else {
     assert.throws(() => { sock.send(buf, 1, 1, -1, host); }, RangeError);
     assert.throws(() => { sock.send(buf, 1, 1, 0, host); }, RangeError);


### PR DESCRIPTION
This commit fixes a C++ abort for connected dgram sockets by improving input validation in the JS layer.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
