### PR TITLE
test: increase test-resource-usage.js validation

### DIFF
--- a/test/parallel/test-resource-usage.js
+++ b/test/parallel/test-resource-usage.js
@@ -3,8 +3,7 @@ require('../common');
 const assert = require('assert');
 
 const rusage = process.resourceUsage();
-
-[
+const fields = [
   'userCPUTime',
   'systemCPUTime',
   'maxRSS',
@@ -21,7 +20,11 @@ const rusage = process.resourceUsage();
   'signalsCount',
   'voluntaryContextSwitches',
   'involuntaryContextSwitches'
-].forEach((n) => {
+];
+
+assert.deepStrictEqual(Object.keys(rusage).sort(), fields.sort());
+
+fields.forEach((n) => {
   assert.strictEqual(typeof rusage[n], 'number', `${n} should be a number`);
   assert(rusage[n] >= 0, `${n} should be above or equal 0`);
 });


### PR DESCRIPTION
This commit adds an assertion checking the exact field names returned by `process.resourceUsage()`. This ensures that no new fields accidentally slip into the returned object in the future.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
