### PR TITLE
domain: use strong reference to domain while active

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -73,13 +73,18 @@ const asyncHook = createHook({
     if (current !== undefined) { // Enter domain for this cb
       // We will get the domain through current.get(), because the resource
       // object's .domain property makes sure it is not garbage collected.
+      // However, we do need to make the reference to the domain non-weak,
+      // so that it cannot be garbage collected before the after() hook.
+      current.incRef();
       current.get().enter();
     }
   },
   after(asyncId) {
     const current = pairing.get(asyncId);
     if (current !== undefined) { // Exit domain for this cb
-      current.get().exit();
+      const domain = current.get();
+      current.decRef();
+      domain.exit();
     }
   },
   destroy(asyncId) {

--- a/test/parallel/test-domain-error-types.js
+++ b/test/parallel/test-domain-error-types.js
@@ -1,3 +1,4 @@
+// Flags: --gc-interval=100 --stress-compaction
 'use strict';
 
 const common = require('../common');
@@ -6,6 +7,8 @@ const domain = require('domain');
 
 // This test is similar to test-domain-multiple-errors, but uses a new domain
 // for each errors.
+// The test flags are not essential, but serve as a way to verify that
+// https://github.com/nodejs/node/issues/28275 is fixed in debug mode.
 
 for (const something of [
   42, null, undefined, false, () => {}, 'string', Symbol('foo')


### PR DESCRIPTION
When an uncaught exception is thrown inside a domain, the domain is
removed from the stack as of 43a51708589ac789ce08beaeb49d6d778dfbdc49.
This means that it might not be kept alive as an object anymore,
and may be garbage collected before the `after()` hook can run,
which tries to exit it as well.

Resolve that by making references to the domain strong while it is
active.

Fixes: https://github.com/nodejs/node/issues/28275

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
