### PR TITLE
http: added closed property

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -553,6 +553,15 @@ changes:
 The `request.aborted` property will be `true` if the request has
 been aborted.
 
+### request.closed
+<!-- YAML
+added: CHANGEME
+-->
+
+* {boolean}
+
+The `request.closed` property indicates whether the request has been closed.
+
 ### request.connection
 <!-- YAML
 added: v0.3.0
@@ -1129,6 +1138,15 @@ response.end();
 
 Attempting to set a header field name or value that contains invalid characters
 will result in a [`TypeError`][] being thrown.
+
+### response.closed
+<!-- YAML
+added: CHANGEME
+-->
+
+* {boolean}
+
+The `response.closed` property indicates whether the response has been closed.
 
 ### response.connection
 <!-- YAML

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -191,6 +191,7 @@ function ClientRequest(input, options, cb) {
   this._ended = false;
   this.res = null;
   this.aborted = false;
+  this.closed = false;
   this.timeoutCb = null;
   this.upgradeOrConnect = false;
   this.parser = null;
@@ -358,14 +359,12 @@ function socketCloseListener() {
       res.aborted = true;
       res.emit('aborted');
     }
-    req.emit('close');
+    emitClose.call(req);
     if (res.readable) {
-      res.on('end', function() {
-        this.emit('close');
-      });
+      res.on('end', emitClose);
       res.push(null);
     } else {
-      res.emit('close');
+      emitClose.call(res);
     }
   } else {
     if (!req.socket._hadError) {
@@ -375,7 +374,7 @@ function socketCloseListener() {
       req.socket._hadError = true;
       req.emit('error', connResetException('socket hang up'));
     }
-    req.emit('close');
+    emitClose.call(req);
   }
 
   // Too bad.  That output wasn't getting written.
@@ -415,6 +414,11 @@ function socketErrorListener(err) {
   socket.removeListener('data', socketOnData);
   socket.removeListener('end', socketOnEnd);
   socket.destroy();
+}
+
+function emitClose() {
+  this.closed = true;
+  this.emit('close');
 }
 
 function freeSocketErrorListener(err) {
@@ -487,6 +491,7 @@ function socketOnData(d) {
       socket.readableFlowing = null;
 
       req.emit(eventName, res, socket, bodyHead);
+      req.closed = true;
       req.emit('close');
     } else {
       // Requested Upgrade or used CONNECT method, but have no handler.

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -56,6 +56,7 @@ function IncomingMessage(socket) {
   this.readable = true;
 
   this.aborted = false;
+  this.closed = false;
 
   this.upgrade = null;
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -96,6 +96,7 @@ function OutgoingMessage() {
   this._trailer = '';
 
   this.finished = false;
+  this.closed = false;
   this._headerSent = false;
   this[kIsCorked] = false;
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -178,7 +178,9 @@ function onServerResponseClose() {
   // Ergo, we need to deal with stale 'close' events and handle the case
   // where the ServerResponse object has already been deconstructed.
   // Fortunately, that requires only a single if check. :-)
-  if (this._httpMessage) this._httpMessage.emit('close');
+  if (this._httpMessage) {
+    emitClose.call(this._httpMessage);
+  }
 }
 
 ServerResponse.prototype.assignSocket = function assignSocket(socket) {
@@ -469,7 +471,7 @@ function abortIncoming(incoming) {
     var req = incoming.shift();
     req.aborted = true;
     req.emit('aborted');
-    req.emit('close');
+    emitClose.call(req);
   }
   // Abort socket._httpMessage ?
 }
@@ -594,6 +596,11 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
   }
 }
 
+function emitClose() {
+  this.closed = true;
+  this.emit('close');
+}
+
 function resOnFinish(req, res, socket, state, server) {
   // Usually the first incoming element should be our request.  it may
   // be that in the case abortIncoming() was called that the incoming
@@ -609,7 +616,8 @@ function resOnFinish(req, res, socket, state, server) {
     req._dump();
 
   res.detachSocket(socket);
-  req.emit('close');
+  res.closed = true;
+  emitClose.call(req);
   process.nextTick(emitCloseNT, res);
 
   if (res._last) {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -297,6 +297,10 @@ class Http2ServerRequest extends Readable {
     this.on('resume', onRequestResume);
   }
 
+  get closed() {
+    return this[kState].closed;
+  }
+
   get aborted() {
     return this[kAborted];
   }
@@ -444,6 +448,10 @@ class Http2ServerResponse extends Stream {
     stream.on('close', onStreamCloseResponse);
     stream.on('wantTrailers', onStreamTrailersReady);
     stream.on('timeout', onStreamTimeout(kResponse));
+  }
+
+  get closed() {
+    return this[kState].closed;
   }
 
   // User land modules such as finalhandler just check truthiness of this

--- a/test/parallel/test-http-client-close-event.js
+++ b/test/parallel/test-http-client-close-event.js
@@ -23,6 +23,7 @@ server.listen(0, common.mustCall(() => {
 
   req.on('close', common.mustCall(() => {
     assert.strictEqual(errorEmitted, true);
+    assert.strictEqual(req.closed, true);
     server.close();
   }));
 

--- a/test/parallel/test-http-req-res-close.js
+++ b/test/parallel/test-http-req-res-close.js
@@ -5,16 +5,15 @@ const http = require('http');
 const assert = require('assert');
 
 const server = http.Server(common.mustCall((req, res) => {
-  let resClosed = false;
-
   res.end();
   res.on('finish', common.mustCall(() => {
-    assert.strictEqual(resClosed, false);
+    assert.strictEqual(res.closed, false);
   }));
   res.on('close', common.mustCall(() => {
-    resClosed = true;
+    assert.strictEqual(res.closed, true);
   }));
   req.on('close', common.mustCall(() => {
+    assert.strictEqual(req.closed, true);
     assert.strictEqual(req._readableState.ended, true);
   }));
   res.socket.on('close', () => server.close());

--- a/test/parallel/test-http-response-close.js
+++ b/test/parallel/test-http-response-close.js
@@ -22,6 +22,7 @@
 'use strict';
 const common = require('../common');
 const http = require('http');
+const assert = require('assert');
 
 {
   const server = http.createServer(
@@ -40,6 +41,7 @@ const http = require('http');
             res.destroy();
           }));
           res.on('close', common.mustCall(() => {
+            assert.strictEqual(res.closed, true);
             server.close();
           }));
         })


### PR DESCRIPTION
This is an alternative to `finished` and `onFinished.isFinished` to more accurately indicate when a request/response has completed.

With this PR the frequently used `on-finished` npm package should no longer be necessary as the "same" (assumed) functionality can be achieved using the `'close'` event and `closed` property.

Refs: https://github.com/nodejs/node/issues/28412

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
