### PR TITLE
worker: handle calling terminate when kHandler is null

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -224,8 +224,6 @@ class Worker extends EventEmitter {
   }
 
   terminate(callback) {
-    if (this[kHandle] === null) return;
-
     debug(`[${threadId}] terminates Worker with ID ${this.threadId}`);
 
     if (typeof callback === 'function') {
@@ -233,8 +231,11 @@ class Worker extends EventEmitter {
         'Passing a callback to worker.terminate() is deprecated. ' +
         'It returns a Promise instead.',
         'DeprecationWarning', 'DEP0132');
+      if (this[kHandle] === null) return;
       this.once('exit', (exitCode) => callback(null, exitCode));
     }
+
+    if (this[kHandle] === null) return Promise.resolve();
 
     this[kHandle].stopThread();
 

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -224,6 +224,8 @@ class Worker extends EventEmitter {
   }
 
   terminate(callback) {
+    if (this[kHandle] === null) return Promise.resolve();
+
     debug(`[${threadId}] terminates Worker with ID ${this.threadId}`);
 
     if (typeof callback === 'function') {
@@ -231,11 +233,8 @@ class Worker extends EventEmitter {
         'Passing a callback to worker.terminate() is deprecated. ' +
         'It returns a Promise instead.',
         'DeprecationWarning', 'DEP0132');
-      if (this[kHandle] === null) return;
       this.once('exit', (exitCode) => callback(null, exitCode));
     }
-
-    if (this[kHandle] === null) return Promise.resolve();
 
     this[kHandle].stopThread();
 

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -224,8 +224,6 @@ class Worker extends EventEmitter {
   }
 
   terminate(callback) {
-    if (this[kHandle] === null) return Promise.resolve();
-
     debug(`[${threadId}] terminates Worker with ID ${this.threadId}`);
 
     if (typeof callback === 'function') {
@@ -233,8 +231,11 @@ class Worker extends EventEmitter {
         'Passing a callback to worker.terminate() is deprecated. ' +
         'It returns a Promise instead.',
         'DeprecationWarning', 'DEP0132');
+      if (this[kHandle] === null) return Promise.resolve();
       this.once('exit', (exitCode) => callback(null, exitCode));
     }
+
+    if (this[kHandle] === null) return Promise.resolve();
 
     this[kHandle].stopThread();
 

--- a/test/parallel/test-worker-terminate-null-handler.js
+++ b/test/parallel/test-worker-terminate-null-handler.js
@@ -1,6 +1,6 @@
 'use strict';
-const assert = require('assert')
 const common = require('../common');
+const assert = require('assert');
 const { Worker } = require('worker_threads');
 
 // Test that calling worker.terminate() if kHandler is null should return an
@@ -18,8 +18,10 @@ process.once('beforeExit', common.mustCall(() => {
 
 w.on('exit', common.mustCall(() => {
   console.log('exit');
-  w.terminate().then(returned => assert.strictEqual(returned, undefined));
-  w.terminate(() => null).then(returned => assert.strictEqual(returned, undefined));
+  w.terminate().then((returned) => assert.strictEqual(returned, undefined));
+  w.terminate(() => null).then(
+    (returned) => assert.strictEqual(returned, undefined)
+  );
 }));
 
 w.unref();

--- a/test/parallel/test-worker-terminate-null-handler.js
+++ b/test/parallel/test-worker-terminate-null-handler.js
@@ -18,9 +18,9 @@ process.once('beforeExit', common.mustCall(() => {
 
 worker.on('exit', common.mustCall(() => {
   console.log('exit');
-  worker.terminate().then((returned) => assert.strictEqual(returned, undefined));
+  worker.terminate().then((res) => assert.strictEqual(res, undefined));
   worker.terminate(() => null).then(
-    (returned) => assert.strictEqual(returned, undefined)
+    (res) => assert.strictEqual(res, undefined)
   );
 }));
 

--- a/test/parallel/test-worker-terminate-null-handler.js
+++ b/test/parallel/test-worker-terminate-null-handler.js
@@ -1,0 +1,25 @@
+'use strict';
+const assert = require('assert')
+const common = require('../common');
+const { Worker } = require('worker_threads');
+
+// Test that calling worker.terminate() if kHandler is null should return an
+// empty promise that resolves to undefined
+
+const w = new Worker(`
+const { parentPort } = require('worker_threads');
+parentPort.postMessage({ hello: 'world' });
+`, { eval: true });
+
+process.once('beforeExit', common.mustCall(() => {
+  console.log('beforeExit');
+  w.ref();
+}));
+
+w.on('exit', common.mustCall(() => {
+  console.log('exit');
+  assert.strictEqual(w.terminate(() => null), undefined);
+  w.terminate().then(returned => assert.strictEqual(returned, undefined));
+}));
+
+w.unref();

--- a/test/parallel/test-worker-terminate-null-handler.js
+++ b/test/parallel/test-worker-terminate-null-handler.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const { Worker } = require('worker_threads');
 
 // Test that calling worker.terminate() if kHandler is null should return an
-// empty promise that resolves to undefined
+// empty promise that resolves to undefined, even when a callback is passed
 
 const w = new Worker(`
 const { parentPort } = require('worker_threads');
@@ -18,8 +18,8 @@ process.once('beforeExit', common.mustCall(() => {
 
 w.on('exit', common.mustCall(() => {
   console.log('exit');
-  assert.strictEqual(w.terminate(() => null), undefined);
   w.terminate().then(returned => assert.strictEqual(returned, undefined));
+  w.terminate(() => null).then(returned => assert.strictEqual(returned, undefined));
 }));
 
 w.unref();

--- a/test/parallel/test-worker-terminate-null-handler.js
+++ b/test/parallel/test-worker-terminate-null-handler.js
@@ -6,22 +6,22 @@ const { Worker } = require('worker_threads');
 // Test that calling worker.terminate() if kHandler is null should return an
 // empty promise that resolves to undefined, even when a callback is passed
 
-const w = new Worker(`
+const worker = new Worker(`
 const { parentPort } = require('worker_threads');
 parentPort.postMessage({ hello: 'world' });
 `, { eval: true });
 
 process.once('beforeExit', common.mustCall(() => {
   console.log('beforeExit');
-  w.ref();
+  worker.ref();
 }));
 
-w.on('exit', common.mustCall(() => {
+worker.on('exit', common.mustCall(() => {
   console.log('exit');
-  w.terminate().then((returned) => assert.strictEqual(returned, undefined));
-  w.terminate(() => null).then(
+  worker.terminate().then((returned) => assert.strictEqual(returned, undefined));
+  worker.terminate(() => null).then(
     (returned) => assert.strictEqual(returned, undefined)
   );
 }));
 
-w.unref();
+worker.unref();


### PR DESCRIPTION
This PR makes a change to the Worker.terminate() method when 
called if the kHandler is null. Before this pull request it was returning
undefined, but the API is expecting a promise. With the changes in
this PR if terminate is called and kHandler is null a resolved Promise
is returned even if a callback is passed, to be consistent with the API
surface, and with [always return promises](https://www.w3.org/2001/tag/doc/promises-guide#always-return-promises).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)