### PR TITLE
doc: replace version with REPLACEME

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -505,7 +505,7 @@ the status of the `highWaterMark`.
 
 ##### writable.writableFinished
 <!-- YAML
-added: v12.4.0
+added: REPLACEME
 -->
 
 * {boolean}


### PR DESCRIPTION
Node 12.4.0 has already been released. Replace the version with REPLACEME so that the proper version gets inserted at release time.

Refs: https://github.com/nodejs/node/pull/28007

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
