### PR TITLE
conf: linux large pages LLVM lld linkage support

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -402,6 +402,11 @@ parser.add_option('--use-largepages',
     help='build with Large Pages support. This feature is supported only on Linux kernel' +
          '>= 2.6.38 with Transparent Huge pages enabled and FreeBSD')
 
+parser.add_option('--use-largepages-script-lld',
+    action='store_true',
+    dest='node_use_large_pages_script_lld',
+    help='link against the LLVM ld linker script. Implies -fuse-ld=lld in the linker flags')
+
 intl_optgroup.add_option('--with-intl',
     action='store',
     dest='with_intl',
@@ -1055,6 +1060,7 @@ def configure_node(o):
         raise Exception(
           'Large pages need Linux kernel version >= 2.6.38')
   o['variables']['node_use_large_pages'] = b(options.node_use_large_pages)
+  o['variables']['node_use_large_pages_script_lld'] = b(options.node_use_large_pages_script_lld)
 
   if options.no_ifaddrs:
     o['defines'] += ['SUNOS_NO_IFADDRS']

--- a/node.gypi
+++ b/node.gypi
@@ -295,10 +295,22 @@
       'ldflags': [ '-Wl,-z,relro',
                    '-Wl,-z,now' ]
     }],
-    [ 'OS=="linux" and target_arch=="x64" and node_use_large_pages=="true"', {
+    [ 'OS=="linux" and '
+      'target_arch=="x64" and '
+      'node_use_large_pages=="true" and '
+      'node_use_large_pages_script_lld=="false"', {
       'ldflags': [
         '-Wl,-T',
         '<!(realpath src/large_pages/ld.implicit.script)',
+      ]
+    }],
+    [ 'OS=="linux" and '
+      'target_arch=="x64" and '
+      'node_use_large_pages=="true" and '
+      'node_use_large_pages_script_lld=="true"', {
+      'ldflags': [
+        '-Wl,-T',
+        '<!(realpath src/large_pages/ld.implicit.script.lld)',
       ]
     }],
     [ 'node_use_openssl=="true"', {

--- a/src/large_pages/ld.implicit.script.lld
+++ b/src/large_pages/ld.implicit.script.lld
@@ -1,0 +1,3 @@
+  PROVIDE (__nodetext = .);
+  PROVIDE (_nodetext = .);
+  PROVIDE (nodetext = .);


### PR DESCRIPTION
The custom linker script is compatible with GNU ld only.
As such, providin a new expliciting option to redirect to
a different one. lld seems unable to migrate this
large section w/o segfaulting so providing only the
base address anchor for now.