### PR TITLE
test: added Ubuntu error code support to test-process-uid-gid.js

### DIFF
--- a/test/parallel/test-process-uid-gid.js
+++ b/test/parallel/test-process-uid-gid.js
@@ -74,7 +74,7 @@ const oldgid = process.getgid();
 try {
   process.setgid('nobody');
 } catch (err) {
-  if (err.message !== 'setgid group id does not exist') {
+  if (err.code !== 'ERR_UNKNOWN_CREDENTIAL') {
     throw err;
   }
   process.setgid('nogroup');


### PR DESCRIPTION
This change adds exception handling for the error code received when process.setgid('nobody') is called on Ubuntu, where the standard 'nobody' group from UNIX systems is named 'nogroup'.  Coverage had previously been added for the error message, but with Ubuntu 18 this message has changed.  Using the error code, which is intended to be unchanging, will hopefully prevent the need for updates in the future.

Refs: https://github.com/nodejs/node/issues/19594

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
