### PR TITLE
fs: fix broken esm

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -345,6 +345,10 @@ function Stats(dev, mode, nlink, uid, gid, rdev, blksize,
 Object.setPrototypeOf(Stats.prototype, StatsBase.prototype);
 Object.setPrototypeOf(Stats, StatsBase);
 
+// HACK: Workaround for https://github.com/standard-things/esm/issues/821.
+// TODO(ronag): Remove this as soon as `esm` publishes a fixed version.
+Stats.prototype.isFile = StatsBase.prototype.isFile;
+
 Stats.prototype._checkModeProperty = function(property) {
   if (isWindows && (property === S_IFIFO || property === S_IFBLK ||
     property === S_IFSOCK)) {


### PR DESCRIPTION
Tries to fix blocked CITGM. See, https://github.com/standard-things/esm/issues/821.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
