### PR TITLE
doc: add documentation for invalid byte sequences

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -207,7 +207,7 @@ For cases regarding operations other than employing backward compatibility
 for 7-bit (and [extended 8-bit]((https://en.wikipedia.org/wiki/UTF-8#Description))
 in rare cases) `'ascii'` data, and the valid [`UTF-8` code units](https://en.wikipedia.org/wiki/UTF-8#Codepage_layout),
 the replacement character (`�`) is returned,
-and *no exception will be thrown*.
+and no exception will be thrown.
 
 It should also be noted that a `U+FFFD` replacement value
 (representing the aforementioned replacement character) will be returned

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -182,7 +182,7 @@ It should also be noted that a `U+FFFD` replacement value
 in case of decoding errors (invalid unicode scalar values).
 
 ```js
-// assume an invalid byte sequence
+// Assuming an invalid byte sequence
 const buf = Buffer.from([237, 166, 164]);
 
 const buf_str = buf.toString('utf-8');

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -206,7 +206,7 @@ invalid byte sequences.
 For cases regarding operations other than employing backward compatibility
 for 7-bit (and [extended 8-bit]((https://en.wikipedia.org/wiki/UTF-8#Description))
 in rare cases) `'ascii'` data, and the valid [`UTF-8` code units](https://en.wikipedia.org/wiki/UTF-8#Codepage_layout),
-it should be noted that the replacement character (`�`) is returned,
+the replacement character (`�`) is returned,
 and *no exception will be thrown*.
 
 It should also be noted that a `U+FFFD` replacement value

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -165,6 +165,38 @@ console.log(Buffer.from('fhqwhgads', 'utf16le'));
 // Prints: <Buffer 66 00 68 00 71 00 77 00 68 00 67 00 61 00 64 00 73 00>
 ```
 
+### Evaluating legal code points for '`utf-8'` encoding
+
+Byte sequences that do not have corresponding UTF-16 encodings and non-legal
+Unicode values, along with their UTF-8 counterparts must be treated as
+invalid byte sequences.
+
+For cases regarding operations other than employing backward compatibility
+for 7-bit (and [extended 8-bit]((https://en.wikipedia.org/wiki/UTF-8#Description))
+in rare cases) `'ascii'` data, and the valid [`UTF-8` code units](https://en.wikipedia.org/wiki/UTF-8#Codepage_layout),
+it should be noted that the replacement character (`�`) is returned,
+and *no exception will be thrown*.
+
+It should also be noted that a `U+FFFD` replacement value
+(representing the aforementioned replacement character) will be returned
+in case of decoding errors (invalid unicode scalar values).
+
+```js
+// assume an invalid byte sequence
+const buf = Buffer.from([237, 166, 164]);
+
+const buf_str = buf.toString('utf-8');
+
+console.log(buf_str);
+// Prints: '�'
+
+console.log(buf.byteLength(buf_str));
+// Prints: 3
+
+console.log(buf.codePointAt(0).toString(16));
+// Prints: 'fffd'
+```
+
 The character encodings currently supported by Node.js include:
 
 * `'ascii'` - For 7-bit ASCII data only. This encoding is fast and will strip

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -165,38 +165,6 @@ console.log(Buffer.from('fhqwhgads', 'utf16le'));
 // Prints: <Buffer 66 00 68 00 71 00 77 00 68 00 67 00 61 00 64 00 73 00>
 ```
 
-### Evaluating legal code points for '`utf-8'` encoding
-
-Byte sequences that do not have corresponding UTF-16 encodings and non-legal
-Unicode values, along with their UTF-8 counterparts must be treated as
-invalid byte sequences.
-
-For cases regarding operations other than employing backward compatibility
-for 7-bit (and [extended 8-bit]((https://en.wikipedia.org/wiki/UTF-8#Description))
-in rare cases) `'ascii'` data, and the valid [`UTF-8` code units](https://en.wikipedia.org/wiki/UTF-8#Codepage_layout),
-it should be noted that the replacement character (`�`) is returned,
-and *no exception will be thrown*.
-
-It should also be noted that a `U+FFFD` replacement value
-(representing the aforementioned replacement character) will be returned
-in case of decoding errors (invalid unicode scalar values).
-
-```js
-// Assuming an invalid byte sequence
-const buf = Buffer.from([237, 166, 164]);
-
-const buf_str = buf.toString('utf-8');
-
-console.log(buf_str);
-// Prints: '�'
-
-console.log(buf.byteLength(buf_str));
-// Prints: 3
-
-console.log(buf.codePointAt(0).toString(16));
-// Prints: 'fffd'
-```
-
 The character encodings currently supported by Node.js include:
 
 * `'ascii'` - For 7-bit ASCII data only. This encoding is fast and will strip
@@ -228,6 +196,38 @@ something like `http.get()`, if the returned charset is one of those listed in
 the WHATWG specification it is possible that the server actually returned
 `'win-1252'`-encoded data, and using `'latin1'` encoding may incorrectly decode
 the characters.
+
+### Evaluating legal code points for '`utf-8'` encoding
+
+Byte sequences that do not have corresponding UTF-16 encodings and non-legal
+Unicode values, along with their UTF-8 counterparts must be treated as
+invalid byte sequences.
+
+For cases regarding operations other than employing backward compatibility
+for 7-bit (and [extended 8-bit]((https://en.wikipedia.org/wiki/UTF-8#Description))
+in rare cases) `'ascii'` data, and the valid [`UTF-8` code units](https://en.wikipedia.org/wiki/UTF-8#Codepage_layout),
+it should be noted that the replacement character (`�`) is returned,
+and *no exception will be thrown*.
+
+It should also be noted that a `U+FFFD` replacement value
+(representing the aforementioned replacement character) will be returned
+in case of decoding errors (invalid unicode scalar values).
+
+```js
+// Assuming an invalid byte sequence
+const buf = Buffer.from([237, 166, 164]);
+
+const buf_str = buf.toString('utf-8');
+
+console.log(buf_str);
+// Prints: '�'
+
+console.log(buf.byteLength(buf_str));
+// Prints: 3
+
+console.log(buf.codePointAt(0).toString(16));
+// Prints: 'fffd'
+```
 
 ## Buffers and TypedArray
 <!-- YAML

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -209,7 +209,7 @@ in rare cases) `'ascii'` data, and the valid [`UTF-8` code units](https://en.wik
 the replacement character (`�`) is returned,
 and no exception will be thrown.
 
-It should also be noted that a `U+FFFD` replacement value
+A `U+FFFD` replacement value
 (representing the aforementioned replacement character) will be returned
 in case of decoding errors (invalid unicode scalar values).
 


### PR DESCRIPTION
added documentation on evaluating legal code points,
and the behavior that stems from it otherwise.

Fixes: https://github.com/nodejs/node/issues/23280

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
