### PR TITLE
stream: eos avoid listeners when possible

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -32,10 +32,6 @@ function eos(stream, opts, callback) {
   const isLegacyWritable = typeof stream.writableFinished !== 'boolean' &&
     writable && !stream._writableState;
 
-  const onlegacyfinish = () => {
-    if (!stream.writable) onfinish();
-  };
-
   var writableEnded = stream._writableState && stream._writableState.finished;
   const onfinish = () => {
     writable = false;
@@ -69,16 +65,21 @@ function eos(stream, opts, callback) {
     }
   };
 
-  const onrequest = () => {
-    stream.req.on('finish', onfinish);
-  };
+  let onrequest;
+  let onlegacyfinish;
 
   if (isLegacyRequest) {
+    onrequest = () => {
+      stream.req.on('finish', onfinish);
+    };
     stream.on('complete', onfinish);
     stream.on('abort', onclose);
     if (stream.req) onrequest();
     else stream.on('request', onrequest);
   } else if (isLegacyWritable) {
+    onlegacyfinish = () => {
+      if (!stream.writable) onfinish();
+    };
     stream.on('end', onlegacyfinish);
     stream.on('close', onlegacyfinish);
   }
@@ -89,12 +90,12 @@ function eos(stream, opts, callback) {
   stream.on('close', onclose);
 
   return function() {
-    if (isLegacyRequest) {
+    if (onrequest) {
       stream.removeListener('complete', onfinish);
       stream.removeListener('abort', onclose);
       stream.removeListener('request', onrequest);
       if (stream.req) stream.req.removeListener('finish', onfinish);
-    } else if (isLegacyWritable) {
+    } else if (onlegacyfinish) {
       stream.removeListener('end', onlegacyfinish);
       stream.removeListener('close', onlegacyfinish);
     }

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -33,23 +33,27 @@ function eos(stream, opts, callback) {
     writable && !stream._writableState;
 
   let writableEnded = stream._writableState && stream._writableState.finished;
-  const onfinish = () => {
-    writable = false;
-    writableEnded = true;
-    if (!readable) callback.call(stream);
-  };
+  let onfinish;
+  if (writable || isLegacyRequest || isLegacyWritable) {
+    onfinish = () => {
+      writable = false;
+      writableEnded = true;
+      if (!readable) callback.call(stream);
+    };
+    stream.on('finish', onfinish);
+  }
 
   let readableEnded = stream.readableEnded ||
     (stream._readableState && stream._readableState.endEmitted);
-  const onend = () => {
-    readable = false;
-    readableEnded = true;
-    if (!writable) callback.call(stream);
-  };
-
-  const onerror = (err) => {
-    callback.call(stream, err);
-  };
+  let onend;
+  if (readable) {
+    onend = () => {
+      readable = false;
+      readableEnded = true;
+      if (!writable) callback.call(stream);
+    };
+    stream.on('end', onend);
+  }
 
   const onclose = () => {
     let err;
@@ -64,6 +68,7 @@ function eos(stream, opts, callback) {
       return callback.call(stream, err);
     }
   };
+  stream.on('close', onclose);
 
   let onrequest;
   let onlegacyfinish;
@@ -84,10 +89,13 @@ function eos(stream, opts, callback) {
     stream.on('close', onlegacyfinish);
   }
 
-  stream.on('end', onend);
-  stream.on('finish', onfinish);
-  if (opts.error !== false) stream.on('error', onerror);
-  stream.on('close', onclose);
+  let onerror;
+  if (opts.error !== false) {
+    onerror = (err) => {
+      callback.call(stream, err);
+    };
+    stream.on('error', onerror);
+  }
 
   return function() {
     if (onrequest) {
@@ -99,9 +107,15 @@ function eos(stream, opts, callback) {
       stream.removeListener('end', onlegacyfinish);
       stream.removeListener('close', onlegacyfinish);
     }
-    stream.removeListener('finish', onfinish);
-    stream.removeListener('end', onend);
-    stream.removeListener('error', onerror);
+    if (onerror) {
+      stream.removeListener('error', onerror);
+    }
+    if (onfinish) {
+      stream.removeListener('finish', onfinish);
+    }
+    if (onend) {
+      stream.removeListener('end', onend);
+    }
     stream.removeListener('close', onclose);
   };
 }

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -32,14 +32,14 @@ function eos(stream, opts, callback) {
   const isLegacyWritable = typeof stream.writableFinished !== 'boolean' &&
     writable && !stream._writableState;
 
-  var writableEnded = stream._writableState && stream._writableState.finished;
+  let writableEnded = stream._writableState && stream._writableState.finished;
   const onfinish = () => {
     writable = false;
     writableEnded = true;
     if (!readable) callback.call(stream);
   };
 
-  var readableEnded = stream.readableEnded ||
+  let readableEnded = stream.readableEnded ||
     (stream._readableState && stream._readableState.endEmitted);
   const onend = () => {
     readable = false;

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -9,10 +9,6 @@ const {
 } = require('internal/errors').codes;
 const { once } = require('internal/util');
 
-function isRequest(stream) {
-  return stream.setHeader && typeof stream.abort === 'function';
-}
-
 function eos(stream, opts, callback) {
   if (arguments.length === 2) {
     callback = opts;
@@ -30,6 +26,11 @@ function eos(stream, opts, callback) {
 
   let readable = opts.readable || (opts.readable !== false && stream.readable);
   let writable = opts.writable || (opts.writable !== false && stream.writable);
+
+  const isLegacyRequest = typeof stream.writableFinished !== 'boolean' &&
+    stream.setHeader && typeof stream.abort === 'function';
+  const isLegacyWritable = typeof stream.writableFinished !== 'boolean' &&
+    writable && !stream._writableState;
 
   const onlegacyfinish = () => {
     if (!stream.writable) onfinish();
@@ -72,12 +73,12 @@ function eos(stream, opts, callback) {
     stream.req.on('finish', onfinish);
   };
 
-  if (isRequest(stream)) {
+  if (isLegacyRequest) {
     stream.on('complete', onfinish);
     stream.on('abort', onclose);
     if (stream.req) onrequest();
     else stream.on('request', onrequest);
-  } else if (writable && !stream._writableState) { // legacy streams
+  } else if (isLegacyWritable) {
     stream.on('end', onlegacyfinish);
     stream.on('close', onlegacyfinish);
   }
@@ -88,12 +89,15 @@ function eos(stream, opts, callback) {
   stream.on('close', onclose);
 
   return function() {
-    stream.removeListener('complete', onfinish);
-    stream.removeListener('abort', onclose);
-    stream.removeListener('request', onrequest);
-    if (stream.req) stream.req.removeListener('finish', onfinish);
-    stream.removeListener('end', onlegacyfinish);
-    stream.removeListener('close', onlegacyfinish);
+    if (isLegacyRequest) {
+      stream.removeListener('complete', onfinish);
+      stream.removeListener('abort', onclose);
+      stream.removeListener('request', onrequest);
+      if (stream.req) stream.req.removeListener('finish', onfinish);
+    } else if (isLegacyWritable) {
+      stream.removeListener('end', onlegacyfinish);
+      stream.removeListener('close', onlegacyfinish);
+    }
     stream.removeListener('finish', onfinish);
     stream.removeListener('end', onend);
     stream.removeListener('error', onerror);


### PR DESCRIPTION
This slightly improves performance and maintainability by applying legacy compat logic only when required.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
