### PR TITLE
test: tsl switch arguments order for the assertion

### DIFF
--- a/test/parallel/test-tls-net-connect-prefer-path.js
+++ b/test/parallel/test-tls-net-connect-prefer-path.js
@@ -52,7 +52,7 @@ function testLib(lib, cb) {
         }));
         client.on('end', common.mustCall(() => {
           const resp = Buffer.concat(bufs).toString();
-          assert.strictEqual(`${libName(lib)}:${unixServer.address()}`, resp);
+          assert.strictEqual(resp, `${libName(lib)}:${unixServer.address()}`);
           tcpServer.close();
           unixServer.close();
           cb();


### PR DESCRIPTION
test: tsl switch arguments order for the assertion
Switch the argument order for the assertion to be in the correct order (`actual`, `expected`)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
