### PR TITLE
stream: eos premature close

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -35,14 +35,22 @@ function eos(stream, opts, callback) {
     if (!stream.writable) onfinish();
   };
 
-  var writableEnded = stream._writableState && stream._writableState.finished;
+  var writableFinished = (
+    stream._writableState &&
+    stream._writableState.finished
+  );
+
   const onfinish = () => {
     writable = false;
-    writableEnded = true;
+    writableFinished = true;
     if (!readable) callback.call(stream);
   };
 
-  var readableEnded = stream._readableState && stream._readableState.endEmitted;
+  var readableEnded = (
+    stream._readableState &&
+    stream._readableState.endEmitted
+  );
+
   const onend = () => {
     readable = false;
     readableEnded = true;
@@ -56,12 +64,12 @@ function eos(stream, opts, callback) {
   const onclose = () => {
     let err;
     if (readable && !readableEnded) {
-      if (!stream._readableState || !stream._readableState.ended)
+      if (!stream._readableState || !stream._readableState.endEmitted)
         err = new ERR_STREAM_PREMATURE_CLOSE();
       return callback.call(stream, err);
     }
-    if (writable && !writableEnded) {
-      if (!stream._writableState || !stream._writableState.ended)
+    if (writable && !writableFinished) {
+      if (!stream._writableState || !stream._writableState.finished)
         err = new ERR_STREAM_PREMATURE_CLOSE();
       return callback.call(stream, err);
     }

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -100,11 +100,25 @@ const { promisify } = require('util');
   const rs = new Readable();
 
   finished(rs, common.mustCall((err) => {
+    assert(err, 'premature close error');
+  }));
+
+  rs.push(null);
+  rs.emit('close');
+  rs.resume();
+}
+
+{
+  const rs = new Readable();
+
+  finished(rs, common.mustCall((err) => {
     assert(!err, 'no error');
   }));
 
   rs.push(null);
-  rs.emit('close'); // Should not trigger an error
+  rs.on('end', common.mustCall(() => {
+    rs.emit('close'); // Should not trigger an error
+  }));
   rs.resume();
 }
 


### PR DESCRIPTION
For writable premature close is `close` before `finish`, i.e. it should look for `finished` instead of `ended`. ~~Would be better with a `finishEmitted` but we don't have that.~~

For readable we should be checking `endEmitted` (which we do first but not later).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
