### PR TITLE
doc: remove unnecessary stability specifiers

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -591,8 +591,6 @@ earlier ones time out or result in some other error.
 
 ## DNS Promises API
 
-> Stability: 2 - Stable
-
 The `dns.promises` API provides an alternative set of asynchronous DNS methods
 that return `Promise` objects rather than using callbacks. The API is accessible
 via `require('dns').promises`.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3788,8 +3788,6 @@ this API: [`fs.write(fd, string...)`][].
 
 ## fs Promises API
 
-> Stability: 2 - Stable
-
 The `fs.promises` API provides an alternative set of asynchronous file system
 methods that return `Promise` objects rather than using callbacks. The
 API is accessible via `require('fs').promises`.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1319,8 +1319,6 @@ changes:
     description: Symbol.asyncIterator support is no longer experimental.
 -->
 
-> Stability: 2 - Stable
-
 * Returns: {AsyncIterator} to fully consume the stream.
 
 ```js


### PR DESCRIPTION
If a top level module is listed as Stable, there is no need to call out individual components of that module as Stable. The extra text is just distracting.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
