### PR TITLE
Add documention to Cluster

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -670,6 +670,34 @@ finished.
 
 This can only be called from the master process.
 
+```js
+const cluster = require('cluster');
+const numCPUs = require('os').cpus().length;
+
+if (cluster.isMaster) {
+  for (let i = 0; i < numCPUs; i++) {
+    //  Workers will be created depending on the CPUs numbers.
+    cluster.fork();
+  }
+  setTimeout(() => {
+    for (let i = 1; i <= numCPUs; i++) {
+      const worker = cluster.workers[i];
+      worker.disconnect();
+    }
+    setTimeout(clusterDisconnect, 2000);
+  }, 2000);
+}
+
+function clusterDisconnect() {
+  if (!Object.keys(cluster.workers).length) {
+    // Cluster should be disconnected when all workers are disconnected.
+    cluster.disconnect(() => {
+      console.log('Cluster disconnect.');
+    });
+  }
+}
+```
+
 ## `cluster.fork([env])`
 <!-- YAML
 added: v0.6.0
@@ -682,7 +710,25 @@ Spawn a new worker process.
 
 This can only be called from the master process.
 
-## `cluster.isMaster`
+```js
+const http = require('http');
+const cluster = require('cluster');
+const numCPUs = require('os').cpus().length;
+
+if (cluster.isMaster) {
+  for (let i = 0; i < numCPUs; i++) {
+    //  Workers will be created depending on the CPUs numbers
+    cluster.fork();
+  }
+}
+
+http.Server((req, res) => {
+  res.writeHead(200);
+  res.end('hello world');
+});
+```
+
+## cluster.isMaster
 <!-- YAML
 added: v0.8.1
 -->


### PR DESCRIPTION
This PR adds documention to the functions disconnect and fork of the Cluster module 
##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
