### PR TITLE
benchmark: allow easy passing of process flags

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -25,6 +25,10 @@ function Benchmark(fn, configs, options) {
   if (options && options.flags) {
     this.flags = this.flags.concat(options.flags);
   }
+  if (process.env.NODE_BENCHMARK_FLAGS) {
+    const flags = process.env.NODE_BENCHMARK_FLAGS.split(/\s+/);
+    this.flags = this.flags.concat(flags);
+  }
   // Holds process.hrtime value
   this._time = [0, 0];
   // Used to make sure a benchmark only start a timer once


### PR DESCRIPTION
Without this, using `--prof` when running benchmarks also produces separate profiler output for the benchmark runner itself, which is generally not helpful. With this change, it's quick and easy to know which profiler output file to look at.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
