### PR TITLE
test: fix race in test-http2-origin

### DIFF
--- a/test/parallel/test-http2-origin.js
+++ b/test/parallel/test-http2-origin.js
@@ -88,7 +88,7 @@ const ca = readKey('fake-startcom-root-cert.pem', 'binary');
       ['https://example.org', 'https://example.com']
     ];
 
-    const countdown = new Countdown(2, () => {
+    const countdown = new Countdown(3, () => {
       client.close();
       server.close();
     });
@@ -101,7 +101,7 @@ const ca = readKey('fake-startcom-root-cert.pem', 'binary');
       countdown.dec();
     }, 2));
 
-    client.request().on('close', mustCall()).resume();
+    client.request().on('close', mustCall(() => countdown.dec())).resume();
   }));
 }
 
@@ -119,15 +119,19 @@ const ca = readKey('fake-startcom-root-cert.pem', 'binary');
     const originSet = [`https://localhost:${server.address().port}`];
     const client = connect(originSet[0], { ca });
 
+    const countdown = new Countdown(2, () => {
+      client.close();
+      server.close();
+    });
+
     client.on('origin', mustCall((origins) => {
       originSet.push(...check);
       deepStrictEqual(client.originSet, originSet);
       deepStrictEqual(origins, check);
-      client.close();
-      server.close();
+      countdown.dec();
     }));
 
-    client.request().on('close', mustCall()).resume();
+    client.request().on('close', mustCall(() => countdown.dec())).resume();
   }));
 }
 


### PR DESCRIPTION
#27861 has uncovered another race in `test-http2-origin`.  If `origin` fires too soon, the session will be closed while the request is in progress:

~~~
Error [ERR_HTTP2_STREAM_ERROR]: Stream closed with error code NGHTTP2_REFUSED_STREAM
    at ClientHttp2Stream._destroy (internal/http2/core.js:1974:13)
    at ClientHttp2Stream.destroy (internal/streams/destroy.js:37:8)
    at ClientHttp2Stream.[kMaybeDestroy] (internal/http2/core.js:1990:12)
    at Http2Stream.onStreamClose (internal/http2/core.js:391:26)
Emitted 'error' event at:
    at emitErrorNT (internal/streams/destroy.js:91:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at processTicksAndRejections (internal/process/task_queues.js:77:11)
~~~

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
