### PR TITLE
doc: mark N-API thread-safe function stable

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -4542,8 +4542,6 @@ NAPI_EXTERN napi_status napi_get_uv_event_loop(napi_env env,
 <!--lint disable no-unused-definitions remark-lint-->
 ## Asynchronous Thread-safe Function Calls
 
-> Stability: 1 - Experimental
-
 JavaScript functions can normally only be called from a native addon's main
 thread. If an addon creates additional threads, then N-API functions that
 require a `napi_env`, `napi_value`, or `napi_ref` must not be called from those


### PR DESCRIPTION
The various* TSFN APIs are marked as stable, but the TSFN heading itself
is still marked as experimental.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

* fixed typo in commit message