### PR TITLE
doc: remove N-API version for Experimental APIs

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1586,7 +1586,6 @@ structure, in most cases using a `TypedArray` will suffice.
 #### napi_create_date
 <!-- YAML
 added: v11.11.0
-napiVersion: 4
 -->
 
 > Stability: 1 - Experimental
@@ -2231,7 +2230,6 @@ This API returns various properties of a `DataView`.
 #### napi_get_date_value
 <!-- YAML
 added: v11.11.0
-napiVersion: 4
 -->
 
 > Stability: 1 - Experimental
@@ -2840,7 +2838,6 @@ This API checks if the `Object` passed in is a buffer.
 ### napi_is_date
 <!-- YAML
 added: v11.11.0
-napiVersion: 4
 -->
 
 > Stability: 1 - Experimental
@@ -3940,7 +3937,6 @@ JavaScript object becomes garbage-collected.
 
 <!-- YAML
 added: v8.0.0
-napiVersion: 1
 -->
 ```C
 napi_status napi_add_finalizer(napi_env env,


### PR DESCRIPTION
Experimental APIs should not have an N-API version
specified. Remove cases were one had been added
incorrectly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
