### PR TITLE
[v10.x] tls: group chunks into TLS segments

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -902,8 +902,9 @@ the value is `undefined`, the stream is not yet ready for use.
 
 All [`Http2Stream`][] instances are destroyed either when:
 
-* An `RST_STREAM` frame for the stream is received by the connected peer.
-* The `http2stream.close()` method is called.
+* An `RST_STREAM` frame for the stream is received by the connected peer,
+  and pending data has been read.
+* The `http2stream.close()` method is called, and pending data has been read.
 * The `http2stream.destroy()` or `http2session.destroy()` methods are called.
 
 When an `Http2Stream` instance is destroyed, an attempt will be made to send an

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -166,7 +166,7 @@ class TLSWrap : public AsyncWrap,
   BIO* enc_in_ = nullptr;   // StreamListener fills this for SSL_read().
   BIO* enc_out_ = nullptr;  // SSL_write()/handshake fills this for EncOut().
   // Waiting for ClearIn() to pass to SSL_write().
-  std::vector<uv_buf_t> pending_cleartext_input_;
+  std::vector<char> pending_cleartext_input_;
   size_t write_size_ = 0;
   WriteWrap* current_write_ = nullptr;
   WriteWrap* current_empty_write_ = nullptr;

--- a/test/parallel/test-http2-large-write-destroy.js
+++ b/test/parallel/test-http2-large-write-destroy.js
@@ -32,6 +32,7 @@ server.listen(0, common.mustCall(() => {
 
   const req = client.request({ ':path': '/' });
   req.end();
+  req.resume(); // Otherwise close won't be emitted if there's pending data.
 
   req.on('close', common.mustCall(() => {
     client.close();

--- a/test/parallel/test-http2-origin.js
+++ b/test/parallel/test-http2-origin.js
@@ -88,7 +88,7 @@ const ca = readKey('fake-startcom-root-cert.pem', 'binary');
       ['https://example.org', 'https://example.com']
     ];
 
-    const countdown = new Countdown(2, () => {
+    const countdown = new Countdown(3, () => {
       client.close();
       server.close();
     });
@@ -101,7 +101,7 @@ const ca = readKey('fake-startcom-root-cert.pem', 'binary');
       countdown.dec();
     }, 2));
 
-    client.request().on('close', mustCall()).resume();
+    client.request().on('close', mustCall(() => countdown.dec())).resume();
   }));
 }
 
@@ -119,15 +119,19 @@ const ca = readKey('fake-startcom-root-cert.pem', 'binary');
     const originSet = [`https://localhost:${server.address().port}`];
     const client = connect(originSet[0], { ca });
 
+    const countdown = new Countdown(2, () => {
+      client.close();
+      server.close();
+    });
+
     client.on('origin', mustCall((origins) => {
       originSet.push(...check);
       deepStrictEqual(originSet, client.originSet);
       deepStrictEqual(origins, check);
-      client.close();
-      server.close();
+      countdown.dec();
     }));
 
-    client.request().on('close', mustCall()).resume();
+    client.request().on('close', mustCall(() => countdown.dec())).resume();
   }));
 }
 


### PR DESCRIPTION
Backport of #27861 (and also #27891 and #28903 to fix tests).

The original code uses `AllocatedBuffer`, so we would need to also backport #26207 (specifically 6c257cdf2). Instead I've defined it as `vector<char>` which has almost identical API; are these changes okay for backports?