### PR TITLE
fs: don't emit open after destroy

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -22,6 +22,8 @@ const { toPathIfFileURL } = require('internal/url');
 
 const kMinPoolSpace = 128;
 
+const kOpenCallback = Symbol('destroyCallback');
+
 let pool;
 // It can happen that we expect to read a large chunk of data, and reserve
 // a large chunk of the pool accordingly, but the read() call only filled
@@ -125,10 +127,14 @@ ReadStream.prototype.open = function() {
     }
 
     this.fd = fd;
-    this.emit('open', fd);
-    this.emit('ready');
-    // Start the flow of data.
-    this.read();
+    if (!this[kOpenCallback]) {
+      this.emit('open', fd);
+      this.emit('ready');
+      // Start the flow of data.
+      this.read();
+    } else {
+      this[kOpenCallback]();
+    }
   });
 };
 
@@ -207,7 +213,7 @@ ReadStream.prototype._read = function(n) {
 
 ReadStream.prototype._destroy = function(err, cb) {
   if (typeof this.fd !== 'number') {
-    this.once('open', closeFsStream.bind(null, this, cb, err));
+    this[kOpenCallback] = closeFsStream.bind(null, this, cb, err);
     return;
   }
 
@@ -291,8 +297,12 @@ WriteStream.prototype.open = function() {
     }
 
     this.fd = fd;
-    this.emit('open', fd);
-    this.emit('ready');
+    if (!this[kOpenCallback]) {
+      this.emit('open', fd);
+      this.emit('ready');
+    } else {
+      this[kOpenCallback]();
+    }
   });
 };
 

--- a/test/parallel/test-fs-stream-destroy-open.js
+++ b/test/parallel/test-fs-stream-destroy-open.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+const fs = require('fs');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+test(fs.createReadStream(__filename));
+test(fs.createWriteStream(`${tmpdir.path}/dummy`));
+
+function test(stream) {
+  stream.on('open', common.mustNotCall());
+  stream.on('ready', common.mustNotCall());
+  stream.on('close', common.mustCall());
+  stream.destroy();
+  stream.on('ready', common.mustNotCall());
+  stream.on('open', common.mustNotCall());
+}

--- a/test/parallel/test-fs-stream-double-close.js
+++ b/test/parallel/test-fs-stream-double-close.js
@@ -27,23 +27,14 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 test1(fs.createReadStream(__filename));
-test2(fs.createReadStream(__filename));
 test3(fs.createReadStream(__filename));
 
 test1(fs.createWriteStream(`${tmpdir.path}/dummy1`));
-test2(fs.createWriteStream(`${tmpdir.path}/dummy2`));
 test3(fs.createWriteStream(`${tmpdir.path}/dummy3`));
 
 function test1(stream) {
   stream.destroy();
   stream.destroy();
-}
-
-function test2(stream) {
-  stream.destroy();
-  stream.on('open', common.mustCall(function(fd) {
-    stream.destroy();
-  }));
 }
 
 function test3(stream) {


### PR DESCRIPTION
Not perfect but still better than it was.

Refs: https://github.com/nodejs/node/issues/23133

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
