### PR TITLE
doc: Move Usage and Example to same header level

### DIFF
--- a/doc/api/synopsis.md
+++ b/doc/api/synopsis.md
@@ -1,4 +1,6 @@
-# Usage
+# Usage & Example
+
+## Usage
 
 <!--introduced_in=v0.10.0-->
 <!--type=misc-->


### PR DESCRIPTION
Having Example under Usage in synopsis.md is misleading. That suggests
that the examples will be examples of the CLI usage, but the example
section is mostly about writing a simple web server. Ideally, the Usage
section should be moved to cli.md and the Example section should
constitute a Getting Started or Quick Start page. But for now, make them
equals under a combined header so that the Table of Contents and the
header/layout of the page is not confusing or misleading.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
