### PR TITLE
test: fix assertion argument order in test-esm-namespace

### DIFF
--- a/test/es-module/test-esm-namespace.mjs
+++ b/test/es-module/test-esm-namespace.mjs
@@ -11,4 +11,4 @@ const keys = Object.entries(
   .concat('default')
   .sort();
 
-assert.deepStrictEqual(Object.keys(fs).sort(), keys);
+assert.deepStrictEqual(keys, Object.keys(fs).sort());


### PR DESCRIPTION
Switch the argument order for the assertion to be in the correct order (actual, expected)

- [x] `make -j4 test` (UNIX)
- [x] commit message follows [commit guidelines]