### PR TITLE
readline: fix position computation

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -732,8 +732,9 @@ Interface.prototype._getDisplayPos = function(str) {
       i++;
     }
     if (code === 0x0a) { // new line \n
+      // row must be incremented by 1 even if offset = 0 or col = +Infinity
+      row += Math.ceil(offset / col) || 1;
       offset = 0;
-      row += 1;
       continue;
     }
     const width = getStringWidth(code);

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -1062,7 +1062,7 @@ function isWarned(emitter) {
       rli.close();
     }
 
-    // multi-line cursor position
+    // Multi-line input cursor position
     {
       const fi = new FakeInput();
       const rli = new readline.Interface({
@@ -1076,6 +1076,23 @@ function isWarned(emitter) {
       const cursorPos = rli._getCursorPos();
       assert.strictEqual(cursorPos.rows, 1);
       assert.strictEqual(cursorPos.cols, 5);
+      rli.close();
+    }
+
+    // Multi-line prompt cursor position
+    {
+      const fi = new FakeInput();
+      const rli = new readline.Interface({
+        input: fi,
+        output: fi,
+        prompt: '\nfilledline\nwraping text\n> ',
+        terminal: terminal
+      });
+      fi.columns = 10;
+      fi.emit('data', 't');
+      const cursorPos = rli._getCursorPos();
+      assert.strictEqual(cursorPos.rows, 4);
+      assert.strictEqual(cursorPos.cols, 3);
       rli.close();
     }
 


### PR DESCRIPTION
The implementation of `_getDisplayPos`, used to compute the cursor position and to find out how many lines to clear up when re-rendering the readline output, was counting each line (except the last one) from the input as one row, even if they were wraping.  This caused some rendering issues when the 'prompt' have at least one wide line ending with a newline char, duplicating the lines at the top of the prompt when calling `_refreshLine` (ex: when the user hits backspace).

This patch fixes the issue by computing the real rows count for each new line in the input string.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
