### PR TITLE
modules: missing exports as MODULE_NOT_FOUND

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1599,13 +1599,6 @@ compiled with ICU support.
 
 A given value is out of the accepted range.
 
-<a id="ERR_PATH_NOT_EXPORTED"></a>
-### ERR_PATH_NOT_EXPORTED
-
-> Stability: 1 - Experimental
-
-An attempt was made to load a protected path from a package using `exports`.
-
 <a id="ERR_REQUIRE_ESM"></a>
 ### ERR_REQUIRE_ESM
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -223,10 +223,10 @@ RESOLVE_BARE_SPECIFIER(DIR, X)
    a. Parse DIR/name/package.json, and look for "exports" field.
    b. If "exports" is null or undefined, GOTO 3.
    c. Find the longest key in "exports" that the subpath starts with.
-   d. If no such key can be found, throw "not exported".
+   d. If no such key can be found, throw "not found".
    e. If the key matches the subpath entirely, return DIR/name/${exports[key]}.
    f. If either the key or exports[key] do not end with a slash (`/`),
-      throw "not exported".
+      throw "not found".
    g. Return DIR/name/${exports[key]}${subpath.slice(key.length)}.
 3. return DIR/X
 ```

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1104,8 +1104,6 @@ E('ERR_OUT_OF_RANGE',
     msg += ` It must be ${range}. Received ${received}`;
     return msg;
   }, RangeError);
-E('ERR_PATH_NOT_EXPORTED',
-  'Package exports for \'%s\' do not define a \'%s\' subpath', Error);
 E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s', Error);
 E('ERR_SCRIPT_EXECUTION_INTERRUPTED',
   'Script execution was interrupted by `SIGINT`', Error);

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -60,7 +60,6 @@ const { compileFunction } = internalBinding('contextify');
 const {
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_OPT_VALUE,
-  ERR_PATH_NOT_EXPORTED,
   ERR_REQUIRE_ESM
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
@@ -377,7 +376,11 @@ function resolveExports(nmPath, request, absoluteRequest) {
           return fileURLToPath(resolved);
         }
       }
-      throw new ERR_PATH_NOT_EXPORTED(basePath, mappingKey);
+      // eslint-disable-next-line no-restricted-syntax
+      const e = new Error(`Package exports for '${basePath}' do not define ` +
+          `a '${mappingKey}' subpath`);
+      e.code = 'MODULE_NOT_FOUND';
+      throw e;
     }
   }
 

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -859,7 +859,7 @@ Maybe<URL> PackageExportsResolve(Environment* env,
   std::string msg = "Package exports for '" +
       URL(".", pjson_url).ToFilePath() + "' do not define a '" + pkg_subpath +
       "' subpath, imported from " + base.ToFilePath();
-  node::THROW_ERR_PATH_NOT_EXPORTED(env, msg.c_str());
+  node::THROW_ERR_MODULE_NOT_FOUND(env, msg.c_str());
   return Nothing<URL>();
 }
 

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -53,7 +53,6 @@ void PrintErrorString(const char* format, ...);
   V(ERR_MISSING_PLATFORM_FOR_WORKER, Error)                                  \
   V(ERR_MODULE_NOT_FOUND, Error)                                             \
   V(ERR_OUT_OF_RANGE, RangeError)                                            \
-  V(ERR_PATH_NOT_EXPORTED, Error)                                            \
   V(ERR_SCRIPT_EXECUTION_INTERRUPTED, Error)                                 \
   V(ERR_SCRIPT_EXECUTION_TIMEOUT, Error)                                     \
   V(ERR_STRING_TOO_LONG, Error)                                              \

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -29,7 +29,7 @@ import { requireFixture, importFixture } from '../fixtures/pkgexports.mjs';
 
   // There's no such export - so there's nothing to do.
   loadFixture('pkgexports/missing').catch(mustCall((err) => {
-    strictEqual(err.code, 'ERR_PATH_NOT_EXPORTED');
+    strictEqual(err.code, (isRequire ? '' : 'ERR_') + 'MODULE_NOT_FOUND');
     assertStartsWith(err.message, 'Package exports');
     assertIncludes(err.message, 'do not define a \'./missing\' subpath');
   }));
@@ -37,7 +37,7 @@ import { requireFixture, importFixture } from '../fixtures/pkgexports.mjs';
   // The file exists but isn't exported. The exports is a number which counts
   // as a non-null value without any properties, just like `{}`.
   loadFixture('pkgexports-number/hidden.js').catch(mustCall((err) => {
-    strictEqual(err.code, 'ERR_PATH_NOT_EXPORTED');
+    strictEqual(err.code, (isRequire ? '' : 'ERR_') + 'MODULE_NOT_FOUND');
     assertStartsWith(err.message, 'Package exports');
     assertIncludes(err.message, 'do not define a \'./hidden.js\' subpath');
   }));
@@ -57,7 +57,7 @@ import { requireFixture, importFixture } from '../fixtures/pkgexports.mjs';
   // Even though 'pkgexports/sub/asdf.js' works, alternate "path-like" variants
   // do not to prevent confusion and accidental loopholes.
   loadFixture('pkgexports/sub/./../asdf.js').catch(mustCall((err) => {
-    strictEqual(err.code, 'ERR_PATH_NOT_EXPORTED');
+    strictEqual(err.code, (isRequire ? '' : 'ERR_') + 'MODULE_NOT_FOUND');
     assertStartsWith(err.message, 'Package exports');
     assertIncludes(err.message,
                    'do not define a \'./sub/./../asdf.js\' subpath');


### PR DESCRIPTION
It seems I missed this change when reviewing https://github.com/nodejs/node/pull/28759, where previously the package.json `"exports"` would throw a `MODULE_NOT_FOUND` error if trying to import something from a package that was a missing export (changed on this line here - https://github.com/nodejs/node/pull/28759/files#diff-4a5950be44f56dfca2e7fa3c4e1fc0e4).

I think it is quite important for the core resolver to have a unified `MODULE_NOT_FOUND` error instead of splitting this off into different cases, as any tool that uses a resolver typically wants to be able to filter these errors specifically, and having many variations of _not found_ error codes will not help that.

Just like the package.json "main" not being found is still a `MODULE_NOT_FOUND` error and not a `MAIN_NOT_FOUND`, I think we should ensure missing `"exports"` are still a `MODULE_NOT_FOUND` error.

This implements that approach for both the CJS and ESM resolvers.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
