### PR TITLE
worker: assign missing deprecation code

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2484,8 +2484,8 @@ The legacy HTTP parser, used by default in versions of Node.js prior to 12.0.0,
 is deprecated. This deprecation applies to users of the
 [`--http-parser=legacy`][] command-line flag.
 
-<a id="DEP0XXX"></a>
-### DEP0XXX: worker.terminate() with callback
+<a id="DEP0132"></a>
+### DEP0132: worker.terminate() with callback
 <!-- YAML
 changes:
   - version: REPLACEME

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -232,7 +232,7 @@ class Worker extends EventEmitter {
       process.emitWarning(
         'Passing a callback to worker.terminate() is deprecated. ' +
         'It returns a Promise instead.',
-        'DeprecationWarning', 'DEP0XXX');
+        'DeprecationWarning', 'DEP0132');
       this.once('exit', (exitCode) => callback(null, exitCode));
     }
 

--- a/test/parallel/test-worker-nexttick-terminate.js
+++ b/test/parallel/test-worker-nexttick-terminate.js
@@ -16,7 +16,7 @@ process.nextTick(() => {
 common.expectWarning(
   'DeprecationWarning',
   'Passing a callback to worker.terminate() is deprecated. ' +
-  'It returns a Promise instead.', 'DEP0XXX');
+  'It returns a Promise instead.', 'DEP0132');
 
 w.on('message', common.mustCall(() => {
   setTimeout(() => {


### PR DESCRIPTION
Deprecation code was not assigned.

@nodejs/tooling ... might be worthwhile adding a check for `DEP00XX` and `DEP0XXX` in the change using git-node-land

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
