### PR TITLE
http: ignore multiple abort

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -312,10 +312,12 @@ ClientRequest.prototype._implicitHeader = function _implicitHeader() {
 };
 
 ClientRequest.prototype.abort = function abort() {
-  if (!this.aborted) {
-    process.nextTick(emitAbortNT.bind(this));
+  if (this.aborted) {
+    return;
   }
+
   this.aborted = true;
+  process.nextTick(emitAbortNT.bind(this));
 
   // If we're aborting, we don't care about any more response data.
   if (this.res) {

--- a/test/parallel/test-http-client-abort2.js
+++ b/test/parallel/test-http-client-abort2.js
@@ -30,7 +30,9 @@ const server = http.createServer(common.mustCall((req, res) => {
 server.listen(0, common.mustCall(() => {
   const options = { port: server.address().port };
   const req = http.get(options, common.mustCall((res) => {
+    res._dump = common.mustCall(res._dump.bind(res));
     res.on('data', (data) => {
+      req.abort();
       req.abort();
       server.close();
     });


### PR DESCRIPTION
All calls expect the first to `abort` should be a noop. `abort` event should not be emitted more than once.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
