### PR TITLE
readline: remove IIFE in SIGCONT handler

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -939,22 +939,20 @@ Interface.prototype._ttyWrite = function(s, key) {
         if (this.listenerCount('SIGTSTP') > 0) {
           this.emit('SIGTSTP');
         } else {
-          process.once('SIGCONT', (function continueProcess(self) {
-            return function() {
-              // Don't raise events if stream has already been abandoned.
-              if (!self.paused) {
-                // Stream must be paused and resumed after SIGCONT to catch
-                // SIGINT, SIGTSTP, and EOF.
-                self.pause();
-                self.emit('SIGCONT');
-              }
-              // Explicitly re-enable "raw mode" and move the cursor to
-              // the correct position.
-              // See https://github.com/joyent/node/issues/3295.
-              self._setRawMode(true);
-              self._refreshLine();
-            };
-          })(this));
+          process.once('SIGCONT', () => {
+            // Don't raise events if stream has already been abandoned.
+            if (!this.paused) {
+              // Stream must be paused and resumed after SIGCONT to catch
+              // SIGINT, SIGTSTP, and EOF.
+              this.pause();
+              this.emit('SIGCONT');
+            }
+            // Explicitly re-enable "raw mode" and move the cursor to
+            // the correct position.
+            // See https://github.com/joyent/node/issues/3295.
+            this._setRawMode(true);
+            this._refreshLine();
+          });
           this._setRawMode(false);
           process.kill(process.pid, 'SIGTSTP');
         }


### PR DESCRIPTION
This commit removes an IIFE in the readline `'SIGCONT'` handler that was previously being used to bind `this`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
