### PR TITLE
test: skip external-exceed-max-by-1-hex on AIX

### DIFF
--- a/test/addons/addon.status
+++ b/test/addons/addon.status
@@ -9,4 +9,11 @@ prefix addons
 stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js: SKIP
 
 # https://github.com/nodejs/node/pull/28516
+stringbytes-external-exceed-max/test-stringbytes-external-at-max: SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii: SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64: SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary: SKIP
 stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex: SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8: SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2: SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max: SKIP

--- a/test/addons/addon.status
+++ b/test/addons/addon.status
@@ -1,0 +1,12 @@
+prefix addons
+
+[true] # This section applies to all platforms
+
+[$system==aix]
+# https://github.com/nodejs/build/issues/1820#issuecomment-505998851
+# https://github.com/nodejs/node/pull/28469
+# https://github.com/nodejs/node/pull/28516
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js: SKIP
+
+# https://github.com/nodejs/node/pull/28516
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex: SKIP

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
@@ -5,11 +5,6 @@ const skipMessage = 'intensive toString tests due to memory confinements';
 if (!common.enoughTestMem)
   common.skip(skipMessage);
 
-// See https://github.com/nodejs/build/issues/1820#issuecomment-505998851
-// See https://github.com/nodejs/node/pull/28469
-if (process.platform === 'aix')
-  common.skip('flaky on AIX');
-
 const binding = require(`./build/${common.buildType}/binding`);
 
 // v8 fails silently if string length > v8::String::kMaxLength


### PR DESCRIPTION
stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex
is failing regularly on AIX. Skip for now.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
