### PR TITLE
lib: correct error.errno to always be numeric

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -419,7 +419,7 @@ attempts to read a file that does not exist.
 * `code` {string} The string error code
 * `dest` {string} If present, the file path destination when reporting a file
   system error
-* `errno` {number|string} The system-provided error number
+* `errno` {number} The system-provided error number
 * `info` {Object} If present, extra details about the error condition
 * `message` {string} A system-provided human-readable description of the error
 * `path` {string} If present, the file path when reporting a file system error
@@ -448,13 +448,16 @@ system error.
 
 ### error.errno
 
-* {string|number}
+* {number}
 
-The `error.errno` property is a number or a string. If it is a number, it is a
-negative value which corresponds to the error code defined in
-[`libuv Error handling`]. See the libuv `errno.h` header file
-(`deps/uv/include/uv/errno.h` in the Node.js source tree) for details. In case
-of a string, it is the same as `error.code`.
+The `error.errno` property is a negative number which corresponds
+to the error code defined in [`libuv Error handling`].
+See the libuv `errno.h` header file (`deps/uv/include/uv/errno.h`
+in the Node.js source tree) for details. On Windows the error number
+provided by the system will be normalized by libuv.
+
+To get the string representation of the error code, use
+[`util.getSystemErrorName(error.errno)`].
 
 ### error.info
 
@@ -2357,6 +2360,7 @@ such as `process.stdout.on('data')`.
 [`stream.write()`]: stream.html#stream_writable_write_chunk_encoding_callback
 [`subprocess.kill()`]: child_process.html#child_process_subprocess_kill_signal
 [`subprocess.send()`]: child_process.html#child_process_subprocess_send_message_sendhandle_options_callback
+[`util.getSystemErrorName(error.errno)`]: util.html#util_util_getsystemerrorname_err
 [`zlib`]: zlib.html
 [ES Module]: esm.html
 [ICU]: intl.html#intl_internationalization_support

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -452,9 +452,8 @@ system error.
 
 The `error.errno` property is a negative number which corresponds
 to the error code defined in [`libuv Error handling`].
-See the libuv `errno.h` header file (`deps/uv/include/uv/errno.h`
-in the Node.js source tree) for details. On Windows the error number
-provided by the system will be normalized by libuv.
+
+On Windows the error number provided by the system will be normalized by libuv.
 
 To get the string representation of the error code, use
 [`util.getSystemErrorName(error.errno)`].

--- a/lib/internal/cluster/round_robin_handle.js
+++ b/lib/internal/cluster/round_robin_handle.js
@@ -2,7 +2,6 @@
 const assert = require('internal/assert');
 const net = require('net');
 const { sendHelper } = require('internal/cluster/utils');
-const uv = internalBinding('uv');
 const { constants } = internalBinding('tcp_wrap');
 
 module.exports = RoundRobinHandle;
@@ -58,10 +57,7 @@ RoundRobinHandle.prototype.add = function(worker, send) {
   // Still busy binding.
   this.server.once('listening', done);
   this.server.once('error', (err) => {
-    // Hack: translate 'EADDRINUSE' error string back to numeric error code.
-    // It works but ideally we'd have some backchannel between the net and
-    // cluster modules for stuff like this.
-    send(uv[`UV_${err.errno}`], null);
+    send(err.errno, null);
   });
 };
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -423,7 +423,7 @@ function uvExceptionWithHostPort(err, syscall, address, port) {
   const ex = new Error(`${message}${details}`);
   Error.stackTraceLimit = tmpLimit;
   ex.code = code;
-  ex.errno = code;
+  ex.errno = err;
   ex.syscall = syscall;
   ex.address = address;
   if (port) {
@@ -455,8 +455,8 @@ function errnoException(err, syscall, original) {
 
   // eslint-disable-next-line no-restricted-syntax
   const ex = new Error(message);
-  // TODO(joyeecheung): errno is supposed to err, like in uvException
-  ex.code = ex.errno = code;
+  ex.errno = err;
+  ex.code = code;
   ex.syscall = syscall;
 
   // eslint-disable-next-line no-restricted-syntax
@@ -499,9 +499,9 @@ function exceptionWithHostPort(err, syscall, address, port, additional) {
   Error.stackTraceLimit = 0;
   // eslint-disable-next-line no-restricted-syntax
   const ex = new Error(`${syscall} ${code}${details}`);
-  // TODO(joyeecheung): errno is supposed to err, like in uvException
   Error.stackTraceLimit = tmpLimit;
-  ex.code = ex.errno = code;
+  ex.errno = err;
+  ex.code = code;
   ex.syscall = syscall;
   ex.address = address;
   if (port) {
@@ -520,9 +520,16 @@ function exceptionWithHostPort(err, syscall, address, port, additional) {
  * @returns {Error}
  */
 function dnsException(code, syscall, hostname) {
+  let errno;
   // If `code` is of type number, it is a libuv error number, else it is a
   // c-ares error code.
+  // TODO(joyeecheung): translate c-ares error codes into numeric ones and
+  // make them available in a property that's not error.errno (since they
+  // can be in conflict with libuv error codes). Also make sure
+  // util.getSystemErrorName() can understand them when an being informed that
+  // the number is a c-ares error code.
   if (typeof code === 'number') {
+    errno = code;
     // ENOTFOUND is not a proper POSIX error, but this error has been in place
     // long enough that it's not practical to remove it.
     if (code === lazyUv().UV_EAI_NODATA || code === lazyUv().UV_EAI_NONAME) {
@@ -539,10 +546,8 @@ function dnsException(code, syscall, hostname) {
   Error.stackTraceLimit = 0;
   // eslint-disable-next-line no-restricted-syntax
   const ex = new Error(message);
-  // TODO(joyeecheung): errno is supposed to be a number / err, like in
   Error.stackTraceLimit = tmpLimit;
-  // uvException.
-  ex.errno = code;
+  ex.errno = errno;
   ex.code = code;
   ex.syscall = syscall;
   if (hostname) {

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -56,9 +56,7 @@ function makeSyncWrite(fd) {
     writeBuffer(fd, chunk, 0, chunk.length, null, undefined, ctx);
     if (ctx.errno !== undefined) {
       const ex = errors.uvException(ctx);
-      // Legacy: net writes have .code === .errno, whereas writeBuffer gives the
-      // raw errno number in .errno.
-      ex.errno = ex.code;
+      ex.errno = ctx.errno;
       return cb(ex);
     }
     cb();

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -24,6 +24,7 @@
 const common = require('../common');
 const { addresses } = require('../common/internet');
 const { internalBinding } = require('internal/test/binding');
+const { getSystemErrorName } = require('util');
 const assert = require('assert');
 const dns = require('dns');
 const net = require('net');
@@ -71,7 +72,10 @@ function checkWrap(req) {
 TEST(function test_reverse_bogus(done) {
   dnsPromises.reverse('bogus ip')
     .then(common.mustNotCall())
-    .catch(common.expectsError({ errno: 'EINVAL' }));
+    .catch(common.mustCall((err) => {
+      assert.strictEqual(err.code, 'EINVAL');
+      assert.strictEqual(getSystemErrorName(err.errno), 'EINVAL');
+    }));
 
   assert.throws(() => {
     dns.reverse('bogus ip', common.mustNotCall());
@@ -161,11 +165,13 @@ TEST(async function test_resolveMx(done) {
 TEST(function test_resolveMx_failure(done) {
   dnsPromises.resolveMx(addresses.INVALID_HOST)
     .then(common.mustNotCall())
-    .catch(common.expectsError({ errno: 'ENOTFOUND' }));
+    .catch(common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ENOTFOUND');
+    }));
 
   const req = dns.resolveMx(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
-    assert.strictEqual(err.errno, 'ENOTFOUND');
+    assert.strictEqual(err.code, 'ENOTFOUND');
 
     assert.strictEqual(result, undefined);
 
@@ -199,11 +205,13 @@ TEST(async function test_resolveNs(done) {
 TEST(function test_resolveNs_failure(done) {
   dnsPromises.resolveNs(addresses.INVALID_HOST)
     .then(common.mustNotCall())
-    .catch(common.expectsError({ errno: 'ENOTFOUND' }));
+    .catch(common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ENOTFOUND');
+    }));
 
   const req = dns.resolveNs(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
-    assert.strictEqual(err.errno, 'ENOTFOUND');
+    assert.strictEqual(err.code, 'ENOTFOUND');
 
     assert.strictEqual(result, undefined);
 
@@ -241,11 +249,13 @@ TEST(async function test_resolveSrv(done) {
 TEST(function test_resolveSrv_failure(done) {
   dnsPromises.resolveSrv(addresses.INVALID_HOST)
     .then(common.mustNotCall())
-    .catch(common.expectsError({ errno: 'ENOTFOUND' }));
+    .catch(common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ENOTFOUND');
+    }));
 
   const req = dns.resolveSrv(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
-    assert.strictEqual(err.errno, 'ENOTFOUND');
+    assert.strictEqual(err.code, 'ENOTFOUND');
 
     assert.strictEqual(result, undefined);
 
@@ -279,11 +289,13 @@ TEST(async function test_resolvePtr(done) {
 TEST(function test_resolvePtr_failure(done) {
   dnsPromises.resolvePtr(addresses.INVALID_HOST)
     .then(common.mustNotCall())
-    .catch(common.expectsError({ errno: 'ENOTFOUND' }));
+    .catch(common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ENOTFOUND');
+    }));
 
   const req = dns.resolvePtr(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
-    assert.strictEqual(err.errno, 'ENOTFOUND');
+    assert.strictEqual(err.code, 'ENOTFOUND');
 
     assert.strictEqual(result, undefined);
 
@@ -322,11 +334,13 @@ TEST(async function test_resolveNaptr(done) {
 TEST(function test_resolveNaptr_failure(done) {
   dnsPromises.resolveNaptr(addresses.INVALID_HOST)
     .then(common.mustNotCall())
-    .catch(common.expectsError({ errno: 'ENOTFOUND' }));
+    .catch(common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ENOTFOUND');
+    }));
 
   const req = dns.resolveNaptr(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
-    assert.strictEqual(err.errno, 'ENOTFOUND');
+    assert.strictEqual(err.code, 'ENOTFOUND');
 
     assert.strictEqual(result, undefined);
 
@@ -369,11 +383,13 @@ TEST(async function test_resolveSoa(done) {
 TEST(function test_resolveSoa_failure(done) {
   dnsPromises.resolveSoa(addresses.INVALID_HOST)
     .then(common.mustNotCall())
-    .catch(common.expectsError({ errno: 'ENOTFOUND' }));
+    .catch(common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ENOTFOUND');
+    }));
 
   const req = dns.resolveSoa(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
-    assert.strictEqual(err.errno, 'ENOTFOUND');
+    assert.strictEqual(err.code, 'ENOTFOUND');
 
     assert.strictEqual(result, undefined);
 
@@ -407,11 +423,13 @@ TEST(async function test_resolveCname(done) {
 TEST(function test_resolveCname_failure(done) {
   dnsPromises.resolveCname(addresses.INVALID_HOST)
     .then(common.mustNotCall())
-    .catch(common.expectsError({ errno: 'ENOTFOUND' }));
+    .catch(common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ENOTFOUND');
+    }));
 
   const req = dns.resolveCname(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
-    assert.strictEqual(err.errno, 'ENOTFOUND');
+    assert.strictEqual(err.code, 'ENOTFOUND');
 
     assert.strictEqual(result, undefined);
 
@@ -443,11 +461,13 @@ TEST(async function test_resolveTxt(done) {
 TEST(function test_resolveTxt_failure(done) {
   dnsPromises.resolveTxt(addresses.INVALID_HOST)
     .then(common.mustNotCall())
-    .catch(common.expectsError({ errno: 'ENOTFOUND' }));
+    .catch(common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ENOTFOUND');
+    }));
 
   const req = dns.resolveTxt(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
-    assert.strictEqual(err.errno, 'ENOTFOUND');
+    assert.strictEqual(err.code, 'ENOTFOUND');
 
     assert.strictEqual(result, undefined);
 
@@ -461,12 +481,12 @@ TEST(function test_resolveTxt_failure(done) {
 TEST(function test_lookup_failure(done) {
   dnsPromises.lookup(addresses.INVALID_HOST, 4)
     .then(common.mustNotCall())
-    .catch(common.expectsError({ errno: dns.NOTFOUND }));
+    .catch(common.expectsError({ code: dns.NOTFOUND }));
 
   const req = dns.lookup(addresses.INVALID_HOST, 4, (err) => {
     assert.ok(err instanceof Error);
-    assert.strictEqual(err.errno, dns.NOTFOUND);
-    assert.strictEqual(err.errno, 'ENOTFOUND');
+    assert.strictEqual(err.code, dns.NOTFOUND);
+    assert.strictEqual(err.code, 'ENOTFOUND');
     assert.ok(!/ENOENT/.test(err.message));
     assert.ok(err.message.includes(addresses.INVALID_HOST));
 

--- a/test/parallel/test-child-process-execfilesync-maxbuf.js
+++ b/test/parallel/test-child-process-execfilesync-maxbuf.js
@@ -5,6 +5,7 @@ require('../common');
 // works as expected.
 
 const assert = require('assert');
+const { getSystemErrorName } = require('util');
 const { execFileSync } = require('child_process');
 const msgOut = 'this is stdout';
 const msgOutBuf = Buffer.from(`${msgOut}\n`);
@@ -20,7 +21,8 @@ const args = [
     execFileSync(process.execPath, args, { maxBuffer: 1 });
   }, (e) => {
     assert.ok(e, 'maxBuffer should error');
-    assert.strictEqual(e.errno, 'ENOBUFS');
+    assert.strictEqual(e.code, 'ENOBUFS');
+    assert.strictEqual(getSystemErrorName(e.errno), 'ENOBUFS');
     // We can have buffers larger than maxBuffer because underneath we alloc 64k
     // that matches our read sizes.
     assert.deepStrictEqual(e.stdout, msgOutBuf);
@@ -44,7 +46,8 @@ const args = [
     );
   }, (e) => {
     assert.ok(e, 'maxBuffer should error');
-    assert.strictEqual(e.errno, 'ENOBUFS');
+    assert.strictEqual(e.code, 'ENOBUFS');
+    assert.strictEqual(getSystemErrorName(e.errno), 'ENOBUFS');
     return true;
   });
 }

--- a/test/parallel/test-child-process-execsync-maxbuf.js
+++ b/test/parallel/test-child-process-execsync-maxbuf.js
@@ -5,6 +5,7 @@ require('../common');
 // works as expected.
 
 const assert = require('assert');
+const { getSystemErrorName } = require('util');
 const { execSync } = require('child_process');
 const msgOut = 'this is stdout';
 const msgOutBuf = Buffer.from(`${msgOut}\n`);
@@ -20,7 +21,8 @@ const args = [
     execSync(`"${process.execPath}" ${args.join(' ')}`, { maxBuffer: 1 });
   }, (e) => {
     assert.ok(e, 'maxBuffer should error');
-    assert.strictEqual(e.errno, 'ENOBUFS');
+    assert.strictEqual(e.code, 'ENOBUFS');
+    assert.strictEqual(getSystemErrorName(e.errno), 'ENOBUFS');
     // We can have buffers larger than maxBuffer because underneath we alloc 64k
     // that matches our read sizes.
     assert.deepStrictEqual(e.stdout, msgOutBuf);
@@ -46,7 +48,8 @@ const args = [
     );
   }, (e) => {
     assert.ok(e, 'maxBuffer should error');
-    assert.strictEqual(e.errno, 'ENOBUFS');
+    assert.strictEqual(e.code, 'ENOBUFS');
+    assert.strictEqual(getSystemErrorName(e.errno), 'ENOBUFS');
     return true;
   });
 }

--- a/test/parallel/test-child-process-spawn-error.js
+++ b/test/parallel/test-child-process-spawn-error.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const { getSystemErrorName } = require('util');
 const spawn = require('child_process').spawn;
 const assert = require('assert');
 const fs = require('fs');
@@ -42,7 +43,7 @@ assert.strictEqual(enoentChild.stdio[2], enoentChild.stderr);
 
 enoentChild.on('error', common.mustCall(function(err) {
   assert.strictEqual(err.code, 'ENOENT');
-  assert.strictEqual(err.errno, 'ENOENT');
+  assert.strictEqual(getSystemErrorName(err.errno), 'ENOENT');
   assert.strictEqual(err.syscall, `spawn ${enoentPath}`);
   assert.strictEqual(err.path, enoentPath);
   assert.deepStrictEqual(err.spawnargs, spawnargs);

--- a/test/parallel/test-child-process-spawnsync-maxbuf.js
+++ b/test/parallel/test-child-process-spawnsync-maxbuf.js
@@ -6,6 +6,7 @@ require('../common');
 
 const assert = require('assert');
 const spawnSync = require('child_process').spawnSync;
+const { getSystemErrorName } = require('util');
 const msgOut = 'this is stdout';
 const msgOutBuf = Buffer.from(`${msgOut}\n`);
 
@@ -19,7 +20,8 @@ const args = [
   const ret = spawnSync(process.execPath, args, { maxBuffer: 1 });
 
   assert.ok(ret.error, 'maxBuffer should error');
-  assert.strictEqual(ret.error.errno, 'ENOBUFS');
+  assert.strictEqual(ret.error.code, 'ENOBUFS');
+  assert.strictEqual(getSystemErrorName(ret.error.errno), 'ENOBUFS');
   // We can have buffers larger than maxBuffer because underneath we alloc 64k
   // that matches our read sizes.
   assert.deepStrictEqual(ret.stdout, msgOutBuf);
@@ -39,7 +41,8 @@ const args = [
   const ret = spawnSync(process.execPath, args);
 
   assert.ok(ret.error, 'maxBuffer should error');
-  assert.strictEqual(ret.error.errno, 'ENOBUFS');
+  assert.strictEqual(ret.error.code, 'ENOBUFS');
+  assert.strictEqual(getSystemErrorName(ret.error.errno), 'ENOBUFS');
 }
 
 // Default maxBuffer size is 1024 * 1024.

--- a/test/parallel/test-child-process-spawnsync-timeout.js
+++ b/test/parallel/test-child-process-spawnsync-timeout.js
@@ -24,6 +24,7 @@ const common = require('../common');
 const assert = require('assert');
 
 const spawnSync = require('child_process').spawnSync;
+const { getSystemErrorName } = require('util');
 
 const TIMER = 200;
 const SLEEP = common.platformTimeout(5000);
@@ -39,7 +40,8 @@ switch (process.argv[2]) {
     const start = Date.now();
     const ret = spawnSync(process.execPath, [__filename, 'child'],
                           { timeout: TIMER });
-    assert.strictEqual(ret.error.errno, 'ETIMEDOUT');
+    assert.strictEqual(ret.error.code, 'ETIMEDOUT');
+    assert.strictEqual(getSystemErrorName(ret.error.errno), 'ETIMEDOUT');
     const end = Date.now() - start;
     assert(end < SLEEP);
     assert(ret.status > 128 || ret.signal);

--- a/test/parallel/test-child-process-spawnsync.js
+++ b/test/parallel/test-child-process-spawnsync.js
@@ -23,6 +23,7 @@
 const common = require('../common');
 const assert = require('assert');
 const { spawnSync } = require('child_process');
+const { getSystemErrorName } = require('util');
 
 // `sleep` does different things on Windows and Unix, but in both cases, it does
 // more-or-less nothing if there are no parameters
@@ -33,7 +34,7 @@ assert.strictEqual(ret.status, 0);
 const ret_err = spawnSync('command_does_not_exist', ['bar']).error;
 
 assert.strictEqual(ret_err.code, 'ENOENT');
-assert.strictEqual(ret_err.errno, 'ENOENT');
+assert.strictEqual(getSystemErrorName(ret_err.errno), 'ENOENT');
 assert.strictEqual(ret_err.syscall, 'spawnSync command_does_not_exist');
 assert.strictEqual(ret_err.path, 'command_does_not_exist');
 assert.deepStrictEqual(ret_err.spawnargs, ['bar']);

--- a/test/parallel/test-dgram-send-error.js
+++ b/test/parallel/test-dgram-send-error.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 const dgram = require('dgram');
 const { internalBinding } = require('internal/test/binding');
 const { UV_UNKNOWN } = internalBinding('uv');
+const { getSystemErrorName } = require('util');
 const { kStateSymbol } = require('internal/dgram');
 const mockError = new Error('mock DNS error');
 
@@ -50,7 +51,7 @@ getSocket((socket) => {
     const callback = common.mustCall((err) => {
       socket.close();
       assert.strictEqual(err.code, 'UNKNOWN');
-      assert.strictEqual(err.errno, 'UNKNOWN');
+      assert.strictEqual(getSystemErrorName(err.errno), 'UNKNOWN');
       assert.strictEqual(err.syscall, 'send');
       assert.strictEqual(err.address, common.localhostIPv4);
       assert.strictEqual(err.port, port);

--- a/test/parallel/test-dns-cancel-reverse-lookup.js
+++ b/test/parallel/test-dns-cancel-reverse-lookup.js
@@ -12,7 +12,6 @@ server.bind(0, common.mustCall(() => {
   resolver.setServers([`127.0.0.1:${server.address().port}`]);
   resolver.reverse('123.45.67.89', common.mustCall((err, res) => {
     assert.strictEqual(err.code, 'ECANCELLED');
-    assert.strictEqual(err.errno, 'ECANCELLED');
     assert.strictEqual(err.syscall, 'getHostByAddr');
     assert.strictEqual(err.hostname, '123.45.67.89');
     server.close();

--- a/test/parallel/test-dns-channel-cancel.js
+++ b/test/parallel/test-dns-channel-cancel.js
@@ -12,7 +12,6 @@ server.bind(0, common.mustCall(() => {
   resolver.setServers([`127.0.0.1:${server.address().port}`]);
   resolver.resolve4('example.org', common.mustCall((err, res) => {
     assert.strictEqual(err.code, 'ECANCELLED');
-    assert.strictEqual(err.errno, 'ECANCELLED');
     assert.strictEqual(err.syscall, 'queryA');
     assert.strictEqual(err.hostname, 'example.org');
     server.close();

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -319,7 +319,6 @@ common.expectsError(() => {
 
 {
   dns.resolveMx('foo.onion', function(err) {
-    assert.deepStrictEqual(err.errno, 'ENOTFOUND');
     assert.deepStrictEqual(err.code, 'ENOTFOUND');
     assert.deepStrictEqual(err.syscall, 'queryMx');
     assert.deepStrictEqual(err.hostname, 'foo.onion');

--- a/test/parallel/test-net-normalize-args.js
+++ b/test/parallel/test-net-normalize-args.js
@@ -4,6 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 const { normalizedArgsSymbol } = require('internal/net');
+const { getSystemErrorName } = require('util');
 
 function validateNormalizedArgs(input, output) {
   const args = net._normalizeArgs(input);
@@ -32,7 +33,7 @@ validateNormalizedArgs([{ port: 1234 }, assert.fail], res);
 
     socket.on('error', common.mustCall((err) => {
       assert(possibleErrors.includes(err.code));
-      assert(possibleErrors.includes(err.errno));
+      assert(possibleErrors.includes(getSystemErrorName(err.errno)));
       assert.strictEqual(err.syscall, 'connect');
       server.close();
     }));

--- a/test/parallel/test-stdout-close-catch.js
+++ b/test/parallel/test-stdout-close-catch.js
@@ -3,6 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const child_process = require('child_process');
 const fixtures = require('../common/fixtures');
+const { getSystemErrorName } = require('util');
 
 const testScript = fixtures.path('catch-stdout-error.js');
 
@@ -13,11 +14,6 @@ const cmd = `${JSON.stringify(process.execPath)} ` +
 
 const child = child_process.exec(cmd);
 let output = '';
-const outputExpect = {
-  code: 'EPIPE',
-  errno: 'EPIPE',
-  syscall: 'write'
-};
 
 child.stderr.on('data', function(c) {
   output += c;
@@ -32,6 +28,8 @@ child.on('close', common.mustCall(function(code) {
     process.exit(1);
   }
 
-  assert.deepStrictEqual(output, outputExpect);
+  assert.strictEqual(output.code, 'EPIPE');
+  assert.strictEqual(getSystemErrorName(output.errno), 'EPIPE');
+  assert.strictEqual(output.syscall, 'write');
   console.log('ok');
 }));

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -20,7 +20,7 @@ keys.forEach((key) => {
   const name = uv.errname(uv[key]);
   assert.strictEqual(getSystemErrorName(uv[key]), name);
   assert.strictEqual(err.code, name);
-  assert.strictEqual(err.code, err.errno);
+  assert.strictEqual(err.code, getSystemErrorName(err.errno));
   assert.strictEqual(err.message, `test ${name}`);
 });
 

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -24,6 +24,7 @@ const common = require('../common');
 const assert = require('assert');
 
 const { execFileSync, execSync, spawnSync } = require('child_process');
+const { getSystemErrorName } = require('util');
 
 const TIMER = 200;
 const SLEEP = 2000;
@@ -48,7 +49,7 @@ try {
   ret = execSync(cmd, { timeout: TIMER });
 } catch (e) {
   caught = true;
-  assert.strictEqual(e.errno, 'ETIMEDOUT');
+  assert.strictEqual(getSystemErrorName(e.errno), 'ETIMEDOUT');
   err = e;
 } finally {
   assert.strictEqual(ret, undefined,


### PR DESCRIPTION
The first commit is taken from https://github.com/nodejs/node/pull/28139

### lib: correct error.errno to always be numeric

Historically `error.errno` of system errors thrown by Node.js
can sometimes be the same as `err.code`, which are string
representations of the error numbers. This is useless and incorrect,
and results in an information loss for users since then they
will have to resort to something like
`process.binding('uv')[`UV_${errno}`]` to get to the numeric
error codes.

This patch corrects this behavior by always setting `error.errno`
to be negative numbers. For fabricated errors like `ENOTFOUND`,
`error.errno` is now undefined since there is no numeric equivalent
for them anyway. For c-ares errors, `error.errno` is now undefined
because the numeric representations (negated) can be in conflict
with libuv error codes - this is fine since numeric codes was
not available for c-ares errors anyway.

Users can use the public API `util.getSystemErrorName(errno)`
to retrieve string codes for these numbers.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
