### PR TITLE
stream: finished cleanup

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -28,6 +28,14 @@ function eos(stream, opts, callback) {
 
   callback = once(callback);
 
+  const cleanup = once(_eos(stream, opts, function(err) {
+    cleanup();
+    callback.call(this, err);
+  }));
+  return cleanup;
+}
+
+function _eos(stream, opts, callback) {
   let readable = opts.readable || (opts.readable !== false && stream.readable);
   let writable = opts.writable || (opts.writable !== false && stream.writable);
 

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -210,6 +210,8 @@ class AsyncWrap : public BaseObject {
     AsyncWrap* wrap_ = nullptr;
   };
 
+  bool IsDoneInitializing() const override;
+
  private:
   friend class PromiseWrap;
 
@@ -218,7 +220,8 @@ class AsyncWrap : public BaseObject {
             ProviderType provider,
             double execution_async_id,
             bool silent);
-  ProviderType provider_type_;
+  ProviderType provider_type_ = PROVIDER_NONE;
+  bool init_hook_ran_ = false;
   // Because the values may be Reset(), cannot be made const.
   double async_id_ = kInvalidAsyncId;
   double trigger_async_id_;

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -83,6 +83,9 @@ class BaseObject : public MemoryRetainer {
                                v8::Local<v8::Value> value,
                                const v8::PropertyCallbackInfo<void>& info);
 
+  // This is a bit of a hack. See the override in async_wrap.cc for details.
+  virtual bool IsDoneInitializing() const;
+
  protected:
   // Can be used to avoid the automatic object deletion when the Environment
   // exits, for example when this object is owned and deleted by another

--- a/src/env.cc
+++ b/src/env.cc
@@ -954,8 +954,8 @@ void MemoryTracker::TrackField(const char* edge_name,
   // identified and tracked here (based on their deleters),
   // but we may convert and track other known types here.
   BaseObject* obj = value.GetBaseObject();
-  if (obj != nullptr) {
-    this->TrackField("arg", obj);
+  if (obj != nullptr && obj->IsDoneInitializing()) {
+    TrackField("arg", obj);
   }
   CHECK_EQ(CurrentNode(), n);
   CHECK_NE(n->size_, 0);
@@ -1076,6 +1076,8 @@ void BaseObject::DeleteMe(void* data) {
   BaseObject* self = static_cast<BaseObject*>(data);
   delete self;
 }
+
+bool BaseObject::IsDoneInitializing() const { return true; }
 
 Local<Object> BaseObject::WrappedObject() const {
   return object();

--- a/test/parallel/test-heapdump-async-hooks-init-promise.js
+++ b/test/parallel/test-heapdump-async-hooks-init-promise.js
@@ -1,0 +1,46 @@
+// Flags: --expose-gc
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+const v8 = require('v8');
+
+// Regression test for https://github.com/nodejs/node/issues/28786
+// Make sure that creating a heap snapshot inside an async_hooks hook
+// works for Promises.
+
+const createSnapshot = common.mustCall(() => {
+  v8.getHeapSnapshot().resume();
+}, 8);  // 2 × init + 2 × resolve + 1 × (after + before) + 2 × destroy = 8 calls
+
+const promiseIds = [];
+
+async_hooks.createHook({
+  init(id, type) {
+    if (type === 'PROMISE') {
+      createSnapshot();
+      promiseIds.push(id);
+    }
+  },
+
+  before(id) {
+    if (promiseIds.includes(id)) createSnapshot();
+  },
+
+  after(id) {
+    if (promiseIds.includes(id)) createSnapshot();
+  },
+
+  promiseResolve(id) {
+    assert(promiseIds.includes(id));
+    createSnapshot();
+  },
+
+  destroy(id) {
+    if (promiseIds.includes(id)) createSnapshot();
+  }
+}).enable();
+
+
+Promise.resolve().then(() => {});
+setImmediate(global.gc);


### PR DESCRIPTION
`finished` should not leave dangling listeners and leave the stream in the same state after as before.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
