### PR TITLE
streams: handle null push for transform in async_iterator

### DIFF
--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -155,7 +155,7 @@ const createReadableStreamAsyncIterator = (stream) => {
   });
   iterator[kLastPromise] = null;
 
-  finished(stream, (err) => {
+  finished(stream, { writable: false }, (err) => {
     if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
       const reject = iterator[kLastReject];
       // Reject if we are waiting for data in the Promise returned by next() and

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -400,9 +400,7 @@ async function tests() {
   {
     const transform = new Transform({
       objectMode: true,
-      transform(chunk, enc, cb) {
-        cb(null, chunk);
-      }
+      transform: common.mustNotCall()
     });
     transform.push(0);
     transform.push(1);

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -396,24 +396,28 @@ async function tests() {
     }
   }
 
-  console.log('readable side of a transform stream pushes null');
   {
+    console.log('readable side of a transform stream pushes null');
     const transform = new Transform({
       objectMode: true,
-      transform: common.mustNotCall()
+      transform: (chunk, enc, cb) => { cb(null, chunk); }
     });
     transform.push(0);
     transform.push(1);
-    transform.push(null);
-    const mustReach = common.mustCall();
+    process.nextTick(() => {
+      transform.push(null);
+    });
+
+    const mustReach = [ common.mustCall(), common.mustCall() ];
+
     const iter = transform[Symbol.asyncIterator]();
     assert.strictEqual((await iter.next()).value, 0);
 
     for await (const d of iter) {
       assert.strictEqual(d, 1);
+      mustReach[0]();
     }
-
-    mustReach();
+    mustReach[1]();
   }
 
   {


### PR DESCRIPTION
when the readable side of a transform ends any for await
loop on that transform stream should also complete. This
fix prevents for await loop on a transform stream
from hanging indefinitely.

Essential for #28501  (see https://github.com/nodejs/node/pull/28501#discussion_r299248335)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
