### PR TITLE
src: implement special member functions for Environment

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -484,6 +484,8 @@ class IsolateData : public MemoryRetainer {
   inline v8::Isolate* isolate() const;
   IsolateData(const IsolateData&) = delete;
   IsolateData& operator=(const IsolateData&) = delete;
+  IsolateData(IsolateData&&) = delete;
+  IsolateData& operator=(IsolateData&&) = delete;
 
  private:
   void DeserializeProperties(const std::vector<size_t>* indexes);
@@ -574,6 +576,12 @@ class AsyncRequest : public MemoryRetainer {
  public:
   AsyncRequest() = default;
   ~AsyncRequest();
+
+  AsyncRequest(const AsyncRequest&) = delete;
+  AsyncRequest& operator=(const AsyncRequest&) = delete;
+  AsyncRequest(AsyncRequest&&) = delete;
+  AsyncRequest& operator=(AsyncRequest&&) = delete;
+
   void Install(Environment* env, void* data, uv_async_cb target);
   void Uninstall();
   void Stop();
@@ -658,6 +666,9 @@ class AsyncHooks : public MemoryRetainer {
 
   AsyncHooks(const AsyncHooks&) = delete;
   AsyncHooks& operator=(const AsyncHooks&) = delete;
+  AsyncHooks(AsyncHooks&&) = delete;
+  AsyncHooks& operator=(AsyncHooks&&) = delete;
+  ~AsyncHooks() = default;
 
   // Used to set the kDefaultTriggerAsyncId in a scope. This is instead of
   // passing the trigger_async_id along with other constructor arguments.
@@ -671,6 +682,9 @@ class AsyncHooks : public MemoryRetainer {
 
     DefaultTriggerAsyncIdScope(const DefaultTriggerAsyncIdScope&) = delete;
     DefaultTriggerAsyncIdScope& operator=(const DefaultTriggerAsyncIdScope&) =
+        delete;
+    DefaultTriggerAsyncIdScope(DefaultTriggerAsyncIdScope&&) = delete;
+    DefaultTriggerAsyncIdScope& operator=(DefaultTriggerAsyncIdScope&&) =
         delete;
 
    private:
@@ -701,6 +715,8 @@ class AsyncCallbackScope {
   ~AsyncCallbackScope();
   AsyncCallbackScope(const AsyncCallbackScope&) = delete;
   AsyncCallbackScope& operator=(const AsyncCallbackScope&) = delete;
+  AsyncCallbackScope(AsyncCallbackScope&&) = delete;
+  AsyncCallbackScope& operator=(AsyncCallbackScope&&) = delete;
 
  private:
   Environment* env_;
@@ -719,6 +735,9 @@ class ImmediateInfo : public MemoryRetainer {
 
   ImmediateInfo(const ImmediateInfo&) = delete;
   ImmediateInfo& operator=(const ImmediateInfo&) = delete;
+  ImmediateInfo(ImmediateInfo&&) = delete;
+  ImmediateInfo& operator=(ImmediateInfo&&) = delete;
+  ~ImmediateInfo() = default;
 
   SET_MEMORY_INFO_NAME(ImmediateInfo)
   SET_SELF_SIZE(ImmediateInfo)
@@ -745,6 +764,9 @@ class TickInfo : public MemoryRetainer {
 
   TickInfo(const TickInfo&) = delete;
   TickInfo& operator=(const TickInfo&) = delete;
+  TickInfo(TickInfo&&) = delete;
+  TickInfo& operator=(TickInfo&&) = delete;
+  ~TickInfo() = default;
 
  private:
   friend class Environment;  // So we can call the constructor.
@@ -779,6 +801,12 @@ class ShouldNotAbortOnUncaughtScope {
   explicit inline ShouldNotAbortOnUncaughtScope(Environment* env);
   inline void Close();
   inline ~ShouldNotAbortOnUncaughtScope();
+  ShouldNotAbortOnUncaughtScope(const ShouldNotAbortOnUncaughtScope&) = delete;
+  ShouldNotAbortOnUncaughtScope& operator=(
+      const ShouldNotAbortOnUncaughtScope&) = delete;
+  ShouldNotAbortOnUncaughtScope(ShouldNotAbortOnUncaughtScope&&) = delete;
+  ShouldNotAbortOnUncaughtScope& operator=(ShouldNotAbortOnUncaughtScope&&) =
+      delete;
 
  private:
   Environment* env_;
@@ -818,6 +846,8 @@ class Environment : public MemoryRetainer {
  public:
   Environment(const Environment&) = delete;
   Environment& operator=(const Environment&) = delete;
+  Environment(Environment&&) = delete;
+  Environment& operator=(Environment&&) = delete;
 
   SET_MEMORY_INFO_NAME(Environment)
 


### PR DESCRIPTION
The Environment class was missing the move constructor
and the move assignmnet operator.
As per the rule of five, a class must implement all the
five special member functions in order to enable the
compiler for better optimization.

Refs: https://en.cppreference.com/w/cpp/language/rule_of_three

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
