### PR TITLE
doc: document family:0 behavior in socket.connect

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -618,8 +618,8 @@ For TCP connections, available `options` are:
 * `host` {string} Host the socket should connect to. **Default:** `'localhost'`.
 * `localAddress` {string} Local address the socket should connect from.
 * `localPort` {number} Local port the socket should connect from.
-* `family` {number}: Version of IP stack. Must be `4`, `6`, or `0`.
-  **Default:** `0`.
+* `family` {number}: Version of IP stack. Must be `4`, `6`, or `0`. The value
+  `0` indicates that both IPv4 and IPv6 addresses are allowed. **Default:** `0`.
 * `hints` {number} Optional [`dns.lookup()` hints][].
 * `lookup` {Function} Custom lookup function. **Default:** [`dns.lookup()`][].
 


### PR DESCRIPTION
Now that `family:0` is documented in `socket.connect()`, add an explanation of what it means since 0 is not an IP family.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
