### PR TITLE
benchmark, http: refactor for code consistency

### DIFF
--- a/benchmark/http/bench-parser.js
+++ b/benchmark/http/bench-parser.js
@@ -22,7 +22,7 @@ function main({ len, n }) {
     const parser = newParser(REQUEST);
 
     bench.start();
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       parser.execute(header, 0, header.length);
       parser.initialize(REQUEST, {});
     }
@@ -45,7 +45,7 @@ function main({ len, n }) {
 
   let header = `GET /hello HTTP/1.1${CRLF}Content-Type: text/plain${CRLF}`;
 
-  for (var i = 0; i < len; i++) {
+  for (let i = 0; i < len; i++) {
     header += `X-Filler${i}: ${Math.random().toString(36).substr(2)}${CRLF}`;
   }
   header += CRLF;

--- a/benchmark/http/check_invalid_header_char.js
+++ b/benchmark/http/check_invalid_header_char.js
@@ -61,7 +61,7 @@ function main({ n, input }) {
 
   const len = inputs.length;
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     _checkInvalidHeaderChar(inputs[i % len]);
   }
   bench.end(n);

--- a/benchmark/http/check_is_http_token.js
+++ b/benchmark/http/check_is_http_token.js
@@ -42,7 +42,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, key }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     _checkIsHttpToken(key);
   }
   bench.end(n);

--- a/benchmark/http/set_header.js
+++ b/benchmark/http/set_header.js
@@ -23,7 +23,7 @@ function main(conf) {
   const og = new OutgoingMessage();
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     og.setHeader(value, '');
   }
   bench.end(n);


### PR DESCRIPTION
In benchmark http directory this changes `for` loops using `var` to `let`
when it applies for consistency and it always add an empty line
after `'use strict'`.

If this is OK, I will do it for the other directories in `benchmark` with single commits so it's easy to review a few files per commit.

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
