### PR TITLE
Centos7 ppc64 le v8 test support

### DIFF
--- a/tools/getarch.py
+++ b/tools/getarch.py
@@ -1,0 +1,10 @@
+from __future__ import print_function
+from utils import GuessArchitecture
+arch = GuessArchitecture()
+
+# assume 64 bit unless set specifically
+print(GuessArchitecture() \
+    .replace('ia32', 'x64') \
+    .replace('ppc', 'ppc64') \
+    .replace('arm', 'arm64') \
+    .replace('s390', 's390x'))

--- a/tools/getendian.py
+++ b/tools/getendian.py
@@ -1,0 +1,4 @@
+from __future__ import print_function
+import sys
+# "little" or "big"
+print(sys.byteorder)

--- a/tools/getmachine.py
+++ b/tools/getmachine.py
@@ -1,0 +1,3 @@
+from __future__ import print_function
+import platform
+print(platform.machine())

--- a/tools/getnodeversion.py
+++ b/tools/getnodeversion.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import re
 

--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -12,7 +12,9 @@ if [[ "$ARCH" == "s390x" ]] || [[ "$ARCH" == "ppc64le" ]]; then
   export BUILD_TOOLS=/home/iojs/build-tools
   export LD_LIBRARY_PATH=$BUILD_TOOLS:$LD_LIBRARY_PATH
   export PATH=$BUILD_TOOLS:$PATH
-  CXX_PATH=`which $CXX |grep g++`
+  if [[ X"$CXX" != X ]]; then
+    CXX_PATH=`which $CXX |grep g++`
+  fi
   rm -f "$BUILD_TOOLS/g++"
   rm -f "$BUILD_TOOLS/gcc"
 fi
@@ -24,8 +26,10 @@ if [[ "$ARCH" == "s390x" ]]; then
   gn gen -v out.gn/$BUILD_ARCH_TYPE --args='is_component_build=false is_debug=false use_goma=false goma_dir="None" use_custom_libcxx=false v8_target_cpu="s390x" target_cpu="s390x"'
   ninja -v -C out.gn/$BUILD_ARCH_TYPE d8 cctest inspector-test
 elif [[ "$ARCH" == "ppc64le" ]]; then
-  ln -s /usr/bin/$CXX "$BUILD_TOOLS/g++"
-  ln -s /usr/bin/$CC "$BUILD_TOOLS/gcc"
+  if [[ X"$CXX" != X ]]; then
+    ln -s /usr/bin/$CXX "$BUILD_TOOLS/g++"
+    ln -s /usr/bin/$CC "$BUILD_TOOLS/gcc"
+  fi
   g++ --version
   export PKG_CONFIG_PATH=$BUILD_TOOLS/pkg-config-files
   gn gen out.gn/$BUILD_ARCH_TYPE --args='is_component_build=false is_debug=false use_goma=false goma_dir="None" use_custom_libcxx=false v8_target_cpu="ppc64" target_cpu="ppc64"'


### PR DESCRIPTION
one:

    tools: move python code out of jenkins shell
    
    https://ci.nodejs.org/job/node-test-commit-v8-linux/configure echoes
    python code into tools and runs it. Move these scripts into tools for
    better maintainability.
    
    Once this lands and is back-ported into LTS branches a bunch of shell
    code can be deleted from the job.

two:

    tools: fix v8 testing with devtoolset on ppcle
    
    The devtoolset doesn't use or set the CXX, etc, env vars, so ignore them
    if not present.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
