### PR TITLE
doc: deprecate finished

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2519,7 +2519,7 @@ Prefer [`response.socket`][] over [`response.connection`] and
 [`request.socket`][] over [`request.connection`].
 
 <a id="DEP0XXX"></a>
-### DEP0XXX: http finished
+### DEP0XXX: http/2 request.finished and response.finished
 <!-- YAML
 changes:
   - version: REPLACEME

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2531,7 +2531,7 @@ Type: Documentation-only
 
 [`response.finished`][] indicates whether [`response.end()`][] has been
 called, not whether `'finish'` has been emitted and the underlying data
-is flushed,
+is flushed.
 
 Use [`response.writableFinished`][] or [`response.writableEnded`][]
 accordingly instead to avoid the ambigiuty.

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2530,9 +2530,8 @@ changes:
 Type: Documentation-only
 
 [`response.finished`][] indicates whether [`response.end()`] has been
-called, not whether the underlying
-data has been flushed, `'finish'` has been emitted and
-[`response.writableFinished`][] is `true`.
+called, not whether `'finish'` has been emitted and the underlying data
+is flushed,
 
 Use [`response.writableFinished`][] or [`response.writableEnded`][]
 accordingly instead to avoid the ambigiuty.

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2596,6 +2596,7 @@ To maintain existing behaviour `response.finished` should be replaced with `resp
 [`request.connection`]: http.html#http_request_connection
 [`response.socket`]: http.html#http_response_socket
 [`response.connection`]: http.html#http_response_connection
+[`response.end()`]: http.html#http_response_end_data_encoding_callback
 [`response.finished`]: #http_response_finished
 [`response.writableFinished`]: #http_response_writablefinished
 [`response.writableEnded`]: #http_response_writableended

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2529,7 +2529,7 @@ changes:
 
 Type: Documentation-only
 
-[`response.finished`][] indicates whether [`response.end()`] has been
+[`response.finished`][] indicates whether [`response.end()`][] has been
 called, not whether `'finish'` has been emitted and the underlying data
 is flushed,
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2537,7 +2537,7 @@ data has been flushed, `'finish'` has been emitted and
 Use [`response.writableFinished`][] or [`response.writableEnded`][]
 accordingly instead to avoid the ambigiuty.
 
-To maintain existing functionality use [`response.writableEnded`][].
+To maintain existing behaviour `response.finished` should be replaced with `response.writableEnded`.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2530,7 +2530,7 @@ changes:
 Type: Documentation-only
 
 [`response.finished`][] indicates whether [`response.end()`] has been
-called and [`response.writableEnded`][] is `true`, not whether the underlying
+called, not whether the underlying
 data has been flushed, `'finish'` has been emitted and
 [`response.writableFinished`][] is `true`.
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2536,7 +2536,8 @@ is flushed,
 Use [`response.writableFinished`][] or [`response.writableEnded`][]
 accordingly instead to avoid the ambigiuty.
 
-To maintain existing behaviour `response.finished` should be replaced with `response.writableEnded`.
+To maintain existing behaviour `response.finished` should be replaced with
+`response.writableEnded`.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2530,8 +2530,11 @@ changes:
 Type: Documentation-only
 
 [`response.finished`][] indicates whether the [`response.end()`] has been
-called, not whether the underlying data has been flushed and `'finish'` has been
-emitted. Use [`response.writableFinished`][] or [`response.writableEnded`][]
+called and [`response.writableEnded`][] is `true`, not whether the underlying
+data has been flushed, `'finish'` has been emitted and
+[`response.writableFinished`][] is `true`.
+
+Use [`response.writableFinished`][] or [`response.writableEnded`][]
 accordingly instead to avoid the ambigiuty.
 
 [`--http-parser=legacy`]: cli.html#cli_http_parser_library

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2537,9 +2537,8 @@ data has been flushed, `'finish'` has been emitted and
 Use [`response.writableFinished`][] or [`response.writableEnded`][]
 accordingly instead to avoid the ambigiuty.
 
-To maintain existing functionality use [`response.writableFinished`][].
+To maintain existing functionality use [`response.writableEnded`][].
 
-[`--http-parser=legacy`]: cli.html#cli_http_parser_library
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2529,13 +2529,15 @@ changes:
 
 Type: Documentation-only
 
-[`response.finished`][] indicates whether the [`response.end()`] has been
+[`response.finished`][] indicates whether [`response.end()`] has been
 called and [`response.writableEnded`][] is `true`, not whether the underlying
 data has been flushed, `'finish'` has been emitted and
 [`response.writableFinished`][] is `true`.
 
 Use [`response.writableFinished`][] or [`response.writableEnded`][]
 accordingly instead to avoid the ambigiuty.
+
+To maintain existing functionality use [`response.writableFinished`][].
 
 [`--http-parser=legacy`]: cli.html#cli_http_parser_library
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2518,6 +2518,23 @@ Type: Documentation-only
 Prefer [`response.socket`][] over [`response.connection`] and
 [`request.socket`][] over [`request.connection`].
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: http finished
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/28679
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+[`response.finished`][] indicates whether the [`response.end()`] has been
+called, not whether the underlying data has been flushed and `'finish'` has been
+emitted. Use [`response.writableFinished`][] or [`response.writableEnded`][]
+accordingly instead to avoid the ambigiuty.
+
+[`--http-parser=legacy`]: cli.html#cli_http_parser_library
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
@@ -2576,6 +2593,9 @@ Prefer [`response.socket`][] over [`response.connection`] and
 [`request.connection`]: http.html#http_request_connection
 [`response.socket`]: http.html#http_response_socket
 [`response.connection`]: http.html#http_response_connection
+[`response.finished`]: #http_response_finished
+[`response.writableFinished`]: #http_response_writablefinished
+[`response.writableEnded`]: #http_response_writableended
 [`script.createCachedData()`]: vm.html#vm_script_createcacheddata
 [`setInterval()`]: timers.html#timers_setinterval_callback_delay_args
 [`setTimeout()`]: timers.html#timers_settimeout_callback_delay_args

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -603,7 +603,10 @@ is finished.
 ### request.finished
 <!-- YAML
 added: v0.0.1
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated. Use [`request.writableEnded`][].
 
 * {boolean}
 
@@ -1202,7 +1205,10 @@ is finished.
 ### response.finished
 <!-- YAML
 added: v0.0.2
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated. Use [`response.writableEnded`][].
 
 * {boolean}
 
@@ -2258,12 +2264,14 @@ not abort the request or do anything besides add a `'timeout'` event.
 [`request.socket.getPeerCertificate()`]: tls.html#tls_tlssocket_getpeercertificate_detailed
 [`request.socket`]: #http_request_socket
 [`request.writableFinished`]: #http_request_writablefinished
+[`request.writableEnded`]: #http_request_writableended
 [`request.write(data, encoding)`]: #http_request_write_chunk_encoding_callback
 [`response.end()`]: #http_response_end_data_encoding_callback
 [`response.getHeader()`]: #http_response_getheader_name
 [`response.setHeader()`]: #http_response_setheader_name_value
 [`response.socket`]: #http_response_socket
 [`response.writableFinished`]: #http_response_writablefinished
+[`response.writableEnded`]: #http_response_writableended
 [`response.write()`]: #http_response_write_chunk_encoding_callback
 [`response.write(data, encoding)`]: #http_response_write_chunk_encoding_callback
 [`response.writeContinue()`]: #http_response_writecontinue

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3033,7 +3033,10 @@ is finished.
 #### response.finished
 <!-- YAML
 added: v8.4.0
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated. Use [`response.writableEnded`][].
 
 * {boolean}
 
@@ -3517,6 +3520,7 @@ following additional properties:
 [`response.end()`]: #http2_response_end_data_encoding_callback
 [`response.setHeader()`]: #http2_response_setheader_name_value
 [`response.socket`]: #http2_response_socket
+[`response.writableEnded`]: #http2_response_writableended
 [`response.write()`]: #http2_response_write_chunk_encoding_callback
 [`response.write(data, encoding)`]: http.html#http_response_write_chunk_encoding_callback
 [`response.writeContinue()`]: #http2_response_writecontinue


### PR DESCRIPTION
Remove `finished` from docs. The naming and function is very confusing and misleading. What is `finished` is actually `ended` in the streams spec. 

Refs: https://github.com/nodejs/node/issues/28651

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
