### PR TITLE
process: hide NodeEnvironmentFlagsSet's `add` function

### DIFF
--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -263,7 +263,9 @@ function buildAllowedFlags() {
 
       // The super constructor consumes `add`, but
       // disallow any future adds.
-      this.add = () => this;
+      Object.defineProperty(this, 'add', {
+        value: () => this
+      });
     }
 
     delete() {


### PR DESCRIPTION
This makes sure that the `add` function is not visible by default
when inspecting `process.allowedNodeEnvironmentFlags`.

![image](https://user-images.githubusercontent.com/8822573/59448748-1bde1d00-8e06-11e9-877b-f16c9699dea3.png)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
