### PR TITLE
http: buffer writes while no socket

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -23,6 +23,7 @@
 
 const { Object, ObjectPrototype } = primordials;
 
+const { getDefaultHighWaterMark } = require('internal/streams/state');
 const assert = require('internal/assert');
 const Stream = require('stream');
 const internalUtil = require('internal/util');
@@ -51,6 +52,7 @@ const {
 } = require('internal/errors');
 const { validateString } = require('internal/validators');
 
+const HIGH_WATER_MARK = getDefaultHighWaterMark();
 const { CRLF, debug } = common;
 
 const kIsCorked = Symbol('isCorked');
@@ -277,7 +279,7 @@ function _writeRaw(data, encoding, callback) {
   this.outputData.push({ data, encoding, callback });
   this.outputSize += data.length;
   this._onPendingData(data.length);
-  return false;
+  return this.outputSize < HIGH_WATER_MARK;
 }
 
 

--- a/lib/internal/streams/state.js
+++ b/lib/internal/streams/state.js
@@ -9,6 +9,10 @@ function highWaterMarkFrom(options, isDuplex, duplexKey) {
     isDuplex ? options[duplexKey] : null;
 }
 
+function getDefaultHighWaterMark(objectMode) {
+  return objectMode ? 16 : 16 * 1024;
+}
+
 function getHighWaterMark(state, options, duplexKey, isDuplex) {
   const hwm = highWaterMarkFrom(options, isDuplex, duplexKey);
   if (hwm != null) {
@@ -20,9 +24,10 @@ function getHighWaterMark(state, options, duplexKey, isDuplex) {
   }
 
   // Default value
-  return state.objectMode ? 16 : 16 * 1024;
+  return getDefaultHighWaterMark(state.objectMode);
 }
 
 module.exports = {
-  getHighWaterMark
+  getHighWaterMark,
+  getDefaultHighWaterMark
 };

--- a/test/parallel/test-http-outgoing-buffer.js
+++ b/test/parallel/test-http-outgoing-buffer.js
@@ -1,0 +1,19 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('assert');
+const { getDefaultHighWaterMark } = require('internal/streams/state');
+
+const http = require('http');
+const OutgoingMessage = http.OutgoingMessage;
+
+const msg = new OutgoingMessage();
+msg._implicitHeader = function() {};
+
+// Writes should be buffered until highwatermark
+// even when no socket is assigned.
+
+assert.strictEqual(msg.write('asd'), true);
+while (msg.write('asd'));
+const highwatermark = msg.writableHighWaterMark || getDefaultHighWaterMark();
+assert(msg.outputSize >= highwatermark);


### PR DESCRIPTION
We should be buffering writes even while no socket is assigned.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
