### PR TITLE
stream: pipeline uncaught error

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -24,8 +24,15 @@ function destroyer(stream, reading, writing, callback) {
     closed = true;
   });
 
+  stream.on('error', () => {
+    // Pipeline should not allow uncaught stream errors to propagate.
+    // 1. eos can complete before 'close' (e.g. 'finish' or 'end')
+    // and therefore 'error' can be emitted after eos.
+    // 2. Buggy streams can emit 'error' after 'close'
+  });
+
   if (eos === undefined) eos = require('internal/streams/end-of-stream');
-  eos(stream, { readable: reading, writable: writing }, (err) => {
+  eos(stream, { readable: reading, writable: writing, error: false }, (err) => {
     if (err) return callback(err);
     closed = true;
     callback();

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -477,3 +477,22 @@ const { promisify } = require('util');
     { code: 'ERR_INVALID_CALLBACK' }
   );
 }
+
+{
+  const read = new Readable({
+    read() {}
+  });
+
+  const write = new Writable({
+    write(data, enc, cb) {
+      cb();
+    }
+  });
+
+  read.push(null);
+  pipeline(read, write, common.mustCall(err => {
+    // Should swallow unexpected errors.
+    read.emit('error', new Error());
+    write.emit('error', new Error());
+  }));
+}


### PR DESCRIPTION
There are stream(like)s both in node and ecosystem that can emit an error after `finished/eos`. This will cause the process to unexpectedly exit with an uncaught error exception.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
