### PR TITLE
tools: remove unused pkgsrc directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1027,7 +1027,6 @@ $(TARBALL): release-only $(NODE_EXE) doc
 	$(RM) -r $(TARNAME)/tools/node_modules
 	$(RM) -r $(TARNAME)/tools/osx-*
 	$(RM) -r $(TARNAME)/tools/osx-pkg.pmdoc
-	$(RM) -r $(TARNAME)/tools/pkgsrc
 	find $(TARNAME)/ -name ".eslint*" -maxdepth 2 | xargs $(RM)
 	find $(TARNAME)/ -type l | xargs $(RM) # annoying on windows
 	tar -cf $(TARNAME).tar $(TARNAME)

--- a/tools/pkgsrc/comment
+++ b/tools/pkgsrc/comment
@@ -1,1 +1,0 @@
-V8 JavaScript for clients and servers (nodejs.org package)

--- a/tools/pkgsrc/description
+++ b/tools/pkgsrc/description
@@ -1,7 +1,0 @@
-Node.js is an evented I/O framework for the V8 JavaScript engine. It is
-intended for writing scalable network programs such as web servers.
-
-Packaged by nodejs.org
-
-Homepage:
-https://nodejs.org/


### PR DESCRIPTION
The pkgsrc Makefile target was removed in 2015

Refs: https://github.com/nodejs/node/pull/1938
