### PR TITLE
Add additional documentation for heap snapshot flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -219,7 +219,7 @@ added: v12.0.0
 Enables a signal handler that causes the Node.js process to write a heap dump
 when the specified signal is received.
 
-```
+```console
 $ node --heapsnapshot-signal=SIGUSR2 index.js &
 $ ps aux        
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -216,7 +216,8 @@ reference. Code may break under this flag.
 added: v12.0.0
 -->
 
-Enables a signal handler that causes the node process to write a heap dump when the specified signal is received.
+Enables a signal handler that causes the Node.js process to write a heap dump
+when the specified signal is received.
 
 ```
 $ node --heapsnapshot-signal=SIGUSR2 index.js &

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -221,7 +221,7 @@ when the specified signal is received.
 
 ```console
 $ node --heapsnapshot-signal=SIGUSR2 index.js &
-$ ps aux        
+$ ps aux
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 node         1  5.5  6.1 787252 247004 ?       Ssl  16:43   0:02 node --heapsnapshot-signal=SIGUSR2 index.js
 $ kill -USR2 1

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -216,6 +216,18 @@ reference. Code may break under this flag.
 added: v12.0.0
 -->
 
+Enables a signal handler that causes the node process to write a heap dump when the specified signal is received.
+
+```
+$ node --heapsnapshot-signal=SIGUSR2 index.js &
+$ ps aux        
+USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+node         1  5.5  6.1 787252 247004 ?       Ssl  16:43   0:02 node --heapsnapshot-signal=SIGUSR2 index.js
+$ kill -USR2 1
+$ ls
+Heap.20190718.133405.15554.0.001.heapsnapshot
+```
+
 ### `--heap-prof`
 <!-- YAML
 added: v12.4.0


### PR DESCRIPTION
It's nice to have usage examples, especially since the flag requires the `SIG` version of the signal name, unlike `kill`.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
