### PR TITLE
src: add fork(2) support

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -325,6 +325,10 @@ MultiIsolatePlatform* InitializeV8Platform(int thread_pool_size) {
   return per_process::v8_platform.Platform();
 }
 
+void ForkPlatform() {
+  per_process::v8_platform.Fork();
+}
+
 void FreePlatform(MultiIsolatePlatform* platform) {
   delete platform;
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -1087,6 +1087,15 @@ int Stop(Environment* env) {
   return 0;
 }
 
+int Fork(Environment* env) {
+  int ret = uv_loop_fork(env->event_loop());
+  if (ret != 0) {
+    return ret;
+  }
+  ForkPlatform();
+  return 0;
+}
+
 }  // namespace node
 
 #if !HAVE_INSPECTOR

--- a/src/node.h
+++ b/src/node.h
@@ -218,6 +218,12 @@ NODE_EXTERN int Start(int argc, char* argv[]);
 // in the loop and / or actively executing JavaScript code).
 NODE_EXTERN int Stop(Environment* env);
 
+// Experimental fork(2) recovery support. Reinitialize any kernel state
+// possible in the child process after a fork(2) system call. Embeders
+// should stop JS code from running at an early stage (not many works have
+// scheduled) to be prepared to fork.
+NODE_EXTERN int Fork(Environment* env);
+
 // TODO(addaleax): Officially deprecate this and replace it with something
 // better suited for a public embedder API.
 NODE_EXTERN void Init(int* argc,
@@ -341,6 +347,7 @@ NODE_EXTERN MultiIsolatePlatform* CreatePlatform(
     int thread_pool_size,
     node::tracing::TracingController* tracing_controller);
 MultiIsolatePlatform* InitializeV8Platform(int thread_pool_size);
+NODE_EXTERN void ForkPlatform();
 NODE_EXTERN void FreePlatform(MultiIsolatePlatform* platform);
 
 NODE_EXTERN void EmitBeforeExit(Environment* env);

--- a/src/node_mutex.h
+++ b/src/node_mutex.h
@@ -22,6 +22,7 @@ class MutexBase {
   inline ~MutexBase();
   inline void Lock();
   inline void Unlock();
+  inline void Reset();
 
   MutexBase(const MutexBase&) = delete;
   MutexBase& operator=(const MutexBase&) = delete;
@@ -72,6 +73,7 @@ class ConditionVariableBase {
   inline void Broadcast(const ScopedLock&);
   inline void Signal(const ScopedLock&);
   inline void Wait(const ScopedLock& scoped_lock);
+  inline void Reset();
 
   ConditionVariableBase(const ConditionVariableBase&) = delete;
   ConditionVariableBase& operator=(const ConditionVariableBase&) = delete;
@@ -147,6 +149,11 @@ void ConditionVariableBase<Traits>::Wait(const ScopedLock& scoped_lock) {
 }
 
 template <typename Traits>
+void ConditionVariableBase<Traits>::Reset() {
+  CHECK_EQ(0, Traits::cond_init(&cond_));
+}
+
+template <typename Traits>
 MutexBase<Traits>::MutexBase() {
   CHECK_EQ(0, Traits::mutex_init(&mutex_));
 }
@@ -164,6 +171,11 @@ void MutexBase<Traits>::Lock() {
 template <typename Traits>
 void MutexBase<Traits>::Unlock() {
   Traits::mutex_unlock(&mutex_);
+}
+
+template <typename Traits>
+void MutexBase<Traits>::Reset() {
+  CHECK_EQ(0, Traits::mutex_init(&mutex_));
 }
 
 template <typename Traits>

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -33,6 +33,7 @@ class TaskQueue {
   void NotifyOfCompletion();
   void BlockingDrain();
   void Stop();
+  void Reset();
 
  private:
   Mutex lock_;
@@ -118,6 +119,7 @@ class WorkerThreadsTaskRunner {
 
   void BlockingDrain();
   void Shutdown();
+  void Reset();
 
   int NumberOfWorkerThreads() const;
 
@@ -138,6 +140,7 @@ class NodePlatform : public MultiIsolatePlatform {
 
   void DrainTasks(v8::Isolate* isolate) override;
   void CancelPendingDelayedTasks(v8::Isolate* isolate) override;
+  void Fork();
   void Shutdown();
 
   // v8::Platform implementation.

--- a/src/node_v8_platform-inl.h
+++ b/src/node_v8_platform-inl.h
@@ -98,6 +98,11 @@ struct V8Platform {
     v8::V8::InitializePlatform(platform_);
   }
 
+  inline void Fork() {
+    platform_->Fork();
+    tracing_agent_->Fork();
+  }
+
   inline void Dispose() {
     StopTracingAgent();
     platform_->Shutdown();

--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -101,6 +101,10 @@ void Agent::Start() {
   started_ = true;
 }
 
+void Agent::Fork() {
+  uv_loop_fork(&tracing_loop_);
+}
+
 AgentWriterHandle Agent::AddClient(
     const std::set<std::string>& categories,
     std::unique_ptr<AsyncTraceWriter> writer,

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -111,6 +111,7 @@ class Agent {
   void AddMetadataEvent(std::unique_ptr<TraceObject> event);
   // Flushes all writers registered through AddClient().
   void Flush(bool blocking);
+  void Fork();
 
   TraceConfig* CreateTraceConfig() const;
 

--- a/test/addons/fork-recover/binding.cc
+++ b/test/addons/fork-recover/binding.cc
@@ -1,0 +1,37 @@
+#include <node.h>
+#include <assert.h>
+#include <unistd.h>
+
+namespace {
+
+inline void Fork(const v8::FunctionCallbackInfo<v8::Value>& info) {
+  auto isolate = info.GetIsolate();
+  auto context = isolate->GetCurrentContext();
+
+  pid_t pid = fork();
+
+  if (pid == 0) {
+    auto env = node::GetCurrentEnvironment(context);
+    node::Fork(env);
+  }
+
+  auto result = v8::Number::New(info.GetIsolate(), pid);
+
+  info.GetReturnValue().Set(result);
+}
+
+inline void Initialize(v8::Local<v8::Object> exports,
+                       v8::Local<v8::Value> module,
+                       v8::Local<v8::Context> context) {
+  auto isolate = context->GetIsolate();
+  auto key = v8::String::NewFromUtf8(
+      isolate, "fork", v8::NewStringType::kNormal).ToLocalChecked();
+  auto value = v8::FunctionTemplate::New(isolate, Fork)
+                   ->GetFunction(context)
+                   .ToLocalChecked();
+  assert(exports->Set(context, key, value).IsJust());
+}
+
+}  // anonymous namespace
+
+NODE_MODULE_CONTEXT_AWARE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/fork-recover/binding.gyp
+++ b/test/addons/fork-recover/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': ['binding.cc'],
+      'includes': ['../common.gypi'],
+    },
+  ]
+}

--- a/test/addons/fork-recover/test.js
+++ b/test/addons/fork-recover/test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+const binding = require(`./build/${common.buildType}/binding`);
+
+function inParentProcess(pid) {
+  process.on('exit', () => {
+    process.kill(pid);
+  });
+
+  function retry(fn, times) {
+    return Promise.resolve()
+      .then(
+        () => fn(),
+        (err) => {
+          if (times > 0) {
+            return retry(fn, times - 1);
+          }
+          throw err;
+        }
+      );
+  }
+  function request() {
+    return new Promise((resolve, reject) => {
+      require('http').request({
+        socketPath: './http.sock',
+        path: '/',
+      }, (res) => {
+        let data = '';
+        res.setEncoding('utf-8');
+        res.on('data', (chunk) => data += chunk);
+        res.on('end', () => resolve(data));
+        res.on('error', reject);
+      }).setTimeout(100).on('error', reject).end();
+    });
+  }
+  retry(request, 3)
+    .then(common.mustCall((data) => assert.strictEqual(data, 'hello world')))
+    .catch((err) => {
+      console.error(err);
+      process.exitCode = 1;
+    });
+}
+
+function inChildProcess() {
+  require('http')
+    .createServer((req, res) => {
+      console.log('on req');
+      res.write('hello world');
+      res.end();
+    })
+    .listen('./http.sock', () => {
+      console.log('server started');
+    });
+}
+
+const pid = binding.fork();
+assert(pid >= 0);
+switch (true) {
+  case pid === 0: inChildProcess(); break;
+  case pid > 0: inParentProcess(pid); break;
+}


### PR DESCRIPTION
Like `uv_loop_fork(uv_loop_t*)`, `node::Fork(Environment*)` or `node::ForkPlatform()` should be called by embedders after `fork(2)` syscall if node was expected to be used after fork.

Though not all types of work would be recovered after fork. Threaded works like queued tasks in v8 platform would be discarded.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
