### PR TITLE
test: add test-fs-writeFileSync-invalid-windows

### DIFF
--- a/test/known_issues/test-fs-writeFileSync-invalid-windows.js
+++ b/test/known_issues/test-fs-writeFileSync-invalid-windows.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+
+// Test that using an invalid file name with writeFileSync() on Windows returns
+// EINVAL. With libuv 1.x, it returns ENOTFOUND. This should be fixed when we
+// update to libuv 2.x.
+//
+// Refs: https://github.com/nodejs/node/issues/8987
+
+const assert = require('assert');
+const fs = require('fs');
+
+if (!common.isWindows) {
+  // Change to `common.skip()` when the test is moved out of `known_issues`.
+  assert.fail('Windows-only test');
+}
+
+assert.throws(() => {
+  fs.writeFileSync('fhqwhgads??', 'come on');
+}, { code: 'EINVAL' });


### PR DESCRIPTION
Add a known_issues test for the Windows returning ENOTFOUND where EINVAL
is more appropriate. This happens with various functions in the `fs`
module when an invalid path is used.

Refs: https://github.com/nodejs/node/issues/8987

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
