### PR TITLE
timers: fix refresh did not call active to make the node exit early.

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -190,7 +190,8 @@ Timeout.prototype[inspect.custom] = function(_, options) {
 };
 
 Timeout.prototype.refresh = function() {
-  if (this[kRefed])
+  // Timers that are active or have been invoked.
+  if (this[kRefed] || this[kRefed] === null)
     active(this);
   else
     unrefActive(this);

--- a/test/parallel/test-timers-refresh-called.js
+++ b/test/parallel/test-timers-refresh-called.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const common = require('../common');
+
+// Check only timer reactivated by `.refresh()` is in loop,
+// only the timer is still active.
+
+const timer = setTimeout(common.mustCall(() => {}, 2), 1);
+
+setTimeout(() => {
+  timer.refresh();
+}, 1);


### PR DESCRIPTION
Refresh.() does not get a timer active that has already been invoked. Add an or option for put refresh back to work. 

```
const timer = setTimeout(() => {
  console.log(1); // emit once
}, 1);

setTimeout(() => {
  timer.refresh();
}, 1);
```
#26721 one reason it can't be overridden it only works in the callback of the current timer(before `finally`).
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
