### PR TITLE
doc: provide an example to fs.stat()

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3077,6 +3077,74 @@ error raised if the file is not available.
 To check if a file exists without manipulating it afterwards, [`fs.access()`]
 is recommended.
 
+For example, given the following folder structure:
+
+-txtDir
+--file.txt
+-app.js
+
+The next program will check for the stats of the given paths:
+
+```js
+const fs = require('fs');
+
+const pathsToCheck = ['./txtDir', './txtDir/file.txt'];
+
+for (i = 0; i < pathsToCheck.length; i++) {
+  fs.stat(pathsToCheck[i], function(err, stats) {
+    console.log(stats.isDirectory());
+    console.log(stats);
+  });
+}
+```
+
+And the output would be:
+
+```console
+true
+Stats {
+  dev: 16777220,
+  mode: 16877,
+  nlink: 3,
+  uid: 501,
+  gid: 20,
+  rdev: 0,
+  blksize: 4096,
+  ino: 14214262,
+  size: 96,
+  blocks: 0,
+  atimeMs: 1561174653071.963,
+  mtimeMs: 1561174614583.3518,
+  ctimeMs: 1561174626623.5366,
+  birthtimeMs: 1561174126937.2893,
+  atime: 2019-06-22T03:37:33.072Z,
+  mtime: 2019-06-22T03:36:54.583Z,
+  ctime: 2019-06-22T03:37:06.624Z,
+  birthtime: 2019-06-22T03:28:46.937Z
+}
+false
+Stats {
+  dev: 16777220,
+  mode: 33188,
+  nlink: 1,
+  uid: 501,
+  gid: 20,
+  rdev: 0,
+  blksize: 4096,
+  ino: 14214074,
+  size: 8,
+  blocks: 8,
+  atimeMs: 1561174616618.8555,
+  mtimeMs: 1561174614584,
+  ctimeMs: 1561174614583.8145,
+  birthtimeMs: 1561174007710.7478,
+  atime: 2019-06-22T03:36:56.619Z,
+  mtime: 2019-06-22T03:36:54.584Z,
+  ctime: 2019-06-22T03:36:54.584Z,
+  birthtime: 2019-06-22T03:26:47.711Z
+}
+```
+
 ## fs.statSync(path[, options])
 <!-- YAML
 added: v0.1.21

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3079,9 +3079,11 @@ is recommended.
 
 For example, given the following folder structure:
 
--txtDir
---file.txt
--app.js
+```fundamental
+- txtDir
+-- file.txt
+- app.js
+```
 
 The next program will check for the stats of the given paths:
 
@@ -3090,7 +3092,7 @@ const fs = require('fs');
 
 const pathsToCheck = ['./txtDir', './txtDir/file.txt'];
 
-for (i = 0; i < pathsToCheck.length; i++) {
+for (let i = 0; i < pathsToCheck.length; i++) {
   fs.stat(pathsToCheck[i], function(err, stats) {
     console.log(stats.isDirectory());
     console.log(stats);


### PR DESCRIPTION
Provided a small example along its output using fs.stat() to check the
stats on two different paths, one a directory and the other a txt file.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
