### PR TITLE
src: move relative uptime init

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -782,6 +782,9 @@ int InitializeNodeWithArgs(std::vector<std::string>* argv,
   // Make sure InitializeNodeWithArgs() is called only once.
   CHECK(!init_called.exchange(true));
 
+  // Initialize node_start_time to get relative uptime.
+  per_process::node_start_time = uv_hrtime();
+
   // Register built-in modules
   binding::RegisterBuiltinModules();
 
@@ -961,7 +964,6 @@ void Init(int* argc,
 InitializationResult InitializeOncePerProcess(int argc, char** argv) {
   atexit(ResetStdio);
   PlatformInit();
-  per_process::node_start_time = uv_hrtime();
 
   CHECK_GT(argc, 0);
 


### PR DESCRIPTION
Upstreams patch from https://github.com/electron/electron/pull/19436.

We ran into an issue where `process.uptime()` of our embedded `node` runtime returned unexpected values. As we found out, the `per_process::node_start_time` variable which stores the relative uptime wasn't set (defaults to 0).

Previous to https://github.com/nodejs/node/pull/26016, the process-relative uptime was set in a method which got called by both `node::Start` (used by nodejs) and `node::Init` (used by embedders) init methods. After mentioned PR, it is set directly in `node::Start` and thereby not when using `node::Init`.

Since i don't see any difference in either way of setting the variable, we wanna upstream this patch so other embedders can benefit from it as well. If i miss sth, feel free to point out possible side-effects.

cc @nornagon

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
