### PR TITLE
https: do not automatically use invalid servername

### DIFF
--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -24,7 +24,13 @@ An [`Agent`][] object for HTTPS similar to [`http.Agent`][]. See
 [`https.request()`][] for more information.
 
 ### new Agent([options])
-
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/28209
+    description: do not automatically set servername if the target host was
+                 specified using an IP address.
+-->
 * `options` {Object} Set of configurable options to set on the agent.
   Can have the same fields as for [`http.Agent(options)`][], and
   * `maxCachedSessions` {number} maximum number of TLS cached sessions.
@@ -32,7 +38,9 @@ An [`Agent`][] object for HTTPS similar to [`http.Agent`][]. See
   * `servername` {string} the value of
     [Server Name Indication extension][sni wiki] to be sent to the server. Use
     empty string `''` to disable sending the extension.
-    **Default:** hostname or IP address of the target server.
+    **Default:** hostname of the target server, unless the target server
+    is specified using an IP address, in which case the default is `''` (no
+    extension).
 
     See [`Session Resumption`][] for infomation about TLS session reuse.
 

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -256,6 +256,9 @@ function calculateServerName(options, req) {
       servername = hostHeader.split(':', 1)[0];
     }
   }
+  // Don't implicitly set invalid (IP) servernames.
+  if (net.isIP(servername))
+    servername = '';
   return servername;
 }
 

--- a/test/parallel/test-https-simple.js
+++ b/test/parallel/test-https-simple.js
@@ -29,6 +29,9 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const https = require('https');
 
+// Assert that the IP-as-servername deprecation warning does not occur.
+process.on('warning', common.mustNotCall());
+
 const options = {
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem')


### PR DESCRIPTION
Stop automatically setting servername in https.request() if the target
host is specified with an IP address. Doing so is invalid, and triggers
a deprecation warning. It is still possible to send an IP address as a
servername if its required, but it needs to be explicity configured, it
won't happen automatically.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
