### PR TITLE
test: fix flaky test of parallel/test-worker-process-cwd

### DIFF
--- a/test/parallel/test-worker-process-cwd.js
+++ b/test/parallel/test-worker-process-cwd.js
@@ -12,7 +12,6 @@ if (!process.env.HAS_STARTED_WORKER) {
   }
   process.chdir(__dirname);
   const w = new Worker(__filename);
-  process.chdir('..');
   w.on('message', common.mustCall((message) => {
     assert.strictEqual(message, process.cwd());
     process.chdir('..');


### PR DESCRIPTION
fix #27669.

You'll confirm fixing by running `python tools/test.py -J --repeat=1000 --mode=release parallel/test-worker-process-cwd` on MacOS

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
