### PR TITLE
src: fix compiler warning in node_worker.cc

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -189,7 +189,9 @@ void Worker::Run() {
     Locker locker(isolate_);
     Isolate::Scope isolate_scope(isolate_);
     SealHandleScope outer_seal(isolate_);
+#if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
     bool inspector_started = false;
+#endif
 
     DeleteFnPtr<Environment, FreeEnvironment> env_;
     OnScopeLeave cleanup_env([&]() {


### PR DESCRIPTION
Currently, when configuring `--without-ssl` the following compiler warning
is generated:
```console
../src/node_worker.cc:192:10:
warning: unused variable 'inspector_started' [-Wunused-variable]
    bool inspector_started = false;
         ^
1 warning generated.
```
This commit adds a macro guard to the variable to avoid the warning.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
