### PR TITLE
test: export public symbols in addons tests

### DIFF
--- a/test/addons/dlopen-ping-pong/binding.cc
+++ b/test/addons/dlopen-ping-pong/binding.cc
@@ -5,7 +5,9 @@
 
 #include <dlfcn.h>
 
-extern "C" const char* dlopen_pong(void) {
+extern "C"
+__attribute__((visibility("default")))
+const char* dlopen_pong(void) {
   return "pong";
 }
 

--- a/test/addons/dlopen-ping-pong/ping.c
+++ b/test/addons/dlopen-ping-pong/ping.c
@@ -2,6 +2,7 @@
 
 const char* dlopen_pong(void);
 
+__attribute__((visibility("default")))
 const char* dlopen_ping(void) {
   return dlopen_pong();
 }

--- a/test/addons/openssl-client-cert-engine/testengine.cc
+++ b/test/addons/openssl-client-cert-engine/testengine.cc
@@ -19,6 +19,12 @@
 #define AGENT_KEY           "test/fixtures/keys/agent1-key.pem"
 #define AGENT_CERT          "test/fixtures/keys/agent1-cert.pem"
 
+#ifdef _WIN32
+# define DEFAULT_VISIBILITY __declspec(dllexport)
+#else
+# define DEFAULT_VISIBILITY __attribute__((visibility("default")))
+#endif
+
 namespace {
 
 int EngineInit(ENGINE* engine) {
@@ -93,8 +99,8 @@ int bind_fn(ENGINE* engine, const char* id) {
 }
 
 extern "C" {
-  IMPLEMENT_DYNAMIC_CHECK_FN();
-  IMPLEMENT_DYNAMIC_BIND_FN(bind_fn);
+  DEFAULT_VISIBILITY IMPLEMENT_DYNAMIC_CHECK_FN();
+  DEFAULT_VISIBILITY IMPLEMENT_DYNAMIC_BIND_FN(bind_fn);
 }
 
 }  // anonymous namespace

--- a/test/addons/openssl-key-engine/testkeyengine.cc
+++ b/test/addons/openssl-key-engine/testkeyengine.cc
@@ -18,6 +18,12 @@
 
 #define PRIVATE_KEY           "test/fixtures/keys/agent1-key.pem"
 
+#ifdef _WIN32
+# define DEFAULT_VISIBILITY __declspec(dllexport)
+#else
+# define DEFAULT_VISIBILITY __attribute__((visibility("default")))
+#endif
+
 namespace {
 
 int EngineInit(ENGINE* engine) {
@@ -66,8 +72,8 @@ int bind_fn(ENGINE* engine, const char* id) {
 }
 
 extern "C" {
-  IMPLEMENT_DYNAMIC_CHECK_FN();
-  IMPLEMENT_DYNAMIC_BIND_FN(bind_fn);
+  DEFAULT_VISIBILITY IMPLEMENT_DYNAMIC_CHECK_FN();
+  DEFAULT_VISIBILITY IMPLEMENT_DYNAMIC_BIND_FN(bind_fn);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
Upcoming changes to node-gyp will turn on `-fvisibility=hidden` on
macOS. Ensure that public symbols that are dlsym'd have default
visibility.

Refs: https://github.com/nodejs/node/pull/28647
Refs: https://github.com/nodejs/node-gyp/pull/1828