### PR TITLE
[v10.x] doc: describe tls.DEFAULT_MIN_VERSION/_MAX_VERSION

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -773,8 +773,6 @@ greater than `4` (its current default value). For more information, see the
 [`Buffer`]: buffer.html#buffer_class_buffer
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
-[`tls.DEFAULT_MAX_VERSION`]: tls.html#tls_tls_default_max_version
-[`tls.DEFAULT_MIN_VERSION`]: tls.html#tls_tls_default_min_version
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
 [REPL]: repl.html
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -773,6 +773,8 @@ greater than `4` (its current default value). For more information, see the
 [`Buffer`]: buffer.html#buffer_class_buffer
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
+[`tls.DEFAULT_MAX_VERSION`]: tls.html#tls_tls_default_max_version
+[`tls.DEFAULT_MIN_VERSION`]: tls.html#tls_tls_default_min_version
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
 [REPL]: repl.html
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1198,12 +1198,12 @@ changes:
     `object.passphrase` if provided, or `options.passphrase` if it is not.
   * `maxVersion` {string} Optionally set the maximum TLS version to allow. One
     of `TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified along with the
-    `secureProtocol` option, use one or the other.  **Default:** `'TLSv1.2'`.
+    `secureProtocol` option, use one or the other.  **Default:** [`tls.DEFAULT_MAX_VERSION`][].
   * `minVersion` {string} Optionally set the minimum TLS version to allow. One
     of `TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified along with the
     `secureProtocol` option, use one or the other.  It is not recommended to use
     less than TLSv1.2, but it may be required for interoperability.
-    **Default:** `'TLSv1'`.
+    **Default:** [`tls.DEFAULT_MIN_VERSION`][].
   * `passphrase` {string} Shared passphrase used for a single private key and/or
     a PFX.
   * `pfx` {string|string[]|Buffer|Buffer[]|Object[]} PFX or PKCS12 encoded
@@ -1358,6 +1358,26 @@ changes:
 The default curve name to use for ECDH key agreement in a tls server. The
 default value is `'auto'`. See [`tls.createSecureContext()`] for further
 information.
+
+## tls.DEFAULT_MAX_VERSION
+<!-- YAML
+added: v10.6.0
+-->
+
+* {string} The default value of the `maxVersion` option of
+  [`tls.createSecureContext()`][]. It can be assigned any of the supported TLS
+  protocol versions, `TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`.
+  **Default:** `'TLSv1.2'`.
+
+## tls.DEFAULT_MIN_VERSION
+<!-- YAML
+added: v10.6.0
+-->
+
+* {string} The default value of the `minVersion` option of
+  [`tls.createSecureContext()`][]. It can be assigned any of the supported TLS
+  protocol versions, `TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`.
+  **Default:** `'TLSv1'`.
 
 ## Deprecated APIs
 

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1198,7 +1198,8 @@ changes:
     `object.passphrase` if provided, or `options.passphrase` if it is not.
   * `maxVersion` {string} Optionally set the maximum TLS version to allow. One
     of `TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified along with the
-    `secureProtocol` option, use one or the other.  **Default:** [`tls.DEFAULT_MAX_VERSION`][].
+    `secureProtocol` option, use one or the other.
+    **Default:** [`tls.DEFAULT_MAX_VERSION`][].
   * `minVersion` {string} Optionally set the minimum TLS version to allow. One
     of `TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified along with the
     `secureProtocol` option, use one or the other.  It is not recommended to use
@@ -1505,6 +1506,8 @@ where `secureSocket` has the same API as `pair.cleartext`.
 [`server.setTicketKeys()`]: #tls_server_setticketkeys_keys
 [`socket.setTimeout(timeout)`]: #net_socket_settimeout_timeout_callback
 [`tls.DEFAULT_ECDH_CURVE`]: #tls_tls_default_ecdh_curve
+[`tls.DEFAULT_MAX_VERSION`]: #tls_tls_default_max_version
+[`tls.DEFAULT_MIN_VERSION`]: #tls_tls_default_min_version
 [`tls.Server`]: #tls_class_tls_server
 [`tls.TLSSocket.getPeerCertificate()`]: #tls_tlssocket_getpeercertificate_detailed
 [`tls.TLSSocket.getSession()`]: #tls_tlssocket_getsession


### PR DESCRIPTION
Add documentation for tls.DEFAULT_MAX_VERSION and
tls.DEFAULT_MIN_VERSION, which existed in v10.6.0

Fixes: https://github.com/nodejs/node/issues/28758
Refs: https://github.com/nodejs/node/pull/26821

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
