### PR TITLE
stream: resolve perf regression introduced by V8 7.3

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -256,7 +256,7 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
     } else if (state.objectMode || chunk && chunk.length > 0) {
       if (typeof chunk !== 'string' &&
           !state.objectMode &&
-          // Do not use Object.getPrototypeOf as it is slower.
+          // Do not use Object.getPrototypeOf as it is slower since V8 7.3.
           !(chunk instanceof Buffer)) {
         chunk = Stream._uint8ArrayToBuffer(chunk);
       }

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -256,7 +256,8 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
     } else if (state.objectMode || chunk && chunk.length > 0) {
       if (typeof chunk !== 'string' &&
           !state.objectMode &&
-          Object.getPrototypeOf(chunk) !== Buffer.prototype) {
+          // Do not use Object.getPrototypeOf as it is slower.
+          !(chunk instanceof Buffer)) {
         chunk = Stream._uint8ArrayToBuffer(chunk);
       }
 
@@ -399,7 +400,13 @@ function howMuchToRead(n, state) {
 // You can override either this method, or the async _read(n) below.
 Readable.prototype.read = function(n) {
   debug('read', n);
-  n = parseInt(n, 10);
+  // Same as parseInt(undefined, 10), however V8 7.3 performance regressed
+  // in this scenario, so we are doing it manually.
+  if (n === undefined) {
+    n = NaN;
+  } else if (!Number.isInteger(n)) {
+    n = parseInt(n, 10);
+  }
   const state = this._readableState;
   const nOrig = n;
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -277,7 +277,7 @@ Writable.prototype.write = function(chunk, encoding, cb) {
   var ret = false;
   const isBuf = !state.objectMode && Stream._isUint8Array(chunk);
 
-  // Do not use Object.getPrototypeOf as it is slower.
+  // Do not use Object.getPrototypeOf as it is slower since V8 7.3.
   if (isBuf && !(chunk instanceof Buffer)) {
     chunk = Stream._uint8ArrayToBuffer(chunk);
   }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -277,7 +277,8 @@ Writable.prototype.write = function(chunk, encoding, cb) {
   var ret = false;
   const isBuf = !state.objectMode && Stream._isUint8Array(chunk);
 
-  if (isBuf && Object.getPrototypeOf(chunk) !== Buffer.prototype) {
+  // Do not use Object.getPrototypeOf as it is slower.
+  if (isBuf && !(chunk instanceof Buffer)) {
     chunk = Stream._uint8ArrayToBuffer(chunk);
   }
 


### PR DESCRIPTION
This commit contains two fixes:
1. use instanceof instead of Object.getPrototypeOf, as checking an
   object prototype with Object.getPrototypeOf is slower
   than an instanceof check.
2. avoid parseInt(undefined, 10) to get NaN as it regressed.

Fixes: https://github.com/nodejs/node/issues/28586

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
