### PR TITLE
test,report: relax CPU match requirements

### DIFF
--- a/test/common/report.js
+++ b/test/common/report.js
@@ -109,7 +109,7 @@ function _validateContent(report) {
     assert.strictEqual(typeof cpu.idle, 'number');
     assert.strictEqual(typeof cpu.irq, 'number');
     assert(cpus.some((c) => {
-      return c.model === cpu.model && c.speed === cpu.speed;
+      return c.model === cpu.model;
     }));
   });
   assert.strictEqual(header.host, os.hostname());


### PR DESCRIPTION
Some CPUs have variable speeds, and so exact matches between what
`os.cpus()` and the report feature yield cannot always be expected:

```
> const results = []
> setInterval(() => results.push(os.cpus().map(({ speed }) => speed)), 1)
[...]
> results
[
  [ 1198, 1150, 1195, 1149 ],
  [ 1198, 1150, 1195, 1149 ],
  [ 1198, 1150, 1195, 1149 ],
  [ 1198, 1150, 1195, 1149 ],
  [ 2401, 2420, 2429, 2413 ],
  [ 2401, 2420, 2429, 2413 ],
  [ 2401, 2420, 2429, 2413 ],
  [ 2401, 2420, 2429, 2413 ],
  [ 2401, 2420, 2429, 2413 ],
  [ 2401, 2420, 2429, 2413 ],
  [ 2401, 2420, 2429, 2413 ],
  [ 2596, 2401, 2699, 2555 ],
[...]
```

Refs: https://github.com/nodejs/node/pull/28829

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
