### PR TITLE
n-api: make thread-safe-function calls properly

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -325,10 +325,9 @@ class ThreadSafeFunction : public node::AsyncResource {
             v8::Local<v8::Function>::New(env->isolate, ref);
           js_callback = v8impl::JsValueFromV8LocalValue(js_cb);
         }
-        call_js_cb(env,
-                   js_callback,
-                   context,
-                   data);
+        NapiCallIntoModuleThrow(env, [&]() {
+          call_js_cb(env, js_callback, context, data);
+        });
       }
     }
   }
@@ -347,7 +346,9 @@ class ThreadSafeFunction : public node::AsyncResource {
     v8::HandleScope scope(env->isolate);
     if (finalize_cb) {
       CallbackScope cb_scope(this);
-      finalize_cb(env, finalize_data, context);
+      NapiCallIntoModuleThrow(env, [&]() {
+        finalize_cb(env, finalize_data, context);
+      });
     }
     EmptyQueueAndDelete();
   }


### PR DESCRIPTION
Use `NapiCallIntoModuleThrow()` to execute the call into JavaScript and
the finalizer for consistency with the rest of the calls into the N-API
addon.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
