### PR TITLE
src: implement runtime option --no-node-snapshot for debugging

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1052,16 +1052,21 @@ int Start(int argc, char** argv) {
 
   {
     Isolate::CreateParams params;
-    // TODO(joyeecheung): collect external references and set it in
-    // params.external_references.
-    std::vector<intptr_t> external_references = {
-        reinterpret_cast<intptr_t>(nullptr)};
-    v8::StartupData* blob = NodeMainInstance::GetEmbeddedSnapshotBlob();
-    const std::vector<size_t>* indexes =
-        NodeMainInstance::GetIsolateDataIndexes();
-    if (blob != nullptr) {
-      params.external_references = external_references.data();
-      params.snapshot_blob = blob;
+    const std::vector<size_t>* indexes = nullptr;
+    std::vector<intptr_t> external_references;
+
+    bool force_no_snapshot =
+        per_process::cli_options->per_isolate->no_node_snapshot;
+    if (!force_no_snapshot) {
+      v8::StartupData* blob = NodeMainInstance::GetEmbeddedSnapshotBlob();
+      if (blob != nullptr) {
+        // TODO(joyeecheung): collect external references and set it in
+        // params.external_references.
+        external_references.push_back(reinterpret_cast<intptr_t>(nullptr));
+        params.external_references = external_references.data();
+        params.snapshot_blob = blob;
+        indexes = NodeMainInstance::GetIsolateDataIndexes();
+      }
     }
 
     NodeMainInstance main_instance(&params,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -522,6 +522,10 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
             "track heap object allocations for heap snapshots",
             &PerIsolateOptions::track_heap_objects,
             kAllowedInEnvironment);
+  AddOption("--no-node-snapshot",
+            "",  // It's a debug-only option.
+            &PerIsolateOptions::no_node_snapshot,
+            kAllowedInEnvironment);
 
   // Explicitly add some V8 flags to mark them as allowed in NODE_OPTIONS.
   AddOption("--abort-on-uncaught-exception",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -171,6 +171,7 @@ class PerIsolateOptions : public Options {
  public:
   std::shared_ptr<EnvironmentOptions> per_env { new EnvironmentOptions() };
   bool track_heap_objects = false;
+  bool no_node_snapshot = false;
 
 #ifdef NODE_REPORT
   bool report_uncaught_exception = false;

--- a/test/parallel/test-no-node-snapshot.js
+++ b/test/parallel/test-no-node-snapshot.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// Flags: --no-node-snapshot
+
+require('../common');

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -79,6 +79,8 @@ const undocumented = difference(process.allowedNodeEnvironmentFlags,
 // Remove intentionally undocumented options.
 assert(undocumented.delete('--debug-arraybuffer-allocations'));
 assert(undocumented.delete('--experimental-worker'));
+assert(undocumented.delete('--no-node-snapshot'));
+
 assert.strictEqual(undocumented.size, 0,
                    'The following options are not documented as allowed in ' +
                    `NODE_OPTIONS in ${cliMd}: ${[...undocumented].join(' ')}`);


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/28558

I did not add any documentation for this flag - the intention is to dedicate it to debugging Node.js core, somewhat similar to `--expose-internals` and `--inspect-brk-node`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
