### PR TITLE
stream: improve read() performance more

### DIFF
--- a/lib/internal/streams/buffer_list.js
+++ b/lib/internal/streams/buffer_list.js
@@ -139,7 +139,10 @@ module.exports = class BufferList {
     while (p = p.next) {
       const buf = p.data;
       const nb = (n > buf.length ? buf.length : n);
-      buf.copy(ret, ret.length - n, 0, nb);
+      if (nb === buf.length)
+        ret.set(buf, ret.length - n);
+      else
+        ret.set(new Uint8Array(buf.buffer, buf.byteOffset, nb), ret.length - n);
       n -= nb;
       if (n === 0) {
         if (nb === buf.length) {


### PR DESCRIPTION
Results:

```
                                                        confidence improvement accuracy (*)    (**)   (***)
 streams/readable-bigread.js n=1000                           ***     43.35 %       ±2.61%  ±3.50%  ±4.61%
 streams/readable-bigunevenread.js n=1000                     ***     26.71 %       ±8.11% ±10.83% ±14.17%
 streams/readable-unevenread.js n=1000                        ***      3.42 %       ±1.13%  ±1.50%  ±1.96%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
