### PR TITLE
src: silence compiler warning

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -646,7 +646,7 @@ Maybe<const PackageConfig*> GetPackageScopeConfig(Environment* env,
     if (pjson_url.path() == last_pjson_url.path()) {
       auto entry = env->package_json_cache.emplace(pjson_url.ToFilePath(),
           PackageConfig { Exists::No, IsValid::Yes, HasMain::No, "",
-                          PackageType::None });
+                          PackageType::None, Global<Value>() });
       const PackageConfig* pcfg = &entry.first->second;
       return Just(pcfg);
     }


### PR DESCRIPTION
This commit fixes the following warning:

warning: missing field 'exports' initializer

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
