### PR TITLE
readline: use named constant for surrogate checks

### DIFF
--- a/lib/internal/readline.js
+++ b/lib/internal/readline.js
@@ -8,7 +8,7 @@
 const ansi =
   /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
 /* eslint-enable no-control-regex */
-
+const kUTF16SurrogateThreshold = 0x10000; // 2 ** 16
 const kEscape = '\x1b';
 
 let getStringWidth;
@@ -63,7 +63,7 @@ if (internalBinding('config').hasIntl) {
     for (var i = 0; i < str.length; i++) {
       const code = str.codePointAt(i);
 
-      if (code >= 0x10000) { // surrogates
+      if (code >= kUTF16SurrogateThreshold) { // Surrogates.
         i++;
       }
 
@@ -434,6 +434,7 @@ module.exports = {
   emitKeys,
   getStringWidth,
   isFullWidthCodePoint,
+  kUTF16SurrogateThreshold,
   stripVTControlCharacters,
   CSI
 };

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -41,6 +41,7 @@ const {
   emitKeys,
   getStringWidth,
   isFullWidthCodePoint,
+  kUTF16SurrogateThreshold,
   stripVTControlCharacters
 } = require('internal/readline');
 
@@ -600,8 +601,8 @@ Interface.prototype._wordRight = function() {
 function charLengthLeft(str, i) {
   if (i <= 0)
     return 0;
-  if (i > 1 && str.codePointAt(i - 2) >= 2 ** 16 ||
-      str.codePointAt(i - 1) >= 2 ** 16) {
+  if (i > 1 && str.codePointAt(i - 2) >= kUTF16SurrogateThreshold ||
+      str.codePointAt(i - 1) >= kUTF16SurrogateThreshold) {
     return 2;
   }
   return 1;
@@ -610,7 +611,7 @@ function charLengthLeft(str, i) {
 function charLengthAt(str, i) {
   if (str.length <= i)
     return 0;
-  return str.codePointAt(i) >= 2 ** 16 ? 2 : 1;
+  return str.codePointAt(i) >= kUTF16SurrogateThreshold ? 2 : 1;
 }
 
 Interface.prototype._deleteLeft = function() {
@@ -728,7 +729,7 @@ Interface.prototype._getDisplayPos = function(str) {
   str = stripVTControlCharacters(str);
   for (var i = 0, len = str.length; i < len; i++) {
     code = str.codePointAt(i);
-    if (code >= 0x10000) { // surrogates
+    if (code >= kUTF16SurrogateThreshold) { // Surrogates.
       i++;
     }
     if (code === 0x0a) { // new line \n


### PR DESCRIPTION
This commit defines a named constant instead of using a mix of `2 ** 16` and `0x10000` throughout the code.

This is just https://github.com/nodejs/node/pull/28407/commits/9ff7ccb798a096b139313023afb400495ae6ed23, extracted from https://github.com/nodejs/node/pull/28407.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
