### PR TITLE
doc: clarify when http emits aborted event

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -318,6 +318,10 @@ Until the data is consumed, the `'end'` event will not fire. Also, until
 the data is read it will consume memory that can eventually lead to a
 'process out of memory' error.
 
+Unlike the `request` object, if the response closes prematurely, the
+`response` object does not emit an `'error'` but instead emits the
+`'aborted'` event.
+
 Node.js does not check whether Content-Length and the length of the
 body which has been transmitted are equal or not.
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -319,7 +319,7 @@ the data is read it will consume memory that can eventually lead to a
 'process out of memory' error.
 
 Unlike the `request` object, if the response closes prematurely, the
-`response` object does not emit an `'error'` but instead emits the
+`response` object does not emit an `'error'` event but instead emits the
 `'aborted'` event.
 
 Node.js does not check whether Content-Length and the length of the


### PR DESCRIPTION
Clarify premature close and `response` object behaviour.

Ref: https://github.com/nodejs/node/issues/28172

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]