### PR TITLE
vm: increase code coverage of source_text_module.js

### DIFF
--- a/test/parallel/test-vm-module-basic.js
+++ b/test/parallel/test-vm-module-basic.js
@@ -82,3 +82,11 @@ const util = require('util');
   );
   assert.strictEqual(util.inspect(m, { depth: -1 }), '[SourceTextModule]');
 }
+
+// Check dependencies getter returns same object every time
+{
+  const m = new SourceTextModule('');
+  const dep = m.dependencySpecifiers;
+  assert.notStrictEqual(dep, undefined);
+  assert.strictEqual(dep, m.dependencySpecifiers);
+}


### PR DESCRIPTION
1 more line of code coverage: https://coverage.nodejs.org/coverage-1a4f27ae21698d0c/lib/internal/vm/source_text_module.js.html#L161

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
