### PR TITLE
test: improve unexpected warnings error

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -528,7 +528,15 @@ let catchWarning;
 function expectWarning(nameOrMap, expected, code) {
   if (catchWarning === undefined) {
     catchWarning = {};
-    process.on('warning', (warning) => catchWarning[warning.name](warning));
+    process.on('warning', (warning) => {
+      if (!catchWarning[warning.name]) {
+        throw new TypeError(
+          `"${warning.name}" was triggered without being expected.\n` +
+          util.inspect(warning)
+        );
+      }
+      catchWarning[warning.name](warning);
+    });
   }
   if (typeof nameOrMap === 'string') {
     catchWarning[nameOrMap] = _expectWarning(nameOrMap, expected, code);


### PR DESCRIPTION
If someone adds an `expectsWarning` listener without handling all
warnings triggered in that test file, it'll result in a cryptic error
message. This improves the situation by providing an explicit error
about the unexpected warning.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
