### PR TITLE
crypto: increase maxmem range from 32 to 53 bits

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2587,6 +2587,9 @@ request.
 <!-- YAML
 added: v10.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/28799
+    description: The `maxmem` value can now be any safe integer.
   - version: v10.9.0
     pr-url: https://github.com/nodejs/node/pull/21525
     description: The `cost`, `blockSize` and `parallelization` option names
@@ -2641,6 +2644,9 @@ crypto.scrypt('secret', 'salt', 64, { N: 1024 }, (err, derivedKey) => {
 <!-- YAML
 added: v10.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/28799
+    description: The `maxmem` value can now be any safe integer.
   - version: v10.9.0
     pr-url: https://github.com/nodejs/node/pull/21525
     description: The `cost`, `blockSize` and `parallelization` option names

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -4,7 +4,7 @@ const { Number } = primordials;
 const { AsyncWrap, Providers } = internalBinding('async_wrap');
 const { Buffer } = require('buffer');
 const { scrypt: _scrypt } = internalBinding('crypto');
-const { validateUint32 } = require('internal/validators');
+const { validateInteger, validateUint32 } = require('internal/validators');
 const {
   ERR_CRYPTO_SCRYPT_INVALID_PARAMETER,
   ERR_CRYPTO_SCRYPT_NOT_SUPPORTED,
@@ -111,12 +111,7 @@ function check(password, salt, keylen, options) {
     }
     if (options.maxmem !== undefined) {
       maxmem = options.maxmem;
-      if (typeof maxmem !== 'number')
-        throw new ERR_INVALID_ARG_TYPE('maxmem', 'number', maxmem);
-      if (!Number.isInteger(maxmem))
-        throw new ERR_OUT_OF_RANGE('maxmem', 'an integer', maxmem);
-      if (maxmem < 0 || maxmem > Number.MAX_SAFE_INTEGER)
-        throw new ERR_OUT_OF_RANGE('maxmem', `>= 0 && < ${2 ** 53}`, maxmem);
+      validateInteger(maxmem, 'maxmem', 0);
     }
     if (N === 0) N = defaults.N;
     if (r === 0) r = defaults.r;

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { Number } = primordials;
 const { AsyncWrap, Providers } = internalBinding('async_wrap');
 const { Buffer } = require('buffer');
 const { scrypt: _scrypt } = internalBinding('crypto');
@@ -8,9 +7,7 @@ const { validateInteger, validateUint32 } = require('internal/validators');
 const {
   ERR_CRYPTO_SCRYPT_INVALID_PARAMETER,
   ERR_CRYPTO_SCRYPT_NOT_SUPPORTED,
-  ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_CALLBACK,
-  ERR_OUT_OF_RANGE
+  ERR_INVALID_CALLBACK
 } = require('internal/errors').codes;
 const {
   getDefaultEncoding,

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -7,7 +7,9 @@ const { validateUint32 } = require('internal/validators');
 const {
   ERR_CRYPTO_SCRYPT_INVALID_PARAMETER,
   ERR_CRYPTO_SCRYPT_NOT_SUPPORTED,
+  ERR_INVALID_ARG_TYPE,
   ERR_INVALID_CALLBACK,
+  ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
 const {
   getDefaultEncoding,
@@ -107,8 +109,13 @@ function check(password, salt, keylen, options) {
       p = options.parallelization;
     }
     if (options.maxmem !== undefined) {
-      validateUint32(options.maxmem, 'maxmem');
       maxmem = options.maxmem;
+      if (typeof maxmem !== 'number')
+        throw new ERR_INVALID_ARG_TYPE('maxmem', 'number', maxmem);
+      if (!Number.isInteger(maxmem))
+        throw new ERR_OUT_OF_RANGE('maxmem', 'an integer', maxmem);
+      if (maxmem < 0 || maxmem > Number.MAX_SAFE_INTEGER)
+        throw new ERR_OUT_OF_RANGE('maxmem', `>= 0 && < ${2 ** 53}`, maxmem);
     }
     if (N === 0) N = defaults.N;
     if (r === 0) r = defaults.r;

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { Number } = primordials;
 const { AsyncWrap, Providers } = internalBinding('async_wrap');
 const { Buffer } = require('buffer');
 const { scrypt: _scrypt } = internalBinding('crypto');

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -6015,7 +6015,7 @@ struct ScryptJob : public CryptoJob {
   uint32_t N;
   uint32_t r;
   uint32_t p;
-  uint32_t maxmem;
+  uint64_t maxmem;
   CryptoErrorVector errors;
 
   inline explicit ScryptJob(Environment* env) : CryptoJob(env) {}
@@ -6070,7 +6070,7 @@ void Scrypt(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[3]->IsUint32());  // N
   CHECK(args[4]->IsUint32());  // r
   CHECK(args[5]->IsUint32());  // p
-  CHECK(args[6]->IsUint32());  // maxmem
+  CHECK(args[6]->IsNumber());  // maxmem
   CHECK(args[7]->IsObject() || args[7]->IsUndefined());  // wrap object
   std::unique_ptr<ScryptJob> job(new ScryptJob(env));
   job->keybuf_data = reinterpret_cast<unsigned char*>(Buffer::Data(args[0]));
@@ -6080,7 +6080,8 @@ void Scrypt(const FunctionCallbackInfo<Value>& args) {
   job->N = args[3].As<Uint32>()->Value();
   job->r = args[4].As<Uint32>()->Value();
   job->p = args[5].As<Uint32>()->Value();
-  job->maxmem = args[6].As<Uint32>()->Value();
+  Local<Context> ctx = env->isolate()->GetCurrentContext();
+  job->maxmem = static_cast<uint64_t>(args[6]->IntegerValue(ctx).ToChecked());
   if (!job->Validate()) {
     // EVP_PBE_scrypt() does not always put errors on the error stack
     // and therefore ToResult() may or may not return an exception

--- a/test/parallel/test-crypto-scrypt.js
+++ b/test/parallel/test-crypto-scrypt.js
@@ -220,3 +220,18 @@ for (const { args, expected } of badargs) {
   common.expectsError(() => crypto.scrypt('', '', 42, {}), expected);
   common.expectsError(() => crypto.scrypt('', '', 42, {}, {}), expected);
 }
+
+{
+  // Values for maxmem that do not fit in 32 bits but that are still safe
+  // integers should be allowed.
+  crypto.scrypt('', '', 4, { maxmem: 2 ** 52 },
+                common.mustCall((err, actual) => {
+                  assert.ifError(err);
+                  assert.strictEqual(actual.toString('hex'), 'd72c87d0');
+                }));
+
+  // Values that exceed Number.isSafeInteger should not be allowed.
+  common.expectsError(() => crypto.scryptSync('', '', 0, { maxmem: 2 ** 53 }), {
+    code: 'ERR_OUT_OF_RANGE'
+  });
+}


### PR DESCRIPTION
This implements @bnoordhuis' [suggestion](https://github.com/nodejs/node/issues/28755#issuecomment-512978288) in order to support larger parameters. The new limit is roughly 8 petabytes, which should be sufficient for the next couple of releases.

Fixes: https://github.com/nodejs/node/issues/28755

cc @nodejs/crypto @michaelsbradleyjr

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
