### PR TITLE
stream: use readableEncoding public api for child_process

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -917,6 +917,16 @@ will be ignored.
 Implementors should not override this method, but instead implement
 [`readable._destroy()`][readable-_destroy].
 
+##### readable.readableEncoding
+<!-- YAML
+added: REPLACEME
+-->
+
+* {null|string}
+
+Getter for the property `encoding` of a given `Readable` stream. The `encoding`
+property can be set using the [`readable.setEncoding()`][] method.
+
 ##### readable.isPaused()
 <!-- YAML
 added: v0.11.14
@@ -2650,6 +2660,7 @@ contain multi-byte characters.
 [`process.stderr`]: process.html#process_process_stderr
 [`process.stdin`]: process.html#process_process_stdin
 [`process.stdout`]: process.html#process_process_stdout
+[`readable.setEncoding()`]: #stream_readable_setencoding_encoding
 [`readable.push('')`]: #stream_readable_push
 [`stream.Readable.from()`]: #stream_stream_readable_from_iterable_options
 [`stream.cork()`]: #stream_writable_cork

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -917,16 +917,6 @@ will be ignored.
 Implementors should not override this method, but instead implement
 [`readable._destroy()`][readable-_destroy].
 
-##### readable.readableEncoding
-<!-- YAML
-added: REPLACEME
--->
-
-* {null|string}
-
-Getter for the property `encoding` of a given `Readable` stream. The `encoding`
-property can be set using the [`readable.setEncoding()`][] method.
-
 ##### readable.isPaused()
 <!-- YAML
 added: v0.11.14
@@ -1095,6 +1085,16 @@ added: v11.4.0
 * {boolean}
 
 Is `true` if it is safe to call [`readable.read()`][stream-read].
+
+##### readable.readableEncoding
+<!-- YAML
+added: REPLACEME
+-->
+
+* {null|string}
+
+Getter for the property `encoding` of a given `Readable` stream. The `encoding`
+property can be set using the [`readable.setEncoding()`][] method.
 
 ##### readable.readableHighWaterMark
 <!-- YAML
@@ -2660,8 +2660,8 @@ contain multi-byte characters.
 [`process.stderr`]: process.html#process_process_stderr
 [`process.stdin`]: process.html#process_process_stdin
 [`process.stdout`]: process.html#process_process_stdout
-[`readable.setEncoding()`]: #stream_readable_setencoding_encoding
 [`readable.push('')`]: #stream_readable_push
+[`readable.setEncoding()`]: #stream_readable_setencoding_encoding
 [`stream.Readable.from()`]: #stream_stream_readable_from_iterable_options
 [`stream.cork()`]: #stream_writable_cork
 [`stream.finished()`]: #stream_stream_finished_stream_options_callback

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1105,6 +1105,13 @@ Object.defineProperty(Readable.prototype, 'readableObjectMode', {
   }
 });
 
+Object.defineProperty(Readable.prototype, 'readableEncoding', {
+  enumerable: false,
+  get() {
+    return this._readableState ? this._readableState.encoding : null;
+  }
+});
+
 // Pluck off n bytes from an array of buffers.
 // Length is the combined lengths of all the buffers in the list.
 // This function is designed to be inlinable, so please take care when making

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -266,8 +266,7 @@ function execFile(file /* , args, options, callback */) {
     if (encoding ||
       (
         child.stdout &&
-        child.stdout._readableState &&
-        child.stdout._readableState.encoding
+        child.stdout.readableEncoding
       )) {
       stdout = _stdout.join('');
     } else {
@@ -276,8 +275,7 @@ function execFile(file /* , args, options, callback */) {
     if (encoding ||
       (
         child.stderr &&
-        child.stderr._readableState &&
-        child.stderr._readableState.encoding
+        child.stderr.readableEncoding
       )) {
       stderr = _stderr.join('');
     } else {
@@ -344,7 +342,7 @@ function execFile(file /* , args, options, callback */) {
       child.stdout.setEncoding(encoding);
 
     child.stdout.on('data', function onChildStdout(chunk) {
-      const encoding = child.stdout._readableState.encoding;
+      const encoding = child.stdout.readableEncoding;
       const length = encoding ?
         Buffer.byteLength(chunk, encoding) :
         chunk.length;
@@ -367,7 +365,7 @@ function execFile(file /* , args, options, callback */) {
       child.stderr.setEncoding(encoding);
 
     child.stderr.on('data', function onChildStderr(chunk) {
-      const encoding = child.stderr._readableState.encoding;
+      const encoding = child.stderr.readableEncoding;
       const length = encoding ?
         Buffer.byteLength(chunk, encoding) :
         chunk.length;

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -423,13 +423,25 @@ class TestWriter extends EE {
 }
 
 {
+  // Verify readableEncoding property
+  assert(R.prototype.hasOwnProperty('readableEncoding'));
+
+  const r = new R({ encoding: 'utf8' });
+  assert.strictEqual(r.readableEncoding, 'utf8');
+}
+
+{
   // Verify readableObjectMode property
+  assert(R.prototype.hasOwnProperty('readableObjectMode'));
+
   const r = new R({ objectMode: true });
   assert.strictEqual(r.readableObjectMode, true);
 }
 
 {
   // Verify writableObjectMode property
+  assert(W.prototype.hasOwnProperty('writableObjectMode'));
+
   const w = new W({ objectMode: true });
   assert.strictEqual(w.writableObjectMode, true);
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Adding encoding getter `readableEncoding` to `stream.Readable` to reduce usage of internal `_readableState.encoding`.

Refs: #445

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
