### PR TITLE
build,v8: support IBM i

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -2536,16 +2536,24 @@
           },
         }],
         ['OS=="aix"', {
+          'variables': {
+            # Used to differentiate `AIX` and `OS400`(IBM i).
+            'aix_variant_name': '<!(uname -s)',
+          },
           'sources': [
             '<(V8_ROOT)/src/base/debug/stack_trace_posix.cc',
             '<(V8_ROOT)/src/base/platform/platform-aix.cc',
           ],
-          'link_settings': {
-            'libraries': [
-              '-ldl',
-              '-lrt'
-            ],
-          },
+          'conditions': [
+            [ '"<(aix_variant_name)"=="AIX"', { # It is `AIX`
+              'link_settings': {
+                'libraries': [
+                  '-ldl',
+                  '-lrt'
+                ],
+              },
+            }],
+          ],
         }],
         ['is_android', {
           'sources': [


### PR DESCRIPTION
On IBM i (OS400), some libraries do not exist.

Only tested on IBM i, may need some help for AIX test due to the code changes.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
