### PR TITLE
Fix http writable finished

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1473,7 +1473,7 @@ added: REPLACEME
 
 * {boolean}
 
-Is `true` if all data has been flushed to the underlying system.
+Becomes `true` when the [`'finish'`][] event is emitted.
 
 ### response.writeContinue()
 <!-- YAML

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -487,7 +487,7 @@ added: v12.6.0
 
 * {boolean}
 
-Is `true` if after the [`'finish'`][] event has been emitted.
+Becomes `true` when the [`'finish'`][] event is emitted.
 
 ##### writable.writableHighWaterMark
 <!-- YAML

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -96,7 +96,9 @@ function OutgoingMessage() {
   this._trailer = '';
 
   this.finished = false;
+  this.writableFinished = false;
   this._headerSent = false;
+
   this[kIsCorked] = false;
 
   this.socket = null;
@@ -108,16 +110,6 @@ function OutgoingMessage() {
 }
 Object.setPrototypeOf(OutgoingMessage.prototype, Stream.prototype);
 Object.setPrototypeOf(OutgoingMessage, Stream);
-
-Object.defineProperty(OutgoingMessage.prototype, 'writableFinished', {
-  get: function() {
-    return (
-      this.finished &&
-      this.outputSize === 0 &&
-      (!this.socket || this.socket.writableLength === 0)
-    );
-  }
-});
 
 Object.defineProperty(OutgoingMessage.prototype, '_headers', {
   get: internalUtil.deprecate(function() {
@@ -655,6 +647,7 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
 };
 
 function onFinish(outmsg) {
+  outmsg.writableFinished = true;
   outmsg.emit('finish');
 }
 


### PR DESCRIPTION
This fixes so that http better follows the behaviour of `writableFinished` for streams.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
