### PR TITLE
[backport v10.x] src: handle empty Maybe in uv binding initialize

### DIFF
--- a/src/uv.cc
+++ b/src/uv.cc
@@ -71,9 +71,11 @@ void Initialize(Local<Object> target,
   Local<Array> arr = Array::New(isolate, 2);                                  \
   arr->Set(0, OneByteString(isolate, #name));                                 \
   arr->Set(1, OneByteString(isolate, msg));                                   \
-  err_map->Set(context,                                                       \
-               Integer::New(isolate, UV_##name),                              \
-               arr).ToLocalChecked();                                         \
+  if (err_map->Set(context,                                                   \
+                   Integer::New(isolate, UV_##name),                          \
+                   arr).IsEmpty()) {                                          \
+    return;                                                                   \
+  }                                                                           \
 } while (0);
   UV_ERRNO_MAP(V)
 #undef V


### PR DESCRIPTION
This can fail when terminating a Worker that loads
the `uv` binding at the same time.

Refs: https://github.com/nodejs/node/pull/25061#issuecomment-447648475
Fixes: https://github.com/nodejs/node/issues/25134
PR-URL: https://github.com/nodejs/node/pull/25079
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Daniel Bevenius <daniel.bevenius@gmail.com>
Reviewed-By: Gireesh Punathil <gpunathi@in.ibm.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
