### PR TITLE
http: end with data should emit write after end error

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -620,17 +620,20 @@ OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
   return ret;
 };
 
+function writeAfterEnd(msg, callback) {
+  const err = new ERR_STREAM_WRITE_AFTER_END();
+  const triggerAsyncId = msg.socket ? msg.socket[async_id_symbol] : undefined;
+  defaultTriggerAsyncIdScope(triggerAsyncId,
+                             process.nextTick,
+                             writeAfterEndNT,
+                             msg,
+                             err,
+                             callback);
+}
+
 function write_(msg, chunk, encoding, callback, fromEnd) {
   if (msg.finished) {
-    const err = new ERR_STREAM_WRITE_AFTER_END();
-    const triggerAsyncId = msg.socket ? msg.socket[async_id_symbol] : undefined;
-    defaultTriggerAsyncIdScope(triggerAsyncId,
-                               process.nextTick,
-                               writeAfterEndNT,
-                               msg,
-                               err,
-                               callback);
-
+    writeAfterEnd(msg, callback);
     return true;
   }
 
@@ -724,17 +727,6 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     encoding = null;
   }
 
-  if (this.finished) {
-    if (typeof callback === 'function') {
-      if (!this.writableFinished) {
-        this.on('finish', callback);
-      } else {
-        callback(new ERR_STREAM_ALREADY_FINISHED('end'));
-      }
-    }
-    return this;
-  }
-
   if (this.socket) {
     this.socket.cork();
   }
@@ -743,6 +735,12 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     if (typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
       throw new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
     }
+
+    if (this.finished) {
+      writeAfterEnd(this, callback);
+      return this;
+    }
+
     if (!this._header) {
       if (typeof chunk === 'string')
         this._contentLength = Buffer.byteLength(chunk, encoding);
@@ -750,6 +748,15 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
         this._contentLength = chunk.length;
     }
     write_(this, chunk, encoding, null, true);
+  } else if (this.finished) {
+    if (typeof callback === 'function') {
+      if (!this.writableFinished) {
+        this.on('finish', callback);
+      } else {
+        callback(new ERR_STREAM_ALREADY_FINISHED('end'));
+      }
+    }
+    return this;
   } else if (!this._header) {
     this._contentLength = 0;
     this._implicitHeader();

--- a/test/parallel/test-http-server-write-end-after-end.js
+++ b/test/parallel/test-http-server-write-end-after-end.js
@@ -9,7 +9,7 @@ function handle(req, res) {
   res.on('error', common.mustCall((err) => {
     common.expectsError({
       code: 'ERR_STREAM_WRITE_AFTER_END',
-      type: Error
+      name: 'Error'
     })(err);
     server.close();
   }));

--- a/test/parallel/test-http-server-write-end-after-end.js
+++ b/test/parallel/test-http-server-write-end-after-end.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+
+const server = http.createServer(handle);
+
+function handle(req, res) {
+  res.on('error', common.mustCall((err) => {
+    common.expectsError({
+      code: 'ERR_STREAM_WRITE_AFTER_END',
+      type: Error
+    })(err);
+    server.close();
+  }));
+
+  res.write('hello');
+  res.end();
+
+  setImmediate(common.mustCall(() => {
+    res.end('world');
+  }));
+}
+
+server.listen(0, common.mustCall(() => {
+  http.get(`http://localhost:${server.address().port}`);
+}));


### PR DESCRIPTION
Calling `end()` with data while `ending` should trigger a write after end error.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
