### PR TITLE
test: make sure test function resolves in test-worker-debug

### DIFF
--- a/test/parallel/test-worker-debug.js
+++ b/test/parallel/test-worker-debug.js
@@ -272,7 +272,7 @@ async function testWaitForDisconnectInWorker(session, post) {
 
   session.disconnect();
   console.log('Test done');
-})().catch((err) => {
+})().then(common.mustCall()).catch((err) => {
   console.error(err);
-  process.abort();
+  process.exitCode = 1;
 });


### PR DESCRIPTION
Use the common `.then(common.mustCall())` check to verify that.
Also, we should not use `process.abort()` in `test/parallel`; if
the test fails, that leaves core dumps lying around on POSIX systems.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
