### PR TITLE
inspector: added --inspect-publish-uid-ipc-path argument

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -397,6 +397,11 @@ Specify ways of the inspector web socket url exposure.
 By default inspector websocket url is available in stderr and under `/json/list`
 endpoint on `http://host:port/json/list`.
 
+### `inspect-publish-uid-ipc-path`
+
+Inspector will send a space-separated list of inspector web socket URLs to IPC
+`net.Socket` with given path at the start.
+
 ### `--loader=file`
 <!-- YAML
 added: v9.0.0
@@ -989,6 +994,7 @@ Node.js options that are allowed are:
 - `--inspect-brk`
 - `--inspect-port`
 - `--inspect-publish-uid`
+- `--inspect-publish-uid-ipc-path`
 - `--loader`
 - `--max-http-header-size`
 - `--napi-modules`

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -49,6 +49,7 @@ void DebugOptions::CheckOptions(std::vector<std::string>* errors) {
       SplitString(inspect_publish_uid_string, ',');
   inspect_publish_uid.console = false;
   inspect_publish_uid.http = false;
+  inspect_publish_uid.ipc_path = inspect_publish_uid_ipc_path;
   for (const std::string& destination : destinations) {
     if (destination == "stderr") {
       inspect_publish_uid.console = true;
@@ -296,6 +297,11 @@ DebugOptionsParser::DebugOptionsParser() {
             "comma separated list of destinations for inspector uid"
             "(default: stderr,http)",
             &DebugOptions::inspect_publish_uid_string,
+            kAllowedInEnvironment);
+
+  AddOption("--inspect-publish-uid-ipc-path",
+            "path for IPC connection, inspector will send websocket URL to it",
+            &DebugOptions::inspect_publish_uid_ipc_path,
             kAllowedInEnvironment);
 }
 

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -53,6 +53,7 @@ class Options {
 struct InspectPublishUid {
   bool console;
   bool http;
+  std::string ipc_path;
 };
 
 // These options are currently essentially per-Environment, but it can be nice
@@ -77,6 +78,7 @@ class DebugOptions : public Options {
   bool break_node_first_line = false;
   // --inspect-publish-uid
   std::string inspect_publish_uid_string = "stderr,http";
+  std::string inspect_publish_uid_ipc_path;
 
   InspectPublishUid inspect_publish_uid;
 

--- a/test/parallel/test-inspect-publish-ipc-path.js
+++ b/test/parallel/test-inspect-publish-ipc-path.js
@@ -1,0 +1,60 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { spawn } = require('child_process');
+const net = require('net');
+
+(async function test() {
+  await testWithServer();
+  await testWithoutServer();
+})();
+
+
+async function testWithServer() {
+  const pipe = common.PIPE;
+  const CHILD_COUNT = 5;
+  const sockets = [];
+  const server = net.createServer((socket) => {
+    let buf = '';
+    socket.on('data', (d) => buf += d.toString());
+    socket.on('end', () => sockets.push(...buf.split(' ')));
+  }).listen(pipe);
+  await runNodeWithChildren(CHILD_COUNT, pipe);
+  server.close();
+  assert.strictEqual(CHILD_COUNT + 1, sockets.length);
+  sockets.forEach((socket) => {
+    const m = socket.match(/ws:\/\/[^/]+\/[-a-z0-9]+/);
+    assert.strictEqual(m[0], socket);
+  });
+}
+
+async function testWithoutServer() {
+  await runNodeWithChildren(5, common.PIPE);
+}
+
+function runNodeWithChildren(childCount, pipe) {
+  const nodeProcess = spawn(process.execPath, [
+    '--inspect=0',
+    `--inspect-publish-uid-ipc-path=${pipe}`,
+    '-e', `(${main.toString()})()`
+  ], {
+    env: {
+      COUNT: childCount
+    }
+  });
+  return new Promise((resolve) => nodeProcess.on('close', resolve));
+
+  function main() {
+    const { spawn } = require('child_process');
+    if (process.env.COUNT * 1 === 0)
+      return;
+    spawn(process.execPath, process.execArgv, {
+      env: {
+        COUNT: process.env.COUNT - 1
+      }
+    });
+  }
+}


### PR DESCRIPTION
The argument takes the IPC path as an argument when it is passed,
the inspector web socket server will send its full web socket url
to IPC server with the given path at the start.

This flag is required to solve inspector web socket url discovery
the problem for child processes.

Only one discovery option is available right now; it is searching
for ws:// URLs in stderr of node process. This approach does not
work when the parent process ignores the stderr of the child process,
e.g. update-notifier uses this technique.

Discussion about using files instead can be found here:
https://github.com/nodejs/diagnostics/issues/298

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
