### PR TITLE
stream: writableComplete

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -725,6 +725,18 @@ Object.defineProperty(Writable.prototype, 'writableFinished', {
   }
 });
 
+Object.defineProperty(Writable.prototype, 'writableComplete', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get() {
+    return !this._writableState ||
+      this._writableState.ending ||
+      this._writableState.destroyed;
+  }
+});
+
 Writable.prototype.destroy = destroyImpl.destroy;
 Writable.prototype._undestroy = destroyImpl.undestroy;
 Writable.prototype._destroy = function(err, cb) {


### PR DESCRIPTION
This is just a suggestion. Would like to see if there is any traction behind it. 

It is quite common (at least in http and middleware) to check whether any further useful work can be performed on a writable stream. This is a bit similar to `onFinished.isFinished`.

We also already have it here: https://github.com/nodejs/node/blob/master/lib/internal/http2/compat.js#L304

Replaces https://github.com/nodejs/node/pull/28628

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)