### PR TITLE
n-api: refactoring napi_create_function testing

### DIFF
--- a/test/js-native-api/test_function/binding.gyp
+++ b/test/js-native-api/test_function/binding.gyp
@@ -3,6 +3,7 @@
     {
       "target_name": "test_function",
       "sources": [
+        "../common.c",
         "../entry_point.c",
         "test_function.c"
       ]

--- a/test/js-native-api/test_function/test.js
+++ b/test/js-native-api/test_function/test.js
@@ -37,8 +37,8 @@ tracked_function = null;
 global.gc();
 
 assert.deepStrictEqual(test_function.TestCreateFunctionParameters(), {
-  envIsNull: 'pass',
-  nameIsNull: 'pass',
-  cbIsNull: 'pass',
-  resultIsNull: 'pass'
+  envIsNull: 'Invalid argument',
+  nameIsNull: 'napi_ok',
+  cbIsNull: 'Invalid argument',
+  resultIsNull: 'Invalid argument'
 });

--- a/test/js-native-api/test_function/test_function.c
+++ b/test/js-native-api/test_function/test_function.c
@@ -3,79 +3,51 @@
 
 static napi_value TestCreateFunctionParameters(napi_env env,
                                                napi_callback_info info) {
-  napi_status ret[4];
-  napi_value result, return_value, prop_value;
-
-
-  ret[0] = napi_create_function(NULL,
-                                "TrackedFunction",
-                                NAPI_AUTO_LENGTH,
-                                TestCreateFunctionParameters,
-                                NULL,
-                                &result);
-
-  ret[1] = napi_create_function(env,
-                                NULL,
-                                NAPI_AUTO_LENGTH,
-                                TestCreateFunctionParameters,
-                                NULL,
-                                &result);
-
-  ret[2] = napi_create_function(env,
-                                "TrackedFunction",
-                                NAPI_AUTO_LENGTH,
-                                NULL,
-                                NULL,
-                                &result);
-
-  ret[3] = napi_create_function(env,
-                                "TrackedFunction",
-                                NAPI_AUTO_LENGTH,
-                                TestCreateFunctionParameters,
-                                NULL,
-                                NULL);
+  napi_status status;
+  napi_value result, return_value;
 
   NAPI_CALL(env, napi_create_object(env, &return_value));
 
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         (ret[0] == napi_invalid_arg ?
-                                             "pass" : "fail"),
-                                         NAPI_AUTO_LENGTH,
-                                         &prop_value));
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         return_value,
-                                         "envIsNull",
-                                         prop_value));
+  status = napi_create_function(NULL,
+                                "TrackedFunction",
+                                NAPI_AUTO_LENGTH,
+                                TestCreateFunctionParameters,
+                                NULL,
+                                &result);
 
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         (ret[1] == napi_ok ?
-                                             "pass" : "fail"),
-                                         NAPI_AUTO_LENGTH,
-                                         &prop_value));
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         return_value,
-                                         "nameIsNull",
-                                         prop_value));
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      status);
 
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         (ret[2] == napi_invalid_arg ?
-                                             "pass" : "fail"),
-                                         NAPI_AUTO_LENGTH,
-                                         &prop_value));
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         return_value,
-                                         "cbIsNull",
-                                         prop_value));
+  napi_create_function(env,
+                       NULL,
+                       NAPI_AUTO_LENGTH,
+                       TestCreateFunctionParameters,
+                       NULL,
+                       &result);
 
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         (ret[3] == napi_invalid_arg ?
-                                             "pass" : "fail"),
-                                         NAPI_AUTO_LENGTH,
-                                         &prop_value));
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         return_value,
-                                         "resultIsNull",
-                                         prop_value));
+  add_last_status(env, "nameIsNull", return_value);
+
+  napi_create_function(env,
+                       "TrackedFunction",
+                       NAPI_AUTO_LENGTH,
+                       NULL,
+                       NULL,
+                       &result);
+
+  add_last_status(env, "cbIsNull", return_value);
+
+  napi_create_function(env,
+                       "TrackedFunction",
+                       NAPI_AUTO_LENGTH,
+                       TestCreateFunctionParameters,
+                       NULL,
+                       NULL);
+
+  add_last_status(env, "resultIsNull", return_value);
 
   return return_value;
 }


### PR DESCRIPTION
PR-URL: https://github.com/nodejs/node/pull/26998

This is a refactoring of https://github.com/nodejs/node/pull/26998
following https://github.com/nodejs/node/pull/28505.

The functions `add_last_status()` and `add_returned_status()` are now
reused, see also https://github.com/nodejs/node/pull/28848.

PR-URL: https://github.com/nodejs/node/pull/26998
PR-URL: https://github.com/nodejs/node/pull/28505
PR-URL: https://github.com/nodejs/node/pull/28848

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
