### PR TITLE
lib: fix stack overflow check to not break on primitives

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -587,7 +587,7 @@ function isStackOverflowError(err) {
     }
   }
 
-  return err.name === maxStack_ErrorName &&
+  return err && err.name === maxStack_ErrorName &&
          err.message === maxStack_ErrorMessage;
 }
 

--- a/test/parallel/test-console-log-throw-primitive.js
+++ b/test/parallel/test-console-log-throw-primitive.js
@@ -1,0 +1,14 @@
+'use strict';
+require('../common');
+const { Writable } = require('stream');
+const { Console } = require('console');
+
+const stream = new Writable({
+  write() {
+    throw null; // eslint-disable-line no-throw-literal
+  }
+});
+
+const console = new Console({ stdout: stream });
+
+console.log('test'); // Should not throw


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines]
