### PR TITLE
bootstrap: run preload prior to --frozen-intrinsics

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -218,6 +218,9 @@ Support is currently only provided for the root context and no guarantees are
 currently provided that `global.Array` is indeed the default intrinsic
 reference. Code may break under this flag.
 
+`--require` runs prior to freezing intrinsics in order to allow polyfills to
+be added.
+
 ### `--heapsnapshot-signal=signal`
 <!-- YAML
 added: v12.0.0

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -48,10 +48,10 @@ function prepareMainThreadExecution(expandArgv1 = false) {
   initializeClusterIPC();
 
   initializeDeprecations();
-  initializeFrozenIntrinsics();
   initializeCJSLoader();
   initializeESMLoader();
   loadPreloadModules();
+  initializeFrozenIntrinsics();
 }
 
 function patchProcessObject(expandArgv1) {

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -106,10 +106,10 @@ port.on('message', (message) => {
       require('internal/process/policy').setup(manifestSrc, manifestURL);
     }
     initializeDeprecations();
-    initializeFrozenIntrinsics();
     initializeCJSLoader();
     initializeESMLoader();
     loadPreloadModules();
+    initializeFrozenIntrinsics();
     publicWorker.parentPort = publicPort;
     publicWorker.workerData = workerData;
 

--- a/test/fixtures/intrinsic-mutation.js
+++ b/test/fixtures/intrinsic-mutation.js
@@ -1,8 +1,10 @@
 'use strict';
 Object.defineProperty(
-  String.prototype,
-  Symbol('fake-polyfill-property'), {
+  Object.prototype,
+  'flatten', {
     enumerable: false,
-    value: null
+    // purposefully named something that
+    // would never land in JS itself
+    value: function smoosh() {}
   }
 );

--- a/test/fixtures/intrinsic-mutation.js
+++ b/test/fixtures/intrinsic-mutation.js
@@ -1,0 +1,7 @@
+Object.defineProperty(
+  String.prototype,
+  Symbol('fake-polyfill-property'), {
+    enumerable: false,
+    value: null
+  }
+);

--- a/test/fixtures/intrinsic-mutation.js
+++ b/test/fixtures/intrinsic-mutation.js
@@ -1,3 +1,4 @@
+'use strict';
 Object.defineProperty(
   String.prototype,
   Symbol('fake-polyfill-property'), {

--- a/test/fixtures/print-intrinsic-mutation-name.js
+++ b/test/fixtures/print-intrinsic-mutation-name.js
@@ -1,0 +1,2 @@
+'use strict';
+console.log({}.flatten.name);

--- a/test/fixtures/worker-from-argv.js
+++ b/test/fixtures/worker-from-argv.js
@@ -1,0 +1,3 @@
+'use strict';
+const {Worker} = require('worker_threads');
+new Worker(process.argv[2]).on('exit', process.exit);

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -71,6 +71,14 @@ childProcess.exec(
     assert.strictEqual(stdout, 'hello\n');
   }
 );
+const workerSrc = `const {Worker} = require('worker_threads');new Worker(${JSON.stringify(fixtureA)});`;
+childProcess.exec(
+  `"${nodeBinary}" --frozen-intrinsics ${preloadOption([fixtureE])}-e ${JSON.stringify(workerSrc)}`,
+  function(err, stdout) {
+    assert.ifError(err);
+    assert.strictEqual(stdout, 'A\n');
+  }
+);
 
 // Test that preload can be used with stdin
 const stdinProc = childProcess.spawn(

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -23,6 +23,7 @@ const fixtureA = fixtures.path('printA.js');
 const fixtureB = fixtures.path('printB.js');
 const fixtureC = fixtures.path('printC.js');
 const fixtureD = fixtures.path('define-global.js');
+const fixtureE = fixtures.path('intrinsic-mutation.js');
 const fixtureThrows = fixtures.path('throws_error4.js');
 
 // Test preloading a single module works
@@ -59,6 +60,15 @@ childProcess.exec(
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.strictEqual(stdout, 'A\nhello\n');
+  }
+);
+
+// Test that preload can be used with --frozen-intrinsics
+childProcess.exec(
+  `"${nodeBinary}" --frozen-intrinsics ${preloadOption([fixtureE])}-e "console.log('hello');"`,
+  function(err, stdout) {
+    assert.ifError(err);
+    assert.strictEqual(stdout, 'hello\n');
   }
 );
 

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -24,6 +24,7 @@ const fixtureB = fixtures.path('printB.js');
 const fixtureC = fixtures.path('printC.js');
 const fixtureD = fixtures.path('define-global.js');
 const fixtureE = fixtures.path('intrinsic-mutation.js');
+const fixtureF = fixtures.path('print-intrinsic-mutation-name.js');
 const fixtureThrows = fixtures.path('throws_error4.js');
 
 // Test preloading a single module works
@@ -65,18 +66,28 @@ childProcess.exec(
 
 // Test that preload can be used with --frozen-intrinsics
 childProcess.exec(
-  `"${nodeBinary}" --frozen-intrinsics ${preloadOption([fixtureE])}-e "console.log('hello');"`,
+  `"${nodeBinary}" --frozen-intrinsics ${
+    preloadOption([fixtureE])
+  } ${
+    fixtureF
+  }`,
   function(err, stdout) {
     assert.ifError(err);
-    assert.strictEqual(stdout, 'hello\n');
+    assert.strictEqual(stdout, 'smoosh\n');
   }
 );
-const workerSrc = `const {Worker} = require('worker_threads');new Worker(${JSON.stringify(fixtureA)});`;
+const workerSrc = `new (require('worker_threads').Worker)(${fixtureF});`;
 childProcess.exec(
-  `"${nodeBinary}" --frozen-intrinsics ${preloadOption([fixtureE])}-e ${JSON.stringify(workerSrc)}`,
+  `"${
+    nodeBinary
+  }" --frozen-intrinsics ${
+    preloadOption([fixtureE])
+  }-e ${
+    workerSrc
+  }`,
   function(err, stdout) {
     assert.ifError(err);
-    assert.strictEqual(stdout, 'A\n');
+    assert.strictEqual(stdout, 'smoosh\n');
   }
 );
 

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -76,7 +76,7 @@ childProcess.exec(
     assert.strictEqual(stdout, 'smoosh\n');
   }
 );
-const workerSrc = `new (require('worker_threads').Worker)(${fixtureF});`;
+const workerSrc = `'new (require("worker_threads").Worker)("${fixtureF}");'`;
 childProcess.exec(
   `"${
     nodeBinary

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -25,6 +25,7 @@ const fixtureC = fixtures.path('printC.js');
 const fixtureD = fixtures.path('define-global.js');
 const fixtureE = fixtures.path('intrinsic-mutation.js');
 const fixtureF = fixtures.path('print-intrinsic-mutation-name.js');
+const fixtureG = fixtures.path('worker-from-argv.js');
 const fixtureThrows = fixtures.path('throws_error4.js');
 
 // Test preloading a single module works
@@ -76,15 +77,14 @@ childProcess.exec(
     assert.strictEqual(stdout, 'smoosh\n');
   }
 );
-const workerSrc = `'new (require("worker_threads").Worker)("${fixtureF}");'`;
 childProcess.exec(
   `"${
     nodeBinary
   }" --frozen-intrinsics ${
     preloadOption([fixtureE])
-  }-e ${
-    workerSrc
-  }`,
+  } ${
+    fixtureG
+  } ${fixtureF}`,
   function(err, stdout) {
     assert.ifError(err);
     assert.strictEqual(stdout, 'smoosh\n');


### PR DESCRIPTION
This is used to allow people to run polyfills.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
