### PR TITLE
[v8.x] n-api: implement date object

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -128,9 +128,13 @@ typedef enum {
   napi_escape_called_twice,
   napi_handle_scope_mismatch,
   napi_callback_scope_mismatch,
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 4
   napi_queue_full,
   napi_closing,
+#endif  // NAPI_VERSION >= 4
+#define NAPI_EXPERIMENTAL
+  napi_bigint_expected,
+  napi_date_expected,
 #endif  // NAPI_EXPERIMENTAL
 } napi_status;
 ```
@@ -1375,6 +1379,31 @@ This API allocates a `node::Buffer` object and initializes it with data copied
 from the passed-in buffer. While this is still a fully-supported data
 structure, in most cases using a TypedArray will suffice.
 
+#### napi_create_date
+<!-- YAML
+added: REPLACEME
+napiVersion: 4
+-->
+
+> Stability: 1 - Experimental
+
+```C
+napi_status napi_create_date(napi_env env,
+                             double time,
+                             napi_value* result);
+```
+
+- `[in] env`: The environment that the API is invoked under.
+- `[in] time`: ECMAScript time value in milliseconds since 01 January, 1970 UTC.
+- `[out] result`: A `napi_value` representing a JavaScript `Date`.
+
+Returns `napi_ok` if the API succeeded.
+
+This API allocates a JavaScript `Date` object.
+
+JavaScript `Date` objects are described in
+[Section 20.3][] of the ECMAScript Language Specification.
+
 #### napi_create_external
 <!-- YAML
 added: v8.0.0
@@ -1956,6 +1985,31 @@ Returns `napi_ok` if the API succeeded.
 
 This API returns various properties of a DataView.
 
+#### napi_get_date_value
+<!-- YAML
+added: REPLACEME
+napiVersion: 4
+-->
+
+> Stability: 1 - Experimental
+
+```C
+napi_status napi_get_date_value(napi_env env,
+                                napi_value value,
+                                double* result)
+```
+
+- `[in] env`: The environment that the API is invoked under.
+- `[in] value`: `napi_value` representing a JavaScript `Date`.
+- `[out] result`: Time value as a `double` represented as milliseconds
+since midnight at the beginning of 01 January, 1970 UTC.
+
+Returns `napi_ok` if the API succeeded. If a non-date `napi_value` is passed
+in it returns `napi_date_expected`.
+
+This API returns the C double primitive of time value for the given JavaScript
+`Date`.
+
 #### napi_get_value_bool
 <!-- YAML
 added: v8.0.0
@@ -2451,6 +2505,27 @@ object.
 Returns `napi_ok` if the API succeeded.
 
 This API checks if the Object passed in is a buffer.
+
+### napi_is_date
+<!-- YAML
+added: REPLACEME
+napiVersion: 4
+-->
+
+> Stability: 1 - Experimental
+
+```C
+napi_status napi_is_date(napi_env env, napi_value value, bool* result)
+```
+
+- `[in] env`: The environment that the API is invoked under.
+- `[in] value`: The JavaScript value to check.
+- `[out] result`: Whether the given `napi_value` represents a JavaScript `Date`
+object.
+
+Returns `napi_ok` if the API succeeded.
+
+This API checks if the `Object` passed in is a date.
 
 ### napi_is_error
 <!-- YAML
@@ -4374,6 +4449,7 @@ This API may only be called from the main thread.
 [Promises]: #n_api_promises
 [Script Execution]: #n_api_script_execution
 [Section 12.5.5]: https://tc39.github.io/ecma262/#sec-typeof-operator
+[Section 20.3]: https://tc39.github.io/ecma262/#sec-date-objects
 [Section 24.3]: https://tc39.github.io/ecma262/#sec-dataview-objects
 [Section 25.4]: https://tc39.github.io/ecma262/#sec-promise-objects
 [Section 9.1.6]: https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -655,6 +655,22 @@ napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 
 #endif  // NAPI_VERSION >= 4
 
+#ifdef NAPI_EXPERIMENTAL
+
+// Dates
+NAPI_EXTERN napi_status napi_create_date(napi_env env,
+                                         double time,
+                                         napi_value* result);
+
+NAPI_EXTERN napi_status napi_is_date(napi_env env,
+                                     napi_value value,
+                                     bool* is_date);
+
+NAPI_EXTERN napi_status napi_get_date_value(napi_env env,
+                                            napi_value value,
+                                            double* result);
+#endif  // NAPI_EXPERIMENTAL
+
 EXTERN_C_END
 
 #endif  // SRC_NODE_API_H_

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -80,6 +80,10 @@ typedef enum {
   napi_queue_full,
   napi_closing,
 #endif  // NAPI_VERSION >= 4
+#ifdef NAPI_EXPERIMENTAL
+  napi_bigint_expected,
+  napi_date_expected,
+#endif  // NAPI_EXPERIMENTAL
 } napi_status;
 
 #if NAPI_VERSION >= 4

--- a/test/addons-napi/test_date/binding.gyp
+++ b/test/addons-napi/test_date/binding.gyp
@@ -1,0 +1,10 @@
+{
+  "targets": [
+    {
+      "target_name": "test_date",
+      "sources": [
+        "test_date.c"
+      ]
+    }
+  ]
+}

--- a/test/addons-napi/test_date/test.js
+++ b/test/addons-napi/test_date/test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../../common');
+
+// This tests the date-related n-api calls
+
+const assert = require('assert');
+const test_date = require(`./build/${common.buildType}/test_date`);
+
+const dateTypeTestDate = test_date.createDate(1549183351);
+assert.strictEqual(test_date.isDate(dateTypeTestDate), true);
+
+assert.strictEqual(test_date.isDate(new Date(1549183351)), true);
+
+assert.strictEqual(test_date.isDate(2.4), false);
+assert.strictEqual(test_date.isDate('not a date'), false);
+assert.strictEqual(test_date.isDate(undefined), false);
+assert.strictEqual(test_date.isDate(null), false);
+assert.strictEqual(test_date.isDate({}), false);
+
+assert.strictEqual(test_date.getDateValue(new Date(1549183351)), 1549183351);

--- a/test/addons-napi/test_date/test_date.c
+++ b/test/addons-napi/test_date/test_date.c
@@ -1,0 +1,67 @@
+#define NAPI_EXPERIMENTAL
+
+#include <node_api.h>
+#include "../common.h"
+
+static napi_value createDate(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+
+  napi_valuetype valuetype0;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+
+  NAPI_ASSERT(env, valuetype0 == napi_number,
+              "Wrong type of arguments. Expects a number as first argument.");
+
+  double time;
+  NAPI_CALL(env, napi_get_value_double(env, args[0], &time));
+
+  napi_value date;
+  NAPI_CALL(env, napi_create_date(env, time, &date));
+
+  return date;
+}
+
+static napi_value isDate(napi_env env, napi_callback_info info) {
+  napi_value date, result;
+  size_t argc = 1;
+  bool is_date;
+
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &date, NULL, NULL));
+  NAPI_CALL(env, napi_is_date(env, date, &is_date));
+  NAPI_CALL(env, napi_get_boolean(env, is_date, &result));
+
+  return result;
+}
+
+static napi_value getDateValue(napi_env env, napi_callback_info info) {
+  napi_value date, result;
+  size_t argc = 1;
+  double value;
+
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &date, NULL, NULL));
+  NAPI_CALL(env, napi_get_date_value(env, date, &value));
+  NAPI_CALL(env, napi_create_double(env, value, &result));
+
+  return result;
+}
+
+EXTERN_C_START
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor descriptors[] = {
+    DECLARE_NAPI_PROPERTY("createDate", createDate),
+    DECLARE_NAPI_PROPERTY("isDate", isDate),
+    DECLARE_NAPI_PROPERTY("getDateValue", getDateValue),
+  };
+
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
+}
+EXTERN_C_END
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
Implements `napi_create_date()` as well as `napi_is_date()` to
allow working with JavaScript Date objects.

PR-URL: https://github.com/nodejs/node/pull/25917

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
