### PR TITLE
Revert "src: remove trace_sync_io_ from env"

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -465,7 +465,7 @@ inline void Environment::set_printed_error(bool value) {
 }
 
 inline void Environment::set_trace_sync_io(bool value) {
-  options_->trace_sync_io = value;
+  trace_sync_io_ = value;
 }
 
 inline bool Environment::abort_on_uncaught_exception() const {

--- a/src/env.cc
+++ b/src/env.cc
@@ -567,7 +567,7 @@ void Environment::StopProfilerIdleNotifier() {
 }
 
 void Environment::PrintSyncTrace() const {
-  if (!options_->trace_sync_io) return;
+  if (!trace_sync_io_) return;
 
   HandleScope handle_scope(isolate());
 

--- a/src/env.h
+++ b/src/env.h
@@ -1272,6 +1272,7 @@ class Environment : public MemoryRetainer {
   const uint64_t timer_base_;
   std::shared_ptr<KVStore> env_vars_;
   bool printed_error_ = false;
+  bool trace_sync_io_ = false;
   bool emit_env_nonstring_warning_ = true;
   bool emit_err_name_warning_ = true;
   size_t async_callback_scope_depth_ = 0;

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -111,6 +111,8 @@ int NodeMainInstance::Run() {
       env->async_hooks()->pop_async_id(1);
     }
 
+    env->set_trace_sync_io(env->options()->trace_sync_io);
+
     {
       SealHandleScope seal(isolate_);
       bool more;


### PR DESCRIPTION
This reverts commit 7fa5f54e6f2854183e45e0e105a1e22a381aac60.

Fixes: https://github.com/nodejs/node/issues/28913

7fa5f54 breaks the logic behind `--trace-sync-io`, it should be enabled only at a certain point in time, while that commit enables it from the very start, causing the issue linked above.

Or am I missing something?

Refs: https://nodejs.org/api/cli.html#cli_trace_sync_io
> Prints a stack trace whenever synchronous I/O is detected **after the first turn of the event loop**.

Refs: https://github.com/nodejs/node/pull/22726

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
