### PR TITLE
benchmark swap var for let refactor in for loops

### DIFF
--- a/benchmark/module/module-loader-deep.js
+++ b/benchmark/module/module-loader-deep.js
@@ -19,7 +19,7 @@ function main({ ext, cache, files }) {
     `${benchmarkDirectory}/a.js`,
     'module.exports = {};'
   );
-  for (var i = 0; i <= files; i++) {
+  for (let i = 0; i <= files; i++) {
     fs.mkdirSync(`${benchmarkDirectory}/${i}`);
     fs.writeFileSync(
       `${benchmarkDirectory}/${i}/package.json`,

--- a/benchmark/module/module-loader.js
+++ b/benchmark/module/module-loader.js
@@ -21,7 +21,7 @@ const bench = common.createBenchmark(main, {
 function main({ n, name, cache, files, dir }) {
   tmpdir.refresh();
   fs.mkdirSync(benchmarkDirectory);
-  for (var i = 0; i <= files; i++) {
+  for (let i = 0; i <= files; i++) {
     fs.mkdirSync(`${benchmarkDirectory}${i}`);
     fs.writeFileSync(
       `${benchmarkDirectory}${i}/package.json`,

--- a/benchmark/os/cpus.js
+++ b/benchmark/os/cpus.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n }) {
   bench.start();
-  for (var i = 0; i < n; ++i)
+  for (let i = 0; i < n; ++i)
     cpus();
   bench.end(n);
 }

--- a/benchmark/os/loadavg.js
+++ b/benchmark/os/loadavg.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n }) {
   bench.start();
-  for (var i = 0; i < n; ++i)
+  for (let i = 0; i < n; ++i)
     loadavg();
   bench.end(n);
 }

--- a/benchmark/os/networkInterfaces.js
+++ b/benchmark/os/networkInterfaces.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n }) {
   bench.start();
-  for (var i = 0; i < n; ++i)
+  for (let i = 0; i < n; ++i)
     networkInterfaces();
   bench.end(n);
 }

--- a/benchmark/path/basename-posix.js
+++ b/benchmark/path/basename-posix.js
@@ -27,7 +27,7 @@ function main({ n, pathext }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     posix.basename(i % 3 === 0 ? `${pathext}${i}` : pathext, ext);
   }
   bench.end(n);

--- a/benchmark/path/basename-win32.js
+++ b/benchmark/path/basename-win32.js
@@ -27,7 +27,7 @@ function main({ n, pathext }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     win32.basename(i % 3 === 0 ? `${pathext}${i}` : pathext, ext);
   }
   bench.end(n);

--- a/benchmark/path/dirname-posix.js
+++ b/benchmark/path/dirname-posix.js
@@ -17,7 +17,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     posix.dirname(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/dirname-win32.js
+++ b/benchmark/path/dirname-win32.js
@@ -17,7 +17,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     win32.dirname(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/extname-posix.js
+++ b/benchmark/path/extname-posix.js
@@ -20,7 +20,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     posix.extname(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/extname-win32.js
+++ b/benchmark/path/extname-win32.js
@@ -20,7 +20,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     win32.extname(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/format-posix.js
+++ b/benchmark/path/format-posix.js
@@ -20,7 +20,7 @@ function main({ n, props }) {
   };
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     obj.base = `a${i}${props[2] || ''}`;
     obj.name = `a${i}${props[4] || ''}`;
     posix.format(obj);

--- a/benchmark/path/format-win32.js
+++ b/benchmark/path/format-win32.js
@@ -20,7 +20,7 @@ function main({ n, props }) {
   };
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     obj.base = `a${i}${props[2] || ''}`;
     obj.name = `a${i}${props[4] || ''}`;
     win32.format(obj);

--- a/benchmark/path/isAbsolute-posix.js
+++ b/benchmark/path/isAbsolute-posix.js
@@ -15,7 +15,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     posix.isAbsolute(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/isAbsolute-win32.js
+++ b/benchmark/path/isAbsolute-win32.js
@@ -16,7 +16,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     win32.isAbsolute(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/join-posix.js
+++ b/benchmark/path/join-posix.js
@@ -15,7 +15,7 @@ function main({ n, paths }) {
   const orig = copy[1];
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 3 === 0) {
       copy[1] = `${orig}${i}`;
       posix.join(...copy);

--- a/benchmark/path/join-win32.js
+++ b/benchmark/path/join-win32.js
@@ -15,7 +15,7 @@ function main({ n, paths }) {
   const orig = copy[1];
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 3 === 0) {
       copy[1] = `${orig}${i}`;
       win32.join(...copy);

--- a/benchmark/path/makeLong-win32.js
+++ b/benchmark/path/makeLong-win32.js
@@ -14,7 +14,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     win32._makeLong(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/normalize-posix.js
+++ b/benchmark/path/normalize-posix.js
@@ -16,7 +16,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     posix.normalize(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/normalize-win32.js
+++ b/benchmark/path/normalize-win32.js
@@ -16,7 +16,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     win32.normalize(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/resolve-posix.js
+++ b/benchmark/path/resolve-posix.js
@@ -18,7 +18,7 @@ function main({ n, paths }) {
   const orig = copy[0];
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 3 === 0) {
       copy[0] = `${orig}${i}`;
       posix.resolve(...copy);

--- a/benchmark/path/resolve-win32.js
+++ b/benchmark/path/resolve-win32.js
@@ -18,7 +18,7 @@ function main({ n, paths }) {
   const orig = copy[0];
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 3 === 0) {
       copy[0] = `${orig}${i}`;
       win32.resolve(...copy);

--- a/benchmark/process/memoryUsage.js
+++ b/benchmark/process/memoryUsage.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     process.memoryUsage();
   }
   bench.end(n);

--- a/benchmark/process/next-tick-breadth-args.js
+++ b/benchmark/process/next-tick-breadth-args.js
@@ -33,7 +33,7 @@ function main({ n }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 4 === 0)
       process.nextTick(cb4, 3.14, 1024, true, false);
     else if (i % 3 === 0)

--- a/benchmark/process/next-tick-breadth.js
+++ b/benchmark/process/next-tick-breadth.js
@@ -15,7 +15,7 @@ function main({ n }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     process.nextTick(cb);
   }
 }

--- a/benchmark/process/next-tick-exec-args.js
+++ b/benchmark/process/next-tick-exec-args.js
@@ -10,7 +10,7 @@ function main({ n }) {
       bench.end(n);
   }
 
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 4 === 0)
       process.nextTick(onNextTick, i, true, 10, 'test');
     else if (i % 3 === 0)

--- a/benchmark/process/next-tick-exec.js
+++ b/benchmark/process/next-tick-exec.js
@@ -10,7 +10,7 @@ function main({ n }) {
       bench.end(n);
   }
 
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     process.nextTick(onNextTick, i);
   }
 

--- a/benchmark/process/queue-microtask-breadth.js
+++ b/benchmark/process/queue-microtask-breadth.js
@@ -15,7 +15,7 @@ function main({ n }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     queueMicrotask(cb);
   }
 }

--- a/benchmark/querystring/querystring-stringify.js
+++ b/benchmark/querystring/querystring-stringify.js
@@ -38,7 +38,7 @@ function main({ type, n }) {
     querystring.stringify(inputs[name]);
 
   bench.start();
-  for (var i = 0; i < n; i += 1)
+  for (let i = 0; i < n; i += 1)
     querystring.stringify(input);
   bench.end(n);
 }

--- a/benchmark/querystring/querystring-unescapebuffer.js
+++ b/benchmark/querystring/querystring-unescapebuffer.js
@@ -14,7 +14,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ input, n }) {
   bench.start();
-  for (var i = 0; i < n; i += 1)
+  for (let i = 0; i < n; i += 1)
     querystring.unescapeBuffer(input);
   bench.end(n);
 }

--- a/benchmark/string_decoder/string-decoder-create.js
+++ b/benchmark/string_decoder/string-decoder-create.js
@@ -11,7 +11,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ encoding, n }) {
   bench.start();
-  for (var i = 0; i < n; ++i) {
+  for (let i = 0; i < n; ++i) {
     const sd = new StringDecoder(encoding);
     !!sd.encoding;
   }

--- a/benchmark/timers/immediate.js
+++ b/benchmark/timers/immediate.js
@@ -66,7 +66,7 @@ function breadth(N) {
     if (n === N)
       bench.end(N);
   }
-  for (var i = 0; i < N; i++) {
+  for (let i = 0; i < N; i++) {
     setImmediate(cb);
   }
 }
@@ -80,7 +80,7 @@ function breadth1(N) {
     if (n === N)
       bench.end(n);
   }
-  for (var i = 0; i < N; i++) {
+  for (let i = 0; i < N; i++) {
     setImmediate(cb, 1);
   }
 }
@@ -95,7 +95,7 @@ function breadth4(N) {
     if (n === N)
       bench.end(n);
   }
-  for (var i = 0; i < N; i++) {
+  for (let i = 0; i < N; i++) {
     setImmediate(cb, 1, 2, 3, 4);
   }
 }
@@ -107,7 +107,7 @@ function clear(N) {
     if (a1 === 2)
       bench.end(N);
   }
-  for (var i = 0; i < N; i++) {
+  for (let i = 0; i < N; i++) {
     clearImmediate(setImmediate(cb, 1));
   }
   setImmediate(cb, 2);

--- a/benchmark/timers/timers-breadth-args.js
+++ b/benchmark/timers/timers-breadth-args.js
@@ -32,7 +32,7 @@ function main({ n }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 4 === 0)
       setTimeout(cb4, 1, 3.14, 1024, true, false);
     else if (i % 3 === 0)

--- a/benchmark/timers/timers-breadth.js
+++ b/benchmark/timers/timers-breadth.js
@@ -13,7 +13,7 @@ function main({ n }) {
     if (j === n)
       bench.end(n);
   }
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     setTimeout(cb, 1);
   }
 }

--- a/benchmark/timers/timers-cancel-pooled.js
+++ b/benchmark/timers/timers-cancel-pooled.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
 function main({ n }) {
 
   var timer = setTimeout(() => {}, 1);
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     setTimeout(cb, 1);
   }
   var next = timer._idlePrev;
@@ -17,7 +17,7 @@ function main({ n }) {
 
   bench.start();
 
-  for (var j = 0; j < n; j++) {
+  for (let j = 0; j < n; j++) {
     timer = next;
     next = timer._idlePrev;
     clearTimeout(timer);

--- a/benchmark/timers/timers-cancel-unpooled.js
+++ b/benchmark/timers/timers-cancel-unpooled.js
@@ -10,7 +10,7 @@ const bench = common.createBenchmark(main, {
 function main({ n, direction }) {
 
   const timersList = [];
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     timersList.push(setTimeout(cb, i + 1));
   }
 

--- a/benchmark/timers/timers-insert-pooled.js
+++ b/benchmark/timers/timers-insert-pooled.js
@@ -9,7 +9,7 @@ function main({ n }) {
 
   bench.start();
 
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     setTimeout(() => {}, 1);
   }
 

--- a/benchmark/timers/timers-insert-unpooled.js
+++ b/benchmark/timers/timers-insert-unpooled.js
@@ -23,7 +23,7 @@ function main({ direction, n }) {
   }
   bench.end(n);
 
-  for (var j = 0; j < n; j++) {
+  for (let j = 0; j < n; j++) {
     clearTimeout(timersList[j]);
   }
 }

--- a/benchmark/timers/timers-timeout-nexttick.js
+++ b/benchmark/timers/timers-timeout-nexttick.js
@@ -30,7 +30,7 @@ function main({ n }) {
       bench.end(n);
   }
 
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     setTimeout(i % 2 ? cb : cb2, 1);
   }
 

--- a/benchmark/timers/timers-timeout-pooled.js
+++ b/benchmark/timers/timers-timeout-pooled.js
@@ -27,7 +27,7 @@ function main({ n }) {
       bench.end(n);
   }
 
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     setTimeout(i % 2 ? cb : cb2, 1);
   }
 

--- a/benchmark/timers/timers-timeout-unpooled.js
+++ b/benchmark/timers/timers-timeout-unpooled.js
@@ -27,7 +27,7 @@ function main({ n }) {
       bench.end(n);
   }
 
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     // unref().ref() will cause each of these timers to
     // allocate their own handle
     setTimeout(i % 2 ? cb : cb2, 1).unref().ref();

--- a/benchmark/tls/convertprotocols.js
+++ b/benchmark/tls/convertprotocols.js
@@ -16,7 +16,7 @@ function main({ n }) {
     m = {};
   }
   bench.start();
-  for (var i = 0; i < n; i++)
+  for (let i = 0; i < n; i++)
     tls.convertALPNProtocols(input, m);
   bench.end(n);
 }

--- a/benchmark/tls/tls-connect.js
+++ b/benchmark/tls/tls-connect.js
@@ -31,7 +31,7 @@ function main(conf) {
 function onListening() {
   setTimeout(done, dur * 1000);
   bench.start();
-  for (var i = 0; i < concurrency; i++)
+  for (let i = 0; i < concurrency; i++)
     makeConnection();
 }
 

--- a/benchmark/v8/get-stats.js
+++ b/benchmark/v8/get-stats.js
@@ -13,7 +13,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ method, n }) {
   bench.start();
-  for (var i = 0; i < n; i++)
+  for (let i = 0; i < n; i++)
     v8[method]();
   bench.end(n);
 }

--- a/benchmark/vm/run-in-context.js
+++ b/benchmark/vm/run-in-context.js
@@ -20,7 +20,7 @@ function main({ n, breakOnSigint, withSigintListener }) {
   const contextifiedSandbox = vm.createContext();
 
   bench.start();
-  for (var i = 0; i < n; i++)
+  for (let i = 0; i < n; i++)
     vm.runInContext('0', contextifiedSandbox, options);
   bench.end(n);
 }

--- a/benchmark/vm/run-in-this-context.js
+++ b/benchmark/vm/run-in-this-context.js
@@ -18,7 +18,7 @@ function main({ n, breakOnSigint, withSigintListener }) {
     process.on('SIGINT', () => {});
 
   bench.start();
-  for (var i = 0; i < n; i++)
+  for (let i = 0; i < n; i++)
     vm.runInThisContext('0', options);
   bench.end(n);
 }

--- a/benchmark/worker/echo.js
+++ b/benchmark/worker/echo.js
@@ -32,7 +32,7 @@ function main({ n, workers, sendsPerBroadcast: sends, payload: payloadType }) {
 
   const workerObjs = [];
 
-  for (var i = 0; i < workers; ++i) {
+  for (let i = 0; i < workers; ++i) {
     const worker = new Worker(workerPath);
     workerObjs.push(worker);
     worker.on('online', onOnline);


### PR DESCRIPTION
In `benchmark` directories this changes for loops using `var` to `let`
when it applies for consistency. So it finishes what started on #28867 

The list of files below remain using `var` in the nested `for` loops, rest which is the majority use `let` now for consistency.


```
$ grep -l 'for (var' benchmark/*/*.js
benchmark/buffers/buffer-fill.js
benchmark/buffers/buffer-iterate.js
benchmark/buffers/buffer-swap.js
benchmark/cluster/echo.js
benchmark/es/foreach-bench.js
benchmark/events/ee-add-remove.js
benchmark/fs/read-stream-throughput.js
benchmark/misc/freelist.js
benchmark/module/module-loader.js
benchmark/streams/readable-bigread.js
benchmark/streams/readable-bigunevenread.js
benchmark/streams/readable-boundaryread.js
benchmark/streams/readable-readall.js
benchmark/streams/readable-unevenread.js
benchmark/string_decoder/string-decoder.js
benchmark/util/normalize-encoding.js
benchmark/worker/echo.js
```

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
