### PR TITLE
http: reset parser.incoming when server response is finished

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -603,6 +603,7 @@ function resOnFinish(req, res, socket, state, server) {
   assert(state.incoming.length === 0 || state.incoming[0] === req);
 
   state.incoming.shift();
+  if (socket.parser) socket.parser.incoming = null;
 
   // If the user never called req.read(), and didn't pipe() or
   // .resume() or .on('data'), then we call req._dump() so that the

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -603,6 +603,7 @@ function resOnFinish(req, res, socket, state, server) {
   assert(state.incoming.length === 0 || state.incoming[0] === req);
 
   state.incoming.shift();
+  // Reset the .incoming property so that the request object can be gc'ed.
   if (socket.parser) socket.parser.incoming = null;
 
   // If the user never called req.read(), and didn't pipe() or


### PR DESCRIPTION
This resolves a memory leak for keep-alive connections with a naïve approach.

Fixes: https://github.com/nodejs/node/issues/9668

/cc @nodejs/http, and in particular @bnoordhuis because you looked into this previously and said it was impossible, which makes me think that this might warrant some extra scrutiny :smile:

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
