### PR TITLE
stream: eos use writableFinished when available

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -35,7 +35,8 @@ function eos(stream, opts, callback) {
     if (!stream.writable) onfinish();
   };
 
-  var writableEnded = stream._writableState && stream._writableState.finished;
+  var writableEnded = stream.writableFinished ||
+    (stream._writableState && stream._writableState.finished);
   const onfinish = () => {
     writable = false;
     writableEnded = true;


### PR DESCRIPTION
 use writableFinished when available

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
