### PR TITLE
doc: fix incorrect name in report docs

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -63,7 +63,7 @@ is provided below for reference.
     "osRelease": "3.10.0-862.el7.x86_64",
     "osVersion": "#1 SMP Wed Mar 21 18:14:51 EDT 2018",
     "osMachine": "x86_64",
-    "osCpus": [
+    "cpus": [
       {
         "model": "Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz",
         "speed": 2700,


### PR DESCRIPTION
In diagnostic reports, the CPUs are listed in a `"cpus"` field. This commit fixes the docs, which refer to the field as `"osCpus"`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
