### PR TITLE
util: change inspect's default depth to 4

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -233,8 +233,8 @@ corresponding argument. Supported specifiers are:
   circular references.
 * `%o` - `Object`. A string representation of an object with generic JavaScript
   object formatting. Similar to `util.inspect()` with options
-  `{ showHidden: true, showProxy: true }`. This will show the full object
-  including non-enumerable properties and proxies.
+  `{ showHidden: true, showProxy: true, depth: 4 }`. This will show the full
+  object including non-enumerable properties and proxies.
 * `%O` - `Object`. A string representation of an object with generic JavaScript
   object formatting. Similar to `util.inspect()` without options. This will show
   the full object not including non-enumerable properties and proxies.
@@ -393,6 +393,9 @@ stream.write('With ES6');
 added: v0.3.0
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/28269
+    description: The `depth` option's default value changed to `4`.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/27685
     description: Circular references now include a marker to the reference.
   - version: v12.0.0
@@ -459,7 +462,7 @@ changes:
   * `depth` {number} Specifies the number of times to recurse while formatting
     `object`. This is useful for inspecting large objects. To recurse up to
     the maximum call stack size pass `Infinity` or `null`.
-    **Default:** `2`.
+    **Default:** `4`.
   * `colors` {boolean} If `true`, the output is styled with ANSI color
     codes. Colors are customizable. See [Customizing `util.inspect` colors][].
     **Default:** `false`.

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -99,7 +99,7 @@ const builtInObjects = new Set(
 
 const inspectDefaultOptions = Object.seal({
   showHidden: false,
-  depth: 2,
+  depth: 4,
   colors: false,
   customInspect: true,
   showProxy: false,

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -90,20 +90,24 @@ const expected1 = 'Proxy [ {}, {} ]';
 const expected2 = 'Proxy [ Proxy [ {}, {} ], {} ]';
 const expected3 = 'Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ]';
 const expected4 = 'Proxy [ Proxy [ {}, {} ], Proxy [ Proxy [ {}, {} ], {} ] ]';
-const expected5 = 'Proxy [\n  ' +
-                  'Proxy [ Proxy [ Proxy [Array], {} ], Proxy [ {}, {} ] ],\n' +
-                  '  Proxy [ Proxy [ {}, {} ], Proxy [ Proxy [Array], {} ] ]' +
-                  '\n]';
-const expected6 = 'Proxy [\n' +
-                  '  Proxy [\n' +
-                  '    Proxy [ Proxy [Array], Proxy [Array] ],\n' +
-                  '    Proxy [ Proxy [Array], Proxy [Array] ]\n' +
-                  '  ],\n' +
-                  '  Proxy [\n' +
-                  '    Proxy [ Proxy [Array], Proxy [Array] ],\n' +
-                  '    Proxy [ Proxy [Array], Proxy [Array] ]\n' +
-                  '  ]\n' +
-                  ']';
+const expected5 =
+'Proxy [\n' +
+'  Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ],\n' +
+'  Proxy [ Proxy [ {}, {} ], Proxy [ Proxy [ {}, {} ], {} ] ]\n' +
+']';
+
+const expected6 =
+'Proxy [\n' +
+'  Proxy [\n' +
+'    Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ],\n' +
+'    Proxy [ Proxy [ {}, {} ], Proxy [ Proxy [ {}, {} ], {} ] ]\n' +
+'  ],\n' +
+'  Proxy [\n' +
+'    Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ],\n' +
+'    Proxy [ Proxy [ {}, {} ], Proxy [ Proxy [ {}, {} ], {} ] ]\n' +
+'  ]\n' +
+']';
+
 assert.strictEqual(
   util.inspect(proxy1, { showProxy: true, depth: null }),
   expected1);


### PR DESCRIPTION
This changed the default inspect depth to 4. This is a revival of https://github.com/nodejs/node/pull/23062 which was closed in favor of https://github.com/nodejs/node/pull/22846 but that one ended up being reverted so we're back at 2 which I think is just too low as I often find myself in need of one or two more depth levels.

Carefully marking it as `semver-major`, thought it probably doesn't need to be strictly speaking.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
