### PR TITLE
test: bind to free port

### DIFF
--- a/test/async-hooks/test-httparser-reuse.js
+++ b/test/async-hooks/test-httparser-reuse.js
@@ -47,13 +47,12 @@ const server = http.createServer((req, res) => {
   res.end();
 });
 
-const PORT = 3000;
-const url = `http://127.0.0.1:${PORT}`;
-
-server.listen(PORT, common.mustCall(() => {
+server.listen(0, common.mustCall(() => {
+  const { port } = server.address();
+  const url = `http://127.0.0.1:${port}`;
   http.get(url, common.mustCall(() => {
     server.close(common.mustCall(() => {
-      server.listen(PORT, common.mustCall(() => {
+      server.listen(port, common.mustCall(() => {
         http.get(url, common.mustCall(() => {
           server.close(common.mustCall(() => {
             setTimeout(common.mustCall(verify), 200);


### PR DESCRIPTION
Bind to port 0 instead of 3000
Test does not require a well known port so it doesn't need port 3000 or
common.PORT. Tests were failing on my CI box because port 3000 was
already taken.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
