### PR TITLE
http: OutgoingMessage inherit EE

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -24,7 +24,7 @@
 const { Object, ObjectPrototype } = primordials;
 
 const assert = require('internal/assert');
-const Stream = require('stream');
+const EE = require('events');
 const internalUtil = require('internal/util');
 const { outHeadersKey, utcDate } = require('internal/http');
 const { Buffer } = require('buffer');
@@ -68,7 +68,7 @@ function isCookieField(s) {
 function noopPendingOutput(amount) {}
 
 function OutgoingMessage() {
-  Stream.call(this);
+  EE.call(this);
 
   // Queue that holds all currently pending data, until the response will be
   // assigned to the socket (until it will its turn in the HTTP pipeline).
@@ -106,8 +106,8 @@ function OutgoingMessage() {
 
   this._onPendingData = noopPendingOutput;
 }
-Object.setPrototypeOf(OutgoingMessage.prototype, Stream.prototype);
-Object.setPrototypeOf(OutgoingMessage, Stream);
+Object.setPrototypeOf(OutgoingMessage.prototype, EE.prototype);
+Object.setPrototypeOf(OutgoingMessage, EE);
 
 Object.defineProperty(OutgoingMessage.prototype, 'writableFinished', {
   get: function() {


### PR DESCRIPTION
There is no obvious reason to why `OutgoingMessage` needs to inherit legacy stream.

If there is a reason we should probably add a comment clarifying.

sem-ver major

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
