### PR TITLE
test: update test-require-json.js

### DIFF
--- a/test/parallel/test-require-json.js
+++ b/test/parallel/test-require-json.js
@@ -26,4 +26,7 @@ const fixtures = require('../common/fixtures');
 
 assert.throws(function() {
   require(fixtures.path('invalid.json'));
-}, SyntaxError);
+}, {
+  name: 'SyntaxError',
+  message: /test[/\\]fixtures[/\\]invalid\.json: /,
+});

--- a/test/parallel/test-require-json.js
+++ b/test/parallel/test-require-json.js
@@ -24,10 +24,6 @@ require('../common');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
 
-try {
+assert.throws(function() {
   require(fixtures.path('invalid.json'));
-} catch (err) {
-  assert.ok(
-    /test[/\\]fixtures[/\\]invalid\.json: /.test(err.message),
-    `require() json error should include path: ${err.message}`);
-}
+}, SyntaxError);


### PR DESCRIPTION
Used assert.throws instead of assert.ok in `test/parallel/test-require-json.`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
