### PR TITLE
build: Re-enable openssl asm for arm64

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -28,6 +28,7 @@
     'clang%': 0,
 
     'openssl_fips%': '',
+    'openssl_no_asm%': 0,
 
     # Some STL containers (e.g. std::vector) do not preserve ABI compatibility
     # between debug and non-debug mode.
@@ -78,12 +79,6 @@
     ##### end V8 defaults #####
 
     'conditions': [
-      ['target_arch=="arm64"', {
-        # Disabled pending https://github.com/nodejs/node/issues/23913.
-        'openssl_no_asm%': 1,
-      }, {
-        'openssl_no_asm%': 0,
-      }],
       ['OS == "win"', {
         'os_posix': 0,
         'v8_postmortem_support%': 0,


### PR DESCRIPTION
Re-enable openssl asm for arm64.

In #23913 it looked like arm64 testing was flaky, and as a result a number of changes were made including disabling openssl asm for that architecture.

This PR is limited to re-enabling the one change to turn on openssl asm for arm64, in the hopes that either it works now, or that this specific change introduces a reproducible condition that shows up with testing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
