### PR TITLE
repl: partially fix repl context

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -875,8 +875,11 @@ REPLServer.prototype.createContext = function() {
       context = vm.createContext();
     });
     for (const name of Object.getOwnPropertyNames(global)) {
-      Object.defineProperty(context, name,
-                            Object.getOwnPropertyDescriptor(global, name));
+      // Only set properties on the context that do not exist as primordial.
+      if (!(name in primordials)) {
+        Object.defineProperty(context, name,
+                              Object.getOwnPropertyDescriptor(global, name));
+      }
     }
     context.global = context;
     const _console = new Console(this.outputStream);

--- a/test/parallel/test-repl-context.js
+++ b/test/parallel/test-repl-context.js
@@ -16,11 +16,21 @@ const stream = new ArrayStream();
     useGlobal: false
   });
 
+  let output = '';
+  stream.write = function(d) {
+    output += d;
+  };
+
   // Ensure that the repl context gets its own "console" instance.
   assert(r.context.console);
 
   // Ensure that the repl console instance is not the global one.
   assert.notStrictEqual(r.context.console, console);
+  assert.notStrictEqual(r.context.Object, Object);
+
+  stream.run(['({} instanceof Object)']);
+
+  assert.strictEqual(output, 'true\n> ');
 
   const context = r.createContext();
   // Ensure that the repl context gets its own "console" instance.


### PR DESCRIPTION
This partially fixes contexts like `{} instanceof Object === false`
in the REPL. This does not fix all cases, since it's something
fundamental from the REPL's design that things like these can happen.

Refs: https://github.com/nodejs/node/issues/27859

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
