### PR TITLE
http2: report memory allocated by nghttp2 to V8

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -561,9 +561,10 @@ class Http2Session::MemoryAllocatorInfo {
       // current_nghttp2_memory_ + AdjustAmountOfExternalAllocatedMemory
       // and provide versions of our memory allocation utilities that take an
       // Environment*/Isolate* parameter and call the V8 method transparently.
-      session->current_nghttp2_memory_ += size - previous_size;
+      const int64_t new_size = size - previous_size;
+      session->current_nghttp2_memory_ += new_size;
       session->env()->isolate()->AdjustAmountOfExternalAllocatedMemory(
-          static_cast<int64_t>(size - previous_size));
+          new_size);
       *reinterpret_cast<size_t*>(mem) = size;
       mem += sizeof(size_t);
     } else if (size == 0) {

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -557,11 +557,19 @@ class Http2Session::MemoryAllocatorInfo {
 
     if (mem != nullptr) {
       // Adjust the memory info counter.
+      // TODO(addaleax): Avoid the double bookkeeping we do with
+      // current_nghttp2_memory_ + AdjustAmountOfExternalAllocatedMemory
+      // and provide versions of our memory allocation utilities that take an
+      // Environment*/Isolate* parameter and call the V8 method transparently.
       session->current_nghttp2_memory_ += size - previous_size;
+      session->env()->isolate()->AdjustAmountOfExternalAllocatedMemory(
+          static_cast<int64_t>(size - previous_size));
       *reinterpret_cast<size_t*>(mem) = size;
       mem += sizeof(size_t);
     } else if (size == 0) {
       session->current_nghttp2_memory_ -= previous_size;
+      session->env()->isolate()->AdjustAmountOfExternalAllocatedMemory(
+          -static_cast<int64_t>(previous_size));
     }
 
     return mem;
@@ -571,6 +579,8 @@ class Http2Session::MemoryAllocatorInfo {
     size_t* original_ptr = reinterpret_cast<size_t*>(
         static_cast<char*>(ptr) - sizeof(size_t));
     session->current_nghttp2_memory_ -= *original_ptr;
+    session->env()->isolate()->AdjustAmountOfExternalAllocatedMemory(
+        -static_cast<int64_t>(*original_ptr));
     *original_ptr = 0;
   }
 


### PR DESCRIPTION
This helps the JS engine have a better understanding of the memory
situation in HTTP/2-heavy applications, and avoids situations that
behave like memory leaks due to previous underestimation of memory
usage which is tied to JS objects.

Refs: https://github.com/nodejs/node/issues/28088#issuecomment-509965105

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
