### PR TITLE
http: add complete property

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -553,6 +553,15 @@ changes:
 The `request.aborted` property will be `true` if the request has
 been aborted.
 
+### request.closed
+<!-- YAML
+added: CHANGEME
+-->
+
+* {boolean}
+
+The `request.closed` property indicates whether the request has been closed.
+
 ### request.connection
 <!-- YAML
 added: v0.3.0
@@ -1129,6 +1138,15 @@ response.end();
 
 Attempting to set a header field name or value that contains invalid characters
 will result in a [`TypeError`][] being thrown.
+
+### response.closed
+<!-- YAML
+added: CHANGEME
+-->
+
+* {boolean}
+
+The `response.closed` property indicates whether the response has been closed.
 
 ### response.connection
 <!-- YAML

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -298,6 +298,16 @@ function ClientRequest(input, options, cb) {
 Object.setPrototypeOf(ClientRequest.prototype, OutgoingMessage.prototype);
 Object.setPrototypeOf(ClientRequest, OutgoingMessage);
 
+Object.defineProperty(ClientRequest.prototype, 'complete', {
+  get() {
+    return Boolean(
+      this.finished ||
+      this.aborted ||
+      this.closed
+    );
+  }
+});
+
 ClientRequest.prototype._finish = function _finish() {
   DTRACE_HTTP_CLIENT_REQUEST(this, this.connection);
   OutgoingMessage.prototype._finish.call(this);

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -191,6 +191,7 @@ function ClientRequest(input, options, cb) {
   this._ended = false;
   this.res = null;
   this.aborted = false;
+  this.closed = false;
   this.timeoutCb = null;
   this.upgradeOrConnect = false;
   this.parser = null;
@@ -358,13 +359,16 @@ function socketCloseListener() {
       res.aborted = true;
       res.emit('aborted');
     }
+    req.closed = true;
     req.emit('close');
     if (res.readable) {
       res.on('end', function() {
+        this.closed = true;
         this.emit('close');
       });
       res.push(null);
     } else {
+      res.closed = true;
       res.emit('close');
     }
   } else {
@@ -375,6 +379,7 @@ function socketCloseListener() {
       req.socket._hadError = true;
       req.emit('error', connResetException('socket hang up'));
     }
+    req.closed = true;
     req.emit('close');
   }
 
@@ -487,6 +492,7 @@ function socketOnData(d) {
       socket.readableFlowing = null;
 
       req.emit(eventName, res, socket, bodyHead);
+      req.closed = true;
       req.emit('close');
     } else {
       // Requested Upgrade or used CONNECT method, but have no handler.

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -56,6 +56,7 @@ function IncomingMessage(socket) {
   this.readable = true;
 
   this.aborted = false;
+  this.closed = false;
 
   this.upgrade = null;
 

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -77,6 +77,16 @@ function IncomingMessage(socket) {
 Object.setPrototypeOf(IncomingMessage.prototype, Stream.Readable.prototype);
 Object.setPrototypeOf(IncomingMessage, Stream.Readable);
 
+Object.defineProperty(IncomingMessage.prototype, 'complete', {
+  get() {
+    return Boolean(
+      this.finished ||
+      this.aborted ||
+      this.closed
+    );
+  }
+});
+
 IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
   if (callback)
     this.on('timeout', callback);

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -110,6 +110,14 @@ function OutgoingMessage() {
 Object.setPrototypeOf(OutgoingMessage.prototype, Stream.prototype);
 Object.setPrototypeOf(OutgoingMessage, Stream);
 
+Object.defineProperty(OutgoingMessage.prototype, 'complete', {
+  get() {
+    return Boolean(
+      this.finished ||
+      this.closed
+    );
+  }
+});
 
 Object.defineProperty(OutgoingMessage.prototype, '_headers', {
   get: internalUtil.deprecate(function() {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -96,6 +96,7 @@ function OutgoingMessage() {
   this._trailer = '';
 
   this.finished = false;
+  this.closed = false;
   this._headerSent = false;
   this[kIsCorked] = false;
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -178,7 +178,10 @@ function onServerResponseClose() {
   // Ergo, we need to deal with stale 'close' events and handle the case
   // where the ServerResponse object has already been deconstructed.
   // Fortunately, that requires only a single if check. :-)
-  if (this._httpMessage) this._httpMessage.emit('close');
+  if (this._httpMessage) {
+    this._httpMessage.closed = true;
+    this._httpMessage.emit('close');
+  }
 }
 
 ServerResponse.prototype.assignSocket = function assignSocket(socket) {
@@ -468,6 +471,7 @@ function abortIncoming(incoming) {
   while (incoming.length) {
     var req = incoming.shift();
     req.aborted = true;
+    req.closed = true;
     req.emit('aborted');
     req.emit('close');
   }
@@ -609,6 +613,7 @@ function resOnFinish(req, res, socket, state, server) {
     req._dump();
 
   res.detachSocket(socket);
+  req.closed = true;
   req.emit('close');
   process.nextTick(emitCloseNT, res);
 
@@ -633,6 +638,7 @@ function resOnFinish(req, res, socket, state, server) {
 }
 
 function emitCloseNT(self) {
+  self.closed = true;
   self.emit('close');
 }
 

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -297,6 +297,10 @@ class Http2ServerRequest extends Readable {
     this.on('resume', onRequestResume);
   }
 
+  get closed() {
+    return this[kState].closed;
+  }
+
   get aborted() {
     return this[kAborted];
   }
@@ -444,6 +448,10 @@ class Http2ServerResponse extends Stream {
     stream.on('close', onStreamCloseResponse);
     stream.on('wantTrailers', onStreamTrailersReady);
     stream.on('timeout', onStreamTimeout(kResponse));
+  }
+
+  get closed() {
+    return this[kState].closed;
   }
 
   // User land modules such as finalhandler just check truthiness of this

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -306,7 +306,8 @@ class Http2ServerRequest extends Readable {
   }
 
   get complete() {
-    return this._readableState.ended ||
+    return this[kAborted] ||
+           this._readableState.ended ||
            this[kState].closed ||
            this[kStream].destroyed;
   }
@@ -452,6 +453,12 @@ class Http2ServerResponse extends Stream {
 
   get closed() {
     return this[kState].closed;
+  }
+
+  get complete() {
+    return this._writableState.ended ||
+           this[kState].closed ||
+           this[kStream].destroyed;
   }
 
   // User land modules such as finalhandler just check truthiness of this

--- a/test/parallel/test-http-client-close-event.js
+++ b/test/parallel/test-http-client-close-event.js
@@ -23,6 +23,7 @@ server.listen(0, common.mustCall(() => {
 
   req.on('close', common.mustCall(() => {
     assert.strictEqual(errorEmitted, true);
+    assert.strictEqual(req.closed, true);
     server.close();
   }));
 

--- a/test/parallel/test-http-connect-req-res.js
+++ b/test/parallel/test-http-connect-req-res.js
@@ -33,7 +33,9 @@ server.listen(0, common.mustCall(function() {
     path: 'example.com:443'
   }, common.mustNotCall());
 
-  req.on('close', common.mustCall());
+  req.on('close', common.mustCall(() => {
+    assert.strictEqual(req.closed, true);
+  }));
 
   req.on('connect', common.mustCall(function(res, socket, firstBodyChunk) {
     console.error('Client got CONNECT request');

--- a/test/parallel/test-http-req-res-close.js
+++ b/test/parallel/test-http-req-res-close.js
@@ -5,16 +5,13 @@ const http = require('http');
 const assert = require('assert');
 
 const server = http.Server(common.mustCall((req, res) => {
-  let resClosed = false;
-
   res.end();
-  res.on('finish', common.mustCall(() => {
-    assert.strictEqual(resClosed, false);
-  }));
+  res.on('finish', common.mustCall());
   res.on('close', common.mustCall(() => {
-    resClosed = true;
+    assert.strictEqual(res.closed, true);
   }));
   req.on('close', common.mustCall(() => {
+    assert.strictEqual(req.closed, true);
     assert.strictEqual(req._readableState.ended, true);
   }));
   res.socket.on('close', () => server.close());

--- a/test/parallel/test-http-response-close.js
+++ b/test/parallel/test-http-response-close.js
@@ -22,6 +22,7 @@
 'use strict';
 const common = require('../common');
 const http = require('http');
+const assert = require('assert');
 
 {
   const server = http.createServer(
@@ -40,6 +41,7 @@ const http = require('http');
             res.destroy();
           }));
           res.on('close', common.mustCall(() => {
+            assert.strictEqual(res.closed, true);
             server.close();
           }));
         })


### PR DESCRIPTION
This is a suggestion to add a `complete` property to http request and response to indicate that no further work can/should be performed on the instance.

I believe this is a better alternative to the current `finished` property which I believe is currently incorrectly used in a lot of scenarios.

Depends on https://github.com/nodejs/node/pull/28621 and https://github.com/nodejs/node/pull/28627 which should probably first be merged.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
