### PR TITLE
build: specify Python version once for all tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ x-ccache-setup-steps: &ccache-setup-steps
   - export CXX='ccache g++-6'
 
 os: linux
-dist: xenial
 language: cpp
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ x-ccache-setup-steps: &ccache-setup-steps
 os: linux
 dist: xenial
 language: cpp
+env:
+  global:
+    - PYTHON_VERSION="2.7.15"
 jobs:
   include:
     - stage: "Compile"
@@ -20,7 +23,7 @@ jobs:
             - g++-6
       install: *ccache-setup-steps
       script:
-        - pyenv global 2.7.15
+        - pyenv global ${PYTHON_VERSION}
         - ./configure
         - make -j2 -C out V=1 v8
 
@@ -34,7 +37,7 @@ jobs:
             - g++-6
       install: *ccache-setup-steps
       script:
-        - pyenv global 2.7.15
+        - pyenv global ${PYTHON_VERSION}
         - ./configure
         - make -j2 V=1
         - cp out/Release/node /home/travis/.ccache
@@ -47,7 +50,7 @@ jobs:
         - mkdir -p out/Release
         - cp /home/travis/.ccache/node out/Release/node
       script:
-        - pyenv global 2.7.15
+        - pyenv global ${PYTHON_VERSION}
         - python tools/test.py -j 2 -p dots --report --mode=release --flaky-tests=dontcare default
 
     - name: "Test C++ Suites"
@@ -63,7 +66,7 @@ jobs:
         - cp /home/travis/.ccache/cctest out/Release/cctest
         - touch config.gypi
       script:
-        - pyenv global 2.7.15
+        - pyenv global ${PYTHON_VERSION}
         - out/Release/cctest
         - make -j1 V=1 test/addons/.buildstamp test/js-native-api/.buildstamp test/node-api/.buildstamp
         - python tools/test.py -j 2 -p dots --report --mode=release --flaky-tests=dontcare addons js-native-api node-api
@@ -72,7 +75,7 @@ jobs:
       language: node_js
       node_js: "node"
       install:
-        - pyenv global 2.7.15
+        - pyenv global ${PYTHON_VERSION}
         - make lint-py-build || true
       script:
         - NODE=$(which node) make lint lint-py


### PR DESCRIPTION
Extracted from #28537 for a hopefully shorter review cycle.  This makes
it easier to experiment with new versions of Python as they become
available on the Travis CI platform.

Also: https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

@nodejs/python 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
