### PR TITLE
http2: propagate session destroy code to streams

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -942,6 +942,7 @@ class Http2Session extends EventEmitter {
     socket[kSession] = this;
 
     this[kState] = {
+      destroyCode: NGHTTP2_NO_ERROR,
       flags: SESSION_FLAGS_PENDING,
       goawayCode: null,
       goawayLastStreamID: null,
@@ -1206,6 +1207,7 @@ class Http2Session extends EventEmitter {
 
     const state = this[kState];
     state.flags |= SESSION_FLAGS_DESTROYED;
+    state.destroyCode = code;
 
     // Clear timeout and remove timeout listeners
     this.setTimeout(0);
@@ -1937,10 +1939,13 @@ class Http2Stream extends Duplex {
 
     debug(`Http2Stream ${this[kID] || '<pending>'} [Http2Session ` +
           `${sessionName(session[kType])}]: destroying stream`);
-    const state = this[kState];
-    const code = err != null ?
-      NGHTTP2_INTERNAL_ERROR : (state.rstCode || NGHTTP2_NO_ERROR);
 
+    const state = this[kState];
+    const sessionCode = session[kState].goawayCode ||
+                        session[kState].destroyCode;
+    const code = err != null ?
+      sessionCode || NGHTTP2_INTERNAL_ERROR :
+      state.rstCode || sessionCode;
     const hasHandle = handle !== undefined;
 
     if (!this.closed)

--- a/test/parallel/test-http2-propagate-session-destroy-code.js
+++ b/test/parallel/test-http2-propagate-session-destroy-code.js
@@ -1,0 +1,54 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const http2 = require('http2');
+const server = http2.createServer();
+const errRegEx = /Session closed with error code 7/;
+const destroyCode = http2.constants.NGHTTP2_REFUSED_STREAM;
+
+server.on('error', common.mustNotCall());
+
+server.on('session', (session) => {
+  session.on('close', common.mustCall());
+  session.on('error', common.mustCall((err) => {
+    assert(errRegEx.test(err));
+    assert.strictEqual(session.closed, false);
+    assert.strictEqual(session.destroyed, true);
+  }));
+
+  session.on('stream', common.mustCall((stream) => {
+    stream.on('error', common.mustCall((err) => {
+      assert.strictEqual(session.closed, false);
+      assert.strictEqual(session.destroyed, true);
+      assert(errRegEx.test(err));
+      assert.strictEqual(stream.rstCode, destroyCode);
+    }));
+
+    session.destroy(destroyCode);
+  }));
+});
+
+server.listen(0, common.mustCall(() => {
+  const session = http2.connect(`http://localhost:${server.address().port}`);
+
+  session.on('error', common.mustCall((err) => {
+    assert(errRegEx.test(err));
+    assert.strictEqual(session.closed, false);
+    assert.strictEqual(session.destroyed, true);
+  }));
+
+  const stream = session.request({ [http2.constants.HTTP2_HEADER_PATH]: '/' });
+
+  stream.on('error', common.mustCall((err) => {
+    assert(errRegEx.test(err));
+    assert.strictEqual(stream.rstCode, destroyCode);
+  }));
+
+  stream.on('close', common.mustCall(() => {
+    server.close();
+  }));
+}));


### PR DESCRIPTION
Currently, when an HTTP2 session is destroyed with a code, that code is not propagated to the `destroy()` call of the session's streams. This commit forwards any code used to destroy a session to its corresponding streams.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
