### PR TITLE
esm: ensure cwd-relative imports for module --eval

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -9,7 +9,10 @@ const {
   ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK,
   ERR_UNKNOWN_MODULE_FORMAT
 } = require('internal/errors').codes;
-const { URL } = require('url');
+const {
+  URL,
+  pathToFileURL
+} = require('url');
 const { validateString } = require('internal/validators');
 const ModuleMap = require('internal/modules/esm/module_map');
 const ModuleJob = require('internal/modules/esm/module_job');
@@ -107,7 +110,10 @@ class Loader {
     return { url, format };
   }
 
-  async eval(source, url = `eval:${++this.evalIndex}`) {
+  async eval(
+    source,
+    url = pathToFileURL(`${process.cwd()}/[eval${++this.evalIndex}]`).href
+  ) {
     const evalInstance = async (url) => {
       return {
         module: new ModuleWrap(source, url),

--- a/test/message/async_error_eval_esm.out
+++ b/test/message/async_error_eval_esm.out
@@ -1,7 +1,7 @@
 Error: test
-    at one (eval:1:2:9)
-    at two (eval:1:15:9)
+    at one (file:*/[eval1]:2:9)
+    at two (file:*/[eval1]:15:9)
     at processTicksAndRejections (internal/process/task_queues.js:*:*)
-    at async three (eval:1:18:3)
-    at async four (eval:1:22:3)
-    at async main (eval:1:28:5)
+    at async three (file:*/[eval1]:18:3)
+    at async four (file:*/[eval1]:22:3)
+    at async main (file:*/[eval1]:28:5)

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -274,3 +274,12 @@ child.exec(
     assert.ifError(err);
     assert.strictEqual(stdout, 'object\n');
   }));
+
+// Assert that packages can be imported cwd-relative with --eval
+child.exec(
+  `${nodejs} ${execOptions} ` +
+  '--eval "import \'./test/fixtures/es-modules/mjs-file.mjs\'"',
+  common.mustCall((err, stdout) => {
+    assert.ifError(err);
+    assert.strictEqual(stdout, '.mjs file\n');
+  }));


### PR DESCRIPTION
Fixes #28160 ensuring that when using `node --experimental-modules --input-type module --eval`, that any `import` statements are cwd-relative.

Huge thanks to @zeckson for setting up these tests to begin with and @Avaq for the clear issue report on this!

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
