### PR TITLE
process: refactor unhandledRejection logic

### DIFF
--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -199,10 +199,12 @@ function processPromiseRejections() {
       }
       case kDefaultUnhandledRejections: {
         const handled = process.emit('unhandledRejection', reason, promise);
-        if (!handled) emitUnhandledRejectionWarning(uid, reason);
-        if (!deprecationWarned) {
-          emitDeprecationWarning();
-          deprecationWarned = true;
+        if (!handled) {
+          emitUnhandledRejectionWarning(uid, reason);
+          if (!deprecationWarned) {
+            emitDeprecationWarning();
+            deprecationWarned = true;
+          }
         }
         break;
       }

--- a/test/parallel/test-promise-handled-rejection-no-warning.js
+++ b/test/parallel/test-promise-handled-rejection-no-warning.js
@@ -1,0 +1,8 @@
+'use strict';
+const common = require('../common');
+
+// This test verifies that DEP0018 does not occur when rejections are handled.
+common.disableCrashOnUnhandledRejection();
+process.on('warning', common.mustNotCall());
+process.on('unhandledRejection', common.mustCall());
+Promise.reject(new Error());


### PR DESCRIPTION
This commit prevents a deprecation warning from being emitted
if the `'unhandledRejection'` event was actually handled.

Fixes: https://github.com/nodejs/node/issues/28539

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
