### PR TITLE
deps: float 15d7e79 from openssl

### DIFF
--- a/deps/openssl/openssl/crypto/rand/rand_lib.c
+++ b/deps/openssl/openssl/crypto/rand/rand_lib.c
@@ -235,7 +235,9 @@ size_t rand_drbg_get_nonce(RAND_DRBG *drbg,
     struct {
         void * instance;
         int count;
-    } data = { NULL, 0 };
+    } data;
+
+    memset(&data, 0, sizeof(data));
 
     pool = rand_pool_new(0, min_len, max_len);
     if (pool == NULL)


### PR DESCRIPTION
As suggested by @shigeki, this is an alternative to https://github.com/nodejs/node/pull/28739 and fixes all valgrind errors that are reported during startup:

Before:
```
==24627== ERROR SUMMARY: 345567 errors from 997 contexts (suppressed: 0 from 0)
```

Patched:
```
==25279== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Closes: https://github.com/nodejs/node/pull/28739

cc @jasnell @nodejs/crypto @nodejs/release

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
