### PR TITLE
streams: end with data should emit write after end error

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -588,8 +588,11 @@ Writable.prototype.end = function(chunk, encoding, cb) {
   }
 
   // Ignore unnecessary end() calls.
-  if (!state.ending)
+  if (!state.ending) {
     endWritable(this, state, cb);
+  } else if (chunk) {
+    writeAfterEnd(this, cb);
+  }
 
   return this;
 };


### PR DESCRIPTION
Writing to stream using `end` while `ending` should emit write after end.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
