### PR TITLE
assert: provide extra context in case of failed error validation checks

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1171,10 +1171,15 @@ assert.throws(
 assert.throws(
   () => {
     const otherErr = new Error('Not found');
-    otherErr.code = 404;
+    // Copy all enumerable properties from `err` to `otherErr`.
+    for (const [key, value] of Object.entries(err)) {
+      otherErr[key] = value;
+    }
     throw otherErr;
   },
-  err // This tests for `message`, `name` and `code`.
+  // The errors `message` and `name` properties will also be checked when using
+  // an error as validation object.
+  err
 );
 ```
 
@@ -1258,11 +1263,9 @@ assert.throws(notThrowing, 'Second');
 // It does not throw because the error messages match.
 assert.throws(throwingSecond, /Second$/);
 
-// If the error message does not match, the error from within the function is
-// not caught.
+// If the error message does not match, an AssertionError is thrown.
 assert.throws(throwingFirst, /Second$/);
-// Error: First
-//     at throwingFirst (repl:2:9)
+// AssertionError [ERR_ASSERTION]
 ```
 
 Due to the confusing notation, it is recommended not to use a string as the

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1210,6 +1210,9 @@ assert.throws(
 
 Custom error validation:
 
+The function must return `true` to indicate all internal validations passed.
+It will otherwise fail with an AssertionError.
+
 ```js
 assert.throws(
   () => {
@@ -1219,9 +1222,10 @@ assert.throws(
     assert(err instanceof Error);
     assert(/value/.test(err));
     // Returning anything from validation functions besides `true` is not
-    // recommended. Doing so results in the caught error being thrown again.
-    // That is usually not the desired outcome. Throw an error about the
-    // specific validation that failed instead (as done in this example).
+    // recommended. By doing that it's not clear what part of the validation
+    // failed. Instead, throw an error about the specific validation that failed
+    // (as done in this example) and add as much helpful debugging information
+    // to that error as possible.
     return true;
   },
   'unexpected error'

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1178,7 +1178,7 @@ assert.throws(
     }
     throw otherErr;
   },
-  // The errors `message` and `name` properties will also be checked when using
+  // The error's `message` and `name` properties will also be checked when using
   // an error as validation object.
   err
 );
@@ -1223,7 +1223,7 @@ assert.throws(
     assert(err instanceof Error);
     assert(/value/.test(err));
     // Returning anything from validation functions besides `true` is not
-    // recommended. By doing that it's not clear what part of the validation
+    // recommended. By doing that, it's not clear what part of the validation
     // failed. Instead, throw an error about the specific validation that failed
     // (as done in this example) and add as much helpful debugging information
     // to that error as possible.

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -220,8 +220,9 @@ are also recursively evaluated by the following rules.
 * [`Symbol`][] properties are not compared.
 * [`WeakMap`][] and [`WeakSet`][] comparison does not rely on their values.
 
-The following example does not throw an `AssertionError` because the primitives
-are considered equal by the [Abstract Equality Comparison][] ( `==` ).
+The following example does not throw an [`AssertionError`][] because the
+primitives are considered equal by the [Abstract Equality Comparison][]
+( `==` ).
 
 ```js
 // WARNING: This does not throw an AssertionError!
@@ -266,11 +267,11 @@ assert.deepEqual(obj1, obj4);
 // AssertionError: { a: { b: 1 } } deepEqual {}
 ```
 
-If the values are not equal, an `AssertionError` is thrown with a `message`
+If the values are not equal, an [`AssertionError`][] is thrown with a `message`
 property set equal to the value of the `message` parameter. If the `message`
 parameter is undefined, a default error message is assigned. If the `message`
 parameter is an instance of an [`Error`][] then it will be thrown instead of the
-`AssertionError`.
+[`AssertionError`][].
 
 ## assert.deepStrictEqual(actual, expected[, message])
 <!-- YAML
@@ -419,7 +420,7 @@ assert.deepStrictEqual(weakMap1, weakMap3);
 //   }
 ```
 
-If the values are not equal, an `AssertionError` is thrown with a `message`
+If the values are not equal, an [`AssertionError`][] is thrown with a `message`
 property set equal to the value of the `message` parameter. If the `message`
 parameter is undefined, a default error message is assigned. If the `message`
 parameter is an instance of an [`Error`][] then it will be thrown instead of the
@@ -500,9 +501,9 @@ When `assert.doesNotThrow()` is called, it will immediately call the `fn`
 function.
 
 If an error is thrown and it is the same type as that specified by the `error`
-parameter, then an `AssertionError` is thrown. If the error is of a different
-type, or if the `error` parameter is undefined, the error is propagated back
-to the caller.
+parameter, then an [`AssertionError`][] is thrown. If the error is of a
+different type, or if the `error` parameter is undefined, the error is
+propagated back to the caller.
 
 If specified, `error` can be a [`Class`][], [`RegExp`][] or a validation
 function. See [`assert.throws()`][] for more details.
@@ -520,7 +521,7 @@ assert.doesNotThrow(
 );
 ```
 
-However, the following will result in an `AssertionError` with the message
+However, the following will result in an [`AssertionError`][] with the message
 'Got unwanted exception...':
 
 <!-- eslint-disable no-restricted-syntax -->
@@ -533,8 +534,8 @@ assert.doesNotThrow(
 );
 ```
 
-If an `AssertionError` is thrown and a value is provided for the `message`
-parameter, the value of `message` will be appended to the `AssertionError`
+If an [`AssertionError`][] is thrown and a value is provided for the `message`
+parameter, the value of `message` will be appended to the [`AssertionError`][]
 message:
 
 <!-- eslint-disable no-restricted-syntax -->
@@ -582,7 +583,7 @@ assert.equal({ a: { b: 1 } }, { a: { b: 1 } });
 // AssertionError: { a: { b: 1 } } == { a: { b: 1 } }
 ```
 
-If the values are not equal, an `AssertionError` is thrown with a `message`
+If the values are not equal, an [`AssertionError`][] is thrown with a `message`
 property set equal to the value of the `message` parameter. If the `message`
 parameter is undefined, a default error message is assigned. If the `message`
 parameter is an instance of an [`Error`][] then it will be thrown instead of the
@@ -594,9 +595,9 @@ added: v0.1.21
 -->
 * `message` {string|Error} **Default:** `'Failed'`
 
-Throws an `AssertionError` with the provided error message or a default error
-message. If the `message` parameter is an instance of an [`Error`][] then it
-will be thrown instead of the `AssertionError`.
+Throws an [`AssertionError`][] with the provided error message or a default
+error message. If the `message` parameter is an instance of an [`Error`][] then
+it will be thrown instead of the [`AssertionError`][].
 
 ```js
 const assert = require('assert').strict;
@@ -683,7 +684,7 @@ changes:
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18247
     description: Instead of throwing the original error it is now wrapped into
-                 an `AssertionError` that contains the full stack trace.
+                 an [`AssertionError`][] that contains the full stack trace.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18247
     description: Value may now only be `undefined` or `null`. Before all falsy
@@ -789,11 +790,11 @@ assert.notDeepEqual(obj1, obj4);
 // OK
 ```
 
-If the values are deeply equal, an `AssertionError` is thrown with a `message`
-property set equal to the value of the `message` parameter. If the `message`
-parameter is undefined, a default error message is assigned. If the `message`
-parameter is an instance of an [`Error`][] then it will be thrown instead of the
-`AssertionError`.
+If the values are deeply equal, an [`AssertionError`][] is thrown with a
+`message` property set equal to the value of the `message` parameter. If the
+`message` parameter is undefined, a default error message is assigned. If the
+`message` parameter is an instance of an [`Error`][] then it will be thrown
+instead of the `AssertionError`.
 
 ## assert.notDeepStrictEqual(actual, expected[, message])
 <!-- YAML
@@ -836,11 +837,11 @@ assert.notDeepStrictEqual({ a: 1 }, { a: '1' });
 // OK
 ```
 
-If the values are deeply and strictly equal, an `AssertionError` is thrown with
-a `message` property set equal to the value of the `message` parameter. If the
-`message` parameter is undefined, a default error message is assigned. If the
-`message` parameter is an instance of an [`Error`][] then it will be thrown
-instead of the `AssertionError`.
+If the values are deeply and strictly equal, an [`AssertionError`][] is thrown
+with a `message` property set equal to the value of the `message` parameter. If
+the `message` parameter is undefined, a default error message is assigned. If
+the `message` parameter is an instance of an [`Error`][] then it will be thrown
+instead of the [`AssertionError`][].
 
 ## assert.notEqual(actual, expected[, message])
 <!-- YAML
@@ -874,10 +875,10 @@ assert.notEqual(1, '1');
 // AssertionError: 1 != '1'
 ```
 
-If the values are equal, an `AssertionError` is thrown with a `message` property
-set equal to the value of the `message` parameter. If the `message` parameter is
-undefined, a default error message is assigned. If the `message` parameter is an
-instance of an [`Error`][] then it will be thrown instead of the
+If the values are equal, an [`AssertionError`][] is thrown with a `message`
+property set equal to the value of the `message` parameter. If the `message`
+parameter is undefined, a default error message is assigned. If the `message`
+parameter is an instance of an [`Error`][] then it will be thrown instead of the
 `AssertionError`.
 
 ## assert.notStrictEqual(actual, expected[, message])
@@ -910,11 +911,11 @@ assert.notStrictEqual(1, '1');
 // OK
 ```
 
-If the values are strictly equal, an `AssertionError` is thrown with a `message`
-property set equal to the value of the `message` parameter. If the `message`
-parameter is undefined, a default error message is assigned. If the `message`
-parameter is an instance of an [`Error`][] then it will be thrown instead of the
-`AssertionError`.
+If the values are strictly equal, an [`AssertionError`][] is thrown with a
+`message` property set equal to the value of the `message` parameter. If the
+`message` parameter is undefined, a default error message is assigned. If the
+`message` parameter is an instance of an [`Error`][] then it will be thrown
+instead of the `AssertionError`.
 
 ## assert.ok(value[, message])
 <!-- YAML
@@ -931,7 +932,7 @@ changes:
 Tests if `value` is truthy. It is equivalent to
 `assert.equal(!!value, true, message)`.
 
-If `value` is not truthy, an `AssertionError` is thrown with a `message`
+If `value` is not truthy, an [`AssertionError`][] is thrown with a `message`
 property set equal to the value of the `message` parameter. If the `message`
 parameter is `undefined`, a default error message is assigned. If the `message`
 parameter is an instance of an [`Error`][] then it will be thrown instead of the
@@ -1009,8 +1010,8 @@ an object where each property will be tested for, or an instance of error where
 each property will be tested for including the non-enumerable `message` and
 `name` properties.
 
-If specified, `message` will be the message provided by the `AssertionError` if
-the `asyncFn` fails to reject.
+If specified, `message` will be the message provided by the [`AssertionError`][]
+if the `asyncFn` fails to reject.
 
 ```js
 (async () => {
@@ -1076,11 +1077,11 @@ assert.strictEqual('Hello foobar', 'Hello World!');
 //          ^
 ```
 
-If the values are not strictly equal, an `AssertionError` is thrown with a
+If the values are not strictly equal, an [`AssertionError`][] is thrown with a
 `message` property set equal to the value of the `message` parameter. If the
 `message` parameter is undefined, a default error message is assigned. If the
 `message` parameter is an instance of an [`Error`][] then it will be thrown
-instead of the `AssertionError`.
+instead of the [`AssertionError`][].
 
 ## assert.throws(fn[, error][, message])
 <!-- YAML
@@ -1211,7 +1212,7 @@ assert.throws(
 Custom error validation:
 
 The function must return `true` to indicate all internal validations passed.
-It will otherwise fail with an AssertionError.
+It will otherwise fail with an [`AssertionError`][].
 
 ```js
 assert.throws(
@@ -1275,6 +1276,7 @@ assert.throws(throwingFirst, /Second$/);
 Due to the confusing notation, it is recommended not to use a string as the
 second argument. This might lead to difficult-to-spot errors.
 
+[`AssertionError`]: #assert_class_assert_assertionerror
 [`Class`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes
 [`ERR_INVALID_RETURN_VALUE`]: errors.html#errors_err_invalid_return_value
 [`Error.captureStackTrace`]: errors.html#errors_error_capturestacktrace_targetobject_constructoropt

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -655,7 +655,21 @@ function expectedException(actual, expected, message, fn) {
   // Check validation functions return value.
   const res = expected.call({}, actual);
   if (res !== true) {
-    throw actual;
+    if (!message) {
+      generatedMessage = true;
+      const name = expected.name ? `"${expected.name}" ` : '';
+      message = `The ${name}validation function is expected to return "true".` +
+        ` Received ${inspect(res)}`;
+    }
+    const err = new AssertionError({
+      actual,
+      expected,
+      message,
+      operator: fn.name,
+      stackStartFn: fn
+    });
+    err.generatedMessage = generatedMessage;
+    throw err;
   }
 }
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -565,6 +565,7 @@ function compareExceptionKey(actual, expected, key, message, keys, fn) {
 
 function expectedException(actual, expected, message, fn) {
   let generatedMessage = false;
+  let throwError = false;
 
   if (typeof expected !== 'function') {
     // Handle regular expressions.
@@ -578,20 +579,9 @@ function expectedException(actual, expected, message, fn) {
         message = 'The input did not match the regular expression ' +
                   `${inspect(expected)}. Input:\n\n${inspect(str)}\n`;
       }
-
-      const err = new AssertionError({
-        actual,
-        expected,
-        message,
-        operator: fn.name,
-        stackStartFn: fn
-      });
-      err.generatedMessage = generatedMessage;
-      throw err;
-    }
-
-    // Handle primitives properly.
-    if (typeof actual !== 'object' || actual === null) {
+      throwError = true;
+      // Handle primitives properly.
+    } else if (typeof actual !== 'object' || actual === null) {
       const err = new AssertionError({
         actual,
         expected,
@@ -601,36 +591,33 @@ function expectedException(actual, expected, message, fn) {
       });
       err.operator = fn.name;
       throw err;
-    }
-
-    // Handle validation objects.
-    const keys = Object.keys(expected);
-    // Special handle errors to make sure the name and the message are compared
-    // as well.
-    if (expected instanceof Error) {
-      keys.push('name', 'message');
-    } else if (keys.length === 0) {
-      throw new ERR_INVALID_ARG_VALUE('error',
-                                      expected, 'may not be an empty object');
-    }
-    if (isDeepEqual === undefined) lazyLoadComparison();
-    for (const key of keys) {
-      if (typeof actual[key] === 'string' &&
-          isRegExp(expected[key]) &&
-          expected[key].test(actual[key])) {
-        continue;
+    } else {
+      // Handle validation objects.
+      const keys = Object.keys(expected);
+      // Special handle errors to make sure the name and the message are
+      // compared as well.
+      if (expected instanceof Error) {
+        keys.push('name', 'message');
+      } else if (keys.length === 0) {
+        throw new ERR_INVALID_ARG_VALUE('error',
+                                        expected, 'may not be an empty object');
       }
-      compareExceptionKey(actual, expected, key, message, keys, fn);
+      if (isDeepEqual === undefined) lazyLoadComparison();
+      for (const key of keys) {
+        if (typeof actual[key] === 'string' &&
+            isRegExp(expected[key]) &&
+            expected[key].test(actual[key])) {
+          continue;
+        }
+        compareExceptionKey(actual, expected, key, message, keys, fn);
+      }
+      return;
     }
-    return;
-  }
-
   // Guard instanceof against arrow functions as they don't have a prototype.
   // Check for matching Error classes.
-  if (expected.prototype !== undefined && actual instanceof expected) {
+  } else if (expected.prototype !== undefined && actual instanceof expected) {
     return;
-  }
-  if (ObjectPrototype.isPrototypeOf(Error, expected)) {
+  } else if (ObjectPrototype.isPrototypeOf(Error, expected)) {
     if (!message) {
       generatedMessage = true;
       message = 'The error is expected to be an instance of ' +
@@ -641,26 +628,22 @@ function expectedException(actual, expected, message, fn) {
         message += `"${inspect(actual, { depth: -1 })}"`;
       }
     }
-    const err = new AssertionError({
-      actual,
-      expected,
-      message,
-      operator: fn.name,
-      stackStartFn: fn
-    });
-    err.generatedMessage = generatedMessage;
-    throw err;
+    throwError = true;
+  } else {
+    // Check validation functions return value.
+    const res = expected.call({}, actual);
+    if (res !== true) {
+      if (!message) {
+        generatedMessage = true;
+        const name = expected.name ? `"${expected.name}" ` : '';
+        message = `The ${name}validation function is expected to return` +
+          ` "true". Received ${inspect(res)}`;
+      }
+      throwError = true;
+    }
   }
 
-  // Check validation functions return value.
-  const res = expected.call({}, actual);
-  if (res !== true) {
-    if (!message) {
-      generatedMessage = true;
-      const name = expected.name ? `"${expected.name}" ` : '';
-      message = `The ${name}validation function is expected to return "true".` +
-        ` Received ${inspect(res)}`;
-    }
+  if (throwError) {
     const err = new AssertionError({
       actual,
       expected,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -622,8 +622,13 @@ function expectedException(actual, expected, message, fn) {
       generatedMessage = true;
       message = 'The error is expected to be an instance of ' +
         `"${expected.name}". Received `;
+      // TODO: Special handle identical names.
       if (isError(actual)) {
-        message += `"${actual.name}"`;
+        const name = actual.constructor && actual.constructor.name;
+        message += `"${name || actual.name}"`;
+        if (actual.message) {
+          message += `\n\nError message:\n\n${actual.message}`;
+        }
       } else {
         message += `"${inspect(actual, { depth: -1 })}"`;
       }
@@ -638,6 +643,10 @@ function expectedException(actual, expected, message, fn) {
         const name = expected.name ? `"${expected.name}" ` : '';
         message = `The ${name}validation function is expected to return` +
           ` "true". Received ${inspect(res)}`;
+
+        if (isError(actual)) {
+          message += `\n\nCaught error:\n\n${actual}`;
+        }
       }
       throwError = true;
     }

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-const { Object } = primordials;
+const { Object, ObjectPrototype } = primordials;
 
 const { Buffer } = require('buffer');
 const { codes: {
@@ -36,6 +36,7 @@ const { inspect } = require('internal/util/inspect');
 const { isPromise, isRegExp } = require('internal/util/types');
 const { EOL } = require('internal/constants');
 const { NativeModule } = require('internal/bootstrap/loaders');
+const { isError } = require('internal/util');
 
 const errorCache = new Map();
 
@@ -563,6 +564,8 @@ function compareExceptionKey(actual, expected, key, message, keys, fn) {
 }
 
 function expectedException(actual, expected, message, fn) {
+  let generatedMessage = false;
+
   if (typeof expected !== 'function') {
     // Handle regular expressions.
     if (isRegExp(expected)) {
@@ -620,8 +623,26 @@ function expectedException(actual, expected, message, fn) {
   if (expected.prototype !== undefined && actual instanceof expected) {
     return;
   }
-  if (Error.isPrototypeOf(expected)) {
-    throw actual;
+  if (ObjectPrototype.isPrototypeOf(Error, expected)) {
+    if (!message) {
+      generatedMessage = true;
+      message = 'The error is expected to be an instance of ' +
+        `"${expected.name}". Received `;
+      if (isError(actual)) {
+        message += `"${actual.name}"`;
+      } else {
+        message += `"${inspect(actual, { depth: -1 })}"`;
+      }
+    }
+    const err = new AssertionError({
+      actual,
+      expected,
+      message,
+      operator: fn.name,
+      stackStartFn: fn
+    });
+    err.generatedMessage = generatedMessage;
+    throw err;
   }
 
   // Check validation functions return value.

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -573,14 +573,21 @@ function expectedException(actual, expected, message, fn) {
       if (expected.test(str))
         return;
 
-      throw new AssertionError({
+      if (!message) {
+        generatedMessage = true;
+        message = 'The input did not match the regular expression ' +
+                  `${inspect(expected)}. Input:\n\n${inspect(str)}\n`;
+      }
+
+      const err = new AssertionError({
         actual,
         expected,
-        message: message || 'The input did not match the regular expression ' +
-                            `${inspect(expected)}. Input:\n\n${inspect(str)}\n`,
+        message,
         operator: fn.name,
         stackStartFn: fn
       });
+      err.generatedMessage = generatedMessage;
+      throw err;
     }
 
     // Handle primitives properly.

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -622,10 +622,14 @@ function expectedException(actual, expected, message, fn) {
       generatedMessage = true;
       message = 'The error is expected to be an instance of ' +
         `"${expected.name}". Received `;
-      // TODO: Special handle identical names.
       if (isError(actual)) {
-        const name = actual.constructor && actual.constructor.name;
-        message += `"${name || actual.name}"`;
+        const name = actual.constructor && actual.constructor.name ||
+                     actual.name;
+        if (expected.name === name) {
+          message += 'an error with identical name but a different prototype.';
+        } else {
+          message += `"${name}"`;
+        }
         if (actual.message) {
           message += `\n\nError message:\n\n${actual.message}`;
         }

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -73,7 +73,8 @@ const invalidThenableFunc = () => {
     () => assert.rejects(Promise.reject(err), validate),
     {
       message: 'The "validate" validation function is expected to ' +
-               "return \"true\". Received 'baz'",
+               "return \"true\". Received 'baz'\n\nCaught error:\n\n" +
+               'Error: foobar',
       code: 'ERR_ASSERTION',
       actual: err,
       expected: validate,

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -66,6 +66,21 @@ const invalidThenableFunc = () => {
       code: 'ERR_INVALID_RETURN_VALUE'
     })
   );
+
+  const err = new Error('foobar');
+  const validate = () => { return 'baz'; };
+  promises.push(assert.rejects(
+    () => assert.rejects(Promise.reject(err), validate),
+    {
+      message: 'The "validate" validation function is expected to ' +
+               "return \"true\". Received 'baz'",
+      code: 'ERR_ASSERTION',
+      actual: err,
+      expected: validate,
+      name: 'AssertionError',
+      operator: 'rejects',
+    }
+  ));
 }
 
 {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -120,7 +120,7 @@ assert.throws(
     name: 'AssertionError',
     operator: 'throws',
     message: 'The error is expected to be an instance of "AssertionError". ' +
-             'Received "TypeError"'
+             'Received "TypeError"\n\nError message:\n\n[object Object]'
   }
 );
 
@@ -231,7 +231,7 @@ a.throws(() => thrower(TypeError), (err) => {
       assert.strictEqual(
         err.message,
         'The error is expected to be an instance of "ES6Error". ' +
-          'Received "Error"'
+          'Received "AnotherErrorType"\n\nError message:\n\nfoo'
       );
       assert.strictEqual(err.actual, actual);
       return true;
@@ -1289,7 +1289,8 @@ assert.throws(
     () => assert.throws(() => { throw err; }, validate),
     {
       message: 'The validation function is expected to ' +
-              `return "true". Received ${inspect(validate())}`,
+              `return "true". Received ${inspect(validate())}\n\nCaught ` +
+              `error:\n\n${err}`,
       code: 'ERR_ASSERTION',
       actual: err,
       expected: validate,

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -25,6 +25,7 @@
 const common = require('../common');
 const assert = require('assert');
 const { inspect } = require('util');
+const vm = require('vm');
 const { internalBinding } = require('internal/test/binding');
 const a = assert;
 
@@ -1299,3 +1300,17 @@ assert.throws(
     }
   );
 }
+
+assert.throws(
+  () => {
+    const script = new vm.Script('new RangeError("foobar");');
+    const context = vm.createContext();
+    const err = script.runInContext(context);
+    assert.throws(() => { throw err; }, RangeError);
+  },
+  {
+    message: 'The error is expected to be an instance of "RangeError". ' +
+             'Received an error with identical name but a different ' +
+             'prototype.\n\nError message:\n\nfoobar'
+  }
+);

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1281,3 +1281,20 @@ assert.throws(
              'Received "[Array]"'
   }
 );
+
+{
+  const err = new TypeError('foo');
+  const validate = (() => () => ({ a: true, b: [ 1, 2, 3 ] }))();
+  assert.throws(
+    () => assert.throws(() => { throw err; }, validate),
+    {
+      message: 'The validation function is expected to ' +
+              `return "true". Received ${inspect(validate())}`,
+      code: 'ERR_ASSERTION',
+      actual: err,
+      expected: validate,
+      name: 'AssertionError',
+      operator: 'throws',
+    }
+  );
+}

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -110,16 +110,19 @@ assert.throws(() => thrower(a.AssertionError));
 assert.throws(() => thrower(TypeError));
 
 // When passing a type, only catch errors of the appropriate type.
-{
-  let threw = false;
-  try {
-    a.throws(() => thrower(TypeError), a.AssertionError);
-  } catch (e) {
-    threw = true;
-    assert.ok(e instanceof TypeError, 'type');
+assert.throws(
+  () => a.throws(() => thrower(TypeError), a.AssertionError),
+  {
+    generatedMessage: true,
+    actual: new TypeError({}),
+    expected: a.AssertionError,
+    code: 'ERR_ASSERTION',
+    name: 'AssertionError',
+    operator: 'throws',
+    message: 'The error is expected to be an instance of "AssertionError". ' +
+             'Received "TypeError"'
   }
-  assert.ok(threw, 'a.throws with an explicit error is eating extra errors');
-}
+);
 
 // doesNotThrow should pass through all errors.
 {
@@ -213,20 +216,27 @@ a.throws(() => thrower(TypeError), (err) => {
 
 // https://github.com/nodejs/node/issues/3188
 {
-  let threw = false;
-  let AnotherErrorType;
-  try {
-    const ES6Error = class extends Error {};
-    AnotherErrorType = class extends Error {};
+  let actual;
+  assert.throws(
+    () => {
+      const ES6Error = class extends Error {};
+      const AnotherErrorType = class extends Error {};
 
-    assert.throws(() => { throw new AnotherErrorType('foo'); }, ES6Error);
-  } catch (e) {
-    threw = true;
-    assert(e instanceof AnotherErrorType,
-           `expected AnotherErrorType, received ${e}`);
-  }
-
-  assert.ok(threw);
+      assert.throws(() => {
+        actual = new AnotherErrorType('foo');
+        throw actual;
+      }, ES6Error);
+    },
+    (err) => {
+      assert.strictEqual(
+        err.message,
+        'The error is expected to be an instance of "ES6Error". ' +
+          'Received "Error"'
+      );
+      assert.strictEqual(err.actual, actual);
+      return true;
+    }
+  );
 }
 
 // Check messages from assert.throws().
@@ -1254,3 +1264,20 @@ assert.throws(
     assert(!err2.stack.includes('hidden'));
   })();
 }
+
+assert.throws(
+  () => assert.throws(() => { throw Symbol('foo'); }, RangeError),
+  {
+    message: 'The error is expected to be an instance of "RangeError". ' +
+             'Received "Symbol(foo)"'
+  }
+);
+
+assert.throws(
+  // eslint-disable-next-line no-throw-literal
+  () => assert.throws(() => { throw [1, 2]; }, RangeError),
+  {
+    message: 'The error is expected to be an instance of "RangeError". ' +
+             'Received "[Array]"'
+  }
+);


### PR DESCRIPTION
Please have a look at the individual commit messages for a detailed description.

I mark this as semver-minor since it adds a wrapper to the actual triggered error and as such it's something new.

// cc @nodejs/assert 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
