### PR TITLE
test: propagate napi_status to JS

### DIFF
--- a/test/js-native-api/common.h
+++ b/test/js-native-api/common.h
@@ -58,3 +58,24 @@
 
 #define DECLARE_NAPI_GETTER(name, func)                                  \
   { (name), NULL, NULL, (func), NULL, NULL, napi_default, NULL }
+
+#define NAPI_STATUS_TO_STRING(status)                                         \
+  (status) == napi_ok ? "napi_ok" :                                           \
+  (status) == napi_invalid_arg ? "napi_invalid_arg" :                         \
+  (status) == napi_object_expected ? "napi_object_expected" :                 \
+  (status) == napi_string_expected ? "napi_string_expected" :                 \
+  (status) == napi_name_expected ? "napi_name_expected" :                     \
+  (status) == napi_function_expected ? "napi_function_expected" :             \
+  (status) == napi_number_expected ? "napi_number_expected" :                 \
+  (status) == napi_boolean_expected ? "napi_boolean_expected" :               \
+  (status) == napi_array_expected ? "napi_array_expected" :                   \
+  (status) == napi_generic_failure ? "napi_generic_failure" :                 \
+  (status) == napi_pending_exception ? "napi_pending_exception" :             \
+  (status) == napi_cancelled ? "napi_cancelled" :                             \
+  (status) == napi_escape_called_twice ? "napi_escape_called_twice" :         \
+  (status) == napi_handle_scope_mismatch ? "napi_handle_scope_mismatch" :     \
+  (status) == napi_callback_scope_mismatch ? "napi_callback_scope_mismatch" : \
+  (status) == napi_queue_full ? "napi_queue_full" :                           \
+  (status) == napi_closing ? "napi_closing" :                                 \
+  (status) == napi_bigint_expected ? "napi_bigint_expected" :                 \
+  (status) == napi_date_expected ? "napi_date_expected" : "UNKNOWN_ERROR"

--- a/test/js-native-api/common.h
+++ b/test/js-native-api/common.h
@@ -58,24 +58,3 @@
 
 #define DECLARE_NAPI_GETTER(name, func)                                  \
   { (name), NULL, NULL, (func), NULL, NULL, napi_default, NULL }
-
-#define NAPI_STATUS_TO_STRING(status)                                         \
-  (status) == napi_ok ? "napi_ok" :                                           \
-  (status) == napi_invalid_arg ? "napi_invalid_arg" :                         \
-  (status) == napi_object_expected ? "napi_object_expected" :                 \
-  (status) == napi_string_expected ? "napi_string_expected" :                 \
-  (status) == napi_name_expected ? "napi_name_expected" :                     \
-  (status) == napi_function_expected ? "napi_function_expected" :             \
-  (status) == napi_number_expected ? "napi_number_expected" :                 \
-  (status) == napi_boolean_expected ? "napi_boolean_expected" :               \
-  (status) == napi_array_expected ? "napi_array_expected" :                   \
-  (status) == napi_generic_failure ? "napi_generic_failure" :                 \
-  (status) == napi_pending_exception ? "napi_pending_exception" :             \
-  (status) == napi_cancelled ? "napi_cancelled" :                             \
-  (status) == napi_escape_called_twice ? "napi_escape_called_twice" :         \
-  (status) == napi_handle_scope_mismatch ? "napi_handle_scope_mismatch" :     \
-  (status) == napi_callback_scope_mismatch ? "napi_callback_scope_mismatch" : \
-  (status) == napi_queue_full ? "napi_queue_full" :                           \
-  (status) == napi_closing ? "napi_closing" :                                 \
-  (status) == napi_bigint_expected ? "napi_bigint_expected" :                 \
-  (status) == napi_date_expected ? "napi_date_expected" : "UNKNOWN_ERROR"

--- a/test/js-native-api/test_constructor/test.js
+++ b/test/js-native-api/test_constructor/test.js
@@ -53,10 +53,10 @@ assert.strictEqual(test_object.staticReadonlyAccessor1, undefined);
 // Verify that passing NULL to napi_define_class() results in the correct
 // error.
 assert.deepStrictEqual(TestConstructor.TestDefineClass(), {
-  envIsNull: 'napi_invalid_arg',
-  nameIsNull: 'napi_invalid_arg',
-  cbIsNull: 'napi_invalid_arg',
+  envIsNull: 'napi_ok',
+  nameIsNull: 'Invalid argument',
+  cbIsNull: 'Invalid argument',
   cbDataIsNull: 'napi_ok',
-  propertiesIsNull: 'napi_invalid_arg',
-  resultIsNull: 'napi_invalid_arg'
+  propertiesIsNull: 'Invalid argument',
+  resultIsNull: 'Invalid argument'
 });

--- a/test/js-native-api/test_constructor/test.js
+++ b/test/js-native-api/test_constructor/test.js
@@ -53,7 +53,7 @@ assert.strictEqual(test_object.staticReadonlyAccessor1, undefined);
 // Verify that passing NULL to napi_define_class() results in the correct
 // error.
 assert.deepStrictEqual(TestConstructor.TestDefineClass(), {
-  envIsNull: 'napi_ok',
+  envIsNull: 'napi_env_null_is_ok',
   nameIsNull: 'Invalid argument',
   cbIsNull: 'Invalid argument',
   cbDataIsNull: 'napi_ok',

--- a/test/js-native-api/test_constructor/test.js
+++ b/test/js-native-api/test_constructor/test.js
@@ -53,10 +53,10 @@ assert.strictEqual(test_object.staticReadonlyAccessor1, undefined);
 // Verify that passing NULL to napi_define_class() results in the correct
 // error.
 assert.deepStrictEqual(TestConstructor.TestDefineClass(), {
-  envIsNull: 'pass',
-  nameIsNull: 'pass',
-  cbIsNull: 'pass',
-  cbDataIsNull: 'pass',
-  propertiesIsNull: 'pass',
-  resultIsNull: 'pass'
+  envIsNull: 'napi_invalid_arg',
+  nameIsNull: 'napi_invalid_arg',
+  cbIsNull: 'napi_invalid_arg',
+  cbDataIsNull: 'napi_ok',
+  propertiesIsNull: 'napi_invalid_arg',
+  resultIsNull: 'napi_invalid_arg'
 });

--- a/test/js-native-api/test_constructor/test.js
+++ b/test/js-native-api/test_constructor/test.js
@@ -53,7 +53,7 @@ assert.strictEqual(test_object.staticReadonlyAccessor1, undefined);
 // Verify that passing NULL to napi_define_class() results in the correct
 // error.
 assert.deepStrictEqual(TestConstructor.TestDefineClass(), {
-  envIsNull: 'napi_env_null_is_ok',
+  envIsNull: 'Invalid argument',
   nameIsNull: 'Invalid argument',
   cbIsNull: 'Invalid argument',
   cbDataIsNull: 'napi_ok',

--- a/test/js-native-api/test_constructor/test_constructor.c
+++ b/test/js-native-api/test_constructor/test_constructor.c
@@ -5,7 +5,7 @@ static double value_ = 1;
 static double static_value_ = 10;
 
 static void
-add_named_property(napi_env env, const char* key, napi_value return_value) {
+add_named_status(napi_env env, const char* key, napi_value return_value) {
   napi_value prop_value;
   const napi_extended_error_info* p_last_error;
   NAPI_CALL_RETURN_VOID(env, napi_get_last_error_info(env, &p_last_error));
@@ -74,7 +74,7 @@ static napi_value TestDefineClass(napi_env env,
                     &property_descriptor,
                     &result);
 
-  add_named_property(env, "nameIsNull", return_value);
+  add_named_status(env, "nameIsNull", return_value);
 
   napi_define_class(env,
                     "TrackedFunction",
@@ -85,7 +85,7 @@ static napi_value TestDefineClass(napi_env env,
                     &property_descriptor,
                     &result);
 
-  add_named_property(env, "cbIsNull", return_value);
+  add_named_status(env, "cbIsNull", return_value);
 
   napi_define_class(env,
                     "TrackedFunction",
@@ -96,7 +96,7 @@ static napi_value TestDefineClass(napi_env env,
                     &property_descriptor,
                     &result);
 
-  add_named_property(env, "cbDataIsNull", return_value);
+  add_named_status(env, "cbDataIsNull", return_value);
 
   napi_define_class(env,
                     "TrackedFunction",
@@ -107,7 +107,7 @@ static napi_value TestDefineClass(napi_env env,
                     NULL,
                     &result);
 
-  add_named_property(env, "propertiesIsNull", return_value);
+  add_named_status(env, "propertiesIsNull", return_value);
 
 
   napi_define_class(env,
@@ -119,7 +119,7 @@ static napi_value TestDefineClass(napi_env env,
                     &property_descriptor,
                     NULL);
 
-  add_named_property(env, "resultIsNull", return_value);
+  add_named_status(env, "resultIsNull", return_value);
 
   return return_value;
 }

--- a/test/js-native-api/test_constructor/test_constructor.c
+++ b/test/js-native-api/test_constructor/test_constructor.c
@@ -1,16 +1,17 @@
 #include <js_native_api.h>
 #include "../common.h"
-
 static double value_ = 1;
 static double static_value_ = 10;
 
-static void add_named_property(napi_env env, const char * key, napi_value return_value) {
+static void add_named_property(napi_env env, const char* key, napi_value return_value) {
   napi_value prop_value;
-  const napi_extended_error_info * p_last_error;
-  napi_get_last_error_info(env, &p_last_error);
+  const napi_extended_error_info* p_last_error;
+  NAPI_CALL_RETURN_VOID(env, napi_get_last_error_info(env, &p_last_error));
 
   NAPI_CALL(env, napi_create_string_utf8(env,
-                                         (p_last_error->error_message == NULL ? "napi_ok" : p_last_error->error_message),
+                                         (p_last_error->error_message == NULL ?
+                                           "napi_ok" :
+                                           p_last_error->error_message),
                                          NAPI_AUTO_LENGTH,
                                          &prop_value));
   NAPI_CALL(env, napi_set_named_property(env,

--- a/test/js-native-api/test_constructor/test_constructor.c
+++ b/test/js-native-api/test_constructor/test_constructor.c
@@ -1,9 +1,11 @@
 #include <js_native_api.h>
 #include "../common.h"
+
 static double value_ = 1;
 static double static_value_ = 10;
 
-static void add_named_property(napi_env env, const char* key, napi_value return_value) {
+static void
+add_named_property(napi_env env, const char* key, napi_value return_value) {
   napi_value prop_value;
   const napi_extended_error_info* p_last_error;
   NAPI_CALL_RETURN_VOID(env, napi_get_last_error_info(env, &p_last_error));
@@ -23,10 +25,9 @@ static void add_named_property(napi_env env, const char* key, napi_value return_
 
 static napi_value TestDefineClass(napi_env env,
                                   napi_callback_info info) {
-
-  napi_value prop_value;
-  napi_value result, return_value;
   napi_status status;
+  napi_value result, return_value, prop_value;
+  char p_napi_message[100] = "";
 
   napi_property_descriptor property_descriptor = {
     "TestDefineClass",
@@ -49,17 +50,22 @@ static napi_value TestDefineClass(napi_env env,
                              &property_descriptor,
                              &result);
 
-  NAPI_CALL_RETURN_VOID(env,
-      napi_create_string_utf8(env,
-                              "napi_env_null_is_ok",
-                              NAPI_AUTO_LENGTH,
-                              &prop_value));
-  NAPI_CALL_RETURN_VOID(env, napi_set_named_property(env,
-                                                     return_value,
-                                                     "envIsNull",
-                                                     prop_value));
+  if (status == napi_invalid_arg) {
+    snprintf(p_napi_message, 99, "Invalid argument");
+  } else {
+    snprintf(p_napi_message, 99, "Invalid status [%d]", status);
+  }
 
-   napi_define_class(env,
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         p_napi_message,
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_value));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         return_value,
+                                         "envIsNull",
+                                          prop_value));
+
+  napi_define_class(env,
                     NULL,
                     NAPI_AUTO_LENGTH,
                     TestDefineClass,

--- a/test/js-native-api/test_constructor/test_constructor.c
+++ b/test/js-native-api/test_constructor/test_constructor.c
@@ -1,6 +1,8 @@
 #include <js_native_api.h>
 #include "../common.h"
 
+#include <stdio.h>
+
 static double value_ = 1;
 static double static_value_ = 10;
 

--- a/test/js-native-api/test_constructor/test_constructor.c
+++ b/test/js-native-api/test_constructor/test_constructor.c
@@ -4,10 +4,25 @@
 static double value_ = 1;
 static double static_value_ = 10;
 
+static void add_named_property(napi_env env, const char * key, napi_value return_value) {
+  napi_value prop_value;
+  const napi_extended_error_info * p_last_error;
+  napi_get_last_error_info(env, &p_last_error);
+
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         (p_last_error->error_message == NULL ? "napi_ok" : p_last_error->error_message),
+                                         NAPI_AUTO_LENGTH,
+                                         &prop_value));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         return_value,
+                                         key,
+                                         prop_value));
+}
+
 static napi_value TestDefineClass(napi_env env,
                                   napi_callback_info info) {
-  napi_status ret[7];
-  napi_value result, return_value, prop_value;
+
+  napi_value result, return_value;
 
   napi_property_descriptor property_descriptor = {
     "TestDefineClass",
@@ -19,115 +34,74 @@ static napi_value TestDefineClass(napi_env env,
     napi_enumerable | napi_static,
     NULL};
 
-  ret[0] = napi_define_class(NULL,
-                             "TrackedFunction",
-                             NAPI_AUTO_LENGTH,
-                             TestDefineClass,
-                             NULL,
-                             1,
-                             &property_descriptor,
-                             &result);
-
-  ret[1] = napi_define_class(env,
-                             NULL,
-                             NAPI_AUTO_LENGTH,
-                             TestDefineClass,
-                             NULL,
-                             1,
-                             &property_descriptor,
-                             &result);
-
-  ret[2] = napi_define_class(env,
-                             "TrackedFunction",
-                             NAPI_AUTO_LENGTH,
-                             NULL,
-                             NULL,
-                             1,
-                             &property_descriptor,
-                             &result);
-
-  ret[3] = napi_define_class(env,
-                             "TrackedFunction",
-                             NAPI_AUTO_LENGTH,
-                             TestDefineClass,
-                             NULL,
-                             1,
-                             &property_descriptor,
-                             &result);
-
-  ret[4] = napi_define_class(env,
-                             "TrackedFunction",
-                             NAPI_AUTO_LENGTH,
-                             TestDefineClass,
-                             NULL,
-                             1,
-                             NULL,
-                             &result);
-
-  ret[5] = napi_define_class(env,
-                             "TrackedFunction",
-                             NAPI_AUTO_LENGTH,
-                             TestDefineClass,
-                             NULL,
-                             1,
-                             &property_descriptor,
-                             NULL);
-
   NAPI_CALL(env, napi_create_object(env, &return_value));
 
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         NAPI_STATUS_TO_STRING(ret[0]),
-                                         NAPI_AUTO_LENGTH,
-                                         &prop_value));
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         return_value,
-                                         "envIsNull",
-                                         prop_value));
+  napi_define_class(NULL,
+                    "TrackedFunction",
+                    NAPI_AUTO_LENGTH,
+                    TestDefineClass,
+                    NULL,
+                    1,
+                    &property_descriptor,
+                    &result);
 
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         NAPI_STATUS_TO_STRING(ret[1]),
-                                         NAPI_AUTO_LENGTH,
-                                         &prop_value));
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         return_value,
-                                         "nameIsNull",
-                                         prop_value));
+  add_named_property(env, "envIsNull", return_value);
 
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         NAPI_STATUS_TO_STRING(ret[2]),
-                                         NAPI_AUTO_LENGTH,
-                                         &prop_value));
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         return_value,
-                                         "cbIsNull",
-                                         prop_value));
+  napi_define_class(env,
+                    NULL,
+                    NAPI_AUTO_LENGTH,
+                    TestDefineClass,
+                    NULL,
+                    1,
+                    &property_descriptor,
+                    &result);
 
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         NAPI_STATUS_TO_STRING(ret[3]),
-                                         NAPI_AUTO_LENGTH,
-                                         &prop_value));
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         return_value,
-                                         "cbDataIsNull",
-                                         prop_value));
+  add_named_property(env, "nameIsNull", return_value);
 
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         NAPI_STATUS_TO_STRING(ret[4]),
-                                         NAPI_AUTO_LENGTH,
-                                         &prop_value));
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         return_value,
-                                         "propertiesIsNull",
-                                         prop_value));
+  napi_define_class(env,
+                    "TrackedFunction",
+                    NAPI_AUTO_LENGTH,
+                    NULL,
+                    NULL,
+                    1,
+                    &property_descriptor,
+                    &result);
 
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         NAPI_STATUS_TO_STRING(ret[5]),
-                                         NAPI_AUTO_LENGTH,
-                                         &prop_value));
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         return_value,
-                                         "resultIsNull",
-                                         prop_value));
+  add_named_property(env, "cbIsNull", return_value);
+
+  napi_define_class(env,
+                    "TrackedFunction",
+                    NAPI_AUTO_LENGTH,
+                    TestDefineClass,
+                    NULL,
+                    1,
+                    &property_descriptor,
+                    &result);
+
+  add_named_property(env, "cbDataIsNull", return_value);
+
+  napi_define_class(env,
+                    "TrackedFunction",
+                    NAPI_AUTO_LENGTH,
+                    TestDefineClass,
+                    NULL,
+                    1,
+                    NULL,
+                    &result);
+
+  add_named_property(env, "propertiesIsNull", return_value);
+
+
+  napi_define_class(env,
+                    "TrackedFunction",
+                    NAPI_AUTO_LENGTH,
+                    TestDefineClass,
+                    NULL,
+                    1,
+                    &property_descriptor,
+                    NULL);
+
+  add_named_property(env, "resultIsNull", return_value);
 
   return return_value;
 }

--- a/test/js-native-api/test_constructor/test_constructor.c
+++ b/test/js-native-api/test_constructor/test_constructor.c
@@ -8,22 +8,25 @@ static void add_named_property(napi_env env, const char* key, napi_value return_
   const napi_extended_error_info* p_last_error;
   NAPI_CALL_RETURN_VOID(env, napi_get_last_error_info(env, &p_last_error));
 
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         (p_last_error->error_message == NULL ?
-                                           "napi_ok" :
-                                           p_last_error->error_message),
-                                         NAPI_AUTO_LENGTH,
-                                         &prop_value));
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         return_value,
-                                         key,
-                                         prop_value));
+  NAPI_CALL_RETURN_VOID(env,
+      napi_create_string_utf8(env,
+                              (p_last_error->error_message == NULL ?
+                                  "napi_ok" :
+                                  p_last_error->error_message),
+                              NAPI_AUTO_LENGTH,
+                              &prop_value));
+  NAPI_CALL_RETURN_VOID(env, napi_set_named_property(env,
+                                                     return_value,
+                                                     key,
+                                                     prop_value));
 }
 
 static napi_value TestDefineClass(napi_env env,
                                   napi_callback_info info) {
 
+  napi_value prop_value;
   napi_value result, return_value;
+  napi_status status;
 
   napi_property_descriptor property_descriptor = {
     "TestDefineClass",
@@ -37,18 +40,26 @@ static napi_value TestDefineClass(napi_env env,
 
   NAPI_CALL(env, napi_create_object(env, &return_value));
 
-  napi_define_class(NULL,
-                    "TrackedFunction",
-                    NAPI_AUTO_LENGTH,
-                    TestDefineClass,
-                    NULL,
-                    1,
-                    &property_descriptor,
-                    &result);
+  status = napi_define_class(NULL,
+                             "TrackedFunction",
+                             NAPI_AUTO_LENGTH,
+                             TestDefineClass,
+                             NULL,
+                             1,
+                             &property_descriptor,
+                             &result);
 
-  add_named_property(env, "envIsNull", return_value);
+  NAPI_CALL_RETURN_VOID(env,
+      napi_create_string_utf8(env,
+                              "napi_env_null_is_ok",
+                              NAPI_AUTO_LENGTH,
+                              &prop_value));
+  NAPI_CALL_RETURN_VOID(env, napi_set_named_property(env,
+                                                     return_value,
+                                                     "envIsNull",
+                                                     prop_value));
 
-  napi_define_class(env,
+   napi_define_class(env,
                     NULL,
                     NAPI_AUTO_LENGTH,
                     TestDefineClass,

--- a/test/js-native-api/test_constructor/test_constructor.c
+++ b/test/js-native-api/test_constructor/test_constructor.c
@@ -76,8 +76,7 @@ static napi_value TestDefineClass(napi_env env,
   NAPI_CALL(env, napi_create_object(env, &return_value));
 
   NAPI_CALL(env, napi_create_string_utf8(env,
-                                         (ret[0] == napi_invalid_arg ?
-                                             "pass" : "fail"),
+                                         NAPI_STATUS_TO_STRING(ret[0]),
                                          NAPI_AUTO_LENGTH,
                                          &prop_value));
   NAPI_CALL(env, napi_set_named_property(env,
@@ -86,8 +85,7 @@ static napi_value TestDefineClass(napi_env env,
                                          prop_value));
 
   NAPI_CALL(env, napi_create_string_utf8(env,
-                                         (ret[1] == napi_invalid_arg ?
-                                             "pass" : "fail"),
+                                         NAPI_STATUS_TO_STRING(ret[1]),
                                          NAPI_AUTO_LENGTH,
                                          &prop_value));
   NAPI_CALL(env, napi_set_named_property(env,
@@ -96,8 +94,7 @@ static napi_value TestDefineClass(napi_env env,
                                          prop_value));
 
   NAPI_CALL(env, napi_create_string_utf8(env,
-                                         (ret[2] == napi_invalid_arg ?
-                                             "pass" : "fail"),
+                                         NAPI_STATUS_TO_STRING(ret[2]),
                                          NAPI_AUTO_LENGTH,
                                          &prop_value));
   NAPI_CALL(env, napi_set_named_property(env,
@@ -106,8 +103,7 @@ static napi_value TestDefineClass(napi_env env,
                                          prop_value));
 
   NAPI_CALL(env, napi_create_string_utf8(env,
-                                         (ret[3] == napi_ok ?
-                                             "pass" : "fail"),
+                                         NAPI_STATUS_TO_STRING(ret[3]),
                                          NAPI_AUTO_LENGTH,
                                          &prop_value));
   NAPI_CALL(env, napi_set_named_property(env,
@@ -116,8 +112,7 @@ static napi_value TestDefineClass(napi_env env,
                                          prop_value));
 
   NAPI_CALL(env, napi_create_string_utf8(env,
-                                         (ret[4] == napi_invalid_arg ?
-                                             "pass" : "fail"),
+                                         NAPI_STATUS_TO_STRING(ret[4]),
                                          NAPI_AUTO_LENGTH,
                                          &prop_value));
   NAPI_CALL(env, napi_set_named_property(env,
@@ -126,8 +121,7 @@ static napi_value TestDefineClass(napi_env env,
                                          prop_value));
 
   NAPI_CALL(env, napi_create_string_utf8(env,
-                                         (ret[5] == napi_invalid_arg ?
-                                             "pass" : "fail"),
+                                         NAPI_STATUS_TO_STRING(ret[5]),
                                          NAPI_AUTO_LENGTH,
                                          &prop_value));
   NAPI_CALL(env, napi_set_named_property(env,


### PR DESCRIPTION
Re: https://github.com/nodejs/node/pull/27945#discussion_r288833979

This commit regards reporting to the JS level an actual event
that happens when using suspected improper null arguments. It is better
to report the exact reason from N-API to the JS level.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
