### PR TITLE
test, util: refactor isObject in test-util

### DIFF
--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -73,7 +73,11 @@ assert.strictEqual(util.isError([]), false);
 assert.strictEqual(util.isError(Object.create(Error.prototype)), true);
 
 // isObject
-assert.ok(util.isObject({}) === true);
+assert.strictEqual(util.isObject({}), true);
+assert.strictEqual(util.isObject([]), true);
+assert.strictEqual(util.isObject(new Number(3)), true);
+assert.strictEqual(util.isObject(Number(4)), false);
+assert.strictEqual(util.isObject(1), false);
 
 // isPrimitive
 assert.strictEqual(util.isPrimitive({}), false);


### PR DESCRIPTION
Refactor the test for `isObject` function including falsy values,
the use of strictEquals and the format `actual`, `expected`

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
