### PR TITLE
test: refactoring test, reordering arguments

### DIFF
--- a/test/parallel/test-buffer-inheritance.js
+++ b/test/parallel/test-buffer-inheritance.js
@@ -32,7 +32,7 @@ vals.forEach(function(t) {
   let cntr = 0;
   for (let i = 0; i < t.length; i++)
     cntr += t[i];
-  assert.strictEqual(t.length * 5, cntr);
+  assert.strictEqual(cntr, t.length * 5);
 
   // Check this does not throw
   t.toString();


### PR DESCRIPTION
Refactors the test-buffer-inheritance.js test, switches the order of the
arguments to be: 'actual', 'expected'

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
