### PR TITLE
stream: readableEnded

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1095,6 +1095,15 @@ added: REPLACEME
 Getter for the property `encoding` of a given `Readable` stream. The `encoding`
 property can be set using the [`readable.setEncoding()`][] method.
 
+##### readable.readableFinished
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+Becomes `true` when [`'end'`][] event is emitted.
+
 ##### readable.readableHighWaterMark
 <!-- YAML
 added: v9.3.0

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1095,7 +1095,7 @@ added: REPLACEME
 Getter for the property `encoding` of a given `Readable` stream. The `encoding`
 property can be set using the [`readable.setEncoding()`][] method.
 
-##### readable.readableFinished
+##### readable.readableEnded
 <!-- YAML
 added: REPLACEME
 -->

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -208,7 +208,7 @@ Object.defineProperty(Readable.prototype, 'readableEnded', {
   // userland will fail
   enumerable: false,
   get() {
-    return this._readableState.endEmitted;
+    return this._readableState ? this._readableState.endEmitted : false;
   }
 });
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -202,6 +202,16 @@ Object.defineProperty(Readable.prototype, 'destroyed', {
   }
 });
 
+Object.defineProperty(Readable.prototype, 'readableEnded', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get() {
+    return this._readableState.endEmitted;
+  }
+});
+
 Readable.prototype.destroy = destroyImpl.destroy;
 Readable.prototype._undestroy = destroyImpl.undestroy;
 Readable.prototype._destroy = function(err, cb) {

--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -132,7 +132,7 @@ const createReadableStreamAsyncIterator = (stream) => {
     [kLastReject]: { value: null, writable: true },
     [kError]: { value: null, writable: true },
     [kEnded]: {
-      value: stream._readableState.endEmitted,
+      value: stream.readableEnded || stream._readableState.endEmitted,
       writable: true
     },
     // The function passed to new Promise is cached so we avoid allocating a new

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -42,7 +42,8 @@ function eos(stream, opts, callback) {
     if (!readable) callback.call(stream);
   };
 
-  var readableEnded = stream._readableState && stream._readableState.endEmitted;
+  var readableEnded = stream.readableEnded ||
+    (stream._readableState && stream._readableState.endEmitted);
   const onend = () => {
     readable = false;
     readableEnded = true;

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 const { Writable, Readable, Transform, finished } = require('stream');
 const assert = require('assert');
+const EE = require('events');
 const fs = require('fs');
 const { promisify } = require('util');
 
@@ -174,4 +175,12 @@ const { promisify } = require('util');
   rs.emit('close');
   rs.push(null);
   rs.resume();
+}
+
+{
+  const streamLike = new EE();
+  streamLike.readableEnded = true;
+  streamLike.readable = true;
+  finished(streamLike, common.mustCall);
+  streamLike.emit('close');
 }

--- a/test/parallel/test-stream-readable-ended.js
+++ b/test/parallel/test-stream-readable-ended.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../common');
+const { Readable } = require('stream');
+const assert = require('assert');
+
+// basic
+{
+  // Find it on Readable.prototype
+  assert(Readable.prototype.hasOwnProperty('readableEnded'));
+}
+
+// event
+{
+  const readable = new Readable();
+
+  readable._read = () => {
+    // The state finished should start in false.
+    assert.strictEqual(readable.readableEnded, false);
+    readable.push('asd');
+    assert.strictEqual(readable.readableEnded, false);
+    readable.push(null);
+    assert.strictEqual(readable.readableEnded, false);
+  };
+
+  readable.on('end', common.mustCall(() => {
+    assert.strictEqual(readable.readableEnded, true);
+  }));
+
+  readable.on('data', common.mustCall(() => {
+    assert.strictEqual(readable.readableEnded, false);
+  }));
+}

--- a/test/parallel/test-stream-readable-ended.js
+++ b/test/parallel/test-stream-readable-ended.js
@@ -15,7 +15,7 @@ const assert = require('assert');
   const readable = new Readable();
 
   readable._read = () => {
-    // The state finished should start in false.
+    // The state ended should start in false.
     assert.strictEqual(readable.readableEnded, false);
     readable.push('asd');
     assert.strictEqual(readable.readableEnded, false);


### PR DESCRIPTION
Adds a `readableEnded` property and improved `finished` compat with possible streamlinke objects.

Refs: https://github.com/nodejs/node/issues/28813

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)