### PR TITLE
http: emit close on socket re-use

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -594,6 +594,11 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
 function responseKeepAlive(req) {
   const socket = req.socket;
 
+  req.emit('close');
+  if (res) {
+    res.emit('close');
+  }
+
   debug('AGENT socket keep-alive');
   if (req.timeoutCb) {
     socket.setTimeout(0, req.timeoutCb);
@@ -635,15 +640,23 @@ function responseOnEnd() {
     // - when we have a socket we write directly to it without buffering.
     // - `req.finished` means `end()` has been called and no further data.
     //   can be written
-    responseKeepAlive(req);
+
+    // Run in next tick so any pending handlers
+    // have a chance to run first and perform any
+    // modifications.
+    process.nextTick(responseKeepAlive, res, req);
   }
 }
 
 function requestOnPrefinish() {
   const req = this;
 
-  if (req.shouldKeepAlive && req._ended)
-    responseKeepAlive(req);
+  if (req.shouldKeepAlive && req._ended) {
+    // Run in next tick so any pending handlers
+    // have a chance to run first and perform any
+    // modifications.
+    process.nextTick(responseKeepAlive, res, req);
+  }
 }
 
 function emitFreeNT(socket) {
@@ -717,6 +730,7 @@ function onSocketNT(req, socket) {
     if (!req.agent) {
       socket.destroy();
     } else {
+      req.emit('close');
       socket.emit('free');
     }
   } else {

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -593,6 +593,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
 // client
 function responseKeepAlive(req) {
   const socket = req.socket;
+  const res = req.res;
 
   req.emit('close');
   if (res) {
@@ -644,7 +645,7 @@ function responseOnEnd() {
     // Run in next tick so any pending handlers
     // have a chance to run first and perform any
     // modifications.
-    process.nextTick(responseKeepAlive, res, req);
+    process.nextTick(responseKeepAlive, req);
   }
 }
 
@@ -655,7 +656,7 @@ function requestOnPrefinish() {
     // Run in next tick so any pending handlers
     // have a chance to run first and perform any
     // modifications.
-    process.nextTick(responseKeepAlive, res, req);
+    process.nextTick(responseKeepAlive, req);
   }
 }
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -593,12 +593,6 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
 // client
 function responseKeepAlive(req) {
   const socket = req.socket;
-  const res = req.res;
-
-  req.emit('close');
-  if (res) {
-    res.emit('close');
-  }
 
   debug('AGENT socket keep-alive');
   if (req.timeoutCb) {
@@ -613,7 +607,7 @@ function responseKeepAlive(req) {
   const asyncId = socket._handle ? socket._handle.getAsyncId() : undefined;
   // Mark this socket as available, AFTER user-added end
   // handlers have a chance to run.
-  defaultTriggerAsyncIdScope(asyncId, process.nextTick, emitFreeNT, socket);
+  defaultTriggerAsyncIdScope(asyncId, process.nextTick, emitFreeNT, req);
 }
 
 function responseOnEnd() {
@@ -635,33 +629,32 @@ function responseOnEnd() {
         socket.end();
     }
     assert(!socket.writable);
-  } else if (req.finished) {
+  } else if (req.finished && !this.aborted) {
     // We can assume `req.finished` means all data has been written since:
     // - `'responseOnEnd'` means we have been assigned a socket.
     // - when we have a socket we write directly to it without buffering.
     // - `req.finished` means `end()` has been called and no further data.
     //   can be written
-
-    // Run in next tick so any pending handlers
-    // have a chance to run first and perform any
-    // modifications.
-    process.nextTick(responseKeepAlive, req);
+    responseKeepAlive(req);
   }
 }
 
 function requestOnPrefinish() {
   const req = this;
 
-  if (req.shouldKeepAlive && req._ended) {
-    // Run in next tick so any pending handlers
-    // have a chance to run first and perform any
-    // modifications.
-    process.nextTick(responseKeepAlive, req);
-  }
+  if (req.shouldKeepAlive && req._ended)
+    responseKeepAlive(req);
 }
 
-function emitFreeNT(socket) {
-  socket.emit('free');
+function emitFreeNT(req) {
+  req.emit('close');
+  if (req.res) {
+    req.res.emit('close');
+  }
+
+  if (req.socket) {
+    req.socket.emit('free');
+  }
 }
 
 function tickOnSocket(req, socket) {

--- a/test/parallel/test-http-client-agent-abort-close-event.js
+++ b/test/parallel/test-http-client-agent-abort-close-event.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+
+const server = http.createServer(common.mustNotCall());
+
+const keepAliveAgent = new http.Agent({ keepAlive: true });
+
+server.listen(0, common.mustCall(() => {
+  const req = http.get({
+    port: server.address().port,
+    agent: keepAliveAgent
+  });
+
+  req
+    .on('socket', common.mustNotCall())
+    .on('response', common.mustNotCall())
+    .on('close', common.mustCall(() => {
+      server.close();
+      keepAliveAgent.destroy();
+    }))
+    .abort();
+}));

--- a/test/parallel/test-http-client-agent-end-close-event.js
+++ b/test/parallel/test-http-client-agent-end-close-event.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  res.end('hello');
+}));
+
+const keepAliveAgent = new http.Agent({ keepAlive: true });
+
+server.listen(0, common.mustCall(() => {
+  const req = http.get({
+    port: server.address().port,
+    agent: keepAliveAgent
+  });
+
+  req
+    .on('response', common.mustCall((res) => {
+      res
+        .on('close', common.mustCall(() => {
+          server.close();
+          keepAliveAgent.destroy();
+        }))
+        .on('data', common.mustCall());
+    }))
+    .end();
+}));


### PR DESCRIPTION
When using agents we currently don't emit `'close'` on req & res.

I will need a little help here... I don't think I quite got it right.

Refs: https://github.com/nodejs/node/issues/28684

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
