### PR TITLE
src: use String::NewFromUtf8 in ProcessEmitWarningGeneric

### DIFF
--- a/src/node_process_events.cc
+++ b/src/node_process_events.cc
@@ -56,16 +56,12 @@ Maybe<bool> ProcessEmitWarningGeneric(Environment* env,
     return Nothing<bool>();
   }
   if (type != nullptr) {
-    if (!String::NewFromOneByte(env->isolate(),
-                                reinterpret_cast<const uint8_t*>(type),
-                                NewStringType::kNormal)
-             .ToLocal(&args[argc++])) {
+    if (!String::NewFromUtf8(env->isolate(), type, NewStringType::kNormal)
+           .ToLocal(&args[argc++])) {
       return Nothing<bool>();
     }
     if (code != nullptr &&
-        !String::NewFromOneByte(env->isolate(),
-                                reinterpret_cast<const uint8_t*>(code),
-                                NewStringType::kNormal)
+        !String::NewFromUtf8(env->isolate(), code, NewStringType::kNormal)
              .ToLocal(&args[argc++])) {
       return Nothing<bool>();
     }


### PR DESCRIPTION
##### Description of Change

Previously, the new warning string in `ProcessEmitWarningGeneric` was allocated using `String::NewFromUtf8`, but `type` and `warning`, despite also being `const char*`, were instead allocated using `String::NewFromOneByte`. I couldn't find a semantic reason for using differing string allocation functions, so this PR improves consistency by using `String::NewFromUtf8` for all three.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
