### PR TITLE
src: allow generic C++ callables in SetImmediate()

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -87,7 +87,7 @@ struct AsyncWrapObject : public AsyncWrap {
   SET_SELF_SIZE(AsyncWrapObject)
 };
 
-void AsyncWrap::DestroyAsyncIdsCallback(Environment* env, void* data) {
+void AsyncWrap::DestroyAsyncIdsCallback(Environment* env) {
   Local<Function> fn = env->async_hooks_destroy_function();
 
   TryCatchScope try_catch(env, TryCatchScope::CatchMode::kFatal);
@@ -642,7 +642,7 @@ void AsyncWrap::EmitDestroy(Environment* env, double async_id) {
   }
 
   if (env->destroy_async_id_list()->empty()) {
-    env->SetUnrefImmediate(DestroyAsyncIdsCallback, nullptr);
+    env->SetUnrefImmediate(&DestroyAsyncIdsCallback);
   }
 
   env->destroy_async_id_list()->push_back(async_id);

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -154,7 +154,7 @@ class AsyncWrap : public BaseObject {
   static void EmitTraceEventAfter(ProviderType type, double async_id);
   void EmitTraceEventDestroy();
 
-  static void DestroyAsyncIdsCallback(Environment* env, void* data);
+  static void DestroyAsyncIdsCallback(Environment* env);
 
   inline ProviderType provider_type() const;
   inline ProviderType set_provider_type(ProviderType provider);

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -690,9 +690,9 @@ class QueryWrap : public AsyncWrap {
   }
 
   void QueueResponseCallback(int status) {
-    env()->SetImmediate([](Environment*, void* data) {
-      static_cast<QueryWrap*>(data)->AfterResponse();
-    }, this, object());
+    env()->SetImmediate([this](Environment*) {
+      AfterResponse();
+    }, object());
 
     channel_->set_query_last_ok(status != ARES_ECONNREFUSED);
     channel_->ModifyActivityQueryCount(-1);

--- a/src/env.cc
+++ b/src/env.cc
@@ -339,7 +339,7 @@ Environment::Environment(IsolateData* isolate_data,
       [](void* arg) {
         Environment* env = static_cast<Environment*>(arg);
         if (!env->destroy_async_id_list()->empty())
-          AsyncWrap::DestroyAsyncIdsCallback(env, nullptr);
+          AsyncWrap::DestroyAsyncIdsCallback(env);
       },
       this);
 
@@ -641,42 +641,38 @@ void Environment::AtExit(void (*cb)(void* arg), void* arg) {
 void Environment::RunAndClearNativeImmediates() {
   TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
                               "RunAndClearNativeImmediates", this);
-  size_t count = native_immediate_callbacks_.size();
-  if (count > 0) {
-    size_t ref_count = 0;
-    std::vector<NativeImmediateCallback> list;
-    native_immediate_callbacks_.swap(list);
-    auto drain_list = [&]() {
-      TryCatchScope try_catch(this);
-      for (auto it = list.begin(); it != list.end(); ++it) {
-        DebugSealHandleScope seal_handle_scope(isolate());
-        it->cb_(this, it->data_);
-        if (it->refed_)
-          ref_count++;
-        if (UNLIKELY(try_catch.HasCaught())) {
-          if (!try_catch.HasTerminated())
-            errors::TriggerUncaughtException(isolate(), try_catch);
+  size_t ref_count = 0;
+  size_t count = 0;
+  std::unique_ptr<NativeImmediateCallback> head;
+  head.swap(native_immediate_callbacks_head_);
+  native_immediate_callbacks_tail_ = nullptr;
 
-          // We are done with the current callback. Increase the counter so that
-          // the steps below make everything *after* the current item part of
-          // the new list.
-          it++;
+  auto drain_list = [&]() {
+    TryCatchScope try_catch(this);
+    for (; head; head = head->get_next()) {
+      DebugSealHandleScope seal_handle_scope(isolate());
+      count++;
+      if (head->is_refed())
+        ref_count++;
 
-          // Bail out, remove the already executed callbacks from list
-          // and set up a new TryCatch for the other pending callbacks.
-          std::move_backward(it, list.end(), list.begin() + (list.end() - it));
-          list.resize(list.end() - it);
-          return true;
-        }
+      head->Call(this);
+      if (UNLIKELY(try_catch.HasCaught())) {
+        if (!try_catch.HasTerminated())
+          errors::TriggerUncaughtException(isolate(), try_catch);
+
+        // We are done with the current callback. Move one iteration along,
+        // as if we had completed successfully.
+        head = head->get_next();
+        return true;
       }
-      return false;
-    };
-    while (drain_list()) {}
+    }
+    return false;
+  };
+  while (head && drain_list()) {}
 
-    DCHECK_GE(immediate_info()->count(), count);
-    immediate_info()->count_dec(count);
-    immediate_info()->ref_count_dec(ref_count);
-  }
+  DCHECK_GE(immediate_info()->count(), count);
+  immediate_info()->count_dec(count);
+  immediate_info()->ref_count_dec(ref_count);
 }
 
 

--- a/src/env.h
+++ b/src/env.h
@@ -1172,15 +1172,15 @@ class Environment : public MemoryRetainer {
     return current_value;
   }
 
-  typedef void (*native_immediate_callback)(Environment* env, void* data);
-  // cb will be called as cb(env, data) on the next event loop iteration.
-  // obj will be kept alive between now and after the callback has run.
-  inline void SetImmediate(native_immediate_callback cb,
-                           void* data,
-                           v8::Local<v8::Object> obj = v8::Local<v8::Object>());
-  inline void SetUnrefImmediate(native_immediate_callback cb,
-                                void* data,
-                                v8::Local<v8::Object> obj =
+  // cb will be called as cb(env) on the next event loop iteration.
+  // keep_alive will be kept alive between now and after the callback has run.
+  template <typename Fn>
+  inline void SetImmediate(Fn&& cb,
+                           v8::Local<v8::Object> keep_alive =
+                               v8::Local<v8::Object>());
+  template <typename Fn>
+  inline void SetUnrefImmediate(Fn&& cb,
+                                v8::Local<v8::Object> keep_alive =
                                     v8::Local<v8::Object>());
   // This needs to be available for the JS-land setImmediate().
   void ToggleImmediateRef(bool ref);
@@ -1245,9 +1245,9 @@ class Environment : public MemoryRetainer {
 #endif  // HAVE_INSPECTOR
 
  private:
-  inline void CreateImmediate(native_immediate_callback cb,
-                              void* data,
-                              v8::Local<v8::Object> obj,
+  template <typename Fn>
+  inline void CreateImmediate(Fn&& cb,
+                              v8::Local<v8::Object> keep_alive,
                               bool ref);
 
   inline void ThrowError(v8::Local<v8::Value> (*fun)(v8::Local<v8::String>),
@@ -1370,13 +1370,38 @@ class Environment : public MemoryRetainer {
 
   std::list<ExitCallback> at_exit_functions_;
 
-  struct NativeImmediateCallback {
-    native_immediate_callback cb_;
-    void* data_;
-    v8::Global<v8::Object> keep_alive_;
+  class NativeImmediateCallback {
+   public:
+    explicit inline NativeImmediateCallback(bool refed);
+
+    virtual ~NativeImmediateCallback() = default;
+    virtual void Call(Environment* env) = 0;
+
+    inline bool is_refed() const;
+    inline std::unique_ptr<NativeImmediateCallback> get_next();
+    inline void set_next(std::unique_ptr<NativeImmediateCallback> next);
+
+   private:
     bool refed_;
+    std::unique_ptr<NativeImmediateCallback> next_;
   };
-  std::vector<NativeImmediateCallback> native_immediate_callbacks_;
+
+  template <typename Fn>
+  class NativeImmediateCallbackImpl final : public NativeImmediateCallback {
+   public:
+    NativeImmediateCallbackImpl(Fn&& callback,
+                                v8::Global<v8::Object>&& keep_alive,
+                                bool refed);
+    void Call(Environment* env) override;
+
+   private:
+    Fn callback_;
+    v8::Global<v8::Object> keep_alive_;
+  };
+
+  std::unique_ptr<NativeImmediateCallback> native_immediate_callbacks_head_;
+  NativeImmediateCallback* native_immediate_callbacks_tail_ = nullptr;
+
   void RunAndClearNativeImmediates();
   static void CheckImmediate(uv_check_t* handle);
 

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -71,18 +71,16 @@ void StreamPipe::Unpipe() {
   // Delay the JS-facing part with SetImmediate, because this might be from
   // inside the garbage collector, so we can’t run JS here.
   HandleScope handle_scope(env()->isolate());
-  env()->SetImmediate([](Environment* env, void* data) {
-    StreamPipe* pipe = static_cast<StreamPipe*>(data);
-
+  env()->SetImmediate([this](Environment* env) {
     HandleScope handle_scope(env->isolate());
     Context::Scope context_scope(env->context());
-    Local<Object> object = pipe->object();
+    Local<Object> object = this->object();
 
     Local<Value> onunpipe;
     if (!object->Get(env->context(), env->onunpipe_string()).ToLocal(&onunpipe))
       return;
     if (onunpipe->IsFunction() &&
-        pipe->MakeCallback(onunpipe.As<Function>(), 0, nullptr).IsEmpty()) {
+        MakeCallback(onunpipe.As<Function>(), 0, nullptr).IsEmpty()) {
       return;
     }
 
@@ -107,7 +105,7 @@ void StreamPipe::Unpipe() {
             .IsNothing()) {
       return;
     }
-  }, static_cast<void*>(this), object());
+  }, object());
 }
 
 uv_buf_t StreamPipe::ReadableListener::OnStreamAlloc(size_t suggested_size) {

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -316,9 +316,9 @@ void TLSWrap::EncOut() {
         // its not clear if it is always correct. Not calling Done() could block
         // data flow, so for now continue to call Done(), just do it in the next
         // tick.
-        env()->SetImmediate([](Environment* env, void* data) {
-            static_cast<TLSWrap*>(data)->InvokeQueued(0);
-        }, this, object());
+        env()->SetImmediate([this](Environment* env) {
+          InvokeQueued(0);
+        }, object());
       }
     }
     return;
@@ -349,9 +349,9 @@ void TLSWrap::EncOut() {
     HandleScope handle_scope(env()->isolate());
 
     // Simulate asynchronous finishing, TLS cannot handle this at the moment.
-    env()->SetImmediate([](Environment* env, void* data) {
-      static_cast<TLSWrap*>(data)->OnStreamAfterWrite(nullptr, 0);
-    }, this, object());
+    env()->SetImmediate([this](Environment* env) {
+      OnStreamAfterWrite(nullptr, 0);
+    }, object());
   }
 }
 
@@ -718,10 +718,9 @@ int TLSWrap::DoWrite(WriteWrap* w,
       StreamWriteResult res =
           underlying_stream()->Write(bufs, count, send_handle);
       if (!res.async) {
-        env()->SetImmediate([](Environment* env, void* data) {
-          TLSWrap* self = static_cast<TLSWrap*>(data);
-          self->OnStreamAfterWrite(self->current_empty_write_, 0);
-        }, this, object());
+        env()->SetImmediate([this](Environment* env) {
+          OnStreamAfterWrite(current_empty_write_, 0);
+        }, object());
       }
       return 0;
     }


### PR DESCRIPTION
Modify the native `SetImmediate()` functions to take generic C++
callables as arguments. This makes passing arguments to the callback
easier, and in particular, it allows passing `std::unique_ptr`s
directly, which in turn makes sure that the data they point to is
deleted if the `Environment` is torn down before the callback can run.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
