### PR TITLE
worker: only unref port for stdin if we ref’ed it before

### DIFF
--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -169,8 +169,10 @@ class ReadableWorkerStdio extends Readable {
     this[kIncrementsPortRef] = true;
     this[kStartedReading] = false;
     this.on('end', () => {
-      if (this[kIncrementsPortRef] && --this[kPort][kWaitingStreams] === 0)
-        this[kPort].unref();
+      if (this[kStartedReading] && this[kIncrementsPortRef]) {
+        if (--this[kPort][kWaitingStreams] === 0)
+          this[kPort].unref();
+      }
     });
   }
 

--- a/test/parallel/test-worker-no-stdin-stdout-interaction.js
+++ b/test/parallel/test-worker-no-stdin-stdout-interaction.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker, isMainThread } = require('worker_threads');
+
+// Regression test for https://github.com/nodejs/node/issues/28144.
+
+if (isMainThread) {
+  const w = new Worker(__filename);
+  w.on('exit', common.mustCall((status) => {
+    assert.strictEqual(status, 0);
+  }));
+  w.stdout.on('data', common.mustCall(10));
+} else {
+  process.stdin.on('data', () => {});
+
+  for (let i = 0; i < 10; ++i) {
+    process.stdout.write(`processing(${i})\n`, common.mustCall());
+  }
+}


### PR DESCRIPTION
We set the `kStartedReading` flag from `_read()` for Worker stdio,
and then `ref()` the port.

However, the `.on('end')` handler is also attached when `._read()`
is not called, e.g. when `process.stdin` inside a Worker is prematurely
ended because stdin was not enabled by the parent thread.

In that case, we should not call `.unref()` for stdin if we did not
also call `.ref()` for it before.

Fixes: https://github.com/nodejs/node/issues/28144

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
