### PR TITLE
doc: cleanup pendingSettingsAck docs

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -451,9 +451,9 @@ added: v8.4.0
 
 * {boolean}
 
-Indicates whether or not the `Http2Session` is currently waiting for an
-acknowledgment for a sent `SETTINGS` frame. Will be `true` after calling the
-`http2session.settings()` method. Will be `false` once all sent SETTINGS
+Indicates whether the `Http2Session` is currently waiting for acknowledgment of
+a sent `SETTINGS` frame. Will be `true` after calling the
+`http2session.settings()` method. Will be `false` once all sent `SETTINGS`
 frames have been acknowledged.
 
 #### http2session.ping([payload, ]callback)


### PR DESCRIPTION
This commit rephrases the first sentence of the http2 session `pendingSettingsAck` property docs. It also formats `SETTINGS` consistently.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
