### PR TITLE
src: allow fatal exceptions to be enhanced

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -448,10 +448,11 @@ TryCatchScope::~TryCatchScope() {
     HandleScope scope(env_->isolate());
     Local<v8::Value> exception = Exception();
     Local<v8::Message> message = Message();
+    EnhanceFatalException enhance = CanContinue() ?
+        EnhanceFatalException::kEnhance : EnhanceFatalException::kDontEnhance;
     if (message.IsEmpty())
       message = Exception::CreateMessage(env_->isolate(), exception);
-    ReportFatalException(
-        env_, exception, message, EnhanceFatalException::kDontEnhance);
+    ReportFatalException(env_, exception, message, enhance);
     env_->Exit(7);
   }
 }

--- a/test/parallel/test-unhandled-exception-rethrow-error.js
+++ b/test/parallel/test-unhandled-exception-rethrow-error.js
@@ -1,0 +1,28 @@
+'use strict';
+require('../common');
+
+if (process.argv[2] === 'child') {
+  process.on('uncaughtException', (err) => {
+    err.rethrow = true;
+    throw err;
+  });
+
+  function throwException() {
+    throw new Error('boom');
+  }
+
+  throwException();
+} else {
+  const assert = require('assert');
+  const { spawnSync } = require('child_process');
+  const result = spawnSync(process.execPath, [__filename, 'child']);
+
+  assert.strictEqual(result.status, 7);
+  assert.strictEqual(result.signal, null);
+  assert.strictEqual(result.stdout.toString().trim(), '');
+  // Verify that the error was thrown and that the stack was preserved.
+  const stderr = result.stderr.toString();
+  assert(/Error: boom/.test(stderr));
+  assert(/at throwException/.test(stderr));
+  assert(/rethrow: true/.test(stderr));
+}


### PR DESCRIPTION
This commit allows fatal exceptions to be enhanced so that exceptions thrown from an `'unhandledException'` handler have the stack attached properly.

I still need to add a test, but first I want to make sure the approach is acceptable. If it's not, another approach could be passing `kEnhance`/`kDontEnhance` to the `TryCatchScope` constructor.

Fixes: https://github.com/nodejs/node/issues/28550

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
