### PR TITLE
lib: refactor unhandled rejection deprecation warning emission

### DIFF
--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -126,7 +126,7 @@ function handledRejection(promise) {
 }
 
 const unhandledRejectionErrName = 'UnhandledPromiseRejectionWarning';
-function emitWarning(uid, reason) {
+function emitUnhandledRejectionWarning(uid, reason) {
   const warning = getError(
     unhandledRejectionErrName,
     'Unhandled promise rejection. This error originated either by ' +
@@ -144,20 +144,15 @@ function emitWarning(uid, reason) {
   } catch {}
 
   process.emitWarning(warning);
-  emitDeprecationWarning();
 }
 
 let deprecationWarned = false;
 function emitDeprecationWarning() {
-  if (unhandledRejectionsMode === kDefaultUnhandledRejections &&
-      !deprecationWarned) {
-    deprecationWarned = true;
-    process.emitWarning(
-      'Unhandled promise rejections are deprecated. In the future, ' +
-      'promise rejections that are not handled will terminate the ' +
-      'Node.js process with a non-zero exit code.',
-      'DeprecationWarning', 'DEP0018');
-  }
+  process.emitWarning(
+    'Unhandled promise rejections are deprecated. In the future, ' +
+    'promise rejections that are not handled will terminate the ' +
+    'Node.js process with a non-zero exit code.',
+    'DeprecationWarning', 'DEP0018');
 }
 
 // If this method returns true, we've executed user code or triggered
@@ -186,7 +181,7 @@ function processPromiseRejections() {
       case kThrowUnhandledRejections: {
         fatalException(reason);
         const handled = process.emit('unhandledRejection', reason, promise);
-        if (!handled) emitWarning(uid, reason);
+        if (!handled) emitUnhandledRejectionWarning(uid, reason);
         break;
       }
       case kIgnoreUnhandledRejections: {
@@ -195,12 +190,16 @@ function processPromiseRejections() {
       }
       case kAlwaysWarnUnhandledRejections: {
         process.emit('unhandledRejection', reason, promise);
-        emitWarning(uid, reason);
+        emitUnhandledRejectionWarning(uid, reason);
         break;
       }
       case kDefaultUnhandledRejections: {
         const handled = process.emit('unhandledRejection', reason, promise);
-        if (!handled) emitWarning(uid, reason);
+        if (!handled) emitUnhandledRejectionWarning(uid, reason);
+        if (!deprecationWarned) {
+          emitDeprecationWarning();
+          deprecationWarned = true;
+        }
         break;
       }
     }

--- a/test/message/unhandled_promise_trace_warnings.out
+++ b/test/message/unhandled_promise_trace_warnings.out
@@ -21,7 +21,6 @@
     at *
     at *
     at *
-    at *
 (node:*) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 1)
     at handledRejection (internal/process/promises.js:*)
     at promiseRejectHandler (internal/process/promises.js:*)


### PR DESCRIPTION
Emit the deprecation warning in the `kDefaultUnhandledRejections`
case to reduce the number of branches on unhandled rejection mode -
there is now only one switch case on it.

Also rename `emitWarning()` to `emitUnhandledRejectionWarning()`
to avoid ambiguity with `process.emitWarning()`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
