### PR TITLE
test: normalize location test-worker-process-cwd.js runs tests

### DIFF
--- a/test/parallel/test-worker-process-cwd.js
+++ b/test/parallel/test-worker-process-cwd.js
@@ -10,6 +10,7 @@ if (!process.env.HAS_STARTED_WORKER) {
   if (!isMainThread) {
     common.skip('This test can only run as main thread');
   }
+  process.chdir(__dirname);
   const w = new Worker(__filename);
   process.chdir('..');
   w.on('message', common.mustCall((message) => {


### PR DESCRIPTION
This change sets the process' directory to __dirname in order to
normalize where the test is ran.  This addresses the situation that
occurs when node is located in the root, and moving up a directory
results in the same directory.  In that case, an error was thrown
because the test interpreted this as a failed directory change.

Fixes: https://github.com/nodejs/node/issues/28193

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
