### PR TITLE
http: add info to invalid header character errors

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -225,14 +225,12 @@ const headerCharRegex = /([^\t\x20-\x7e\x80-\xff])/;
  *  field-vchar    = VCHAR / obs-text
  */
 function checkInvalidHeaderChar(val) {
+  if (!headerCharRegex.test(val)) return null;
   const checkInvalidVal = headerCharRegex.exec(val);
-  if (checkInvalidVal !== null) {
-    const invalidCharObj = {};
-    invalidCharObj.char = checkInvalidVal[0];
-    invalidCharObj.index = checkInvalidVal.index;
-    return invalidCharObj;
-  }
-  return checkInvalidVal;
+  const invalidCharObj = {};
+  invalidCharObj.char = checkInvalidVal[0];
+  invalidCharObj.index = checkInvalidVal.index;
+  return invalidCharObj;
 }
 
 function cleanParser(parser) {

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -217,7 +217,7 @@ function checkIsHttpToken(val) {
   return tokenRegExp.test(val);
 }
 
-const headerCharRegex = /([^\t\x20-\x7e\x80-\xff])/;
+const headerCharRegex = /[^\t\x20-\x7e\x80-\xff]/;
 /**
  * Returns object if val contains an invalid field-vchar
  *  field-value    = *( field-content / obs-fold )

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -217,15 +217,22 @@ function checkIsHttpToken(val) {
   return tokenRegExp.test(val);
 }
 
-const headerCharRegex = /[^\t\x20-\x7e\x80-\xff]/;
+const headerCharRegex = /([^\t\x20-\x7e\x80-\xff])/;
 /**
- * True if val contains an invalid field-vchar
+ * Returns object if val contains an invalid field-vchar
  *  field-value    = *( field-content / obs-fold )
  *  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
  *  field-vchar    = VCHAR / obs-text
  */
 function checkInvalidHeaderChar(val) {
-  return headerCharRegex.test(val);
+  const checkInvalidVal = headerCharRegex.exec(val);
+  if (checkInvalidVal !== null) {
+    const invalidCharObj = {};
+    invalidCharObj.char = checkInvalidVal[0];
+    invalidCharObj.index = checkInvalidVal.index;
+    return invalidCharObj;
+  }
+  return checkInvalidVal;
 }
 
 function cleanParser(parser) {

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -225,12 +225,9 @@ const headerCharRegex = /([^\t\x20-\x7e\x80-\xff])/;
  *  field-vchar    = VCHAR / obs-text
  */
 function checkInvalidHeaderChar(val) {
-  if (!headerCharRegex.test(val)) return null;
-  const checkInvalidVal = headerCharRegex.exec(val);
-  const invalidCharObj = {};
-  invalidCharObj.char = checkInvalidVal[0];
-  invalidCharObj.index = checkInvalidVal.index;
-  return invalidCharObj;
+  if (!headerCharRegex.test(val)) return undefined;
+  const result = headerCharRegex.exec(val);
+  return { char: result[0], index: result.index };
 }
 
 function cleanParser(parser) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -444,9 +444,10 @@ const validateHeaderValue = hideStackFrames((name, value) => {
   if (value === undefined) {
     throw new ERR_HTTP_INVALID_HEADER_VALUE(value, name);
   }
-  if (checkInvalidHeaderChar(value)) {
+  const invalidChar = checkInvalidHeaderChar(value);
+  if (invalidChar) {
     debug('Header "%s" contains invalid characters', name);
-    throw new ERR_INVALID_CHAR('header content', name);
+    throw new ERR_INVALID_CHAR('header content', name, invalidChar);
   }
 });
 
@@ -637,7 +638,7 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
     if (typeof field !== 'string' || !field || !checkIsHttpToken(field)) {
       throw new ERR_INVALID_HTTP_TOKEN('Trailer name', field);
     }
-    if (checkInvalidHeaderChar(value)) {
+    if (checkInvalidHeaderChar(value) !== null) {
       debug('Trailer "%s" contains invalid characters', field);
       throw new ERR_INVALID_CHAR('trailer content', field);
     }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -638,7 +638,7 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
     if (typeof field !== 'string' || !field || !checkIsHttpToken(field)) {
       throw new ERR_INVALID_HTTP_TOKEN('Trailer name', field);
     }
-    if (checkInvalidHeaderChar(value) !== null) {
+    if (!checkInvalidHeaderChar(value)) {
       debug('Trailer "%s" contains invalid characters', field);
       throw new ERR_INVALID_CHAR('trailer content', field);
     }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -638,7 +638,7 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
     if (typeof field !== 'string' || !field || !checkIsHttpToken(field)) {
       throw new ERR_INVALID_HTTP_TOKEN('Trailer name', field);
     }
-    if (!checkInvalidHeaderChar(value)) {
+    if (checkInvalidHeaderChar(value)) {
       debug('Trailer "%s" contains invalid characters', field);
       throw new ERR_INVALID_CHAR('trailer content', field);
     }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -272,7 +272,7 @@ function writeHead(statusCode, reason, obj) {
     headers = obj;
   }
 
-  if (checkInvalidHeaderChar(this.statusMessage) !== null)
+  if (!checkInvalidHeaderChar(this.statusMessage))
     throw new ERR_INVALID_CHAR('statusMessage');
 
   const statusLine = `HTTP/1.1 ${statusCode} ${this.statusMessage}${CRLF}`;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -272,7 +272,7 @@ function writeHead(statusCode, reason, obj) {
     headers = obj;
   }
 
-  if (checkInvalidHeaderChar(this.statusMessage))
+  if (checkInvalidHeaderChar(this.statusMessage) !== null)
     throw new ERR_INVALID_CHAR('statusMessage');
 
   const statusLine = `HTTP/1.1 ${statusCode} ${this.statusMessage}${CRLF}`;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -272,7 +272,7 @@ function writeHead(statusCode, reason, obj) {
     headers = obj;
   }
 
-  if (!checkInvalidHeaderChar(this.statusMessage))
+  if (checkInvalidHeaderChar(this.statusMessage))
     throw new ERR_INVALID_CHAR('statusMessage');
 
   const statusLine = `HTTP/1.1 ${statusCode} ${this.statusMessage}${CRLF}`;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -942,10 +942,13 @@ E('ERR_INVALID_CALLBACK',
 E('ERR_INVALID_CHAR',
   // Using a default argument here is important so the argument is not counted
   // towards `Function#length`.
-  (name, field = undefined) => {
+  (name, field = undefined, invalidChar = undefined) => {
     let msg = `Invalid character in ${name}`;
     if (field !== undefined) {
       msg += ` ["${field}"]`;
+    }
+    if (invalidChar !== undefined) {
+      msg += `: ${invalidChar.char} at index ${invalidChar.index}.`;
     }
     return msg;
   }, TypeError);

--- a/test/parallel/test-http-common.js
+++ b/test/parallel/test-http-common.js
@@ -25,12 +25,12 @@ assert.deepStrictEqual(
   { char: 'あ', index: 4 }
 );
 
-assert.strictEqual(checkInvalidHeaderChar(''), null);
-assert.strictEqual(checkInvalidHeaderChar(1), null);
-assert.strictEqual(checkInvalidHeaderChar(' '), null);
-assert.strictEqual(checkInvalidHeaderChar(false), null);
-assert.strictEqual(checkInvalidHeaderChar('t'), null);
-assert.strictEqual(checkInvalidHeaderChar('tt'), null);
-assert.strictEqual(checkInvalidHeaderChar('ttt'), null);
-assert.strictEqual(checkInvalidHeaderChar('tttt'), null);
-assert.strictEqual(checkInvalidHeaderChar('ttttt'), null);
+assert.strictEqual(checkInvalidHeaderChar(''), undefined);
+assert.strictEqual(checkInvalidHeaderChar(1), undefined);
+assert.strictEqual(checkInvalidHeaderChar(' '), undefined);
+assert.strictEqual(checkInvalidHeaderChar(false), undefined);
+assert.strictEqual(checkInvalidHeaderChar('t'), undefined);
+assert.strictEqual(checkInvalidHeaderChar('tt'), undefined);
+assert.strictEqual(checkInvalidHeaderChar('ttt'), undefined);
+assert.strictEqual(checkInvalidHeaderChar('tttt'), undefined);
+assert.strictEqual(checkInvalidHeaderChar('ttttt'), undefined);

--- a/test/parallel/test-http-common.js
+++ b/test/parallel/test-http-common.js
@@ -19,15 +19,18 @@ assert.strictEqual(checkIsHttpToken('あa'), false);
 assert.strictEqual(checkIsHttpToken('aaaaあaaaa'), false);
 
 // checkInvalidHeaderChar
-assert(checkInvalidHeaderChar('あ'));
-assert(checkInvalidHeaderChar('aaaaあaaaa'));
+assert.deepStrictEqual(checkInvalidHeaderChar('あ'), { char: 'あ', index: 0 });
+assert.deepStrictEqual(
+    checkInvalidHeaderChar('aaaaあaaaa'),
+    { char: 'あ', index: 2 }
+);
 
-assert.strictEqual(checkInvalidHeaderChar(''), false);
-assert.strictEqual(checkInvalidHeaderChar(1), false);
-assert.strictEqual(checkInvalidHeaderChar(' '), false);
-assert.strictEqual(checkInvalidHeaderChar(false), false);
-assert.strictEqual(checkInvalidHeaderChar('t'), false);
-assert.strictEqual(checkInvalidHeaderChar('tt'), false);
-assert.strictEqual(checkInvalidHeaderChar('ttt'), false);
-assert.strictEqual(checkInvalidHeaderChar('tttt'), false);
-assert.strictEqual(checkInvalidHeaderChar('ttttt'), false);
+assert.strictEqual(checkInvalidHeaderChar(''), null);
+assert.strictEqual(checkInvalidHeaderChar(1), null);
+assert.strictEqual(checkInvalidHeaderChar(' '), null);
+assert.strictEqual(checkInvalidHeaderChar(false), null);
+assert.strictEqual(checkInvalidHeaderChar('t'), null);
+assert.strictEqual(checkInvalidHeaderChar('tt'), null);
+assert.strictEqual(checkInvalidHeaderChar('ttt'), null);
+assert.strictEqual(checkInvalidHeaderChar('tttt'), null);
+assert.strictEqual(checkInvalidHeaderChar('ttttt'), null);

--- a/test/parallel/test-http-common.js
+++ b/test/parallel/test-http-common.js
@@ -22,7 +22,7 @@ assert.strictEqual(checkIsHttpToken('aaaaあaaaa'), false);
 assert.deepStrictEqual(checkInvalidHeaderChar('あ'), { char: 'あ', index: 0 });
 assert.deepStrictEqual(
   checkInvalidHeaderChar('aaaaあaaaa'),
-  { char: 'あ', index: 2 }
+  { char: 'あ', index: 4 }
 );
 
 assert.strictEqual(checkInvalidHeaderChar(''), null);

--- a/test/parallel/test-http-common.js
+++ b/test/parallel/test-http-common.js
@@ -21,8 +21,8 @@ assert.strictEqual(checkIsHttpToken('aaaaあaaaa'), false);
 // checkInvalidHeaderChar
 assert.deepStrictEqual(checkInvalidHeaderChar('あ'), { char: 'あ', index: 0 });
 assert.deepStrictEqual(
-    checkInvalidHeaderChar('aaaaあaaaa'),
-    { char: 'あ', index: 2 }
+  checkInvalidHeaderChar('aaaaあaaaa'),
+  { char: 'あ', index: 2 }
 );
 
 assert.strictEqual(checkInvalidHeaderChar(''), null);

--- a/test/parallel/test-http-invalidheaderfield2.js
+++ b/test/parallel/test-http-invalidheaderfield2.js
@@ -67,7 +67,7 @@ const { _checkIsHttpToken, _checkInvalidHeaderChar } = require('_http_common');
   '!@#$%^&*()-_=+\\;\':"[]{}<>,./?|~`'
 ].forEach(function(str) {
   assert.strictEqual(
-    _checkInvalidHeaderChar(str), null,
+    _checkInvalidHeaderChar(str), undefined,
     `_checkInvalidHeaderChar(${inspect(str)}) unexpectedly failed`);
 });
 

--- a/test/parallel/test-http-invalidheaderfield2.js
+++ b/test/parallel/test-http-invalidheaderfield2.js
@@ -67,11 +67,22 @@ const { _checkIsHttpToken, _checkInvalidHeaderChar } = require('_http_common');
   '!@#$%^&*()-_=+\\;\':"[]{}<>,./?|~`'
 ].forEach(function(str) {
   assert.strictEqual(
-    _checkInvalidHeaderChar(str), false,
+    _checkInvalidHeaderChar(str), null,
     `_checkInvalidHeaderChar(${inspect(str)}) unexpectedly failed`);
 });
 
 // Bad header field values
+const output = [ 
+  { char: '\r', index: 3 },
+  { char: '\n', index: 3 },
+  { char: '\r', index: 3 },
+  { char: '中', index: 0 },
+  { char: '', index: 0 },
+  { char: '\u0000', index: 11 },
+  { char: '\u000b', index: 3 },
+  { char: '\u0007', index: 5 }
+];
+
 [
   'foo\rbar',
   'foo\nbar',
@@ -81,8 +92,8 @@ const { _checkIsHttpToken, _checkInvalidHeaderChar } = require('_http_common');
   'Testing 123\x00',
   'foo\vbar',
   'Ding!\x07'
-].forEach(function(str) {
-  assert.strictEqual(
-    _checkInvalidHeaderChar(str), true,
+].forEach(function(str, i) {
+  assert.deepStrictEqual(
+    _checkInvalidHeaderChar(str), output[i],
     `_checkInvalidHeaderChar(${inspect(str)}) unexpectedly succeeded`);
 });

--- a/test/parallel/test-http-invalidheaderfield2.js
+++ b/test/parallel/test-http-invalidheaderfield2.js
@@ -72,7 +72,7 @@ const { _checkIsHttpToken, _checkInvalidHeaderChar } = require('_http_common');
 });
 
 // Bad header field values
-const output = [ 
+const output = [
   { char: '\r', index: 3 },
   { char: '\n', index: 3 },
   { char: '\r', index: 3 },

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -55,7 +55,7 @@ common.expectsError(() => {
 }, {
   code: 'ERR_INVALID_CHAR',
   type: TypeError,
-  message: 'Invalid character in header content ["200"]'
+  message: 'Invalid character in header content ["200"]: あ at index 0.'
 });
 
 // write

--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -28,7 +28,7 @@ function test(res, code, key, value, char, index) {
     {
       code: 'ERR_INVALID_CHAR',
       type: TypeError,
-      message: 'Invalid character in header content ' + 
+      message: 'Invalid character in header content ' +
           `["${key}"]: ${char} at index ${index}.`
     }
   );

--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -21,14 +21,15 @@ const y = 'foo⠊Set-Cookie: foo=bar';
 let count = 0;
 const countdown = new Countdown(3, () => server.close());
 
-function test(res, code, key, value) {
+function test(res, code, key, value, char, index) {
   const header = { [key]: value };
   common.expectsError(
     () => res.writeHead(code, header),
     {
       code: 'ERR_INVALID_CHAR',
       type: TypeError,
-      message: `Invalid character in header content ["${key}"]`
+      message: 'Invalid character in header content ' + 
+          `["${key}"]: ${char} at index ${index}.`
     }
   );
 }
@@ -37,13 +38,13 @@ const server = http.createServer((req, res) => {
   switch (count++) {
     case 0:
       const loc = url.parse(req.url, true).query.lang;
-      test(res, 302, 'Location', `/foo?lang=${loc}`);
+      test(res, 302, 'Location', `/foo?lang=${loc}`, 'č', 13);
       break;
     case 1:
-      test(res, 200, 'foo', x);
+      test(res, 200, 'foo', x, 'ഊ', '3');
       break;
     case 2:
-      test(res, 200, 'foo', y);
+      test(res, 200, 'foo', y, '⠊', 3);
       break;
     default:
       assert.fail('should not get to here.');


### PR DESCRIPTION
Update error message thrown when setting header to a value that contains
and invalid character to include the invalid character and its index.
Fixes: https://github.com/nodejs/node/issues/28797

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @ryzokuken @gengjiawen 