### PR TITLE
tools: change editorconfig's 'ignore' to 'unset'

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,11 +16,11 @@ indent_size = 8
 indent_style = tab
 
 [{deps}/**]
-charset = ignore
-end_of_line = ignore
-indent_size = ignore
-indent_style = ignore
-trim_trailing_whitespace = ignore
+charset = unset
+end_of_line = unset
+indent_size = unset
+indent_style = unset
+trim_trailing_whitespace = unset
 
 [{test/fixtures,deps,tools/node_modules,tools/gyp,tools/icu,tools/msvs}/**]
 insert_final_newline = false


### PR DESCRIPTION
According to https://editorconfig.org/#supported-properties the canonical way to disable a property is to set it to 'unset'. We did use 'ignore' and this generally works because tools ignore unknown values but some of them like `eclint` are picky on it.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
