### PR TITLE
doc: clarify async iterator leak

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2502,6 +2502,9 @@ and async iterators are provided below.
 })();
 ```
 
+Async iterators register a permanent error handler on the stream to prevent any
+unhandled post-destroy errors.
+
 #### Creating Readable Streams with Async Generators
 
 We can construct a Node.js Readable Stream from an asynchronous generator


### PR DESCRIPTION
Clarifies that creating multiple async iterators from the same stream can lead to event listener leak.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
