### PR TITLE
stream: stop reading after buffer is full

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1108,7 +1108,7 @@ function fromList(n, state) {
     else if (state.buffer.length === 1)
       ret = state.buffer.first();
     else
-      ret = state.buffer.concat(state.length);
+      ret = state.buffer.concat();
     state.buffer.clear();
   } else {
     // read part of list

--- a/lib/internal/streams/buffer_list.js
+++ b/lib/internal/streams/buffer_list.js
@@ -59,10 +59,10 @@ module.exports = class BufferList {
     return ret;
   }
 
-  concat(n) {
+  concat() {
     if (this.length === 0)
       return Buffer.alloc(0);
-    const ret = Buffer.allocUnsafe(n >>> 0);
+    const ret = Buffer.allocUnsafe(this.length >>> 0);
     var p = this.head;
     var i = 0;
     while (p) {
@@ -70,6 +70,7 @@ module.exports = class BufferList {
       i += p.data.length;
       p = p.next;
     }
+
     return ret;
   }
 


### PR DESCRIPTION
We should stop reading once the buffer is full.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
