### PR TITLE
Build static libnode_internal to avoid cyclic dependency on mkcodecache

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -427,56 +427,6 @@
             },
           },
          }],
-        ['want_separate_host_toolset==0', {
-          'dependencies': [
-            'mkcodecache',
-          ],
-          'actions': [
-            {
-              'action_name': 'run_mkcodecache',
-              'process_outputs_as_sources': 1,
-              'inputs': [
-                '<(mkcodecache_exec)',
-              ],
-              'outputs': [
-                '<(SHARED_INTERMEDIATE_DIR)/node_code_cache.cc',
-              ],
-              'action': [
-                '<@(_inputs)',
-                '<@(_outputs)',
-              ],
-            },
-          ],
-        }, {
-          'sources': [
-            'src/node_code_cache_stub.cc'
-          ],
-        }],
-        ['node_use_node_snapshot=="true"', {
-          'dependencies': [
-            'node_mksnapshot',
-          ],
-          'actions': [
-            {
-              'action_name': 'node_mksnapshot',
-              'process_outputs_as_sources': 1,
-              'inputs': [
-                '<(node_mksnapshot_exec)',
-              ],
-              'outputs': [
-                '<(SHARED_INTERMEDIATE_DIR)/node_snapshot.cc',
-              ],
-              'action': [
-                '<@(_inputs)',
-                '<@(_outputs)',
-              ],
-            },
-          ],
-        }, {
-          'sources': [
-            'src/node_snapshot_stub.cc'
-          ],
-        }],
       ],
     }, # node_core_target_name
     {
@@ -667,8 +617,7 @@
         '<@(library_files)',
         # node.gyp is added by default, common.gypi is added for change detection
         'common.gypi',
-        '<(SHARED_INTERMEDIATE_DIR)/node_code_cache.cc',
-        'src/node_snapshot_stub.cc'
+        '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',
       ],
 
       'variables': {
@@ -689,6 +638,56 @@
       'msvs_disabled_warnings!': [4244],
 
       'conditions': [
+        ['want_separate_host_toolset==0', {
+          'dependencies': [
+            'mkcodecache',
+          ],
+          'actions': [
+            {
+              'action_name': 'run_mkcodecache',
+              'process_outputs_as_sources': 1,
+              'inputs': [
+                '<(mkcodecache_exec)',
+              ],
+              'outputs': [
+                '<(SHARED_INTERMEDIATE_DIR)/node_code_cache.cc',
+              ],
+              'action': [
+                '<@(_inputs)',
+                '<@(_outputs)',
+              ],
+            },
+          ],
+        }, {
+          'sources': [
+            'src/node_code_cache_stub.cc'
+          ],
+        }],
+        ['node_use_node_snapshot=="true"', {
+          'dependencies': [
+            'node_mksnapshot',
+          ],
+          'actions': [
+            {
+              'action_name': 'node_mksnapshot',
+              'process_outputs_as_sources': 1,
+              'inputs': [
+                '<(node_mksnapshot_exec)',
+              ],
+              'outputs': [
+                '<(SHARED_INTERMEDIATE_DIR)/node_snapshot.cc',
+              ],
+              'action': [
+                '<@(_inputs)',
+                '<@(_outputs)',
+              ],
+            },
+          ],
+        }, {
+          'sources': [
+            'src/node_snapshot_stub.cc'
+          ],
+        }],
         [ 'node_shared=="true" and node_module_version!="" and OS!="win"', {
           'product_extension': '<(shlib_suffix)',
           'xcode_settings': {
@@ -868,37 +867,6 @@
             },
           ],
         }],
-      ],
-      'actions': [
-        {
-          'action_name': 'node_js2c',
-          'process_outputs_as_sources': 1,
-          'inputs': [
-            # Put the code first so it's a dependency and can be used for invocation.
-            'tools/js2c.py',
-            '<@(library_files)',
-            'config.gypi',
-            'tools/js2c_macros/check_macros.py'
-          ],
-          'outputs': [
-            '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',
-          ],
-          'conditions': [
-            [ 'node_use_dtrace=="false" and node_use_etw=="false"', {
-              'inputs': [ 'tools/js2c_macros/notrace_macros.py' ]
-            }],
-            [ 'node_debug_lib=="false"', {
-              'inputs': [ 'tools/js2c_macros/nodcheck_macros.py' ]
-            }],
-            [ 'node_debug_lib=="true"', {
-              'inputs': [ 'tools/js2c_macros/dcheck_macros.py' ]
-            }]
-          ],
-          'action': [
-            'python', '<@(_inputs)',
-            '--target', '<@(_outputs)',
-          ],
-        },
       ],
     }, # node_lib_target_name
     {
@@ -1087,8 +1055,6 @@
       'defines': [ 'NODE_WANT_INTERNALS=1' ],
 
       'sources': [
-        'src/node_snapshot_stub.cc',
-        'src/node_code_cache_stub.cc',
         'test/cctest/gtest/gtest-all.cc',
         'test/cctest/gtest/gtest_main.cc',
         'test/cctest/node_test_fixture.cc',
@@ -1272,7 +1238,6 @@
         'src/udp_wrap.cc',
         'src/util.cc',
         'src/uv.cc',
-        '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',
       ],
       'conditions': [
         [ 'node_use_openssl=="true"', {
@@ -1283,7 +1248,38 @@
             'src/tls_wrap.cc',
           ],
         }],
-      ]
+      ],
+      'actions': [
+        {
+          'action_name': 'node_js2c',
+          'process_outputs_as_sources': 1,
+          'inputs': [
+            # Put the code first so it's a dependency and can be used for invocation.
+            'tools/js2c.py',
+            '<@(library_files)',
+            'config.gypi',
+            'tools/js2c_macros/check_macros.py'
+          ],
+          'outputs': [
+            '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',
+          ],
+          'conditions': [
+            [ 'node_use_dtrace=="false" and node_use_etw=="false"', {
+              'inputs': [ 'tools/js2c_macros/notrace_macros.py' ]
+            }],
+            [ 'node_debug_lib=="false"', {
+              'inputs': [ 'tools/js2c_macros/nodcheck_macros.py' ]
+            }],
+            [ 'node_debug_lib=="true"', {
+              'inputs': [ 'tools/js2c_macros/dcheck_macros.py' ]
+            }]
+          ],
+          'action': [
+            'python', '<@(_inputs)',
+            '--target', '<@(_outputs)',
+          ],
+        },
+      ],
     }, {
       'target_name': 'mkcodecache',
       'type': 'executable',

--- a/node.gyp
+++ b/node.gyp
@@ -23,6 +23,7 @@
     'node_v8_options%': '',
     'node_core_target_name%': 'node',
     'node_lib_target_name%': 'libnode',
+    'node_lib_internal_target_name': 'libnode_internal',
     'node_intermediate_lib_type%': 'static_library',
     'library_files': [
       'lib/internal/bootstrap/environment.js',
@@ -666,6 +667,8 @@
         '<@(library_files)',
         # node.gyp is added by default, common.gypi is added for change detection
         'common.gypi',
+        '<(SHARED_INTERMEDIATE_DIR)/node_code_cache.cc',
+        'src/node_snapshot_stub.cc'
       ],
 
       'variables': {
@@ -1165,11 +1168,128 @@
     # So generate_code_cache -> mkcodecache -> node_lib_base,
     #    node_lib -> node_lib_base & generate_code_cache
     {
+      'target_name': '<(node_lib_internal_target_name)',
+      'type': 'static_library',
+      'includes': [
+        'node.gypi',
+      ],
+
+      'include_dirs': [
+        'src',
+        '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
+      ],
+
+      'dependencies': [ 'deps/histogram/histogram.gyp:histogram' ],
+
+      'defines': [ 
+        'NODE_ARCH="<(target_arch)"',
+        'NODE_PLATFORM="<(OS)"',
+        'NODE_WANT_INTERNALS=1',
+        'HAVE_INSPECTOR=0',
+        'NODE_OPENSSL_SYSTEM_CERT_PATH=""',
+      ],
+
+      'sources': [
+        'src/api/async_resource.cc',
+        'src/api/callback.cc',
+        'src/api/encoding.cc',
+        'src/api/environment.cc',
+        'src/api/exceptions.cc',
+        'src/api/hooks.cc',
+        'src/api/utils.cc',
+        'src/async_wrap.cc',
+        'src/cares_wrap.cc',
+        'src/connect_wrap.cc',
+        'src/connection_wrap.cc',
+        'src/debug_utils.cc',
+        'src/env.cc',
+        'src/fs_event_wrap.cc',
+        'src/handle_wrap.cc',
+        'src/heap_utils.cc',
+        'src/js_native_api_v8.cc',
+        'src/js_native_api_v8.h',
+        'src/js_stream.cc',
+        'src/module_wrap.cc',
+        'src/node.cc',
+        'src/node_api.cc',
+        'src/node_binding.cc',
+        'src/node_buffer.cc',
+        'src/node_config.cc',
+        'src/node_constants.cc',
+        'src/node_contextify.cc',
+        'src/node_credentials.cc',
+        'src/node_domain.cc',
+        'src/node_env_var.cc',
+        'src/node_errors.cc',
+        'src/node_file.cc',
+        'src/node_http_parser_llhttp.cc',
+        'src/node_http_parser_traditional.cc',
+        'src/node_http2.cc',
+        'src/node_i18n.cc',
+        'src/node_main_instance.cc',
+        'src/node_messaging.cc',
+        'src/node_metadata.cc',
+        'src/node_native_module.cc',
+        'src/node_native_module_env.cc',
+        'src/node_options.cc',
+        'src/node_os.cc',
+        'src/node_perf.cc',
+        'src/node_platform.cc',
+        'src/node_postmortem_metadata.cc',
+        'src/node_process_events.cc',
+        'src/node_process_methods.cc',
+        'src/node_process_object.cc',
+        'src/node_serdes.cc',
+        'src/node_stat_watcher.cc',
+        'src/node_symbols.cc',
+        'src/node_task_queue.cc',
+        'src/node_trace_events.cc',
+        'src/node_types.cc',
+        'src/node_url.cc',
+        'src/node_util.cc',
+        'src/node_v8.cc',
+        'src/node_watchdog.cc',
+        'src/node_worker.cc',
+        'src/node_zlib.cc',
+        'src/pipe_wrap.cc',
+        'src/process_wrap.cc',
+        'src/sharedarraybuffer_metadata.cc',
+        'src/signal_wrap.cc',
+        'src/spawn_sync.cc',
+        'src/stream_base.cc',
+        'src/stream_pipe.cc',
+        'src/stream_wrap.cc',
+        'src/string_bytes.cc',
+        'src/string_decoder.cc',
+        'src/tcp_wrap.cc',
+        'src/timers.cc',
+        'src/tracing/agent.cc',
+        'src/tracing/node_trace_buffer.cc',
+        'src/tracing/node_trace_writer.cc',
+        'src/tracing/trace_event.cc',
+        'src/tracing/traced_value.cc',
+        'src/tty_wrap.cc',
+        'src/udp_wrap.cc',
+        'src/util.cc',
+        'src/uv.cc',
+        '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',
+      ],
+      'conditions': [
+        [ 'node_use_openssl=="true"', {
+          'sources': [
+            'src/node_crypto.cc',
+            'src/node_crypto_bio.cc',
+            'src/node_crypto_clienthello.cc',
+            'src/tls_wrap.cc',
+          ],
+        }],
+      ]
+    }, {
       'target_name': 'mkcodecache',
       'type': 'executable',
 
       'dependencies': [
-        '<(node_lib_target_name)',
+        '<(node_lib_internal_target_name)',
         'deps/histogram/histogram.gyp:histogram',
       ],
 
@@ -1212,7 +1332,7 @@
       'type': 'executable',
 
       'dependencies': [
-        '<(node_lib_target_name)',
+        '<(node_lib_internal_target_name)',
         'deps/histogram/histogram.gyp:histogram',
       ],
 


### PR DESCRIPTION
Here is a first draft to fix https://github.com/nodejs/node/issues/27431 by implementing exactly this:

https://github.com/nodejs/node/blob/62a809fa54949fb1416b2462f995bb98037db2d0/node.gyp#L1161-L1166

The problem here is that the `libnode` shared library is missing the code cache symbols because of the cyclical dependency between `libnode` and `mkcodecache` in [node.gyp](node.gyp).

We need to build `mkcodecache` to generate `node_code_cache.cc`. However currently `mkcodecache` itself depends on `libnode` so we cannot include the generated symbols to `libnode`. In the current setup `node_code_cache.cc` is linked when building `node.exe` but when building node as a shared library the symbols are missing `libnode`, which causes the issues in https://github.com/nodejs/node/issues/27431. 

The solution is described comment above: modify the `mkcodecache` build such that it does not depend on the full `libnode`, but instead on a smaller `libnode_internal` which suffices to generate the cache symbols. And then we can include `node_code_cache.cc` in `libnode.so`.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
