### PR TITLE
fs: don't double emit close on error

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -217,11 +217,8 @@ ReadStream.prototype._destroy = function(err, cb) {
 
 function closeFsStream(stream, cb, err) {
   fs.close(stream.fd, (er) => {
-    er = er || err;
-    cb(er);
+    cb(er || err);
     stream.closed = true;
-    if (!er)
-      stream.emit('close');
   });
 }
 


### PR DESCRIPTION
Readable `destroy` will emit `'close'` on error. No reason to emit it before. Will just cause the error to be emitted twice.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
