### PR TITLE
Add documentation line for host:port invocation

### DIFF
--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -164,7 +164,6 @@ function print(stream) {
   options.set('--', { helpText: 'indicate the end of node options' });
   stream.write(
     'Usage: node [options] [ -e script | script.js | - ] [arguments]\n' +
-    '       node inspect script.js [arguments]\n' +
     '       node inspect [script.js | -e "script" | <host>:<port>] …\n\n' +
     'Options:\n');
   stream.write(indent(format({

--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -163,8 +163,8 @@ function print(stream) {
                                'interactive mode if a tty)' });
   options.set('--', { helpText: 'indicate the end of node options' });
   stream.write(
-    'Usage: node [options] [ -e script | script.js | - ] [arguments]\n' +
-    '       node inspect [script.js | -e "script" | <host>:<port>] …\n\n' +
+    'Usage: node [options] [ script.js ] [arguments]\n' +
+    '       node inspect [options] [ script.js | host:port ] [arguments]\n\n' +
     'Options:\n');
   stream.write(indent(format({
     options, aliases, firstColumn, secondColumn

--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -164,7 +164,8 @@ function print(stream) {
   options.set('--', { helpText: 'indicate the end of node options' });
   stream.write(
     'Usage: node [options] [ -e script | script.js | - ] [arguments]\n' +
-    '       node inspect script.js [arguments]\n\n' +
+    '       node inspect script.js [arguments]\n' +
+    '       node inspect 192.0.0.1:9229\n\n' +
     'Options:\n');
   stream.write(indent(format({
     options, aliases, firstColumn, secondColumn

--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -165,7 +165,7 @@ function print(stream) {
   stream.write(
     'Usage: node [options] [ -e script | script.js | - ] [arguments]\n' +
     '       node inspect script.js [arguments]\n' +
-    '       node inspect 192.0.0.1:9229\n\n' +
+    '       node inspect [script.js | -e "script" | <host>:<port>] …\n\n' +
     'Options:\n');
   stream.write(indent(format({
     options, aliases, firstColumn, secondColumn


### PR DESCRIPTION
I just wasted a load of time not knowing how to invoke 'node inspect' with host:port to debug a process started with --inspect-port=0 because it didn't show up from a lot of Googling. Having it in the help text would have saved that.