### PR TITLE
test: specialize OOM check for AIX

### DIFF
--- a/test/addons/addon.status
+++ b/test/addons/addon.status
@@ -3,17 +3,3 @@ prefix addons
 [true] # This section applies to all platforms
 
 [$system==aix]
-# https://github.com/nodejs/build/issues/1820#issuecomment-505998851
-# https://github.com/nodejs/node/pull/28469
-# https://github.com/nodejs/node/pull/28516
-stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js: SKIP
-
-# https://github.com/nodejs/node/pull/28516
-stringbytes-external-exceed-max/test-stringbytes-external-at-max: SKIP
-stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii: SKIP
-stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64: SKIP
-stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary: SKIP
-stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex: SKIP
-stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8: SKIP
-stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2: SKIP
-stringbytes-external-exceed-max/test-stringbytes-external-exceed-max: SKIP

--- a/test/addons/stringbytes-external-exceed-max/binding.cc
+++ b/test/addons/stringbytes-external-exceed-max/binding.cc
@@ -2,12 +2,42 @@
 #include <node.h>
 #include <v8.h>
 
+#ifdef _AIX
+// AIX allows over-allocation, and will SIGKILL when the allocated pages are
+// used if there is not enough VM. Check for available space until
+// out-of-memory.  Don't allow more then some (large) proportion of it to be
+// used for the test strings, so Node & V8 have some space for allocations.
+#include <signal.h>
+#include <sys/vminfo.h>
+
+static void* Allowed(size_t size) {
+  blkcnt_t allowedBlocks = psdanger(SIGKILL);
+
+  if (allowedBlocks < 1) {
+    // Already OOM
+    return nullptr;
+  }
+  const size_t BYTES_PER_BLOCK = 512;
+  size_t allowed = (allowedBlocks * BYTES_PER_BLOCK * 4) / 5;
+  if (size < allowed) {
+    return malloc(size);
+  }
+  return nullptr;
+}
+#else
+// Other systems also allow over-allocation, but this malloc-and-free approach
+// seems to be working for them.
+static void* Allowed(size_t size) {
+  return malloc(size);
+}
+#endif  // _AIX
+
 void EnsureAllocation(const v8::FunctionCallbackInfo<v8::Value> &args) {
   v8::Isolate* isolate = args.GetIsolate();
   uintptr_t size = args[0].As<v8::Integer>()->Value();
   v8::Local<v8::Boolean> success;
 
-  void* buffer = malloc(size);
+  void* buffer = Allowed(size);
   if (buffer) {
     success = v8::Boolean::New(isolate, true);
     free(buffer);


### PR DESCRIPTION
Assumption that if memory can be malloc()ed it can be used is not true
on AIX. Later access of the allocated pages can trigger SIGKILL if there
are insufficient VM pages.

Use psdanger() to better estimate available memory.

Fixes: https://github.com/nodejs/build/issues/1849

More info:
- https://www.ibm.com/support/knowledgecenter/en/ssw_aix_71/generalprogramming/sys_mem_alloc.html
- https://www.ibm.com/support/knowledgecenter/en/ssw_aix_71/p_bostechref/psdanger.html

Related to:
- https://github.com/nodejs/build/issues/1820#issuecomment-505998851
- https://github.com/nodejs/node/pull/28469
- https://github.com/nodejs/node/pull/28516

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
