### PR TITLE
doc: add tls-min/max options to NODE_OPTIONS

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1001,6 +1001,12 @@ Node.js options that are allowed are:
 - `--throw-deprecation`
 - `--title`
 - `--tls-cipher-list`
+- `--tls-max-v1.2`
+- `--tls-max-v1.3`
+- `--tls-min-v1.0`
+- `--tls-min-v1.1`
+- `--tls-min-v1.2`
+- `--tls-min-v1.3`
 - `--trace-deprecation`
 - `--trace-event-categories`
 - `--trace-event-file-pattern`


### PR DESCRIPTION
This commit add the `--tls-min` and `--tls-max` command line options to the
list of allowed options for the `NODE_OPTIONS` environment variable.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
