### PR TITLE
src: add public virtual destructor for KVStore

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -602,6 +602,13 @@ class AsyncRequest : public MemoryRetainer {
 
 class KVStore {
  public:
+  KVStore() = default;
+  virtual ~KVStore() = default;
+  KVStore(const KVStore&) = delete;
+  KVStore& operator=(const KVStore&) = delete;
+  KVStore(KVStore&&) = delete;
+  KVStore& operator=(KVStore&&) = delete;
+
   virtual v8::Local<v8::String> Get(v8::Isolate* isolate,
                                     v8::Local<v8::String> key) const = 0;
   virtual void Set(v8::Isolate* isolate,


### PR DESCRIPTION
As KVStore has derived classes, it is essential to
declare a public virtual destructor in the base
KVStore class. Otherwise, deleting derived class
instances using base class pointers would
potentially cause undefined behaviour.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
