### PR TITLE
http: simplify OutgoingMessage

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -53,8 +53,6 @@ const { validateString } = require('internal/validators');
 
 const { CRLF, debug } = common;
 
-const kIsCorked = Symbol('isCorked');
-
 const RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
 const RE_TE_CHUNKED = common.chunkExpression;
 
@@ -97,7 +95,6 @@ function OutgoingMessage() {
 
   this.finished = false;
   this._headerSent = false;
-  this[kIsCorked] = false;
 
   this.socket = null;
   this.connection = null;
@@ -558,10 +555,14 @@ Object.defineProperty(OutgoingMessage.prototype, 'headersSent', {
 
 const crlf_buf = Buffer.from('\r\n');
 OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
-  return write_(this, chunk, encoding, callback, false);
+  if (typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
+    throw new ERR_INVALID_ARG_TYPE('first argument',
+                                   ['string', 'Buffer'], chunk);
+  }
+  return write_(this, chunk, encoding, callback);
 };
 
-function write_(msg, chunk, encoding, callback, fromEnd) {
+function write_(msg, chunk, encoding, callback) {
   if (msg.finished) {
     const err = new ERR_STREAM_WRITE_AFTER_END();
     const triggerAsyncId = msg.socket ? msg.socket[async_id_symbol] : undefined;
@@ -586,15 +587,10 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
     return true;
   }
 
-  if (!fromEnd && typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
-    throw new ERR_INVALID_ARG_TYPE('first argument',
-                                   ['string', 'Buffer'], chunk);
-  }
-
-  if (!fromEnd && msg.connection && !msg[kIsCorked]) {
-    msg.connection.cork();
-    msg[kIsCorked] = true;
-    process.nextTick(connectionCorkNT, msg, msg.connection);
+  const conn = msg.connection;
+  if (conn && !conn._writableState.corked) {
+    conn.cork();
+    process.nextTick(connectionCorkNT, conn);
   }
 
   var len, ret;
@@ -623,8 +619,7 @@ function writeAfterEndNT(msg, err, callback) {
 }
 
 
-function connectionCorkNT(msg, conn) {
-  msg[kIsCorked] = false;
+function connectionCorkNT(conn) {
   conn.uncork();
 }
 
@@ -667,26 +662,28 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     encoding = null;
   }
 
+  if (chunk && typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
+    throw new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
+  }
+
   if (this.finished) {
     return this;
   }
 
-  var uncork;
+  const conn = this.connection;
+
+  if (conn) {
+    conn.cork();
+  }
+
   if (chunk) {
-    if (typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
-      throw new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
-    }
     if (!this._header) {
       if (typeof chunk === 'string')
         this._contentLength = Buffer.byteLength(chunk, encoding);
       else
         this._contentLength = chunk.length;
     }
-    if (this.connection) {
-      this.connection.cork();
-      uncork = true;
-    }
-    write_(this, chunk, encoding, null, true);
+    write_(this, chunk, encoding, null);
   } else if (!this._header) {
     this._contentLength = 0;
     this._implicitHeader();
@@ -704,8 +701,9 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     this._send('', 'latin1', finish);
   }
 
-  if (uncork)
-    this.connection.uncork();
+  if (conn) {
+    conn.uncork();
+  }
 
   this.finished = true;
 

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -71,7 +71,14 @@ common.expectsError(() => {
   outgoingMessage.write('');
 }
 
-assert(OutgoingMessage.prototype.write.call({ _header: 'test' }));
+common.expectsError(() => {
+  OutgoingMessage.prototype.write.call({ _header: 'test' });
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The first argument must be one of type string or Buffer. ' +
+           'Received type undefined'
+});
 
 common.expectsError(() => {
   const outgoingMessage = new OutgoingMessage();


### PR DESCRIPTION
This tries to slightly simplify and improve performance and memory overhead of `OutgoingMessage`.

There is one test case which fails and that I don't quite understand the purpose of.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
