### PR TITLE
http2: compat req.complete

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -302,7 +302,8 @@ class Http2ServerRequest extends Readable {
   }
 
   get complete() {
-    return this._readableState.ended ||
+    return this[kAborted] ||
+           this._readableState.ended ||
            this[kState].closed ||
            this[kStream].destroyed;
   }

--- a/test/parallel/test-http2-compat-aborted.js
+++ b/test/parallel/test-http2-compat-aborted.js
@@ -10,8 +10,10 @@ const assert = require('assert');
 const server = h2.createServer(common.mustCall(function(req, res) {
   req.on('aborted', common.mustCall(function() {
     assert.strictEqual(this.aborted, true);
+    assert.strictEqual(this.complete, true);
   }));
   assert.strictEqual(req.aborted, false);
+  assert.strictEqual(req.complete, false);
   res.write('hello');
   server.close();
 }));


### PR DESCRIPTION
Note sure exactly what the `req.complete` property is supposed to indicate. However, if it is what I assume it is then I think it's missing a check for `aborted`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

ping @apapirovski 