### PR TITLE
test: do not spawn rmdir in test-statwatcher

### DIFF
--- a/test/async-hooks/test-statwatcher.js
+++ b/test/async-hooks/test-statwatcher.js
@@ -11,7 +11,7 @@ const path = require('path');
 if (!common.isMainThread)
   common.skip('Worker bootstrapping works differently -> different async IDs');
 
-tmpdir.refresh();
+tmpdir.refresh({ spawn: false });
 
 const file1 = path.join(tmpdir.path, 'file1');
 const file2 = path.join(tmpdir.path, 'file2');


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/21425

When running `async-hooks/test-statwatcher` locally in a loop, the first invocation always succeeds and all others fail. I see the same thing happening in recent stress tests (https://ci.nodejs.org/view/All/job/node-stress-single-test/2230/nodes=win2016-vs2017/consoleFull).

This is related to the presence of the tmpdir. Deleting the directory manually makes the next test run pass. This change prevents `tmpdir.refresh()` from spawning `rmdir`, and makes the test pass.

I don't know if this will fix https://github.com/nodejs/node/issues/21425. Doesn't seem related to the older failures listed there, but might be related to the failures that are happening so often now. At least I'm hopping this will help debugging locally and produce more relevant stress test runs.

I'm not familiar with async hooks, I don't know if spawning interferes by design or is an indication of a real bug. Hence, I don't know if we should land this or keep investigating. @addaleax (by looking at file history) if you have an opinion about this it would be welcome, thanks!

Stress test: https://ci.nodejs.org/view/All/job/node-stress-single-test/2231/nodes=win2016-vs2017/consoleFull

cc @nodejs/testing 


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
