### PR TITLE
include stubs in shared library

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -686,6 +686,12 @@
       'msvs_disabled_warnings!': [4244],
 
       'conditions': [
+        [ 'node_shared=="true"', {
+          'sources': [
+            'src/node_snapshot_stub.cc',
+            'src/node_code_cache_stub.cc',
+          ]
+        }],
         [ 'node_shared=="true" and node_module_version!="" and OS!="win"', {
           'product_extension': '<(shlib_suffix)',
           'xcode_settings': {


### PR DESCRIPTION
This is needed for external applications to link to shared libnode. Fixes #27431

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

@refack does this seem OK?