### PR TITLE
test: fix flaky test-worker-debug

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -21,8 +21,6 @@ test-worker-memory: PASS,FLAKY
 test-http2-client-upload: PASS,FLAKY
 # https://github.com/nodejs/node/issues/20750
 test-http2-client-upload-reject: PASS,FLAKY
-# https://github.com/nodejs/node/issues/28106
-test-worker-debug: PASS,FLAKY
 
 [$system==linux]
 


### PR DESCRIPTION
Address a race condition in the test; the Worker’s exit events
may have been not recorded because the Worker exited before
the listeners were attached.

Fix the by attaching the event listeners before telling the Worker
to exit.

Fixes: https://github.com/nodejs/node/issues/28299
Fixes: https://github.com/nodejs/node/issues/28106

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
