### PR TITLE
DoubleToSmiInteger exception when value is NaN

### DIFF
--- a/deps/v8/src/conversions-inl.h
+++ b/deps/v8/src/conversions-inl.h
@@ -110,6 +110,7 @@ int32_t DoubleToInt32(double x) {
 }
 
 bool DoubleToSmiInteger(double value, int* smi_int_value) {
+  if (std::isnan(value)) return false;
   if (!IsSmiDouble(value)) return false;
   *smi_int_value = FastD2I(value);
   DCHECK(Smi::IsValid(*smi_int_value));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
Fixing an unhandled exception in node (crashing the node process) when DoubleToSmiInteger receives a NaN. This is a problem especially when loading an NAPI addon (not sure why though).
