### PR TITLE
util: attach return value to promisified functions

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -260,6 +260,7 @@ function getSystemErrorName(err) {
   return entry ? entry[0] : `Unknown system error ${err}`;
 }
 
+const kPromisifyResultSymbol = Symbol('util.promisify.result');
 const kCustomPromisifiedSymbol = Symbol('util.promisify.custom');
 const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
 
@@ -282,21 +283,34 @@ function promisify(original) {
   const argumentNames = original[kCustomPromisifyArgsSymbol];
 
   function fn(...args) {
-    return new Promise((resolve, reject) => {
-      original.call(this, ...args, (err, ...values) => {
+    let resolveFn, rejectFn;
+    let result = null;
+
+    const promise = new Promise((resolve, reject) => {
+      resolveFn = resolve;
+      rejectFn = reject;
+    });
+
+    try {
+      result = original.call(this, ...args, (err, ...values) => {
         if (err) {
-          return reject(err);
+          return rejectFn(err);
         }
         if (argumentNames !== undefined && values.length > 1) {
           const obj = {};
           for (var i = 0; i < argumentNames.length; i++)
             obj[argumentNames[i]] = values[i];
-          resolve(obj);
+          resolveFn(obj);
         } else {
-          resolve(values[0]);
+          resolveFn(values[0]);
         }
       });
-    });
+    } catch (err) {
+      rejectFn(err);
+    }
+
+    promise[kPromisifyResultSymbol] = result;
+    return promise;
   }
 
   Object.setPrototypeOf(fn, Object.getPrototypeOf(original));
@@ -310,6 +324,7 @@ function promisify(original) {
   );
 }
 
+promisify.result = kPromisifyResultSymbol;
 promisify.custom = kCustomPromisifiedSymbol;
 
 // The build-in Array#join is slower in v8 6.0

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -193,3 +193,19 @@ const stat = promisify(fs.stat);
                `Received type ${typeof input}`
     });
 });
+
+{
+  const func = (arg1, arg2, callback) => {
+    setTimeout(() => callback(null, arg1 + arg2), 1);
+    return arg2 - arg1;
+  };
+
+  const promisified = promisify(func);
+  const promise = promisified(5, 7);
+  const result = promise[promisify.result];
+
+  assert.strictEqual(result, 2);
+  promise.then(common.mustCall((finalResult) => {
+    assert.strictEqual(finalResult, 12);
+  }));
+}


### PR DESCRIPTION
Some functions that perform asynchronous tasks and
take a callback also return a synchronous result which
can be used in the same tick. Previously util.promisify
was discarding the return value.

While #28325 solved the problem for some specific functions, the general problem for user-defined functions remained. It seems that not so rare practice is to return a useful value along with scheduling asynchronous actions in a function which takes a callback.

Documentation is not added yet. I would like to hear some feedback first regarding whether this change is a good change (or maybe some better suggestions for the symbol name?).

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
