### PR TITLE
lib: support min/max values in validateInteger()

### DIFF
--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -13,6 +13,7 @@ const {
   isArrayBufferView
 } = require('internal/util/types');
 const { signals } = internalBinding('constants').os;
+const { MAX_SAFE_INTEGER, MIN_SAFE_INTEGER } = Number;
 
 function isInt32(value) {
   return value === (value | 0);
@@ -60,12 +61,16 @@ function parseMode(value, name, def) {
   throw new ERR_INVALID_ARG_VALUE(name, value, modeDesc);
 }
 
-const validateInteger = hideStackFrames((value, name) => {
-  if (typeof value !== 'number')
-    throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
-  if (!Number.isSafeInteger(value))
-    throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
-});
+const validateInteger = hideStackFrames(
+  (value, name, min = MIN_SAFE_INTEGER, max = MAX_SAFE_INTEGER) => {
+    if (typeof value !== 'number')
+      throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+    if (!Number.isInteger(value))
+      throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
+    if (value < min || value > max)
+      throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
+  }
+);
 
 const validateInt32 = hideStackFrames(
   (value, name, min = -2147483648, max = 2147483647) => {


### PR DESCRIPTION
This commit updates `validateInteger()` in two ways:

- `Number.isInteger()` is used instead of `Number.isSafeInteger()`. This ensures that all integer values are supported.
- Minimum and maximum values are supported. They default to the min and max safe integer values, but can be customized.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
