### PR TITLE
inspector: change api to promise-like

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -45,15 +45,13 @@ class Session extends EventEmitter {
     const parsed = JSON.parse(message);
     try {
       if (parsed.id) {
-        const callback = this[messageCallbacksSymbol].get(parsed.id);
+        const {pResolve, pReject} = this[messageCallbacksSymbol].get(parsed.id);
         this[messageCallbacksSymbol].delete(parsed.id);
-        if (callback) {
-          if (parsed.error) {
-            return callback(new ERR_INSPECTOR_COMMAND(parsed.error.code,
-                                                      parsed.error.message));
-          }
-
-          callback(null, parsed.result);
+        if (parsed.error) {
+          pReject(new ERR_INSPECTOR_COMMAND(parsed.error.code,
+            parsed.error.message));
+        } else {
+          pResolve(parsed.result)
         }
       } else {
         this.emit(parsed.method, parsed);
@@ -64,17 +62,10 @@ class Session extends EventEmitter {
     }
   }
 
-  post(method, params, callback) {
+  post(method, params) {
     validateString(method, 'method');
-    if (!callback && util.isFunction(params)) {
-      callback = params;
-      params = null;
-    }
     if (params && typeof params !== 'object') {
       throw new ERR_INVALID_ARG_TYPE('params', 'Object', params);
-    }
-    if (callback && typeof callback !== 'function') {
-      throw new ERR_INVALID_CALLBACK(callback);
     }
 
     if (!this[connectionSymbol]) {
@@ -85,10 +76,16 @@ class Session extends EventEmitter {
     if (params) {
       message.params = params;
     }
-    if (callback) {
-      this[messageCallbacksSymbol].set(id, callback);
-    }
+    let pResolve, pReject;
+    const p = new Promise((resolve, reject) => {
+      pResolve = resolve;
+      pReject = reject;
+
+    });
+    this[messageCallbacksSymbol].set(id, {pResolve, pReject});
     this[connectionSymbol].dispatch(JSON.stringify(message));
+
+    return p;
   }
 
   disconnect() {


### PR DESCRIPTION
The old way is very easy to write callback hell hard to read and maintain

## old way
```js
const inspector = require('inspector');
const fs = require('fs');
const session = new inspector.Session();
session.connect();

session.post('Profiler.enable', () => {
  session.post('Profiler.start', () => {
    // Invoke business logic under measurement here...

    // some time later...
    session.post('Profiler.stop', (err, { profile }) => {
      // Write profile to disk, upload, etc.
      if (!err) {
        fs.writeFileSync('./profile.cpuprofile', JSON.stringify(profile));
      }
    });
  });
});
```

## new way
New way should be something like this:
```js
const inspector = require('inspector')
const session = new inspector.Session()
session.connect()
const wait = n => new Promise(resolve => {
    setTimeout(() => resolve(), n)
})
session
  .post('Profiler.enable')
  .then(() => session.post('Profiler.start'))
  .then(wait(2000))
  .then(() => session.post('Profiler.stop'))
  .then(console.log)
  .catch(console.error)
```

cc @nodejs/inspector 
I don't know whether this should create a issue to discuss it.

I have not touch the test case and doc (luckily it's still an experimental api).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
