### PR TITLE
src: expose TraceEventHelper with NODE_EXTERN

### DIFF
--- a/src/tracing/trace_event.h
+++ b/src/tracing/trace_event.h
@@ -310,6 +310,8 @@ const int kZeroNumArgs = 0;
 const decltype(nullptr) kGlobalScope = nullptr;
 const uint64_t kNoId = 0;
 
+// Extern (for now) because embedders need access to TraceEventHelper.
+// Refs: https://github.com/nodejs/node/pull/28724
 class NODE_EXTERN TraceEventHelper {
  public:
   static TracingController* GetTracingController();

--- a/src/tracing/trace_event.h
+++ b/src/tracing/trace_event.h
@@ -310,7 +310,7 @@ const int kZeroNumArgs = 0;
 const decltype(nullptr) kGlobalScope = nullptr;
 const uint64_t kNoId = 0;
 
-class TraceEventHelper {
+class NODE_EXTERN TraceEventHelper {
  public:
   static TracingController* GetTracingController();
   static Agent* GetAgent();


### PR DESCRIPTION
As node requires a tracing controller to be initialized, embedders need
access to the TraceEventHelper so that we can actually set the tracing
controller.

Refs: https://github.com/electron/electron/commit/0e5b6f93000e4718c9e35332ddbd0f6b76cdd585/#diff-89b287b2edd0a02dddae60cb26157f47

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
