### PR TITLE
src: loop over uv_cpu_info() results

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -334,13 +334,13 @@ static void PrintCpuInfo(JSONWriter* writer) {
     writer->json_arraystart("cpus");
     for (int i = 0; i < count; i++) {
       writer->json_start();
-      writer->json_keyvalue("model", cpu_info->model);
-      writer->json_keyvalue("speed", cpu_info->speed);
-      writer->json_keyvalue("user", cpu_info->cpu_times.user);
-      writer->json_keyvalue("nice", cpu_info->cpu_times.nice);
-      writer->json_keyvalue("sys", cpu_info->cpu_times.sys);
-      writer->json_keyvalue("idle", cpu_info->cpu_times.idle);
-      writer->json_keyvalue("irq", cpu_info->cpu_times.irq);
+      writer->json_keyvalue("model", cpu_info[i].model);
+      writer->json_keyvalue("speed", cpu_info[i].speed);
+      writer->json_keyvalue("user", cpu_info[i].cpu_times.user);
+      writer->json_keyvalue("nice", cpu_info[i].cpu_times.nice);
+      writer->json_keyvalue("sys", cpu_info[i].cpu_times.sys);
+      writer->json_keyvalue("idle", cpu_info[i].cpu_times.idle);
+      writer->json_keyvalue("irq", cpu_info[i].cpu_times.irq);
       writer->json_end();
     }
     writer->json_arrayend();

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const util = require('util');
+const cpus = os.cpus();
 
 function findReports(pid, dir) {
   // Default filenames are of the form
@@ -98,6 +99,7 @@ function _validateContent(report) {
   assert.strictEqual(typeof header.osVersion, 'string');
   assert.strictEqual(typeof header.osMachine, 'string');
   assert(Array.isArray(header.cpus));
+  assert.strictEqual(header.cpus.length, cpus.length);
   header.cpus.forEach((cpu) => {
     assert.strictEqual(typeof cpu.model, 'string');
     assert.strictEqual(typeof cpu.speed, 'number');
@@ -106,6 +108,9 @@ function _validateContent(report) {
     assert.strictEqual(typeof cpu.sys, 'number');
     assert.strictEqual(typeof cpu.idle, 'number');
     assert.strictEqual(typeof cpu.irq, 'number');
+    assert(cpus.some((c) => {
+      return c.model === cpu.model && c.speed === cpu.speed;
+    }));
   });
   assert.strictEqual(header.host, os.hostname());
 


### PR DESCRIPTION
The code currently loops over the results, but only the first result is accessed.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
