### PR TITLE
events: give subclass name in unhandled 'error' message

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -136,7 +136,13 @@ function identicalSequenceRange(a, b) {
 }
 
 function enhanceStackTrace(err, own) {
-  const sep = '\nEmitted \'error\' event at:\n';
+  let ctorInfo = '';
+  try {
+    const { name } = this.constructor;
+    if (name !== 'EventEmitter')
+      ctorInfo = ` on ${name} instance`;
+  } catch {}
+  const sep = `\nEmitted 'error' event${ctorInfo} at:\n`;
 
   const errStack = err.stack.split('\n').slice(1);
   const ownStack = own.stack.split('\n').slice(1);
@@ -170,7 +176,7 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
         // eslint-disable-next-line no-restricted-syntax
         Error.captureStackTrace(capture, EventEmitter.prototype.emit);
         Object.defineProperty(er, kEnhanceStackBeforeInspector, {
-          value: enhanceStackTrace.bind(null, er, capture),
+          value: enhanceStackTrace.bind(this, er, capture),
           configurable: true
         });
       } catch {}

--- a/test/message/events_unhandled_error_subclass.js
+++ b/test/message/events_unhandled_error_subclass.js
@@ -1,0 +1,5 @@
+'use strict';
+require('../common');
+const EventEmitter = require('events');
+class Foo extends EventEmitter {}
+new Foo().emit('error', new Error());

--- a/test/message/events_unhandled_error_subclass.out
+++ b/test/message/events_unhandled_error_subclass.out
@@ -1,0 +1,17 @@
+events.js:*
+      throw er; // Unhandled 'error' event
+      ^
+
+Error
+    at Object.<anonymous> (*events_unhandled_error_subclass.js:*:*)
+    at Module._compile (internal/modules/cjs/loader.js:*:*)
+    at Object.Module._extensions..js (internal/modules/cjs/loader.js:*:*)
+    at Module.load (internal/modules/cjs/loader.js:*:*)
+    at Function.Module._load (internal/modules/cjs/loader.js:*:*)
+    at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
+    at internal/main/run_main_module.js:*:*
+Emitted 'error' event on Foo instance at:
+    at Object.<anonymous> (*events_unhandled_error_subclass.js:*:*)
+    at Module._compile (internal/modules/cjs/loader.js:*:*)
+    [... lines matching original stack trace ...]
+    at internal/main/run_main_module.js:*:*


### PR DESCRIPTION
For unhandled `'error'` events, include the constructor name for
subclasses of EventEmitter, if possible. This makes tracing errors
easier when both creation of the `Error` object and emitting it
happen in code that does not refer back to the event emitter.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
