### PR TITLE
benchmark: let refactor

### DIFF
--- a/benchmark/buffers/buffer-base64-decode-wrapped.js
+++ b/benchmark/buffers/buffer-base64-decode-wrapped.js
@@ -18,7 +18,7 @@ function main({ charsPerLine, linesCount, n }) {
   const buffer = Buffer.alloc(bytesCount, line, 'base64');
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     buffer.base64Write(data, 0, bytesCount);
   }
   bench.end(n);

--- a/benchmark/buffers/buffer-base64-decode.js
+++ b/benchmark/buffers/buffer-base64-decode.js
@@ -16,6 +16,6 @@ function main({ n, size }) {
   const b = Buffer.allocUnsafe(encodedSize);
   b.write(s, 0, encodedSize, 'base64');
   bench.start();
-  for (var i = 0; i < n; i += 1) b.base64Write(s, 0, s.length);
+  for (let i = 0; i < n; i += 1) b.base64Write(s, 0, s.length);
   bench.end(n);
 }

--- a/benchmark/buffers/buffer-bytelength.js
+++ b/benchmark/buffers/buffer-bytelength.js
@@ -37,7 +37,7 @@ function main({ n, len, encoding }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     const index = n % strings.length;
     // Go!
     const r = Buffer.byteLength(strings[index], encoding);

--- a/benchmark/buffers/buffer-compare-offset.js
+++ b/benchmark/buffers/buffer-compare-offset.js
@@ -8,12 +8,12 @@ const bench = common.createBenchmark(main, {
 });
 
 function compareUsingSlice(b0, b1, len, iter) {
-  for (var i = 0; i < iter; i++)
+  for (let i = 0; i < iter; i++)
     Buffer.compare(b0.slice(1, len), b1.slice(1, len));
 }
 
 function compareUsingOffset(b0, b1, len, iter) {
-  for (var i = 0; i < iter; i++)
+  for (let i = 0; i < iter; i++)
     b0.compare(b1, 1, len, 1, len);
 }
 

--- a/benchmark/buffers/buffer-compare.js
+++ b/benchmark/buffers/buffer-compare.js
@@ -34,7 +34,7 @@ function main({ n, size }) {
   b1[size - 1] = 'b'.charCodeAt(0);
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     Buffer.compare(b0, b1);
   }
   bench.end(n);

--- a/benchmark/buffers/buffer-concat.js
+++ b/benchmark/buffers/buffer-concat.js
@@ -15,7 +15,7 @@ function main({ n, pieces, pieceSize, withTotalLength }) {
   const totalLength = withTotalLength ? pieces * pieceSize : undefined;
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     Buffer.concat(list, totalLength);
   }
   bench.end(n);

--- a/benchmark/buffers/buffer-indexof-number.js
+++ b/benchmark/buffers/buffer-indexof-number.js
@@ -15,7 +15,7 @@ function main({ n, value }) {
 
   let count = 0;
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     count += aliceBuffer.indexOf(value, 0, undefined);
   }
   bench.end(n);

--- a/benchmark/buffers/buffer-indexof.js
+++ b/benchmark/buffers/buffer-indexof.js
@@ -42,7 +42,7 @@ function main({ n, search, encoding, type }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     aliceBuffer.indexOf(search, 0, encoding);
   }
   bench.end(n);

--- a/benchmark/buffers/buffer-normalize-encoding.js
+++ b/benchmark/buffers/buffer-normalize-encoding.js
@@ -31,7 +31,7 @@ function main({ encoding, n }) {
   const { normalizeEncoding } = require('internal/util');
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     normalizeEncoding(encoding);
   }
   bench.end(n);

--- a/benchmark/buffers/buffer-read-float.js
+++ b/benchmark/buffers/buffer-read-float.js
@@ -32,7 +32,7 @@ function main({ n, type, endian, value }) {
   buff[`write${type}${endian}`](values[type][value], 0);
 
   bench.start();
-  for (var i = 0; i !== n; i++) {
+  for (let i = 0; i !== n; i++) {
     buff[fn](0);
   }
   bench.end(n);

--- a/benchmark/buffers/buffer-read-with-byteLength.js
+++ b/benchmark/buffers/buffer-read-with-byteLength.js
@@ -23,7 +23,7 @@ function main({ n, buf, type, byteLength }) {
 
   buff.writeDoubleLE(0, 0);
   bench.start();
-  for (var i = 0; i !== n; i++) {
+  for (let i = 0; i !== n; i++) {
     buff[fn](0, byteLength);
   }
   bench.end(n);

--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -33,7 +33,7 @@ function main({ n, buf, type }) {
   buff.writeDoubleLE(0, 0);
   bench.start();
 
-  for (var i = 0; i !== n; i++) {
+  for (let i = 0; i !== n; i++) {
     buff[fn](0);
   }
   bench.end(n);

--- a/benchmark/buffers/buffer-slice.js
+++ b/benchmark/buffers/buffer-slice.js
@@ -13,7 +13,7 @@ const slowBuf = new SlowBuffer(1024);
 function main({ n, type }) {
   const b = type === 'fast' ? buf : slowBuf;
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     b.slice(10, 256);
   }
   bench.end(n);

--- a/benchmark/buffers/buffer-swap.js
+++ b/benchmark/buffers/buffer-swap.js
@@ -27,7 +27,7 @@ function swap(b, n, m) {
 Buffer.prototype.htons = function htons() {
   if (this.length % 2 !== 0)
     throw new RangeError();
-  for (var i = 0; i < this.length; i += 2) {
+  for (let i = 0; i < this.length; i += 2) {
     swap(this, i, i + 1);
   }
   return this;
@@ -46,7 +46,7 @@ Buffer.prototype.htonl = function htonl() {
 Buffer.prototype.htonll = function htonll() {
   if (this.length % 8 !== 0)
     throw new RangeError();
-  for (var i = 0; i < this.length; i += 8) {
+  for (let i = 0; i < this.length; i += 8) {
     swap(this, i, i + 7);
     swap(this, i + 1, i + 6);
     swap(this, i + 2, i + 5);
@@ -58,7 +58,7 @@ Buffer.prototype.htonll = function htonll() {
 function createBuffer(len, aligned) {
   len += aligned ? 0 : 1;
   const buf = Buffer.allocUnsafe(len);
-  for (var i = 1; i <= len; i++)
+  for (let i = 1; i <= len; i++)
     buf[i - 1] = i;
   return aligned ? buf : buf.slice(1);
 }

--- a/benchmark/buffers/buffer-tojson.js
+++ b/benchmark/buffers/buffer-tojson.js
@@ -11,7 +11,7 @@ function main({ n, len }) {
   const buf = Buffer.allocUnsafe(len);
 
   bench.start();
-  for (var i = 0; i < n; ++i)
+  for (let i = 0; i < n; ++i)
     buf.toJSON();
   bench.end(n);
 }

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -89,7 +89,7 @@ function main({ n, buf, type }) {
 function benchBigInt(buff, fn, n) {
   const m = mod[fn];
   bench.start();
-  for (var i = 0n; i !== n; i++) {
+  for (let i = 0n; i !== n; i++) {
     buff[fn](i & m, 0);
   }
   bench.end(Number(n));
@@ -98,7 +98,7 @@ function benchBigInt(buff, fn, n) {
 function benchInt(buff, fn, n) {
   const m = mod[fn];
   bench.start();
-  for (var i = 0; i !== n; i++) {
+  for (let i = 0; i !== n; i++) {
     buff[fn](i & m, 0);
   }
   bench.end(n);
@@ -108,7 +108,7 @@ function benchSpecialInt(buff, fn, n) {
   const m = mod[fn];
   const byte = byteLength[fn];
   bench.start();
-  for (var i = 0; i !== n; i++) {
+  for (let i = 0; i !== n; i++) {
     buff[fn](i & m, 0, byte);
   }
   bench.end(n);
@@ -116,7 +116,7 @@ function benchSpecialInt(buff, fn, n) {
 
 function benchFloat(buff, fn, n) {
   bench.start();
-  for (var i = 0; i !== n; i++) {
+  for (let i = 0; i !== n; i++) {
     buff[fn](i, 0);
   }
   bench.end(n);

--- a/benchmark/buffers/buffer-zero.js
+++ b/benchmark/buffers/buffer-zero.js
@@ -14,6 +14,6 @@ function main({ n, type }) {
   const data = type === 'buffer' ? zeroBuffer : zeroString;
 
   bench.start();
-  for (var i = 0; i < n; i++) Buffer.from(data);
+  for (let i = 0; i < n; i++) Buffer.from(data);
   bench.end(n);
 }

--- a/benchmark/buffers/dataview-set.js
+++ b/benchmark/buffers/dataview-set.js
@@ -56,7 +56,7 @@ function benchInt(dv, fn, len, le) {
   const m = mod[fn];
   const method = dv[fn];
   bench.start();
-  for (var i = 0; i < len; i++) {
+  for (let i = 0; i < len; i++) {
     method.call(dv, 0, i % m, le);
   }
   bench.end(len);
@@ -65,7 +65,7 @@ function benchInt(dv, fn, len, le) {
 function benchFloat(dv, fn, len, le) {
   const method = dv[fn];
   bench.start();
-  for (var i = 0; i < len; i++) {
+  for (let i = 0; i < len; i++) {
     method.call(dv, 0, i * 0.1, le);
   }
   bench.end(len);

--- a/benchmark/url/legacy-vs-whatwg-url-get-prop.js
+++ b/benchmark/url/legacy-vs-whatwg-url-get-prop.js
@@ -26,7 +26,7 @@ function useLegacy(data) {
   // It's necessary to assign the values to an object
   // to avoid loop invariant code motion.
   bench.start();
-  for (var i = 0; i < len; i++) {
+  for (let i = 0; i < len; i++) {
     const obj = data[i];
     noDead.protocol = obj.protocol;
     noDead.auth = obj.auth;
@@ -55,7 +55,7 @@ function useWHATWG(data) {
   };
   const len = data.length;
   bench.start();
-  for (var i = 0; i < len; i++) {
+  for (let i = 0; i < len; i++) {
     const obj = data[i];
     noDead.protocol = obj.protocol;
     noDead.auth = `${obj.username}:${obj.password}`;

--- a/benchmark/url/legacy-vs-whatwg-url-parse.js
+++ b/benchmark/url/legacy-vs-whatwg-url-parse.js
@@ -15,7 +15,7 @@ function useLegacy(data) {
   const len = data.length;
   var result = url.parse(data[0]);  // Avoid dead code elimination
   bench.start();
-  for (var i = 0; i < len; ++i) {
+  for (let i = 0; i < len; ++i) {
     result = url.parse(data[i]);
   }
   bench.end(len);
@@ -26,7 +26,7 @@ function useWHATWGWithBase(data) {
   const len = data.length;
   var result = new URL(data[0][0], data[0][1]);  // Avoid dead code elimination
   bench.start();
-  for (var i = 0; i < len; ++i) {
+  for (let i = 0; i < len; ++i) {
     const item = data[i];
     result = new URL(item[0], item[1]);
   }
@@ -38,7 +38,7 @@ function useWHATWGWithoutBase(data) {
   const len = data.length;
   var result = new URL(data[0]);  // Avoid dead code elimination
   bench.start();
-  for (var i = 0; i < len; ++i) {
+  for (let i = 0; i < len; ++i) {
     result = new URL(data[i]);
   }
   bench.end(len);

--- a/benchmark/url/legacy-vs-whatwg-url-searchparams-parse.js
+++ b/benchmark/url/legacy-vs-whatwg-url-searchparams-parse.js
@@ -13,7 +13,7 @@ const bench = common.createBenchmark(main, {
 function useLegacy(n, input) {
   querystring.parse(input);
   bench.start();
-  for (var i = 0; i < n; i += 1) {
+  for (let i = 0; i < n; i += 1) {
     querystring.parse(input);
   }
   bench.end(n);
@@ -22,7 +22,7 @@ function useLegacy(n, input) {
 function useWHATWG(n, param) {
   new URLSearchParams(param);
   bench.start();
-  for (var i = 0; i < n; i += 1) {
+  for (let i = 0; i < n; i += 1) {
     new URLSearchParams(param);
   }
   bench.end(n);

--- a/benchmark/url/legacy-vs-whatwg-url-searchparams-serialize.js
+++ b/benchmark/url/legacy-vs-whatwg-url-searchparams-serialize.js
@@ -14,7 +14,7 @@ function useLegacy(n, input, prop) {
   const obj = querystring.parse(input);
   querystring.stringify(obj);
   bench.start();
-  for (var i = 0; i < n; i += 1) {
+  for (let i = 0; i < n; i += 1) {
     querystring.stringify(obj);
   }
   bench.end(n);
@@ -24,7 +24,7 @@ function useWHATWG(n, param, prop) {
   const obj = new URLSearchParams(param);
   obj.toString();
   bench.start();
-  for (var i = 0; i < n; i += 1) {
+  for (let i = 0; i < n; i += 1) {
     obj.toString();
   }
   bench.end(n);

--- a/benchmark/url/legacy-vs-whatwg-url-serialize.js
+++ b/benchmark/url/legacy-vs-whatwg-url-serialize.js
@@ -15,7 +15,7 @@ function useLegacy(data) {
   const len = data.length;
   var noDead = url.format(obj);
   bench.start();
-  for (var i = 0; i < len; i++) {
+  for (let i = 0; i < len; i++) {
     noDead = data[i].toString();
   }
   bench.end(len);
@@ -27,7 +27,7 @@ function useWHATWG(data) {
   const len = data.length;
   var noDead = obj.toString();
   bench.start();
-  for (var i = 0; i < len; i++) {
+  for (let i = 0; i < len; i++) {
     noDead = data[i].toString();
   }
   bench.end(len);

--- a/benchmark/url/url-format.js
+++ b/benchmark/url/url-format.js
@@ -21,7 +21,7 @@ function main({ type, n }) {
     url.format(inputs[name]);
 
   bench.start();
-  for (var i = 0; i < n; i += 1)
+  for (let i = 0; i < n; i += 1)
     url.format(input);
   bench.end(n);
 }

--- a/benchmark/url/url-parse.js
+++ b/benchmark/url/url-parse.js
@@ -16,7 +16,7 @@ function main({ type, n }) {
   const input = inputs[type] || '';
 
   bench.start();
-  for (var i = 0; i < n; i += 1)
+  for (let i = 0; i < n; i += 1)
     url.parse(input);
   bench.end(n);
 }

--- a/benchmark/url/url-resolve.js
+++ b/benchmark/url/url-resolve.js
@@ -23,7 +23,7 @@ function main({ n, href, path }) {
   const p = paths[path];
 
   bench.start();
-  for (var i = 0; i < n; i += 1)
+  for (let i = 0; i < n; i += 1)
     url.resolve(h, p);
   bench.end(n);
 }

--- a/benchmark/url/url-searchparams-iteration.js
+++ b/benchmark/url/url-searchparams-iteration.js
@@ -19,7 +19,7 @@ function forEach(n) {
   };
 
   bench.start();
-  for (var i = 0; i < n; i += 1)
+  for (let i = 0; i < n; i += 1)
     params.forEach(cb);
   bench.end(n);
 
@@ -32,7 +32,7 @@ function iterator(n) {
   const noDead = [];
 
   bench.start();
-  for (var i = 0; i < n; i += 1) {
+  for (let i = 0; i < n; i += 1) {
     for (const pair of params) {
       noDead[0] = pair[0];
       noDead[1] = pair[1];

--- a/benchmark/url/url-searchparams-read.js
+++ b/benchmark/url/url-searchparams-read.js
@@ -16,7 +16,7 @@ function main({ accessMethod, param, n }) {
     throw new Error(`Unknown method ${accessMethod}`);
 
   bench.start();
-  for (var i = 0; i < n; i += 1)
+  for (let i = 0; i < n; i += 1)
     params[accessMethod](param);
   bench.end(n);
 }

--- a/benchmark/url/url-searchparams-sort.js
+++ b/benchmark/url/url-searchparams-sort.js
@@ -39,7 +39,7 @@ function main({ type, n }) {
   const array = getParams(input);
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     params[searchParams] = array.slice();
     params.sort();
   }

--- a/benchmark/url/usvstring.js
+++ b/benchmark/url/usvstring.js
@@ -21,7 +21,7 @@ function main({ input, n }) {
   const str = inputs[input];
 
   bench.start();
-  for (var i = 0; i < n; i++)
+  for (let i = 0; i < n; i++)
     toUSVString(str);
   bench.end(n);
 }

--- a/benchmark/url/whatwg-url-idna.js
+++ b/benchmark/url/whatwg-url-idna.js
@@ -36,7 +36,7 @@ function main({ n, to, domain }) {
   const method = to === 'ascii' ? domainToASCII : domainToUnicode;
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     method(value);
   }
   bench.end(n);

--- a/benchmark/url/whatwg-url-properties.js
+++ b/benchmark/url/whatwg-url-properties.js
@@ -14,7 +14,7 @@ function setAndGet(data, prop) {
   const len = data.length;
   var result = data[0][prop];
   bench.start();
-  for (var i = 0; i < len; ++i) {
+  for (let i = 0; i < len; ++i) {
     result = data[i][prop];
     data[i][prop] = result;
   }
@@ -26,7 +26,7 @@ function get(data, prop) {
   const len = data.length;
   var result = data[0][prop];
   bench.start();
-  for (var i = 0; i < len; ++i) {
+  for (let i = 0; i < len; ++i) {
     result = data[i][prop]; // get
   }
   bench.end(len);

--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -25,7 +25,7 @@ function main({ n, type }) {
   const [first, second] = inputs[type || 'string'];
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     util.format(first, second);
   }
   bench.end(n);

--- a/benchmark/util/inspect-proxy.js
+++ b/benchmark/util/inspect-proxy.js
@@ -9,7 +9,7 @@ function main({ n }) {
   const proxyA = new Proxy({}, { get: () => {} });
   const proxyB = new Proxy(() => {}, {});
   bench.start();
-  for (var i = 0; i < n; i += 1)
+  for (let i = 0; i < n; i += 1)
     util.inspect({ a: proxyA, b: proxyB }, { showProxy: true });
   bench.end(n);
 }

--- a/benchmark/util/inspect.js
+++ b/benchmark/util/inspect.js
@@ -30,7 +30,7 @@ const bench = common.createBenchmark(main, {
 
 function benchmark(n, obj, options) {
   bench.start();
-  for (var i = 0; i < n; i += 1) {
+  for (let i = 0; i < n; i += 1) {
     util.inspect(obj, options);
   }
   bench.end(n);

--- a/benchmark/util/splice-one.js
+++ b/benchmark/util/splice-one.js
@@ -25,7 +25,7 @@ function main({ n, pos, size }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     spliceOne(arr, index);
     arr.push('');
   }

--- a/benchmark/util/type-check.js
+++ b/benchmark/util/type-check.js
@@ -45,7 +45,7 @@ function main({ type, argument, version, n }) {
   const arg = args[type][argument];
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     func(arg);
   }
   bench.end(n);


### PR DESCRIPTION
In `benchmark: url`, `util` and `buffers` directories this changes for loops using `var` to `let`
when it applies for consistency. 

I didn't touch for instance:
```
function benchFor(buffer, n) {
  for (var k = 0; k < n; k++) {
    for (var i = 0; i < buffer.length; i++) {
      assert(buffer[i] === 0);
    }
  }
}
```
in `benchmark/buffers/buffer-iterate.js` because `let` has block scoping and I think it might cause issues in previous versions in nested for loops, but I am not 100% about it.

If this is OK, I will do it for the other directories in benchmark with single commits so it's easy to review a few files per commit.

Look at this for reference: #28791 

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
