### PR TITLE
[Linting] Spacing of #defines in node.h file

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -24,9 +24,9 @@
 
 #ifdef _WIN32
 # ifndef BUILDING_NODE_EXTENSION
-#   define NODE_EXTERN __declspec(dllexport)
+#  define NODE_EXTERN __declspec(dllexport)
 # else
-#   define NODE_EXTERN __declspec(dllimport)
+#  define NODE_EXTERN __declspec(dllimport)
 # endif
 #else
 # define NODE_EXTERN __attribute__((visibility("default")))
@@ -43,7 +43,7 @@
 // See issue https://github.com/nodejs/node-v0.x-archive/issues/1236
 #if defined(__MINGW32__) || defined(_MSC_VER)
 #ifndef _WIN32_WINNT
-# define _WIN32_WINNT   0x0600  // Windows Server 2008
+# define _WIN32_WINNT 0x0600  // Windows Server 2008
 #endif
 
 #ifndef NOMINMAX
@@ -57,7 +57,7 @@
 #endif
 
 #ifdef _WIN32
-# define SIGKILL         9
+# define SIGKILL 9
 #endif
 
 #include "v8.h"  // NOLINT(build/include_order)
@@ -190,8 +190,8 @@ NODE_DEPRECATED("Use MakeCallback(..., async_context)",
 #include <cstdint>
 
 #ifndef NODE_STRINGIFY
-#define NODE_STRINGIFY(n) NODE_STRINGIFY_HELPER(n)
-#define NODE_STRINGIFY_HELPER(n) #n
+# define NODE_STRINGIFY(n) NODE_STRINGIFY_HELPER(n)
+# define NODE_STRINGIFY_HELPER(n) #n
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
I noticed a few inconsistent spaces when reading through the node.h file. This PR is to make the spacing use the same pattern as the rest of the file/project.

By the way, I checked the Style Guides and there's no real consensus on this. Do we have some formal rule about when to use a space for an indented line within:
1. #if defined
2. #ifndef 
3. #ifdef 
4. If the #ifndef itself is within a bracket { } scope and the #ifndef should be tabbed.

? I can cite some examples of each one of these situations if required.

##### Checklist
- [x] `make -j4 test` (UNIX) passes
- [x] commit message follows [commit guidelines]
