### PR TITLE
doc: fix introduced_in note in querystring.md

### DIFF
--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -1,6 +1,6 @@
 # Query String
 
-<!--introduced_in=v0.10.0-->
+<!--introduced_in=v0.1.25-->
 
 > Stability: 2 - Stable
 


### PR DESCRIPTION
The method descriptions mentioned the right version but for some reason
the top-level description did not. Well, now it does.