### PR TITLE
deps: V8: extend workaround for MSVC optimizer bug

### DIFF
--- a/deps/v8/src/builtins/setup-builtins-internal.cc
+++ b/deps/v8/src/builtins/setup-builtins-internal.cc
@@ -297,7 +297,7 @@ Code GenerateBytecodeHandler(Isolate* isolate, int builtin_index,
 
 }  // namespace
 
-#if _MSC_VER == 1920
+#ifdef _MSC_VER
 #pragma optimize( "", off )
 #endif
 
@@ -384,7 +384,7 @@ void SetupIsolateDelegate::SetupBuiltinsInternal(Isolate* isolate) {
   builtins->MarkInitialized();
 }
 
-#if _MSC_VER == 1920
+#ifdef _MSC_VER
 #pragma optimize( "", on )
 #endif
 


### PR DESCRIPTION
Builds are starting to fail in CI with V8 7.5 and 7.6.

Refs: https://developercommunity.visualstudio.com/content/problem/512352/compiler-doesnt-finish-142027508.html
