### PR TITLE
deps: cherry-pick ARM64 Windows changes to node-gyp

### DIFF
--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/MSVSSettings.py
+++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/MSVSSettings.py
@@ -969,7 +969,9 @@ _Same(_midl, 'TargetEnvironment',
       _Enumeration(['NotSet',
                     'Win32',  # /env win32
                     'Itanium',  # /env ia64
-                    'X64']))  # /env x64
+                    'X64',  # /env x64
+                    'ARM64',  # /env arm64
+                    ]))
 _Same(_midl, 'EnableErrorChecks',
       _Enumeration(['EnableCustom',
                     'None',  # /error none

--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/msvs.py
+++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/msvs.py
@@ -1885,6 +1885,8 @@ def _InitNinjaFlavor(params, target_list, target_dicts):
       configuration = '$(Configuration)'
       if params.get('target_arch') == 'x64':
         configuration += '_x64'
+      if params.get('target_arch') == 'arm64':
+        configuration += '_arm64'
       spec['msvs_external_builder_out_dir'] = os.path.join(
           gyp.common.RelativePath(params['options'].toplevel_dir, gyp_dir),
           ninja_generator.ComputeOutputDir(params),

--- a/deps/npm/node_modules/node-gyp/lib/build.js
+++ b/deps/npm/node_modules/node-gyp/lib/build.js
@@ -210,9 +210,13 @@ function build (gyp, argv, callback) {
 
     // Specify the build type, Release by default
     if (win) {
+      // Convert .gypi config target_arch to MSBuild /Platform
+      // Since there are many ways to state '32-bit Intel', default to it.
+      // N.B. msbuild's Condition string equality tests are case-insensitive.
       var archLower = arch.toLowerCase()
       var p = archLower === 'x64' ? 'x64' :
-              (archLower === 'arm' ? 'ARM' : 'Win32')
+              (archLower === 'arm' ? 'ARM' :
+              (archLower === 'arm64' ? 'ARM64' : 'Win32'))
       argv.push('/p:Configuration=' + buildType + ';Platform=' + p)
       if (jobs) {
         var j = parseInt(jobs, 10)

--- a/deps/npm/node_modules/node-gyp/lib/configure.js
+++ b/deps/npm/node_modules/node-gyp/lib/configure.js
@@ -142,6 +142,9 @@ function configure (gyp, argv, callback) {
 
     // set the target_arch variable
     variables.target_arch = gyp.opts.arch || process.arch || 'ia32'
+    if (variables.target_arch == 'arm64') {
+      defaults['msvs_configuration_platform'] = 'ARM64'
+    }
 
     // set the node development directory
     variables.nodedir = nodeDir


### PR DESCRIPTION
It is very important to me (and to my employer) that the Electron v6 release at the end of this month (July 2019) supports ARM64 Windows without manual patching of anything. Right now, developers have to manually patch npm with node-gyp v5 or greater.

This change cherry-picks the one node-gyp change that is needed:
https://github.com/nodejs/node-gyp/pull/1739

I am hoping that the size and simplicity of this change will allow it to quickly make it to Node.js v12.

This change only affects Windows and should only affect ARM64 Windows.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
