### PR TITLE
http: don't emit 'data' after 'error'

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -399,9 +399,6 @@ function socketErrorListener(err) {
     req.emit('error', err);
   }
 
-  // Handle any pending data
-  socket.read();
-
   const parser = socket.parser;
   if (parser) {
     parser.finish();

--- a/test/parallel/test-http-client-read-in-error.js
+++ b/test/parallel/test-http-client-read-in-error.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const net = require('net');
 const http = require('http');
 
@@ -37,4 +37,5 @@ http.request({
   agent
 }).once('error', function() {
   console.log('ignore');
+  this.on('data', common.mustNotCall());
 });


### PR DESCRIPTION
Don't emit pending 'data' after 'error'.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
