### PR TITLE
stream: uncorking a not corked stream should error

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1703,6 +1703,11 @@ An attempt was made to call [`stream.pipe()`][] on a [`Writable`][] stream.
 A stream method was called that cannot complete because the stream was
 destroyed using `stream.destroy()`.
 
+<a id="ERR_STREAM_NOT_CORKED"></a>
+### ERR_STREAM_NOT_CORKED
+
+Tried to uncork a not corked stream.
+
 <a id="ERR_STREAM_NULL_VALUES"></a>
 ### ERR_STREAM_NULL_VALUES
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -41,6 +41,7 @@ const {
   ERR_MULTIPLE_CALLBACK,
   ERR_STREAM_CANNOT_PIPE,
   ERR_STREAM_DESTROYED,
+  ERR_STREAM_NOT_CORKED,
   ERR_STREAM_NULL_VALUES,
   ERR_STREAM_WRITE_AFTER_END,
   ERR_UNKNOWN_ENCODING
@@ -312,15 +313,16 @@ Writable.prototype.cork = function() {
 Writable.prototype.uncork = function() {
   const state = this._writableState;
 
-  if (state.corked) {
-    state.corked--;
+  if (!state.corked)
+    throw new ERR_STREAM_NOT_CORKED();
 
-    if (!state.writing &&
-        !state.corked &&
-        !state.bufferProcessing &&
-        state.bufferedRequest)
-      clearBuffer(this, state);
-  }
+  state.corked--;
+
+  if (!state.corked &&
+      !state.writing &&
+      !state.bufferProcessing &&
+      state.bufferedRequest)
+    clearBuffer(this, state);
 };
 
 Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1130,6 +1130,7 @@ E('ERR_SRI_PARSE',
   SyntaxError);
 E('ERR_STREAM_CANNOT_PIPE', 'Cannot pipe, not readable', Error);
 E('ERR_STREAM_DESTROYED', 'Cannot call %s after a stream was destroyed', Error);
+E('ERR_STREAM_NOT_CORKED', 'Cannot call %s when not corked', Error);
 E('ERR_STREAM_NULL_VALUES', 'May not write null values to stream', TypeError);
 E('ERR_STREAM_PREMATURE_CLOSE', 'Premature close', Error);
 E('ERR_STREAM_PUSH_AFTER_EOF', 'stream.push() after EOF', Error);


### PR DESCRIPTION
Uncorking a not corked stream should be an error and not quietly swallowed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
