### PR TITLE
[x] stream: simplify writable buffering

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -482,7 +482,10 @@ function clearBuffer(stream, state) {
 
   state.bufferProcessing = true;
   if (bufferedLength === 1) {
-    const { chunk, encoding, callback } = buffered[0];
+    const chunk = buffered[0].chunk;
+    const encoding = buffered[0].encoding;
+    const callback = buffered[0].callback;
+
     const len = state.objectMode ? 1 : chunk.length;
     doWrite(stream, state, false, len, chunk, encoding, callback);
     buffered.length = 0;
@@ -490,7 +493,10 @@ function clearBuffer(stream, state) {
   } else if (stream._writev) {
     state.pendingcb++;
     // doWrite mutates buffered array. Keep a copy of callbacks.
-    const callbacks = buffered.map(({ callback }) => callback);
+    const callbacks = [];
+    for (let n = 0; n < buffered.length; ++n) {
+      callbacks.push(buffered[n].callback);
+    }
     doWrite(stream, state, true, state.length, buffered, '', (err) => {
       for (const callback of callbacks) {
         state.pendingcb--;
@@ -501,8 +507,11 @@ function clearBuffer(stream, state) {
     state.buffered.allBuffers = true;
   } else {
     let i = 0;
-    while (i < bufferedLength && !state.writing) {
-      const { chunk, encoding, callback } = buffered[i++];
+    for (; i < bufferedLength && !state.writing; i++) {
+      const chunk = buffered[i].chunk;
+      const encoding = buffered[i].encoding;
+      const callback = buffered[i].callback;
+
       const len = state.objectMode ? 1 : chunk.length;
       doWrite(stream, state, false, len, chunk, encoding, callback);
     }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -135,8 +135,8 @@ function WritableState(options, stream, isDuplex) {
   // The amount that is being written when _write is called.
   this.writelen = 0;
 
-  this.bufferedRequest = null;
-  this.lastBufferedRequest = null;
+  this.buffered = [];
+  this.buffered.allBuffers = true;
 
   // Number of pending user-supplied write callbacks
   // this must be 0 before 'finish' can be emitted
@@ -154,25 +154,10 @@ function WritableState(options, stream, isDuplex) {
 
   // Should .destroy() be called after 'finish' (and potentially 'end')
   this.autoDestroy = !!options.autoDestroy;
-
-  // Count buffered requests
-  this.bufferedRequestCount = 0;
-
-  // Allocate the first CorkedRequest, there is always
-  // one allocated and free to use, and we maintain at most two
-  const corkReq = { next: null, entry: null, finish: undefined };
-  corkReq.finish = onCorkedFinish.bind(undefined, corkReq, this);
-  this.corkedRequestsFree = corkReq;
 }
 
 WritableState.prototype.getBuffer = function getBuffer() {
-  var current = this.bufferedRequest;
-  const out = [];
-  while (current) {
-    out.push(current);
-    current = current.next;
-  }
-  return out;
+  return this.buffered;
 };
 
 Object.defineProperty(WritableState.prototype, 'buffer', {
@@ -180,6 +165,12 @@ Object.defineProperty(WritableState.prototype, 'buffer', {
     return this.getBuffer();
   }, '_writableState.buffer is deprecated. Use _writableState.getBuffer ' +
      'instead.', 'DEP0003')
+});
+
+Object.defineProperty(WritableState.prototype, 'bufferedRequestCount', {
+  get() {
+    return this.buffered.length;
+  }
 });
 
 // Test _writableState for inheritance to account for Duplex streams,
@@ -315,12 +306,7 @@ Writable.prototype.uncork = function() {
 
   if (state.corked) {
     state.corked--;
-
-    if (!state.writing &&
-        !state.corked &&
-        !state.bufferProcessing &&
-        state.bufferedRequest)
-      clearBuffer(this, state);
+    clearBuffer(this, state);
   }
 };
 
@@ -376,7 +362,7 @@ Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
 // If we're already writing something, then just put this
 // in the queue, and wait our turn.  Otherwise, call _write
 // If we return false, then we need a drain event, so set that flag.
-function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
+function writeOrBuffer(stream, state, isBuf, chunk, encoding, callback) {
   if (!isBuf) {
     var newChunk = decodeChunk(state, chunk, encoding);
     if (chunk !== newChunk) {
@@ -395,22 +381,11 @@ function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
     state.needDrain = true;
 
   if (state.writing || state.corked) {
-    var last = state.lastBufferedRequest;
-    state.lastBufferedRequest = {
-      chunk,
-      encoding,
-      isBuf,
-      callback: cb,
-      next: null
-    };
-    if (last) {
-      last.next = state.lastBufferedRequest;
-    } else {
-      state.bufferedRequest = state.lastBufferedRequest;
-    }
-    state.bufferedRequestCount += 1;
+    const buffered = state.buffered;
+    buffered.push({ chunk, encoding, callback });
+    buffered.allBuffers = isBuf && buffered.allBuffers;
   } else {
-    doWrite(stream, state, false, len, chunk, encoding, cb);
+    doWrite(stream, state, false, len, chunk, encoding, callback);
   }
 
   return ret;
@@ -471,10 +446,7 @@ function onwrite(stream, er) {
     // Check if we're actually ready to finish, but don't emit yet
     var finished = needFinish(state) || stream.destroyed;
 
-    if (!finished &&
-        !state.corked &&
-        !state.bufferProcessing &&
-        state.bufferedRequest) {
+    if (!finished) {
       clearBuffer(stream, state);
     }
 
@@ -500,67 +472,42 @@ function afterWrite(stream, state, cb) {
 
 // If there's something in the buffer waiting, then process it
 function clearBuffer(stream, state) {
-  state.bufferProcessing = true;
-  var entry = state.bufferedRequest;
+  const buffered = state.buffered;
+  const bufferedLength = buffered.length;
 
-  if (stream._writev && entry && entry.next) {
-    // Fast case, write everything using _writev()
-    var l = state.bufferedRequestCount;
-    var buffer = new Array(l);
-    var holder = state.corkedRequestsFree;
-    holder.entry = entry;
-
-    var count = 0;
-    var allBuffers = true;
-    while (entry) {
-      buffer[count] = entry;
-      if (!entry.isBuf)
-        allBuffers = false;
-      entry = entry.next;
-      count += 1;
-    }
-    buffer.allBuffers = allBuffers;
-
-    doWrite(stream, state, true, state.length, buffer, '', holder.finish);
-
-    // doWrite is almost always async, defer these to save a bit of time
-    // as the hot path ends with doWrite
-    state.pendingcb++;
-    state.lastBufferedRequest = null;
-    if (holder.next) {
-      state.corkedRequestsFree = holder.next;
-      holder.next = null;
-    } else {
-      var corkReq = { next: null, entry: null, finish: undefined };
-      corkReq.finish = onCorkedFinish.bind(undefined, corkReq, state);
-      state.corkedRequestsFree = corkReq;
-    }
-    state.bufferedRequestCount = 0;
-  } else {
-    // Slow case, write chunks one-by-one
-    while (entry) {
-      var chunk = entry.chunk;
-      var encoding = entry.encoding;
-      var cb = entry.callback;
-      var len = state.objectMode ? 1 : chunk.length;
-
-      doWrite(stream, state, false, len, chunk, encoding, cb);
-      entry = entry.next;
-      state.bufferedRequestCount--;
-      // If we didn't call the onwrite immediately, then
-      // it means that we need to wait until it does.
-      // also, that means that the chunk and cb are currently
-      // being processed, so move the buffer counter past them.
-      if (state.writing) {
-        break;
-      }
-    }
-
-    if (entry === null)
-      state.lastBufferedRequest = null;
+  if (!bufferedLength || state.corked || state.bufferProcessing ||
+    state.writing) {
+    return;
   }
 
-  state.bufferedRequest = entry;
+  state.bufferProcessing = true;
+  if (bufferedLength === 1) {
+    const { chunk, encoding, callback } = buffered[0];
+    const len = state.objectMode ? 1 : chunk.length;
+    doWrite(stream, state, false, len, chunk, encoding, callback);
+    buffered.length = 0;
+    buffered.allBuffers = true;
+  } else if (stream._writev) {
+    state.pendingcb++;
+    // doWrite mutates buffered array. Keep a copy of callbacks.
+    const callbacks = buffered.map(({ callback }) => callback);
+    doWrite(stream, state, true, state.length, buffered, '', (err) => {
+      for (const callback of callbacks) {
+        state.pendingcb--;
+        callback(err);
+      }
+    });
+    state.buffered = [];
+    state.buffered.allBuffers = true;
+  } else {
+    let i = 0;
+    while (i < bufferedLength && !state.writing) {
+      const { chunk, encoding, callback } = buffered[i++];
+      const len = state.objectMode ? 1 : chunk.length;
+      doWrite(stream, state, false, len, chunk, encoding, callback);
+    }
+    buffered.splice(0, i);
+  }
   state.bufferProcessing = false;
 }
 
@@ -617,8 +564,8 @@ Object.defineProperty(Writable.prototype, 'writableLength', {
 
 function needFinish(state) {
   return (state.ending &&
-          state.length === 0 &&
-          state.bufferedRequest === null &&
+          !state.length &&
+          !state.buffered.length &&
           !state.finished &&
           !state.writing);
 }
@@ -679,20 +626,6 @@ function endWritable(stream, state, cb) {
   }
   state.ended = true;
   stream.writable = false;
-}
-
-function onCorkedFinish(corkReq, state, err) {
-  var entry = corkReq.entry;
-  corkReq.entry = null;
-  while (entry) {
-    var cb = entry.callback;
-    state.pendingcb--;
-    cb(err);
-    entry = entry.next;
-  }
-
-  // Reuse the free corkReq.
-  state.corkedRequestsFree.next = corkReq;
 }
 
 Object.defineProperty(Writable.prototype, 'destroyed', {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -506,8 +506,8 @@ function clearBuffer(stream, state) {
     state.buffered = [];
     state.buffered.allBuffers = true;
   } else {
-    let i = 0;
-    for (; i < bufferedLength && !state.writing; i++) {
+    let i;
+    for (i = 0; i < bufferedLength && !state.writing; i++) {
       const chunk = buffered[i].chunk;
       const encoding = buffered[i].encoding;
       const callback = buffered[i].callback;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -493,9 +493,9 @@ function clearBuffer(stream, state) {
   } else if (stream._writev) {
     state.pendingcb++;
     // doWrite mutates buffered array. Keep a copy of callbacks.
-    const callbacks = [];
+    const callbacks = new Array(buffered.length);
     for (let n = 0; n < buffered.length; ++n) {
-      callbacks.push(buffered[n].callback);
+      callbacks[n] = buffered[n].callback;
     }
     doWrite(stream, state, true, state.length, buffered, '', (err) => {
       for (const callback of callbacks) {


### PR DESCRIPTION
This simplifies the buffering logic in writable_stream and makes it easier to maintain and possiblinly optimize. Also minor speed and memory overhead optimisation.

I have a few ideas on how to further optimize this. But as a first step, simplify while maintaining current performance.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

```
 streams/writable-manywrites.js n=2000000                 4.05 %       ±4.69% ±6.24% ±8.13%
```