### PR TITLE
doc: use named import and Set for builtinModules

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -507,16 +507,16 @@ be written:
 ```js
 import path from 'path';
 import process from 'process';
-import Module from 'module';
+import { builtinModules } from 'module';
 
-const builtins = Module.builtinModules;
+const builtins = new Set(builtinModules);
 const JS_EXTENSIONS = new Set(['.js', '.mjs']);
 
 const baseURL = new URL('file://');
 baseURL.pathname = `${process.cwd()}/`;
 
 export function resolve(specifier, parentModuleURL = baseURL, defaultResolve) {
-  if (builtins.includes(specifier)) {
+  if (builtins.has(specifier)) {
     return {
       url: specifier,
       format: 'builtin'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed ~or added~
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

just using **named import** for good measure, as well as using a Set, to be consistent with:
```js
const JS_EXTENSIONS = new Set(['.js', '.mjs']);
```

