### PR TITLE
repl: fix repl .load

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1535,10 +1535,10 @@ function defineDefaultCommands(repl) {
     help: 'Save all evaluated commands in this REPL session to a file',
     action: function(file) {
       try {
-        fs.writeFileSync(file, this.lines.join('\n') + '\n');
-        this.outputStream.write('Session saved to: ' + file + '\n');
+        fs.writeFileSync(file, `${this.lines.join('\n')}\n`);
+        this.outputStream.write(`Session saved to: ${file}\n`);
       } catch {
-        this.outputStream.write('Failed to save: ' + file + '\n');
+        this.outputStream.write(`Failed to save: ${file}\n`);
       }
       this.displayPrompt();
     }
@@ -1548,23 +1548,24 @@ function defineDefaultCommands(repl) {
     help: 'Load JS from a file into the REPL session',
     action: function(file) {
       try {
-        var stats = fs.statSync(file);
+        const stats = fs.statSync(file);
         if (stats && stats.isFile()) {
           _turnOnEditorMode(this);
-          var data = fs.readFileSync(file, 'utf8');
-          var lines = data.split('\n');
-          for (var n = 0; n < lines.length; n++) {
-            if (lines[n])
-              this.write(`${lines[n]}\n`);
+          const data = fs.readFileSync(file, 'utf8');
+          if (data.endsWith('\n')) {
+            this.write(data.slice(0, -1));
+          } else {
+            this.write(data);
           }
           _turnOffEditorMode(this);
           this.write('\n');
         } else {
-          this.outputStream.write('Failed to load: ' + file +
-                                  ' is not a valid file\n');
+          this.outputStream.write(
+            `Failed to load: ${file} is not a valid file\n`
+          );
         }
       } catch {
-        this.outputStream.write('Failed to load: ' + file + '\n');
+        this.outputStream.write(`Failed to load: ${file}\n`);
       }
       this.displayPrompt();
     }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1535,7 +1535,7 @@ function defineDefaultCommands(repl) {
     help: 'Save all evaluated commands in this REPL session to a file',
     action: function(file) {
       try {
-        fs.writeFileSync(file, `${this.lines.join('\n')}\n`);
+        fs.writeFileSync(file, this.lines.join('\n'));
         this.outputStream.write(`Session saved to: ${file}\n`);
       } catch {
         this.outputStream.write(`Failed to save: ${file}\n`);
@@ -1552,11 +1552,7 @@ function defineDefaultCommands(repl) {
         if (stats && stats.isFile()) {
           _turnOnEditorMode(this);
           const data = fs.readFileSync(file, 'utf8');
-          if (data.endsWith('\n')) {
-            this.write(data.slice(0, -1));
-          } else {
-            this.write(data);
-          }
+          this.write(data);
           _turnOffEditorMode(this);
           this.write('\n');
         } else {

--- a/test/parallel/test-repl-load-multiline.js
+++ b/test/parallel/test-repl-load-multiline.js
@@ -16,6 +16,7 @@ const getLunch = () =>
 
 const placeOrder = (order) => Promise.resolve(order);
 const eat = (food) => '<nom nom nom>';
+
 undefined
 `;
 

--- a/test/parallel/test-repl-load-multiline.js
+++ b/test/parallel/test-repl-load-multiline.js
@@ -13,9 +13,9 @@ const expected = `${command}
 const getLunch = () =>
   placeOrder('tacos')
     .then(eat);
+
 const placeOrder = (order) => Promise.resolve(order);
 const eat = (food) => '<nom nom nom>';
-
 undefined
 `;
 

--- a/test/parallel/test-repl-pretty-custom-stack.js
+++ b/test/parallel/test-repl-pretty-custom-stack.js
@@ -5,6 +5,7 @@ const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const repl = require('repl');
 
+const stackRegExp = /repl:[0-9]+:[0-9]+/g;
 
 function run({ command, expected }) {
   let accum = '';
@@ -23,7 +24,10 @@ function run({ command, expected }) {
   });
 
   r.write(`${command}\n`);
-  assert.strictEqual(accum, expected);
+  assert.strictEqual(
+    accum.replace(stackRegExp, 'repl:*:*'),
+    expected.replace(stackRegExp, 'repl:*:*')
+  );
   r.close();
 }
 
@@ -44,8 +48,8 @@ const tests = [
   {
     // test .load for a file that throws
     command: `.load ${fixtures.path('repl-pretty-stack.js')}`,
-    expected: 'Thrown:\nError: Whoops!--->\nrepl:9:24--->\nd (repl:12:3)' +
-              '--->\nc (repl:9:3)--->\nb (repl:6:3)--->\na (repl:3:3)\n'
+    expected: 'Thrown:\nError: Whoops!--->\nrepl:*:*--->\nd (repl:*:*)' +
+              '--->\nc (repl:*:*)--->\nb (repl:*:*)--->\na (repl:*:*)\n'
   },
   {
     command: 'let x y;',
@@ -63,7 +67,7 @@ const tests = [
   // test anonymous IIFE
   {
     command: '(function() { throw new Error(\'Whoops!\'); })()',
-    expected: 'Thrown:\nError: Whoops!--->\nrepl:1:21\n'
+    expected: 'Thrown:\nError: Whoops!--->\nrepl:*:*\n'
   }
 ];
 

--- a/test/parallel/test-repl-pretty-stack.js
+++ b/test/parallel/test-repl-pretty-stack.js
@@ -5,6 +5,7 @@ const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const repl = require('repl');
 
+const stackRegExp = /(at .*repl:)[0-9]+:[0-9]+/g;
 
 function run({ command, expected, ...extraREPLOptions }) {
   let accum = '';
@@ -24,7 +25,10 @@ function run({ command, expected, ...extraREPLOptions }) {
   });
 
   r.write(`${command}\n`);
-  assert.strictEqual(accum, expected);
+  assert.strictEqual(
+    accum.replace(stackRegExp, '$1*:*'),
+    expected.replace(stackRegExp, '$1*:*')
+  );
   r.close();
 }
 
@@ -32,9 +36,9 @@ const tests = [
   {
     // Test .load for a file that throws.
     command: `.load ${fixtures.path('repl-pretty-stack.js')}`,
-    expected: 'Thrown:\nError: Whoops!\n    at repl:9:24\n' +
-              '    at d (repl:12:3)\n    at c (repl:9:3)\n' +
-              '    at b (repl:6:3)\n    at a (repl:3:3)\n'
+    expected: 'Thrown:\nError: Whoops!\n    at repl:*:*\n' +
+              '    at d (repl:*:*)\n    at c (repl:*:*)\n' +
+              '    at b (repl:*:*)\n    at a (repl:*:*)\n'
   },
   {
     command: 'let x y;',
@@ -48,12 +52,12 @@ const tests = [
   {
     command: '(() => { const err = Error(\'Whoops!\'); ' +
              'err.foo = \'bar\'; throw err; })()',
-    expected: "Thrown:\nError: Whoops!\n    at repl:1:22 {\n  foo: 'bar'\n}\n",
+    expected: "Thrown:\nError: Whoops!\n    at repl:*:* {\n  foo: 'bar'\n}\n",
   },
   {
     command: '(() => { const err = Error(\'Whoops!\'); ' +
              'err.foo = \'bar\'; throw err; })()',
-    expected: 'Thrown:\nError: Whoops!\n    at repl:1:22 {\n  foo: ' +
+    expected: 'Thrown:\nError: Whoops!\n    at repl:*:* {\n  foo: ' +
               "\u001b[32m'bar'\u001b[39m\n}\n",
     useColors: true
   },
@@ -64,7 +68,7 @@ const tests = [
   // Test anonymous IIFE.
   {
     command: '(function() { throw new Error(\'Whoops!\'); })()',
-    expected: 'Thrown:\nError: Whoops!\n    at repl:1:21\n'
+    expected: 'Thrown:\nError: Whoops!\n    at repl:*:*\n'
   }
 ];
 

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const join = require('path').join;
@@ -57,13 +57,13 @@ putIn.run([`.save ${saveFileName}`]);
 
 // The file should have what I wrote.
 assert.strictEqual(fs.readFileSync(saveFileName, 'utf8'),
-                   `${testFile.join('\n')}\n`);
+                   testFile.join('\n'));
 
 // Make sure that the REPL data is "correct".
-testMe.complete('inner.o', function(error, data) {
+testMe.complete('inner.o', common.mustCall(function(error, data) {
   assert.ifError(error);
   assert.deepStrictEqual(data, works);
-});
+}));
 
 // Clear the REPL.
 putIn.run(['.clear']);
@@ -72,10 +72,10 @@ putIn.run(['.clear']);
 putIn.run([`.load ${saveFileName}`]);
 
 // Make sure that the REPL data is "correct".
-testMe.complete('inner.o', function(error, data) {
+testMe.complete('inner.o', common.mustCall(function(error, data) {
   assert.ifError(error);
   assert.deepStrictEqual(data, works);
-});
+}));
 
 // Clear the REPL.
 putIn.run(['.clear']);
@@ -83,20 +83,20 @@ putIn.run(['.clear']);
 let loadFile = join(tmpdir.path, 'file.does.not.exist');
 
 // Should not break.
-putIn.write = function(data) {
+putIn.write = common.mustCall(function(data) {
   // Make sure I get a failed to load message and not some crazy error.
   assert.strictEqual(data, `Failed to load: ${loadFile}\n`);
   // Eat me to avoid work.
   putIn.write = () => {};
-};
+});
 putIn.run([`.load ${loadFile}`]);
 
 // Throw error on loading directory.
 loadFile = tmpdir.path;
-putIn.write = function(data) {
+putIn.write = common.mustCall(function(data) {
   assert.strictEqual(data, `Failed to load: ${loadFile} is not a valid file\n`);
   putIn.write = () => {};
-};
+});
 putIn.run([`.load ${loadFile}`]);
 
 // Clear the REPL.
@@ -107,12 +107,12 @@ putIn.run(['.clear']);
 const invalidFileName = join(tmpdir.path, '\0\0\0\0\0');
 
 // Should not break.
-putIn.write = function(data) {
+putIn.write = common.mustCall(function(data) {
   // Make sure I get a failed to save message and not some other error.
   assert.strictEqual(data, `Failed to save: ${invalidFileName}\n`);
   // Reset to no-op.
   putIn.write = () => {};
-};
+});
 
 // Save it to a file.
 putIn.run([`.save ${invalidFileName}`]);
@@ -134,5 +134,5 @@ putIn.run([`.save ${invalidFileName}`]);
   putIn.run([`.save ${saveFileName}`]);
   replServer.close();
   assert.strictEqual(fs.readFileSync(saveFileName, 'utf8'),
-                     `${cmds.join('\n')}\n\n`);
+                     `${cmds.join('\n')}\n`);
 }

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -36,6 +36,12 @@ const works = [['inner.one'], 'inner.o'];
 const putIn = new ArrayStream();
 const testMe = repl.start('', putIn);
 
+// Some errors might be passed to the domain.
+testMe._domain.on('error', function(reason) {
+  const err = new Error('Test failed');
+  err.reason = reason;
+  throw err;
+});
 
 const testFile = [
   'var top = function() {',
@@ -43,18 +49,76 @@ const testFile = [
 ];
 const saveFileName = join(tmpdir.path, 'test.save.js');
 
-// input some data
+// Add some data.
 putIn.run(testFile);
 
-// save it to a file
+// Save it to a file.
 putIn.run([`.save ${saveFileName}`]);
 
-// The file should have what I wrote
+// The file should have what I wrote.
 assert.strictEqual(fs.readFileSync(saveFileName, 'utf8'),
                    `${testFile.join('\n')}\n`);
 
+// Make sure that the REPL data is "correct".
+testMe.complete('inner.o', function(error, data) {
+  assert.ifError(error);
+  assert.deepStrictEqual(data, works);
+});
+
+// Clear the REPL.
+putIn.run(['.clear']);
+
+// Load the file back in.
+putIn.run([`.load ${saveFileName}`]);
+
+// Make sure that the REPL data is "correct".
+testMe.complete('inner.o', function(error, data) {
+  assert.ifError(error);
+  assert.deepStrictEqual(data, works);
+});
+
+// Clear the REPL.
+putIn.run(['.clear']);
+
+let loadFile = join(tmpdir.path, 'file.does.not.exist');
+
+// Should not break.
+putIn.write = function(data) {
+  // Make sure I get a failed to load message and not some crazy error.
+  assert.strictEqual(data, `Failed to load: ${loadFile}\n`);
+  // Eat me to avoid work.
+  putIn.write = () => {};
+};
+putIn.run([`.load ${loadFile}`]);
+
+// Throw error on loading directory.
+loadFile = tmpdir.path;
+putIn.write = function(data) {
+  assert.strictEqual(data, `Failed to load: ${loadFile} is not a valid file\n`);
+  putIn.write = () => {};
+};
+putIn.run([`.load ${loadFile}`]);
+
+// Clear the REPL.
+putIn.run(['.clear']);
+
+// NUL (\0) is disallowed in filenames in UNIX-like operating systems and
+// Windows so we can use that to test failed saves.
+const invalidFileName = join(tmpdir.path, '\0\0\0\0\0');
+
+// Should not break.
+putIn.write = function(data) {
+  // Make sure I get a failed to save message and not some other error.
+  assert.strictEqual(data, `Failed to save: ${invalidFileName}\n`);
+  // Reset to no-op.
+  putIn.write = () => {};
+};
+
+// Save it to a file.
+putIn.run([`.save ${invalidFileName}`]);
+
 {
-  // save .editor mode code
+  // Save .editor mode code.
   const cmds = [
     'function testSave() {',
     'return "saved";',
@@ -72,60 +136,3 @@ assert.strictEqual(fs.readFileSync(saveFileName, 'utf8'),
   assert.strictEqual(fs.readFileSync(saveFileName, 'utf8'),
                      `${cmds.join('\n')}\n\n`);
 }
-
-// Make sure that the REPL data is "correct"
-// so when I load it back I know I'm good
-testMe.complete('inner.o', function(error, data) {
-  assert.deepStrictEqual(data, works);
-});
-
-// clear the REPL
-putIn.run(['.clear']);
-
-// Load the file back in
-putIn.run([`.load ${saveFileName}`]);
-
-// Make sure that the REPL data is "correct"
-testMe.complete('inner.o', function(error, data) {
-  assert.deepStrictEqual(data, works);
-});
-
-// clear the REPL
-putIn.run(['.clear']);
-
-let loadFile = join(tmpdir.path, 'file.does.not.exist');
-
-// should not break
-putIn.write = function(data) {
-  // Make sure I get a failed to load message and not some crazy error
-  assert.strictEqual(data, `Failed to load:${loadFile}\n`);
-  // Eat me to avoid work
-  putIn.write = () => {};
-};
-putIn.run([`.load ${loadFile}`]);
-
-// Throw error on loading directory
-loadFile = tmpdir.path;
-putIn.write = function(data) {
-  assert.strictEqual(data, `Failed to load:${loadFile} is not a valid file\n`);
-  putIn.write = () => {};
-};
-putIn.run([`.load ${loadFile}`]);
-
-// clear the REPL
-putIn.run(['.clear']);
-
-// NUL (\0) is disallowed in filenames in UNIX-like operating systems and
-// Windows so we can use that to test failed saves
-const invalidFileName = join(tmpdir.path, '\0\0\0\0\0');
-
-// should not break
-putIn.write = function(data) {
-  // Make sure I get a failed to save message and not some other error
-  assert.strictEqual(data, `Failed to save:${invalidFileName}\n`);
-  // reset to no-op
-  putIn.write = () => {};
-};
-
-// save it to a file
-putIn.run([`.save ${invalidFileName}`]);


### PR DESCRIPTION
Please have a look at the individual commit messages for details.

Fixes: #28546

@nodejs/repl PTAL.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
