### PR TITLE
test: use openssl_is_fips instead of hasFipsCrypto

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -194,7 +194,12 @@ Indicates whether OpenSSL is available.
 ### hasFipsCrypto
 * [&lt;boolean>]
 
-Indicates `hasCrypto` and `crypto` with fips.
+Indicates that Node.js has been linked with a FIPS compatible OpenSSL library, 
+and that FIPS as been enabled using `--enable-fips`.
+
+To only detect if the OpenSSL library is FIPS compatible, regardless if it has
+been enabled or not, then `process.config.variables.openssl_is_fips` can be
+used to determine that situation.
 
 ### hasIntl
 * [&lt;boolean>]

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -194,7 +194,7 @@ Indicates whether OpenSSL is available.
 ### hasFipsCrypto
 * [&lt;boolean>]
 
-Indicates that Node.js has been linked with a FIPS compatible OpenSSL library, 
+Indicates that Node.js has been linked with a FIPS compatible OpenSSL library,
 and that FIPS as been enabled using `--enable-fips`.
 
 To only detect if the OpenSSL library is FIPS compatible, regardless if it has

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -46,7 +46,7 @@ const conditionalOpts = [
       return ['--openssl-config', '--tls-cipher-list', '--use-bundled-ca',
               '--use-openssl-ca' ].includes(opt);
     } },
-  { include: common.hasFipsCrypto,
+  { include: process.config.variables.openssl_is_fips,
     filter: (opt) => opt.includes('-fips') },
   { include: common.hasIntl,
     filter: (opt) => opt === '--icu-data-dir' },

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -46,7 +46,14 @@ const conditionalOpts = [
       return ['--openssl-config', '--tls-cipher-list', '--use-bundled-ca',
               '--use-openssl-ca' ].includes(opt);
     } },
-  { include: process.config.variables.openssl_is_fips,
+  {
+    // We are using openssl_is_fips from the configuration because it could be
+    // the case that OpenSSL is FIPS compatible but fips has not been enabled
+    // (starting node with --enable-fips). If we use common.hasFipsCrypto
+    // that would only tells us if fips has been enabled, but in this case we
+    // want to check options which will be available regardless of whether fips
+    // is enabled at runtime or not.
+    include: process.config.variables.openssl_is_fips,
     filter: (opt) => opt.includes('-fips') },
   { include: common.hasIntl,
     filter: (opt) => opt === '--icu-data-dir' },


### PR DESCRIPTION
Currently, when dynamically linking against a FIPS enabled OpenSSL
library test-process-env-allowed-flags-are-documented will fail with
the following error:
```console
assert.js:89
throw new AssertionError(obj);
^

AssertionError [ERR_ASSERTION]:
The following options are not documented as allowed in NODE_OPTIONS in
/root/node/doc/api/cli.md: --enable-fips --force-fips
at Object.<anonymous>
(/test/parallel/test-process-env-allowed-flags-are-documented.js:82:8)
  at Module._compile (internal/modules/cjs/loader.js:779:30)
  at Object.Module._extensions..js (internal/modules/cjs/loader.js:790:10)
  at Module.load (internal/modules/cjs/loader.js:642:32)
  at Function.Module._load (internal/modules/cjs/loader.js:555:12)
  at Function.Module.runMain (internal/modules/cjs/loader.js:842:10)
  at internal/main/run_main_module.js:17:11 {
  generatedMessage: false,
  code: 'ERR_ASSERTION',
  actual: 2,
  expected: 0,
  operator: 'strictEqual'
}
```
This commit updates the test to use
process.config.variables.openssl_is_fips instead of common.hasFipsCrypto
as hasFipsCrypto only returns true if the OpenSSL library that is
shipped with node was configured with FIPS enabled.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
