### PR TITLE
doc: mention N-API as recommended approach

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -10,7 +10,7 @@ provide an interface between JavaScript running in Node.js and C/C++ libraries.
 
 There are currently three options for implementing Addons: N-API, nan, or direct
 use of internal V8, libuv and Node.js libraries. Unless you need direct
-access to functionality which is not exposed by N-API, N-API is the
+access to functionality which is not exposed by N-API, use N-API.
 recommended approach. Refer to the section [C/C++ Addons - N-API](n-api.html)
 for more information on N-API.
 

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -8,7 +8,7 @@ can be loaded into Node.js using the [`require()`][require] function, and used
 just as if they were an ordinary Node.js module. They are used primarily to
 provide an interface between JavaScript running in Node.js and C/C++ libraries.
 
-There are currently two options for implementing Addons: N-API or direct
+There are currently three options for implementing Addons: N-API, nan, or direct
 use of internal V8, libuv and Node.js libraries. Unless you need direct
 access to functionality which is not exposed by N-API, N-API is the
 recommended approach. Refer to the section [C/C++ Addons - N-API](n-api.html)

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -11,7 +11,7 @@ provide an interface between JavaScript running in Node.js and C/C++ libraries.
 There are currently three options for implementing Addons: N-API, nan, or direct
 use of internal V8, libuv and Node.js libraries. Unless you need direct
 access to functionality which is not exposed by N-API, use N-API.
-recommended approach. Refer to the section [C/C++ Addons - N-API](n-api.html)
+Refer to the section [C/C++ Addons - N-API](n-api.html)
 for more information on N-API.
 
 When not using N-API, implementing Addons is complicated,

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -8,7 +8,13 @@ can be loaded into Node.js using the [`require()`][require] function, and used
 just as if they were an ordinary Node.js module. They are used primarily to
 provide an interface between JavaScript running in Node.js and C/C++ libraries.
 
-At the moment, the method for implementing Addons is rather complicated,
+There are currently two options for implementing Addons: N-API or direct
+use of internal V8, libuv and Node.js libraries. Unless you need direct
+access to functionality which is not exposed by N-API, N-API is the
+recommended approach. Refer to the section [C/C++ Addons - N-API](n-api.html)
+for more information on N-API.
+
+When not using N-API, the method for implementing Addons is rather complicated,
 involving knowledge of several components and APIs:
 
  - V8: the C++ library Node.js currently uses to provide the

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -8,7 +8,7 @@ can be loaded into Node.js using the [`require()`][require] function, and used
 just as if they were an ordinary Node.js module. They are used primarily to
 provide an interface between JavaScript running in Node.js and C/C++ libraries.
 
-There are currently three options for implementing Addons: N-API, nan, or direct
+There are three options for implementing Addons: N-API, nan, or direct
 use of internal V8, libuv and Node.js libraries. Unless you need direct
 access to functionality which is not exposed by N-API, use N-API.
 Refer to the section [C/C++ Addons - N-API](n-api.html)

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -14,7 +14,7 @@ access to functionality which is not exposed by N-API, N-API is the
 recommended approach. Refer to the section [C/C++ Addons - N-API](n-api.html)
 for more information on N-API.
 
-When not using N-API, the method for implementing Addons is rather complicated,
+When not using N-API, implementing Addons is complicated,
 involving knowledge of several components and APIs:
 
  - V8: the C++ library Node.js currently uses to provide the


### PR DESCRIPTION
We've had a few comments that from the doc it might not
be clear that N-API is the recommended approach for Addons.
As a start, mention N-API early in the non N-API section
as the recommended approach unless lower level access
is required.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
