### PR TITLE
doc: make unshift doc compliant with push doc

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1244,12 +1244,14 @@ changes:
     description: The `chunk` argument can now be a `Uint8Array` instance.
 -->
 
-* `chunk` {Buffer|Uint8Array|string|any} Chunk of data to unshift onto the
+* `chunk` {Buffer|Uint8Array|string|null|any} Chunk of data to unshift onto the
   read queue. For streams not operating in object mode, `chunk` must be a
   string, `Buffer` or `Uint8Array`. For object mode streams, `chunk` may be
   any JavaScript value other than `null`.
 * `encoding` {string} Encoding of string chunks. Must be a valid
   `Buffer` encoding, such as `'utf8'` or `'ascii'`.
+
+Passing chunk as null signals the end of the stream (EOF), after which no more data can be written.
 
 The `readable.unshift()` method pushes a chunk of data back into the internal
 buffer. This is useful in certain situations where a stream is being consumed by
@@ -2028,7 +2030,7 @@ changes:
 * `chunk` {Buffer|Uint8Array|string|null|any} Chunk of data to push into the
   read queue. For streams not operating in object mode, `chunk` must be a
   string, `Buffer` or `Uint8Array`. For object mode streams, `chunk` may be
-  any JavaScript value.
+  any JavaScript value other than `null`..
 * `encoding` {string} Encoding of string chunks. Must be a valid
   `Buffer` encoding, such as `'utf8'` or `'ascii'`.
 * Returns: {boolean} `true` if additional chunks of data may continue to be

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1251,7 +1251,7 @@ changes:
 * `encoding` {string} Encoding of string chunks. Must be a valid
   `Buffer` encoding, such as `'utf8'` or `'ascii'`.
 
-Passing chunk as null signals the end of the stream (EOF), after which no more data can be written.
+Passing `chunk` as `null` signals the end of the stream (EOF), after which no more data can be written.
 
 The `readable.unshift()` method pushes a chunk of data back into the internal
 buffer. This is useful in certain situations where a stream is being consumed by

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1246,12 +1246,13 @@ changes:
 
 * `chunk` {Buffer|Uint8Array|string|null|any} Chunk of data to unshift onto the
   read queue. For streams not operating in object mode, `chunk` must be a
-  string, `Buffer` or `Uint8Array`. For object mode streams, `chunk` may be
-  any JavaScript value other than `null`.
+  string, `Buffer`, `Uint8Array` or `null`. For object mode streams, `chunk`
+  may be any JavaScript value.
 * `encoding` {string} Encoding of string chunks. Must be a valid
   `Buffer` encoding, such as `'utf8'` or `'ascii'`.
 
-Passing `chunk` as `null` signals the end of the stream (EOF), after which no more data can be written.
+Passing `chunk` as `null` signals the end of the stream (EOF), after which no
+more data can be written.
 
 The `readable.unshift()` method pushes a chunk of data back into the internal
 buffer. This is useful in certain situations where a stream is being consumed by
@@ -2030,7 +2031,7 @@ changes:
 * `chunk` {Buffer|Uint8Array|string|null|any} Chunk of data to push into the
   read queue. For streams not operating in object mode, `chunk` must be a
   string, `Buffer` or `Uint8Array`. For object mode streams, `chunk` may be
-  any JavaScript value other than `null`..
+  any JavaScript value.
 * `encoding` {string} Encoding of string chunks. Must be a valid
   `Buffer` encoding, such as `'utf8'` or `'ascii'`.
 * Returns: {boolean} `true` if additional chunks of data may continue to be


### PR DESCRIPTION
As `readable.unshift()` share implementation with `readable.push()` it makes sense to make the doc similar.

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/
