### PR TITLE
--policy-integrity

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -428,7 +428,7 @@ developers may leverage to detect deprecated API usage.
 
 ### `--policy-integrity`
 <!-- YAML
-added: TODO
+added: REPLACEME
 -->
 
 Instructs node to error prior to running any code if the policy does not have

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -431,7 +431,7 @@ developers may leverage to detect deprecated API usage.
 added: REPLACEME
 -->
 
-Instructs node to error prior to running any code if the policy does not have
+Instructs Node.js to error prior to running any code if the policy does not have
 the specified integrity.
 
 ### `--preserve-symlinks`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -431,6 +431,8 @@ developers may leverage to detect deprecated API usage.
 added: REPLACEME
 -->
 
+> Stability: 1 - Experimental
+
 Instructs Node.js to error prior to running any code if the policy does not have
 the specified integrity. It expects a [Subresource Integrity][] string as a
 parameter.

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -432,7 +432,8 @@ added: REPLACEME
 -->
 
 Instructs Node.js to error prior to running any code if the policy does not have
-the specified integrity. It expects a [Subresource Integrity] string as a parameter.
+the specified integrity. It expects a [Subresource Integrity][] string as a
+parameter.
 
 ### `--preserve-symlinks`
 <!-- YAML

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1173,6 +1173,7 @@ greater than `4` (its current default value). For more information, see the
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
 [REPL]: repl.html
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage
+[Subresource Integrity]: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
 [V8 JavaScript code coverage]: https://v8project.blogspot.com/2017/12/javascript-code-coverage.html
 [customizing esm specifier resolution]: esm.html#esm_customizing_esm_specifier_resolution_algorithm
 [debugger]: debugger.html
@@ -1181,4 +1182,3 @@ greater than `4` (its current default value). For more information, see the
 [experimental ECMAScript Module]: esm.html#esm_resolve_hook
 [libuv threadpool documentation]: http://docs.libuv.org/en/latest/threadpool.html
 [remote code execution]: https://www.owasp.org/index.php/Code_Injection
-[Subresource Integrity]: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -426,13 +426,13 @@ unless either the `--pending-deprecation` command line flag, or the
 are used to provide a kind of selective "early warning" mechanism that
 developers may leverage to detect deprecated API usage.
 
-### `--policy-integrity`
+### `--policy-integrity=sri`
 <!-- YAML
 added: REPLACEME
 -->
 
 Instructs Node.js to error prior to running any code if the policy does not have
-the specified integrity.
+the specified integrity. It expects a [Subresource Integrity] string as a parameter.
 
 ### `--preserve-symlinks`
 <!-- YAML
@@ -1180,3 +1180,4 @@ greater than `4` (its current default value). For more information, see the
 [experimental ECMAScript Module]: esm.html#esm_resolve_hook
 [libuv threadpool documentation]: http://docs.libuv.org/en/latest/threadpool.html
 [remote code execution]: https://www.owasp.org/index.php/Code_Injection
+[Subresource Integrity]: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -426,6 +426,14 @@ unless either the `--pending-deprecation` command line flag, or the
 are used to provide a kind of selective "early warning" mechanism that
 developers may leverage to detect deprecated API usage.
 
+### `--policy-integrity`
+<!-- YAML
+added: TODO
+-->
+
+Instructs node to error prior to running any code if the policy does not have
+the specified integrity.
+
 ### `--preserve-symlinks`
 <!-- YAML
 added: v6.3.0
@@ -959,6 +967,7 @@ Node.js options that are allowed are:
 - `--no-warnings`
 - `--openssl-config`
 - `--pending-deprecation`
+- `--policy-integrity`
 - `--preserve-symlinks-main`
 - `--preserve-symlinks`
 - `--prof-process`

--- a/doc/api/policy.md
+++ b/doc/api/policy.md
@@ -38,6 +38,15 @@ node --experimental-policy=policy.json app.js
 The policy manifest will be used to enforce constraints on code loaded by
 Node.js.
 
+In order to mitigate tampering with policy files on disk, an integrity for
+the policy file itself may be provided via `--policy-integrity`.
+This allows running `node` and asserting the policy file contents
+even if the file is changed on disk.
+
+```sh
+node --experimental-policy=policy.json --policy-integrity="sha384-SggXRQHwCG8g+DktYYzxkXRIkTiEYWBHqev0xnpCxYlqMBufKZHAHQM3/boDaI/0" app.js
+```
+
 ## Features
 
 ### Error Behavior

--- a/doc/node.1
+++ b/doc/node.1
@@ -228,7 +228,7 @@ Among other uses, this can be used to enable FIPS-compliant crypto if Node.js is
 .It Fl -pending-deprecation
 Emit pending deprecation warnings.
 .
-.It Fl -policy-integrity=sri
+.It Fl -policy-integrity Ns = Ns Ar sri
 Instructs Node.js to error prior to running any code if the policy does not have the specified integrity. It expects a [Subresource Integrity] string as a parameter.
 .
 .It Fl -preserve-symlinks

--- a/doc/node.1
+++ b/doc/node.1
@@ -228,6 +228,9 @@ Among other uses, this can be used to enable FIPS-compliant crypto if Node.js is
 .It Fl -pending-deprecation
 Emit pending deprecation warnings.
 .
+.It Fl -experimental-policy
+Instructs node to error prior to running any code if the policy does not have the specified integrity.
+.
 .It Fl -preserve-symlinks
 Instructs the module loader to preserve symbolic links when resolving and caching modules other than the main module.
 .

--- a/doc/node.1
+++ b/doc/node.1
@@ -228,7 +228,7 @@ Among other uses, this can be used to enable FIPS-compliant crypto if Node.js is
 .It Fl -pending-deprecation
 Emit pending deprecation warnings.
 .
-.It Fl -experimental-policy
+.It Fl -policy-integrity
 Instructs node to error prior to running any code if the policy does not have the specified integrity.
 .
 .It Fl -preserve-symlinks

--- a/doc/node.1
+++ b/doc/node.1
@@ -228,8 +228,8 @@ Among other uses, this can be used to enable FIPS-compliant crypto if Node.js is
 .It Fl -pending-deprecation
 Emit pending deprecation warnings.
 .
-.It Fl -policy-integrity
-Instructs Node.js to error prior to running any code if the policy does not have the specified integrity.
+.It Fl -policy-integrity=sri
+Instructs Node.js to error prior to running any code if the policy does not have the specified integrity. It expects a [Subresource Integrity] string as a parameter.
 .
 .It Fl -preserve-symlinks
 Instructs the module loader to preserve symbolic links when resolving and caching modules other than the main module.

--- a/doc/node.1
+++ b/doc/node.1
@@ -229,7 +229,7 @@ Among other uses, this can be used to enable FIPS-compliant crypto if Node.js is
 Emit pending deprecation warnings.
 .
 .It Fl -policy-integrity Ns = Ns Ar sri
-Instructs Node.js to error prior to running any code if the policy does not have the specified integrity. It expects a [Subresource Integrity] string as a parameter.
+Instructs Node.js to error prior to running any code if the policy does not have the specified integrity. It expects a Subresource Integrity string as a parameter.
 .
 .It Fl -preserve-symlinks
 Instructs the module loader to preserve symbolic links when resolving and caching modules other than the main module.

--- a/doc/node.1
+++ b/doc/node.1
@@ -229,7 +229,7 @@ Among other uses, this can be used to enable FIPS-compliant crypto if Node.js is
 Emit pending deprecation warnings.
 .
 .It Fl -policy-integrity
-Instructs node to error prior to running any code if the policy does not have the specified integrity.
+Instructs Node.js to error prior to running any code if the policy does not have the specified integrity.
 .
 .It Fl -preserve-symlinks
 Instructs the module loader to preserve symbolic links when resolving and caching modules other than the main module.

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -4,6 +4,7 @@ const { Object, SafeWeakMap } = primordials;
 
 const { getOptionValue } = require('internal/options');
 const { Buffer } = require('buffer');
+const { ERR_MANIFEST_ASSERT_INTEGRITY } = require('internal/errors').codes;
 
 function prepareMainThreadExecution(expandArgv1 = false) {
   // Patch the process object with legacy properties and normalizations
@@ -332,6 +333,32 @@ function initializePolicy() {
     }
     const fs = require('fs');
     const src = fs.readFileSync(manifestURL, 'utf8');
+    const experimentalPolicyIntegrity = getOptionValue('--policy-integrity');
+    if (experimentalPolicyIntegrity) {
+      const SRI = require('internal/policy/sri');
+      const { createHash, timingSafeEqual } = require('crypto');
+      const realIntegrities = new Map();
+      const integrityEntries = SRI.parse(experimentalPolicyIntegrity);
+      let foundMatch = false;
+      for (var i = 0; i < integrityEntries.length; i++) {
+        const {
+          algorithm,
+          value: expected
+        } = integrityEntries[i];
+        const hash = createHash(algorithm);
+        hash.update(src);
+        const digest = hash.digest();
+        if (digest.length === expected.length &&
+          timingSafeEqual(digest, expected)) {
+          foundMatch = true;
+          break;
+        }
+        realIntegrities.set(algorithm, digest.toString('base64'));
+      }
+      if (!foundMatch) {
+        throw new ERR_MANIFEST_ASSERT_INTEGRITY(manifestURL, realIntegrities);
+      }
+    }
     require('internal/process/policy')
       .setup(src, manifestURL.href);
   }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -121,6 +121,13 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
   if (!userland_loader.empty() && !experimental_modules) {
     errors->push_back("--loader requires --experimental-modules be enabled");
   }
+  if (has_policy_integrity_string && experimental_policy.empty()) {
+    errors->push_back("--policy-integrity requires "
+                      "--experimental-policy be enabled");
+  }
+  if (has_policy_integrity_string && experimental_policy_integrity.empty()) {
+    errors->push_back("--policy-integrity cannot be empty");
+  }
 
   if (!module_type.empty()) {
     if (!experimental_modules) {
@@ -313,6 +320,15 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "security policy",
             &EnvironmentOptions::experimental_policy,
             kAllowedInEnvironment);
+  AddOption("[has_policy_integrity_string]",
+            "",
+            &EnvironmentOptions::has_policy_integrity_string);
+  AddOption("--policy-integrity",
+            "ensure the security policy contents match "
+            "the specified integrity",
+            &EnvironmentOptions::experimental_policy_integrity,
+            kAllowedInEnvironment);
+  Implies("--policy-integrity", "[has_policy_integrity_string]");
   AddOption("--experimental-repl-await",
             "experimental await keyword support in REPL",
             &EnvironmentOptions::experimental_repl_await,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -105,6 +105,8 @@ class EnvironmentOptions : public Options {
   bool experimental_wasm_modules = false;
   std::string module_type;
   std::string experimental_policy;
+  std::string experimental_policy_integrity;
+  bool has_policy_integrity_string;
   bool experimental_repl_await = false;
   bool experimental_vm_modules = false;
   bool expose_internals = false;

--- a/test/fixtures/policy/dep-policy.json
+++ b/test/fixtures/policy/dep-policy.json
@@ -1,7 +1,7 @@
 {
   "resources": {
     "./dep.js": {
-      "integrity": "sha512-7CMcc2oytFfMnGQaXbJk84gYWF2J7p/fmWPW7dsnJyniD+vgxtK9VAZ/22UxFOA4q5d27RoGLxSqNZ/nGCJkMw=="
+      "integrity": "sha512-7CMcc2oytFfMnGQaXbJk84gYWF2J7p/fmWPW7dsnJyniD+vgxtK9VAZ/22UxFOA4q5d27RoGLxSqNZ/nGCJkMw== sha512-scgN9Td0bGMlGH2lUHvEeHtz92Hx6AO+sYhU3WRI6bn3jEUCXbXJs68nOOsGzRWR7a2tbqGoETnOCpHHf1Njhw=="
     }
   }
 }

--- a/test/fixtures/policy/dep-policy.json
+++ b/test/fixtures/policy/dep-policy.json
@@ -1,0 +1,7 @@
+{
+  "resources": {
+    "./dep.js": {
+      "integrity": "sha512-7CMcc2oytFfMnGQaXbJk84gYWF2J7p/fmWPW7dsnJyniD+vgxtK9VAZ/22UxFOA4q5d27RoGLxSqNZ/nGCJkMw=="
+    }
+  }
+}

--- a/test/fixtures/policy/dep.js
+++ b/test/fixtures/policy/dep.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = 'The Secret Ingredient';

--- a/test/parallel/test-policy-integrity-flag.js
+++ b/test/parallel/test-policy-integrity-flag.js
@@ -45,7 +45,7 @@ const depPolicySRI = `sha512-${policyHash.digest('base64')}`;
   assert.strictEqual(status, 9);
 }
 {
-  const { status } = spawnSync(
+  const { status, stderr } = spawnSync(
     process.execPath,
     [
       '--policy-integrity', depPolicySRI,
@@ -53,5 +53,5 @@ const depPolicySRI = `sha512-${policyHash.digest('base64')}`;
     ]
   );
 
-  assert.strictEqual(status, 0);
+  assert.strictEqual(status, 0, `status: ${status}\nstderr: ${stderr}`);
 }

--- a/test/parallel/test-policy-integrity-flag.js
+++ b/test/parallel/test-policy-integrity-flag.js
@@ -19,7 +19,11 @@ emptyHash.update('');
 const emptySRI = `sha512-${emptyHash.digest('base64')}`;
 const policyHash = crypto.createHash('sha512');
 policyHash.update(fs.readFileSync(depPolicy));
-const depPolicySRI = `sha512-${policyHash.digest('base64')}`;
+// When using \n only
+const nixPolicySRI = 'sha512-u/nXI6UacK5fKDC2bopcgnuQY4JXJKlK3dESO3GIKKxwogVHjJqpF9rgk7Zw+TJXIc96xBUWKHuUgOzic8/4tQ==';
+// When \n is turned into \r\n
+const windowsPolicySRI = 'sha512-OeyCPRo4OZMosHyquZXDHpuU1F4KzG9UHFnn12FMaHsvqFUt3TFZ+7wmZE7ThZ5rsQWkUjc9ZH0knGZ2e8BYPQ==';
+const depPolicySRI = `${nixPolicySRI} ${windowsPolicySRI}`;
 console.dir({
   depPolicySRI,
   body: JSON.stringify(fs.readFileSync(depPolicy).toString('utf8'))

--- a/test/parallel/test-policy-integrity-flag.js
+++ b/test/parallel/test-policy-integrity-flag.js
@@ -11,7 +11,7 @@ const { spawnSync } = require('child_process');
 const fs = require('fs');
 const crypto = require('crypto');
 
-const depPolicy =fixtures.path('policy', 'dep-policy.json');
+const depPolicy = fixtures.path('policy', 'dep-policy.json');
 const dep = fixtures.path('policy', 'dep.js');
 
 const emptyHash = crypto.createHash('sha512');

--- a/test/parallel/test-policy-integrity-flag.js
+++ b/test/parallel/test-policy-integrity-flag.js
@@ -45,7 +45,7 @@ const depPolicySRI = `sha512-${policyHash.digest('base64')}`;
   assert.strictEqual(status, 9);
 }
 {
-  const { status, stderr } = spawnSync(
+  const { status } = spawnSync(
     process.execPath,
     [
       '--policy-integrity', depPolicySRI,
@@ -53,5 +53,5 @@ const depPolicySRI = `sha512-${policyHash.digest('base64')}`;
     ]
   );
 
-  assert.strictEqual(status, 0, `status: ${status}\nstderr: ${stderr}`);
+  assert.strictEqual(status, 0);
 }

--- a/test/parallel/test-policy-integrity-flag.js
+++ b/test/parallel/test-policy-integrity-flag.js
@@ -20,6 +20,10 @@ const emptySRI = `sha512-${emptyHash.digest('base64')}`;
 const policyHash = crypto.createHash('sha512');
 policyHash.update(fs.readFileSync(depPolicy));
 const depPolicySRI = `sha512-${policyHash.digest('base64')}`;
+console.dir({
+  depPolicySRI,
+  body: JSON.stringify(fs.readFileSync(depPolicy).toString('utf8'))
+})
 {
   const { status, stderr } = spawnSync(
     process.execPath,

--- a/test/parallel/test-policy-integrity-flag.js
+++ b/test/parallel/test-policy-integrity-flag.js
@@ -19,15 +19,19 @@ emptyHash.update('');
 const emptySRI = `sha512-${emptyHash.digest('base64')}`;
 const policyHash = crypto.createHash('sha512');
 policyHash.update(fs.readFileSync(depPolicy));
+
+/* eslint-disable max-len */
 // When using \n only
 const nixPolicySRI = 'sha512-u/nXI6UacK5fKDC2bopcgnuQY4JXJKlK3dESO3GIKKxwogVHjJqpF9rgk7Zw+TJXIc96xBUWKHuUgOzic8/4tQ==';
 // When \n is turned into \r\n
 const windowsPolicySRI = 'sha512-OeyCPRo4OZMosHyquZXDHpuU1F4KzG9UHFnn12FMaHsvqFUt3TFZ+7wmZE7ThZ5rsQWkUjc9ZH0knGZ2e8BYPQ==';
+/* eslint-enable max-len */
+
 const depPolicySRI = `${nixPolicySRI} ${windowsPolicySRI}`;
 console.dir({
   depPolicySRI,
   body: JSON.stringify(fs.readFileSync(depPolicy).toString('utf8'))
-})
+});
 {
   const { status, stderr } = spawnSync(
     process.execPath,

--- a/test/parallel/test-policy-integrity-flag.js
+++ b/test/parallel/test-policy-integrity-flag.js
@@ -53,5 +53,5 @@ const depPolicySRI = `sha512-${policyHash.digest('base64')}`;
     ]
   );
 
-  assert.strictEqual(status, 0);
+  assert.strictEqual(status, 0, `status: ${status}\nstderr: ${stderr}`);
 }

--- a/test/parallel/test-policy-integrity-flag.js
+++ b/test/parallel/test-policy-integrity-flag.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const fixtures = require('../common/fixtures');
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const crypto = require('crypto');
+
+const depPolicy =fixtures.path('policy', 'dep-policy.json');
+const dep = fixtures.path('policy', 'dep.js');
+
+const emptyHash = crypto.createHash('sha512');
+emptyHash.update('');
+const emptySRI = `sha512-${emptyHash.digest('base64')}`;
+const policyHash = crypto.createHash('sha512');
+policyHash.update(fs.readFileSync(depPolicy));
+const depPolicySRI = `sha512-${policyHash.digest('base64')}`;
+{
+  const { status, stderr } = spawnSync(
+    process.execPath,
+    [
+      '--policy-integrity', emptySRI,
+      '--experimental-policy', depPolicy, dep,
+    ]
+  );
+
+  assert.ok(stderr.includes('ERR_MANIFEST_ASSERT_INTEGRITY'));
+  assert.strictEqual(status, 1);
+}
+{
+  const { status, stderr } = spawnSync(
+    process.execPath,
+    [
+      '--policy-integrity', '',
+      '--experimental-policy', depPolicy, dep,
+    ]
+  );
+
+  assert.ok(stderr.includes('--policy-integrity'));
+  assert.strictEqual(status, 9);
+}
+{
+  const { status } = spawnSync(
+    process.execPath,
+    [
+      '--policy-integrity', depPolicySRI,
+      '--experimental-policy', depPolicy, dep,
+    ]
+  );
+
+  assert.strictEqual(status, 0);
+}

--- a/test/parallel/test-policy-integrity-flag.js
+++ b/test/parallel/test-policy-integrity-flag.js
@@ -45,7 +45,7 @@ const depPolicySRI = `sha512-${policyHash.digest('base64')}`;
   assert.strictEqual(status, 9);
 }
 {
-  const { status } = spawnSync(
+  const { status, stderr } = spawnSync(
     process.execPath,
     [
       '--policy-integrity', depPolicySRI,


### PR DESCRIPTION
This allows mitigating if a policy file is changed on disk and prevents `node` from running with the modified file. An attacker would need to modify the command that runs `node` in order to escape this mitigation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
