### PR TITLE
http: emit ECONNRESET if no 'aborted' listener

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2217,7 +2217,9 @@ will be emitted in the following order:
   * `'data'` any number of times, on the `res` object
 * (`req.abort()` called here)
 * `'abort'`
-* `'aborted'` on the `res` object
+* `'aborted'` on the `res` object if `'aborted'` listener exists, otherwise
+  `'error'` with an error with message `'Error: aborted'` and code
+  `'ECONNRESET'`
 * `'close'`
 * `'end'` on the `res` object
 * `'close'` on the `res` object

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -360,7 +360,9 @@ function socketCloseListener() {
     // Socket closed before we emitted 'end' below.
     if (!res.complete) {
       res.aborted = true;
-      res.emit('aborted');
+      if (!res.emit('aborted')) {
+        res.emit('error', connResetException('aborted'));
+      }
     }
     req.emit('close');
     if (res.readable) {

--- a/test/parallel/test-domain-multi.js
+++ b/test/parallel/test-domain-multi.js
@@ -68,6 +68,7 @@ const server = http.createServer((req, res) => {
   req.on('response', (res) => {
     // Add the response object to the C domain
     c.add(res);
+    res.on('aborted', common.mustCall());
     res.pipe(process.stdout);
   });
 

--- a/test/parallel/test-http-abort-stream-end.js
+++ b/test/parallel/test-http-abort-stream-end.js
@@ -40,6 +40,7 @@ const server = http.createServer(common.mustCall((req, res) => {
 
 server.listen(0, () => {
   const res = common.mustCall((res) => {
+    res.on('error', common.mustCall());
     res.on('data', (chunk) => {
       size += chunk.length;
       assert(!req.aborted, 'got data after abort');

--- a/test/parallel/test-http-agent-remove.js
+++ b/test/parallel/test-http-agent-remove.js
@@ -11,7 +11,8 @@ const server = http.createServer(mustCall((req, res) => {
 server.listen(0, mustCall(() => {
   const req = http.get({
     port: server.address().port
-  }, mustCall(() => {
+  }, mustCall((res) => {
+    res.on('error', mustCall());
     const { socket } = req;
     socket.emit('agentRemove');
     strictEqual(socket._httpMessage, req);

--- a/test/parallel/test-http-catch-uncaughtexception.js
+++ b/test/parallel/test-http-catch-uncaughtexception.js
@@ -16,6 +16,7 @@ const server = http.createServer(function(req, res) {
 }).listen(0, function() {
   http.get({ port: this.address().port }, function(res) {
     res.resume();
+    res.on('error', common.mustCall());
     throw new Error('get did fail');
   }).on('close', function() {
     server.close();

--- a/test/parallel/test-http-client-abort.js
+++ b/test/parallel/test-http-client-abort.js
@@ -48,6 +48,7 @@ server.listen(0, common.mustCall(() => {
     requests.push(
       http.get(options, common.mustCall((res) => {
         res.resume();
+        res.on('error', common.mustCall());
         reqCountdown.dec();
       })));
   }

--- a/test/parallel/test-http-client-response-reset.js
+++ b/test/parallel/test-http-client-response-reset.js
@@ -1,6 +1,7 @@
 'use strict';
 const common = require('../common');
 const http = require('http');
+const assert = require('assert');
 
 let serverRes;
 const server = http.Server(function(req, res) {
@@ -15,7 +16,8 @@ server.listen(0, common.mustCall(function() {
   }, common.mustCall(function(res) {
     server.close();
     serverRes.destroy();
-    res.on('aborted', common.mustCall());
-    res.on('error', common.mustNotCall());
+    res.on('error', common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ECONNRESET');
+    }));
   }));
 }));

--- a/test/parallel/test-http-flush-response-headers.js
+++ b/test/parallel/test-http-flush-response-headers.js
@@ -22,6 +22,7 @@ server.listen(0, common.localhostIPv4, function() {
   function onResponse(res) {
     assert.strictEqual(res.headers.foo, 'bar');
     res.destroy();
+    res.on('error', common.mustCall());
     server.close();
   }
 });

--- a/test/parallel/test-http-response-close.js
+++ b/test/parallel/test-http-response-close.js
@@ -39,6 +39,7 @@ const http = require('http');
           res.on('data', common.mustCall(() => {
             res.destroy();
           }));
+          res.on('error', common.mustCall());
           res.on('close', common.mustCall(() => {
             server.close();
           }));

--- a/test/parallel/test-https-close.js
+++ b/test/parallel/test-https-close.js
@@ -48,6 +48,7 @@ server.listen(0, () => {
 
   const req = https.request(requestOptions, (res) => {
     res.on('data', () => {});
+    res.on('aborted', common.mustCall());
     setImmediate(shutdown);
   });
   req.end();

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -187,6 +187,7 @@ const { promisify } = require('util');
 
     req.end();
     req.on('response', (res) => {
+      res.on('aborted', common.mustCall());
       setImmediate(() => {
         res.destroy();
         server.close();


### PR DESCRIPTION
Emits an ECONNRESET of response object when there is no listener for `aborted`.

Refs: https://github.com/nodejs/node/issues/28172

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
