### PR TITLE
perf_hooks,trace_events: use stricter equality

### DIFF
--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -332,7 +332,7 @@ class PerformanceObserver extends AsyncResource {
   }
 
   observe(options) {
-    if (typeof options !== 'object' || options == null) {
+    if (typeof options !== 'object' || options === null) {
       throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
     if (!Array.isArray(options.entryTypes)) {

--- a/lib/trace_events.js
+++ b/lib/trace_events.js
@@ -73,7 +73,7 @@ class Tracing {
 }
 
 function createTracing(options) {
-  if (typeof options !== 'object' || options == null)
+  if (typeof options !== 'object' || options === null)
     throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
 
   if (!Array.isArray(options.categories)) {


### PR DESCRIPTION
There is no need to use loose equality on these checks because `undefined` is caught by the preceding `typeof` check.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
