### PR TITLE
src: add cleanup hook for ContextifyContext

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -114,6 +114,19 @@ ContextifyContext::ContextifyContext(
 
   context_.Reset(env->isolate(), v8_context.ToLocalChecked());
   context_.SetWeak(this, WeakCallback, WeakCallbackType::kParameter);
+  env->AddCleanupHook(CleanupHook, this);
+}
+
+
+ContextifyContext::~ContextifyContext() {
+  env()->RemoveCleanupHook(CleanupHook, this);
+}
+
+
+void ContextifyContext::CleanupHook(void* arg) {
+  ContextifyContext* self = static_cast<ContextifyContext*>(arg);
+  self->context_.Reset();
+  delete self;
 }
 
 

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -22,6 +22,8 @@ class ContextifyContext {
   ContextifyContext(Environment* env,
                     v8::Local<v8::Object> sandbox_obj,
                     const ContextOptions& options);
+  ~ContextifyContext();
+  static void CleanupHook(void* arg);
 
   v8::MaybeLocal<v8::Object> CreateDataWrapper(Environment* env);
   v8::MaybeLocal<v8::Context> CreateV8Context(Environment* env,


### PR DESCRIPTION
Otherwise there’s a memory leak left by the context when the Isolate
tears down without having run the weak callback.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
