### PR TITLE
doc: add node-gyp guide to install prerequisite

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -477,7 +477,7 @@ Prerequisites:
   to `PATH`. A build with the `openssl-no-asm` option does not need this, nor
   does a build targeting ARM64 Windows.
   
-Note: To install all prerequisites you can install node-gyp with npm using the following command
+To install all prerequisites, you can install `node-gyp` with `npm`:
 
 ```console
 > npm install -g node-gyp

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -476,6 +476,14 @@ Prerequisites:
   If not installed in the default location, it needs to be manually added
   to `PATH`. A build with the `openssl-no-asm` option does not need this, nor
   does a build targeting ARM64 Windows.
+  
+Note: To install all prerequisites you can install node-gyp with npm using the following command
+
+```console
+> npm install -g node-gyp
+> npm install -g --production windows-build-tools
+```
+  
 * **Optional** (to build the MSI): the [WiX Toolset v3.11](http://wixtoolset.org/releases/)
   and the [Wix Toolset Visual Studio 2017 Extension](https://marketplace.visualstudio.com/items?itemName=RobMensching.WixToolsetVisualStudio2017Extension).
 * **Optional** Requirements for compiling for Windows 10 on ARM (ARM64):
@@ -490,6 +498,7 @@ Prerequisites:
 
 If the path to your build directory contains a space or a non-ASCII character,
 the build will likely fail.
+
 
 ```console
 > .\vcbuild


### PR DESCRIPTION
The current doc did not mention possibility to install
all windows prerequisites using node-gyp and
windows-build-tools. Using npm to install node-gyp
and windows-build-tools makes building node
easier. It solves the problem of "failed to find 
visual studio installation".
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] documentation is changed or added
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
