### PR TITLE
path: improve normalization performance

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -95,7 +95,10 @@ function normalizeString(path, allowAboveRoot, separator, isPathSeparator) {
           lastSegmentLength = 2;
         }
       } else {
-        res += (res.length > 0 ? separator : '') + path.slice(lastSlash + 1, i);
+        if (res.length > 0)
+          res += `${separator}${path.slice(lastSlash + 1, i)}`;
+        else
+          res = path.slice(lastSlash + 1, i);
         lastSegmentLength = i - lastSlash - 1;
       }
       lastSlash = i;


### PR DESCRIPTION
Some results:

```
                                                                                             confidence improvement accuracy (*)   (**)  (***)
path/normalize-posix.js n=10000000 path='.'                                                        ***      8.62 %       ±1.91% ±2.54% ±3.30%
path/normalize-posix.js n=10000000 path=''                                                         ***      8.71 %       ±2.00% ±2.67% ±3.49%
path/normalize-posix.js n=10000000 path='/../'                                                     ***      7.54 %       ±1.97% ±2.64% ±3.46%
path/normalize-posix.js n=10000000 path='/foo'                                                     ***     16.09 %       ±2.77% ±3.71% ±4.88%
path/normalize-posix.js n=10000000 path='/foo/bar'                                                 ***     11.90 %       ±1.86% ±2.47% ±3.22%
path/normalize-posix.js n=10000000 path='/foo/bar//baz/asdf/quux/..'                               ***      9.30 %       ±1.98% ±2.64% ±3.45%
path/normalize-win32.js n=10000000 path='.'                                                        ***      4.80 %       ±1.29% ±1.73% ±2.28%
path/normalize-win32.js n=10000000 path=''                                                         ***      4.49 %       ±0.94% ±1.26% ±1.66%
path/normalize-win32.js n=10000000 path='C:\\\\..\\\\'                                                      1.48 %       ±1.56% ±2.08% ±2.72%
path/normalize-win32.js n=10000000 path='C:\\\\foo'                                                ***      3.33 %       ±1.61% ±2.14% ±2.80%
path/normalize-win32.js n=10000000 path='C:\\\\foo\\\\bar'                                          **      2.26 %       ±1.39% ±1.86% ±2.42%
path/normalize-win32.js n=10000000 path='C:\\\\foo\\\\bar\\\\\\\\baz\\\\asdf\\\\quux\\\\..'                 0.35 %       ±1.28% ±1.71% ±2.24%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
