### PR TITLE
doc: fix family default value in socket.connect

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -618,8 +618,8 @@ For TCP connections, available `options` are:
 * `host` {string} Host the socket should connect to. **Default:** `'localhost'`.
 * `localAddress` {string} Local address the socket should connect from.
 * `localPort` {number} Local port the socket should connect from.
-* `family` {number}: Version of IP stack, can be either `4` or `6`.
-  **Default:** `4`.
+* `family` {number}: Version of IP stack. Must be `4`, `6`, or `0`.
+  **Default:** `0`.
 * `hints` {number} Optional [`dns.lookup()` hints][].
 * `lookup` {Function} Custom lookup function. **Default:** [`dns.lookup()`][].
 


### PR DESCRIPTION
Documentation says that default value is `4`, but in code no any default value: https://github.com/nodejs/node/blob/d3b10f66bd4943f7da9aa25415ea6900d7f48086/lib/net.js#L942

as result `dns.lookup` uses own default -- `0`.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)