### PR TITLE
stream: don't flush destroyed writable

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -275,7 +275,23 @@ function validChunk(stream, state, chunk, cb) {
 
 Writable.prototype.write = function(chunk, encoding, cb) {
   const state = this._writableState;
-  var ret = false;
+
+  if (typeof encoding === 'function') {
+    cb = encoding;
+    encoding = null;
+  }
+
+  if (typeof cb !== 'function')
+    cb = nop;
+
+  if (state.ending || state.destroyed) {
+    const err = state.ending ? new ERR_STREAM_WRITE_AFTER_END() :
+      new ERR_STREAM_DESTROYED('write');
+    process.nextTick(cb, err);
+    errorOrDestroy(this, err);
+    return false;
+  }
+
   const isBuf = !state.objectMode && Stream._isUint8Array(chunk);
 
   // Do not use Object.getPrototypeOf as it is slower since V8 7.3.
@@ -283,45 +299,18 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     chunk = Stream._uint8ArrayToBuffer(chunk);
   }
 
-  if (typeof encoding === 'function') {
-    cb = encoding;
-    encoding = null;
-  }
-
-  if (this._writableState.ending) {
-    const err = new ERR_STREAM_WRITE_AFTER_END();
-    if (typeof cb === 'function') {
-      process.nextTick(cb, err);
-    }
-    errorOrDestroy(this, err);
-    return false;
-  }
-
-  if (this.destroyed) {
-    const err = new ERR_STREAM_DESTROYED('write');
-    if (typeof cb === 'function') {
-      process.nextTick(cb, err);
-    }
-    errorOrDestroy(this, err);
-    return false;
-  }
-
   if (isBuf)
     encoding = 'buffer';
   else if (!encoding)
     encoding = state.defaultEncoding;
 
-  if (typeof cb !== 'function')
-    cb = nop;
-
-  if (state.ending)
+  if (state.ending) {
     writeAfterEnd(this, cb);
-  else if (isBuf || validChunk(this, state, chunk, cb)) {
+    return false;
+  } else if (isBuf || validChunk(this, state, chunk, cb)) {
     state.pendingcb++;
-    ret = writeOrBuffer(this, state, isBuf, chunk, encoding, cb);
+    return writeOrBuffer(this, state, isBuf, chunk, encoding, cb);
   }
-
-  return ret;
 };
 
 Writable.prototype.cork = function() {
@@ -759,14 +748,14 @@ Writable.prototype.destroy = function(err, cb) {
   const state = this._writableState;
   if (!state.destroyed) {
     for (let entry = state.bufferedRequest; entry; entry = entry.next) {
-      entry.callback(new ERR_STREAM_DESTROYED('write'));
+      process.nextTick(entry.callback, new ERR_STREAM_DESTROYED('write'));
     }
     state.bufferedRequest = null;
     state.lastBufferedRequest = null;
     state.bufferedRequestCount = 0;
   }
   destroy.call(this, err, cb);
-}
+};
 
 Writable.prototype._undestroy = destroyImpl.undestroy;
 Writable.prototype._destroy = function(err, cb) {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -275,23 +275,7 @@ function validChunk(stream, state, chunk, cb) {
 
 Writable.prototype.write = function(chunk, encoding, cb) {
   const state = this._writableState;
-
-  if (typeof encoding === 'function') {
-    cb = encoding;
-    encoding = null;
-  }
-
-  if (typeof cb !== 'function')
-    cb = nop;
-
-  if (state.ending || state.destroyed) {
-    const err = state.ending ? new ERR_STREAM_WRITE_AFTER_END() :
-      new ERR_STREAM_DESTROYED('write');
-    process.nextTick(cb, err);
-    errorOrDestroy(this, err);
-    return false;
-  }
-
+  var ret = false;
   const isBuf = !state.objectMode && Stream._isUint8Array(chunk);
 
   // Do not use Object.getPrototypeOf as it is slower since V8 7.3.
@@ -299,18 +283,31 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     chunk = Stream._uint8ArrayToBuffer(chunk);
   }
 
+  if (typeof encoding === 'function') {
+    cb = encoding;
+    encoding = null;
+  }
+
   if (isBuf)
     encoding = 'buffer';
   else if (!encoding)
     encoding = state.defaultEncoding;
 
+  if (typeof cb !== 'function')
+    cb = nop;
+
   if (state.ending) {
     writeAfterEnd(this, cb);
-    return false;
+  } else if (state.destroyed) {
+    const err = new ERR_STREAM_DESTROYED('write');
+    process.nextTick(cb, err);
+    errorOrDestroy(this, err);
   } else if (isBuf || validChunk(this, state, chunk, cb)) {
     state.pendingcb++;
-    return writeOrBuffer(this, state, isBuf, chunk, encoding, cb);
+    ret = writeOrBuffer(this, state, isBuf, chunk, encoding, cb);
   }
+
+  return ret;
 };
 
 Writable.prototype.cork = function() {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -755,6 +755,7 @@ Writable.prototype.destroy = function(err, cb) {
     state.bufferedRequestCount = 0;
   }
   destroy.call(this, err, cb);
+  return this;
 };
 
 Writable.prototype._undestroy = destroyImpl.undestroy;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -288,6 +288,24 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     encoding = null;
   }
 
+  if (this._writableState.ending) {
+    const err = new ERR_STREAM_WRITE_AFTER_END();
+    if (typeof cb === 'function') {
+      process.nextTick(cb, err);
+    }
+    errorOrDestroy(this, err);
+    return false;
+  }
+
+  if (this.destroyed) {
+    const err = new ERR_STREAM_DESTROYED('write');
+    if (typeof cb === 'function') {
+      process.nextTick(cb, err);
+    }
+    errorOrDestroy(this, err);
+    return false;
+  }
+
   if (isBuf)
     encoding = 'buffer';
   else if (!encoding)
@@ -736,7 +754,20 @@ Object.defineProperty(Writable.prototype, 'writableFinished', {
   }
 });
 
-Writable.prototype.destroy = destroyImpl.destroy;
+const destroy = destroyImpl.destroy;
+Writable.prototype.destroy = function(err, cb) {
+  const state = this._writableState;
+  if (!state.destroyed) {
+    for (let entry = state.bufferedRequest; entry; entry = entry.next) {
+      entry.callback(new ERR_STREAM_DESTROYED('write'));
+    }
+    state.bufferedRequest = null;
+    state.lastBufferedRequest = null;
+    state.bufferedRequestCount = 0;
+  }
+  destroy.call(this, err, cb);
+}
+
 Writable.prototype._undestroy = destroyImpl.undestroy;
 Writable.prototype._destroy = function(err, cb) {
   cb(err);

--- a/test/parallel/test-http2-server-stream-session-destroy.js
+++ b/test/parallel/test-http2-server-stream-session-destroy.js
@@ -39,7 +39,11 @@ server.on('stream', common.mustCall((stream) => {
     code: 'ERR_STREAM_WRITE_AFTER_END',
     message: 'write after end'
   }));
-  assert.strictEqual(stream.write('data'), false);
+  assert.strictEqual(stream.write('data', common.expectsError({
+    type: Error,
+    code: 'ERR_STREAM_WRITE_AFTER_END',
+    message: 'write after end'
+  })), false);
 }));
 
 server.listen(0, common.mustCall(() => {

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -232,3 +232,49 @@ const assert = require('assert');
   write._undestroy();
   write.end();
 }
+
+{
+  const write = new Writable();
+
+  write.destroy();
+  write.on('error', common.expectsError({
+    type: Error,
+    code: 'ERR_STREAM_DESTROYED',
+    message: 'Cannot call write after a stream was destroyed'
+  }));
+  write.write('asd', common.expectsError({
+    type: Error,
+    code: 'ERR_STREAM_DESTROYED',
+    message: 'Cannot call write after a stream was destroyed'
+  }));
+}
+
+{
+  const write = new Writable({
+    write(chunk, enc, cb) { cb(); }
+  });
+
+  write.on('error', common.expectsError({
+    type: Error,
+    code: 'ERR_STREAM_DESTROYED',
+    message: 'Cannot call write after a stream was destroyed'
+  }));
+
+  write.cork();
+  write.write('asd', common.mustCall());
+  write.uncork();
+
+  write.cork();
+  write.write('asd', common.expectsError({
+    type: Error,
+    code: 'ERR_STREAM_DESTROYED',
+    message: 'Cannot call write after a stream was destroyed'
+  }));
+  write.destroy();
+  write.write('asd', common.expectsError({
+    type: Error,
+    code: 'ERR_STREAM_DESTROYED',
+    message: 'Cannot call write after a stream was destroyed'
+  }));
+  write.uncork();
+}


### PR DESCRIPTION
It doesn't make much sense (and is a bit weird) to flush a stream which has been destroyed.

I need help creating a relevant test for this.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

NOTE TO SELF: Look into needFinish & stream destroyed. `errorOrDestroy` added in this PR should preferably be async.