### PR TITLE
crypto: add outputLength option to crypto.createHash

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1788,7 +1788,7 @@ added: v0.1.92
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/28805
-    description: The `hashSize` option was added for XOF hash functions.
+    description: The `outputLength` option was added for XOF hash functions.
 -->
 * `algorithm` {string}
 * `options` {Object} [`stream.transform` options][]
@@ -1796,7 +1796,7 @@ changes:
 
 Creates and returns a `Hash` object that can be used to generate hash digests
 using the given `algorithm`. Optional `options` argument controls stream
-behavior. For XOF hash functions such as `'shake256'`, the `hashSize` option
+behavior. For XOF hash functions such as `'shake256'`, the `outputLength` option
 can be used to specify the desired output length in bytes.
 
 The `algorithm` is dependent on the available algorithms supported by the

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1787,7 +1787,7 @@ and description of each available elliptic curve.
 added: v0.1.92
 changes:
   - version: REPLACEME
-    pr-url: ???
+    pr-url: https://github.com/nodejs/node/pull/28805
     description: The `hashSize` option was added for XOF hash functions.
 -->
 * `algorithm` {string}

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1785,6 +1785,10 @@ and description of each available elliptic curve.
 ### crypto.createHash(algorithm[, options])
 <!-- YAML
 added: v0.1.92
+changes:
+  - version: REPLACEME
+    pr-url: ???
+    description: The `hashSize` option was added for XOF hash functions.
 -->
 * `algorithm` {string}
 * `options` {Object} [`stream.transform` options][]
@@ -1792,7 +1796,8 @@ added: v0.1.92
 
 Creates and returns a `Hash` object that can be used to generate hash digests
 using the given `algorithm`. Optional `options` argument controls stream
-behavior.
+behavior. For XOF hash functions such as `'shake256'`, the `hashSize` option
+can be used to specify the desired output length in bytes.
 
 The `algorithm` is dependent on the available algorithms supported by the
 version of OpenSSL on the platform. Examples are `'sha256'`, `'sha512'`, etc.

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -36,9 +36,9 @@ function Hash(algorithm, options) {
   if (!(this instanceof Hash))
     return new Hash(algorithm, options);
   validateString(algorithm, 'algorithm');
-  const xofLen = typeof options === 'object' ? options.hashSize : undefined;
+  const xofLen = typeof options === 'object' ? options.outputLength : undefined;
   if (xofLen !== undefined)
-    validateUint32(xofLen, 'options.hashSize');
+    validateUint32(xofLen, 'options.outputLength');
   this[kHandle] = new _Hash(algorithm, xofLen);
   this[kState] = {
     [kFinalized]: false

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -25,7 +25,7 @@ const {
   ERR_CRYPTO_HASH_UPDATE_FAILED,
   ERR_INVALID_ARG_TYPE
 } = require('internal/errors').codes;
-const { validateString } = require('internal/validators');
+const { validateString, validateUint32 } = require('internal/validators');
 const { normalizeEncoding } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 const LazyTransform = require('internal/streams/lazy_transform');
@@ -36,7 +36,10 @@ function Hash(algorithm, options) {
   if (!(this instanceof Hash))
     return new Hash(algorithm, options);
   validateString(algorithm, 'algorithm');
-  this[kHandle] = new _Hash(algorithm);
+  const xofLen = typeof options === 'object' ? options.hashSize : undefined;
+  if (xofLen !== undefined)
+    validateUint32(xofLen, 'options.hashSize');
+  this[kHandle] = new _Hash(algorithm, xofLen);
   this[kState] = {
     [kFinalized]: false
   };

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -585,7 +585,7 @@ class Hash : public BaseObject {
   SET_MEMORY_INFO_NAME(Hash)
   SET_SELF_SIZE(Hash)
 
-  bool HashInit(const char* hash_type);
+  bool HashInit(const char* hash_type, v8::Maybe<unsigned int> xof_md_len);
   bool HashUpdate(const char* data, int len);
 
  protected:
@@ -596,18 +596,21 @@ class Hash : public BaseObject {
   Hash(Environment* env, v8::Local<v8::Object> wrap)
       : BaseObject(env, wrap),
         mdctx_(nullptr),
-        md_len_(0) {
+        has_md_(false),
+        md_value_(nullptr) {
     MakeWeak();
   }
 
   ~Hash() override {
-    OPENSSL_cleanse(md_value_, md_len_);
+    if (md_value_ != nullptr)
+      OPENSSL_clear_free(md_value_, md_len_);
   }
 
  private:
   EVPMDPointer mdctx_;
-  unsigned char md_value_[EVP_MAX_MD_SIZE];
+  bool has_md_;
   unsigned int md_len_;
+  unsigned char* md_value_;
 };
 
 class SignBase : public BaseObject {

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -185,3 +185,68 @@ common.expectsError(
   assert(instance instanceof Hash, 'Hash is expected to return a new instance' +
                                    ' when called without `new`');
 }
+
+// Test XOF hash functions and the hashSize option.
+{
+  // Default hashSizes.
+  assert.strictEqual(crypto.createHash('shake128').digest('hex'),
+                     '7f9c2ba4e88f827d616045507605853e');
+  assert.strictEqual(crypto.createHash('shake256').digest('hex'),
+                     '46b9dd2b0ba88d13233b3feb743eeb24' +
+                     '3fcd52ea62b81b82b50c27646ed5762f');
+
+  // Short hashSizes.
+  assert.strictEqual(crypto.createHash('shake128', { hashSize: 0 })
+                           .digest('hex'),
+                     '');
+  assert.strictEqual(crypto.createHash('shake128', { hashSize: 5 })
+                           .digest('hex'),
+                     '7f9c2ba4e8');
+  assert.strictEqual(crypto.createHash('shake128', { hashSize: 15 })
+                           .digest('hex'),
+                     '7f9c2ba4e88f827d61604550760585');
+  assert.strictEqual(crypto.createHash('shake256', { hashSize: 16 })
+                           .digest('hex'),
+                     '46b9dd2b0ba88d13233b3feb743eeb24');
+
+  // Large hashSizes.
+  assert.strictEqual(crypto.createHash('shake128', { hashSize: 128 })
+                           .digest('hex'),
+                     '7f9c2ba4e88f827d616045507605853e' +
+                     'd73b8093f6efbc88eb1a6eacfa66ef26' +
+                     '3cb1eea988004b93103cfb0aeefd2a68' +
+                     '6e01fa4a58e8a3639ca8a1e3f9ae57e2' +
+                     '35b8cc873c23dc62b8d260169afa2f75' +
+                     'ab916a58d974918835d25e6a435085b2' +
+                     'badfd6dfaac359a5efbb7bcc4b59d538' +
+                     'df9a04302e10c8bc1cbf1a0b3a5120ea');
+  const superLongHash = crypto.createHash('shake256', { hashSize: 1024 * 1024 })
+                              .update('The message is shorter than the hash!')
+                              .digest('hex');
+  assert.strictEqual(superLongHash.length, 2 * 1024 * 1024);
+  assert.ok(superLongHash.endsWith('193414035ddba77bf7bba97981e656ec'));
+  assert.ok(superLongHash.startsWith('a2a28dbc49cfd6e5d6ceea3d03e77748'));
+
+  // Non-XOF hash functions should accept valid hashSize options as well.
+  assert.strictEqual(crypto.createHash('sha224', { hashSize: 28 })
+                           .digest('hex'),
+                     'd14a028c2a3a2bc9476102bb288234c4' +
+                     '15a2b01f828ea62ac5b3e42f');
+
+  // Passing invalid sizes should throw during creation.
+  common.expectsError(() => {
+    crypto.createHash('sha256', { hashSize: 28 });
+  }, {
+    code: 'ERR_OSSL_EVP_NOT_XOF_OR_INVALID_LENGTH'
+  });
+
+  for (const hashSize of [null, {}, 'foo', false]) {
+    common.expectsError(() => crypto.createHash('sha256', { hashSize }),
+                        { code: 'ERR_INVALID_ARG_TYPE' });
+  }
+
+  for (const hashSize of [-1, .5, Infinity, 2 ** 90]) {
+    common.expectsError(() => crypto.createHash('sha256', { hashSize }),
+                        { code: 'ERR_OUT_OF_RANGE' });
+  }
+}

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -186,31 +186,31 @@ common.expectsError(
                                    ' when called without `new`');
 }
 
-// Test XOF hash functions and the hashSize option.
+// Test XOF hash functions and the outputLength option.
 {
-  // Default hashSizes.
+  // Default outputLengths.
   assert.strictEqual(crypto.createHash('shake128').digest('hex'),
                      '7f9c2ba4e88f827d616045507605853e');
   assert.strictEqual(crypto.createHash('shake256').digest('hex'),
                      '46b9dd2b0ba88d13233b3feb743eeb24' +
                      '3fcd52ea62b81b82b50c27646ed5762f');
 
-  // Short hashSizes.
-  assert.strictEqual(crypto.createHash('shake128', { hashSize: 0 })
+  // Short outputLengths.
+  assert.strictEqual(crypto.createHash('shake128', { outputLength: 0 })
                            .digest('hex'),
                      '');
-  assert.strictEqual(crypto.createHash('shake128', { hashSize: 5 })
+  assert.strictEqual(crypto.createHash('shake128', { outputLength: 5 })
                            .digest('hex'),
                      '7f9c2ba4e8');
-  assert.strictEqual(crypto.createHash('shake128', { hashSize: 15 })
+  assert.strictEqual(crypto.createHash('shake128', { outputLength: 15 })
                            .digest('hex'),
                      '7f9c2ba4e88f827d61604550760585');
-  assert.strictEqual(crypto.createHash('shake256', { hashSize: 16 })
+  assert.strictEqual(crypto.createHash('shake256', { outputLength: 16 })
                            .digest('hex'),
                      '46b9dd2b0ba88d13233b3feb743eeb24');
 
-  // Large hashSizes.
-  assert.strictEqual(crypto.createHash('shake128', { hashSize: 128 })
+  // Large outputLengths.
+  assert.strictEqual(crypto.createHash('shake128', { outputLength: 128 })
                            .digest('hex'),
                      '7f9c2ba4e88f827d616045507605853e' +
                      'd73b8093f6efbc88eb1a6eacfa66ef26' +
@@ -220,33 +220,34 @@ common.expectsError(
                      'ab916a58d974918835d25e6a435085b2' +
                      'badfd6dfaac359a5efbb7bcc4b59d538' +
                      'df9a04302e10c8bc1cbf1a0b3a5120ea');
-  const superLongHash = crypto.createHash('shake256', { hashSize: 1024 * 1024 })
-                              .update('The message is shorter than the hash!')
-                              .digest('hex');
+  const superLongHash = crypto.createHash('shake256', {
+    outputLength: 1024 * 1024
+  }).update('The message is shorter than the hash!')
+    .digest('hex');
   assert.strictEqual(superLongHash.length, 2 * 1024 * 1024);
   assert.ok(superLongHash.endsWith('193414035ddba77bf7bba97981e656ec'));
   assert.ok(superLongHash.startsWith('a2a28dbc49cfd6e5d6ceea3d03e77748'));
 
-  // Non-XOF hash functions should accept valid hashSize options as well.
-  assert.strictEqual(crypto.createHash('sha224', { hashSize: 28 })
+  // Non-XOF hash functions should accept valid outputLength options as well.
+  assert.strictEqual(crypto.createHash('sha224', { outputLength: 28 })
                            .digest('hex'),
                      'd14a028c2a3a2bc9476102bb288234c4' +
                      '15a2b01f828ea62ac5b3e42f');
 
   // Passing invalid sizes should throw during creation.
   common.expectsError(() => {
-    crypto.createHash('sha256', { hashSize: 28 });
+    crypto.createHash('sha256', { outputLength: 28 });
   }, {
     code: 'ERR_OSSL_EVP_NOT_XOF_OR_INVALID_LENGTH'
   });
 
-  for (const hashSize of [null, {}, 'foo', false]) {
-    common.expectsError(() => crypto.createHash('sha256', { hashSize }),
+  for (const outputLength of [null, {}, 'foo', false]) {
+    common.expectsError(() => crypto.createHash('sha256', { outputLength }),
                         { code: 'ERR_INVALID_ARG_TYPE' });
   }
 
-  for (const hashSize of [-1, .5, Infinity, 2 ** 90]) {
-    common.expectsError(() => crypto.createHash('sha256', { hashSize }),
+  for (const outputLength of [-1, .5, Infinity, 2 ** 90]) {
+    common.expectsError(() => crypto.createHash('sha256', { outputLength }),
                         { code: 'ERR_OUT_OF_RANGE' });
   }
 }


### PR DESCRIPTION
This change adds a `hashSize` option to `crypto.createHash` which allows users to produce variable-length hash values using XOF hash functons.

There are two important differences to the OpenSSL API here:

1. `hashSize` is an option for `createHash`, meaning that the hash size needs to be specified when the hash instance is created. OpenSSL only requires it to be specified at the very end (equivalent to `hash.digest()` in Node.js). I decided to do it this way since it aligns better with our API (adding options to `.digest()` would not be pretty whereas `createHash` already accepts an options object), and I cannot think of a use case where it would be impossible to know the hash size in advance.
2. With this patch, Node.js accepts a `hashSize` option for all hash functions, not just for XOF functions. If the `hashSize` matches the "default" hash size, it is accepted, if it does not, an error is thrown. OpenSSL does not provide such a feature.

If someone sees a problem with either of these API differences, please let me know so we can find a solution.

I had a hard time debugging some segmentation faults on certain platforms and finally tracked it down to the assembly code behind OpenSSL's `SHA3_squeeze` (thanks to @addaleax who helped me a lot, thank you!). I [opened a bug report](https://github.com/openssl/openssl/issues/9431) with OpenSSL and added a workaround to this patch.

Fixes: https://github.com/nodejs/node/issues/28757

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
