### PR TITLE
feat: allow ".local" suffixed addresses for inspector

### DIFF
--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -585,7 +585,8 @@ class HttpHandler : public ProtocolHandler {
     std::string host = TrimPort(host_with_port);
     return host.empty() || IsIPAddress(host)
            || node::StringEqualNoCase(host.data(), "localhost")
-           || node::StringEqualNoCase(host.data(), "localhost6");
+           || node::StringEqualNoCase(host.data(), "localhost6")
+           || node::StringEndsWith(host.data(), ".local");
   }
 
   bool parsing_value_;

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -317,6 +317,16 @@ bool StringEqualNoCaseN(const char* a, const char* b, size_t length) {
   return true;
 }
 
+bool StringEndsWith(const char* str, const char* suffix) {
+  if (!str || !suffix)
+    return false;
+  size_t lenstr = strlen(str);
+  size_t lensuffix = strlen(suffix);
+  if (lensuffix > lenstr)
+    return false;
+  return StringEqualNoCaseN(str + lenstr - lensuffix, suffix, lensuffix);
+}
+
 template <typename T>
 inline T MultiplyWithOverflowCheck(T a, T b) {
   auto ret = a * b;

--- a/src/util.h
+++ b/src/util.h
@@ -310,6 +310,9 @@ inline bool StringEqualNoCase(const char* a, const char* b);
 // strncasecmp() is locale-sensitive.  Use StringEqualNoCaseN() instead.
 inline bool StringEqualNoCaseN(const char* a, const char* b, size_t length);
 
+// tests if str ends with the given suffix
+inline bool StringEndsWith(const char* str, const char* suffix);
+
 // Allocates an array of member type T. For up to kStackStorageSize items,
 // the stack is used, otherwise malloc().
 template <typename T, size_t kStackStorageSize = 1024>


### PR DESCRIPTION
The restriction of "localhost" and "localhost6" as the only hostnames allowed for debug prevents easy debugging of locally running VMs especially those inside Kubernetes.  This PR relaxes that restriction slightly to allow for any ".local" suffixed address.

https://github.com/nodejs/help/issues/1700

