### PR TITLE
readline: simplify isFullWidthCodePoint()

### DIFF
--- a/lib/internal/readline.js
+++ b/lib/internal/readline.js
@@ -82,48 +82,38 @@ if (internalBinding('config').hasIntl) {
    * Unicode code point is full-width. Otherwise returns false.
    */
   isFullWidthCodePoint = function isFullWidthCodePoint(code) {
-    if (!Number.isInteger(code)) {
-      return false;
-    }
-
     // Code points are derived from:
     // http://www.unicode.org/Public/UNIDATA/EastAsianWidth.txt
-    if (
-      code >= 0x1100 && (
-        code <= 0x115f ||  // Hangul Jamo
-        code === 0x2329 || // LEFT-POINTING ANGLE BRACKET
-        code === 0x232a || // RIGHT-POINTING ANGLE BRACKET
-        // CJK Radicals Supplement .. Enclosed CJK Letters and Months
-        code >= 0x2e80 && code <= 0x3247 && code !== 0x303f ||
-        // Enclosed CJK Letters and Months .. CJK Unified Ideographs Extension A
-        code >= 0x3250 && code <= 0x4dbf ||
-        // CJK Unified Ideographs .. Yi Radicals
-        code >= 0x4e00 && code <= 0xa4c6 ||
-        // Hangul Jamo Extended-A
-        code >= 0xa960 && code <= 0xa97c ||
-        // Hangul Syllables
-        code >= 0xac00 && code <= 0xd7a3 ||
-        // CJK Compatibility Ideographs
-        code >= 0xf900 && code <= 0xfaff ||
-        // Vertical Forms
-        code >= 0xfe10 && code <= 0xfe19 ||
-        // CJK Compatibility Forms .. Small Form Variants
-        code >= 0xfe30 && code <= 0xfe6b ||
-        // Halfwidth and Fullwidth Forms
-        code >= 0xff01 && code <= 0xff60 ||
-        code >= 0xffe0 && code <= 0xffe6 ||
-        // Kana Supplement
-        code >= 0x1b000 && code <= 0x1b001 ||
-        // Enclosed Ideographic Supplement
-        code >= 0x1f200 && code <= 0x1f251 ||
-        // CJK Unified Ideographs Extension B .. Tertiary Ideographic Plane
-        code >= 0x20000 && code <= 0x3fffd
-      )
-    ) {
-      return true;
-    }
-
-    return false;
+    return Number.isInteger(code) && code >= 0x1100 && (
+      code <= 0x115f ||  // Hangul Jamo
+      code === 0x2329 || // LEFT-POINTING ANGLE BRACKET
+      code === 0x232a || // RIGHT-POINTING ANGLE BRACKET
+      // CJK Radicals Supplement .. Enclosed CJK Letters and Months
+      code >= 0x2e80 && code <= 0x3247 && code !== 0x303f ||
+      // Enclosed CJK Letters and Months .. CJK Unified Ideographs Extension A
+      code >= 0x3250 && code <= 0x4dbf ||
+      // CJK Unified Ideographs .. Yi Radicals
+      code >= 0x4e00 && code <= 0xa4c6 ||
+      // Hangul Jamo Extended-A
+      code >= 0xa960 && code <= 0xa97c ||
+      // Hangul Syllables
+      code >= 0xac00 && code <= 0xd7a3 ||
+      // CJK Compatibility Ideographs
+      code >= 0xf900 && code <= 0xfaff ||
+      // Vertical Forms
+      code >= 0xfe10 && code <= 0xfe19 ||
+      // CJK Compatibility Forms .. Small Form Variants
+      code >= 0xfe30 && code <= 0xfe6b ||
+      // Halfwidth and Fullwidth Forms
+      code >= 0xff01 && code <= 0xff60 ||
+      code >= 0xffe0 && code <= 0xffe6 ||
+      // Kana Supplement
+      code >= 0x1b000 && code <= 0x1b001 ||
+      // Enclosed Ideographic Supplement
+      code >= 0x1f200 && code <= 0x1f251 ||
+      // CJK Unified Ideographs Extension B .. Tertiary Ideographic Plane
+      code >= 0x20000 && code <= 0x3fffd
+    );
   };
 }
 


### PR DESCRIPTION
The non-ICU-based `isFullWidthCodePoint()` can be simplified to a single `return` statement. This commit removes the extra branching logic.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
