### PR TITLE
doc: add missing types

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -499,6 +499,8 @@ Return the value of `highWaterMark` passed when constructing this
 added: v9.4.0
 -->
 
+* {number}
+
 This property contains the number of bytes (or objects) in the queue
 ready to be written. The value provides introspection data regarding
 the status of the `highWaterMark`.
@@ -517,6 +519,8 @@ the [`'finish'`][] event has been emitted.
 <!-- YAML
 added: v12.3.0
 -->
+
+* {boolean}
 
 Getter for the property `objectMode` of a given `Writable` stream.
 
@@ -1111,6 +1115,8 @@ the status of the `highWaterMark`.
 <!-- YAML
 added: v12.3.0
 -->
+
+* {boolean}
 
 Getter for the property `objectMode` of a given `Readable` stream.
 


### PR DESCRIPTION
Document the types returned by the `readable.readableObjectMode`,
`writable.writableLength`, and `writable.writableObjectMode` getters.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
