### PR TITLE
test: permit test-graph.signal to work without test runner

### DIFF
--- a/test/async-hooks/test-graph.signal.js
+++ b/test/async-hooks/test-graph.signal.js
@@ -53,7 +53,11 @@ function onexit() {
       { type: 'PIPEWRAP', id: 'pipe:4', triggerAsyncId: 'signal:1' },
       { type: 'PIPEWRAP', id: 'pipe:5', triggerAsyncId: 'signal:1' },
       { type: 'PIPEWRAP', id: 'pipe:6', triggerAsyncId: 'signal:1' },
-      { type: 'SIGNALWRAP', id: 'signal:2', triggerAsyncId: 'signal:1' },
+      { type: 'SIGNALWRAP', id: 'signal:2',
+        // TEST_THREAD_ID is set by tools/test.py. Adjust test results depending
+        // on whether the test was invoked via test.py or from the shell
+        // directly.
+        triggerAsyncId: process.env.TEST_THREAD_ID ? 'signal:1' : 'pipe:2' },
       { type: 'PROCESSWRAP', id: 'process:3', triggerAsyncId: 'signal:1' },
       { type: 'PIPEWRAP', id: 'pipe:7', triggerAsyncId: 'signal:1' },
       { type: 'PIPEWRAP', id: 'pipe:8', triggerAsyncId: 'signal:1' },


### PR DESCRIPTION
test/async-hooks/test-graph.signal.js passes with the test.py test runner
but fails if run directly with the `node` executable. Modify the test so
it passes in both cases.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
