### PR TITLE
docs: fix description of _writev()

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1754,8 +1754,9 @@ methods only.
 
 The `writable._writev()` method may be implemented in addition to
 `writable._write()` in stream implementations that are capable of processing
-multiple chunks of data at once. If implemented, the method will be called with
-all chunks of data currently buffered in the write queue.
+multiple chunks of data at once. If implemented, the first chunk will be written with 
+`_write()`. When the initial write is complete, buffered chunks in the write queue, if available, 
+will be written all at once with `_writev()`.
 
 The `writable._writev()` method is prefixed with an underscore because it is
 internal to the class that defines it, and should never be called directly by


### PR DESCRIPTION
The documentation gave the impression that when the _writev method is
used, it is used instead of _write. However, when _writev is used,
_write loads the first chunk of data, then _writev loads all the
remaining bufferred chunks in the write queue. The docs have been
changed to reflect this behavior.

Fixes: https://github.com/nodejs/node/issues/28408

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
