### PR TITLE
http: writableFinished

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1458,6 +1458,15 @@ Returns `true` if the entire data was flushed successfully to the kernel
 buffer. Returns `false` if all or part of the data was queued in user memory.
 `'drain'` will be emitted when the buffer is free again.
 
+### response.writableFinished
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+Is `true` if all data has been flushed to the underlying system.
+
 ### response.writeContinue()
 <!-- YAML
 added: v0.3.0

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -109,6 +109,15 @@ function OutgoingMessage() {
 Object.setPrototypeOf(OutgoingMessage.prototype, Stream.prototype);
 Object.setPrototypeOf(OutgoingMessage, Stream);
 
+Object.defineProperty(OutgoingMessage.prototype, 'writableFinished', {
+  get: function() {
+    return (
+      this.finished &&
+      this.outputSize === 0 &&
+      (!this.socket || this.socket.writableLength === 0)
+    );
+  }
+});
 
 Object.defineProperty(OutgoingMessage.prototype, '_headers', {
   get: internalUtil.deprecate(function() {

--- a/test/parallel/test-http-outgoing-writableFinished.js
+++ b/test/parallel/test-http-outgoing-writableFinished.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(common.mustCall(function(req, res) {
+  assert.strictEqual(res.writableFinished, false);
+  res
+    .on('finish', common.mustCall(() => {
+      assert.strictEqual(res.writableFinished, true);
+      server.close();
+    }))
+    .end();
+}));
+
+server.listen(0);
+
+server.on('listening', common.mustCall(function() {
+  const clientRequest = http.request({
+    port: server.address().port,
+    method: 'GET',
+    path: '/'
+  });
+
+  assert.strictEqual(clientRequest.writableFinished, false);
+  clientRequest
+    .on('finish', common.mustCall(() => {
+      assert.strictEqual(clientRequest.writableFinished, true);
+    }))
+    .end();
+  assert.strictEqual(clientRequest.writableFinished, false);
+}));


### PR DESCRIPTION
This follows from the `OutgoingMessage` "quacks" like a `Writable` (https://github.com/nodejs/node/issues/20946).

We recently added a `writableFinished` property to `Writable` (https://github.com/nodejs/node/commit/33aef82b42ca689411673784e203e59d3f4eb142). `OutgoingMessage` should also implement this.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
