### PR TITLE
docs: correct import statement

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -381,8 +381,9 @@ To include an ES module into CommonJS, use [`import()`][].
 
 ### <code>import</code> statements
 
-An `import` statement can reference either ES module or CommonJS JavaScript.
-Other file types such as JSON and Native modules are not supported. For those,
+An `import` statement can reference either ES module or CommonJS JavaScript
+or JSON.
+Other file types such as Native modules are not supported. For those,
 use [`module.createRequire()`][].
 
 `import` statements are permitted only in ES modules. For similar functionality

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -381,8 +381,7 @@ To include an ES module into CommonJS, use [`import()`][].
 
 ### <code>import</code> statements
 
-An `import` statement can reference either ES module or CommonJS JavaScript
-or JSON.
+An `import` statement can reference an ES module, a CommonJS module, or JSON.
 Other file types such as Native modules are not supported. For those,
 use [`module.createRequire()`][].
 


### PR DESCRIPTION
fix #28861

JSON file can be imported now
```js
// index.mjs
import pkg from  '../package.json'
console.log(pkg)
```
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
