### PR TITLE
process: improve handling of formatted error stack

### DIFF
--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -151,9 +151,6 @@ function createOnGlobalUncaughtException() {
       // If someone handled it, then great. Otherwise, die in C++ land
       // since that means that we'll exit the process, emit the 'exit' event.
       const { inspect } = require('internal/util/inspect');
-      const colors = internalBinding('util').guessHandleType(2) === 'TTY' &&
-                     require('internal/tty').hasColors() ||
-                     inspect.defaultOptions.colors;
       try {
         if (!process._exiting) {
           process._exiting = true;
@@ -167,7 +164,7 @@ function createOnGlobalUncaughtException() {
         const { kExpandStackSymbol } = require('internal/util');
         if (typeof er[kExpandStackSymbol] === 'function')
           er[kExpandStackSymbol]();
-        er.stack = inspect(er, { colors });
+        er.stack = inspect(er);
       } catch {
         // Nothing to be done about it at this point.
       }


### PR DESCRIPTION
Fatal errors are logged from C++ directly to stderr.
If colored stack trace is used, ANSI color escape sequences
are literally included in the stack trace string. It works
in console on Unix-like systems, but does not work on
Windows or in inspector's DevTools. This PR disables colored
stack trace for fatal errors.

Fixes #28287

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)