### PR TITLE
src: fix type name in comment

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -6085,7 +6085,7 @@ void Scrypt(const FunctionCallbackInfo<Value>& args) {
     // EVP_PBE_scrypt() does not always put errors on the error stack
     // and therefore ToResult() may or may not return an exception
     // object.  Return a sentinel value to inform JS land it should
-    // throw an ERR_CRYPTO_SCRYPT_PARAMETER_ERROR on our behalf.
+    // throw an ERR_CRYPTO_SCRYPT_INVALID_PARAMETER on our behalf.
     auto result = job->ToResult();
     if (result->IsUndefined()) result = Null(args.GetIsolate());
     return args.GetReturnValue().Set(result);


### PR DESCRIPTION
The comment refers to an exception type that JS land throws on the C++
code's behalf but apparently I changed the JS name before landing the
pull request and forgot to update the comment.

Refs: https://github.com/nodejs/node/pull/20816