### PR TITLE
http: OutgoingMessage stream properties

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -112,12 +112,30 @@ Object.setPrototypeOf(OutgoingMessage.prototype, Stream.prototype);
 Object.setPrototypeOf(OutgoingMessage, Stream);
 
 Object.defineProperty(OutgoingMessage.prototype, 'writableFinished', {
-  get: function() {
+  get() {
     return (
       this.finished &&
       this.outputSize === 0 &&
       (!this.socket || this.socket.writableLength === 0)
     );
+  }
+});
+
+Object.defineProperty(OutgoingMessage.prototype, 'writableObjectMode', {
+  get() {
+    return false;
+  }
+});
+
+Object.defineProperty(OutgoingMessage.prototype, 'writableLength', {
+  get() {
+    return this.outputSize + (this.socket ? this.socket.writableLength : 0);
+  }
+});
+
+Object.defineProperty(OutgoingMessage.prototype, 'writableHighWaterMark', {
+  get() {
+    return this.socket ? this.socket.writableHighWaterMark : HIGH_WATER_MARK;
   }
 });
 

--- a/test/parallel/test-http-outgoing-properties.js
+++ b/test/parallel/test-http-outgoing-properties.js
@@ -1,0 +1,53 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const http = require('http');
+const OutgoingMessage = http.OutgoingMessage;
+
+{
+  const msg = new OutgoingMessage();
+  assert.strictEqual(msg.writableObjectMode, false);
+}
+
+{
+  const msg = new OutgoingMessage();
+  assert(msg.writableHighWaterMark > 0);
+}
+
+{
+  const server = http.createServer(common.mustCall(function(req, res) {
+    const hwm = req.socket.writableHighWaterMark;
+    assert.strictEqual(res.writableHighWaterMark, hwm);
+
+    assert.strictEqual(res.writableLength, 0);
+    res.write('');
+    const len = res.writableLength;
+    res.write('asd');
+    assert.strictEqual(res.writableLength, len + 8);
+    res.end();
+    res.on('finish', common.mustCall(() => {
+      assert.strictEqual(res.writableLength, 0);
+      server.close();
+    }));
+  }));
+
+  server.listen(0);
+
+  server.on('listening', common.mustCall(function() {
+    const clientRequest = http.request({
+      port: server.address().port,
+      method: 'GET',
+      path: '/'
+    });
+    clientRequest.end();
+  }));
+}
+
+{
+  const msg = new OutgoingMessage();
+  msg._implicitHeader = function() {};
+  assert.strictEqual(msg.writableLength, 0);
+  msg.write('asd');
+  assert.strictEqual(msg.writableLength, 7);
+}


### PR DESCRIPTION
Adds some missing "streamlike" properties to `OutgoingMessage`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
