### PR TITLE
errors: dont call null object in ERR_INVALID_RETURN_PROPERTY_VALUE

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -984,6 +984,8 @@ E('ERR_INVALID_RETURN_PROPERTY_VALUE', (input, name, prop, value) => {
   let type;
   if (value && value.constructor && value.constructor.name) {
     type = `instance of ${value.constructor.name}`;
+  } else if (type === null) {
+    type = 'value null';
   } else {
     type = `type ${typeof value}`;
   }


### PR DESCRIPTION
Since typeof null is 'object', you sometimes get confusing messages like:
Expected string to be returned for the "url" from the loader resolve
function but got type object.

While this is technically true, it is still hard to understand on a glance.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
