### PR TITLE
[v10.x-backport] src: extract common Bind method

### DIFF
--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -219,8 +219,11 @@ void TCPWrap::Open(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(err);
 }
 
-
-void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
+template <typename T>
+void TCPWrap::Bind(
+    const FunctionCallbackInfo<Value>& args,
+    int family,
+    std::function<int(const char* ip_address, int port, T* addr)> uv_ip_addr) {
   TCPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
@@ -228,9 +231,16 @@ void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
   Environment* env = wrap->env();
   node::Utf8Value ip_address(env->isolate(), args[0]);
   int port;
+  unsigned int flags = 0;
   if (!args[1]->Int32Value(env->context()).To(&port)) return;
-  sockaddr_in addr;
-  int err = uv_ip4_addr(*ip_address, port, &addr);
+  if (family == AF_INET6 &&
+      !args[2]->Uint32Value(env->context()).To(&flags)) {
+    return;
+  }
+
+  T addr;
+  int err = uv_ip_addr(*ip_address, port, &addr);
+
   if (err == 0) {
     err = uv_tcp_bind(&wrap->handle_,
                       reinterpret_cast<const sockaddr*>(&addr),
@@ -239,24 +249,13 @@ void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(err);
 }
 
+void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
+  Bind<sockaddr_in>(args, AF_INET, uv_ip4_addr);
+}
+
 
 void TCPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
-  TCPWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
-                          args.GetReturnValue().Set(UV_EBADF));
-  Environment* env = wrap->env();
-  node::Utf8Value ip6_address(env->isolate(), args[0]);
-  int port;
-  if (!args[1]->Int32Value(env->context()).To(&port)) return;
-  sockaddr_in6 addr;
-  int err = uv_ip6_addr(*ip6_address, port, &addr);
-  if (err == 0) {
-    err = uv_tcp_bind(&wrap->handle_,
-                      reinterpret_cast<const sockaddr*>(&addr),
-                      0);
-  }
-  args.GetReturnValue().Set(err);
+  Bind<sockaddr_in6>(args, AF_INET6, uv_ip6_addr);
 }
 
 

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -79,6 +79,11 @@ class TCPWrap : public ConnectionWrap<TCPWrap, uv_tcp_t> {
   static void Connect(const v8::FunctionCallbackInfo<v8::Value>& args,
       std::function<int(const char* ip_address, T* addr)> uv_ip_addr);
   static void Open(const v8::FunctionCallbackInfo<v8::Value>& args);
+  template <typename T>
+  static void Bind(
+      const v8::FunctionCallbackInfo<v8::Value>& args,
+      int family,
+      std::function<int(const char* ip_address, int port, T* addr)> uv_ip_addr);
 
 #ifdef _WIN32
   static void SetSimultaneousAccepts(


### PR DESCRIPTION
`TCPWrap::Bind` and `TCPWrap::Bind6` share a large amount of
functionality, so a common `Bind` was extracted to remove duplication.

PR-URL: https://github.com/nodejs/node/pull/22315

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
