### PR TITLE
doc: add examples to fs truncate and fs truncateSync

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3187,6 +3187,18 @@ first argument. In this case, `fs.ftruncate()` is called.
 Passing a file descriptor is deprecated and may result in an error being thrown
 in the future.
 
+```js
+console.log(fs.readFileSync('/path/to/file', 'utf8'));
+// Prints: Node + Learn
+
+// Truncate the file to first four bytes
+fs.truncate('/path/to/file', 4, function callback(err){
+  console.log(fs.readFileSync('/path/to/file', 'utf8'));
+});
+// Prints: Node
+```
+
+
 ## fs.truncateSync(path[, len])
 <!-- YAML
 added: v0.8.6
@@ -3200,6 +3212,16 @@ passed as the first argument. In this case, `fs.ftruncateSync()` is called.
 
 Passing a file descriptor is deprecated and may result in an error being thrown
 in the future.
+
+```js
+console.log(fs.readFileSync('/path/to/file', 'utf8'));
+// Prints: Node + Learn
+
+// Truncate the file to first four bytes
+fs.truncateSync('/path/to/file', 4);
+// Prints: Node
+```
+
 
 ## fs.unlink(path, callback)
 <!-- YAML


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
## Description

Add code example for how to use fs.truncate() and fs.truncateSync()

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
