### PR TITLE
fs: document the Date conversion in Stats objects

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -286,6 +286,12 @@ function nsFromTimeSpecBigInt(sec, nsec) {
   return sec * kNsPerSecBigInt + nsec;
 }
 
+// The Date constructor performs Math.floor() to the timestamp.
+// https://www.ecma-international.org/ecma-262/#sec-timeclip 
+// Since there may be a precision loss when the timestamp is
+// converted to a floating point number, we manually round
+// the the timestamp here before passing it to Date().
+// Refs: https://github.com/nodejs/node/pull/12607 
 function dateFromMs(ms) {
   return new Date(Number(ms) + 0.5);
 }

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -287,11 +287,11 @@ function nsFromTimeSpecBigInt(sec, nsec) {
 }
 
 // The Date constructor performs Math.floor() to the timestamp.
-// https://www.ecma-international.org/ecma-262/#sec-timeclip 
+// https://www.ecma-international.org/ecma-262/#sec-timeclip
 // Since there may be a precision loss when the timestamp is
 // converted to a floating point number, we manually round
-// the the timestamp here before passing it to Date().
-// Refs: https://github.com/nodejs/node/pull/12607 
+// the timestamp here before passing it to Date().
+// Refs: https://github.com/nodejs/node/pull/12607
 function dateFromMs(ms) {
   return new Date(Number(ms) + 0.5);
 }


### PR DESCRIPTION
Document why the dates are calculated with the timestamp
in Numbers + 0.5.

The comment was previously lost in a revert.

Refs: https://github.com/nodejs/node/commit/ae6c7044c8d48cc8e7c267efca7429d5aa4df993

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
