### PR TITLE
doc: writableFinished is true before 'finish'

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1473,7 +1473,9 @@ added: REPLACEME
 
 * {boolean}
 
-Is `true` if all data has been flushed to the underlying system.
+Is `true` if all data has been flushed to the underlying system and
+immediately before the [`'finish'`][] event is emitted.
+
 
 ### response.writeContinue()
 <!-- YAML
@@ -2191,6 +2193,7 @@ not abort the request or do anything besides add a `'timeout'` event.
 [`agent.createConnection()`]: #http_agent_createconnection_options_callback
 [`agent.getName()`]: #http_agent_getname_options
 [`destroy()`]: #http_agent_destroy
+[`'finish'`]: #http_event_finish
 [`getHeader(name)`]: #http_request_getheader_name
 [`http.Agent`]: #http_class_http_agent
 [`http.ClientRequest`]: #http_class_http_clientrequest

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -487,7 +487,7 @@ added: v12.6.0
 
 * {boolean}
 
-Is `true` if after the [`'finish'`][] event has been emitted.
+Is set to `true` immediately before the [`'finish'`][] event is emitted.
 
 ##### writable.writableHighWaterMark
 <!-- YAML


### PR DESCRIPTION
The current description for `stream.writableFinished` is not entirely correct.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
