### PR TITLE
test: refactor test-buffer-failed-alloc-type

### DIFF
--- a/test/parallel/test-buffer-failed-alloc-typed-arrays.js
+++ b/test/parallel/test-buffer-failed-alloc-typed-arrays.js
@@ -27,7 +27,7 @@ for (const allocator of allocators) {
       // Uint32Array should still produce a zeroed out result.
       allocator(size);
     } catch {
-      assert.deepStrictEqual(new Uint32Array(10), zeroArray);
+      assert.deepStrictEqual(zeroArray, new Uint32Array(10));
     }
   }
 }


### PR DESCRIPTION
Switch the argument order for the assertion to be in the correct order (`actual`, `expected`)

- [x] `make -j4 test` (UNIX)
- [x ] commit message follows [commit guidelines]