### PR TITLE
test: fix order of assertion arguments in test-event-emitter-num-args

### DIFF
--- a/test/parallel/test-event-emitter-num-args.js
+++ b/test/parallel/test-event-emitter-num-args.js
@@ -50,5 +50,5 @@ e.emit('numArgs', null, null, null, null, null);
 e.emit('foo', null, null, null, null);
 
 process.on('exit', function() {
-  assert.deepStrictEqual([0, 1, 2, 3, 4, 5, 4, 4], num_args_emitted);
+  assert.deepStrictEqual(num_args_emitted, [0, 1, 2, 3, 4, 5, 4, 4]);
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
