### PR TITLE
assert: avoid potentially misleading reference to object identity

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -22,7 +22,7 @@ const kReadableOperator = {
   notStrictEqualObject:
     'Expected "actual" not to be reference-equal to "expected":',
   notDeepEqual: 'Expected "actual" not to be loosely deep-equal to:',
-  notIdentical: 'Values identical but not reference-equal:',
+  notIdentical: 'Values have same structure but are not reference-equal:',
   notDeepEqualUnequal: 'Expected values not to be loosely deep-equal:'
 };
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1101,7 +1101,7 @@ assert.throws(() => { throw null; }, 'foo');
 assert.throws(
   () => assert.strictEqual([], []),
   {
-    message: 'Values identical but not reference-equal:\n\n[]\n'
+    message: 'Values have same structure but are not reference-equal:\n\n[]\n'
   }
 );
 


### PR DESCRIPTION
Often, the word “identical” when referring to JS objects will
be read as referring to having the same object identity (which is
called “reference equality” here), but what the error message is
trying to say here is that the objects are different but yield the
same `util.inspect()` output.

Since `util.inspect()` output represents the structure rather than
the identity of objects, (hopefully) clarify the error message to
reflect that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
