### PR TITLE
stream: add Transform.by utility function

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -630,6 +630,12 @@ display if `block` does not throw.
 An iterable argument (i.e. a value that works with `for...of` loops) was
 required, but not provided to a Node.js API.
 
+<a id="ERR_ARG_RETURN_VALUE_NOT_ASYNC_ITERABLE"></a>
+### ERR_ARG_RETURN_VALUE_NOT_ASYNC_ITERABLE
+
+A function argument that returns an async iterable (i.e. a value that works
+with `for await...of` loops) was required, but not provided to a Node.js API.
+
 <a id="ERR_ASSERTION"></a>
 ### ERR_ASSERTION
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1649,7 +1649,7 @@ for performance reasons.
 ### stream.Transform.by(asyncGeneratorFunction, [options])
 
 * `asyncGeneratorFunction` {AsyncGeneratorFunction} A mapping function which
-accepts a `source` iterable which can be used to read incoming data, while
+accepts a `source` async iterable which can be used to read incoming data, while
 transformed data is pushed to the stream with the `yield` keyword.
 * `options` {Object} Options provided to `new stream.Transform([options])`.
 By default, `Transform.by()` will set `options.objectMode` to `true`,

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1688,7 +1688,6 @@ of the `WriteableStream` side of the transform. This is the same `encoding`
 value that would be passed as the second parameter to the `transform()` function
 option (or `_transform()` method) supplied to `stream.Transform`.
 
-
 ## API for Stream Implementers
 
 <!--type=misc-->

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2670,6 +2670,36 @@ readable.on('data', (chunk) => {
 });
 ```
 
+#### Creating Transform Streams with Async Generator Functions
+
+We can construct a Node.js Transform stream with an asynchronous
+generator function using the `Transform.by` utility method.
+
+
+```js
+const { Readable, Transform } = require('stream');
+
+async function * toUpperCase(source) {
+  for await (const chunk of source) {
+    yield chunk.toUpperCase();
+  }
+}
+const transform = Transform.by(toUpperCase);
+
+async function * generate() {
+  yield 'a';
+  yield 'b';
+  yield 'c';
+}
+
+const readable = Readable.from(generate());
+
+readable.pipe(transform);
+transform.on('data', (chunk) => {
+  console.log(chunk);
+});
+```
+
 #### Piping to Writable Streams from Async Iterators
 
 In the scenario of writing to a writable stream from an async iterator, ensure

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1646,7 +1646,7 @@ Calling `Readable.from(string)` or `Readable.from(buffer)` will not have
 the strings or buffers be iterated to match the other streams semantics
 for performance reasons.
 
-### stream.Transform.by(asyncGeneratorFunction, [options])
+### stream.Transform.by(asyncGeneratorFunction[, options])
 <!-- YAML
 added: REPLACEME
 -->

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1679,8 +1679,8 @@ transform.on('data', (chunk) => {
 
 The `source` parameter has an `encoding` property which represents the encoding
 of the `WriteableStream` side of the transform. This is the same `encoding`
-value that would be passed as the second parameter to the `transform` function
-option (or `_transform` method) supplied to `stream.Transform`.
+value that would be passed as the second parameter to the `transform()` function
+option (or `_transform()` method) supplied to `stream.Transform`.
 
 
 ## API for Stream Implementers

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1667,6 +1667,9 @@ const { Readable, Transform } = require('stream');
 const readable = Readable.from(['hello', 'streams']);
 async function * mapper(source) {
   for await (const chunk of source) {
+    // If objectMode was set to false, the buffer would have to be converted
+    // to a string here but since it is true by default for both Readable.from
+    // and Transform.by each chunk is already a string
     yield chunk.toUpperCase();
   }
 }

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1668,8 +1668,8 @@ const readable = Readable.from(['hello', 'streams']);
 async function * mapper(source) {
   for await (const chunk of source) {
     // If objectMode was set to false, the buffer would have to be converted
-    // to a string here but since it is true by default for both Readable.from
-    // and Transform.by each chunk is already a string
+    // to a string here but since it is true by default for both Readable.from()
+    // and Transform.by() each chunk is already a string.
     yield chunk.toUpperCase();
   }
 }

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1657,6 +1657,7 @@ transformed data is pushed to the stream with the `yield` keyword.
 * `options` {Object} Options provided to `new stream.Transform([options])`.
 By default, `Transform.by()` will set `options.objectMode` to `true`,
 unless this is explicitly opted out by setting `options.objectMode` to `false`.
+* Returns: {stream.Transform}
 
 A utility method for creating Transform Streams with async generator functions.
 The async generator is supplied a single argument, `source`, which is used to

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1652,7 +1652,7 @@ for performance reasons.
 accepts a `source` iterable which can be used to read incoming data, while
 transformed data is pushed to the stream with the `yield` keyword.
 * `options` {Object} Options provided to `new stream.Transform([options])`.
-By default, `Tranfrom.by()` will set `options.objectMode` to `true`,
+By default, `Transform.by()` will set `options.objectMode` to `true`,
 unless this is explicitly opted out by setting `options.objectMode` to `false`.
 
 A utility method for creating Transform Streams with async generator functions.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1652,7 +1652,7 @@ for performance reasons.
 accepts a `source` iterable which can be used to read incoming data, while
 transformed data is pushed to the stream with the `yield` keyword.
 * `options` {Object} Options provided to `new stream.Transform([options])`.
-By default, `Readable.transform()` will set `options.objectMode` to `true`,
+By default, `Tranfrom.by()` will set `options.objectMode` to `true`,
 unless this is explicitly opted out by setting `options.objectMode` to `false`.
 
 A utility method for creating Transform Streams with async generator functions.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1732,7 +1732,7 @@ on the type of stream being created, as detailed in the chart below:
 | Reading only | [`Readable`][] | [`_read()`][stream-_read] |
 | Writing only | [`Writable`][] | [`_write()`][stream-_write], [`_writev()`][stream-_writev], [`_final()`][stream-_final] |
 | Reading and writing | [`Duplex`][] | [`_read()`][stream-_read], [`_write()`][stream-_write], [`_writev()`][stream-_writev], [`_final()`][stream-_final] |
-| Operate on written data, then read the result | [`Transform`][] | [`_transform()`][stream-_transform], [`_flush()`][stream-_flush], [`_final()`][stream-_final] |
+| Operate on written data, then read the result | [`Transform`][] | [`_transform()`][], [`_flush()`][stream-_flush], [`_final()`][stream-_final] |
 
 The implementation code for a stream should *never* call the "public" methods
 of a stream that are intended for use by consumers (as described in the
@@ -2473,7 +2473,7 @@ The `stream.Transform` class is extended to implement a [`Transform`][] stream.
 The `stream.Transform` class prototypically inherits from `stream.Duplex` and
 implements its own versions of the `writable._write()` and `readable._read()`
 methods. Custom `Transform` implementations *must* implement the
-[`transform._transform()`][stream-_transform] method and *may* also implement
+[`transform._transform()`][] method and *may* also implement
 the [`transform._flush()`][stream-_flush] method.
 
 Care must be taken when using `Transform` streams in that data written to the
@@ -2485,7 +2485,7 @@ output on the `Readable` side is not consumed.
 * `options` {Object} Passed to both `Writable` and `Readable`
   constructors. Also has the following fields:
   * `transform` {Function} Implementation for the
-    [`stream._transform()`][stream-_transform] method.
+    [`stream._transform()`][] method.
   * `flush` {Function} Implementation for the [`stream._flush()`][stream-_flush]
     method.
 
@@ -2532,7 +2532,7 @@ const myTransform = new Transform({
 The [`'finish'`][] and [`'end'`][] events are from the `stream.Writable`
 and `stream.Readable` classes, respectively. The `'finish'` event is emitted
 after [`stream.end()`][stream-end] is called and all chunks have been processed
-by [`stream._transform()`][stream-_transform]. The `'end'` event is emitted
+by [`stream._transform()`][]. The `'end'` event is emitted
 after all data has been output, which occurs after the callback in
 [`transform._flush()`][stream-_flush] has been called. In the case of an error,
 neither `'finish'` nor `'end'` should be emitted.
@@ -2926,7 +2926,7 @@ contain multi-byte characters.
 [stream-_final]: #stream_writable_final_callback
 [stream-_flush]: #stream_transform_flush_callback
 [stream-_read]: #stream_readable_read_size_1
-[stream-_transform]: #stream_transform_transform_chunk_encoding_callback
+[]: #stream_transform_transform_chunk_encoding_callback
 [stream-_write]: #stream_writable_write_chunk_encoding_callback_1
 [stream-_writev]: #stream_writable_writev_chunks_callback
 [stream-end]: #stream_writable_end_chunk_encoding_callback

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1647,6 +1647,9 @@ the strings or buffers be iterated to match the other streams semantics
 for performance reasons.
 
 ### stream.Transform.by(asyncGeneratorFunction, [options])
+<!-- YAML
+added: REPLACEME
+-->
 
 * `asyncGeneratorFunction` {AsyncGeneratorFunction} A mapping function which
 accepts a `source` async iterable which can be used to read incoming data, while

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2673,7 +2673,7 @@ readable.on('data', (chunk) => {
 #### Creating Transform Streams with Async Generator Functions
 
 We can construct a Node.js Transform stream with an asynchronous
-generator function using the `Transform.by` utility method.
+generator function using the `Transform.by()` utility method.
 
 
 ```js

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2677,7 +2677,6 @@ readable.on('data', (chunk) => {
 We can construct a Node.js Transform stream with an asynchronous
 generator function using the `Transform.by()` utility method.
 
-
 ```js
 const { Readable, Transform } = require('stream');
 

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -243,8 +243,7 @@ function SourceIterator(asyncGeneratorFn, opts) {
     objectMode: true,
     ...opts,
     transform(chunk, encoding, cb) {
-      source.encoding = encoding ||
-        source[kSourceIteratorStream]._transformState.writeencoding;
+      source.encoding = encoding
       if (source[kSourceIteratorResolve] === null) {
         source[kSourceIteratorChunk] = chunk;
         source[kSourceIteratorPull] = cb;

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -69,15 +69,13 @@ const {
 
 module.exports = Transform;
 const {
-  ERR_INVALID_ARG_TYPE,
+  ERR_ARG_RETURN_VALUE_NOT_ASYNC_ITERABLE,
   ERR_METHOD_NOT_IMPLEMENTED,
   ERR_MULTIPLE_CALLBACK,
   ERR_TRANSFORM_ALREADY_TRANSFORMING,
   ERR_TRANSFORM_WITH_LENGTH_0
 } = require('internal/errors').codes;
 const Duplex = require('_stream_duplex');
-// eslint-disable-next-line func-style
-const { constructor: AsyncGeneratorFunction } = async function * () {};
 const AsyncIteratorPrototype = Object.getPrototypeOf(
   Object.getPrototypeOf(async function* () {}).prototype);
 
@@ -86,7 +84,6 @@ const kSourceIteratorResolve = Symbol('kSourceIteratorResolve');
 const kSourceIteratorChunk = Symbol('kSourceIteratorChunk');
 const kSourceIteratorStream = Symbol('kSourceIteratorStream');
 const kSourceIteratorPump = Symbol('kSourceIteratorPump');
-const kSourceIteratorGenerator = Symbol('kSourceIteratorGenerator');
 const kSourceIteratorGrabResolve = Symbol('kSourceIteratorGrabResolve');
 
 Object.setPrototypeOf(Transform.prototype, Duplex.prototype);
@@ -235,10 +232,18 @@ function done(stream, er, data) {
 
 function SourceIterator(asyncGeneratorFn, opts) {
   const source = this;
+  const result = asyncGeneratorFn(this);
+  if (typeof result[Symbol.asyncIterator] !== 'function') {
+    throw new ERR_ARG_RETURN_VALUE_NOT_ASYNC_ITERABLE('asyncGeneratorFn');
+  }
+  const iter = result[Symbol.asyncIterator]();
+  if (typeof iter.next !== 'function') {
+    throw new ERR_ARG_RETURN_VALUE_NOT_ASYNC_ITERABLE('asyncGeneratorFn');
+  }
+
   this[kSourceIteratorPull] = null;
   this[kSourceIteratorChunk] = null;
   this[kSourceIteratorResolve] = null;
-  this[kSourceIteratorGenerator] = asyncGeneratorFn;
   this[kSourceIteratorStream] = new Transform({
     objectMode: true,
     ...opts,
@@ -258,7 +263,11 @@ function SourceIterator(asyncGeneratorFn, opts) {
   this[kSourceIteratorGrabResolve] = (resolve) => {
     this[kSourceIteratorResolve] = resolve;
   };
-  this[kSourceIteratorPump]();
+  const first = iter.next();
+  if (!first || typeof first.then !== 'function') {
+    throw new ERR_ARG_RETURN_VALUE_NOT_ASYNC_ITERABLE('asyncGeneratorFn');
+  }
+  this[kSourceIteratorPump](iter, first);
 }
 
 SourceIterator.prototype[Symbol.asyncIterator] = function() {
@@ -282,19 +291,18 @@ SourceIterator.prototype.next = function next() {
   return result;
 };
 
-SourceIterator.prototype[kSourceIteratorPump] = async function pump() {
+SourceIterator.prototype[kSourceIteratorPump] = async function pump(iter, p) {
   const stream = this[kSourceIteratorStream];
   try {
-    const asyncGeneratorFn = this[kSourceIteratorGenerator];
-    const transformIter = asyncGeneratorFn(this);
     stream.removeListener('prefinish', prefinish);
     stream.on('prefinish', () => {
       if (this[kSourceIteratorResolve] !== null) {
         this[kSourceIteratorResolve]({ value: undefined, done: true });
       }
     });
+    let next = await p;
     while (true) {
-      const { done, value } = await transformIter.next();
+      const { done, value } = next;
       if (done) {
         if (value !== undefined) stream.push(value);
 
@@ -314,6 +322,7 @@ SourceIterator.prototype[kSourceIteratorPump] = async function pump() {
         break;
       }
       stream.push(value);
+      next = await iter.next();
     }
   } catch (err) {
     stream.destroy(err);
@@ -321,19 +330,12 @@ SourceIterator.prototype[kSourceIteratorPump] = async function pump() {
     this[kSourceIteratorPull] = null;
     this[kSourceIteratorChunk] = null;
     this[kSourceIteratorResolve] = null;
-    this[kSourceIteratorGenerator] = null;
     this[kSourceIteratorStream] = null;
   }
 };
 
 
 Transform.by = function by(asyncGeneratorFn, opts) {
-  if (!(asyncGeneratorFn instanceof AsyncGeneratorFunction))
-    throw new ERR_INVALID_ARG_TYPE(
-      'asyncGeneratorFn',
-      ['AsyncGeneratorFunction'],
-      asyncGeneratorFn);
-
   const source = new SourceIterator(asyncGeneratorFn, opts);
   const stream = source[kSourceIteratorStream];
 

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -69,14 +69,27 @@ const {
 
 module.exports = Transform;
 const {
+  ERR_INVALID_ARG_TYPE,
   ERR_METHOD_NOT_IMPLEMENTED,
   ERR_MULTIPLE_CALLBACK,
   ERR_TRANSFORM_ALREADY_TRANSFORMING,
   ERR_TRANSFORM_WITH_LENGTH_0
 } = require('internal/errors').codes;
 const Duplex = require('_stream_duplex');
-ObjectSetPrototypeOf(Transform.prototype, Duplex.prototype);
-ObjectSetPrototypeOf(Transform, Duplex);
+// eslint-disable-next-line func-style
+const { constructor: AsyncGeneratorFunction } = async function * () {};
+const AsyncIteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf(async function* () {}).prototype);
+
+const kSourceIteratorPull = Symbol('SourceIteratorPull');
+const kSourceIteratorResolve = Symbol('SourceIteratorResolve');
+const kSourceIteratorChunk = Symbol('SourceIteratorChunk');
+const kSourceIteratorStream = Symbol('SourceIteratorStream');
+const kSourceIteratorPump = Symbol('SourceIteratorPump');
+const kSourceIteratorGenerator = Symbol('SourceIteratorGenerator');
+
+Object.setPrototypeOf(Transform.prototype, Duplex.prototype);
+Object.setPrototypeOf(Transform, Duplex);
 
 
 function afterTransform(er, data) {
@@ -203,7 +216,6 @@ Transform.prototype._destroy = function(err, cb) {
   });
 };
 
-
 function done(stream, er, data) {
   if (er)
     return stream.emit('error', er);
@@ -219,3 +231,109 @@ function done(stream, er, data) {
     throw new ERR_TRANSFORM_ALREADY_TRANSFORMING();
   return stream.push(null);
 }
+
+function SourceIterator(asyncGeneratorFn, opts) {
+  const source = this;
+  this[kSourceIteratorPull] = null;
+  this[kSourceIteratorChunk] = null;
+  this[kSourceIteratorResolve] = null;
+  this[kSourceIteratorGenerator] = asyncGeneratorFn;
+  this[kSourceIteratorStream] = new Transform({
+    objectMode: true,
+    ...opts,
+    transform(chunk, encoding, cb) {
+      source.encoding = encoding ||
+        source[kSourceIteratorStream]._transformState.writeencoding;
+      if (source[kSourceIteratorResolve] === null) {
+        source[kSourceIteratorChunk] = chunk;
+        source[kSourceIteratorPull] = cb;
+        return;
+      }
+      source[kSourceIteratorResolve]({ value: chunk, done: false });
+      source[kSourceIteratorResolve] = null;
+      cb(null);
+    }
+  });
+  this.encoding = this[kSourceIteratorStream]._transformState.writeencoding;
+
+  this[kSourceIteratorPump]();
+}
+
+SourceIterator.prototype[Symbol.asyncIterator] = function() {
+  return this;
+};
+
+Object.setPrototypeOf(SourceIterator.prototype,
+                      AsyncIteratorPrototype);
+
+SourceIterator.prototype.next = function next() {
+  if (this[kSourceIteratorPull] === null ||
+    this[kSourceIteratorChunk] === null) return new Promise((resolve) => {
+    this[kSourceIteratorResolve] = resolve;
+  });
+  this[kSourceIteratorPull](null);
+  const result = Promise.resolve({
+    value: this[kSourceIteratorChunk],
+    done: false });
+  this[kSourceIteratorChunk] = null;
+  this[kSourceIteratorPull] = null;
+  return result;
+};
+
+SourceIterator.prototype[kSourceIteratorPump] = async function pump() {
+  const stream = this[kSourceIteratorStream];
+  try {
+    const asyncGeneratorFn = this[kSourceIteratorGenerator];
+    const transformIter = asyncGeneratorFn(this);
+    stream.removeListener('prefinish', prefinish);
+    stream.on('prefinish', () => {
+      if (this[kSourceIteratorResolve] !== null) {
+        this[kSourceIteratorResolve]({ value: undefined, done: true });
+      }
+    });
+    let next = await transformIter.next();
+    do {
+      if (next.done) {
+        if (next.value !== undefined) stream.push(next.value);
+
+        // In the event of an early return we explicitly
+        // discard any buffered state
+        if (stream._writableState.length > 0) {
+          const { length } = stream._writableState;
+          const { transforming } = stream._transformState;
+          stream._writableState.length = 0;
+          stream._transformState.transforming = false;
+          prefinish.call(stream);
+          stream._writableState.length = length;
+          stream._transformState.transforming = transforming;
+        } else {
+          prefinish.call(stream);
+        }
+        break;
+      }
+      stream.push(next.value);
+    } while (next = await transformIter.next());
+  } catch (err) {
+    stream.destroy(err);
+  } finally {
+    this[kSourceIteratorPull] = null;
+    this[kSourceIteratorChunk] = null;
+    this[kSourceIteratorResolve] = null;
+    this[kSourceIteratorGenerator] = null;
+    this[kSourceIteratorStream] = null;
+  }
+};
+
+
+Transform.by = function by(asyncGeneratorFn, opts) {
+  if (!(asyncGeneratorFn instanceof AsyncGeneratorFunction))
+    throw new ERR_INVALID_ARG_TYPE(
+      'asyncGeneratorFn',
+      ['AsyncGeneratorFunction'],
+      asyncGeneratorFn);
+
+  const source = new SourceIterator(asyncGeneratorFn, opts);
+  const stream = source[kSourceIteratorStream];
+
+  return stream;
+};

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -65,6 +65,8 @@
 
 const {
   ObjectSetPrototypeOf,
+  ObjectGetPrototypeOf,
+  Symbol
 } = primordials;
 
 module.exports = Transform;
@@ -76,8 +78,8 @@ const {
   ERR_TRANSFORM_WITH_LENGTH_0
 } = require('internal/errors').codes;
 const Duplex = require('_stream_duplex');
-const AsyncIteratorPrototype = Object.getPrototypeOf(
-  Object.getPrototypeOf(async function* () {}).prototype);
+const AsyncIteratorPrototype = ObjectGetPrototypeOf(
+  ObjectGetPrototypeOf(async function* () {}).prototype);
 
 const kSourceIteratorPull = Symbol('kSourceIteratorPull');
 const kSourceIteratorResolve = Symbol('kSourceIteratorResolve');
@@ -86,8 +88,8 @@ const kSourceIteratorStream = Symbol('kSourceIteratorStream');
 const kSourceIteratorPump = Symbol('kSourceIteratorPump');
 const kSourceIteratorGrabResolve = Symbol('kSourceIteratorGrabResolve');
 
-Object.setPrototypeOf(Transform.prototype, Duplex.prototype);
-Object.setPrototypeOf(Transform, Duplex);
+ObjectSetPrototypeOf(Transform.prototype, Duplex.prototype);
+ObjectSetPrototypeOf(Transform, Duplex);
 
 
 function afterTransform(er, data) {
@@ -271,8 +273,7 @@ SourceIterator.prototype[Symbol.asyncIterator] = function() {
   return this;
 };
 
-Object.setPrototypeOf(SourceIterator.prototype,
-                      AsyncIteratorPrototype);
+ObjectSetPrototypeOf(SourceIterator.prototype, AsyncIteratorPrototype);
 
 SourceIterator.prototype.next = function next() {
   if (this[kSourceIteratorPull] === null || this[kSourceIteratorChunk] === null)

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -325,7 +325,7 @@ SourceIterator.prototype[kSourceIteratorPump] = async function pump(iter, p) {
       next = await iter.next();
     }
   } catch (err) {
-    stream.destroy(err);
+    process.nextTick(() => stream.destroy(err));
   } finally {
     this[kSourceIteratorPull] = null;
     this[kSourceIteratorChunk] = null;

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -81,13 +81,13 @@ const { constructor: AsyncGeneratorFunction } = async function * () {};
 const AsyncIteratorPrototype = Object.getPrototypeOf(
   Object.getPrototypeOf(async function* () {}).prototype);
 
-const kSourceIteratorPull = Symbol('SourceIteratorPull');
-const kSourceIteratorResolve = Symbol('SourceIteratorResolve');
-const kSourceIteratorChunk = Symbol('SourceIteratorChunk');
-const kSourceIteratorStream = Symbol('SourceIteratorStream');
-const kSourceIteratorPump = Symbol('SourceIteratorPump');
-const kSourceIteratorGenerator = Symbol('SourceIteratorGenerator');
-const kSourceIteratorGrabResolve = Symbol('SourceIteratorGrabResolve');
+const kSourceIteratorPull = Symbol('kSourceIteratorPull');
+const kSourceIteratorResolve = Symbol('kSourceIteratorResolve');
+const kSourceIteratorChunk = Symbol('kSourceIteratorChunk');
+const kSourceIteratorStream = Symbol('kSourceIteratorStream');
+const kSourceIteratorPump = Symbol('kSourceIteratorPump');
+const kSourceIteratorGenerator = Symbol('kSourceIteratorGenerator');
+const kSourceIteratorGrabResolve = Symbol('kSourceIteratorGrabResolve');
 
 Object.setPrototypeOf(Transform.prototype, Duplex.prototype);
 Object.setPrototypeOf(Transform, Duplex);
@@ -243,7 +243,7 @@ function SourceIterator(asyncGeneratorFn, opts) {
     objectMode: true,
     ...opts,
     transform(chunk, encoding, cb) {
-      source.encoding = encoding
+      source.encoding = encoding;
       if (source[kSourceIteratorResolve] === null) {
         source[kSourceIteratorChunk] = chunk;
         source[kSourceIteratorPull] = cb;
@@ -293,10 +293,10 @@ SourceIterator.prototype[kSourceIteratorPump] = async function pump() {
         this[kSourceIteratorResolve]({ value: undefined, done: true });
       }
     });
-    let next = await transformIter.next();
-    do {
-      if (next.done) {
-        if (next.value !== undefined) stream.push(next.value);
+    while (true) {
+      const { done, value } = await transformIter.next();
+      if (done) {
+        if (value !== undefined) stream.push(value);
 
         // In the event of an early return we explicitly
         // discard any buffered state
@@ -313,8 +313,8 @@ SourceIterator.prototype[kSourceIteratorPump] = async function pump() {
         }
         break;
       }
-      stream.push(next.value);
-    } while (next = await transformIter.next());
+      stream.push(value);
+    }
   } catch (err) {
     stream.destroy(err);
   } finally {

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -87,6 +87,7 @@ const kSourceIteratorChunk = Symbol('SourceIteratorChunk');
 const kSourceIteratorStream = Symbol('SourceIteratorStream');
 const kSourceIteratorPump = Symbol('SourceIteratorPump');
 const kSourceIteratorGenerator = Symbol('SourceIteratorGenerator');
+const kSourceIteratorGrabResolve = Symbol('SourceIteratorGrabResolve');
 
 Object.setPrototypeOf(Transform.prototype, Duplex.prototype);
 Object.setPrototypeOf(Transform, Duplex);
@@ -255,7 +256,9 @@ function SourceIterator(asyncGeneratorFn, opts) {
     }
   });
   this.encoding = this[kSourceIteratorStream]._transformState.writeencoding;
-
+  this[kSourceIteratorGrabResolve] = (resolve) => {
+    this[kSourceIteratorResolve] = resolve;
+  };
   this[kSourceIteratorPump]();
 }
 
@@ -267,10 +270,9 @@ Object.setPrototypeOf(SourceIterator.prototype,
                       AsyncIteratorPrototype);
 
 SourceIterator.prototype.next = function next() {
-  if (this[kSourceIteratorPull] === null ||
-    this[kSourceIteratorChunk] === null) return new Promise((resolve) => {
-    this[kSourceIteratorResolve] = resolve;
-  });
+  if (this[kSourceIteratorPull] === null || this[kSourceIteratorChunk] === null)
+    return new Promise(this[kSourceIteratorGrabResolve]);
+
   this[kSourceIteratorPull](null);
   const result = Promise.resolve({
     value: this[kSourceIteratorChunk],

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -264,9 +264,6 @@ function SourceIterator(asyncGeneratorFn, opts) {
     this[kSourceIteratorResolve] = resolve;
   };
   const first = iter.next();
-  if (!first || typeof first.then !== 'function') {
-    throw new ERR_ARG_RETURN_VALUE_NOT_ASYNC_ITERABLE('asyncGeneratorFn');
-  }
   this[kSourceIteratorPump](iter, first);
 }
 

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -275,7 +275,8 @@ SourceIterator.prototype.next = function next() {
   this[kSourceIteratorPull](null);
   const result = Promise.resolve({
     value: this[kSourceIteratorChunk],
-    done: false });
+    done: false
+  });
   this[kSourceIteratorChunk] = null;
   this[kSourceIteratorPull] = null;
   return result;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -720,6 +720,8 @@ module.exports = {
 // Note: Node.js specific errors must begin with the prefix ERR_
 E('ERR_AMBIGUOUS_ARGUMENT', 'The "%s" argument is ambiguous. %s', TypeError);
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable', TypeError);
+E('ERR_ARG_RETURN_VALUE_NOT_ASYNC_ITERABLE', '%s must return an async iterable',
+  TypeError);
 E('ERR_ASSERTION', '%s', Error);
 E('ERR_ASYNC_CALLBACK', '%s must be a function', TypeError);
 E('ERR_ASYNC_TYPE', 'Invalid name for async "type": %s', TypeError);

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -396,6 +396,28 @@ async function tests() {
     }
   }
 
+  console.log('readable side of a transform stream pushes null');
+  {
+    const transform = new Transform({
+      objectMode: true,
+      transform(chunk, enc, cb) {
+        cb(null, chunk);
+      }
+    });
+    transform.push(0);
+    transform.push(1);
+    transform.push(null);
+    const mustReach = common.mustCall();
+    const iter = transform[Symbol.asyncIterator]();
+    assert.strictEqual((await iter.next()).value, 0);
+
+    for await (const d of iter) {
+      assert.strictEqual(d, 1);
+    }
+
+    mustReach();
+  }
+
   {
     console.log('readable side of a transform stream pushes null');
     const transform = new Transform({

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -400,9 +400,7 @@ async function tests() {
   {
     const transform = new Transform({
       objectMode: true,
-      transform(chunk, enc, cb) {
-        cb(null, chunk);
-      }
+      transform: common.mustNotCall()
     });
     transform.push(0);
     transform.push(1);

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -396,24 +396,28 @@ async function tests() {
     }
   }
 
-  console.log('readable side of a transform stream pushes null');
   {
+    console.log('readable side of a transform stream pushes null');
     const transform = new Transform({
       objectMode: true,
-      transform: common.mustNotCall()
+      transform: (chunk, enc, cb) => { cb(null, chunk); }
     });
     transform.push(0);
     transform.push(1);
-    transform.push(null);
-    const mustReach = common.mustCall();
+    process.nextTick(() => {
+      transform.push(null);
+    });
+
+    const mustReach = [ common.mustCall(), common.mustCall() ];
+
     const iter = transform[Symbol.asyncIterator]();
     assert.strictEqual((await iter.next()).value, 0);
 
     for await (const d of iter) {
       assert.strictEqual(d, 1);
+      mustReach[0]();
     }
-
-    mustReach();
+    mustReach[1]();
   }
 
   {

--- a/test/parallel/test-transform-by.js
+++ b/test/parallel/test-transform-by.js
@@ -272,11 +272,27 @@ async function transformByOnErrorAndTryCatchAndDestroyed() {
   }
 }
 
+async function transformByThrowPriorToForAwait() {
+  async function * generate() {
+    yield 'a';
+    yield 'b';
+    yield 'c';
+  }
+  const read = Readable.from(generate());
+  const stream = Transform.by(async function * transformA(source) {
+    throw new Error('kaboom');
+  });
+  stream.on('error', mustCall((err) => {
+    strictEqual(err.message, 'kaboom');
+  }));
+
+  read.pipe(stream);
+}
+
 Promise.all([
   transformBy(),
   transformByFuncReturnsObjectWithSymbolAsyncIterator(),
   transformByObjReturnedWSymbolAsyncIteratorWithNonPromiseReturningNext(),
-
   transformByObjReturnedWSymbolAsyncIteratorWithNoNext(),
   transformByObjReturnedWSymbolAsyncIteratorThatIsNotFunction(),
   transformByFuncReturnsObjectWithoutSymbolAsyncIterator(),
@@ -288,5 +304,6 @@ Promise.all([
   transformByOnDataNonObject(),
   transformByOnErrorAndDestroyed(),
   transformByErrorTryCatchAndDestroyed(),
-  transformByOnErrorAndTryCatchAndDestroyed()
+  transformByOnErrorAndTryCatchAndDestroyed(),
+  transformByThrowPriorToForAwait()
 ]).then(mustCall());

--- a/test/parallel/test-transform-by.js
+++ b/test/parallel/test-transform-by.js
@@ -1,0 +1,209 @@
+'use strict';
+const { mustCall } = require('../common');
+const { once } = require('events');
+const { Readable, Transform } = require('stream');
+const { strictEqual } = require('assert');
+
+async function transformBy() {
+  const readable = Readable.from('test');
+  async function * mapper(source) {
+    for await (const chunk of source) {
+      yield chunk.toUpperCase();
+    }
+  }
+
+  const stream = Transform.by(mapper);
+  readable.pipe(stream);
+  const expected = ['T', 'E', 'S', 'T'];
+  for await (const chunk of stream) {
+    strictEqual(chunk, expected.shift());
+  }
+}
+
+async function transformByEncoding() {
+  const readable = Readable.from('test');
+  async function * mapper(source) {
+    for await (const chunk of source) {
+      strictEqual(source.encoding, 'ascii');
+      yield chunk.toUpperCase();
+    }
+  }
+  const stream = Transform.by(mapper);
+  stream.setDefaultEncoding('ascii');
+  readable.pipe(stream);
+
+  const expected = ['T', 'E', 'S', 'T'];
+  for await (const chunk of stream) {
+    strictEqual(chunk, expected.shift());
+  }
+}
+
+async function transformBySourceIteratorCompletes() {
+  const readable = Readable.from('test');
+  const mustReach = mustCall();
+  async function * mapper(source) {
+    for await (const chunk of source) {
+      yield chunk.toUpperCase();
+    }
+    mustReach();
+  }
+
+  const stream = Transform.by(mapper);
+  readable.pipe(stream);
+  const expected = ['T', 'E', 'S', 'T'];
+  for await (const chunk of stream) {
+    strictEqual(chunk, expected.shift());
+  }
+}
+
+async function transformByYieldPlusReturn() {
+  const readable = Readable.from('test');
+  async function * mapper(source) {
+    for await (const chunk of source) {
+      yield chunk.toUpperCase();
+    }
+    return 'final chunk';
+  }
+
+  const stream = Transform.by(mapper);
+  readable.pipe(stream);
+  const expected = ['T', 'E', 'S', 'T', 'final chunk'];
+  for await (const chunk of stream) {
+    strictEqual(chunk, expected.shift());
+  }
+}
+
+async function transformByReturnEndsStream() {
+  const readable = Readable.from('test');
+  async function * mapper(source) {
+    for await (const chunk of source) {
+      yield chunk.toUpperCase();
+      return 'stop';
+    }
+  }
+
+  const stream = Transform.by(mapper);
+  readable.pipe(stream);
+  const expected = ['T', 'stop'];
+  const mustReach = mustCall();
+  for await (const chunk of stream) {
+    strictEqual(chunk, expected.shift());
+  }
+  mustReach();
+}
+
+async function transformByOnData() {
+  const readable = Readable.from('test');
+  async function * mapper(source) {
+    for await (const chunk of source) {
+      yield chunk.toUpperCase();
+    }
+  }
+
+  const stream = Transform.by(mapper);
+  readable.pipe(stream);
+  const expected = ['T', 'E', 'S', 'T'];
+  let iterations = 0;
+  stream.on('data', (chunk) => {
+    iterations++;
+    strictEqual(chunk, expected.shift());
+  });
+
+  await once(stream, 'end');
+  strictEqual(iterations, 4);
+}
+
+async function transformByOnDataNonObject() {
+  const readable = Readable.from('test', { objectMode: false });
+  async function * mapper(source) {
+    for await (const chunk of source) {
+      yield chunk.toString().toUpperCase();
+    }
+  }
+  const stream = Transform.by(mapper, { objectMode: false });
+  readable.pipe(stream);
+  const expected = ['T', 'E', 'S', 'T'];
+  let iterations = 0;
+  stream.on('data', (chunk) => {
+    iterations++;
+    strictEqual(chunk instanceof Buffer, true);
+    strictEqual(chunk.toString(), expected.shift());
+  });
+
+  await once(stream, 'end');
+  strictEqual(iterations, 4);
+}
+
+async function transformByOnErrorAndDestroyed() {
+  const stream = Readable.from('test').pipe(Transform.by(
+    async function * mapper(source) {
+      for await (const chunk of source) {
+        if (chunk === 'e') throw new Error('kaboom');
+        yield chunk.toUpperCase();
+      }
+    }
+  ));
+  stream.on('data', (chunk) => {
+    strictEqual(chunk.toString(), 'T');
+  });
+  strictEqual(stream.destroyed, false);
+  const [ err ] = await once(stream, 'error');
+  strictEqual(err.message, 'kaboom');
+  strictEqual(stream.destroyed, true);
+}
+
+async function transformByErrorTryCatchAndDestroyed() {
+  const stream = Readable.from('test').pipe(Transform.by(
+    async function * mapper(source) {
+      for await (const chunk of source) {
+        if (chunk === 'e') throw new Error('kaboom');
+        yield chunk.toUpperCase();
+      }
+    }
+  ));
+  strictEqual(stream.destroyed, false);
+  try {
+    for await (const chunk of stream) {
+      strictEqual(chunk.toString(), 'T');
+    }
+  } catch (err) {
+    strictEqual(err.message, 'kaboom');
+    strictEqual(stream.destroyed, true);
+  }
+}
+
+async function transformByOnErrorAndTryCatchAndDestroyed() {
+  const stream = Readable.from('test').pipe(Transform.by(
+    async function * mapper(source) {
+      for await (const chunk of source) {
+        if (chunk === 'e') throw new Error('kaboom');
+        yield chunk.toUpperCase();
+      }
+    }
+  ));
+  strictEqual(stream.destroyed, false);
+  stream.once('error', mustCall((err) => {
+    strictEqual(err.message, 'kaboom');
+  }));
+  try {
+    for await (const chunk of stream) {
+      strictEqual(chunk.toString(), 'T');
+    }
+  } catch (err) {
+    strictEqual(err.message, 'kaboom');
+    strictEqual(stream.destroyed, true);
+  }
+}
+
+Promise.all([
+  transformBy(),
+  transformByEncoding(),
+  transformBySourceIteratorCompletes(),
+  transformByYieldPlusReturn(),
+  transformByReturnEndsStream(),
+  transformByOnData(),
+  transformByOnDataNonObject(),
+  transformByOnErrorAndDestroyed(),
+  transformByErrorTryCatchAndDestroyed(),
+  transformByOnErrorAndTryCatchAndDestroyed()
+]).then(mustCall());

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -26,7 +26,7 @@ const customTypesMap = {
 
   'this': `${jsDocPrefix}Reference/Operators/this`,
 
-  'AsyncIterator': 'https://tc39.github.io/ecma262/#sec-asynciterator-interface',
+  'AsyncGeneratorFunction': 'https://tc39.es/ecma262/#sec-async-generator-function-definitions',
 
   'AsyncIterator': 'https://tc39.github.io/ecma262/#sec-asynciterator-interface',
 

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -28,6 +28,8 @@ const customTypesMap = {
 
   'AsyncIterator': 'https://tc39.github.io/ecma262/#sec-asynciterator-interface',
 
+  'AsyncGeneratorFunction': 'https://tc39.es/ecma262/#sec-async-generator-function-definitions',
+
   'bigint': `${jsDocPrefix}Reference/Global_Objects/BigInt`,
 
   'Iterable':

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -28,7 +28,7 @@ const customTypesMap = {
 
   'AsyncIterator': 'https://tc39.github.io/ecma262/#sec-asynciterator-interface',
 
-  'AsyncGeneratorFunction': 'https://tc39.es/ecma262/#sec-async-generator-function-definitions',
+  'AsyncIterator': 'https://tc39.github.io/ecma262/#sec-asynciterator-interface',
 
   'bigint': `${jsDocPrefix}Reference/Global_Objects/BigInt`,
 


### PR DESCRIPTION
Analogous to `Readable.from`, `Transform.by` creates transform streams
from async function generators.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
