### PR TITLE
tools: allow single JS file for --link-module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,10 @@ jstest: build-addons build-js-native-api-tests build-node-api-tests ## Runs addo
 		$(CI_JS_SUITES) \
 		$(CI_NATIVE_SUITES)
 
+.PHONY: tooltest
+tooltest:
+	@$(PYTHON) test/tools/test-js2c.py
+
 .PHONY: coverage-run-js
 coverage-run-js:
 	$(RM) -r out/$(BUILDTYPE)/.coverage
@@ -311,6 +315,7 @@ test: all ## Runs default tests, linters, and builds docs.
 	$(MAKE) -s build-node-api-tests
 	$(MAKE) -s cctest
 	$(MAKE) -s jstest
+	$(MAKE) -s tooltest
 
 .PHONY: test-only
 test-only: all  ## For a quick test, does not run linter or build docs.
@@ -319,6 +324,7 @@ test-only: all  ## For a quick test, does not run linter or build docs.
 	$(MAKE) build-node-api-tests
 	$(MAKE) cctest
 	$(MAKE) jstest
+	$(MAKE) tooltest
 
 # Used by `make coverage-test`
 test-cov: all

--- a/test/tools/test-js2c.py
+++ b/test/tools/test-js2c.py
@@ -1,0 +1,14 @@
+import unittest
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                             '..', '..', 'tools')))
+from js2c import NormalizeFileName
+
+class Js2ctest(unittest.TestCase):
+    def testNormalizeFileName(self):
+        self.assertEqual(NormalizeFileName('dir/mod.js'), 'mod')
+        self.assertEqual(NormalizeFileName('deps/mod.js'), 'internal/deps/mod')
+        self.assertEqual(NormalizeFileName('mod.js'), 'mod')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -261,7 +261,7 @@ def NormalizeFileName(filename):
     split = ['internal'] + split
   else:  # `lib/**/*.js` so drop the 'lib' part
     split = split[1:]
-  if split != []:
+  if len(split):
     filename = '/'.join(split)
   return os.path.splitext(filename)[0]
 

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -261,7 +261,8 @@ def NormalizeFileName(filename):
     split = ['internal'] + split
   else:  # `lib/**/*.js` so drop the 'lib' part
     split = split[1:]
-  filename = '/'.join(split)
+  if split != []:
+    filename = '/'.join(split)
   return os.path.splitext(filename)[0]
 
 


### PR DESCRIPTION
The description for the `--link-module` configuration option is as
follows:
```console
$ ./configure --help | grep -A 5 'link-module'
  --link-module=LINKED_MODULE
                      Path to a JS file to be bundled in the binary as a
                      builtin. This module will be referenced by path
                      without extension; e.g. /root/x/y.js will be
                      referenced via require('root/x/y'). Can be used
                      multiple times
```
This lead me to think that it was possible to specify a file like this:
```console
$ ./configure --link-module=something.js
$ NODE_DEBUG=mkcodecache make -j8
```
This will lead to a compilation error as an entry in the source_ map in
node_javascript.cc will end up having an empty string as its key:
```c++
source_.emplace("", UnionBytes{_raw, 105});
```
This will then be used by CodeCacheBuilder when it iterates over the
module ids, which will lead to the following compilation errors:
```console
/node/out/Release/obj/gen/node_code_cache.cc:12:23: warning:
ISO C++17 does not allow a decomposition group to be
empty [-Wempty-decomposition]
static const uint8_t [] = {
                      ^
/node/out/Release/obj/gen/node_code_cache.cc:12:22: warning:
decomposition declarations are a C++17 extension [-Wc++17-extensions]
static const uint8_t [] = {
                     ^~
/node/out/Release/obj/gen/node_code_cache.cc:12:1: error:
decomposition declaration cannot be declared 'static'
static const uint8_t [] = {
^~~~~~
/node/out/Release/obj/gen/node_code_cache.cc:12:22: error:
decomposition declaration cannot be declared with type 'const uint8_t'
(aka 'const unsigned char'); declared type must be 'auto' or
reference to 'auto'
static const uint8_t [] = {
                     ^
/node/out/Release/obj/gen/node_code_cache.cc:12:22: error:
excess elements in scalar initializer
static const uint8_t [] = {
                     ^
/node/out/Release/obj/gen/node_code_cache.cc:660:7: error:
expected expression
      ,
      ^
/node/out/Release/obj/gen/node_code_cache.cc:661:24: error:
no matching function for call to 'arraysize'
      static_cast<int>(arraysize()), policy
                       ^~~~~~~~~
../src/util.h:667:18: note: candidate function template not viable:
requires 1 argument, but 0 were provided
constexpr size_t arraysize(const T (&)[N]) {
                 ^
2 warnings and 5 errors generated.
```
This commit suggests that passing a single file be allowed by modifying
tools/js2c.py, or alternatively raise an Exception with an message that
indicates the cause of this.

With the changes in this PR the usage would look like this:
```console
$ cat something.js
'use strict';

function logit() {
  console.log('something module...');
}

module.exports = {
  logit,
}
$ ./configure --link-module=something.js && NODE_DEBUG=mkcodecache make -j8
...
Generated cache for something, size = 840.00B, total = 643.00KB
...
$ rm something.js
$ ./node -p "require('something').logit()"
something module...
undefined
```
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
