### PR TITLE
test: create home for test-npm-install

### DIFF
--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -13,6 +13,8 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 const npmSandbox = path.join(tmpdir.path, 'npm-sandbox');
 fs.mkdirSync(npmSandbox);
+const homeDir = path.join(tmpdir.path, 'home');
+fs.mkdirSync(homeDir);
 const installDir = path.join(tmpdir.path, 'install-dir');
 fs.mkdirSync(installDir);
 
@@ -40,7 +42,7 @@ const env = Object.assign({}, process.env, {
   PATH: path.dirname(process.execPath),
   NPM_CONFIG_PREFIX: path.join(npmSandbox, 'npm-prefix'),
   NPM_CONFIG_TMP: path.join(npmSandbox, 'npm-tmp'),
-  HOME: path.join(npmSandbox, 'home'),
+  HOME: homeDir,
 });
 
 exec(`${process.execPath} ${npmPath} install`, {


### PR DESCRIPTION
This test currently fails if run as root:
```console
npm ERR! makeDirectory homeless?
npm WARN install-dir No description
npm WARN install-dir No repository field.
npm WARN install-dir No license field.

npm ERR! path /root/node/test/.tmp.0/npm-sandbox/home
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall stat
npm ERR! enoent ENOENT:
no such file or directory,
  stat '/root/node/test/.tmp.0/npm-sandbox/home'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

assert.js:89
  throw new AssertionError(obj);
  ^

AssertionError [ERR_ASSERTION]: npm install got error code 254
    at handleExit (/root/node/test/parallel/test-npm-install.js:60:10)
    at /root/node/test/common/index.js:371:15
    at ChildProcess.exithandler (child_process.js:304:5)
    at ChildProcess.emit (events.js:203:13)
    at maybeClose (internal/child_process.js:1028:16)
    at Process.ChildProcess._handle.onexit
      (internal/child_process.js:283:5) {
       generatedMessage: false,
       code: 'ERR_ASSERTION',
       actual: 254,
       expected: 0,
       operator: 'strictEqual'
    }
```
The home directory will be created as expected by npm in the npmSandbox
when run as non-root, but when run as root this directory has to exist.

This commit creates the home directory to allow the test to pass also
when run as the root user.

Refs: https://github.com/npm/cli/blob/31718e72cb5a03cee7127fc36843e4b55c868d93/lib/utils/correct-mkdir.js#L82-L105


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
