### PR TITLE
http2: remove square brackets from parsed hostname

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2774,7 +2774,7 @@ function connect(authority, options, listener) {
   const protocol = authority.protocol || options.protocol || 'https:';
   const port = '' + (authority.port !== '' ?
     authority.port : (authority.protocol === 'http:' ? 80 : 443));
-  let host = '';
+  let host = 'localhost';
 
   if (authority.hostname) {
     host = authority.hostname;
@@ -2783,8 +2783,6 @@ function connect(authority, options, listener) {
       host = host.slice(1, -1);
   } else if (authority.host) {
     host = authority.host;
-  } else {
-    host = 'localhost';
   }
 
   let socket;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2774,7 +2774,18 @@ function connect(authority, options, listener) {
   const protocol = authority.protocol || options.protocol || 'https:';
   const port = '' + (authority.port !== '' ?
     authority.port : (authority.protocol === 'http:' ? 80 : 443));
-  const host = authority.hostname || authority.host || 'localhost';
+  let host = '';
+
+  if (authority.hostname) {
+    host = authority.hostname;
+
+    if (host.startsWith('['))
+      host = host.slice(1, -1);
+  } else if (authority.host) {
+    host = authority.host;
+  } else {
+    host = 'localhost';
+  }
 
   let socket;
   if (typeof options.createConnection === 'function') {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2779,7 +2779,7 @@ function connect(authority, options, listener) {
   if (authority.hostname) {
     host = authority.hostname;
 
-    if (host.startsWith('['))
+    if (host[0] === '[')
       host = host.slice(1, -1);
   } else if (authority.host) {
     host = authority.host;

--- a/test/parallel/test-http2-connect.js
+++ b/test/parallel/test-http2-connect.js
@@ -1,6 +1,12 @@
 'use strict';
 
-const { mustCall, hasCrypto, skip, expectsError } = require('../common');
+const {
+  mustCall,
+  hasCrypto,
+  hasIPv6,
+  skip,
+  expectsError
+} = require('../common');
 if (!hasCrypto)
   skip('missing crypto');
 const { createServer, connect } = require('http2');
@@ -72,4 +78,26 @@ const { connect: netConnect } = require('net');
     code: 'ERR_HTTP2_UNSUPPORTED_PROTOCOL',
     type: Error
   });
+}
+
+// Check for literal IPv6 addresses in URL's
+if (hasIPv6) {
+  const server = createServer();
+  server.listen(0, '::1', mustCall(() => {
+    const { port } = server.address();
+    const clients = new Set();
+
+    clients.add(connect(`http://[::1]:${port}`));
+    clients.add(connect(new URL(`http://[::1]:${port}`)));
+
+    for (const client of clients) {
+      client.once('connect', mustCall(() => {
+        client.close();
+        clients.delete(client);
+        if (clients.size === 0) {
+          server.close();
+        }
+      }));
+    }
+  }));
 }


### PR DESCRIPTION
Make `http2.connect()` work when using URLs with literal IPv6
addresses.

Fixes: https://github.com/nodejs/node/issues/28216

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
