### PR TITLE
tools: add coverage to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ _UpgradeReport_Files/
 # coverage related
 /gcovr
 /build
+/coverage
 
 # === Rules for XCode artifacts ===
 *.xcodeproj


### PR DESCRIPTION
This adds the coverage directory to the .gitignore file.

I noticed that when i ran the build with coverage enabled,  the coverage directory was not being ignored by git.  This adds that directory

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
