### PR TITLE
doc: Updating Table of Content in Building.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,12 +21,14 @@ file a new issue.
 * [Building Node.js on supported platforms](#building-nodejs-on-supported-platforms)
   * [Installing Prerequisites](#installing-prerequisites)
   * [Unix/macOS](#unixmacos)
+    * [Prerequisites](#prerequisites)
     * [Building Node.js](#building-nodejs)
     * [Running Tests](#running-tests)
     * [Running Coverage](#running-coverage)
     * [Building the documentation](#building-the-documentation)
     * [Building a debug build](#building-a-debug-build)
   * [Windows](#windows)
+    * [Prerequisites](#prerequisites-1)
   * [Android/Android-based devices (e.g. Firefox OS)](#androidandroid-based-devices-eg-firefox-os)
   * [`Intl` (ECMA-402) support](#intl-ecma-402-support)
     * [Default: `small-icu` (English only) support](#default-small-icu-english-only-support)
@@ -221,7 +223,7 @@ explains how to install all prerequisites.
 
 ### Unix/macOS
 
-Prerequisites:
+##### Prerequisites:
 
 * `gcc` and `g++` >= 6.3 or newer, or
 * macOS: Xcode Command Line Tools >= 8
@@ -462,7 +464,7 @@ $ backtrace
 
 ### Windows
 
-Prerequisites:
+##### Prerequisites:
 
 * [Python 2.7](https://www.python.org/downloads/)
 * The "Desktop development with C++" workload from

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,8 +19,8 @@ file a new issue.
     * [OpenSSL asm support](#openssl-asm-support)
   * [Previous versions of this document](#previous-versions-of-this-document)
 * [Building Node.js on supported platforms](#building-nodejs-on-supported-platforms)
+  * [Installing Prerequisites](#installing-prerequisites)
   * [Unix/macOS](#unixmacos)
-    * [Prerequisites](#prerequisites)
     * [Building Node.js](#building-nodejs)
     * [Running Tests](#running-tests)
     * [Running Coverage](#running-coverage)
@@ -215,12 +215,13 @@ Consult previous versions of this document for older versions of Node.js:
 
 ## Building Node.js on supported platforms
 
+#### Installing Prerequisites
 The [bootstrapping guide](https://github.com/nodejs/node/blob/master/tools/bootstrap/README.md)
 explains how to install all prerequisites.
 
 ### Unix/macOS
 
-#### Prerequisites
+Prerequisites:
 
 * `gcc` and `g++` >= 6.3 or newer, or
 * macOS: Xcode Command Line Tools >= 8


### PR DESCRIPTION
1. A first time user will most likely not see the instruction to install all
prerequisites using the bootstrapping guide because it was not
properly linked in the table of contents. I also did not see it.

2. The 'Prerequisites' link in the table of content links only to the
'prerequisites' for Unix/macOS skipping over the 'prerequisites'
section that refers to the bootstrapping guide.

I added a new link to the section that refers to the bootstrapping guide
called it 'Installing Prerequisites' and removed the link to the prerequisite
under Unix/macOS section. Now both Unix/macOS and the Windows
section do not have their prerequisites in the 'table of contents'. Initially,
only Unix/macOS had.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] documentation is changed or added
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
