### PR TITLE
build: guard test-doc recipe with node_use_openssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -586,8 +586,12 @@ test-hash-seed: all
 
 .PHONY: test-doc
 test-doc: doc-only ## Builds, lints, and verifies the docs.
-	$(MAKE) lint
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) $(CI_DOC)
+	@if [ "$(shell $(node_use_openssl))" != "true" ]; then \
+		echo "Skipping test-doc (no crypto)"; \
+	else \
+		$(MAKE) lint; \
+		$(PYTHON) tools/test.py $(PARALLEL_ARGS) $(CI_DOC); \
+	fi
 
 test-known-issues: all
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) known_issues


### PR DESCRIPTION
Currently, when configuring `--without-ssl` the `test-doc` target fails with
the following error:
```console
/node/test/common/index.js:707
const crashOnUnhandledRejection = (err) => { throw err; };
                                             ^

Error [ERR_NO_CRYPTO]:
Node.js is not compiled with OpenSSL crypto support
    at Object.assertCrypto (internal/util.js:97:11)
    at https.js:26:26
    at NativeModule.compile (internal/bootstrap/loaders.js:300:5)
    ...
    at /node/tools/doc/versions.js:7:19
    at new Promise (<anonymous>)
    at getUrl (/node/tools/doc/versions.js:6:10)
Command: out/Release/node /node/test/doctool/test-doctool-html.js
[00:02|% 100|+   3|-   1]: Done
make: *** [test-doc] Error 1
```
This commit guards the test-doc recipe to not run if node was
configured without crypto support.

@nodejs/build, @nodejs/build-files 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
