### PR TITLE
doc: remove obsolete external link

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -306,9 +306,6 @@ console.log(addon.hello());
 // Prints: 'world'
 ```
 
-Please see the examples below for further information or
-<https://github.com/arturadib/node-qt> for an example in production.
-
 Because the exact path to the compiled Addon binary can vary depending on how
 it is compiled (i.e. sometimes it may be in `./build/Debug/`), Addons can use
 the [bindings][] package to load the compiled module.


### PR DESCRIPTION
The addons documentation links to an external node-qt repo as a production example. That repo hasn't been updated in over five years. This commit removes the link.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
