### PR TITLE
test: use regex for OpenSSL function name

### DIFF
--- a/test/parallel/test-crypto-scrypt.js
+++ b/test/parallel/test-crypto-scrypt.js
@@ -169,7 +169,8 @@ for (const options of bad) {
 
 for (const options of toobig) {
   const expected = {
-    message: /error:[^:]+:digital envelope routines:[^:]+:memory limit exceeded/,
+    message: new RegExp('error:[^:]+:digital envelope routines:' +
+                        '(?:EVP_PBE_scrypt|scrypt_alg):memory limit exceeded'),
     type: Error,
   };
   common.expectsError(() => crypto.scrypt('pass', 'salt', 1, options, () => {}),

--- a/test/parallel/test-crypto-scrypt.js
+++ b/test/parallel/test-crypto-scrypt.js
@@ -169,7 +169,7 @@ for (const options of bad) {
 
 for (const options of toobig) {
   const expected = {
-    message: /error:[^:]+:digital envelope routines:EVP_PBE_scrypt:memory limit exceeded/,
+    message: /error:[^:]+:digital envelope routines:[^:]+:memory limit exceeded/,
     type: Error,
   };
   common.expectsError(() => crypto.scrypt('pass', 'salt', 1, options, () => {}),


### PR DESCRIPTION
This commit modifies test-crypt-scrypt.js to use a regular expression
for the function name in the error message, similar to what is done for
the error code.

The motivation for this change comes from a case where we (Red Hat)
patch OpenSSL and the memory limit checking is done in a different
function, meaning that the function name from which this error
originates differs from that when linking to the OpenSSL version shipped
with Node.js.


- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
