### PR TITLE
doc: mention markdown linting in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -322,8 +322,7 @@ Make sure the linter does not report any issues and that all tests pass. Please
 do not submit patches that fail either check.
 
 If you want to run the linter without running tests, use
-`make lint`/`vcbuild lint`. It will run both JavaScript linting and
-C++ linting.
+`make lint`/`vcbuild lint`. It will lint JavaScript, C++, and Markdown files.
 
 If you are updating tests and want to run tests in a single test file
 (e.g. `test/parallel/test-stream2-transform.js`):


### PR DESCRIPTION
In the [Running Tests section of BUILDING.md](https://github.com/nodejs/node/blob/master/BUILDING.md#running-tests), there's a sentence that says `make lint` runs JavaScript and C++ linting. However, `make lint` also runs a Markdown linter. This PR updates that sentence in the documentation to mention that Markdown linting is run.

Which is super useful to know since small documentation change PRs don't need the full test suite run, and `make lint` is good enough for testing. (I think.)

##### Checklist
- [x] `make lint`
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
