### PR TITLE
worker: fix crash when SharedArrayBuffer outlives creating thread

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -76,6 +76,8 @@ static MaybeLocal<Value> PrepareStackTraceCallback(Local<Context> context,
   return result;
 }
 
+thread_local uint32_t NodeArrayBufferAllocator::zero_fill_field_ = 1;
+
 void* NodeArrayBufferAllocator::Allocate(size_t size) {
   if (zero_fill_field_ || per_process::cli_options->zero_fill_all_buffers)
     return UncheckedCalloc(size);

--- a/src/env.cc
+++ b/src/env.cc
@@ -930,6 +930,7 @@ void AsyncHooks::MemoryInfo(MemoryTracker* tracker) const {
 void AsyncHooks::grow_async_ids_stack() {
   async_ids_stack_.reserve(async_ids_stack_.Length() * 3);
 
+  CHECK(!env()->async_hooks_binding().IsEmpty());
   env()->async_hooks_binding()->Set(
       env()->context(),
       env()->async_ids_stack_string(),

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -121,7 +121,8 @@ class NodeArrayBufferAllocator : public ArrayBufferAllocator {
   NodeArrayBufferAllocator* GetImpl() final { return this; }
 
  private:
-  uint32_t zero_fill_field_ = 1;  // Boolean but exposed as uint32 to JS land.
+  // Boolean but exposed as uint32 to JS land.
+  static thread_local uint32_t zero_fill_field_;
 };
 
 class DebuggingArrayBufferAllocator final : public NodeArrayBufferAllocator {

--- a/test/parallel/test-worker-arraybuffer-zerofill.js
+++ b/test/parallel/test-worker-arraybuffer-zerofill.js
@@ -1,0 +1,33 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Make sure that allocating uninitialized ArrayBuffers in one thread does not
+// affect the zero-initialization in other threads.
+
+const w = new Worker(`
+const { parentPort } = require('worker_threads');
+
+function post() {
+  const uint32array = new Uint32Array(64);
+  parentPort.postMessage(uint32array.reduce((a, b) => a + b));
+}
+
+setInterval(post, 0);
+`, { eval: true });
+
+function allocBuffers() {
+  Buffer.allocUnsafe(32 * 1024 * 1024);
+}
+
+const interval = setInterval(allocBuffers, 0);
+
+let messages = 0;
+w.on('message', (sum) => {
+  assert.strictEqual(sum, 0);
+  if (messages++ === 100) {
+    clearInterval(interval);
+    w.terminate();
+  }
+});

--- a/test/parallel/test-worker-sharedarraybuffer-from-worker-thread.js
+++ b/test/parallel/test-worker-sharedarraybuffer-from-worker-thread.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Regression test for https://github.com/nodejs/node/issues/28777
+// Make sure that SharedArrayBuffers created in Worker threads are accessible
+// after the creating thread ended.
+
+const w = new Worker(`
+const { parentPort } = require('worker_threads');
+const sharedArrayBuffer = new SharedArrayBuffer(4);
+parentPort.postMessage(sharedArrayBuffer);
+`, { eval: true });
+
+let sharedArrayBuffer;
+w.once('message', common.mustCall((message) => sharedArrayBuffer = message));
+w.once('exit', common.mustCall(() => {
+  const uint8array = new Uint8Array(sharedArrayBuffer);
+  uint8array[0] = 42;
+  assert.deepStrictEqual(uint8array, new Uint8Array([42, 0, 0, 0]));
+}));


### PR DESCRIPTION
Use the parent thread’s `ArrayBuffer::Allocator` when creating a
Worker instance, as that allocator is guaranteed to outlive the
Worker itself.

Fixes: https://github.com/nodejs/node/issues/28777
Fixes: https://github.com/nodejs/node/issues/28773

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
