### PR TITLE
timers: add getActiveTimers that returns all active timers

### DIFF
--- a/benchmark/timers/getActiveTimers-bench.js
+++ b/benchmark/timers/getActiveTimers-bench.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common.js');
+const { getActiveTimers } = require('timers');
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+  default_value: [1, 0],
+});
+
+function main({ n, default_value }) {
+  for (let i = 1; i <= n; i++) {
+    setTimeout(() => {}, (default_value ? i : 10));
+  }
+
+  bench.start();
+  const timers = getActiveTimers();
+  bench.end(n);
+
+  for (var j = 0; j < n; j++) {
+    clearTimeout(timers[j]);
+  }
+}

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -263,6 +263,17 @@ added: v0.0.1
 
 Cancels a `Timeout` object created by [`setTimeout()`][].
 
+## Diagnostics
+
+### getActiveTimers()
+<!-- YAML
+added: REPLACE ME
+-->
+
+Returns an array of all currently active timers by duration
+from shortest to longest. Order of timers with the same
+duration will be based on expiration time in ascending order.
+
 [Event Loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout
 [`TypeError`]: errors.html#errors_class_typeerror
 [`clearImmediate()`]: timers.html#timers_clearimmediate_immediate

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -267,7 +267,7 @@ Cancels a `Timeout` object created by [`setTimeout()`][].
 
 ### getActiveTimers()
 <!-- YAML
-added: REPLACE ME
+added: REPLACEME
 -->
 
 Returns an array of all currently active timers by duration

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -573,6 +573,19 @@ function getTimerCallbacks(runNextTicks) {
   };
 }
 
+function getActiveTimers() {
+  const timers = [];
+  for (const key in timerListMap) {
+    const timersList = timerListMap[key];
+    let timeout = timersList._idlePrev;
+    while (timeout !== timersList) {
+      timers.push(timeout);
+      timeout = timeout._idlePrev;
+    }
+  }
+  return timers;
+}
+
 module.exports = {
   TIMEOUT_MAX,
   kTimeout: Symbol('timeout'), // For hiding Timeouts on other internals.
@@ -583,6 +596,7 @@ module.exports = {
   initAsyncResource,
   setUnrefTimeout,
   getTimerDuration,
+  getActiveTimers,
   immediateQueue,
   getTimerCallbacks,
   immediateInfoFields: {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -39,6 +39,7 @@ const {
   kRefed,
   initAsyncResource,
   getTimerDuration,
+  getActiveTimers,
   timerListMap,
   timerListQueue,
   immediateQueue,
@@ -302,6 +303,7 @@ module.exports = {
   clearImmediate,
   setInterval,
   clearInterval,
+  getActiveTimers,
   _unrefActive: deprecate(
     unrefActive,
     'timers._unrefActive() is deprecated.' +

--- a/test/parallel/test-timers-get-active-timers.js
+++ b/test/parallel/test-timers-get-active-timers.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { getActiveTimers } = require('timers');
+
+const inputs = [
+  1,
+  2,
+  35,
+  47,
+  47,
+  200,
+  200,
+  256,
+];
+
+// Setting timeouts and intervals using values from the inputs array.
+// These timers should not be called.
+inputs.forEach((value) => setTimeout(common.mustNotCall(), value));
+inputs.forEach((value) => setInterval(common.mustNotCall(), value));
+
+// Setting timers that should not be showing up when
+// we use clearTimeout before calling getActiveTimers.
+const clearedTimers = inputs.map((value) =>
+  setTimeout(common.mustNotCall(), value));
+
+clearedTimers.forEach(clearTimeout);
+
+const activeTimers = getActiveTimers();
+
+// Checking to see if any of the cleared timers are
+// showing up in the getActiveTimers array.
+// If any of them show up, the test will fail.
+const allTimers = new Set([...activeTimers, ...clearedTimers]);
+if (allTimers.size !== activeTimers.length + clearedTimers.length) {
+  assert.fail('cleared timer should not be returned by getActiveTimers');
+}
+
+// Clearing all timers. If the test succeeds, the test will exit.
+activeTimers.forEach(clearTimeout);


### PR DESCRIPTION
getActiveTimers will return all active timers.
Includes benchmarks and tests, as well as documentation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
