### PR TITLE
util: improve debuglog performance

### DIFF
--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -33,7 +33,7 @@ function emitWarningIfNeeded(set) {
 
 function debuglogImpl(set) {
   set = set.toUpperCase();
-  if (!debugs[set]) {
+  if (debugs[set] === undefined) {
     if (debugEnvRegex.test(set)) {
       const pid = process.pid;
       emitWarningIfNeeded(set);
@@ -42,7 +42,7 @@ function debuglogImpl(set) {
         process.stderr.write(format('%s %d: %s\n', set, pid, msg));
       };
     } else {
-      debugs[set] = function debug() {};
+      debugs[set] = null;
     }
   }
   return debugs[set];
@@ -55,12 +55,13 @@ function debuglogImpl(set) {
 function debuglog(set) {
   let debug;
   return function(...args) {
-    if (!debug) {
+    if (debug === undefined) {
       // Only invokes debuglogImpl() when the debug function is
       // called for the first time.
       debug = debuglogImpl(set);
     }
-    debug(...args);
+    if (debug !== null)
+      debug(...args);
   };
 }
 


### PR DESCRIPTION
Sample results:

```
 streams/pipe-object-mode.js n=5000000                        ***     14.74 %       ±1.49% ±1.99%  ±2.60%
 streams/pipe.js n=5000000                                    ***     14.54 %       ±2.10% ±2.79%  ±3.64%
 streams/readable-bigread.js n=1000                           ***      7.85 %       ±1.15% ±1.53%  ±1.99%
 streams/readable-boundaryread.js type='buffer' n=2000        ***     28.70 %       ±1.95% ±2.60%  ±3.40%
 streams/readable-boundaryread.js type='string' n=2000        ***      6.98 %       ±1.55% ±2.07%  ±2.70%
 streams/readable-readall.js n=5000                           ***      7.49 %       ±1.61% ±2.14%  ±2.79%
 streams/readable-unevenread.js n=1000                        ***      9.55 %       ±1.41% ±1.87%  ±2.44%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
