### PR TITLE
http: don't error after http client response

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1717,6 +1717,11 @@ instance.setEncoding('utf8');
 An attempt was made to call [`stream.write()`][] after `stream.end()` has been
 called.
 
+<a id="ERR_REQUEST_WRITE_AFTER_RESPONSE"></a>
+### ERR_REQUEST_WRITE_AFTER_RESPONSE
+
+An attempt was made to call [`req.write()`][] after `'response'` has been emitted.
+
 <a id="ERR_STRING_TOO_LONG"></a>
 ### ERR_STRING_TOO_LONG
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -46,7 +46,8 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_HTTP_TOKEN,
   ERR_INVALID_PROTOCOL,
-  ERR_UNESCAPED_CHARACTERS
+  ERR_UNESCAPED_CHARACTERS,
+  ERR_REQUEST_WRITE_AFTER_RESPONSE
 } = codes;
 const { getTimerDuration } = require('internal/timers');
 const {
@@ -300,6 +301,22 @@ Object.setPrototypeOf(ClientRequest, OutgoingMessage);
 ClientRequest.prototype._finish = function _finish() {
   DTRACE_HTTP_CLIENT_REQUEST(this, this.connection);
   OutgoingMessage.prototype._finish.call(this);
+};
+
+ClientRequest.prototype.write = function write(chunk, encoding, callback) {
+  if (this.res) {
+    this.emit('error', new ERR_REQUEST_WRITE_AFTER_RESPONSE());
+    return true;
+  }
+  OutgoingMessage.prototype.write.call(this, chunk, encoding, callback);
+};
+
+ClientRequest.prototype.end = function end(chunk, encoding, callback) {
+  if (this.res) {
+    this.emit('error', new ERR_REQUEST_WRITE_AFTER_RESPONSE());
+    return this;
+  }
+  OutgoingMessage.prototype.end.call(this, chunk, encoding, callback);
 };
 
 ClientRequest.prototype._implicitHeader = function _implicitHeader() {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1052,6 +1052,7 @@ E('ERR_OUT_OF_RANGE',
     msg += ` It must be ${range}. Received ${received}`;
     return msg;
   }, RangeError);
+E('ERR_REQUEST_WRITE_AFTER_RESPONSE', 'write after response', Error);
 E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s', Error);
 E('ERR_SCRIPT_EXECUTION_INTERRUPTED',
   'Script execution was interrupted by `SIGINT`', Error);


### PR DESCRIPTION
This tries to solve https://github.com/nodejs/node/issues/27916. Where an `error` can be emitted from a `HttpClient` request after the response has been `ended`.

In particular see the comment https://github.com/nodejs/node/issues/27916#issuecomment-496107610

Depends on https://github.com/nodejs/node/pull/28621.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)