### PR TITLE
http: avoid buffering header

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -271,12 +271,8 @@ function _writeRaw(data, encoding, callback) {
     encoding = null;
   }
 
-  if (conn && conn._httpMessage === this && conn.writable && !conn.destroyed) {
-    // There might be pending data in the this.output buffer.
-    if (this.outputData.length) {
-      this._flushOutput(conn);
-    }
-    // Directly write to socket.
+  if (conn && conn._httpMessage === this && conn.writable) {
+    this._flushOutput(conn);
     return conn.write(data, encoding, callback);
   }
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -278,7 +278,7 @@ function _writeRaw(data, encoding, callback) {
 
   // Buffer, as long as we're not destroyed.
 
-  this.outputData.push({ data, encoding, callback });
+  this.outputData.push(data, encoding, callback);
   this.outputSize += data.length;
   this._onPendingData(data.length);
   return this.outputSize < HIGH_WATER_MARK;
@@ -777,8 +777,10 @@ OutgoingMessage.prototype._flushOutput = function _flushOutput(socket) {
   const outputData = this.outputData;
   socket.cork();
   let ret;
-  for (var i = 0; i < outputLength; i++) {
-    const { data, encoding, callback } = outputData[i];
+  for (let i = 0; i < outputLength; i += 3) {
+    const data = outputData[i + 0];
+    const encoding = outputData[i + 1];
+    const callback = outputData[i + 2];
     ret = socket.write(data, encoding, callback);
   }
   socket.uncork();

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -252,7 +252,6 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback) {
     }
     this._headerSent = true;
   }
-
   return this._writeRaw(data, encoding, callback);
 };
 
@@ -271,14 +270,16 @@ function _writeRaw(data, encoding, callback) {
     encoding = null;
   }
 
-  if (conn && conn._httpMessage === this && conn.writable) {
-    this._flushOutput(conn);
+  if (conn && conn._httpMessage === this && conn.writable && !conn.destroyed) {
+    // There might be pending data in the this.output buffer.
+    if (this.outputData.length) {
+      this._flushOutput(conn);
+    }
+    // Directly write to socket.
     return conn.write(data, encoding, callback);
   }
-
   // Buffer, as long as we're not destroyed.
-
-  this.outputData.push(data, encoding, callback);
+  this.outputData.push({ data, encoding, callback });
   this.outputSize += data.length;
   this._onPendingData(data.length);
   return this.outputSize < HIGH_WATER_MARK;
@@ -777,10 +778,8 @@ OutgoingMessage.prototype._flushOutput = function _flushOutput(socket) {
   const outputData = this.outputData;
   socket.cork();
   let ret;
-  for (let i = 0; i < outputLength; i += 3) {
-    const data = outputData[i + 0];
-    const encoding = outputData[i + 1];
-    const callback = outputData[i + 2];
+  for (var i = 0; i < outputLength; i++) {
+    const { data, encoding, callback } = outputData[i];
     ret = socket.write(data, encoding, callback);
   }
   socket.uncork();

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -248,25 +248,11 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback) {
         (encoding === 'utf8' || encoding === 'latin1' || !encoding)) {
       data = this._header + data;
     } else {
-      var header = this._header;
-      if (this.outputData.length === 0) {
-        this.outputData = [{
-          data: header,
-          encoding: 'latin1',
-          callback: null
-        }];
-      } else {
-        this.outputData.unshift({
-          data: header,
-          encoding: 'latin1',
-          callback: null
-        });
-      }
-      this.outputSize += header.length;
-      this._onPendingData(header.length);
+      this._writeRaw(this._header, 'latin1', null);
     }
     this._headerSent = true;
   }
+
   return this._writeRaw(data, encoding, callback);
 };
 
@@ -293,7 +279,9 @@ function _writeRaw(data, encoding, callback) {
     // Directly write to socket.
     return conn.write(data, encoding, callback);
   }
+
   // Buffer, as long as we're not destroyed.
+
   this.outputData.push({ data, encoding, callback });
   this.outputSize += data.length;
   this._onPendingData(data.length);


### PR DESCRIPTION
This changes the buffernig logic for headers as to not unnecessarily create buffer queue entries when no buffering is required. Also removes the need to perform object allocations while buffering.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
