### PR TITLE
process: add .stillSynchronous

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -92,6 +92,22 @@ const rawMethods = internalBinding('process_methods');
   };
 }
 
+{
+  let perf_hooks;
+  let initialEventLoop = true;
+  ObjectDefineProperty(process, 'initialEventLoop', {
+    enumerable: true,
+    configurable: false,
+    get() {
+      if (initialEventLoop) {
+        if (!perf_hooks) perf_hooks = require('perf_hooks');
+        initialEventLoop = perf_hooks.performance.nodeTiming.loopStart < 0;
+      }
+      return initialEventLoop;
+    }
+  });
+}
+
 const credentials = internalBinding('credentials');
 if (credentials.implementsPosixCredentials) {
   process.getuid = credentials.getuid;


### PR DESCRIPTION
This adds a `process.stillSynchronous` public property to check if the process is still in synchronous state (i.e. a sync script or startup phase of an async app/server) or not.

Could be used as an additional safeguard for #28439 (refs: https://github.com/nodejs/node/pull/28439#issuecomment-516934923), could be used to fence large deprecations like #22584 (the approach there was broken as far as I remember), also refs: https://github.com/nodejs/help/issues/1740 (though this does not expose the tick id, only if we got past the first one or not).

~Operates very similar to `--trace-sync-io`, ref: #28926.~
*Upd:* switched to `perf_hooks` instead.

Docs will be added soon.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
