### PR TITLE
doc: fix links in synopsis.md

### DIFF
--- a/doc/api/synopsis.md
+++ b/doc/api/synopsis.md
@@ -84,6 +84,6 @@ Now, open any preferred web browser and visit `http://127.0.0.1:3000`.
 If the browser displays the string `Hello, World!`, that indicates
 the server is working.
 
-[Command Line Options]: cli.html#cli_command_line_options
+[Command Line Options]: cli.md#command_line_options
 [this guide]: https://nodejs.org/en/download/package-manager/
-[web server]: http.html
+[web server]: http.md


### PR DESCRIPTION
I was looking at synopsis.md and noticed that the links in the file are broken. Basically, they point to .html files instead of .md files. This PR fixes it.

Testing:
In the [node repository's synopsis.md](https://github.com/nodejs/node/blob/master/doc/api/synopsis.md#usage):
1. Click the "Command Line Options" link. Notice it takes you to a 404 page.
2. Click the "web server" link. Notice it takes you to a 404 page.

In [my branch's synopsis.md](https://github.com/srcmake/node/blob/feature/synposis-fix-links/doc/api/synopsis.md#usage)
1. Click the "Command Line Options" link. Notice it takes you to the correct page.
2. Click the "web server" link. Notice it takes you to the correct page.

##### Checklist
- [x] `make lint`
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
