### PR TITLE
src: make `CompiledFnEntry` a `BaseObject`

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -39,7 +39,6 @@ using v8::NewStringType;
 using v8::Number;
 using v8::Object;
 using v8::Private;
-using v8::ScriptOrModule;
 using v8::SnapshotCreator;
 using v8::StackTrace;
 using v8::String;
@@ -47,7 +46,6 @@ using v8::Symbol;
 using v8::TracingController;
 using v8::Undefined;
 using v8::Value;
-using v8::WeakCallbackInfo;
 using worker::Worker;
 
 int const Environment::kNodeContextTag = 0x6e6f64;
@@ -385,24 +383,6 @@ Environment::Environment(IsolateData* isolate_data,
   // TODO(joyeecheung): deserialize when the snapshot covers the environment
   // properties.
   CreateProperties();
-}
-
-static void WeakCallbackCompiledFn(
-    const WeakCallbackInfo<CompiledFnEntry>& data) {
-  CompiledFnEntry* entry = data.GetParameter();
-  entry->env->id_to_function_map.erase(entry->id);
-  delete entry;
-}
-
-CompiledFnEntry::CompiledFnEntry(Environment* env,
-                                 uint32_t id,
-                                 Local<ScriptOrModule> script)
-    : env(env),
-      id(id),
-      cache_key(env->isolate(), Object::New(env->isolate())),
-      script(env->isolate(), script) {
-  this->script.SetWeak(
-      this, WeakCallbackCompiledFn, v8::WeakCallbackType::kParameter);
 }
 
 Environment::~Environment() {

--- a/src/env.h
+++ b/src/env.h
@@ -55,6 +55,7 @@ namespace node {
 
 namespace contextify {
 class ContextifyScript;
+class CompiledFnEntry;
 }
 
 namespace fs {
@@ -377,6 +378,7 @@ constexpr size_t kFsStatsBufferLength =
   V(as_callback_data_template, v8::FunctionTemplate)                           \
   V(async_wrap_ctor_template, v8::FunctionTemplate)                            \
   V(async_wrap_object_ctor_template, v8::FunctionTemplate)                     \
+  V(compiled_fn_entry_template, v8::ObjectTemplate)                            \
   V(fd_constructor_template, v8::ObjectTemplate)                               \
   V(fdclose_constructor_template, v8::ObjectTemplate)                          \
   V(filehandlereadwrap_template, v8::ObjectTemplate)                           \
@@ -521,16 +523,6 @@ struct ContextInfo {
   const std::string name;
   std::string origin;
   bool is_default = false;
-};
-
-struct CompiledFnEntry {
-  Environment* env;
-  uint32_t id;
-  v8::Global<v8::Object> cache_key;
-  v8::Global<v8::ScriptOrModule> script;
-  CompiledFnEntry(Environment* env,
-                  uint32_t id,
-                  v8::Local<v8::ScriptOrModule> script);
 };
 
 // Listing the AsyncWrap provider types first enables us to cast directly
@@ -1010,7 +1002,7 @@ class Environment : public MemoryRetainer {
   std::unordered_map<uint32_t, loader::ModuleWrap*> id_to_module_map;
   std::unordered_map<uint32_t, contextify::ContextifyScript*>
       id_to_script_map;
-  std::unordered_map<uint32_t, CompiledFnEntry*> id_to_function_map;
+  std::unordered_map<uint32_t, contextify::CompiledFnEntry*> id_to_function_map;
 
   inline uint32_t get_next_module_id();
   inline uint32_t get_next_script_id();

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -1041,7 +1041,9 @@ static MaybeLocal<Promise> ImportModuleDynamically(
     ModuleWrap* wrap = ModuleWrap::GetFromID(env, id);
     object = wrap->object();
   } else if (type == ScriptType::kFunction) {
-    object = env->id_to_function_map.find(id)->second->cache_key.Get(iso);
+    auto it = env->id_to_function_map.find(id);
+    CHECK_NE(it, env->id_to_function_map.end());
+    object = it->second->object();
   } else {
     UNREACHABLE();
   }

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -133,6 +133,25 @@ class ContextifyScript : public BaseObject {
   uint32_t id_;
 };
 
+class CompiledFnEntry final : public BaseObject {
+ public:
+  SET_NO_MEMORY_INFO()
+  SET_MEMORY_INFO_NAME(CompiledFnEntry)
+  SET_SELF_SIZE(CompiledFnEntry)
+
+  CompiledFnEntry(Environment* env,
+                  v8::Local<v8::Object> object,
+                  uint32_t id,
+                  v8::Local<v8::ScriptOrModule> script);
+  ~CompiledFnEntry();
+
+ private:
+  uint32_t id_;
+  v8::Global<v8::ScriptOrModule> script_;
+
+  static void WeakCallback(const v8::WeakCallbackInfo<CompiledFnEntry>& data);
+};
+
 }  // namespace contextify
 }  // namespace node
 


### PR DESCRIPTION
In particular:

- Move the class definition to the relevant header file,
  i.e. `node_contextify.h`.
- Make sure that class instances are destroyed on
  `Environment` teardown.
- Make instances of the key object traceable in heap dumps. This is
  particularly relevant here because our C++ script → map key mapping
  could introduce memory leaks when the import function metadata refers
  back to the script in some way.

Refs: https://github.com/nodejs/node/pull/28671

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
