### PR TITLE
deps: V8: backport d2ccc59

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.14',
+    'v8_embedder_string': '-node.15',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/snapshot/serializer.cc
+++ b/deps/v8/src/snapshot/serializer.cc
@@ -116,10 +116,12 @@ void Serializer::SerializeRootObject(Object object) {
 }
 
 #ifdef DEBUG
-void Serializer::PrintStack() {
+void Serializer::PrintStack() { PrintStack(std::cout); }
+
+void Serializer::PrintStack(std::ostream& out) {
   for (const auto o : stack_) {
-    o->Print();
-    PrintF("\n");
+    o.Print(out);
+    out << "\n";
   }
 }
 #endif  // DEBUG

--- a/deps/v8/src/snapshot/serializer.h
+++ b/deps/v8/src/snapshot/serializer.h
@@ -250,6 +250,7 @@ class Serializer : public SerializerDeserializer {
   void PushStack(HeapObject o) { stack_.push_back(o); }
   void PopStack() { stack_.pop_back(); }
   void PrintStack();
+  void PrintStack(std::ostream&);
 #endif  // DEBUG
 
   SerializerReferenceMap* reference_map() { return &reference_map_; }

--- a/deps/v8/src/snapshot/startup-serializer.cc
+++ b/deps/v8/src/snapshot/startup-serializer.cc
@@ -72,7 +72,16 @@ bool IsUnexpectedCodeObject(Isolate* isolate, HeapObject obj) {
 #endif  // DEBUG
 
 void StartupSerializer::SerializeObject(HeapObject obj) {
-  DCHECK(!obj->IsJSFunction());
+#ifdef DEBUG
+  if (obj.IsJSFunction()) {
+    v8::base::OS::PrintError("Reference stack:\n");
+    PrintStack(std::cerr);
+    obj.Print(std::cerr);
+    FATAL(
+        "JSFunction should be added through the context snapshot instead of "
+        "the isolate snapshot");
+  }
+#endif  // DEBUG
   DCHECK(!IsUnexpectedCodeObject(isolate(), obj));
 
   if (SerializeHotObject(obj)) return;


### PR DESCRIPTION
Original commit message:

    [snapshot] print reference stack for JSFunctions in the isolate snapshot

    This helps debugging incorrect usage of the SnapshotCreator API in
    debug mode.

    Change-Id: Ibd9db76a5f460cdf7ea6d14e865592ebaf69aeef
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1648240
    Reviewed-by: Yang Guo <yangguo@chromium.org>
    Commit-Queue: Yang Guo <yangguo@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#62095}

Refs: https://github.com/v8/v8/commit/d2ccc599c7a31838752350ae927e41bc386df414

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
