### PR TITLE
test: skip tests related to CI failures on AIX

### DIFF
--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
@@ -5,6 +5,11 @@ const skipMessage = 'intensive toString tests due to memory confinements';
 if (!common.enoughTestMem)
   common.skip(skipMessage);
 
+// See https://github.com/nodejs/build/issues/1820#issuecomment-505998851
+// See https://github.com/nodejs/node/pull/28469
+if (process.platform === 'aix')
+  common.skip('flaky on AIX');
+
 const binding = require(`./build/${common.buildType}/binding`);
 
 // v8 fails silently if string length > v8::String::kMaxLength

--- a/test/message/message.status
+++ b/test/message/message.status
@@ -16,3 +16,6 @@ prefix message
 
 [$system==freebsd]
 
+[$system==aix]
+# https://github.com/nodejs/node/pull/28469
+vm_dont_display_syntax_error: SKIP

--- a/test/pseudo-tty/pseudo-tty.status
+++ b/test/pseudo-tty/pseudo-tty.status
@@ -1,6 +1,10 @@
 prefix pseudo-tty
 
 [$system==aix]
+# https://github.com/nodejs/build/issues/1820#issuecomment-505998851
+# https://github.com/nodejs/node/pull/28469
+console-dumb-tty: SKIP
+test-fatal-error: SKIP
 
 [$system==solaris]
 # https://github.com/nodejs/node/pull/16225 - `ioctl(fd, TIOCGWINSZ)` seems

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -19,5 +19,8 @@ test-http2-large-file: PASS, FLAKY
 [$system==freebsd]
 
 [$system==aix]
+# https://github.com/nodejs/node/pull/28469
+test-async-wrap-getasyncid: SKIP
+test-buffer-creation-regression: SKIP
 
 [$arch==arm]


### PR DESCRIPTION
These tests seem to trigger failures in the entire CI job (not just the
test) on AIX. Skip them to see if that helps alleviate spurious failures
in node-test-commit-aix (and the upstream PR and commit test jobs).

See:
- https://github.com/nodejs/build/issues/1820#issuecomment-505998851
- https://github.com/nodejs/build/issues/1847#issuecomment-504210708

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
