### PR TITLE
doc: drop 'Note that' in addons docs

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -83,7 +83,7 @@ NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)
 }  // namespace demo
 ```
 
-Note that all Node.js Addons must export an initialization function following
+All Node.js Addons must export an initialization function following
 the pattern:
 
 ```cpp
@@ -310,9 +310,8 @@ Because the exact path to the compiled Addon binary can vary depending on how
 it is compiled (i.e. sometimes it may be in `./build/Debug/`), Addons can use
 the [bindings][] package to load the compiled module.
 
-Note that while the `bindings` package implementation is more sophisticated
-in how it locates Addon modules, it is essentially using a try-catch pattern
-similar to:
+While the `bindings` package implementation is more sophisticated in how it
+locates Addon modules, it is essentially using a try-catch pattern similar to:
 
 ```js
 try {
@@ -588,10 +587,10 @@ NODE_MODULE(NODE_GYP_MODULE_NAME, Init)
 }  // namespace demo
 ```
 
-Note that this example uses a two-argument form of `Init()` that receives
-the full `module` object as the second argument. This allows the Addon
-to completely overwrite `exports` with a single function instead of
-adding the function as a property of `exports`.
+This example uses a two-argument form of `Init()` that receives the full
+`module` object as the second argument. This allows the Addon to completely
+overwrite `exports` with a single function instead of adding the function as a
+property of `exports`.
 
 To test it, run the following JavaScript:
 
@@ -605,7 +604,7 @@ addon((msg) => {
 });
 ```
 
-Note that, in this example, the callback function is invoked synchronously.
+In this example, the callback function is invoked synchronously.
 
 ### Object factory
 


### PR DESCRIPTION
This commit removes the usage of 'Note that' in the addons documentation. Note that this phrase was not adding anything meaningful to the docs.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
