### PR TITLE
stream: writableCorked

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -510,7 +510,7 @@ does not indicate whether the data has been flushed, for this use
 added: REPLACEME
 -->
 
-* {Integer}
+* {integer}
 
 Number of times [`writable.uncork()`][stream-uncork] needs to be
 called in order to fully uncork the stream.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -505,6 +505,16 @@ Is `true` after [`writable.end()`][] has been called. This property
 does not indicate whether the data has been flushed, for this use
 [`writable.writableFinished`][] instead.
 
+##### writable.writableCorked
+<!-- YAML
+added: REPLACEME
+-->
+
+* {Integer}
+
+Number of times [`writable.uncork()`][stream-uncork] needs to be
+called in order to fully uncork the stream.
+
 ##### writable.writableFinished
 <!-- YAML
 added: v12.6.0
@@ -2759,6 +2769,7 @@ contain multi-byte characters.
 [stream-push]: #stream_readable_push_chunk_encoding
 [stream-read]: #stream_readable_read_size
 [stream-resume]: #stream_readable_resume
+[stream-uncork]: #stream_writable_uncork
 [stream-write]: #stream_writable_write_chunk_encoding_callback
 [writable-_destroy]: #stream_writable_destroy_err_callback
 [writable-destroy]: #stream_writable_destroy_error

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -56,8 +56,6 @@ const { validateString } = require('internal/validators');
 const HIGH_WATER_MARK = getDefaultHighWaterMark();
 const { CRLF, debug } = common;
 
-const kIsCorked = Symbol('isCorked');
-
 const RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
 const RE_TE_CHUNKED = common.chunkExpression;
 
@@ -101,7 +99,6 @@ function OutgoingMessage() {
 
   this.finished = false;
   this._headerSent = false;
-  this[kIsCorked] = false;
 
   this.socket = null;
   this._header = null;
@@ -628,10 +625,9 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
                                    ['string', 'Buffer'], chunk);
   }
 
-  if (!fromEnd && msg.socket && !msg[kIsCorked]) {
+  if (!fromEnd && msg.socket && !msg.socket.writableCorked) {
     msg.socket.cork();
-    msg[kIsCorked] = true;
-    process.nextTick(connectionCorkNT, msg, msg.socket);
+    process.nextTick(connectionCorkNT, msg.socket);
   }
 
   var len, ret;
@@ -660,8 +656,7 @@ function writeAfterEndNT(msg, err, callback) {
 }
 
 
-function connectionCorkNT(msg, conn) {
-  msg[kIsCorked] = false;
+function connectionCorkNT(conn) {
   conn.uncork();
 }
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -373,6 +373,16 @@ Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
   }
 });
 
+Object.defineProperty(Writable.prototype, 'writableCorked', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get: function() {
+    return this._writableState ? this._writableState.corked : 0;
+  }
+});
+
 // If we're already writing something, then just put this
 // in the queue, and wait our turn.  Otherwise, call _write
 // If we return false, then we need a drain event, so set that flag.

--- a/test/parallel/test-stream-writable-properties.js
+++ b/test/parallel/test-stream-writable-properties.js
@@ -1,0 +1,22 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const { Writable } = require('stream');
+
+{
+  const w = new Writable();
+  assert.strictEqual(w.writableCorked, 0);
+  w.uncork();
+  assert.strictEqual(w.writableCorked, 0);
+  w.cork();
+  assert.strictEqual(w.writableCorked, 1);
+  w.cork();
+  assert.strictEqual(w.writableCorked, 2);
+  w.uncork();
+  assert.strictEqual(w.writableCorked, 1);
+  w.uncork();
+  assert.strictEqual(w.writableCorked, 0);
+  w.uncork();
+  assert.strictEqual(w.writableCorked, 0);
+}


### PR DESCRIPTION
Expose `_writableState.corked`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
