### PR TITLE
src: es-module parse './' when not specified 'main'

### DIFF
--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -3,15 +3,15 @@
 import { mustCall } from '../common/index.mjs';
 import { ok, strictEqual } from 'assert';
 
-import { asdf, asdf2, space } from '../fixtures/pkgexports.mjs';
+import { asdf, asdf2, asdf3, space } from '../fixtures/pkgexports.mjs';
 import {
   loadMissing,
-  loadFromNumber,
-  loadDot,
+  loadFromNumber
 } from '../fixtures/pkgexports-missing.mjs';
 
 strictEqual(asdf, 'asdf');
 strictEqual(asdf2, 'asdf');
+strictEqual(asdf3, 'asdf');
 strictEqual(space, 'encoded path');
 
 loadMissing().catch(mustCall((err) => {
@@ -22,8 +22,4 @@ loadMissing().catch(mustCall((err) => {
 loadFromNumber().catch(mustCall((err) => {
   ok(err.message.toString().startsWith('Package exports'));
   ok(err.message.toString().indexOf('do not define a \'./missing\' subpath'));
-}));
-
-loadDot().catch(mustCall((err) => {
-  ok(err.message.toString().startsWith('Cannot find main entry point'));
 }));

--- a/test/fixtures/pkgexports.mjs
+++ b/test/fixtures/pkgexports.mjs
@@ -1,3 +1,4 @@
 export { default as asdf } from 'pkgexports/asdf';
 export { default as asdf2 } from 'pkgexports/sub/asdf.js';
+export { default as asdf3 } from 'pkgexports';
 export { default as space } from 'pkgexports/space';


### PR DESCRIPTION
try to fix #28889 
but this is a breaking change, I don't know if this is correct

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
