### PR TITLE
stream: don't emit after 'error'

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -607,10 +607,11 @@ function callFinal(stream, state) {
     state.pendingcb--;
     if (err) {
       errorOrDestroy(stream, err);
+    } else {
+      state.prefinished = true;
+      stream.emit('prefinish');
+      finishMaybe(stream, state);
     }
-    state.prefinished = true;
-    stream.emit('prefinish');
-    finishMaybe(stream, state);
   });
 }
 function prefinish(stream, state) {

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -441,3 +441,20 @@ const helloWorldBuffer = Buffer.from('hello world');
   w.write('hello');
   w.destroy(new Error());
 }
+
+{
+  // Verify that finish is not emitted after error
+  const w = new W();
+
+  w._final = common.mustCall(function(cb) {
+    cb(new Error());
+  });
+  w._write = function(chunk, e, cb) {
+    process.nextTick(cb);
+  };
+  w.on('error', common.mustCall());
+  w.on('prefinish', common.mustNotCall());
+  w.on('finish', common.mustNotCall());
+  w.write(Buffer.allocUnsafe(1));
+  w.end(Buffer.allocUnsafe(0));
+}


### PR DESCRIPTION
We should not be emitting e.g. `prefinish` etc... after `error`.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
