### PR TITLE
doc: add example of event close for child_process

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -921,7 +921,7 @@ ls.stdout.on('data', (data) => {
 });
 
 ls.on('close', (code) => {
-	console.log(`child process close all stdio with code ${code}`);
+  console.log(`child process close all stdio with code ${code}`);
 });
 
 ls.on('exit', (code) => {

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -912,6 +912,23 @@ The `'close'` event is emitted when the stdio streams of a child process have
 been closed. This is distinct from the [`'exit'`][] event, since multiple
 processes might share the same stdio streams.
 
+```js
+const { spawn } = require('child_process');
+const ls = spawn('ls', ['-lh', '/usr']);
+
+ls.stdout.on('data', (data) => {
+  console.log(`stdout: ${data}`);
+});
+
+ls.on('close', (code) => {
+	console.log(`child process close all stdio with code ${code}`);
+});
+
+ls.on('exit', (code) => {
+  console.log(`child process exited with code ${code}`);
+});
+```
+
 ### Event: 'disconnect'
 <!-- YAML
 added: v0.7.2


### PR DESCRIPTION
 add a missing example   of the event close for child_process

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
