### PR TITLE
http2: override authority with options

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2795,7 +2795,7 @@ function connect(authority, options, listener) {
   } else {
     switch (protocol) {
       case 'http:':
-        socket = net.connect(port, host);
+        socket = net.connect(options.port || port, options.host || host);
         break;
       case 'https:':
         socket = tls.connect(port, host, initializeTLSOptions(options, host));

--- a/test/parallel/test-http2-connect.js
+++ b/test/parallel/test-http2-connect.js
@@ -101,3 +101,18 @@ if (hasIPv6) {
     }
   }));
 }
+
+// Check that `options.host` and `options.port` take precedence over
+// `authority.host` and `authority.port`.
+{
+  const server = createServer();
+  server.listen(0, mustCall(() => {
+    connect('http://foo.bar', {
+      host: 'localhost',
+      port: server.address().port
+    }, mustCall((session) => {
+      session.close();
+      server.close();
+    }));
+  }));
+}


### PR DESCRIPTION
Make `options.host` and `options.port` take precedence over
`authority.host` and `authority.port` respectively.

Fixes: https://github.com/nodejs/node/issues/28182

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
