### PR TITLE
[v12.x] backport #27685

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -391,9 +391,6 @@ stream.write('With ES6');
 <!-- YAML
 added: v0.3.0
 changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/27685
-    description: Circular references now include a marker to the reference.
   - version: v12.0.0
     pr-url: https://github.com/nodejs/node/pull/27109
     description: The `compact` options default is changed to `3` and the
@@ -516,7 +513,7 @@ util.inspect(new Bar()); // 'Bar {}'
 util.inspect(baz);       // '[foo] {}'
 ```
 
-Circular references point to their anchor by using a reference index:
+Circular references are marked as `'[Circular]'`:
 
 ```js
 const { inspect } = require('util');
@@ -528,9 +525,9 @@ obj.b.inner = obj.b;
 obj.b.obj = obj;
 
 console.log(inspect(obj));
-// <ref *1> {
-//   a: [ [Circular *1] ],
-//   b: <ref *2> { inner: [Circular *2], obj: [Circular *1] }
+// {
+//   a: [ [Circular] ],
+//   b: { inner: [Circular], obj: [Circular] }
 // }
 ```
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -391,6 +391,9 @@ stream.write('With ES6');
 <!-- YAML
 added: v0.3.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/27685
+    description: Circular references now include a marker to the reference.
   - version: v12.0.0
     pr-url: https://github.com/nodejs/node/pull/27109
     description: The `compact` options default is changed to `3` and the
@@ -513,6 +516,24 @@ util.inspect(new Bar()); // 'Bar {}'
 util.inspect(baz);       // '[foo] {}'
 ```
 
+Circular references point to their anchor by using a reference index:
+
+```js
+const { inspect } = require('util');
+
+const obj = {};
+obj.a = [obj];
+obj.b = {};
+obj.b.inner = obj.b;
+obj.b.obj = obj;
+
+console.log(inspect(obj));
+// <ref *1> {
+//   a: [ [Circular *1] ],
+//   b: <ref *2> { inner: [Circular *2], obj: [Circular *1] }
+// }
+```
+
 The following example inspects all properties of the `util` object:
 
 ```js
@@ -535,8 +556,6 @@ const o = {
   b: new Map([['za', 1], ['zb', 'test']])
 };
 console.log(util.inspect(o, { compact: true, depth: 5, breakLength: 80 }));
-
-// This will print
 
 // { a:
 //   [ 1,

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -572,7 +572,7 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
         ctx.circular.set(value, index);
       }
     }
-    return ctx.stylize(`[Circular *${index}]`, 'special');
+    return ctx.stylize('[Circular]', 'special');
   }
 
   return formatRaw(ctx, value, recurseTimes, typedArray);
@@ -778,12 +778,11 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
   if (ctx.circular !== undefined) {
     const index = ctx.circular.get(value);
     if (index !== undefined) {
-      const reference = ctx.stylize(`<ref *${index}>`, 'special');
       // Add reference always to the very beginning of the output.
       if (ctx.compact !== true) {
-        base = base === '' ? reference : `${reference} ${base}`;
+        base = base === '' ? '' : `${base}`;
       } else {
-        braces[0] = `${reference} ${braces[0]}`;
+        braces[0] = `${braces[0]}`;
       }
     }
   }

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -561,8 +561,19 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
 
   // Using an array here is actually better for the average case than using
   // a Set. `seen` will only check for the depth and will never grow too large.
-  if (ctx.seen.includes(value))
-    return ctx.stylize('[Circular]', 'special');
+  if (ctx.seen.includes(value)) {
+    let index = 1;
+    if (ctx.circular === undefined) {
+      ctx.circular = new Map([[value, index]]);
+    } else {
+      index = ctx.circular.get(value);
+      if (index === undefined) {
+        index = ctx.circular.size + 1;
+        ctx.circular.set(value, index);
+      }
+    }
+    return ctx.stylize(`[Circular *${index}]`, 'special');
+  }
 
   return formatRaw(ctx, value, recurseTimes, typedArray);
 }
@@ -763,6 +774,18 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
   } catch (err) {
     const constructorName = getCtxStyle(value, constructor, tag).slice(0, -1);
     return handleMaxCallStackSize(ctx, err, constructorName, indentationLvl);
+  }
+  if (ctx.circular !== undefined) {
+    const index = ctx.circular.get(value);
+    if (index !== undefined) {
+      const reference = ctx.stylize(`<ref *${index}>`, 'special');
+      // Add reference always to the very beginning of the output.
+      if (ctx.compact !== true) {
+        base = base === '' ? reference : `${reference} ${base}`;
+      } else {
+        braces[0] = `${reference} ${braces[0]}`;
+      }
+    }
   }
   ctx.seen.pop();
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -342,7 +342,8 @@ testAssertionMessage(/abc/gim, '/abc/gim');
 testAssertionMessage({}, '{}');
 testAssertionMessage([1, 2, 3], '[\n+   1,\n+   2,\n+   3\n+ ]');
 testAssertionMessage(function f() {}, '[Function: f]');
-testAssertionMessage(circular, '{\n+   x: [Circular],\n+   y: 1\n+ }');
+testAssertionMessage(circular,
+                     '<ref *1> {\n+   x: [Circular *1],\n+   y: 1\n+ }');
 testAssertionMessage({ a: undefined, b: null },
                      '{\n+   a: undefined,\n+   b: null\n+ }');
 testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -343,7 +343,7 @@ testAssertionMessage({}, '{}');
 testAssertionMessage([1, 2, 3], '[\n+   1,\n+   2,\n+   3\n+ ]');
 testAssertionMessage(function f() {}, '[Function: f]');
 testAssertionMessage(circular,
-                     '<ref *1> {\n+   x: [Circular *1],\n+   y: 1\n+ }');
+                     '{\n+   x: [Circular],\n+   y: 1\n+ }');
 testAssertionMessage({ a: undefined, b: null },
                      '{\n+   a: undefined,\n+   b: null\n+ }');
 testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -195,10 +195,10 @@ assert.strictEqual(
   '{\n' +
   '  foo: \'bar\',\n' +
   '  foobar: 1,\n' +
-  '  func: [Function: func] {\n' +
+  '  func: <ref *1> [Function: func] {\n' +
   '    [length]: 0,\n' +
   '    [name]: \'func\',\n' +
-  '    [prototype]: func { [constructor]: [Circular] }\n' +
+  '    [prototype]: func { [constructor]: [Circular *1] }\n' +
   '  }\n' +
   '}');
 assert.strictEqual(
@@ -208,10 +208,10 @@ assert.strictEqual(
   '  foobar: 1,\n' +
   '  func: [\n' +
   '    {\n' +
-  '      a: [Function: a] {\n' +
+  '      a: <ref *1> [Function: a] {\n' +
   '        [length]: 0,\n' +
   '        [name]: \'a\',\n' +
-  '        [prototype]: a { [constructor]: [Circular] }\n' +
+  '        [prototype]: a { [constructor]: [Circular *1] }\n' +
   '      }\n' +
   '    },\n' +
   '    [length]: 1\n' +
@@ -223,10 +223,10 @@ assert.strictEqual(
   '  foo: \'bar\',\n' +
   '  foobar: {\n' +
   '    foo: \'bar\',\n' +
-  '    func: [Function: func] {\n' +
+  '    func: <ref *1> [Function: func] {\n' +
   '      [length]: 0,\n' +
   '      [name]: \'func\',\n' +
-  '      [prototype]: func { [constructor]: [Circular] }\n' +
+  '      [prototype]: func { [constructor]: [Circular *1] }\n' +
   '    }\n' +
   '  }\n' +
   '}');
@@ -235,18 +235,18 @@ assert.strictEqual(
   '{\n' +
   '  foo: \'bar\',\n' +
   '  foobar: 1,\n' +
-  '  func: [Function: func] {\n' +
+  '  func: <ref *1> [Function: func] {\n' +
   '    [length]: 0,\n' +
   '    [name]: \'func\',\n' +
-  '    [prototype]: func { [constructor]: [Circular] }\n' +
+  '    [prototype]: func { [constructor]: [Circular *1] }\n' +
   '  }\n' +
   '} {\n' +
   '  foo: \'bar\',\n' +
   '  foobar: 1,\n' +
-  '  func: [Function: func] {\n' +
+  '  func: <ref *1> [Function: func] {\n' +
   '    [length]: 0,\n' +
   '    [name]: \'func\',\n' +
-  '    [prototype]: func { [constructor]: [Circular] }\n' +
+  '    [prototype]: func { [constructor]: [Circular *1] }\n' +
   '  }\n' +
   '}');
 assert.strictEqual(
@@ -254,10 +254,10 @@ assert.strictEqual(
   '{\n' +
   '  foo: \'bar\',\n' +
   '  foobar: 1,\n' +
-  '  func: [Function: func] {\n' +
+  '  func: <ref *1> [Function: func] {\n' +
   '    [length]: 0,\n' +
   '    [name]: \'func\',\n' +
-  '    [prototype]: func { [constructor]: [Circular] }\n' +
+  '    [prototype]: func { [constructor]: [Circular *1] }\n' +
   '  }\n' +
   '} %o');
 

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -195,10 +195,10 @@ assert.strictEqual(
   '{\n' +
   '  foo: \'bar\',\n' +
   '  foobar: 1,\n' +
-  '  func: <ref *1> [Function: func] {\n' +
+  '  func: [Function: func] {\n' +
   '    [length]: 0,\n' +
   '    [name]: \'func\',\n' +
-  '    [prototype]: func { [constructor]: [Circular *1] }\n' +
+  '    [prototype]: func { [constructor]: [Circular] }\n' +
   '  }\n' +
   '}');
 assert.strictEqual(
@@ -208,10 +208,10 @@ assert.strictEqual(
   '  foobar: 1,\n' +
   '  func: [\n' +
   '    {\n' +
-  '      a: <ref *1> [Function: a] {\n' +
+  '      a: [Function: a] {\n' +
   '        [length]: 0,\n' +
   '        [name]: \'a\',\n' +
-  '        [prototype]: a { [constructor]: [Circular *1] }\n' +
+  '        [prototype]: a { [constructor]: [Circular] }\n' +
   '      }\n' +
   '    },\n' +
   '    [length]: 1\n' +
@@ -223,10 +223,10 @@ assert.strictEqual(
   '  foo: \'bar\',\n' +
   '  foobar: {\n' +
   '    foo: \'bar\',\n' +
-  '    func: <ref *1> [Function: func] {\n' +
+  '    func: [Function: func] {\n' +
   '      [length]: 0,\n' +
   '      [name]: \'func\',\n' +
-  '      [prototype]: func { [constructor]: [Circular *1] }\n' +
+  '      [prototype]: func { [constructor]: [Circular] }\n' +
   '    }\n' +
   '  }\n' +
   '}');
@@ -235,18 +235,18 @@ assert.strictEqual(
   '{\n' +
   '  foo: \'bar\',\n' +
   '  foobar: 1,\n' +
-  '  func: <ref *1> [Function: func] {\n' +
+  '  func: [Function: func] {\n' +
   '    [length]: 0,\n' +
   '    [name]: \'func\',\n' +
-  '    [prototype]: func { [constructor]: [Circular *1] }\n' +
+  '    [prototype]: func { [constructor]: [Circular] }\n' +
   '  }\n' +
   '} {\n' +
   '  foo: \'bar\',\n' +
   '  foobar: 1,\n' +
-  '  func: <ref *1> [Function: func] {\n' +
+  '  func: [Function: func] {\n' +
   '    [length]: 0,\n' +
   '    [name]: \'func\',\n' +
-  '    [prototype]: func { [constructor]: [Circular *1] }\n' +
+  '    [prototype]: func { [constructor]: [Circular] }\n' +
   '  }\n' +
   '}');
 assert.strictEqual(
@@ -254,10 +254,10 @@ assert.strictEqual(
   '{\n' +
   '  foo: \'bar\',\n' +
   '  foobar: 1,\n' +
-  '  func: <ref *1> [Function: func] {\n' +
+  '  func: [Function: func] {\n' +
   '    [length]: 0,\n' +
   '    [name]: \'func\',\n' +
-  '    [prototype]: func { [constructor]: [Circular *1] }\n' +
+  '    [prototype]: func { [constructor]: [Circular] }\n' +
   '  }\n' +
   '} %o');
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1060,10 +1060,7 @@ if (typeof Symbol !== 'undefined') {
 
   assert.strictEqual(
     inspect(obj),
-    '{\n' +
-    '  a: [ [Circular] ],\n' +
-    '  b: { inner: [Circular], obj: [Circular] }\n' +
-    '}'
+    '{ a: [ [Circular] ], b: { inner: [Circular], obj: [Circular] } }'
   );
 }
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1021,7 +1021,7 @@ if (typeof Symbol !== 'undefined') {
 {
   const set = new Set();
   set.add(set);
-  assert.strictEqual(util.inspect(set), 'Set { [Circular] }');
+  assert.strictEqual(util.inspect(set), '<ref *1> Set { [Circular *1] }');
 }
 
 // Test Map.
@@ -1039,12 +1039,32 @@ if (typeof Symbol !== 'undefined') {
 {
   const map = new Map();
   map.set(map, 'map');
-  assert.strictEqual(util.inspect(map), "Map { [Circular] => 'map' }");
+  assert.strictEqual(inspect(map), "<ref *1> Map { [Circular *1] => 'map' }");
   map.set(map, map);
-  assert.strictEqual(util.inspect(map), 'Map { [Circular] => [Circular] }');
+  assert.strictEqual(
+    inspect(map),
+    '<ref *1> Map { [Circular *1] => [Circular *1] }'
+  );
   map.delete(map);
   map.set('map', map);
-  assert.strictEqual(util.inspect(map), "Map { 'map' => [Circular] }");
+  assert.strictEqual(inspect(map), "<ref *1> Map { 'map' => [Circular *1] }");
+}
+
+// Test multiple circular references.
+{
+  const obj = {};
+  obj.a = [obj];
+  obj.b = {};
+  obj.b.inner = obj.b;
+  obj.b.obj = obj;
+
+  assert.strictEqual(
+    inspect(obj),
+    '<ref *1> {\n' +
+    '  a: [ [Circular *1] ],\n' +
+    '  b: <ref *2> { inner: [Circular *2], obj: [Circular *1] }\n' +
+    '}'
+  );
 }
 
 // Test Promise.
@@ -1242,7 +1262,9 @@ if (typeof Symbol !== 'undefined') {
   arr[0][0][0] = { a: 2 };
   assert.strictEqual(util.inspect(arr), '[ [ [ [Object] ] ] ]');
   arr[0][0][0] = arr;
-  assert.strictEqual(util.inspect(arr), '[ [ [ [Circular] ] ] ]');
+  assert.strictEqual(util.inspect(arr), '<ref *1> [ [ [ [Circular *1] ] ] ]');
+  arr[0][0][0] = arr[0][0];
+  assert.strictEqual(util.inspect(arr), '[ [ <ref *1> [ [Circular *1] ] ] ]');
 }
 
 // Corner cases.
@@ -1609,7 +1631,7 @@ util.inspect(process);
     '      2,',
     '      [length]: 2',
     '    ]',
-    '  } => [Map Iterator] {',
+    '  } => <ref *1> [Map Iterator] {',
     '    Uint8Array [',
     '      [BYTES_PER_ELEMENT]: 1,',
     '      [length]: 0,',
@@ -1620,7 +1642,7 @@ util.inspect(process);
     '        foo: true',
     '      }',
     '    ],',
-    '    [Circular]',
+    '    [Circular *1]',
     '  },',
     '  [size]: 2',
     '}'
@@ -1648,7 +1670,7 @@ util.inspect(process);
     '    [byteOffset]: 0,',
     '    [buffer]: ArrayBuffer { byteLength: 0, foo: true }',
     '  ],',
-    '  [Set Iterator] { [ 1, 2, [length]: 2 ] } => [Map Iterator] {',
+    '  [Set Iterator] { [ 1, 2, [length]: 2 ] } => <ref *1> [Map Iterator] {',
     '    Uint8Array [',
     '      [BYTES_PER_ELEMENT]: 1,',
     '      [length]: 0,',
@@ -1656,7 +1678,7 @@ util.inspect(process);
     '      [byteOffset]: 0,',
     '      [buffer]: ArrayBuffer { byteLength: 0, foo: true }',
     '    ],',
-    '    [Circular]',
+    '    [Circular *1]',
     '  },',
     '  [size]: 2',
     '}'
@@ -1688,7 +1710,7 @@ util.inspect(process);
     '  [Set Iterator] {',
     '    [ 1,',
     '      2,',
-    '      [length]: 2 ] } => [Map Iterator] {',
+    '      [length]: 2 ] } => <ref *1> [Map Iterator] {',
     '    Uint8Array [',
     '      [BYTES_PER_ELEMENT]: 1,',
     '      [length]: 0,',
@@ -1697,7 +1719,7 @@ util.inspect(process);
     '      [buffer]: ArrayBuffer {',
     '        byteLength: 0,',
     '        foo: true } ],',
-    '    [Circular] },',
+    '    [Circular *1] },',
     '  [size]: 2 }'
   ].join('\n');
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1021,7 +1021,7 @@ if (typeof Symbol !== 'undefined') {
 {
   const set = new Set();
   set.add(set);
-  assert.strictEqual(util.inspect(set), '<ref *1> Set { [Circular *1] }');
+  assert.strictEqual(util.inspect(set), 'Set { [Circular] }');
 }
 
 // Test Map.
@@ -1039,15 +1039,15 @@ if (typeof Symbol !== 'undefined') {
 {
   const map = new Map();
   map.set(map, 'map');
-  assert.strictEqual(inspect(map), "<ref *1> Map { [Circular *1] => 'map' }");
+  assert.strictEqual(inspect(map), "Map { [Circular] => 'map' }");
   map.set(map, map);
   assert.strictEqual(
     inspect(map),
-    '<ref *1> Map { [Circular *1] => [Circular *1] }'
+    'Map { [Circular] => [Circular] }'
   );
   map.delete(map);
   map.set('map', map);
-  assert.strictEqual(inspect(map), "<ref *1> Map { 'map' => [Circular *1] }");
+  assert.strictEqual(inspect(map), "Map { 'map' => [Circular] }");
 }
 
 // Test multiple circular references.
@@ -1060,9 +1060,9 @@ if (typeof Symbol !== 'undefined') {
 
   assert.strictEqual(
     inspect(obj),
-    '<ref *1> {\n' +
-    '  a: [ [Circular *1] ],\n' +
-    '  b: <ref *2> { inner: [Circular *2], obj: [Circular *1] }\n' +
+    '{\n' +
+    '  a: [ [Circular] ],\n' +
+    '  b: { inner: [Circular], obj: [Circular] }\n' +
     '}'
   );
 }
@@ -1262,9 +1262,9 @@ if (typeof Symbol !== 'undefined') {
   arr[0][0][0] = { a: 2 };
   assert.strictEqual(util.inspect(arr), '[ [ [ [Object] ] ] ]');
   arr[0][0][0] = arr;
-  assert.strictEqual(util.inspect(arr), '<ref *1> [ [ [ [Circular *1] ] ] ]');
+  assert.strictEqual(util.inspect(arr), '[ [ [ [Circular] ] ] ]');
   arr[0][0][0] = arr[0][0];
-  assert.strictEqual(util.inspect(arr), '[ [ <ref *1> [ [Circular *1] ] ] ]');
+  assert.strictEqual(util.inspect(arr), '[ [ [ [Circular] ] ] ]');
 }
 
 // Corner cases.
@@ -1631,7 +1631,7 @@ util.inspect(process);
     '      2,',
     '      [length]: 2',
     '    ]',
-    '  } => <ref *1> [Map Iterator] {',
+    '  } => [Map Iterator] {',
     '    Uint8Array [',
     '      [BYTES_PER_ELEMENT]: 1,',
     '      [length]: 0,',
@@ -1642,7 +1642,7 @@ util.inspect(process);
     '        foo: true',
     '      }',
     '    ],',
-    '    [Circular *1]',
+    '    [Circular]',
     '  },',
     '  [size]: 2',
     '}'
@@ -1670,7 +1670,7 @@ util.inspect(process);
     '    [byteOffset]: 0,',
     '    [buffer]: ArrayBuffer { byteLength: 0, foo: true }',
     '  ],',
-    '  [Set Iterator] { [ 1, 2, [length]: 2 ] } => <ref *1> [Map Iterator] {',
+    '  [Set Iterator] { [ 1, 2, [length]: 2 ] } => [Map Iterator] {',
     '    Uint8Array [',
     '      [BYTES_PER_ELEMENT]: 1,',
     '      [length]: 0,',
@@ -1678,7 +1678,7 @@ util.inspect(process);
     '      [byteOffset]: 0,',
     '      [buffer]: ArrayBuffer { byteLength: 0, foo: true }',
     '    ],',
-    '    [Circular *1]',
+    '    [Circular]',
     '  },',
     '  [size]: 2',
     '}'
@@ -1710,7 +1710,7 @@ util.inspect(process);
     '  [Set Iterator] {',
     '    [ 1,',
     '      2,',
-    '      [length]: 2 ] } => <ref *1> [Map Iterator] {',
+    '      [length]: 2 ] } => [Map Iterator] {',
     '    Uint8Array [',
     '      [BYTES_PER_ELEMENT]: 1,',
     '      [length]: 0,',
@@ -1719,7 +1719,7 @@ util.inspect(process);
     '      [buffer]: ArrayBuffer {',
     '        byteLength: 0,',
     '        foo: true } ],',
-    '    [Circular *1] },',
+    '    [Circular] },',
     '  [size]: 2 }'
   ].join('\n');
 


### PR DESCRIPTION
This backports #27685 (a semver-major PR) with a compatibility patch on top.

The main code change works similar to a no-op.

@nodejs/util @nodejs/releasers PTAL

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
