### PR TITLE
docs: clarify response.finished

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1170,8 +1170,8 @@ added: v0.0.2
 
 * {boolean}
 
-Boolean value that indicates whether the response has completed. Starts
-as `false`. After [`response.end()`][] executes, the value will be `true`.
+The `response.finished` property will be `true` if [`response.end()`][]
+has been called.
 
 ### response.getHeader(name)
 <!-- YAML


### PR DESCRIPTION
This fixes some regular confusion in regards to the `response.finished` property and makes it more consistent with the description for `request.finished`.

Refs: https://github.com/jshttp/on-finished/issues/30

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)