### PR TITLE
buffer: add Buffer.harden() method

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -965,7 +965,7 @@ deprecated unsafe Buffer API, freezes `Buffer` and `require('buffer')` objects.
 
 The exact behaviour could be fine-tuned: for example, to still allow unsafe
 Buffer API for compatibility reasons (e.g. if that us required by application
-dependencies), `Buffer.haden({ throwOnUnsafe: false })` could be used.
+dependencies), `Buffer.harden({ throwOnUnsafe: false })` could be used.
 
 ### Class Method: Buffer.from(string[, encoding])
 <!-- YAML

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -924,6 +924,8 @@ other type appropriate for `Buffer.from()` variants.
 added: TODO
 -->
 
+> Stability: 1 - Experimental
+
 * `options` {Object}
   * `zeroFill` {boolean}
     If `true`, all future `Buffer` instances, even the ones created with

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -954,8 +954,9 @@ This method has effect only of subsequent Buffer API usage, Buffer instances
 created before `Buffer.harden()` is called are not affected.
 
 Warning: for ecosystem compatibility and security reasons `Buffer.harden()` can
-be called only once and only from the top-level application code. Attempting to
-call it from a library in `node_modules` will throw.
+be called only once and only from the top-level application code and only before
+the first turn of the event loop. Attempting to call it asynchronously in
+runtime or from a library in `node_modules` will throw.
 
 By default, it enables mandratory zero fill, disables Buffer pooling, disables
 deprecated unsafe Buffer API, freezes `Buffer` and `require('buffer')` objects.

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -919,6 +919,51 @@ const buf = Buffer.from(new Foo(), 'utf8');
 A `TypeError` will be thrown if `object` has not mentioned methods or is not of
 other type appropriate for `Buffer.from()` variants.
 
+### Class Method: Buffer.harden([options])
+<!-- YAML
+added: TODO
+-->
+
+* `options` {Object}
+  * `zeroFill` {boolean}
+    If `true`, all future `Buffer` instances, even the ones created with
+    `Buffer.allocUnsafe`, will be zero-filled by default.
+    **Default:** `true`.
+  * `disablePool` {boolean}
+    If `true`, all future `Buffer` allocations will not be pooled and their
+    underlying `ArrayBuffer` will have the same size as `Buffer` instance.
+     **Default:** `true`.
+  * `throwOnUnsafe` {boolean}
+    If `true`, unsafe `Buffer(arg)` API will throw instead of showing a
+    deprecation warning.
+    Otherwise, if `false`, first call to unsafe `Buffer(arg)` will trigger a
+    deprecation warning, regardless of whether it was called from inside of
+    `node_modules` directory or not (unlike the default warning).
+    **Default:** `true`.
+  * `freeze` {boolean}
+    If `true`, `Buffer` and `require('buffer')` objects are frozen and can
+    not be monkey-patched.
+    `Buffer.prototype` is not frozen for compatibility reasons.
+    **Default:** `true`.
+
+Calling `Buffer.harden()` enables additional security measures for Buffer API,
+disabling some trade-offs between security and performance/compatibility that
+are present by default.
+
+This method has effect only of subsequent Buffer API usage, Buffer instances
+created before `Buffer.harden()` is called are not affected.
+
+Warning: for ecosystem compatibility and security reasons `Buffer.harden()` can
+be called only once and only from the top-level application code. Attempting to
+call it from a library in `node_modules` will throw.
+
+By default, it enables mandratory zero fill, disables Buffer pooling, disables
+deprecated unsafe Buffer API, freezes `Buffer` and `require('buffer')` objects.
+
+The exact behaviour could be fine-tuned: for example, to still allow unsafe
+Buffer API for compatibility reasons (e.g. if that us required by application
+dependencies), `Buffer.haden({ throwOnUnsafe: false })` could be used.
+
 ### Class Method: Buffer.from(string[, encoding])
 <!-- YAML
 added: v5.10.0

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -199,6 +199,12 @@ Buffer.harden = function({
       'Calling Buffer.harden() from dependencies is not supported.'
     );
   }
+  const perf_hooks = require('perf_hooks');
+  const stillSynchronous = perf_hooks.performance.nodeTiming.loopStart < 0;
+  if (!stillSynchronous) throw new ERR_ASSERTION(
+    'Buffer.harden() should be called only in synchronous mode, during app ' +
+    'startup. Calling Buffer.harden() asynchronously is not supported.'
+  );
   Object.assign(hardened, {
     applied: true,
     zeroFill: Boolean(zeroFill),

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -63,6 +63,7 @@ const {
 
 const {
   codes: {
+    ERR_ASSERTION,
     ERR_BUFFER_OUT_OF_BOUNDS,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
@@ -109,8 +110,13 @@ let poolSize, poolOffset, allocPool;
 // do not own the ArrayBuffer allocator.  Zero fill is always on in that case.
 const zeroFill = bindingZeroFill || [0];
 
+// Hardening Buffer enables Buffer constructor runtime deprecation,
+// disables pooling, and enables mandratory zero-fill. This is more secure, but
+// has potential performance impact, depending on the usecase.
+let hardened = false;
+
 function createUnsafeBuffer(size) {
-  zeroFill[0] = 0;
+  zeroFill[0] = hardened ? 1 : 0;
   try {
     return new FastBuffer(size);
   } finally {
@@ -140,6 +146,15 @@ const bufferWarning = 'Buffer() is deprecated due to security and usability ' +
                       'Buffer.allocUnsafe(), or Buffer.from() methods instead.';
 
 function showFlaggedDeprecation() {
+  if (hardened) {
+    if (bufferWarningAlreadyEmitted) return;
+    process.emitWarning(
+      bufferWarning + ' Buffer() will soon throw in hardened mode.',
+      'DeprecationWarning', 'DEP0XXX');
+    bufferWarningAlreadyEmitted = true;
+    return;
+  }
+
   if (bufferWarningAlreadyEmitted ||
       ++nodeModulesCheckCounter > 10000 ||
       (!require('internal/options').getOptionValue('--pending-deprecation') &&
@@ -156,6 +171,26 @@ function showFlaggedDeprecation() {
   process.emitWarning(bufferWarning, 'DeprecationWarning', 'DEP0005');
   bufferWarningAlreadyEmitted = true;
 }
+
+// Calling this method does not affect existing buffers, only new ones.
+Buffer.harden = function() {
+  if (hardened) return;
+  if (isInsideNodeModules()) {
+    throw new ERR_ASSERTION(
+      'Buffer.harden() should be called only from the top-level module. ' +
+      'Calling Buffer.harden() from dependencies is not supported.'
+    );
+  }
+  hardened = true;
+  Object.defineProperty(Buffer, 'poolSize', {
+    enumerable: true,
+    get: () => 0,
+    set: () => {},
+  });
+  Object.freeze(Buffer);
+  Object.freeze(Buffer.prototype);
+  Object.freeze(module.exports);
+};
 
 function toInteger(n, defaultVal) {
   n = +n;
@@ -365,7 +400,7 @@ function allocate(size) {
   if (size <= 0) {
     return new FastBuffer();
   }
-  if (size < (Buffer.poolSize >>> 1)) {
+  if (size < (Buffer.poolSize >>> 1) && !hardened) {
     if (size > (poolSize - poolOffset))
       createPool();
     const b = new FastBuffer(allocPool, poolOffset, size);

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -110,9 +110,9 @@ let poolSize, poolOffset, allocPool;
 // do not own the ArrayBuffer allocator.  Zero fill is always on in that case.
 const zeroFill = bindingZeroFill || [0];
 
-// Hardening Buffer enables Buffer constructor runtime deprecation,
-// disables pooling, and enables mandratory zero-fill. This is more secure, but
-// has potential performance impact, depending on the usecase.
+// Hardening Buffer enables disables unsafe Buffer API, disables pooling,
+// and enables mandratory zero-fill. This is more secure, but has potential
+// performance and compatibility impact, depending on the usecase.
 const hardened = {
   applied: false,
   zeroFill: false,

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -188,7 +188,6 @@ Buffer.harden = function() {
     set: () => {},
   });
   Object.freeze(Buffer);
-  Object.freeze(Buffer.prototype);
   Object.freeze(module.exports);
 };
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -113,15 +113,15 @@ const zeroFill = bindingZeroFill || [0];
 // Hardening Buffer enables Buffer constructor runtime deprecation,
 // disables pooling, and enables mandratory zero-fill. This is more secure, but
 // has potential performance impact, depending on the usecase.
-const harden = {
-  NONE: 0, // falsy
-  STRICT: 1,
-  LAX: 2,
+const hardened = {
+  applied: false,
+  zeroFill: false,
+  disablePool: false,
+  throwOnUnsafe: false,
 };
-let hardened = harden.NONE;
 
 function createUnsafeBuffer(size) {
-  zeroFill[0] = hardened ? 1 : 0;
+  zeroFill[0] = hardened.zeroFill ? 1 : 0;
   try {
     return new FastBuffer(size);
   } finally {
@@ -151,8 +151,8 @@ const bufferWarning = 'Buffer() is deprecated due to security and usability ' +
                       'Buffer.allocUnsafe(), or Buffer.from() methods instead.';
 
 function showFlaggedDeprecation() {
-  if (hardened) {
-    if (hardened !== harden.LAX) {
+  if (hardened.applied) {
+    if (hardened.throwOnUnsafe) {
       throw new ERR_ASSERTION(
         'Unsafe Buffer() API is forbidden by Buffer strict hardening opt-in.'
       );
@@ -181,8 +181,13 @@ function showFlaggedDeprecation() {
 }
 
 // Calling this method does not affect existing buffers, only new ones.
-Buffer.harden = function({ strict = true } = {}) {
-  if (hardened) {
+Buffer.harden = function({
+  zeroFill = true,
+  disablePool = true,
+  throwOnUnsafe = true,
+  freeze = true,
+} = {}) {
+  if (hardened.applied) {
     // So that params are not changed afterwards
     throw new ERR_ASSERTION(
       'Buffer.harden can be called only once'
@@ -194,14 +199,23 @@ Buffer.harden = function({ strict = true } = {}) {
       'Calling Buffer.harden() from dependencies is not supported.'
     );
   }
-  hardened = strict ? harden.STRICT : harden.LAX;
-  Object.defineProperty(Buffer, 'poolSize', {
-    enumerable: true,
-    get: () => 0,
-    set: () => {},
+  Object.assign(hardened, {
+    applied: true,
+    zeroFill: Boolean(zeroFill),
+    disablePool: Boolean(disablePool),
+    throwOnUnsafe: Boolean(throwOnUnsafe),
   });
-  Object.freeze(Buffer);
-  Object.freeze(module.exports);
+  if (disablePool) {
+    Object.defineProperty(Buffer, 'poolSize', {
+      enumerable: true,
+      get: () => 0,
+      set: () => {},
+    });
+  }
+  if (freeze) {
+    Object.freeze(Buffer);
+    Object.freeze(module.exports);
+  }
 };
 
 function toInteger(n, defaultVal) {
@@ -412,7 +426,7 @@ function allocate(size) {
   if (size <= 0) {
     return new FastBuffer();
   }
-  if (size < (Buffer.poolSize >>> 1) && !hardened) {
+  if (size < (Buffer.poolSize >>> 1) && !hardened.disablePool) {
     if (size > (poolSize - poolOffset))
       createPool();
     const b = new FastBuffer(allocPool, poolOffset, size);

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -113,7 +113,12 @@ const zeroFill = bindingZeroFill || [0];
 // Hardening Buffer enables Buffer constructor runtime deprecation,
 // disables pooling, and enables mandratory zero-fill. This is more secure, but
 // has potential performance impact, depending on the usecase.
-let hardened = false;
+const harden = {
+  NONE: 0, // falsy
+  STRICT: 1,
+  LAX: 2,
+};
+let hardened = harden.NONE;
 
 function createUnsafeBuffer(size) {
   zeroFill[0] = hardened ? 1 : 0;
@@ -147,10 +152,13 @@ const bufferWarning = 'Buffer() is deprecated due to security and usability ' +
 
 function showFlaggedDeprecation() {
   if (hardened) {
+    if (hardened !== harden.LAX) {
+      throw new ERR_ASSERTION(
+        'Unsafe Buffer() API is forbidden by Buffer strict hardening opt-in.'
+      );
+    }
     if (bufferWarningAlreadyEmitted) return;
-    process.emitWarning(
-      bufferWarning + ' Buffer() will soon throw in hardened mode.',
-      'DeprecationWarning', 'DEP0XXX');
+    process.emitWarning(bufferWarning, 'DeprecationWarning', 'DEP0005');
     bufferWarningAlreadyEmitted = true;
     return;
   }
@@ -173,15 +181,20 @@ function showFlaggedDeprecation() {
 }
 
 // Calling this method does not affect existing buffers, only new ones.
-Buffer.harden = function() {
-  if (hardened) return;
+Buffer.harden = function({ strict = true } = {}) {
+  if (hardened) {
+    // So that params are not changed afterwards
+    throw new ERR_ASSERTION(
+      'Buffer.harden can be called only once'
+    );
+  }
   if (isInsideNodeModules()) {
     throw new ERR_ASSERTION(
       'Buffer.harden() should be called only from the top-level module. ' +
       'Calling Buffer.harden() from dependencies is not supported.'
     );
   }
-  hardened = true;
+  hardened = strict ? harden.STRICT : harden.LAX;
   Object.defineProperty(Buffer, 'poolSize', {
     enumerable: true,
     get: () => 0,


### PR DESCRIPTION
This is a strawperson currently, targeted at resolving Buffer controversies and providing an alternate safer Buffer API that could be opted in from the top level app code. This should both resolve potential concerns about Buffer unsafety (that are otherwise non-resolvable in general for performance reasons) and give ecosystem another nudge to migrate off unsafe deprecated `Buffer(arg)` API. 

This adds `Buffer.harden()` method that:

1. Ensures all new buffers are zero-filled, even from `Buffer.allocUnsafe()` (similar to `--zero-fill-buffers` CLI flag).
2. Ensures that pooling is permanently disabled.
3. Enables runtime deprecation for deprecated `Buffer(arg)`
4. Freezes `Buffer` object.

That method is callable only from the top-level app, it will throw when called from dependencies (reuses already existing `isInsideNodeModules()` check for that).

Example:
```console
> Buffer.allocUnsafe(10)
<Buffer 80 26 00 03 01 00 00 00 00 00>
> Buffer.from('sdfds').buffer
ArrayBuffer {
  [Uint8Contents]: <80 26 00 03 01 00 00 00 00 00 00 00 00 00 00 00 73 64 66 64 73 00 00 00 80 00 10 03 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ff ff ff ff 0a 00 00 00 ff ff ff ff 32 00 00 00 ff ff ff ff 38 00 00 00 80 26 00 03 01 00 00 00 00 00 00 00 00 00 00 00 38 24 81 03 01 00 00 00 00 00 00 00 ... 8092 more bytes>,
  byteLength: 8192
}
> Buffer.harden()
undefined
> Buffer.allocUnsafe(10)
<Buffer 00 00 00 00 00 00 00 00 00 00>
> Buffer.from('sdfds').buffer
ArrayBuffer { [Uint8Contents]: <73 64 66 64 73>, byteLength: 5 }
>
```

Unresolved:
1. Re-evaluating Buffer module could create non-hardened Buffers?
2. Child process Buffers are non hardened -- I thought about going into those by an env var, but let's keep that out of scope

/cc @nodejs/security-wg @nodejs/security @nodejs/buffer @mafintosh -- comments?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
