### PR TITLE
test: use unique tmpdirs for each test

### DIFF
--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -3,10 +3,13 @@
 
 const path = require('path');
 const common = require('../common.js');
-const filename = path.resolve(process.env.NODE_TMPDIR || __dirname,
-                              `.removeme-benchmark-garbage-${process.pid}`);
 const fs = require('fs');
 const assert = require('assert');
+
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+const filename = path.resolve(tmpdir.path,
+                              `.removeme-benchmark-garbage-${process.pid}`);
 
 let encodingType, encoding, size, filesize;
 

--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -5,10 +5,13 @@
 
 const path = require('path');
 const common = require('../common.js');
-const filename = path.resolve(process.env.NODE_TMPDIR || __dirname,
-                              `.removeme-benchmark-garbage-${process.pid}`);
 const fs = require('fs');
 const assert = require('assert');
+
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+const filename = path.resolve(tmpdir.path,
+                              `.removeme-benchmark-garbage-${process.pid}`);
 
 const bench = common.createBenchmark(main, {
   dur: [5],

--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -3,9 +3,12 @@
 
 const path = require('path');
 const common = require('../common.js');
-const filename = path.resolve(process.env.NODE_TMPDIR || __dirname,
-                              `.removeme-benchmark-garbage-${process.pid}`);
 const fs = require('fs');
+
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+const filename = path.resolve(tmpdir.path,
+                              `.removeme-benchmark-garbage-${process.pid}`);
 
 const bench = common.createBenchmark(main, {
   dur: [5],

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -264,7 +264,8 @@ async function rename(oldPath, newPath) {
 }
 
 async function truncate(path, len = 0) {
-  return ftruncate(await open(path, 'r+'), len);
+  const fd = await open(path, 'r+');
+  return ftruncate(fd, len).finally(fd.close.bind(fd));
 }
 
 async function ftruncate(handle, len = 0) {

--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -93,6 +93,7 @@ function setupHistory(repl, historyPath, ready) {
     fs.ftruncate(hnd, 0, (err) => {
       repl._historyHandle = hnd;
       repl.on('line', online);
+      repl.once('exit', onexit);
 
       // Reading the file data out erases it
       repl.once('flushHistory', function() {
@@ -136,6 +137,15 @@ function setupHistory(repl, historyPath, ready) {
         repl.emit('flushHistory');
       }
     }
+  }
+
+  function onexit() {
+    if (repl._flushing) {
+      repl.once('flushHistory', onexit);
+      return;
+    }
+    repl.off('line', online);
+    fs.close(repl._historyHandle, () => {});
   }
 }
 

--- a/test/addons/load-long-path/test.js
+++ b/test/addons/load-long-path/test.js
@@ -6,9 +6,9 @@ if (common.isWindows && (process.env.PROCESSOR_ARCHITEW6432 !== undefined))
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
+const { fork } = require('child_process');
 
 const tmpdir = require('../../common/tmpdir');
-tmpdir.refresh();
 
 // Make a path that is more than 260 chars long.
 // Any given folder cannot have a name longer than 260 characters,
@@ -17,7 +17,6 @@ let addonDestinationDir = path.resolve(tmpdir.path);
 
 for (let i = 0; i < 10; i++) {
   addonDestinationDir = path.join(addonDestinationDir, 'x'.repeat(30));
-  fs.mkdirSync(addonDestinationDir);
 }
 
 const addonPath = path.join(__dirname,
@@ -26,11 +25,29 @@ const addonPath = path.join(__dirname,
                             'binding.node');
 const addonDestinationPath = path.join(addonDestinationDir, 'binding.node');
 
+// Loading an addon keeps the file open until the process terminates. Load
+// the addon in a child process so that when the parent terminates the file
+// is already closed and the tmpdir can be cleaned up.
+
+// Child
+if (process.argv[2] === 'child') {
+  // Attempt to load at long path destination
+  const addon = require(addonDestinationPath);
+  assert.notStrictEqual(addon, null);
+  assert.strictEqual(addon.hello(), 'world');
+  return;
+}
+
+// Parent
+tmpdir.refresh();
+
 // Copy binary to long path destination
+fs.mkdirSync(addonDestinationDir, { recursive: true });
 const contents = fs.readFileSync(addonPath);
 fs.writeFileSync(addonDestinationPath, contents);
 
-// Attempt to load at long path destination
-const addon = require(addonDestinationPath);
-assert.notStrictEqual(addon, null);
-assert.strictEqual(addon.hello(), 'world');
+// Run test
+const child = fork(__filename, ['child'], { stdio: 'inherit' });
+child.on('exit', common.mustCall(function(code) {
+  assert.strictEqual(code, 0);
+}));

--- a/test/benchmark/test-benchmark-fs.js
+++ b/test/benchmark/test-benchmark-fs.js
@@ -19,4 +19,4 @@ runBenchmark('fs', [
   'filesize=1024',
   'dir=.github',
   'withFileTypes=false'
-], { NODE_TMPDIR: tmpdir.path, NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -906,11 +906,12 @@ The realpath of the testing temporary directory.
 
 Deletes and recreates the testing temporary directory.
 
-The first time refresh is run it adds a listener to process `'exit'` that
+The first time `refresh()` runs,  it adds a listener to process `'exit'` that
 cleans the temporary directory. Thus, every file under `tmpdir.path` needs to
 be closed before the test completes. A good way to do this is to add a
-listener to process `'beforeExit'`. If a file needs to be left open until Node
-completes, use a child process and call `refresh` only in the parent.
+listener to process `'beforeExit'`. If a file needs to be left open until
+Node.js completes, use a child process and call `refresh()` only in the
+parent.
 
 ## WPT Module
 

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -906,6 +906,12 @@ The realpath of the testing temporary directory.
 
 Deletes and recreates the testing temporary directory.
 
+The first time refresh is run it adds a listener to process `'exit'` that
+cleans the temporary directory. Thus, every file under `tmpdir.path` needs to
+be closed before the test completes. A good way to do this is to add a
+listener to process `'beforeExit'`. If a file needs to be left open until Node
+completes, use a child process and call `refresh` only in the parent.
+
 ## WPT Module
 
 ### harness

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -89,7 +89,8 @@ const testRoot = process.env.NODE_TEST_DIR ?
 
 // Using a `.` prefixed name, which is the convention for "hidden" on POSIX,
 // gets tools to ignore it by default or by simple rules, especially eslint.
-const tmpdirName = '.tmp.' + (process.env.TEST_THREAD_ID || '0');
+const tmpdirName = '.tmp.' +
+  (process.env.TEST_SERIAL_ID || process.env.TEST_THREAD_ID || '0');
 const tmpPath = path.join(testRoot, tmpdirName);
 
 function refresh(opts = {}) {

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -5,6 +5,7 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const { debuglog } = require('util');
+const { isMainThread } = require('worker_threads');
 
 const debug = debuglog('test/tmpdir');
 
@@ -110,7 +111,8 @@ function refresh(opts = {}) {
     process.on('exit', () => {
       try {
         // Change dit to avoid possible EBUSY
-        process.chdir(testRoot);
+        if (isMainThread)
+          process.chdir(testRoot);
         rimrafSync(tmpPath, { spawn: false });
       } catch (e) {
         console.error('Can\'t clean tmpdir:', tmpPath);

--- a/test/parallel/test-fs-append-file-sync.js
+++ b/test/parallel/test-fs-append-file-sync.js
@@ -99,13 +99,3 @@ const fileData5 = fs.readFileSync(filename5);
 
 assert.strictEqual(Buffer.byteLength(data) + currentFileData.length,
                    fileData5.length);
-
-// Exit logic for cleanup.
-
-process.on('exit', function() {
-  fs.unlinkSync(filename);
-  fs.unlinkSync(filename2);
-  fs.unlinkSync(filename3);
-  fs.unlinkSync(filename4);
-  fs.unlinkSync(filename5);
-});

--- a/test/parallel/test-fs-buffertype-writesync.js
+++ b/test/parallel/test-fs-buffertype-writesync.js
@@ -19,4 +19,5 @@ v.forEach((value) => {
   const fd = fs.openSync(filePath, 'w');
   fs.writeSync(fd, value);
   assert.strictEqual(fs.readFileSync(filePath).toString(), String(value));
+  fs.closeSync(fd);
 });

--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -46,6 +46,7 @@ fs.open(fileTemp, 'a', 0o777, common.mustCall(function(err, fd) {
     assert.ifError(err);
     fs.fsync(fd, common.mustCall(function(err) {
       assert.ifError(err);
+      fs.closeSync(fd);
     }));
   }));
 }));

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -49,7 +49,3 @@ fs.writeFile(fullPath, 'ok', common.mustCall(function(err) {
     assert.ifError(err);
   }));
 }));
-
-process.on('exit', function() {
-  fs.unlinkSync(fullPath);
-});

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -94,5 +94,8 @@ if (common.isLinux || common.isOSX) {
   tmpdir.refresh();
   const file = path.join(tmpdir.path, 'a.js');
   fs.copyFileSync(fixtures.path('a.js'), file);
-  fs.open(file, O_DSYNC, common.mustCall(assert.ifError));
+  fs.open(file, O_DSYNC, common.mustCall((err, fd) => {
+    assert.ifError(err);
+    fs.closeSync(fd);
+  }));
 }

--- a/test/parallel/test-fs-options-immutable.js
+++ b/test/parallel/test-fs-options-immutable.js
@@ -70,6 +70,6 @@ if (common.canCreateSymLink()) {
 {
   const fileName = path.resolve(tmpdir.path, 'streams');
   fs.WriteStream(fileName, options).once('open', common.mustCall(() => {
-    fs.ReadStream(fileName, options);
-  }));
+    fs.ReadStream(fileName, options).destroy();
+  })).end();
 }

--- a/test/parallel/test-fs-promises-file-handle-append-file.js
+++ b/test/parallel/test-fs-promises-file-handle-append-file.js
@@ -22,6 +22,8 @@ async function validateAppendBuffer() {
   await fileHandle.appendFile(buffer);
   const appendedFileData = fs.readFileSync(filePath);
   assert.deepStrictEqual(appendedFileData, buffer);
+
+  await fileHandle.close();
 }
 
 async function validateAppendString() {
@@ -33,6 +35,8 @@ async function validateAppendString() {
   const stringAsBuffer = Buffer.from(string, 'utf8');
   const appendedFileData = fs.readFileSync(filePath);
   assert.deepStrictEqual(appendedFileData, stringAsBuffer);
+
+  await fileHandle.close();
 }
 
 validateAppendBuffer()

--- a/test/parallel/test-fs-promises-file-handle-chmod.js
+++ b/test/parallel/test-fs-promises-file-handle-chmod.js
@@ -38,6 +38,8 @@ async function validateFilePermission() {
   await fileHandle.chmod(newPermissions);
   const statsAfterMod = fs.statSync(filePath);
   assert.deepStrictEqual(statsAfterMod.mode & expectedAccess, expectedAccess);
+
+  await fileHandle.close();
 }
 
 validateFilePermission().then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -26,6 +26,8 @@ async function validateRead() {
   const readAsyncHandle = await fileHandle.read(Buffer.alloc(11), 0, 11, 0);
   assert.deepStrictEqual(buffer.length, readAsyncHandle.bytesRead);
   assert.deepStrictEqual(buffer, readAsyncHandle.buffer);
+
+  await fileHandle.close();
 }
 
 async function validateEmptyRead() {
@@ -38,6 +40,8 @@ async function validateEmptyRead() {
   fs.closeSync(fd);
   const readAsyncHandle = await fileHandle.read(Buffer.alloc(11), 0, 11, 0);
   assert.deepStrictEqual(buffer.length, readAsyncHandle.bytesRead);
+
+  await fileHandle.close();
 }
 
 async function validateLargeRead() {

--- a/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -25,6 +25,8 @@ async function validateReadFile() {
 
   const readFileData = await fileHandle.readFile();
   assert.deepStrictEqual(buffer, readFileData);
+
+  await fileHandle.close();
 }
 
 async function validateReadFileProc() {

--- a/test/parallel/test-fs-promises-file-handle-stat.js
+++ b/test/parallel/test-fs-promises-file-handle-stat.js
@@ -17,6 +17,7 @@ async function validateStat() {
   const fileHandle = await open(filePath, 'w+');
   const stats = await fileHandle.stat();
   assert.ok(stats.mtime instanceof Date);
+  await fileHandle.close();
 }
 
 validateStat()

--- a/test/parallel/test-fs-promises-file-handle-sync.js
+++ b/test/parallel/test-fs-promises-file-handle-sync.js
@@ -20,6 +20,7 @@ async function validateSync() {
   const ret = await handle.read(Buffer.alloc(11), 0, 11, 0);
   assert.strictEqual(ret.bytesRead, 11);
   assert.deepStrictEqual(ret.buffer, buf);
+  await handle.close();
 }
 
 validateSync();

--- a/test/parallel/test-fs-promises-file-handle-truncate.js
+++ b/test/parallel/test-fs-promises-file-handle-truncate.js
@@ -20,6 +20,8 @@ async function validateTruncate() {
 
   await fileHandle.truncate(5);
   assert.deepStrictEqual((await readFile(filename)).toString(), 'Hello');
+
+  await fileHandle.close();
 }
 
 validateTruncate().then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-write.js
+++ b/test/parallel/test-fs-promises-file-handle-write.js
@@ -22,6 +22,8 @@ async function validateWrite() {
   await fileHandle.write(buffer, 0, buffer.length);
   const readFileData = fs.readFileSync(filePathForHandle);
   assert.deepStrictEqual(buffer, readFileData);
+
+  await fileHandle.close();
 }
 
 async function validateEmptyWrite() {
@@ -32,6 +34,8 @@ async function validateEmptyWrite() {
   await fileHandle.write(buffer, 0, buffer.length);
   const readFileData = fs.readFileSync(filePathForHandle);
   assert.deepStrictEqual(buffer, readFileData);
+
+  await fileHandle.close();
 }
 
 async function validateNonUint8ArrayWrite() {
@@ -42,6 +46,8 @@ async function validateNonUint8ArrayWrite() {
   await fileHandle.write(buffer, 0, buffer.length);
   const readFileData = fs.readFileSync(filePathForHandle);
   assert.deepStrictEqual(Buffer.from(buffer, 'utf8'), readFileData);
+
+  await fileHandle.close();
 }
 
 async function validateNonStringValuesWrite() {
@@ -55,6 +61,8 @@ async function validateNonStringValuesWrite() {
   const readFileData = fs.readFileSync(filePathForHandle);
   const expected = ['123', '[object Object]', '[object Map]'].join('');
   assert.deepStrictEqual(Buffer.from(expected, 'utf8'), readFileData);
+
+  await fileHandle.close();
 }
 
 Promise.all([

--- a/test/parallel/test-fs-promises-file-handle-writeFile.js
+++ b/test/parallel/test-fs-promises-file-handle-writeFile.js
@@ -22,6 +22,8 @@ async function validateWriteFile() {
   await fileHandle.writeFile(buffer);
   const readFileData = fs.readFileSync(filePathForHandle);
   assert.deepStrictEqual(buffer, readFileData);
+
+  await fileHandle.close();
 }
 
 validateWriteFile()

--- a/test/parallel/test-fs-promises-readfile-with-fd.js
+++ b/test/parallel/test-fs-promises-readfile-with-fd.js
@@ -28,6 +28,8 @@ async function readFileTest() {
 
   /* readFile() should read from position five, instead of zero. */
   assert.deepStrictEqual((await handle.readFile()).toString(), ' World');
+
+  await handle.close();
 }
 
 

--- a/test/parallel/test-fs-promises-writefile-with-fd.js
+++ b/test/parallel/test-fs-promises-writefile-with-fd.js
@@ -29,6 +29,8 @@ async function writeFileTest() {
 
   /* New content should be written at position five, instead of zero. */
   assert.deepStrictEqual(readFileSync(fn).toString(), 'HelloWorld');
+
+  await handle.close();
 }
 
 

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -83,6 +83,7 @@ async function getHandle(dest) {
     {
       const handle = await getHandle(dest);
       assert.strictEqual(typeof handle, 'object');
+      await handle.close();
     }
 
     // file stats
@@ -106,6 +107,7 @@ async function getHandle(dest) {
 
       await handle.datasync();
       await handle.sync();
+      await handle.close();
     }
 
     // Test fs.read promises when length to read is zero bytes
@@ -119,6 +121,7 @@ async function getHandle(dest) {
       assert.strictEqual(ret.bytesRead, 0);
 
       await unlink(dest);
+      await handle.close();
     }
 
     // Bytes written to file match buffer
@@ -130,6 +133,7 @@ async function getHandle(dest) {
       const ret = await handle.read(Buffer.alloc(bufLen), 0, bufLen, 0);
       assert.strictEqual(ret.bytesRead, bufLen);
       assert.deepStrictEqual(ret.buffer, buf);
+      await handle.close();
     }
 
     // Truncate file to specified length
@@ -143,6 +147,7 @@ async function getHandle(dest) {
       assert.deepStrictEqual(ret.buffer, buf);
       await truncate(dest, 5);
       assert.deepStrictEqual((await readFile(dest)).toString(), 'hello');
+      await handle.close();
     }
 
     // Invalid change of ownership
@@ -181,6 +186,8 @@ async function getHandle(dest) {
           message: 'The value of "gid" is out of range. ' +
                     'It must be >= 0 && < 4294967296. Received -1'
         });
+
+      await handle.close();
     }
 
     // Set modification times

--- a/test/parallel/test-fs-readdir-types.js
+++ b/test/parallel/test-fs-readdir-types.js
@@ -82,6 +82,7 @@ fs.readdir(readdirDir, {
 // Check for correct types when the binding returns unknowns
 const UNKNOWN = constants.UV_DIRENT_UNKNOWN;
 const oldReaddir = binding.readdir;
+process.on('beforeExit', () => { binding.readdir = oldReaddir; });
 binding.readdir = common.mustCall((path, encoding, types, req, ctx) => {
   if (req) {
     const oldCb = req.oncomplete;

--- a/test/parallel/test-fs-readfile-fd.js
+++ b/test/parallel/test-fs-readfile-fd.js
@@ -71,6 +71,8 @@ function tempFdSync(callback) {
 
     /* readFileSync() should read from position five, instead of zero. */
     assert.deepStrictEqual(fs.readFileSync(fd).toString(), ' World');
+
+    fs.closeSync(fd);
   }
 
   {
@@ -89,6 +91,8 @@ function tempFdSync(callback) {
           assert.ifError(err);
           /* readFile() should read from position five, instead of zero. */
           assert.deepStrictEqual(data.toString(), ' World');
+
+          fs.closeSync(fd);
         }));
       }));
     }));

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -43,7 +43,3 @@ exec(cmd, { maxBuffer: 1000000 }, common.mustCall((err, stdout, stderr) => {
   );
   console.log('ok');
 }));
-
-process.on('exit', function() {
-  fs.unlinkSync(filename);
-});

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -36,7 +36,3 @@ exec(
     console.log('ok');
   })
 );
-
-process.on('exit', function() {
-  fs.unlinkSync(filename);
-});

--- a/test/parallel/test-fs-ready-event-stream.js
+++ b/test/parallel/test-fs-ready-event-stream.js
@@ -17,4 +17,5 @@ const writeStream = fs.createWriteStream(writeFile, { autoClose: true });
 assert.strictEqual(writeStream.pending, true);
 writeStream.on('ready', common.mustCall(() => {
   assert.strictEqual(writeStream.pending, false);
+  writeStream.end();
 }));

--- a/test/parallel/test-fs-truncate-fd.js
+++ b/test/parallel/test-fs-truncate-fd.js
@@ -21,7 +21,7 @@ fs.truncate(fd, 5, common.mustCall((err) => {
   assert.strictEqual(fs.readFileSync(filename, 'utf8'), 'hello');
 }));
 
-process.on('beforeExit', () => {
+process.once('beforeExit', () => {
   fs.closeSync(fd);
   fs.unlinkSync(filename);
   console.log('ok');

--- a/test/parallel/test-fs-truncate-fd.js
+++ b/test/parallel/test-fs-truncate-fd.js
@@ -21,7 +21,7 @@ fs.truncate(fd, 5, common.mustCall((err) => {
   assert.strictEqual(fs.readFileSync(filename, 'utf8'), 'hello');
 }));
 
-process.on('exit', () => {
+process.on('beforeExit', () => {
   fs.closeSync(fd);
   fs.unlinkSync(filename);
   console.log('ok');

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -147,7 +147,7 @@ function testFtruncate(cb) {
   const file2 = path.resolve(tmp, 'truncate-file-2.txt');
   fs.writeFileSync(file2, 'Hi');
   const fd = fs.openSync(file2, 'r+');
-  process.on('exit', () => fs.closeSync(fd));
+  process.on('beforeExit', () => fs.closeSync(fd));
   fs.ftruncateSync(fd, 4);
   assert(fs.readFileSync(file2).equals(Buffer.from('Hi\u0000\u0000')));
 }
@@ -165,7 +165,7 @@ function testFtruncate(cb) {
   const file4 = path.resolve(tmp, 'truncate-file-4.txt');
   fs.writeFileSync(file4, 'Hi');
   const fd = fs.openSync(file4, 'r+');
-  process.on('exit', () => fs.closeSync(fd));
+  process.on('beforeExit', () => fs.closeSync(fd));
   fs.ftruncate(fd, 4, common.mustCall(function(err) {
     assert.ifError(err);
     assert(fs.readFileSync(file4).equals(Buffer.from('Hi\u0000\u0000')));
@@ -176,7 +176,7 @@ function testFtruncate(cb) {
   const file5 = path.resolve(tmp, 'truncate-file-5.txt');
   fs.writeFileSync(file5, 'Hi');
   const fd = fs.openSync(file5, 'r+');
-  process.on('exit', () => fs.closeSync(fd));
+  process.on('beforeExit', () => fs.closeSync(fd));
 
   ['', false, null, {}, []].forEach((input) => {
     assert.throws(
@@ -232,7 +232,7 @@ function testFtruncate(cb) {
   const file6 = path.resolve(tmp, 'truncate-file-6.txt');
   fs.writeFileSync(file6, 'Hi');
   const fd = fs.openSync(file6, 'r+');
-  process.on('exit', () => fs.closeSync(fd));
+  process.on('beforeExit', () => fs.closeSync(fd));
   fs.ftruncate(fd, -1, common.mustCall(function(err) {
     assert.ifError(err);
     assert(fs.readFileSync(file6).equals(Buffer.from('')));

--- a/test/parallel/test-fs-write-file.js
+++ b/test/parallel/test-fs-write-file.js
@@ -102,10 +102,3 @@ fs.open(filename4, 'w+', common.mustCall(function(e, fd) {
     }));
   }));
 }));
-
-process.on('exit', function() {
-  fs.unlinkSync(filename);
-  fs.unlinkSync(filename2);
-  fs.unlinkSync(filename3);
-  fs.unlinkSync(filename4);
-});

--- a/test/parallel/test-fs-write-stream-change-open.js
+++ b/test/parallel/test-fs-write-stream-change-open.js
@@ -46,6 +46,7 @@ fs.close = function(fd) {
   assert.ok(fd, 'fs.close must not be called with an undefined fd.');
   fs.close = _fs_close;
   fs.open = _fs_open;
+  fs.closeSync(fd);
 };
 
 stream.write('foo');

--- a/test/parallel/test-fs-write-stream-err.js
+++ b/test/parallel/test-fs-write-stream-err.js
@@ -56,6 +56,7 @@ fs.write = function() {
 fs.close = common.mustCall(function(fd_, cb) {
   console.error('fs.close', fd_, stream.fd);
   assert.strictEqual(fd_, stream.fd);
+  fs.closeSync(fd_);
   process.nextTick(cb);
 });
 

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -9,10 +9,10 @@ const example = path.join(tmpdir.path, 'dummy');
 
 tmpdir.refresh();
 // Should not throw.
-fs.createWriteStream(example, undefined);
-fs.createWriteStream(example, null);
-fs.createWriteStream(example, 'utf8');
-fs.createWriteStream(example, { encoding: 'utf8' });
+fs.createWriteStream(example, undefined).end();
+fs.createWriteStream(example, null).end();
+fs.createWriteStream(example, 'utf8').end();
+fs.createWriteStream(example, { encoding: 'utf8' }).end();
 
 const createWriteStreamErr = (path, opt) => {
   common.expectsError(

--- a/test/parallel/test-fs-write-stream.js
+++ b/test/parallel/test-fs-write-stream.js
@@ -38,6 +38,7 @@ tmpdir.refresh();
   fs.close = function(fd) {
     assert.ok(fd, 'fs.close must not be called without an undefined fd.');
     fs.close = _fs_close;
+    fs.closeSync(fd);
   };
   stream.destroy();
 }

--- a/test/parallel/test-fs-writefile-with-fd.js
+++ b/test/parallel/test-fs-writefile-with-fd.js
@@ -30,6 +30,9 @@ tmpdir.refresh();
 
   /* New content should be written at position five, instead of zero. */
   assert.deepStrictEqual(fs.readFileSync(filename).toString(), 'HelloWorld');
+
+  /* Close the file descriptor. */
+  fs.closeSync(fd);
 }
 
 {
@@ -52,6 +55,9 @@ tmpdir.refresh();
 
         /* New content should be written at position five, instead of zero. */
         assert.deepStrictEqual(fs.readFileSync(file).toString(), 'HelloWorld');
+
+        /* Close the file descriptor. */
+        fs.closeSync(fd);
       }));
     }));
   }));

--- a/test/parallel/test-http2-respond-file-error-pipe-offset.js
+++ b/test/parallel/test-http2-respond-file-error-pipe-offset.js
@@ -21,8 +21,6 @@ if (mkfifo.error && mkfifo.error.code === 'ENOENT') {
   common.skip('missing mkfifo');
 }
 
-process.on('exit', () => fs.unlinkSync(pipeName));
-
 const server = http2.createServer();
 server.on('stream', (stream) => {
   stream.respondWithFile(pipeName, {

--- a/test/parallel/test-http2-respond-file-with-pipe.js
+++ b/test/parallel/test-http2-respond-file-with-pipe.js
@@ -21,8 +21,6 @@ if (mkfifo.error && mkfifo.error.code === 'ENOENT') {
   common.skip('missing mkfifo');
 }
 
-process.on('exit', () => fs.unlinkSync(pipeName));
-
 const server = http2.createServer();
 server.on('stream', (stream) => {
   stream.respondWithFile(pipeName, {

--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -38,6 +38,8 @@ const filename = path.join(tmpdir.path, 'sync-write-stream.txt');
 
   assert.strictEqual(stream._write(chunk, null, common.mustCall(1)), true);
   assert.strictEqual(fs.readFileSync(filename).equals(chunk), true);
+
+  fs.closeSync(fd);
 }
 
 // Verify that the stream will unset the fd after destroy().

--- a/test/parallel/test-pipe-unref.js
+++ b/test/parallel/test-pipe-unref.js
@@ -1,12 +1,29 @@
 'use strict';
 const common = require('../common');
 const net = require('net');
+const assert = require('assert');
+const { fork } = require('child_process');
 
 // This test should end immediately after `unref` is called
+// The pipe will stay open as Node.js completes, thus run in a child process
+// so that tmpdir can be cleaned up.
 
 const tmpdir = require('../common/tmpdir');
-tmpdir.refresh();
 
+if (process.argv[2] !== 'child') {
+  // Parent
+  tmpdir.refresh();
+
+  // Run test
+  const child = fork(__filename, ['child'], { stdio: 'inherit' });
+  child.on('exit', common.mustCall(function(code) {
+    assert.strictEqual(code, 0);
+  }));
+
+  return;
+}
+
+// Child
 const s = net.Server();
 s.listen(common.PIPE);
 s.unref();

--- a/test/parallel/test-readline-async-iterators-destroy.js
+++ b/test/parallel/test-readline-async-iterators-destroy.js
@@ -42,6 +42,9 @@ async function testSimpleDestroy() {
     expectedLines.splice(1);
 
     assert.deepStrictEqual(iteratedLines, expectedLines);
+
+    rli.close();
+    readable.destroy();
   }
 }
 
@@ -72,6 +75,9 @@ async function testMutualDestroy() {
     }
 
     assert.deepStrictEqual(iteratedLines, expectedLines);
+
+    rli.close();
+    readable.destroy();
   }
 }
 

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -38,12 +38,15 @@ const replHistoryPath = path.join(tmpdir.path, '.node_repl_history');
 const checkResults = common.mustCall(function(err, r) {
   assert.ifError(err);
 
-  r.input.end();
   const stat = fs.statSync(replHistoryPath);
   const fileMode = stat.mode & 0o777;
   assert.strictEqual(
     fileMode, 0o600,
     `REPL history file should be mode 0600 but was 0${fileMode.toString(8)}`);
+
+  // Close the REPL
+  r.input.emit('keypress', '', { ctrl: true, name: 'd' });
+  r.input.end();
 });
 
 repl.createInternalRepl(

--- a/test/pummel/test-fs-largefile.js
+++ b/test/pummel/test-fs-largefile.js
@@ -47,9 +47,3 @@ assert.strictEqual(readBuf[0], 0);
 // Verify that floating point positions do not throw.
 fs.writeSync(fd, writeBuf, 0, writeBuf.length, 42.000001);
 fs.close(fd, common.mustCall());
-
-// Normally, we don't clean up tmp files at the end of a test, but we'll make an
-// exception for a 5 GB file.
-process.on('exit', function() {
-  fs.unlinkSync(filepath);
-});

--- a/test/pummel/test-fs-watch-file-slow.js
+++ b/test/pummel/test-fs-watch-file-slow.js
@@ -27,6 +27,7 @@ const fs = require('fs');
 
 const tmpdir = require('../common/tmpdir');
 
+tmpdir.refresh();
 const FILENAME = path.join(tmpdir.path, 'watch-me');
 const TIMEOUT = 1300;
 

--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -46,10 +46,6 @@ const filenameThree = 'charm'; // Because the third time is
 const filenameFour = 'get';
 
 process.on('exit', function() {
-  fs.unlinkSync(filepathOne);
-  fs.unlinkSync(filepathTwoAbs);
-  fs.unlinkSync(filenameThree);
-  fs.unlinkSync(filenameFour);
   assert.strictEqual(watchSeenOne, 1);
   assert.strictEqual(watchSeenTwo, 2);
   assert.strictEqual(watchSeenThree, 1);
@@ -57,6 +53,7 @@ process.on('exit', function() {
 });
 
 
+tmpdir.refresh();
 fs.writeFileSync(filepathOne, 'hello');
 
 assert.throws(

--- a/test/pummel/test-regress-GH-814.js
+++ b/test/pummel/test-regress-GH-814.js
@@ -37,6 +37,8 @@ function newBuffer(size, value) {
 }
 
 const fs = require('fs');
+
+tmpdir.refresh();
 const testFileName = require('path').join(tmpdir.path, 'GH-814_testFile.txt');
 const testFileFD = fs.openSync(testFileName, 'w');
 console.log(testFileName);

--- a/test/pummel/test-regress-GH-814_2.js
+++ b/test/pummel/test-regress-GH-814_2.js
@@ -27,6 +27,8 @@ const assert = require('assert');
 
 const fs = require('fs');
 const tmpdir = require('../common/tmpdir');
+
+tmpdir.refresh();
 const testFileName = require('path').join(tmpdir.path, 'GH-814_test.txt');
 const testFD = fs.openSync(testFileName, 'w');
 console.error(`${testFileName}\n`);

--- a/test/sequential/test-http2-timeout-large-write-file.js
+++ b/test/sequential/test-http2-timeout-large-write-file.js
@@ -33,6 +33,7 @@ const content = Buffer.alloc(writeSize, 0x44);
 const filepath = path.join(tmpdir.path, 'http2-large-write.tmp');
 fs.writeFileSync(filepath, content, 'binary');
 const fd = fs.openSync(filepath, 'r');
+process.on('beforeExit', () => fs.closeSync(fd));
 
 const server = http2.createSecureServer({
   key: fixtures.readKey('agent1-key.pem'),

--- a/tools/test.py
+++ b/tools/test.py
@@ -77,6 +77,7 @@ class ProgressIndicator(object):
 
   def __init__(self, cases, flaky_tests_mode):
     self.cases = cases
+    self.serial_id = 0
     self.flaky_tests_mode = flaky_tests_mode
     self.parallel_queue = Queue(len(cases))
     self.sequential_queue = Queue(len(cases))
@@ -146,6 +147,8 @@ class ProgressIndicator(object):
       case = test
       case.thread_id = thread_id
       self.lock.acquire()
+      case.serial_id = self.serial_id
+      self.serial_id += 1
       self.AboutToRun(case)
       self.lock.release()
       try:
@@ -504,6 +507,7 @@ class TestCase(object):
     self.mode = mode
     self.parallel = False
     self.disable_core_files = False
+    self.serial_id = 0
     self.thread_id = 0
 
   def IsNegative(self):
@@ -535,6 +539,7 @@ class TestCase(object):
   def Run(self):
     try:
       result = self.RunCommand(self.GetCommand(), {
+        "TEST_SERIAL_ID": "%d" % self.serial_id,
         "TEST_THREAD_ID": "%d" % self.thread_id,
         "TEST_PARALLEL" : "%d" % self.parallel
       })


### PR DESCRIPTION
Some of the recent failures in CI have happened because tests leave processes running or somehow block the tmpdir, causing the next test that tries to use the same tmpdir to fail. We use one tmpdir per thread of the test runner.

This changes the test system to use a different directory for each test, removing interference between tests.

~With this, a test run will leave about 200 tmpdirs in `test/`, but these will be reused in future runs so they don't accumulate. Removing the tmpdir on process exit interferes with cleanup that some tests already do so it's not straightforward. For now, this doesn't create any false positives, only makes unrelated tests pass.~

cc @nodejs/testing 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
