### PR TITLE
doc: add code example of subprocess.stderr

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1326,15 +1326,19 @@ then this will be `null`.
 refer to the same value.
 
 ```js
-const assert = require('assert');
 const { spawn } = require('child_process');
 
 const filePath = process.argv[1];
+const subprocess = spawn('cat', [filePath], { stdio: ['inherit', 'inherit', 'pipe'] });
 
-const subprocess = spawn('cat', [filePath], { stdio: 'inherit' });
-
-assert.strictEqual(subprocess.stdio[2], null);
-assert.strictEqual(subprocess.stdio[2], subprocess.stderr);
+console.log('stderr some data')
+console.log('server:', subprocess.stderr.server);
+console.log('handle:', subprocess.stderr._handle);
+console.log('parent:', subprocess.stderr._parent);
+console.log('events:', subprocess.stderr._events);
+console.log('redeable:', subprocess.stderr.readable);
+console.log('connecting:', subprocess.stderr.connecting);
+console.log('readable state:', subprocess.stderr._readableState);
 ```
 
 ### subprocess.stdin

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1336,12 +1336,10 @@ const subprocess = spawn('cat', [filePath], {
 
 console.log('stderr some data');
 console.log('server:', subprocess.stderr.server);
-console.log('handle:', subprocess.stderr._handle);
-console.log('parent:', subprocess.stderr._parent);
-console.log('events:', subprocess.stderr._events);
 console.log('redeable:', subprocess.stderr.readable);
+console.log('writable:', subprocess.stderr.writable);
 console.log('connecting:', subprocess.stderr.connecting);
-console.log('readable state:', subprocess.stderr._readableState);
+console.log('allow half open:', subprocess.stderr.allowHalfOpen);
 ```
 
 ### subprocess.stdin

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1329,9 +1329,12 @@ refer to the same value.
 const { spawn } = require('child_process');
 
 const filePath = process.argv[1];
-const subprocess = spawn('cat', [filePath], { stdio: ['inherit', 'inherit', 'pipe'] });
 
-console.log('stderr some data')
+const subprocess = spawn('cat', [filePath], {
+  stdio: ['inherit', 'inherit', 'pipe']
+});
+
+console.log('stderr some data');
 console.log('server:', subprocess.stderr.server);
 console.log('handle:', subprocess.stderr._handle);
 console.log('parent:', subprocess.stderr._parent);

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1325,6 +1325,18 @@ then this will be `null`.
 `subprocess.stderr` is an alias for `subprocess.stdio[2]`. Both properties will
 refer to the same value.
 
+```js
+const assert = require('assert');
+const { spawn } = require('child_process');
+
+const filePath = process.argv[1];
+
+const subprocess = spawn('cat', [filePath], { stdio: 'inherit' });
+
+assert.strictEqual(subprocess.stdio[2], null);
+assert.strictEqual(subprocess.stdio[2], subprocess.stderr);
+```
+
 ### subprocess.stdin
 <!-- YAML
 added: v0.1.90


### PR DESCRIPTION
add a missing example of the property stderr for subprocess.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
