### PR TITLE
test: don't use deprecated crypto.fips property

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -789,7 +789,7 @@ module.exports = {
   get localhostIPv6() { return '::1'; },
 
   get hasFipsCrypto() {
-    return hasCrypto && require('crypto').fips;
+    return hasCrypto && require('crypto').getFips();
   },
 
   get inFreeBSDJail() {


### PR DESCRIPTION
`crypto.fips` was deprecated in commit 6e7992e8b8 ("crypto: docs-only
deprecate crypto.fips, replace") but its usage in `common.hasFipsCrypto`
seems to have been overlooked.