### PR TITLE
fs: refactor autoClose

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -106,9 +106,7 @@ function ReadStream(path, options) {
     this.open();
 
   this.on('end', function() {
-    if (this.autoClose) {
-      this.destroy();
-    }
+    closeMaybe(this);
   });
 }
 Object.setPrototypeOf(ReadStream.prototype, Readable.prototype);
@@ -117,10 +115,7 @@ Object.setPrototypeOf(ReadStream, Readable);
 ReadStream.prototype.open = function() {
   fs.open(this.path, this.flags, this.mode, (er, fd) => {
     if (er) {
-      if (this.autoClose) {
-        this.destroy();
-      }
-      this.emit('error', er);
+      closeMaybe(this, er);
       return;
     }
 
@@ -167,10 +162,7 @@ ReadStream.prototype._read = function(n) {
   // the actual read.
   fs.read(this.fd, pool, pool.used, toRead, this.pos, (er, bytesRead) => {
     if (er) {
-      if (this.autoClose) {
-        this.destroy();
-      }
-      this.emit('error', er);
+      closeMaybe(this, er);
     } else {
       let b = null;
       // Now that we know how much data we have actually read, re-wind the
@@ -273,20 +265,14 @@ Object.setPrototypeOf(WriteStream.prototype, Writable.prototype);
 Object.setPrototypeOf(WriteStream, Writable);
 
 WriteStream.prototype._final = function(callback) {
-  if (this.autoClose) {
-    this.destroy();
-  }
-
+  closeMaybe(this);
   callback();
 };
 
 WriteStream.prototype.open = function() {
   fs.open(this.path, this.flags, this.mode, (er, fd) => {
     if (er) {
-      if (this.autoClose) {
-        this.destroy();
-      }
-      this.emit('error', er);
+      closeMaybe(this, er);
       return;
     }
 
@@ -311,10 +297,8 @@ WriteStream.prototype._write = function(data, encoding, cb) {
 
   fs.write(this.fd, data, 0, data.length, this.pos, (er, bytes) => {
     if (er) {
-      if (this.autoClose) {
-        this.destroy();
-      }
-      return cb(er);
+      closeMaybe(this, er, cb);
+      return;
     }
     this.bytesWritten += bytes;
     cb();
@@ -358,8 +342,8 @@ WriteStream.prototype._writev = function(data, cb) {
 
   writev(this.fd, chunks, this.pos, function(er, bytes) {
     if (er) {
-      self.destroy();
-      return cb(er);
+      closeMaybe(this, er, cb);
+      return;
     }
     self.bytesWritten += bytes;
     cb();
@@ -399,6 +383,15 @@ Object.defineProperty(WriteStream.prototype, 'pending', {
   get() { return this.fd === null; },
   configurable: true
 });
+
+function closeMaybe(stream, er, cb) {
+  if (stream.autoClose) {
+    stream.destroy(er, cb);
+  } else if (er) {
+    stream.emit('error', er);
+    if (cb) cb(er);
+  }
+}
 
 module.exports = {
   ReadStream,


### PR DESCRIPTION
Simplify `autoClose` logic into a helper. Also pass error through `destroy` instead of emitting when possible.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
