### PR TITLE
build: link libatomic on gcc or clang on linux

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -289,7 +289,7 @@
           '-Wl,-bnoerrmsg',
         ],
       }],
-      ['(OS=="linux" or OS=="mac") and llvm_version!=0', {
+      ['OS=="linux" and llvm_version!=0', {
         'libraries': ['-latomic'],
       }],
     ],


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
See: https://github.com/nodejs/node/issues/28231 https://github.com/nodejs/node/pull/28232
libatomic is a gcc library. Clang default is to be built to use it on Linux.
cc: @devsnek @addaleax 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
