### PR TITLE
build: fix cctest target for --without-report

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -1096,7 +1096,6 @@
         'test/cctest/test_linked_binding.cc',
         'test/cctest/test_per_process.cc',
         'test/cctest/test_platform.cc',
-        'test/cctest/test_report_util.cc',
         'test/cctest/test_traced_value.cc',
         'test/cctest/test_util.cc',
         'test/cctest/test_url.cc',
@@ -1134,6 +1133,9 @@
           },
         }],
         [ 'node_report=="true"', {
+          'sources': [
+            'test/cctest/test_report_util.cc',
+          ],
           'defines': [
             'NODE_REPORT',
             'NODE_ARCH="<(target_arch)"',


### PR DESCRIPTION
Conditionally build `test/cctest/test_report_util.cc` only when
configured to include the diagnostic report feature.

Fixes the following link error when configured with `--without-report`:

```console
/home/users/riclau/sandbox/github/nodejs/out/Release/obj.target/cctest/test/cctest/test_report_util.o: In function `ReportUtilTest_EscapeJsonChars_Test::TestBody()':
test_report_util.cc:(.text+0x57): undefined reference to `report::EscapeJsonChars(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
test_report_util.cc:(.text+0x1ad): undefined reference to `report::EscapeJsonChars(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
test_report_util.cc:(.text+0x302): undefined reference to `report::EscapeJsonChars(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
test_report_util.cc:(.text+0x44a): undefined reference to `report::EscapeJsonChars(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
test_report_util.cc:(.text+0x592): undefined reference to `report::EscapeJsonChars(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/home/users/riclau/sandbox/github/nodejs/out/Release/obj.target/cctest/test/cctest/test_report_util.o:test_report_util.cc:(.text+0xd7a): more undefined references to `report::EscapeJsonChars(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)' follow
collect2: error: ld returned 1 exit status
make[1]: *** [/home/users/riclau/sandbox/github/nodejs/out/Release/cctest] Error 1
```

cc @nodejs/build-files 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
