### PR TITLE
[v12.x] backport #28609

### DIFF
--- a/test/parallel/test-worker-process-cwd.js
+++ b/test/parallel/test-worker-process-cwd.js
@@ -3,6 +3,9 @@ const common = require('../common');
 const assert = require('assert');
 const { Worker, isMainThread, parentPort } = require('worker_threads');
 
+// Verify that cwd changes from the main thread are handled correctly in
+// workers.
+
 // Do not use isMainThread directly, otherwise the test would time out in case
 // it's started inside of another worker thread.
 if (!process.env.HAS_STARTED_WORKER) {
@@ -10,36 +13,55 @@ if (!process.env.HAS_STARTED_WORKER) {
   if (!isMainThread) {
     common.skip('This test can only run as main thread');
   }
+  // Normalize the current working dir to also work with the root folder.
   process.chdir(__dirname);
+
+  assert(!process.cwd.toString().includes('Atomics.load'));
+
+  // 1. Start the first worker.
   const w = new Worker(__filename);
-  process.chdir('..');
-  w.on('message', common.mustCall((message) => {
+  w.once('message', common.mustCall((message) => {
+    // 5. Change the cwd and send that to the spawned worker.
     assert.strictEqual(message, process.cwd());
     process.chdir('..');
     w.postMessage(process.cwd());
   }));
 } else if (!process.env.SECOND_WORKER) {
   process.env.SECOND_WORKER = '1';
-  const firstCwd = process.cwd();
+
+  // 2. Save the current cwd and verify that `process.cwd` includes the
+  //    Atomics.load call and spawn a new worker.
+  const cwd = process.cwd();
+  assert(!process.cwd.toString().includes('Atomics.load'));
+
   const w = new Worker(__filename);
-  w.on('message', common.mustCall((message) => {
-    assert.strictEqual(message, process.cwd());
-    parentPort.postMessage(firstCwd);
-    parentPort.onmessage = common.mustCall((obj) => {
-      const secondCwd = process.cwd();
-      assert.strictEqual(secondCwd, obj.data);
-      assert.notStrictEqual(secondCwd, firstCwd);
-      w.postMessage(secondCwd);
-      parentPort.unref();
-    });
+  w.once('message', common.mustCall((message) => {
+    // 4. Verify at the current cwd is identical to the received and the
+    //    original one.
+    assert.strictEqual(process.cwd(), message);
+    assert.strictEqual(message, cwd);
+    parentPort.postMessage(cwd);
+  }));
+
+  parentPort.once('message', common.mustCall((message) => {
+    // 6. Verify that the current cwd is identical to the received one but not
+    //    with the original one.
+    assert.strictEqual(process.cwd(), message);
+    assert.notStrictEqual(message, cwd);
+    w.postMessage(message);
   }));
 } else {
-  const firstCwd = process.cwd();
-  parentPort.postMessage(firstCwd);
-  parentPort.onmessage = common.mustCall((obj) => {
-    const secondCwd = process.cwd();
-    assert.strictEqual(secondCwd, obj.data);
-    assert.notStrictEqual(secondCwd, firstCwd);
-    process.exit();
-  });
+  // 3. Save the current cwd, post back to the "main" thread and verify that
+  //    `process.cwd` includes the Atomics.load call.
+  const cwd = process.cwd();
+  // Send the current cwd to the parent.
+  parentPort.postMessage(cwd);
+  assert(!process.cwd.toString().includes('Atomics.load'));
+
+  parentPort.once('message', common.mustCall((message) => {
+    // 7. Verify that the current cwd is identical to the received one but
+    //    not with the original one.
+    assert.strictEqual(process.cwd(), message);
+    assert.notStrictEqual(message, cwd);
+  }));
 }


### PR DESCRIPTION
The difference to the original PR are that the atomics assertion fail on older code and had to be changed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
