### PR TITLE
src: replace ToLocalChecked calls with a safer ToLocal

### DIFF
--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -175,8 +175,10 @@ std::unique_ptr<Environment> NodeMainInstance::CreateMainEnvironment(
 
   Local<Context> context;
   if (deserialize_mode_) {
-    context =
-        Context::FromSnapshot(isolate_, kNodeContextIndex).ToLocalChecked();
+    if (!Context::FromSnapshot(isolate_, kNodeContextIndex).ToLocal(&context)) {
+      *exit_code = 1;
+      return nullptr;
+    }
     SetIsolateUpForNode(isolate_, IsolateSettingCategories::kErrorHandlers);
   } else {
     context = NewContext(isolate_);


### PR DESCRIPTION
ToLocalChecked was being called without performing an
IsEmpty check. This could be fatal, as calling
ToLocalChecked on an empty v8::Value would crash the
process.
This patch replaces ToLocalChecked with a safer ToLocal
call which will yield the v8::Local instance to the
out parameter for non-empty v8 objects.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
