### PR TITLE
build: remove support for s390 (but not s390x)

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -388,10 +388,6 @@
             'cflags': [ '-m64', '-mminimal-toc' ],
             'ldflags': [ '-m64' ],
           }],
-          [ 'target_arch=="s390"', {
-            'cflags': [ '-m31', '-march=z196' ],
-            'ldflags': [ '-m31', '-march=z196' ],
-          }],
           [ 'target_arch=="s390x"', {
             'cflags': [ '-m64', '-march=z196' ],
             'ldflags': [ '-m64', '-march=z196' ],

--- a/configure.py
+++ b/configure.py
@@ -47,7 +47,7 @@ parser = optparse.OptionParser()
 valid_os = ('win', 'mac', 'solaris', 'freebsd', 'openbsd', 'linux',
             'android', 'aix', 'cloudabi')
 valid_arch = ('arm', 'arm64', 'ia32', 'mips', 'mipsel', 'mips64el', 'ppc',
-              'ppc64', 'x32','x64', 'x86', 'x86_64', 's390', 's390x')
+              'ppc64', 'x32','x64', 'x86', 'x86_64', 's390x')
 valid_arm_float_abi = ('soft', 'softfp', 'hard')
 valid_arm_fpu = ('vfp', 'vfpv3', 'vfpv3-d16', 'neon')
 valid_mips_arch = ('loongson', 'r1', 'r2', 'r6', 'rx')
@@ -867,7 +867,6 @@ def host_arch_cc():
     '__PPC64__'   : 'ppc64',
     '__PPC__'     : 'ppc64',
     '__x86_64__'  : 'x64',
-    '__s390__'    : 's390',
     '__s390x__'   : 's390x',
   }
 
@@ -876,8 +875,7 @@ def host_arch_cc():
   for i in matchup:
     if i in k and k[i] != '0':
       rtn = matchup[i]
-      if rtn != 's390':
-        break
+      break
 
   if rtn == 'mipsel' and '_LP64' in k:
     rtn = 'mips64el'

--- a/deps/openssl/openssl-cl_asm.gypi
+++ b/deps/openssl/openssl-cl_asm.gypi
@@ -10,8 +10,6 @@
       'includes': ['config/archs/linux-ppc64le/asm/openssl-cl.gypi'],
     }, 'target_arch=="ppc64" and OS=="linux"', {
       'includes': ['config/archs/linux-ppc64/asm/openssl-cl.gypi'],
-    }, 'target_arch=="s390" and OS=="linux"', {
-      'includes': ['config/archs/linux32-s390x/asm/openssl-cl.gypi'],
     }, 'target_arch=="s390x" and OS=="linux"', {
       'includes': ['config/archs/linux64-s390x/asm/openssl-cl.gypi'],
     }, 'target_arch=="arm" and OS=="linux"', {

--- a/deps/openssl/openssl-cl_asm_avx2.gypi
+++ b/deps/openssl/openssl-cl_asm_avx2.gypi
@@ -10,8 +10,6 @@
       'includes': ['config/archs/linux-ppc64le/asm_avx2/openssl-cl.gypi'],
     }, 'target_arch=="ppc64" and OS=="linux"', {
       'includes': ['config/archs/linux-ppc64/asm_avx2/openssl-cl.gypi'],
-    }, 'target_arch=="s390" and OS=="linux"', {
-      'includes': ['config/archs/linux32-s390x/asm_avx2/openssl-cl.gypi'],
     }, 'target_arch=="s390x" and OS=="linux"', {
       'includes': ['config/archs/linux64-s390x/asm_avx2/openssl-cl.gypi'],
     }, 'target_arch=="arm" and OS=="linux"', {

--- a/deps/openssl/openssl-cl_no_asm.gypi
+++ b/deps/openssl/openssl-cl_no_asm.gypi
@@ -10,8 +10,6 @@
       'includes': ['config/archs/linux-ppc64le/no-asm/openssl-cl.gypi'],
     }, 'target_arch=="ppc64" and OS=="linux"', {
       'includes': ['config/archs/linux-ppc64/no-asm/openssl-cl.gypi'],
-    }, 'target_arch=="s390" and OS=="linux"', {
-      'includes': ['config/archs/linux32-s390x/no-asm/openssl-cl.gypi'],
     }, 'target_arch=="s390x" and OS=="linux"', {
       'includes': ['config/archs/linux64-s390x/no-asm/openssl-cl.gypi'],
     }, 'target_arch=="arm" and OS=="linux"', {

--- a/deps/openssl/openssl_asm.gypi
+++ b/deps/openssl/openssl_asm.gypi
@@ -10,8 +10,6 @@
       'includes': ['config/archs/linux-ppc64le/asm/openssl.gypi'],
     }, 'target_arch=="ppc64" and OS=="linux"', {
       'includes': ['config/archs/linux-ppc64/asm/openssl.gypi'],
-    }, 'target_arch=="s390" and OS=="linux"', {
-      'includes': ['config/archs/linux32-s390x/asm/openssl.gypi'],
     }, 'target_arch=="s390x" and OS=="linux"', {
       'includes': ['config/archs/linux64-s390x/asm/openssl.gypi'],
     }, 'target_arch=="arm" and OS=="linux"', {

--- a/deps/openssl/openssl_asm_avx2.gypi
+++ b/deps/openssl/openssl_asm_avx2.gypi
@@ -10,8 +10,6 @@
       'includes': ['config/archs/linux-ppc64le/asm_avx2/openssl.gypi'],
     }, 'target_arch=="ppc64" and OS=="linux"', {
       'includes': ['config/archs/linux-ppc64/asm_avx2/openssl.gypi'],
-    }, 'target_arch=="s390" and OS=="linux"', {
-      'includes': ['config/archs/linux32-s390x/asm_avx2/openssl.gypi'],
     }, 'target_arch=="s390x" and OS=="linux"', {
       'includes': ['config/archs/linux64-s390x/asm_avx2/openssl.gypi'],
     }, 'target_arch=="arm" and OS=="linux"', {

--- a/deps/openssl/openssl_no_asm.gypi
+++ b/deps/openssl/openssl_no_asm.gypi
@@ -11,8 +11,6 @@
       'includes': ['config/archs/linux-ppc64le/no-asm/openssl.gypi'],
     }, 'target_arch=="ppc64" and OS=="linux"', {
       'includes': ['config/archs/linux-ppc64/no-asm/openssl.gypi'],
-    }, 'target_arch=="s390" and OS=="linux"', {
-      'includes': ['config/archs/linux32-s390x/no-asm/openssl.gypi'],
     }, 'target_arch=="s390x" and OS=="linux"', {
       'includes': ['config/archs/linux64-s390x/no-asm/openssl.gypi'],
     }, 'target_arch=="arm" and OS=="linux"', {

--- a/tools/v8_gypfiles/broken/standalone.gypi
+++ b/tools/v8_gypfiles/broken/standalone.gypi
@@ -165,7 +165,7 @@
         }, {
           'gomadir': '<!(/bin/echo -n ${HOME}/goma)',
         }],
-        ['host_arch!="ppc" and host_arch!="ppc64" and host_arch!="ppc64le" and host_arch!="s390" and host_arch!="s390x"', {
+        ['host_arch!="ppc" and host_arch!="ppc64" and host_arch!="ppc64le" and host_arch!="s390x"', {
           'host_clang%': 1,
         }, {
           'host_clang%': 0,

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -140,7 +140,7 @@
   'conditions': [
     ['host_arch=="ia32" or host_arch=="x64" or \
       host_arch=="ppc" or host_arch=="ppc64" or \
-      host_arch=="s390" or host_arch=="s390x" or \
+      host_arch=="s390x" or \
       clang==1', {
       'variables': {
         'host_cxx_is_biarch%': 1,
@@ -151,7 +151,7 @@
       },
     }],
     ['target_arch=="ia32" or target_arch=="x64" or \
-      target_arch=="ppc" or target_arch=="ppc64" or target_arch=="s390" or \
+      target_arch=="ppc" or target_arch=="ppc64" or \
       target_arch=="s390x" or clang==1', {
       'variables': {
         'target_cxx_is_biarch%': 1,
@@ -302,7 +302,7 @@
           'V8_TARGET_ARCH_ARM64',
         ],
       }],
-      ['v8_target_arch=="s390" or v8_target_arch=="s390x"', {
+      ['v8_target_arch=="s390x"', {
         'defines': [
           'V8_TARGET_ARCH_S390',
         ],
@@ -320,7 +320,7 @@
             'cflags': [ '-march=z196' ],
           }],
           ],
-      }],  # s390
+      }],  # s390x
       ['v8_target_arch=="ppc" or v8_target_arch=="ppc64"', {
         'defines': [
           'V8_TARGET_ARCH_PPC',
@@ -1045,13 +1045,13 @@
          or OS=="netbsd" or OS=="mac" or OS=="android" or OS=="qnx") and \
         (v8_target_arch=="arm" or v8_target_arch=="ia32" or \
          v8_target_arch=="mips" or v8_target_arch=="mipsel" or \
-         v8_target_arch=="ppc" or v8_target_arch=="s390")', {
+         v8_target_arch=="ppc")', {
         'target_conditions': [
           ['_toolset=="host"', {
             'conditions': [
               ['host_cxx_is_biarch==1', {
                 'conditions': [
-                  ['host_arch=="s390" or host_arch=="s390x"', {
+                  ['host_arch=="s390x"', {
                     'cflags': [ '-m31' ],
                     'ldflags': [ '-m31' ]
                   },{
@@ -1069,7 +1069,7 @@
             'conditions': [
               ['target_cxx_is_biarch==1', {
                 'conditions': [
-                  ['host_arch=="s390" or host_arch=="s390x"', {
+                  ['host_arch=="s390x"', {
                     'cflags': [ '-m31' ],
                     'ldflags': [ '-m31' ]
                   },{

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -653,7 +653,7 @@
             '<(V8_ROOT)/src/builtins/ppc/builtins-ppc.cc',
           ],
         }],
-        ['v8_target_arch=="s390" or v8_target_arch=="s390x"', {
+        ['v8_target_arch=="s390x"', {
           'sources': [
             '<(V8_ROOT)/src/builtins/s390/builtins-s390.cc',
           ],
@@ -2187,7 +2187,7 @@
             '<(V8_ROOT)/src/wasm/baseline/ppc/liftoff-assembler-ppc.h',
           ],
         }],
-        ['v8_target_arch=="s390" or v8_target_arch=="s390x"', {
+        ['v8_target_arch=="s390x"', {
           'sources': [  ### gcmole(arch:s390) ###
             '<(V8_ROOT)/src/compiler/backend/s390/code-generator-s390.cc',
             '<(V8_ROOT)/src/compiler/backend/s390/instruction-codes-s390.h',
@@ -2298,7 +2298,7 @@
         }],
         # Platforms that don't have Compare-And-Swap (CAS) support need to link atomic library
         # to implement atomic memory access
-        ['v8_current_cpu in ["mips", "mipsel", "mips64", "mips64el", "ppc", "ppc64", "s390", "s390x"]', {
+        ['v8_current_cpu in ["mips", "mipsel", "mips64", "mips64el", "ppc", "ppc64", "s390x"]', {
           'link_settings': {
             'libraries': ['-latomic', ],
           },


### PR DESCRIPTION
Upstream V8 removed support for s390 earlier this year and it's known
to no longer build. Remove the support from our build scripts.

Fixes: https://github.com/nodejs/node/issues/28866