### PR TITLE
doc: fix link from bootstrap README to BUILDING

### DIFF
--- a/tools/bootstrap/README.md
+++ b/tools/bootstrap/README.md
@@ -1,2 +1,2 @@
-See the main project [README.md](../../README.md#boxstarter) for details on how
-to use this script.
+See the main project [BUILDING.md](../../BUILDING.md#boxstarter) for details on
+how to use this script.


### PR DESCRIPTION
I messed up #28465 and only noticed after it landed. tools/bootstrap/README.md points to README.md when it should point to BUILDING.md.

Here's the rendered version if you want to confirm I have it right this time.