### PR TITLE
build: re-enable custom V8 snapshot by default

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -421,10 +421,10 @@ parser.add_option('--with-ltcg',
     dest='with_ltcg',
     help='Use Link Time Code Generation. This feature is only available on Windows.')
 
-parser.add_option('--with-node-snapshot',
+parser.add_option('--without-node-snapshot',
     action='store_true',
-    dest='with_node_snapshot',
-    help='Turn on V8 snapshot integration. Currently experimental.')
+    dest='without_node_snapshot',
+    help='Turn off V8 snapshot integration. Currently experimental.')
 
 intl_optgroup.add_option('--download',
     action='store',
@@ -940,11 +940,9 @@ def configure_node(o):
   o['variables']['want_separate_host_toolset'] = int(
       cross_compiling and want_snapshots)
 
-  if options.with_node_snapshot:
-    o['variables']['node_use_node_snapshot'] = 'true'
+  if not options.without_node_snapshot:
+    o['variables']['node_use_node_snapshot'] = b(not cross_compiling)
   else:
-    # Default to false for now.
-    # TODO(joyeecheung): enable it once we fix the hashseed uniqueness
     o['variables']['node_use_node_snapshot'] = 'false'
 
   if target_arch == 'arm':

--- a/tools/snapshot/snapshot_builder.cc
+++ b/tools/snapshot/snapshot_builder.cc
@@ -96,6 +96,7 @@ std::string SnapshotBuilder::Generate(
     // Must be out of HandleScope
     StartupData blob =
         creator.CreateBlob(SnapshotCreator::FunctionCodeHandling::kClear);
+    CHECK(blob.CanBeRehashed());
     // Must be done while the snapshot creator isolate is entered i.e. the
     // creator is still alive.
     main_instance->Dispose();


### PR DESCRIPTION
#### tools: assert that the snapshot can be rehashed in node_mksnapshot

#### build: turn on custom V8 snapshot by default

This patch re-enables custom V8 snapshot integration. Also renames
the experimental configure switch from `--with-node-snapshot`
to `--without-node-snapshot` to be consistent with`--without-snapshot`
which is used for the default V8 snapshot.

Refs: https://github.com/nodejs/node/pull/27365
Refs: https://github.com/nodejs/node/issues/17058

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
