### PR TITLE
tls: remove unnecessary set of DEFAULT_MAX_VERSION

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -56,8 +56,6 @@ exports.DEFAULT_CIPHERS =
 
 exports.DEFAULT_ECDH_CURVE = 'auto';
 
-exports.DEFAULT_MAX_VERSION = 'TLSv1.3';
-
 if (getOptionValue('--tls-min-v1.0'))
   exports.DEFAULT_MIN_VERSION = 'TLSv1';
 else if (getOptionValue('--tls-min-v1.1'))


### PR DESCRIPTION
This commit removes what looks like an unnecessary setting of
`exports.DEFAULT_MAX_VALUE`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
