### PR TITLE
build: block SIGTTOU before calling tcsetattr()

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -688,14 +688,20 @@ void ResetStdio() {
     }
 
     if (s.isatty) {
+      sigset_t sa;
       int err;
+
+      // We might be a background job that doesn't own the TTY so block SIGTTOU
+      // before making the tcsetattr() call, otherwise that signal suspends us.
+      sigemptyset(&sa);
+      sigaddset(&sa, SIGTTOU);
+
+      CHECK_EQ(0, pthread_sigmask(SIG_BLOCK, &sa, nullptr));
       do
         err = tcsetattr(fd, TCSANOW, &s.termios);
       while (err == -1 && errno == EINTR);  // NOLINT
-      // EIO has been observed to be returned by the Linux kernel under some
-      // circumstances. Reading through drivers/tty/tty_io*.c, it seems to
-      // indicate the tty went away. Of course none of this is documented.
-      CHECK_IMPLIES(err == -1, errno == EIO);
+      CHECK_EQ(0, pthread_sigmask(SIG_UNBLOCK, &sa, nullptr));
+      CHECK_EQ(0, err);
     }
   }
 #endif  // __POSIX__


### PR DESCRIPTION
We might be a background job that doesn't own the TTY so block SIGTTOU
before making the tcsetattr() call, otherwise that signal suspends us.

This is a better fix than PR #28490 for issue #28479.

Fixes: https://github.com/nodejs/node/issues/28530
Fixes: https://github.com/nodejs/node/issues/28479
Refs: https://github.com/nodejs/node/pull/28490