### PR TITLE
Increase limit for network space overhead test

### DIFF
--- a/test/sequential/test-net-bytes-per-incoming-chunk-overhead.js
+++ b/test/sequential/test-net-bytes-per-incoming-chunk-overhead.js
@@ -37,5 +37,5 @@ process.on('exit', () => {
   const bytesPerChunk =
     (process.memoryUsage().rss - baseRSS) / receivedChunks.length;
   // We should always have less than one page (usually ~ 4 kB) per chunk.
-  assert(bytesPerChunk < 512, `measured ${bytesPerChunk} bytes per chunk`);
+  assert(bytesPerChunk < 600, `measured ${bytesPerChunk} bytes per chunk`);
 });


### PR DESCRIPTION
This test imposes a limit on the average bytes of space per chunk for network traffic. However this number depends on VM implementation details, and upcoming changes to V8's array buffer management require a small bump to this limit in this test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
