### PR TITLE
test: remove cpu speed expectation in report test

### DIFF
--- a/test/common/report.js
+++ b/test/common/report.js
@@ -108,9 +108,7 @@ function _validateContent(report) {
     assert.strictEqual(typeof cpu.sys, 'number');
     assert.strictEqual(typeof cpu.idle, 'number');
     assert.strictEqual(typeof cpu.irq, 'number');
-    assert(cpus.some((c) => {
-      return c.model === cpu.model && c.speed === cpu.speed;
-    }));
+    assert(cpus.some((c) => c.model === cpu.model));
   });
   assert.strictEqual(header.host, os.hostname());
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/28886

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
