### PR TITLE
doc: Include "exports" resolver specification

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -723,12 +723,11 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >       1. Return the result of **PACKAGE_MAIN_RESOLVE**(_packageURL_,
 >          _pjson_).
 >    1. Otherwise,
->       1. If _pjson_ is not **null** and _pjson.exports_ is **null** or
->          **undefined**, then
->          1. Throw a _Module Not Found_ error.
->       1. If _pjson_ is not **null** and _pjson.exports_ is an Object, then
->          1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packagePath_,
->             _pjson_).
+>       1. If _pjson_ is not **null** and _pjson_ has an "exports" key, then
+>          1. Let _exports_ be _pjson.exports_.
+>          1. If _exports_ is not **null** or **undefined**, then
+>             1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_,
+>                _packagePath_, _pjson.exports_).
 >       1. Return the URL resolution of _packagePath_ in _packageURL_.
 > 1. Throw a _Module Not Found_ error.
 
@@ -749,23 +748,22 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >    1. Throw an _Unsupported File Extension_ error.
 > 1. Return _legacyMainURL_.
 
-**PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packagePath_, _pjson_)
-> 1. Assert: _pjson_ is not **null**.
-> 1. If _pjson.exports_ is an Object, then
+**PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packagePath_, _exports_)
+> 1. If _exports_ is an Object, then
 >    1. Set _packagePath_ to _"./"_ concatenated with _packagePath_.
->    1. If _packagePath_ is a key of _pjson.exports_, then
->       1. Let _target_ be the value of _pjson.exports[packagePath]_.
+>    1. If _packagePath_ is a key of _exports_, then
+>       1. Let _target_ be the value of _exports[packagePath]_.
 >       1. If _target_ is not a String, continue the loop.
 >       1. Return the URL resolution of the concatenation of _packageURL_ and
 >          _target_.
->    1. Let _directoryKeys_ be the list of keys of _pjson.exports_ ending in
+>    1. Let _directoryKeys_ be the list of keys of _exports_ ending in
 >       _"/"_, sorted by length descending.
 >    1. For each key _directory_ in _directoryKeys_, do
 >       1. If _packagePath_ starts with _directory_, then
->          1. Let _target_ be the value of _pjson.exports[directory]_.
+>          1. Let _target_ be the value of _exports[directory]_.
 >          1. If _target_ is not a String, continue the loop.
->          1. Let _subpath_ be the substring of _target_ starting at the index of
->             the length of _directory_.
+>          1. Let _subpath_ be the substring of _target_ starting at the index
+>             of the length of _directory_.
 >          1. Return the URL resolution of the concatenation of _packageURL_,
 >             _target_ and _subpath_.
 > 1. Throw a _Module Not Found_ error.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -723,7 +723,10 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >       1. Return the result of **PACKAGE_MAIN_RESOLVE**(_packageURL_,
 >          _pjson_).
 >    1. Otherwise,
->       1. Return the URL resolution of _packageSubpath_ in _packageURL_.
+>       1. If _pjson_ is not **null** and _pjson.exports_ is an Object, then
+>          1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packagePath_,
+>             _pjson_).
+>       1. Return the URL resolution of _packagePath_ in _packageURL_.
 > 1. Throw a _Module Not Found_ error.
 
 **PACKAGE_MAIN_RESOLVE**(_packageURL_, _pjson_)
@@ -742,6 +745,27 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 > 1. If _legacyMainURL_ does not end in _".js"_ then,
 >    1. Throw an _Unsupported File Extension_ error.
 > 1. Return _legacyMainURL_.
+
+**PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packagePath_, _pjson_)
+> 1. Assert: _pjson_ is not **null**.
+> 1. Assert: _pjson.exports_ is an Object.
+> 1. Set _packagePath_ to _"./"_ concatenated with _packagePath_.
+> 1. If _packagePath_ is a key of _pjson.exports_, then
+>    1. Let _target_ be the value of _pjson.exports[packagePath]_.
+>    1. If _target_ is not a String, continue the loop.
+>    1. Return the URL resolution of the concatenation of _packageURL_ and
+>       _target_.
+> 1. Let _directoryKeys_ be the list of keys of _pjson.exports_ ending in
+>    _"/"_, sorted by length descending.
+> 1. For each key _directory_ in _directoryKeys_, do
+>    1. If _packagePath_ starts with _directory_, then
+>       1. Let _target_ be the value of _pjson.exports[directory]_.
+>       1. If _target_ is not a String, continue the loop.
+>       1. Let _subpath_ be the substring of _target_ starting at the index of
+>          the length of _directory_.
+>       1. Return the URL resolution of the concatenation of _packageURL_,
+>          _target_ and _subpath_.
+> 1. Throw a _Module Not Found_ error.
 
 **ESM_FORMAT**(_url_, _isMain_)
 > 1. Assert: _url_ corresponds to an existing file.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -723,7 +723,8 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >       1. Return the result of **PACKAGE_MAIN_RESOLVE**(_packageURL_,
 >          _pjson_).
 >    1. Otherwise,
->       1. If _pjson_ is not **null* and _pjson.exports_ is *falsy*, then
+>       1. If _pjson_ is not **null** and _pjson.exports_ is **null** or
+>          **undefined**, then
 >          1. Throw a _Module Not Found_ error.
 >       1. If _pjson_ is not **null** and _pjson.exports_ is an Object, then
 >          1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packagePath_,
@@ -750,23 +751,23 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 
 **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packagePath_, _pjson_)
 > 1. Assert: _pjson_ is not **null**.
-> 1. Assert: _pjson.exports_ is an Object.
-> 1. Set _packagePath_ to _"./"_ concatenated with _packagePath_.
-> 1. If _packagePath_ is a key of _pjson.exports_, then
->    1. Let _target_ be the value of _pjson.exports[packagePath]_.
->    1. If _target_ is not a String, continue the loop.
->    1. Return the URL resolution of the concatenation of _packageURL_ and
->       _target_.
-> 1. Let _directoryKeys_ be the list of keys of _pjson.exports_ ending in
->    _"/"_, sorted by length descending.
-> 1. For each key _directory_ in _directoryKeys_, do
->    1. If _packagePath_ starts with _directory_, then
->       1. Let _target_ be the value of _pjson.exports[directory]_.
+> 1. If _pjson.exports_ is an Object, then
+>    1. Set _packagePath_ to _"./"_ concatenated with _packagePath_.
+>    1. If _packagePath_ is a key of _pjson.exports_, then
+>       1. Let _target_ be the value of _pjson.exports[packagePath]_.
 >       1. If _target_ is not a String, continue the loop.
->       1. Let _subpath_ be the substring of _target_ starting at the index of
->          the length of _directory_.
->       1. Return the URL resolution of the concatenation of _packageURL_,
->          _target_ and _subpath_.
+>       1. Return the URL resolution of the concatenation of _packageURL_ and
+>          _target_.
+>    1. Let _directoryKeys_ be the list of keys of _pjson.exports_ ending in
+>       _"/"_, sorted by length descending.
+>    1. For each key _directory_ in _directoryKeys_, do
+>       1. If _packagePath_ starts with _directory_, then
+>          1. Let _target_ be the value of _pjson.exports[directory]_.
+>          1. If _target_ is not a String, continue the loop.
+>          1. Let _subpath_ be the substring of _target_ starting at the index of
+>             the length of _directory_.
+>          1. Return the URL resolution of the concatenation of _packageURL_,
+>             _target_ and _subpath_.
 > 1. Throw a _Module Not Found_ error.
 
 **ESM_FORMAT**(_url_, _isMain_)

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -712,7 +712,7 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >    module, then
 >    1. Return the string _"node:"_ concatenated with _packageSpecifier_.
 > 1. While _parentURL_ is not the file system root,
->    1. Let _packageURL_ be the URL resolution of "node_modules/"
+>    1. Let _packageURL_ be the URL resolution of _"node_modules/"_
 >       concatenated with _packageSpecifier_, relative to _parentURL_.
 >    1. Set _parentURL_ to the parent folder URL of _parentURL_.
 >    1. If the folder at _packageURL_ does not exist, then
@@ -723,7 +723,7 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >       1. Return the result of **PACKAGE_MAIN_RESOLVE**(_packageURL_,
 >          _pjson_).
 >    1. Otherwise,
->       1. If _pjson_ is not **null** and _pjson_ has an "exports" key, then
+>       1. If _pjson_ is not **null** and _pjson_ has an _"exports"_ key, then
 >          1. Let _exports_ be _pjson.exports_.
 >          1. If _exports_ is not **null** or **undefined**, then
 >             1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_,

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -723,6 +723,8 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >       1. Return the result of **PACKAGE_MAIN_RESOLVE**(_packageURL_,
 >          _pjson_).
 >    1. Otherwise,
+>       1. If _pjson_ is not **null* and _pjson.exports_ is *falsy*, then
+>          1. Throw a _Module Not Found_ error.
 >       1. If _pjson_ is not **null** and _pjson.exports_ is an Object, then
 >          1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packagePath_,
 >             _pjson_).


### PR DESCRIPTION
This amends the ES module resolver specification in the documentation to include the behaviour of the "exports" feature as implemented and merged in https://github.com/nodejs/node/pull/28568.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
