### PR TITLE
doc: change from txt to bash for better highlighting

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -85,7 +85,7 @@ variable:
 Omitting the callback function on asynchronous fs functions is deprecated and
 may result in an error being thrown in the future.
 
-```txt
+```bash
 $ cat script.js
 function bad() {
   require('fs').readFile('/');


### PR DESCRIPTION
Another option could be change it to ```console but it just highlights the `$` character.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
