### PR TITLE
 http2: destroy when call settingsFn throw an error

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -972,7 +972,13 @@ class Http2Session extends EventEmitter {
     if (socket.connecting) {
       const connectEvent =
         socket instanceof tls.TLSSocket ? 'secureConnect' : 'connect';
-      socket.once(connectEvent, setupFn);
+      socket.once(connectEvent, () => {
+        try {
+          setupFn();
+        } catch (error) {
+          socket.destroy(error);
+        }
+      });
     } else {
       setupFn();
     }

--- a/test/parallel/test-http2-connect.js
+++ b/test/parallel/test-http2-connect.js
@@ -69,6 +69,20 @@ const { connect: netConnect } = require('net');
   connect(authority).on('error', () => {});
 }
 
+// Check for error for init settings error
+{
+  createServer(function() {
+    connect(`http://localhost:${this.address().port}`, {
+      settings: {
+        maxFrameSize: 1   // An incorrect settings
+      }
+    }).on('error', expectsError({
+      code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+      type: RangeError
+    }));
+  });
+}
+
 // Check for error for an invalid protocol (not http or https)
 {
   const authority = 'ssh://localhost';


### PR DESCRIPTION
fix #28895
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
