### PR TITLE
report: add cpu info to report output

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -62,6 +62,26 @@ is provided below for reference.
     "osRelease": "3.10.0-862.el7.x86_64",
     "osVersion": "#1 SMP Wed Mar 21 18:14:51 EDT 2018",
     "osMachine": "x86_64",
+    "osCpus": [
+      {
+        "model": "Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz",
+        "speed": 2700,
+        "user": 88902660,
+        "nice": 0,
+        "sys": 50902570,
+        "idle": 241732220,
+        "irq": 0
+      },
+      {
+        "model": "Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz",
+        "speed": 2700,
+        "user": 88902660,
+        "nice": 0,
+        "sys": 50902570,
+        "idle": 241732220,
+        "irq": 0
+      }
+    ],
     "host": "test_machine"
   },
   "javascriptStack": {

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -62,8 +62,8 @@ function _validateContent(data) {
                         'dumpEventTimeStamp', 'processId', 'commandLine',
                         'nodejsVersion', 'wordSize', 'arch', 'platform',
                         'componentVersions', 'release', 'osName', 'osRelease',
-                        'osVersion', 'osMachine', 'host', 'glibcVersionRuntime',
-                        'glibcVersionCompiler', 'cwd'];
+                        'osVersion', 'osMachine', 'cpus', 'host',
+                        'glibcVersionRuntime', 'glibcVersionCompiler', 'cwd'];
   checkForUnknownFields(header, headerFields);
   assert.strictEqual(typeof header.event, 'string');
   assert.strictEqual(typeof header.trigger, 'string');
@@ -87,6 +87,16 @@ function _validateContent(data) {
   assert.strictEqual(header.osRelease, os.release());
   assert.strictEqual(typeof header.osVersion, 'string');
   assert.strictEqual(typeof header.osMachine, 'string');
+  assert(Array.isArray(header.cpus));
+  header.cpus.forEach((cpu) => {
+    assert.strictEqual(typeof cpu.model, 'string');
+    assert.strictEqual(typeof cpu.speed, 'number');
+    assert.strictEqual(typeof cpu.user, 'number');
+    assert.strictEqual(typeof cpu.nice, 'number');
+    assert.strictEqual(typeof cpu.sys, 'number');
+    assert.strictEqual(typeof cpu.idle, 'number');
+    assert.strictEqual(typeof cpu.irq, 'number');
+  });
   assert.strictEqual(header.host, os.hostname());
 
   // Verify the format of the javascriptStack section.


### PR DESCRIPTION
The report shows CPU consumption %, but without
the number of CPU cores, a consumer cannot tell
if the percent (given across all cores) is
actually problematic. E.g., 100% on one CPU
is a problem, but 100% on four CPUs is not
necessarily (**EDIT**: the max theoretical usage is 400% in this case)

This change adds CPU information (similar to
`os.cpus()`) to the report output. Extra
info besides the count is also provided as
to avoid future breaking changes in the
eventuality that someone needs it;
changing the datatype of `header.cpus`
would be breaking.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
