### PR TITLE
doc: cleanup isDead() example

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -401,19 +401,14 @@ if (cluster.isMaster) {
   cluster.on('exit', (worker, code, signal) => {
     console.log('worker is dead:', worker.isDead());
   });
-
 } else {
-  // Workers can share any TCP connection
-  // In this case it is an HTTP server
+  // Workers can share any TCP connection. In this case, it is an HTTP server.
   http.createServer((req, res) => {
     res.writeHead(200);
     res.end(`Current process\n ${process.pid}`);
     process.kill(process.pid);
   }).listen(8000);
-
-  // Make http://localhost:8000 to ckeck isDead method.
 }
-
 ```
 
 ### worker.kill([signal='SIGTERM'])


### PR DESCRIPTION
This commit removes extra whitespace and some awkward text containing typos from the cluster `worker.isDead()` code sample.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
