### PR TITLE
[v10.x] deps:openssl: cherry-pick c19c5a6 from upstream

### DIFF
--- a/deps/openssl/openssl/crypto/rand/rand_unix.c
+++ b/deps/openssl/openssl/crypto/rand/rand_unix.c
@@ -510,29 +510,6 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
     bytes_needed = rand_pool_bytes_needed(pool, 1 /*entropy_factor*/);
     {
         size_t i;
-#ifdef DEVRANDOM_WAIT
-        static int wait_done = 0;
-
-        /*
-         * On some implementations reading from /dev/urandom is possible
-         * before it is initialized. Therefore we wait for /dev/random
-         * to be readable to make sure /dev/urandom is initialized.
-         */
-        if (!wait_done && bytes_needed > 0) {
-             int f = open(DEVRANDOM_WAIT, O_RDONLY);
-
-             if (f >= 0) {
-                 fd_set fds;
-
-                 FD_ZERO(&fds);
-                 FD_SET(f, &fds);
-                 while (select(f+1, &fds, NULL, NULL, NULL) < 0
-                        && errno == EINTR);
-                 close(f);
-             }
-             wait_done = 1;
-        }
-#endif
 
         for (i = 0; bytes_needed > 0 && i < OSSL_NELEM(random_device_paths); i++) {
             ssize_t bytes = 0;

--- a/deps/openssl/openssl/e_os.h
+++ b/deps/openssl/openssl/e_os.h
@@ -28,9 +28,6 @@
  * default, we will try to read at least one of these files
  */
 #  define DEVRANDOM "/dev/urandom", "/dev/random", "/dev/hwrng", "/dev/srandom"
-#  ifdef __linux
-#   define DEVRANDOM_WAIT "/dev/random"
-#  endif
 # endif
 # if !defined(OPENSSL_NO_EGD) && !defined(DEVRANDOM_EGD)
 /*


### PR DESCRIPTION
Original commit message:

    Revert the DEVRANDOM_WAIT feature

    The DEVRANDOM_WAIT feature added a select() call to wait for the
    `/dev/random` device to become readable before reading from the
    `/dev/urandom` device. It was introduced in commit 38023b8
    in order to mitigate the fact that the `/dev/urandom` device
    does not block until the initial seeding of the kernel CSPRNG
    has completed, contrary to the behaviour of the `getrandom()`
    system call.

    It turned out that this change had negative side effects on the
    performance which were not acceptable. After some discussion it
    was decided to revert this feature and leave it up to the OS
    resp. the platform maintainer to ensure a proper initialization
    during early boot time.

    Fixes 9078

    This partially reverts commit 38023b8.

Refs: https://github.com/openssl/openssl/pull/9084
Fixes: https://github.com/nodejs/node/issues/28932

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
