### PR TITLE
switch the argument order for the assertion

### DIFF
--- a/test/parallel/test-next-tick-errors.js
+++ b/test/parallel/test-next-tick-errors.js
@@ -74,5 +74,5 @@ process.on('uncaughtException', function(err, errorOrigin) {
 });
 
 process.on('exit', function() {
-  assert.deepStrictEqual(['A', 'B', 'C'], order);
+  assert.deepStrictEqual(order, ['A', 'B', 'C']);
 });


### PR DESCRIPTION
Switch the argument order for the assertion.

net: Switch the argument order for the assertion to be in the correct order ('actual', 'expect').
src: test/parallel/test-next-tick-errors.js
