### PR TITLE
crypto: move _scrypt call out of handleError funct

### DIFF
--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -60,7 +60,7 @@ function generateKeyPair(type, options, callback) {
     callback.call(wrap, null, pubkey, privkey);
   };
 
-  handleError(impl, wrap);
+  handleError(impl(wrap));
 }
 
 Object.defineProperty(generateKeyPair, customPromisifyArgs, {
@@ -70,11 +70,10 @@ Object.defineProperty(generateKeyPair, customPromisifyArgs, {
 
 function generateKeyPairSync(type, options) {
   const impl = check(type, options);
-  return handleError(impl);
+  return handleError(impl());
 }
 
-function handleError(impl, wrap) {
-  const ret = impl(wrap);
+function handleError(ret) {
   if (ret === undefined)
     return; // async
 

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -38,14 +38,15 @@ function pbkdf2(password, salt, iterations, keylen, digest, callback) {
     callback.call(wrap, null, keybuf.toString(encoding));
   };
 
-  handleError(keybuf, password, salt, iterations, digest, wrap);
+  handleError(_pbkdf2(keybuf, password, salt, iterations, digest, wrap),
+              digest);
 }
 
 function pbkdf2Sync(password, salt, iterations, keylen, digest) {
   ({ password, salt, iterations, keylen, digest } =
     check(password, salt, iterations, keylen, digest));
   const keybuf = Buffer.alloc(keylen);
-  handleError(keybuf, password, salt, iterations, digest);
+  handleError(_pbkdf2(keybuf, password, salt, iterations, digest), digest);
   const encoding = getDefaultEncoding();
   if (encoding === 'buffer') return keybuf;
   return keybuf.toString(encoding);
@@ -71,9 +72,7 @@ function check(password, salt, iterations, keylen, digest) {
   return { password, salt, iterations, keylen, digest };
 }
 
-function handleError(keybuf, password, salt, iterations, digest, wrap) {
-  const rc = _pbkdf2(keybuf, password, salt, iterations, digest, wrap);
-
+function handleError(rc, digest) {
   if (rc === -1)
     throw new ERR_CRYPTO_INVALID_DIGEST(digest);
 

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -51,7 +51,7 @@ function randomBytes(size, cb) {
 
   const buf = Buffer.alloc(size);
 
-  if (!cb) return handleError(buf, 0, size);
+  if (!cb) return handleError(_randomBytes(buf, 0, size), buf);
 
   const wrap = new AsyncWrap(Providers.RANDOMBYTESREQUEST);
   wrap.ondone = (ex) => {  // Retains buf while request is in flight.
@@ -77,7 +77,7 @@ function randomFillSync(buf, offset = 0, size) {
     size = assertSize(size, elementSize, offset, buf.byteLength);
   }
 
-  return handleError(buf, offset, size);
+  return handleError(_randomBytes(buf, offset, size), buf);
 }
 
 function randomFill(buf, offset, size, cb) {
@@ -115,8 +115,7 @@ function randomFill(buf, offset, size, cb) {
   _randomBytes(buf, offset, size, wrap);
 }
 
-function handleError(buf, offset, size) {
-  const ex = _randomBytes(buf, offset, size);
+function handleError(ex, buf) {
   if (ex) throw ex;
   return buf;
 }

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -44,7 +44,7 @@ function scrypt(password, salt, keylen, options, callback = defaults) {
     callback.call(wrap, null, keybuf.toString(encoding));
   };
 
-  handleError(keybuf, password, salt, N, r, p, maxmem, wrap);
+  handleError(_scrypt(keybuf, password, salt, N, r, p, maxmem, wrap));
 }
 
 function scryptSync(password, salt, keylen, options = defaults) {
@@ -52,22 +52,20 @@ function scryptSync(password, salt, keylen, options = defaults) {
   const { N, r, p, maxmem } = options;
   ({ password, salt, keylen } = options);
   const keybuf = Buffer.alloc(keylen);
-  handleError(keybuf, password, salt, N, r, p, maxmem);
+  handleError(_scrypt(keybuf, password, salt, N, r, p, maxmem));
   const encoding = getDefaultEncoding();
   if (encoding === 'buffer') return keybuf;
   return keybuf.toString(encoding);
 }
 
-function handleError(keybuf, password, salt, N, r, p, maxmem, wrap) {
-  const ex = _scrypt(keybuf, password, salt, N, r, p, maxmem, wrap);
-
-  if (ex === undefined)
+function handleError(error) {
+  if (error === undefined)
     return;
 
-  if (ex === null)
+  if (error === null)
     throw new ERR_CRYPTO_SCRYPT_INVALID_PARAMETER();  // Bad N, r, p, or maxmem.
 
-  throw ex;  // Scrypt operation failed, exception object contains details.
+  throw error;  // Scrypt operation failed, exception object contains details.
 }
 
 function check(password, salt, keylen, options) {

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -58,14 +58,14 @@ function scryptSync(password, salt, keylen, options = defaults) {
   return keybuf.toString(encoding);
 }
 
-function handleError(error) {
-  if (error === undefined)
+function handleError(ex) {
+  if (ex === undefined)
     return;
 
-  if (error === null)
+  if (ex === null)
     throw new ERR_CRYPTO_SCRYPT_INVALID_PARAMETER();  // Bad N, r, p, or maxmem.
 
-  throw error;  // Scrypt operation failed, exception object contains details.
+  throw ex;  // Scrypt operation failed, exception object contains details.
 }
 
 function check(password, salt, keylen, options) {


### PR DESCRIPTION
This commit moves the `_scrypt` function call out of the `handleError`
function, which now only takes in an error object as its parameter.

The motivation for this is to hopefully improve readability as it was
not clear to me the first time I stepped through the code where the
actual call to `_scrypt` was.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
