### PR TITLE
worker: fix passing multiple SharedArrayBuffers at once

### DIFF
--- a/test/parallel/test-worker-message-port-multiple-sharedarraybuffers.js
+++ b/test/parallel/test-worker-message-port-multiple-sharedarraybuffers.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { MessageChannel } = require('worker_threads');
+
+// Regression test for https://github.com/nodejs/node/issues/28559
+
+const obj = [
+  [ new SharedArrayBuffer(0), new SharedArrayBuffer(1) ],
+  [ new SharedArrayBuffer(2), new SharedArrayBuffer(3) ]
+];
+
+const { port1, port2 } = new MessageChannel();
+port1.once('message', common.mustCall((message) => {
+  assert.deepStrictEqual(message, obj);
+}));
+port2.postMessage(obj);


### PR DESCRIPTION
V8 has a handle scope below each `GetSharedArrayBufferId()` call,
so using a `v8::Local` that outlives that handle scope to store
references to `SharedArrayBuffer`s is invalid and may cause accidental
de-duplication of passed `SharedArrayBuffer`s.

Use a persistent handle instead to address this issue.

Fixes: https://github.com/nodejs/node/issues/28559

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
