### PR TITLE
doc: address missing paren

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -171,7 +171,7 @@ try {
 
 This will not work because the callback function passed to `fs.readFile()` is
 called asynchronously. By the time the callback has been called, the
-surrounding code (including the `try { } catch (err) { }` block will have
+surrounding code, including the `try { } catch (err) { }` block, will have
 already exited. Throwing an error inside the callback **can crash the Node.js
 process** in most cases. If [domains][] are enabled, or a handler has been
 registered with `process.on('uncaughtException')`, such errors can be


### PR DESCRIPTION
The closing paren was missing. Move to using commas instead.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
