### PR TITLE
test: use assert() in N-API async test

### DIFF
--- a/test/node-api/test_async/test_async.cc
+++ b/test/node-api/test_async/test_async.cc
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdio.h>
 #include <node_api.h>
 #include "../../js-native-api/common.h"
@@ -29,10 +30,7 @@ void Execute(napi_env env, void* data) {
 #endif
   carrier* c = static_cast<carrier*>(data);
 
-  if (c != &the_carrier) {
-    napi_throw_type_error(env, nullptr, "Wrong data parameter to Execute.");
-    return;
-  }
+  assert(c == &the_carrier);
 
   c->_output = c->_input * 2;
 }


### PR DESCRIPTION
The `Execute()` callback is not allowed to call into JS, so
we should use `assert()` instead of potentially throwing JS errors.

Fixes: https://github.com/nodejs/help/issues/1998

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
