### PR TITLE
test: switch the param order in the assertion

### DIFF
--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -138,8 +138,8 @@ test({
 function test(options, clientResult, serverResult, clientError, serverError) {
   const server = tls.createServer(serverOptions, (c) => {
     assert.deepStrictEqual(
-      { sni: c.servername, authorized: c.authorized },
-      serverResult
+      serverResult,
+      { sni: c.servername, authorized: c.authorized }
     );
   });
 


### PR DESCRIPTION
Switch the param order in the assertion at line 140
so that they are in the correct order (actual, expected)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
