### PR TITLE
util: hide toStringTags if already included in the constructor

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -386,7 +386,7 @@ function getPrefix(constructor, tag, fallback) {
     return `[${fallback}: null prototype] `;
   }
 
-  if (tag !== '' && constructor !== tag) {
+  if (tag !== '' && !constructor.includes(tag)) {
     return `${constructor} [${tag}] `;
   }
   return `${constructor} `;

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1227,7 +1227,9 @@ if (typeof Symbol !== 'undefined') {
   class ArraySubclass extends Array {}
   class SetSubclass extends Set {}
   class MapSubclass extends Map {}
+  class MSubclass extends Map {}
   class PromiseSubclass extends Promise {}
+  class PSubclass extends Promise {}
 
   const x = new ObjectSubclass();
   x.foo = 42;
@@ -1236,11 +1238,15 @@ if (typeof Symbol !== 'undefined') {
   assert.strictEqual(util.inspect(new ArraySubclass(1, 2, 3)),
                      'ArraySubclass [ 1, 2, 3 ]');
   assert.strictEqual(util.inspect(new SetSubclass([1, 2, 3])),
-                     'SetSubclass [Set] { 1, 2, 3 }');
+                     'SetSubclass { 1, 2, 3 }');
   assert.strictEqual(util.inspect(new MapSubclass([['foo', 42]])),
-                     "MapSubclass [Map] { 'foo' => 42 }");
+                     "MapSubclass { 'foo' => 42 }");
+  assert.strictEqual(util.inspect(new MSubclass([['foo', 42]])),
+                     "MSubclass [Map] { 'foo' => 42 }");
   assert.strictEqual(util.inspect(new PromiseSubclass(() => {})),
-                     'PromiseSubclass [Promise] { <pending> }');
+                     'PromiseSubclass { <pending> }');
+  assert.strictEqual(util.inspect(new PSubclass(() => {})),
+                     'PSubclass [Promise] { <pending> }');
   assert.strictEqual(
     util.inspect({ a: { b: new ArraySubclass([1, [2], 3]) } }, { depth: 1 }),
     '{ a: { b: [ArraySubclass] } }'


### PR DESCRIPTION
This makes sure that `Symbol.toStringTag` entries won't be taken
into account when inspecting objects with `util.inspect()` in case
the tag is already included in the found constructor name.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
