### PR TITLE
src: simplify DEP0062 logic

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -34,15 +34,10 @@ void DebugOptions::CheckOptions(std::vector<std::string>* errors) {
   }
 #endif
 
-  if (deprecated_debug && !inspector_enabled) {
+  if (deprecated_debug) {
     errors->push_back("[DEP0062]: `node --debug` and `node --debug-brk` "
-                      "are invalid. Please use `node --inspect` or "
+                      "are invalid. Please use `node --inspect` and "
                       "`node --inspect-brk` instead.");
-  }
-
-  if (deprecated_debug && inspector_enabled && break_first_line) {
-    errors->push_back("[DEP0062]: `node --inspect --debug-brk` is deprecated. "
-                      "Please use `node --inspect-brk` instead.");
   }
 
   std::vector<std::string> destinations =

--- a/test/sequential/test-inspector-invalid-args.js
+++ b/test/sequential/test-inspector-invalid-args.js
@@ -10,7 +10,7 @@ const execFile = require('child_process').execFile;
 const mainScript = fixtures.path('loop.js');
 const expected =
   '`node --debug` and `node --debug-brk` are invalid. ' +
-  'Please use `node --inspect` or `node --inspect-brk` instead.';
+  'Please use `node --inspect` and `node --inspect-brk` instead.';
 for (const invalidArg of ['--debug-brk', '--debug']) {
   execFile(
     process.execPath,


### PR DESCRIPTION
This commit simplifies the `DEP0062` error logic. Instead of looking for certain combinations of flags, just show an error for any usage of `--debug` or `--debug-brk`.

Fixes: https://github.com/nodejs/node/issues/28588

It's also worth noting that `DEP0062` was moved to End-of-Life, meaning that all of this logic can be removed. However, it might be worth leaving it around to print the deprecation message since `--debug` is a much more logical name than `--inspect`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
