### PR TITLE
 test: skip `test-worker-prof` on all platforms.

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -8,7 +8,7 @@ prefix parallel
 # https://github.com/nodejs/node/issues/23207
 test-net-connect-options-port: PASS,FLAKY
 # https://github.com/nodejs/node/issues/26401
-test-worker-prof: PASS,FLAKY
+test-worker-prof: SKIP
 
 [$system==win32]
 # https://github.com/nodejs/node/issues/20750


### PR DESCRIPTION
There was a problem with V8 GC which potentially could
crash this test on all platforms. Issue is fixed on V8 master. SKIPPING until
the V8 patch is backported to 7.5 and 7.6.

Bug:
https://bugs.chromium.org/p/v8/issues/detail?id=9333

