### PR TITLE
crypto: fix handling of malicious getters (scrypt)

### DIFF
--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -80,31 +80,31 @@ function check(password, salt, keylen, options) {
   if (options && options !== defaults) {
     let has_N, has_r, has_p;
     if (has_N = (options.N !== undefined)) {
-      validateUint32(options.N, 'N');
       N = options.N;
+      validateUint32(N, 'N');
     }
     if (options.cost !== undefined) {
       if (has_N) throw new ERR_CRYPTO_SCRYPT_INVALID_PARAMETER();
-      validateUint32(options.cost, 'cost');
       N = options.cost;
+      validateUint32(N, 'cost');
     }
     if (has_r = (options.r !== undefined)) {
-      validateUint32(options.r, 'r');
       r = options.r;
+      validateUint32(r, 'r');
     }
     if (options.blockSize !== undefined) {
       if (has_r) throw new ERR_CRYPTO_SCRYPT_INVALID_PARAMETER();
-      validateUint32(options.blockSize, 'blockSize');
       r = options.blockSize;
+      validateUint32(r, 'blockSize');
     }
     if (has_p = (options.p !== undefined)) {
-      validateUint32(options.p, 'p');
       p = options.p;
+      validateUint32(p, 'p');
     }
     if (options.parallelization !== undefined) {
       if (has_p) throw new ERR_CRYPTO_SCRYPT_INVALID_PARAMETER();
-      validateUint32(options.parallelization, 'parallelization');
       p = options.parallelization;
+      validateUint32(p, 'parallelization');
     }
     if (options.maxmem !== undefined) {
       maxmem = options.maxmem;


### PR DESCRIPTION
It is possible to bypass parameter validation in `crypto.scrypt` and `crypto.scryptSync` by crafting option objects with malicious getters as demonstrated in the regression test. After bypassing validation, any value can be passed to the C++ layer, causing an assertion to crash the process.

Fixes: https://github.com/nodejs/node/issues/28836

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
