### PR TITLE
src: add error codes to errors thrown in node_i18n.cc

### DIFF
--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -655,7 +655,7 @@ static void ToUnicode(const FunctionCallbackInfo<Value>& args) {
   int32_t len = ToUnicode(&buf, *val, val.length());
 
   if (len < 0) {
-    return env->ThrowError("Cannot convert name to Unicode");
+    return THROW_ERR_INVALID_ARG_VALUE(env, "Cannot convert name to Unicode");
   }
 
   args.GetReturnValue().Set(
@@ -678,7 +678,7 @@ static void ToASCII(const FunctionCallbackInfo<Value>& args) {
   int32_t len = ToASCII(&buf, *val, val.length(), mode);
 
   if (len < 0) {
-    return env->ThrowError("Cannot convert name to ASCII");
+    return THROW_ERR_INVALID_ARG_VALUE(env, "Cannot convert name to ASCII");
   }
 
   args.GetReturnValue().Set(

--- a/test/parallel/test-icu-punycode.js
+++ b/test/parallel/test-icu-punycode.js
@@ -33,8 +33,6 @@ const wptToASCIITests = require(
 }
 
 {
-  const errMessage = /^Error: Cannot convert name to ASCII$/;
-
   for (const [i, test] of wptToASCIITests.entries()) {
     if (typeof test === 'string')
       continue; // skip comments
@@ -43,8 +41,14 @@ const wptToASCIITests = require(
     if (comment)
       caseComment += ` (${comment})`;
     if (output === null) {
-      assert.throws(() => icu.toASCII(input),
-                    errMessage, `ToASCII ${caseComment}`);
+      common.expectsError(
+        () => icu.toASCII(input),
+        {
+          code: 'ERR_INVALID_ARG_VALUE',
+          type: TypeError,
+          message: 'Cannot convert name to ASCII'
+        }
+      );
       icu.toASCII(input, true); // Should not throw.
     } else {
       assert.strictEqual(icu.toASCII(input), output, `ToASCII ${caseComment}`);


### PR DESCRIPTION
This PR follows #20121 and adds error codes to errors thrown in `node_i18n.cc`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)