### PR TITLE
build: detect node_g (debug) for `available-node` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ V ?= 0
 available-node = \
   if [ -x $(PWD)/$(NODE) ] && [ -e $(PWD)/$(NODE) ]; then \
 		$(PWD)/$(NODE) $(1); \
+	elif [ -x $(PWD)/$(NODE_G_EXE) ] && [ -e $(PWD)/$(NODE_G_EXE) ]; then \
+		$(PWD)/$(NODE_G_EXE) $(1); \
 	elif [ -x `which node` ] && [ -e `which node` ] && [ `which node` ]; then \
 		`which node` $(1); \
 	else \


### PR DESCRIPTION
This lets us run `test-ci` with debug builds, currently we're using a custom invocation of tools/test.py. Since Node 10, we have `--mode=$(BUILDTYPE_LOWER)` in Makefile which gets us most of the way there. The doc tests in particular rely on `available-node` to run and since they are part of `test-ci` we get a failure because it's not looking for the right executable.

Here's a new version of node-test-commit-linux-containered that runs debug using both `build-ci` then `test-ci` rather than the current `build-ci` and custom `tools/test.py` invocation and it's green for this branch: https://ci.nodejs.org/job/rvagg-test-commit-linux-containered/11/nodes=ubuntu1604_sharedlibs_debug_x64/