### PR TITLE
doc: update readline asyncIterator docs

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -322,7 +322,7 @@ changes:
 
 Create an `AsyncIterator` object that iterates through each line in the input
 stream as a string. This method allows asynchronous iteration of
-`readline.Interface` objects through `for`-`await`-`of` loops.
+`readline.Interface` objects through `for await...of` loops.
 
 Errors in the input stream are not forwarded.
 
@@ -556,7 +556,7 @@ rl.on('line', (line) => {
 
 A common use case for `readline` is to consume an input file one line at a
 time. The easiest way to do so is leveraging the [`fs.ReadStream`][] API as
-well as a `for`-`await`-`of` loop:
+well as a `for await...of` loop:
 
 ```js
 const fs = require('fs');
@@ -597,7 +597,7 @@ rl.on('line', (line) => {
 });
 ```
 
-Currently, `for`-`await`-`of` loop can be a bit slower. If `async` / `await`
+Currently, `for await...of` loop can be a bit slower. If `async` / `await`
 flow and speed are both essential, a mixed approach can be applied:
 
 ```js

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -318,8 +318,6 @@ changes:
     description: Symbol.asyncIterator support is no longer experimental.
 -->
 
-> Stability: 2 - Stable
-
 * Returns: {AsyncIterator}
 
 Create an `AsyncIterator` object that iterates through each line in the input
@@ -332,10 +330,8 @@ If the loop is terminated with `break`, `throw`, or `return`,
 [`rl.close()`][] will be called. In other words, iterating over a
 `readline.Interface` will always consume the input stream fully.
 
-A caveat with using this experimental API is that the performance is
-currently not on par with the traditional `'line'` event API, and thus it is
-not recommended for performance-sensitive applications. We expect this
-situation to improve in the future.
+Performance is not on par with the traditional `'line'` event API. Use `'line'`
+instead for performance-sensitive applications.
 
 ```js
 async function processLineByLine() {


### PR DESCRIPTION
This commit:
- Removes an unnecessary stability index entry. These generally are not included for Stable entries.
- Reformat `for`-`await`-`of`.
- Remove mention of experimental status that is not true anymore.
- Remove use of "we"

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
