### PR TITLE
src: readlink("/proc/self/exe") -> uv_exename()

### DIFF
--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -107,8 +107,12 @@ static struct text_region FindNodeTextRegion() {
   std::string exename;
   {
       char selfexe[PATH_MAX];
-      ssize_t count = readlink("/proc/self/exe", selfexe, PATH_MAX);
-      exename = std::string(selfexe, count);
+
+      size_t size = sizeof(selfexe);
+      if (uv_exepath(selfexe, &size))
+        return nregion;
+
+      exename = std::string(selfexe, size);
   }
 
   while (std::getline(ifs, map_line)) {


### PR DESCRIPTION
This commit also adds error handling. A THP-enabled build terminated
with an out-of-memory error on a system without /proc because it cast
the -1 from readlink() to size_t (i.e. ULONG_MAX) and then tried to
allocate a string of that size.

Caveat emptor: this code path isn't exercised by the CI.