### PR TITLE
doc: simplify `process.resourceUsage()` section

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1820,60 +1820,48 @@ Additional documentation is available in the [report documentation][].
 added: REPLACEME
 -->
 
-* Returns: {Object}
-    * `userCPUTime` {integer}
-    * `systemCPUTime` {integer}
-    * `maxRSS` {integer}
-    * `sharedMemorySize` {integer}
-    * `unsharedDataSize` {integer}
-    * `unsharedStackSize` {integer}
-    * `minorPageFault` {integer}
-    * `majorPageFault` {integer}
-    * `swappedOut` {integer}
-    * `fsRead` {integer}
-    * `fsWrite` {integer}
-    * `ipcSent` {integer}
-    * `ipcReceived` {integer}
-    * `signalsCount` {integer}
-    * `voluntaryContextSwitches` {integer}
-    * `involuntaryContextSwitches` {integer}
-
-The `process.resourceUsage()` method returns the resource usage
-for the current process.
-All of these values come from the `uv_getrusage` call which returns
-[this struct][uv_rusage_t], here the mapping between node and libuv:
-- `userCPUTime` maps to `ru_utime` computed in microseconds.
-It is the values as [`process.cpuUsage().user`][process.cpuUsage]
-- `systemCPUTime` maps to `ru_stime` computed in microseconds.
-It is the value as [`process.cpuUsage().system`][process.cpuUsage]
-- `maxRSS` maps to `ru_maxrss` which is the maximum resident set size
-used (in kilobytes).
-- `sharedMemorySize` maps to `ru_ixrss` but is not supported by any platform.
-- `unsharedDataSize` maps to `ru_idrss` but is not supported by any platform.
-- `unsharedStackSize` maps to `ru_isrss` but is not supported by any platform.
-- `minorPageFault` maps to `ru_minflt` which is the number of minor page fault
-for the process, see [this article for more details][wikipedia_minor_fault]
-- `majorPageFault` maps to `ru_majflt` which is the number of major page fault
-for the process, see [this article for more details][wikipedia_major_fault].
-This field is not supported on Windows platforms.
-- `swappedOut` maps to `ru_nswap` which is not supported by any platform.
-- `fsRead` maps to `ru_inblock` which is the number of times the file system
-had to perform input.
-- `fsWrite` maps to `ru_oublock` which is the number of times the file system
-had to perform output.
-- `ipcSent` maps to `ru_msgsnd` but is not supported by any platform.
-- `ipcReceived` maps to `ru_msgrcv` but is not supported by any platform.
-- `signalsCount` maps to `ru_nsignals` but is not supported by any platform.
-- `voluntaryContextSwitches` maps to `ru_nvcsw` which is the number of times
-a CPU context switch resulted due to a process voluntarily giving up the
-processor before its time slice was completed
-(usually to await availability of a resource).
-This field is not supported on Windows platforms.
-- `involuntaryContextSwitches` maps to `ru_nivcsw` which is the number of times
-a CPU context switch resulted due to a higher priority process becoming runnable
- or because the current process exceeded its time slice.
-This field is not supported on Windows platforms.
-
+* Returns: {Object} the resource usage for the current process. All of these
+  values come from the `uv_getrusage` call which returns
+  a [`uv_rusage_t` struct][uv_rusage_t].
+    * `userCPUTime` {integer} maps to `ru_utime` computed in microseconds.
+      It is the same value as [`process.cpuUsage().user`][process.cpuUsage].
+    * `systemCPUTime` {integer} maps to `ru_stime` computed in microseconds.
+      It is the same value as [`process.cpuUsage().system`][process.cpuUsage].
+    * `maxRSS` {integer} maps to `ru_maxrss` which is the maximum resident set
+      size used in kilobytes.
+    * `sharedMemorySize` {integer} maps to `ru_ixrss` but is not supported by
+      any platform.
+    * `unsharedDataSize` {integer} maps to `ru_idrss` but is not supported by
+      any platform.
+    * `unsharedStackSize` {integer} maps to `ru_isrss` but is not supported by
+      any platform.
+    * `minorPageFault` {integer} maps to `ru_minflt` which is the number of
+      minor page faults for the process, see
+      [this article for more details][wikipedia_minor_fault].
+    * `majorPageFault` {integer} maps to `ru_majflt` which is the number of
+      major page faults for the process, see
+      [this article for more details][wikipedia_major_fault]. This field is not
+      supported on Windows.
+    * `swappedOut` {integer} maps to `ru_nswap` but is not supported by any
+      platform.
+    * `fsRead` {integer} maps to `ru_inblock` which is the number of times the
+      file system had to perform input.
+    * `fsWrite` {integer} maps to `ru_oublock` which is the number of times the
+      file system had to perform output.
+    * `ipcSent` {integer} maps to `ru_msgsnd` but is not supported by any
+      platform.
+    * `ipcReceived` {integer} maps to `ru_msgrcv` but is not supported by any
+      platform.
+    * `signalsCount` {integer} maps to `ru_nsignals` but is not supported by any
+      platform.
+    * `voluntaryContextSwitches` {integer} maps to `ru_nvcsw` which is the
+      number of times a CPU context switch resulted due to a process voluntarily
+      giving up the processor before its time slice was completed (usually to
+      await availability of a resource). This field is not supported on Windows.
+    * `involuntaryContextSwitches` {integer} maps to `ru_nivcsw` which is the
+      number of times a CPU context switch resulted due to a higher priority
+      process becoming runnable or because the current process exceeded its
+      time slice. This field is not supported on Windows.
 
 ```js
 console.log(process.resourceUsage());


### PR DESCRIPTION
### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Merge options list with its description to reduce redundancy (some possible typos were also fixed and some periods added).
