### PR TITLE
Refine package name validations in esm resolver

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -700,6 +700,8 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >       1. Throw an _Invalid Specifier_ error.
 >    1. Set _packageName_ to the substring of _packageSpecifier_
 >       until the second _"/"_ separator or the end of the string.
+> 1. If _packageName_ starts with _"."_ or contains _"\\"_ or _"%"_, then
+>    1. Throw an _Invalid Specifier_ error.
 > 1. Let _packageSubpath_ be the substring of _packageSpecifier_ from the
 >    position at the length of _packageName_ plus one, if any.
 > 1. Assert: _packageName_ is a valid package name or scoped package name.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -702,15 +702,15 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >       until the second _"/"_ separator or the end of the string.
 > 1. If _packageName_ starts with _"."_ or contains _"\\"_ or _"%"_, then
 >    1. Throw an _Invalid Specifier_ error.
-> 1. Let _packageSubpath_ be the substring of _packageSpecifier_ from the
->    position at the length of _packageName_ plus one, if any.
-> 1. Assert: _packageName_ is a valid package name or scoped package name.
-> 1. Assert: _packageSubpath_ is either empty, or a path without a leading
->    separator.
+> 1. Let _packageSubpath_ be _undefined_.
+> 1. If the length of _packageSpecifier_ is greater than the length of
+>    _packageName_, then
+>    1. Set _packageSubpath_ to _"."_ concatenated with the substring of
+>       _packageSpecifier_ from the position at the length of _packageName_.
 > 1. If _packageSubpath_ contains any _"."_ or _".."_ segments or percent
 >    encoded strings for _"/"_ or _"\\"_ then,
 >    1. Throw an _Invalid Specifier_ error.
-> 1. If _packageSubpath_ is empty and _packageName_ is a Node.js builtin
+> 1. If _packageSubpath_ is _undefined_ and _packageName_ is a Node.js builtin
 >    module, then
 >    1. Return the string _"node:"_ concatenated with _packageSpecifier_.
 > 1. While _parentURL_ is not the file system root,
@@ -721,7 +721,7 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >       1. Set _parentURL_ to the parent URL path of _parentURL_.
 >       1. Continue the next loop iteration.
 >    1. Let _pjson_ be the result of **READ_PACKAGE_JSON**(_packageURL_).
->    1. If _packageSubpath_ is empty, then
+>    1. If _packageSubpath_ is _undefined__, then
 >       1. Return the result of **PACKAGE_MAIN_RESOLVE**(_packageURL_,
 >          _pjson_).
 >    1. Otherwise,
@@ -729,8 +729,8 @@ _isMain_ is **true** when resolving the Node.js application entry point.
 >          1. Let _exports_ be _pjson.exports_.
 >          1. If _exports_ is not **null** or **undefined**, then
 >             1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_,
->                _packagePath_, _pjson.exports_).
->       1. Return the URL resolution of _packagePath_ in _packageURL_.
+>                _packageSubpath_, _pjson.exports_).
+>       1. Return the URL resolution of _packageSubpath_ in _packageURL_.
 > 1. Throw a _Module Not Found_ error.
 
 **PACKAGE_MAIN_RESOLVE**(_packageURL_, _pjson_)

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -336,7 +336,7 @@ function findLongestRegisteredExtension(filename) {
 // This only applies to requests of a specific form:
 // 1. name/.*
 // 2. @scope/name/.*
-const EXPORTS_PATTERN = /^((?:@[^./@\\][^/@\\]*\/)?[^@./\\][^/\\]*)(\/.*)$/;
+const EXPORTS_PATTERN = /^((?:@[^@/\\%][^@/\\%]*\/)?[^@/\\%]+)(\/.*)$/;
 function resolveExports(nmPath, request, absoluteRequest) {
   // The implementation's behavior is meant to mirror resolution in ESM.
   if (experimentalExports && !absoluteRequest) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -336,7 +336,7 @@ function findLongestRegisteredExtension(filename) {
 // This only applies to requests of a specific form:
 // 1. name/.*
 // 2. @scope/name/.*
-const EXPORTS_PATTERN = /^((?:@[^@/\\%][^@/\\%]*\/)?[^@/\\%]+)(\/.*)$/;
+const EXPORTS_PATTERN = /^((?:@[^/\\%]+\/)?[^./\\%][^/\\%]*)(\/.*)$/;
 function resolveExports(nmPath, request, absoluteRequest) {
   // The implementation's behavior is meant to mirror resolution in ESM.
   if (experimentalExports && !absoluteRequest) {

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -876,10 +876,12 @@ Maybe<URL> PackageResolve(Environment* env,
     } else {
       sep_index = specifier.find('/', sep_index + 1);
     }
+  } else if (specifier[0] == '.') {
+    valid_package_name = false;
   }
   std::string pkg_name = specifier.substr(0,
       sep_index == std::string::npos ? std::string::npos : sep_index);
-  // Package name can only have leading @, and cannot have percent-encoding or
+  // Package name cannot have leading . and cannot have percent-encoding or
   // separators.
   for (size_t i = 0; i < pkg_name.length(); i++) {
     char c = pkg_name[i];

--- a/test/es-module/test-esm-pkgname.mjs
+++ b/test/es-module/test-esm-pkgname.mjs
@@ -1,0 +1,18 @@
+// Flags: --experimental-modules
+
+import { mustCall } from '../common/index.mjs';
+import { strictEqual } from 'assert';
+
+import { importFixture } from '../fixtures/pkgexports.mjs';
+
+importFixture('as%2Ff').catch(mustCall((err) => {
+  strictEqual(err.code, 'ERR_INVALID_MODULE_SPECIFIER');
+}));
+
+importFixture('as\\df').catch(mustCall((err) => {
+  strictEqual(err.code, 'ERR_INVALID_MODULE_SPECIFIER');
+}));
+
+importFixture('@as@df').catch(mustCall((err) => {
+  strictEqual(err.code, 'ERR_INVALID_MODULE_SPECIFIER');
+}));


### PR DESCRIPTION
This ensures that the way package name parsing is done in the ESM resolver is consistent and well-defined based on the rules:

1. Package name must start with @ and contain a separator, or not start with @ and contain no separator.
2. Package names cannot contain percent encodings
3. Package names cannot contain backslashes
4. Package names cannot start with .

This also gives us consistency when dealing with package names between the CJS and ESM exports handling.

Effectively we can then think of `import 'x/y'` as having the package name only being allowed to exist as a valid package name, while the `./y` component can in theory exist in URL space with percent encodings support.

If package names want to contain non-standard characters then they must be valid file paths, and not URL percent-encoded.

npm already restricts package names effectively to `/^(@[-a-zA-Z\d][-_\.a-zA-Z\d]*\/)?[-a-zA-Z\d][-_\.a-zA-Z\d]*/$`, so that this is still a pretty unrestricted validation, the main thing is to avoid odd edge cases with things like percent-encoded backtracking.

An alternative here could just be to disallow the percent encodings of `/` and `\\` explicitly, instead of all percent encodings, which I'd be open to as well.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
