### PR TITLE
[v10.x backport] test: remove `util.inherits()` usage

### DIFF
--- a/test/common/arraystream.js
+++ b/test/common/arraystream.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const { Stream } = require('stream');
-const { inherits } = require('util');
 function noop() {}
 
 // A stream to push an array into a REPL
@@ -14,7 +13,8 @@ function ArrayStream() {
   };
 }
 
-inherits(ArrayStream, Stream);
+Object.setPrototypeOf(ArrayStream.prototype, Stream.prototype);
+Object.setPrototypeOf(ArrayStream, Stream);
 ArrayStream.prototype.readable = true;
 ArrayStream.prototype.writable = true;
 ArrayStream.prototype.pause = noop;

--- a/test/parallel/test-event-emitter-prepend.js
+++ b/test/parallel/test-event-emitter-prepend.js
@@ -31,7 +31,6 @@ common.expectsError(() => {
 
 // Test fallback if prependListener is undefined.
 const stream = require('stream');
-const util = require('util');
 
 delete EventEmitter.prototype.prependListener;
 
@@ -39,13 +38,15 @@ function Writable() {
   this.writable = true;
   stream.Stream.call(this);
 }
-util.inherits(Writable, stream.Stream);
+Object.setPrototypeOf(Writable.prototype, stream.Stream.prototype);
+Object.setPrototypeOf(Writable, stream.Stream);
 
 function Readable() {
   this.readable = true;
   stream.Stream.call(this);
 }
-util.inherits(Readable, stream.Stream);
+Object.setPrototypeOf(Readable.prototype, stream.Stream.prototype);
+Object.setPrototypeOf(Readable, stream.Stream);
 
 const w = new Writable();
 const r = new Readable();

--- a/test/parallel/test-event-emitter-subclass.js
+++ b/test/parallel/test-event-emitter-subclass.js
@@ -23,9 +23,9 @@
 const common = require('../common');
 const assert = require('assert');
 const EventEmitter = require('events').EventEmitter;
-const util = require('util');
 
-util.inherits(MyEE, EventEmitter);
+Object.setPrototypeOf(MyEE.prototype, EventEmitter.prototype);
+Object.setPrototypeOf(MyEE, EventEmitter);
 
 function MyEE(cb) {
   this.once(1, cb);
@@ -38,7 +38,8 @@ const myee = new MyEE(common.mustCall());
 
 myee.hasOwnProperty('usingDomains');
 
-util.inherits(ErrorEE, EventEmitter);
+Object.setPrototypeOf(ErrorEE.prototype, EventEmitter.prototype);
+Object.setPrototypeOf(ErrorEE, EventEmitter);
 function ErrorEE() {
   this.emit('error', new Error('blerg'));
 }

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -24,7 +24,6 @@
 require('../common');
 const assert = require('assert');
 
-const util = require('util');
 const net = require('net');
 const http = require('http');
 
@@ -69,7 +68,8 @@ function testServer() {
   });
 }
 
-util.inherits(testServer, http.Server);
+Object.setPrototypeOf(testServer.prototype, http.Server.prototype);
+Object.setPrototypeOf(testServer, http.Server);
 
 
 function writeReq(socket, data, encoding) {

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 const { Duplex } = require('stream');
 const assert = require('assert');
-const { inherits } = require('util');
 
 {
   const duplex = new Duplex({
@@ -190,7 +189,8 @@ const { inherits } = require('util');
     Duplex.call(this);
   }
 
-  inherits(MyDuplex, Duplex);
+  Object.setPrototypeOf(MyDuplex.prototype, Duplex.prototype);
+  Object.setPrototypeOf(MyDuplex, Duplex);
 
   new MyDuplex();
 }

--- a/test/parallel/test-stream-pipe-cleanup.js
+++ b/test/parallel/test-stream-pipe-cleanup.js
@@ -25,14 +25,14 @@
 require('../common');
 const stream = require('stream');
 const assert = require('assert');
-const util = require('util');
 
 function Writable() {
   this.writable = true;
   this.endCalls = 0;
   stream.Stream.call(this);
 }
-util.inherits(Writable, stream.Stream);
+Object.setPrototypeOf(Writable.prototype, stream.Stream.prototype);
+Object.setPrototypeOf(Writable, stream.Stream);
 Writable.prototype.end = function() {
   this.endCalls++;
 };
@@ -45,13 +45,15 @@ function Readable() {
   this.readable = true;
   stream.Stream.call(this);
 }
-util.inherits(Readable, stream.Stream);
+Object.setPrototypeOf(Readable.prototype, stream.Stream.prototype);
+Object.setPrototypeOf(Readable, stream.Stream);
 
 function Duplex() {
   this.readable = true;
   Writable.call(this);
 }
-util.inherits(Duplex, Writable);
+Object.setPrototypeOf(Duplex.prototype, Writable.prototype);
+Object.setPrototypeOf(Duplex, Writable);
 
 let i = 0;
 const limit = 100;

--- a/test/parallel/test-stream-pipe-event.js
+++ b/test/parallel/test-stream-pipe-event.js
@@ -23,19 +23,20 @@
 require('../common');
 const stream = require('stream');
 const assert = require('assert');
-const util = require('util');
 
 function Writable() {
   this.writable = true;
   stream.Stream.call(this);
 }
-util.inherits(Writable, stream.Stream);
+Object.setPrototypeOf(Writable.prototype, stream.Stream.prototype);
+Object.setPrototypeOf(Writable, stream.Stream);
 
 function Readable() {
   this.readable = true;
   stream.Stream.call(this);
 }
-util.inherits(Readable, stream.Stream);
+Object.setPrototypeOf(Readable.prototype, stream.Stream.prototype);
+Object.setPrototypeOf(Readable, stream.Stream);
 
 let passed = false;
 

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 const { Readable } = require('stream');
 const assert = require('assert');
-const { inherits } = require('util');
 
 {
   const read = new Readable({
@@ -160,7 +159,8 @@ const { inherits } = require('util');
     Readable.call(this);
   }
 
-  inherits(MyReadable, Readable);
+  Object.setPrototypeOf(MyReadable.prototype, Readable.prototype);
+  Object.setPrototypeOf(MyReadable, Readable);
 
   new MyReadable();
 }

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 const { Writable } = require('stream');
 const assert = require('assert');
-const { inherits } = require('util');
 
 {
   const write = new Writable({
@@ -199,7 +198,8 @@ const { inherits } = require('util');
     Writable.call(this);
   }
 
-  inherits(MyWritable, Writable);
+  Object.setPrototypeOf(MyWritable.prototype, Writable.prototype);
+  Object.setPrototypeOf(MyWritable, Writable);
 
   new MyWritable();
 }

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -312,6 +312,7 @@ function BadCustomError(msg) {
   Object.defineProperty(this, 'name',
                         { value: 'BadCustomError', enumerable: false });
 }
-util.inherits(BadCustomError, Error);
+Object.setPrototypeOf(BadCustomError.prototype, Error.prototype);
+Object.setPrototypeOf(BadCustomError, Error);
 assert.strictEqual(util.format(new BadCustomError('foo')),
                    '[BadCustomError: foo]');

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -596,7 +596,8 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
     Object.defineProperty(this, 'name',
                           { value: 'BadCustomError', enumerable: false });
   }
-  util.inherits(BadCustomError, Error);
+  Object.setPrototypeOf(BadCustomError.prototype, Error.prototype);
+  Object.setPrototypeOf(BadCustomError, Error);
   assert.strictEqual(
     util.inspect(new BadCustomError('foo')),
     '[BadCustomError: foo]'

--- a/test/parallel/test-zlib-deflate-raw-inherits.js
+++ b/test/parallel/test-zlib-deflate-raw-inherits.js
@@ -2,17 +2,17 @@
 
 require('../common');
 const { DeflateRaw } = require('zlib');
-const { inherits } = require('util');
 const { Readable } = require('stream');
 
 // validates that zlib.DeflateRaw can be inherited
-// with util.inherits
+// with Object.setPrototypeOf
 
 function NotInitialized(options) {
   DeflateRaw.call(this, options);
   this.prop = true;
 }
-inherits(NotInitialized, DeflateRaw);
+Object.setPrototypeOf(NotInitialized.prototype, DeflateRaw.prototype);
+Object.setPrototypeOf(NotInitialized, DeflateRaw);
 
 const dest = new NotInitialized();
 


### PR DESCRIPTION
PR-URL: https://github.com/nodejs/node/pull/25245
Refs: https://github.com/nodejs/node/pull/24755
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>
Reviewed-By: Anna Henningsen <anna@addaleax.net>

Backport of #25245

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
