### PR TITLE
doc: claim NODE_MODULE_VERSION=76 for Electron 8

### DIFF
--- a/doc/abi_version_registry.json
+++ b/doc/abi_version_registry.json
@@ -1,5 +1,6 @@
 {
   "NODE_MODULE_VERSION": [
+    { "modules": 76, "runtime": "electron", "variant": "electron",             "versions": "8" },
     { "modules": 75, "runtime": "electron", "variant": "electron",             "versions": "7" },
     { "modules": 74, "runtime": "node",     "variant": "v8_7.5",               "versions": "13.0.0-pre" },
     { "modules": 73, "runtime": "electron", "variant": "electron",             "versions": "6" },


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Follow up to https://github.com/nodejs/node/pull/28774 to make sure we're shipping with the right NMV from day 1, Electron 8 nightlies will start some time next week.

Refs: https://github.com/electron/electron/projects/20#card-24099810
