### PR TITLE
Fix various crypto Diffie-Hellmann issues in pummel tests

### DIFF
--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -388,3 +388,30 @@ common.expectsError(
     message: 'The "curve" argument must be of type string. ' +
              'Received type undefined'
   });
+
+assert.throws(
+  function() {
+    crypto.getDiffieHellman('unknown-group');
+  },
+  /^Error: Unknown group$/,
+  'crypto.getDiffieHellman(\'unknown-group\') ' +
+  'failed to throw the expected error.'
+);
+assert.throws(
+  function() {
+    crypto.getDiffieHellman('modp1').setPrivateKey('');
+  },
+  new RegExp('^TypeError: crypto\\.getDiffieHellman\\(\\.\\.\\.\\)\\.' +
+  'setPrivateKey is not a function$'),
+  'crypto.getDiffieHellman(\'modp1\').setPrivateKey(\'\') ' +
+  'failed to throw the expected error.'
+);
+assert.throws(
+  function() {
+    crypto.getDiffieHellman('modp1').setPublicKey('');
+  },
+  new RegExp('^TypeError: crypto\\.getDiffieHellman\\(\\.\\.\\.\\)\\.' +
+  'setPublicKey is not a function$'),
+  'crypto.getDiffieHellman(\'modp1\').setPublicKey(\'\') ' +
+  'failed to throw the expected error.'
+);

--- a/test/pummel/test-crypto-dh-hash.js
+++ b/test/pummel/test-crypto-dh-hash.js
@@ -1,0 +1,49 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('node compiled without OpenSSL.');
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+const hashes = {
+  modp1: '630e9acd2cc63f7e80d8507624ba60ac0757201a',
+  modp2: '18f7aa964484137f57bca64b21917a385b6a0b60',
+  modp5: 'c0a8eec0c2c8a5ec2f9c26f9661eb339a010ec61',
+  modp14: 'af5455606fe74cec49782bb374e4c63c9b1d132c',
+  modp15: '7bdd39e5cdbb9748113933e5c2623b559c534e74',
+  modp16: 'daea5277a7ad0116e734a8e0d2f297ef759d1161',
+  modp17: '3b62aaf0142c2720f0bf26a9589b0432c00eadc1',
+  modp18: 'a870b491bbbec9b131ae9878d07449d32e54f160'
+};
+
+for (const name in hashes) {
+  const group = crypto.getDiffieHellman(name);
+  const private_key = group.getPrime('hex');
+  const hash1 = hashes[name];
+  const hash2 = crypto.createHash('sha1')
+                    .update(private_key.toUpperCase()).digest('hex');
+  assert.strictEqual(hash1, hash2);
+  assert.strictEqual(group.getGenerator('hex'), '02');
+}

--- a/test/pummel/test-crypto-dh-keys.js
+++ b/test/pummel/test-crypto-dh-keys.js
@@ -27,7 +27,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-[ 'modp1', 'modp2', 'modp5', 'modp14', 'modp15', 'modp16', 'modp17', 'modp18' ]
+[ 'modp1', 'modp2', 'modp5', 'modp14', 'modp15', 'modp16', 'modp17' ]
 .forEach((name) => {
   // modp1 is 768 bits, FIPS requires >= 1024
   if (name === 'modp1' && common.hasFipsCrypto)

--- a/test/pummel/test-crypto-dh-keys.js
+++ b/test/pummel/test-crypto-dh-keys.js
@@ -27,31 +27,11 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-const hashes = {
-  modp1: '630e9acd2cc63f7e80d8507624ba60ac0757201a',
-  modp2: '18f7aa964484137f57bca64b21917a385b6a0b60',
-  modp5: 'c0a8eec0c2c8a5ec2f9c26f9661eb339a010ec61',
-  modp14: 'af5455606fe74cec49782bb374e4c63c9b1d132c',
-  modp15: '7bdd39e5cdbb9748113933e5c2623b559c534e74',
-  modp16: 'daea5277a7ad0116e734a8e0d2f297ef759d1161',
-  modp17: '3b62aaf0142c2720f0bf26a9589b0432c00eadc1',
-  modp18: 'a870b491bbbec9b131ae9878d07449d32e54f160'
-};
-
-for (const name in hashes) {
-  const group = crypto.getDiffieHellman(name);
-  const private_key = group.getPrime('hex');
-  const hash1 = hashes[name];
-  const hash2 = crypto.createHash('sha1')
-                    .update(private_key.toUpperCase()).digest('hex');
-  assert.strictEqual(hash1, hash2);
-  assert.strictEqual(group.getGenerator('hex'), '02');
-}
-
-for (const name in hashes) {
+[ 'modp1', 'modp2', 'modp5', 'modp14', 'modp15', 'modp16', 'modp17', 'modp18' ]
+.forEach((name) => {
   // modp1 is 768 bits, FIPS requires >= 1024
   if (name === 'modp1' && common.hasFipsCrypto)
-    continue;
+    return;
   const group1 = crypto.getDiffieHellman(name);
   const group2 = crypto.getDiffieHellman(name);
   group1.generateKeys();
@@ -59,4 +39,4 @@ for (const name in hashes) {
   const key1 = group1.computeSecret(group2.getPublicKey());
   const key2 = group2.computeSecret(group1.getPublicKey());
   assert.deepStrictEqual(key1, key2);
-}
+});

--- a/test/pummel/test-crypto-dh.js
+++ b/test/pummel/test-crypto-dh.js
@@ -27,33 +27,6 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-assert.throws(
-  function() {
-    crypto.getDiffieHellman('unknown-group');
-  },
-  /^Error: Unknown group$/,
-  'crypto.getDiffieHellman(\'unknown-group\') ' +
-  'failed to throw the expected error.'
-);
-assert.throws(
-  function() {
-    crypto.getDiffieHellman('modp1').setPrivateKey('');
-  },
-  new RegExp('^TypeError: crypto\\.getDiffieHellman\\(\\.\\.\\.\\)\\.' +
-  'setPrivateKey is not a function$'),
-  'crypto.getDiffieHellman(\'modp1\').setPrivateKey(\'\') ' +
-  'failed to throw the expected error.'
-);
-assert.throws(
-  function() {
-    crypto.getDiffieHellman('modp1').setPublicKey('');
-  },
-  new RegExp('^TypeError: crypto\\.getDiffieHellman\\(\\.\\.\\.\\)\\.' +
-  'setPublicKey is not a function$'),
-  'crypto.getDiffieHellman(\'modp1\').setPublicKey(\'\') ' +
-  'failed to throw the expected error.'
-);
-
 const hashes = {
   modp1: '630e9acd2cc63f7e80d8507624ba60ac0757201a',
   modp2: '18f7aa964484137f57bca64b21917a385b6a0b60',

--- a/test/pummel/test-dh-regr.js
+++ b/test/pummel/test-dh-regr.js
@@ -27,7 +27,11 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-const p = crypto.createDiffieHellman(1024).getPrime();
+// FIPS requires length >= 1024 but we use 256 in this test to keep it from
+// taking too long and timing out in CI.
+const length = common.hasFipsCrypto ? 1024 : 256;
+
+const p = crypto.createDiffieHellman(length).getPrime();
 
 for (let i = 0; i < 2000; i++) {
   const a = crypto.createDiffieHellman(p);


### PR DESCRIPTION
```txt
commit caceabd828d28f627ec7fd711bcb876d76cd20df (HEAD -> fix-pummel-dh, origin/fix-pummel-dh)
Author: Rich Trott <rtrott@gmail.com>
Date:   Sat Jun 22 15:57:14 2019 -0600

    test: make test-dh-regr more efficient where possible
    
    test-dh-regr is timing out in CI because crypto.createDiffieHellman() is
    considerably slower after an OpenSSL upgrade. This PR modifies the
    change from 11ad744a92374ad71730cbfb7abea71fda0abb74 which made the test
    FIPS-compatible. When not in FIPS mode, the test will use a shorter key
    which will enable it to run much faster.

commit 6a4c29bdbb695eff52578061cec23772664b7c62
Author: Rich Trott <rtrott@gmail.com>
Date:   Sat Jun 22 15:38:22 2019 -0600

    test: split pummel crypto dh test into two separate tests
    
    Split test-crypto-dh into two tests so that it does not time out in CI.
    With a recent OpenSSL upgrade, getDiffieHellman() is much slower than
    before.

commit 6c417a5fa22b02e0dcf76c14b213f953d7c26c84
Author: Rich Trott <rtrott@gmail.com>
Date:   Sat Jun 22 14:06:11 2019 -0600

    test: move non-pummel crypto DH tests to parallel
    
    Some parts of pummel/test-crypto-dh.js will be just fine in
    parallel/test-crypto-dh.js. Move them there.
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
