### PR TITLE
src: silence compiler warning node_process_methods

### DIFF
--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -66,7 +66,8 @@ static void Abort(const FunctionCallbackInfo<Value>& args) {
 // For internal testing only, not exposed to userland.
 static void CauseSegfault(const FunctionCallbackInfo<Value>& args) {
   // This should crash hard all platforms.
-  *static_cast<void**>(nullptr) = nullptr;
+  volatile void** d = static_cast<volatile void**>(nullptr);
+  *d = nullptr;
 }
 
 static void Chdir(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
Currently, the following compiler warning is generated by clang:
```console
../src/node_process_methods.cc:71:3:
warning: indirection of non-volatile null pointer will be deleted,
not trap [-Wnull-dereference]
  *static_cast<volatile void**>(nullptr) = nullptr;
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/node_process_methods.cc:71:3: note:
consider using __builtin_trap() or qualifying pointer with 'volatile'
1 warning generated.
```
This commit adds the volatile qualifier to avoid this warning.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
