### PR TITLE
stream: buffer-list encapsulation

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -337,16 +337,15 @@ Readable.prototype.setEncoding = function(enc) {
   // If setEncoding(null), decoder.encoding equals utf8
   this._readableState.encoding = this._readableState.decoder.encoding;
 
+  const buffer = this._readableState.buffer;
   // Iterate over current buffer to convert already stored Buffers:
-  let p = this._readableState.buffer.head;
   let content = '';
-  while (p !== null) {
-    content += decoder.write(p.data);
-    p = p.next;
+  for (const data of buffer) {
+    content += decoder.write(data);
   }
-  this._readableState.buffer.clear();
+  buffer.clear();
   if (content !== '')
-    this._readableState.buffer.push(content);
+    buffer.push(content);
   this._readableState.length = content.length;
   return this;
 };
@@ -380,7 +379,7 @@ function howMuchToRead(n, state) {
   if (Number.isNaN(n)) {
     // Only flow one buffer at a time
     if (state.flowing && state.length)
-      return state.buffer.head.data.length;
+      return state.buffer.first().length;
     else
       return state.length;
   }

--- a/lib/internal/streams/buffer_list.js
+++ b/lib/internal/streams/buffer_list.js
@@ -90,6 +90,12 @@ module.exports = class BufferList {
     return this.head.data;
   }
 
+  *[Symbol.iterator]() {
+    for (let p = this.head; p; p = p.next) {
+      yield p.data;
+    }
+  }
+
   // Consumes a specified amount of characters from the buffered data.
   _getString(n) {
     var p = this.head;

--- a/test/parallel/test-stream-buffer-list.js
+++ b/test/parallel/test-stream-buffer-list.js
@@ -16,11 +16,28 @@ assert.deepStrictEqual(emptyList.concat(0), Buffer.alloc(0));
 
 const buf = Buffer.from('foo');
 
+function testIterator(list, count) {
+  // test iterator
+  let len = 0;
+  // eslint-disable-next-line no-unused-vars
+  for (const x of list) {
+    len++;
+  }
+  assert.strictEqual(len, count);
+}
+
 // Test buffer list with one element.
 const list = new BufferList();
+testIterator(list, 0);
+
 list.push(buf);
+testIterator(list, 1);
+for (const x of list) {
+  assert.strictEqual(x, buf);
+}
 
 const copy = list.concat(3);
+testIterator(copy, 3);
 
 assert.notStrictEqual(copy, buf);
 assert.deepStrictEqual(copy, buf);
@@ -28,5 +45,6 @@ assert.deepStrictEqual(copy, buf);
 assert.strictEqual(list.join(','), 'foo');
 
 const shifted = list.shift();
+testIterator(list, 0);
 assert.strictEqual(shifted, buf);
 assert.deepStrictEqual(list, new BufferList());


### PR DESCRIPTION
Only use public API on buffer list to improve encapsulation and make it easier to experiment with alternative implementations.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
