### PR TITLE
doc: fix typo in process.disconnect() docs

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -763,8 +763,8 @@ and [Cluster][] documentation), the `process.disconnect()` method will close the
 IPC channel to the parent process, allowing the child process to exit gracefully
 once there are no other connections keeping it alive.
 
-The effect of calling `process.disconnect()` is that same as calling the parent
-process's [`ChildProcess.disconnect()`][].
+The effect of calling `process.disconnect()` is the same as calling
+[`ChildProcess.disconnect()`][] from the parent process.
 
 If the Node.js process was not spawned with an IPC channel,
 `process.disconnect()` will be `undefined`.


### PR DESCRIPTION
"that" should be "the" in this sentence. This commit also
restructures the sentence to avoid the word "process's"

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
