### PR TITLE
doc: fix swapedOut typo

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1829,7 +1829,7 @@ added: REPLACEME
     * `unsharedStackSize` {integer}
     * `minorPageFault` {integer}
     * `majorPageFault` {integer}
-    * `swapedOut` {integer}
+    * `swappedOut` {integer}
     * `fsRead` {integer}
     * `fsWrite` {integer}
     * `ipcSent` {integer}
@@ -1888,7 +1888,7 @@ console.log(process.resourceUsage());
     unsharedStackSize: 0,
     minorPageFault: 2469,
     majorPageFault: 0,
-    swapedOut: 0,
+    swappedOut: 0,
     fsRead: 0,
     fsWrite: 8,
     ipcSent: 0,


### PR DESCRIPTION
This corrects a typo in the `process.resourceUsage()` docs. The field is named `swappedOut`, not `swapedOut`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
