### PR TITLE
test: do not use fixed port in async-hooks/test-httparser-reuse

### DIFF
--- a/test/async-hooks/test-httparser-reuse.js
+++ b/test/async-hooks/test-httparser-reuse.js
@@ -47,10 +47,9 @@ const server = http.createServer((req, res) => {
   res.end();
 });
 
-const PORT = 3000;
-const url = `http://127.0.0.1:${PORT}`;
-
-server.listen(PORT, common.mustCall(() => {
+server.listen(0, common.mustCall(() => {
+  const PORT = server.address().port;
+  const url = `http://127.0.0.1:${PORT}`;
   http.get(url, common.mustCall(() => {
     server.close(common.mustCall(() => {
       server.listen(PORT, common.mustCall(() => {


### PR DESCRIPTION
Otherwise this was failing on machines which already had a service
running on port 3000.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
