### PR TITLE
modules: Package exports validations and fallbacks

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -787,15 +787,19 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 
 **PACKAGE_EXPORTS_TARGET_RESOLVE**(_packageURL_, _target_, _subpath_)
 > 1. If _target_ is a String, then
->    1. If _target_ does not start with _"./"_, or _subpath_ has non-zero
->       length and _target_ does not end with _"/"_, then
->       1. Throw a _Module Not Found_ error.
+>    1. If _target_ does not start with _"./"_, throw a _Module Not Found_
+>       error.
+>    1. If _subpath_ has non-zero length or _target_ does not end with _"/"_,
+>       throw a _Module Not Found_ error.
+>    1. If _target_ or _subpath_ contain any _"node_modules"_ segments including
+>       _"node_modules"_ percent-encoding, throw a _Module Not Found_ error.
 >    1. Let _resolvedTarget_ be the URL resolution of the concatenation of
 >       _packageURL_ and _target_.
 >    1. If _resolvedTarget_ is contained in _packageURL_, then
 >       1. Let _resolved_ be the URL resolution of the concatenation of
 >          _subpath_ and _resolvedTarget_.
->       1. If _resolved_ is contained in _packageURL_, then
+>       1. If _resolved_ is contained in _packageURL_ and contains no
+>          _"node_modules"_ segments, then
 >          1. Return _resolved_.
 > 1. Otherwise, if _target_ is an Array, then
 >    1. For each item _targetValue_ in _target_, do
@@ -827,6 +831,7 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 **READ_PACKAGE_SCOPE**(_url_)
 > 1. Let _scopeURL_ be _url_.
 > 1. While _scopeURL_ is not the file system root,
+>    1. If _scopeURL_ ends in a _"node_modules"_ path segment, return **null**.
 >    1. Let _pjson_ be the result of **READ_PACKAGE_JSON**(_scopeURL_).
 >    1. If _pjson_ is not **null**, then
 >       1. Return _pjson_.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -242,13 +242,13 @@ throw when an attempt is made to import them:
 
 ```js
 import submodule from 'es-module-package/private-module.js';
-// Throws - Package exports error
+// Throws - Module not found
 ```
 
 > Note: this is not a strong encapsulation as any private modules can still be
 > loaded by absolute paths.
 
-Folders can also be mapped with package exports as well:
+Folders can also be mapped with package exports:
 
 <!-- eslint-skip -->
 ```js
@@ -268,8 +268,24 @@ import feature from 'es-module-package/features/x.js';
 If a package has no exports, setting `"exports": false` can be used instead of
 `"exports": {}` to indicate the package does not intend for submodules to be
 exposed.
-This is just a convention that works because `false`, just like `{}`, has no
-iterable own properties.
+
+Any invalid exports entries will be ignored. This includes exports not
+starting with `"./"` or a missing trailing `"/"` for directory exports.
+
+Array fallback support is provided for exports, similarly to import maps
+in order to be forward-compatible with fallback workflows in future:
+
+<!-- eslint-skip -->
+```js
+{
+  "exports": {
+    "./submodule": ["not:valid", "./submodule.js"]
+  }
+}
+```
+
+Since `"not:valid"` is not a supported target, `"./submodule.js"` is used
+instead as the fallback, as if it were the only target.
 
 ## <code>import</code> Specifiers
 
@@ -660,7 +676,7 @@ CommonJS loader. Additional formats such as _"addon"_ can be extended in future
 updates.
 
 In the following algorithms, all subroutine errors are propagated as errors
-of these top-level routines.
+of these top-level routines unless stated otherwise.
 
 _isMain_ is **true** when resolving the Node.js application entry point.
 
@@ -681,6 +697,9 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >    1. Note: _specifier_ is now a bare specifier.
 >    1. Set _resolvedURL_ the result of
 >       **PACKAGE_RESOLVE**(_specifier_, _parentURL_).
+> 1. If _resolvedURL_ contains any percent encodings of _"/"_ or _"\"_ (_"%2f"_
+>    and _"%5C"_ respectively), then
+>    1. Throw an _Invalid Specifier_ error.
 > 1. If the file at _resolvedURL_ does not exist, then
 >    1. Throw a _Module Not Found_ error.
 > 1. Set _resolvedURL_ to the real path of _resolvedURL_.
@@ -753,19 +772,39 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >    1. Set _packagePath_ to _"./"_ concatenated with _packagePath_.
 >    1. If _packagePath_ is a key of _exports_, then
 >       1. Let _target_ be the value of _exports[packagePath]_.
->       1. If _target_ is not a String, continue the loop.
->       1. Return the URL resolution of the concatenation of _packageURL_ and
->          _target_.
+>       1. Return **PACKAGE_EXPORTS_TARGET_RESOLVE**(_packageURL_, _target_,
+>          _""_).
 >    1. Let _directoryKeys_ be the list of keys of _exports_ ending in
 >       _"/"_, sorted by length descending.
 >    1. For each key _directory_ in _directoryKeys_, do
 >       1. If _packagePath_ starts with _directory_, then
 >          1. Let _target_ be the value of _exports[directory]_.
->          1. If _target_ is not a String, continue the loop.
 >          1. Let _subpath_ be the substring of _target_ starting at the index
 >             of the length of _directory_.
->          1. Return the URL resolution of the concatenation of _packageURL_,
->             _target_ and _subpath_.
+>          1. Return **PACKAGE_EXPORTS_TARGET_RESOLVE**(_packageURL_, _target_,
+>             _subpath_.
+> 1. Throw a _Module Not Found_ error.
+
+**PACKAGE_EXPORTS_TARGET_RESOLVE**(_packageURL_, _target_, _subpath_)
+> 1. If _target_ is a String, then
+>    1. If _target_ does not start with _"./"_, or _subpath_ has non-zero
+>       length and _target_ does not end with _"/"_, then
+>       1. Throw a _Module Not Found_ error.
+>    1. Let _resolvedTarget_ be the URL resolution of the concatenation of
+>       _packageURL_ and _target_.
+>    1. If _resolvedTarget_ is contained in _packageURL_, then
+>       1. Let _resolved_ be the URL resolution of the concatenation of
+>          _subpath_ and _resolvedTarget_.
+>       1. If _resolved_ is contained in _packageURL_, then
+>          1. Return _resolved_.
+> 1. Otherwise, if _target_ is an Array, then
+>    1. For each item _targetValue_ in _target_, do
+>       1. If _targetValue_ is not a String, continue the loop.
+>       1. Let _resolved_ be the result of
+>          **PACKAGE_EXPORTS_TARGET_RESOLVE**(_packageURL_, _targetValue_,
+>          _subpath_), continuing the loop on abrupt completion.
+>       1. Assert: _resolved_ is a String.
+>       1. Return _resolved_.
 > 1. Throw a _Module Not Found_ error.
 
 **ESM_FORMAT**(_url_, _isMain_)

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -697,7 +697,7 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >    1. Note: _specifier_ is now a bare specifier.
 >    1. Set _resolvedURL_ the result of
 >       **PACKAGE_RESOLVE**(_specifier_, _parentURL_).
-> 1. If _resolvedURL_ contains any percent encodings of _"/"_ or _"\"_ (_"%2f"_
+> 1. If _resolvedURL_ contains any percent encodings of _"/"_ or _"\\"_ (_"%2f"_
 >    and _"%5C"_ respectively), then
 >    1. Throw an _Invalid Specifier_ error.
 > 1. If the file at _resolvedURL_ does not exist, then

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -789,7 +789,7 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 > 1. If _target_ is a String, then
 >    1. If _target_ does not start with _"./"_, throw a _Module Not Found_
 >       error.
->    1. If _subpath_ has non-zero length or _target_ does not end with _"/"_,
+>    1. If _subpath_ has non-zero length and _target_ does not end with _"/"_,
 >       throw a _Module Not Found_ error.
 >    1. If _target_ or _subpath_ contain any _"node_modules"_ segments including
 >       _"node_modules"_ percent-encoding, throw a _Module Not Found_ error.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -798,8 +798,7 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >    1. If _resolvedTarget_ is contained in _packageURL_, then
 >       1. Let _resolved_ be the URL resolution of the concatenation of
 >          _subpath_ and _resolvedTarget_.
->       1. If _resolved_ is contained in _packageURL_ and contains no
->          _"node_modules"_ segments, then
+>       1. If _resolved_ is contained in _packageURL_, then
 >          1. Return _resolved_.
 > 1. Otherwise, if _target_ is an Array, then
 >    1. For each item _targetValue_ in _target_, do

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -754,7 +754,7 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 > 1. If _pjson_ is **null**, then
 >    1. Throw a _Module Not Found_ error.
 > 1. If _pjson.main_ is a String, then
->    1. Let _resolvedMain_ be the concatenation of _packageURL_, "/", and
+>    1. Let _resolvedMain_ be the URL resolution of _packageURL_, "/", and
 >       _pjson.main_.
 >    1. If the file at _resolvedMain_ exists, then
 >       1. Return _resolvedMain_.
@@ -763,8 +763,6 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 > 1. Let _legacyMainURL_ be the result applying the legacy
 >    **LOAD_AS_DIRECTORY** CommonJS resolver to _packageURL_, throwing a
 >    _Module Not Found_ error for no resolution.
-> 1. If _legacyMainURL_ does not end in _".js"_ then,
->    1. Throw an _Unsupported File Extension_ error.
 > 1. Return _legacyMainURL_.
 
 **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packagePath_, _exports_)
@@ -798,7 +796,7 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >    1. If _resolvedTarget_ is contained in _packageURL_, then
 >       1. Let _resolved_ be the URL resolution of the concatenation of
 >          _subpath_ and _resolvedTarget_.
->       1. If _resolved_ is contained in _packageURL_, then
+>       1. If _resolved_ is contained in _resolvedTarget_, then
 >          1. Return _resolved_.
 > 1. Otherwise, if _target_ is an Array, then
 >    1. For each item _targetValue_ in _target_, do

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -782,7 +782,7 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >          1. Let _subpath_ be the substring of _target_ starting at the index
 >             of the length of _directory_.
 >          1. Return **PACKAGE_EXPORTS_TARGET_RESOLVE**(_packageURL_, _target_,
->             _subpath_.
+>             _subpath_).
 > 1. Throw a _Module Not Found_ error.
 
 **PACKAGE_EXPORTS_TARGET_RESOLVE**(_packageURL_, _target_, _subpath_)

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -202,11 +202,12 @@ NODE_MODULES_PATHS(START)
 5. return DIRS
 ```
 
-If `--experimental-exports` is enabled,
-node allows packages loaded via `LOAD_NODE_MODULES` to explicitly declare
-which filepaths to expose and how they should be interpreted.
-This expands on the control packages already had using the `main` field.
-With this feature enabled, the `LOAD_NODE_MODULES` changes as follows:
+If `--experimental-exports` is enabled, Node.js allows packages loaded via
+`LOAD_NODE_MODULES` to explicitly declare which file paths to expose and how
+they should be interpreted. This expands on the control packages already had
+using the `main` field.
+
+With this feature enabled, the `LOAD_NODE_MODULES` changes are:
 
 ```txt
 LOAD_NODE_MODULES(X, START)
@@ -224,10 +225,10 @@ RESOLVE_BARE_SPECIFIER(DIR, X)
    b. If "exports" is null or undefined, GOTO 3.
    c. Find the longest key in "exports" that the subpath starts with.
    d. If no such key can be found, throw "not found".
-   e. If the key matches the subpath entirely, return DIR/name/${exports[key]}.
-   f. If either the key or exports[key] do not end with a slash (`/`),
-      throw "not found".
-   g. Return DIR/name/${exports[key]}${subpath.slice(key.length)}.
+   e. let RESOLVED_URL =
+        PACKAGE_EXPORTS_TARGET_RESOLVE(pathToFileURL(DIR/name), exports[key],
+        subpath.slice(key.length)), as defined in the esm resolver.
+   f. return fileURLToPath(RESOLVED_URL)
 3. return DIR/X
 ```
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -417,8 +417,8 @@ function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
     }
   }
   // eslint-disable-next-line no-restricted-syntax
-  const e = new Error(`Package exports for '${basePath}' do not define ` +
-      `a '${mappingKey}' subpath`);
+  const e = new Error(`Package exports for '${basePath}' do not define a ` +
+      `valid '${mappingKey}' target${subpath ? 'for ' + subpath : ''}`);
   e.code = 'MODULE_NOT_FOUND';
   throw e;
 }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -391,16 +391,16 @@ function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
     if (target.startsWith('./') &&
         (subpath.length === 0 || target.endsWith('/'))) {
       const resolvedTarget = new URL(target, pkgPath);
-      const pkgPathHref = pkgPath.href;
-      const resolvedTargetHref = resolvedTarget.href;
-      if (StringPrototype.startsWith(resolvedTargetHref, pkgPathHref) &&
-          StringPrototype.indexOf(resolvedTargetHref, '/node_modules/',
-                                  pkgPathHref.length - 1) === -1) {
+      const pkgPathPath = pkgPath.pathname;
+      const resolvedTargetPath = resolvedTarget.pathname;
+      if (StringPrototype.startsWith(resolvedTargetPath, pkgPathPath) &&
+          StringPrototype.indexOf(resolvedTargetPath, '/node_modules/',
+                                  pkgPathPath.length - 1) === -1) {
         const resolved = new URL(subpath, resolvedTarget);
-        const resolvedHref = resolved.href;
-        if (StringPrototype.startsWith(resolvedHref, pkgPathHref) &&
-            StringPrototype.indexOf(resolvedHref, '/node_modules/',
-                                    pkgPathHref.length - 1) === -1) {
+        const resolvedPath = resolved.pathname;
+        if (StringPrototype.startsWith(resolvedPath, pkgPathPath) &&
+            StringPrototype.indexOf(resolvedPath, '/node_modules/',
+                                    pkgPathPath.length - 1) === -1) {
           return fileURLToPath(resolved);
         }
       }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -395,12 +395,12 @@ function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
       const resolvedTargetHref = resolvedTarget.href;
       if (StringPrototype.startsWith(resolvedTargetHref, pkgPathHref) &&
           StringPrototype.indexOf(resolvedTargetHref, '/node_modules/',
-          pkgPathHref.length - 1) === -1) {
+                                  pkgPathHref.length - 1) === -1) {
         const resolved = new URL(subpath, resolvedTarget);
         const resolvedHref = resolved.href;
         if (StringPrototype.startsWith(resolvedHref, pkgPathHref) &&
             StringPrototype.indexOf(resolvedHref, '/node_modules/',
-            pkgPathHref.length - 1) === -1) {
+                                    pkgPathHref.length - 1) === -1) {
           return fileURLToPath(resolved);
         }
       }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -348,18 +348,18 @@ function resolveExports(nmPath, request, absoluteRequest) {
 
     const basePath = path.resolve(nmPath, name);
     const pkgExports = readExports(basePath);
+    const mappingKey = `.${expansion}`;
 
-    if (pkgExports != null) {
-      const mappingKey = `.${expansion}`;
-      const mapping = pkgExports[mappingKey];
-      if (typeof mapping === 'string') {
-        return fileURLToPath(new URL(mapping, `${pathToFileURL(basePath)}/`));
+    if (typeof pkgExports === 'object' && pkgExports !== null) {
+      if (mappingKey in pkgExports) {
+        const mapping = pkgExports[mappingKey];
+        return resolveExportsTarget(pathToFileURL(basePath + '/'), mapping, '',
+                                    basePath, mappingKey);
       }
 
       let dirMatch = '';
-      for (const [candidateKey, candidateValue] of Object.entries(pkgExports)) {
+      for (const candidateKey of Object.keys(pkgExports)) {
         if (candidateKey[candidateKey.length - 1] !== '/') continue;
-        if (candidateValue[candidateValue.length - 1] !== '/') continue;
         if (candidateKey.length > dirMatch.length &&
             StringPrototype.startsWith(mappingKey, candidateKey)) {
           dirMatch = candidateKey;
@@ -367,15 +367,13 @@ function resolveExports(nmPath, request, absoluteRequest) {
       }
 
       if (dirMatch !== '') {
-        const dirMapping = pkgExports[dirMatch];
-        const remainder = StringPrototype.slice(mappingKey, dirMatch.length);
-        const expectedPrefix =
-          new URL(dirMapping, `${pathToFileURL(basePath)}/`);
-        const resolved = new URL(remainder, expectedPrefix).href;
-        if (StringPrototype.startsWith(resolved, expectedPrefix.href)) {
-          return fileURLToPath(resolved);
-        }
+        const mapping = pkgExports[dirMatch];
+        const subpath = StringPrototype.slice(mappingKey, dirMatch.length);
+        return resolveExportsTarget(pathToFileURL(basePath + '/'), mapping,
+                                    subpath, basePath, mappingKey);
       }
+    }
+    if (pkgExports != null) {
       // eslint-disable-next-line no-restricted-syntax
       const e = new Error(`Package exports for '${basePath}' do not define ` +
           `a '${mappingKey}' subpath`);
@@ -385,6 +383,36 @@ function resolveExports(nmPath, request, absoluteRequest) {
   }
 
   return path.resolve(nmPath, request);
+}
+
+function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
+  if (typeof target === 'string') {
+    if (target.substr(0, 2) === './' &&
+        (subpath.length === 0 || target.endsWith('/'))) {
+      const resolvedTarget = new URL(target, pkgPath);
+      if (StringPrototype.startsWith(resolvedTarget.href, pkgPath.href)) {
+        const resolved = new URL(subpath, resolvedTarget);
+        if (StringPrototype.startsWith(resolved.href, pkgPath.href)) {
+          return fileURLToPath(resolved);
+        }
+      }
+    }
+  } else if (Array.isArray(target)) {
+    for (const targetValue of target) {
+      if (typeof targetValue !== 'string') continue;
+      try {
+        return resolveExportsTarget(pkgPath, targetValue, subpath, basePath,
+                                    mappingKey);
+      } catch (e) {
+        if (e.code !== 'MODULE_NOT_FOUND') throw e;
+      }
+    }
+  }
+  // eslint-disable-next-line no-restricted-syntax
+  const e = new Error(`Package exports for '${basePath}' do not define ` +
+      `a '${mappingKey}' subpath`);
+  e.code = 'MODULE_NOT_FOUND';
+  throw e;
 }
 
 Module._findPath = function(request, paths, isMain) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -24,6 +24,7 @@
 const {
   JSON,
   Object,
+  ObjectPrototype,
   Reflect,
   SafeMap,
   StringPrototype,
@@ -351,7 +352,7 @@ function resolveExports(nmPath, request, absoluteRequest) {
     const mappingKey = `.${expansion}`;
 
     if (typeof pkgExports === 'object' && pkgExports !== null) {
-      if (mappingKey in pkgExports) {
+      if (ObjectPrototype.hasOwnProperty(pkgExports, mappingKey)) {
         const mapping = pkgExports[mappingKey];
         return resolveExportsTarget(pathToFileURL(basePath + '/'), mapping, '',
                                     basePath, mappingKey);
@@ -387,7 +388,7 @@ function resolveExports(nmPath, request, absoluteRequest) {
 
 function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
   if (typeof target === 'string') {
-    if (target.substr(0, 2) === './' &&
+    if (target.startsWith('./') &&
         (subpath.length === 0 || target.endsWith('/'))) {
       const resolvedTarget = new URL(target, pkgPath);
       if (StringPrototype.startsWith(resolvedTarget.href, pkgPath.href)) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -398,7 +398,7 @@ function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
                                   pkgPathPath.length - 1) === -1) {
         const resolved = new URL(subpath, resolvedTarget);
         const resolvedPath = resolved.pathname;
-        if (StringPrototype.startsWith(resolvedPath, pkgPathPath) &&
+        if (StringPrototype.startsWith(resolvedPath, resolvedTargetPath) &&
             StringPrototype.indexOf(resolvedPath, '/node_modules/',
                                     pkgPathPath.length - 1) === -1) {
           return fileURLToPath(resolved);

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -391,9 +391,16 @@ function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
     if (target.startsWith('./') &&
         (subpath.length === 0 || target.endsWith('/'))) {
       const resolvedTarget = new URL(target, pkgPath);
-      if (StringPrototype.startsWith(resolvedTarget.href, pkgPath.href)) {
+      const pkgPathHref = pkgPath.href;
+      const resolvedTargetHref = resolvedTarget.href;
+      if (StringPrototype.startsWith(resolvedTargetHref, pkgPathHref) &&
+          StringPrototype.indexOf(resolvedTargetHref, '/node_modules/',
+          pkgPathHref.length - 1) === -1) {
         const resolved = new URL(subpath, resolvedTarget);
-        if (StringPrototype.startsWith(resolved.href, pkgPath.href)) {
+        const resolvedHref = resolved.href;
+        if (StringPrototype.startsWith(resolvedHref, pkgPathHref) &&
+            StringPrototype.indexOf(resolvedHref, '/node_modules/',
+            pkgPathHref.length - 1) === -1) {
           return fileURLToPath(resolved);
         }
       }

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -854,7 +854,7 @@ Maybe<URL> PackageExportsResolve(Environment* env,
   Local<String> subpath = String::NewFromUtf8(isolate,
       pkg_subpath.c_str(), v8::NewStringType::kNormal).ToLocalChecked();
 
-  if (exports_obj->Has(context, subpath).FromJust()) {
+  if (exports_obj->HasOwnProperty(context, subpath).FromJust()) {
     Local<Value> target = exports_obj->Get(context, subpath).ToLocalChecked();
     if (target->IsString()) {
       Utf8Value target_utf8(isolate, target.As<v8::String>());

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -876,7 +876,7 @@ Maybe<URL> ResolveExportsTarget(Environment* env,
   if (subpath.length() == 0) return Just(resolved);
   URL subpath_resolved(subpath, resolved);
   std::string subpath_resolved_path = subpath_resolved.path();
-  if (subpath_resolved_path.find(pkg_path) != 0 ||
+  if (subpath_resolved_path.find(resolved_path) != 0 ||
       subpath_resolved_path.find("/node_modules/", pkg_path.length() - 1)
       != std::string::npos) {
     if (throw_invalid) {

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -55,6 +55,8 @@ import { requireFixture, importFixture } from '../fixtures/pkgexports.mjs';
     // Missing / invalid fallbacks
     ['pkgexports/nofallback1', './nofallback1'],
     ['pkgexports/nofallback2', './nofallback2'],
+    // Reaching into nested node_modules
+    ['pkgexports/nodemodules', './nodemodules'],
   ]);
 
   for (const [specifier, subpath] of undefinedExports) {

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -36,6 +36,9 @@ import { requireFixture, importFixture } from '../fixtures/pkgexports.mjs';
     // The file exists but isn't exported. The exports is a number which counts
     // as a non-null value without any properties, just like `{}`.
     ['pkgexports-number/hidden.js', './hidden.js'],
+  ]);
+
+  const invalidExports = new Map([
     // Even though 'pkgexports/sub/asdf.js' works, alternate "path-like"
     // variants do not to prevent confusion and accidental loopholes.
     ['pkgexports/sub/./../asdf.js', './sub/./../asdf.js'],
@@ -64,6 +67,17 @@ import { requireFixture, importFixture } from '../fixtures/pkgexports.mjs';
       strictEqual(err.code, (isRequire ? '' : 'ERR_') + 'MODULE_NOT_FOUND');
       assertStartsWith(err.message, 'Package exports');
       assertIncludes(err.message, `do not define a '${subpath}' subpath`);
+    }));
+  }
+
+  for (const [specifier, subpath] of invalidExports) {
+    loadFixture(specifier).catch(mustCall((err) => {
+      strictEqual(err.code, (isRequire ? '' : 'ERR_') + 'MODULE_NOT_FOUND');
+      assertStartsWith(err.message, (isRequire ? 'Package exports' :
+        'Cannot resolve'));
+      assertIncludes(err.message, isRequire ?
+        `do not define a valid '${subpath}' subpath` :
+        `matched for '${subpath}'`);
     }));
   }
 

--- a/test/es-module/test-esm-scope-node-modules.mjs
+++ b/test/es-module/test-esm-scope-node-modules.mjs
@@ -1,0 +1,10 @@
+// Flags: --experimental-modules
+import '../common/index.mjs';
+import cjs from '../fixtures/baz.js';
+import { message } from '../fixtures/es-modules/message.mjs';
+import assert from 'assert';
+
+// Assert we loaded esm dependency as ".js" in this mode
+assert.strictEqual(message, 'A message');
+// Assert we loaded CommonJS dependency
+assert.strictEqual(cjs, 'perhaps I work');

--- a/test/fixtures/es-modules/package-type-module/index.js
+++ b/test/fixtures/es-modules/package-type-module/index.js
@@ -1,3 +1,4 @@
+import 'dep/dep.js';
 const identifier = 'package-type-module';
 console.log(identifier);
 export default identifier;

--- a/test/fixtures/es-modules/package-type-module/node_modules/dep/dep.js
+++ b/test/fixtures/es-modules/package-type-module/node_modules/dep/dep.js
@@ -1,0 +1,2 @@
+// No package.json -> should still be CommonJS as it is in node_modules
+module.exports = 42;

--- a/test/fixtures/node_modules/pkgexports/node_modules/internalpkg/x.js
+++ b/test/fixtures/node_modules/pkgexports/node_modules/internalpkg/x.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -15,6 +15,7 @@
     "./fallbackdir/": [[], null, {}, "builtin:x/", "./fallbackfile", "./"],
     "./fallbackfile": [[], null, {}, "builtin:x", "./asdf.js"],
     "./nofallback1": [],
-    "./nofallback2": [null, {}, "builtin:x"]
+    "./nofallback2": [null, {}, "builtin:x"],
+    "./nodemodules": "./node_modules/internalpkg/x.js"
   }
 }

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -3,6 +3,18 @@
     ".": "./asdf.js",
     "./space": "./sp%20ce.js",
     "./valid-cjs": "./asdf.js",
-    "./sub/": "./"
+    "./sub/": "./",
+    "./belowdir/": "../belowdir/",
+    "./belowfile": "../belowfile",
+    "./missingtrailer/": ".",
+    "./null": null,
+    "./invalid1": {},
+    "./invalid2": 1234,
+    "./invalid3": "",
+    "./invalid4": {},
+    "./fallbackdir/": [[], null, {}, "builtin:x/", "./fallbackfile", "./"],
+    "./fallbackfile": [[], null, {}, "builtin:x", "./asdf.js"],
+    "./nofallback1": [],
+    "./nofallback2": [null, {}, "builtin:x"]
   }
 }


### PR DESCRIPTION
This clarifies and specifies the package "exports" proposal validations roughly in a way similar to as specified for import maps (except slightly more restrictive - no URLs or backtracking).

The validations implemented are:

* Directory mappings must end in a trailing `/`
* Backtracking below the package base is not permitted
* If a user attempts to load a directory mapping below the package base, that is not permitted (`pkg/map/../../below`).
* Targets starting with `../` or `/` are not permitted
* Targets that are bare specifiers are not permitted
* Targets that are URLs are not permitted
* Targets cannot map into a `node_modules` path segment
* Directory mappings into `node_modules` segments are not permitted

Instead of throwing on array targets, a very simple version of fallback arrays is added to allow for forwards compatibility in future, behaving just like import maps where the first valid match of the array is selected, based on the validation rules above.

The implementation is provided for both CJS and ESM, with associated specification changes for both as well.

Along with banning `node_modules` segments for exports, for consistency an associated addition to the package scope lookup algorithm is provided to avoid checking package scope package.json lookups through any node_modules path segment.

In addition a test has been included for the use of `%2F` in exports targets and user paths.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
