### PR TITLE
crypto: add null check to outputLength logic

### DIFF
--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -36,7 +36,8 @@ function Hash(algorithm, options) {
   if (!(this instanceof Hash))
     return new Hash(algorithm, options);
   validateString(algorithm, 'algorithm');
-  const xofLen = typeof options === 'object' ? options.outputLength : undefined;
+  const xofLen = typeof options === 'object' && options !== null ?
+    options.outputLength : undefined;
   if (xofLen !== undefined)
     validateUint32(xofLen, 'options.outputLength');
   this[kHandle] = new _Hash(algorithm, xofLen);

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -191,6 +191,8 @@ common.expectsError(
   // Default outputLengths.
   assert.strictEqual(crypto.createHash('shake128').digest('hex'),
                      '7f9c2ba4e88f827d616045507605853e');
+  assert.strictEqual(crypto.createHash('shake128', null).digest('hex'),
+                     '7f9c2ba4e88f827d616045507605853e');
   assert.strictEqual(crypto.createHash('shake256').digest('hex'),
                      '46b9dd2b0ba88d13233b3feb743eeb24' +
                      '3fcd52ea62b81b82b50c27646ed5762f');


### PR DESCRIPTION
The `Hash` constructor's `outputLength` logic checks if the `options` input is an object, but doesn't check for `null` objects. This commit adds that check.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
