### PR TITLE
test: changed function to arrow function

### DIFF
--- a/test/parallel/test-http-wget.js
+++ b/test/parallel/test-http-wget.js
@@ -40,7 +40,7 @@ const http = require('http');
 // content-length is not provided, that the connection is in fact
 // closed.
 
-const server = http.createServer(function(req, res) {
+const server = http.createServer((req, res) => {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.write('hello ');
   res.write('world\n');
@@ -48,30 +48,30 @@ const server = http.createServer(function(req, res) {
 });
 server.listen(0);
 
-server.on('listening', common.mustCall(function() {
-  const c = net.createConnection(this.address().port);
+server.on('listening', common.mustCall(() => {
+  const c = net.createConnection(server.address().port);
   let server_response = '';
 
   c.setEncoding('utf8');
 
-  c.on('connect', function() {
+  c.on('connect', () => {
     c.write('GET / HTTP/1.0\r\n' +
             'Connection: Keep-Alive\r\n\r\n');
   });
 
-  c.on('data', function(chunk) {
+  c.on('data', (chunk) => {
     console.log(chunk);
     server_response += chunk;
   });
 
-  c.on('end', common.mustCall(function() {
+  c.on('end', common.mustCall(() => {
     const m = server_response.split('\r\n\r\n');
     assert.strictEqual(m[1], 'hello world\n');
     console.log('got end');
     c.end();
   }));
 
-  c.on('close', common.mustCall(function() {
+  c.on('close', common.mustCall(() => {
     console.log('got close');
     server.close();
   }));


### PR DESCRIPTION
Convert callback functions that are anonymous
to arrow functions for better readability.
Also adjusted the `this` object in places
where that was required.

 This is my first PR, as shorter functions
 and behaviour of this keyword influenced
 the need for arrow function I changed function
 to arrow function.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
