### PR TITLE
build: remove --code-cache-path help option

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -515,11 +515,6 @@ parser.add_option('--without-siphash',
     dest='without_siphash',
     help=optparse.SUPPRESS_HELP)
 
-parser.add_option('--code-cache-path',
-    action='store',
-    dest='code_cache_path',
-    help='optparse.SUPPRESS_HELP')
-
 # End dummy list.
 
 parser.add_option('--without-ssl',

--- a/configure.py
+++ b/configure.py
@@ -1111,7 +1111,7 @@ def configure_node(o):
   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
   # TODO(refack): fix this when implementing embedded code-cache when cross-compiling.
   if o['variables']['want_separate_host_toolset'] == 0:
-    o['variables']['node_code_cache'] = 'yes'
+    o['variables']['node_code_cache'] = 'yes' # For testing
   o['variables']['node_shared'] = b(options.shared)
   node_module_version = getmoduleversion.get_version()
 

--- a/configure.py
+++ b/configure.py
@@ -1111,7 +1111,7 @@ def configure_node(o):
   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
   # TODO(refack): fix this when implementing embedded code-cache when cross-compiling.
   if o['variables']['want_separate_host_toolset'] == 0:
-    o['variables']['node_code_cache_path'] = 'yes'
+    o['variables']['node_code_cache'] = 'yes'
   o['variables']['node_shared'] = b(options.shared)
   node_module_version = getmoduleversion.get_version()
 

--- a/test/parallel/test-code-cache.js
+++ b/test/parallel/test-code-cache.js
@@ -47,7 +47,7 @@ if (!process.features.cached_builtins) {
   }
 } else {  // Native compiled
   assert.strictEqual(
-    process.config.variables.node_code_cache_path,
+    process.config.variables.node_code_cache,
     'yes'
   );
 


### PR DESCRIPTION
This commit removes the now obsolete option.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
