### PR TITLE
assert.deepEqual: fix bug with faked boxed primitives

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -221,7 +221,9 @@ function innerDeepEqual(val1, val2, strict, memos) {
     if (!areEqualArrayBuffers(val1, val2)) {
       return false;
     }
-  } else if (isBoxedPrimitive(val1) && !isEqualBoxedPrimitive(val1, val2)) {
+  }
+  if ((isBoxedPrimitive(val1) || isBoxedPrimitive(val2)) &&
+    !isEqualBoxedPrimitive(val1, val2)) {
     return false;
   }
   return keyCheck(val1, val2, strict, memos, kNoIterator);

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -98,8 +98,11 @@ function isEqualBoxedPrimitive(val1, val2) {
     return isBigIntObject(val2) &&
            BigIntPrototype.valueOf(val1) === BigIntPrototype.valueOf(val2);
   }
-  return isSymbolObject(val2) &&
-         SymbolPrototype.valueOf(val1) === SymbolPrototype.valueOf(val2);
+  if (isSymbolObject(val1)) {
+    return isSymbolObject(val2) &&
+          SymbolPrototype.valueOf(val1) === SymbolPrototype.valueOf(val2);
+  }
+  return false;
 }
 
 // Notes: Type tags are historical [[Class]] properties that can be set by

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -28,8 +28,7 @@ function re(literals, ...values) {
       getters: true
     });
     // Need to escape special characters.
-    result += str;
-    result += literals[i + 1];
+    result += `${str}${literals[i + 1]}`;
   }
   return {
     code: 'ERR_ASSERTION',
@@ -605,11 +604,21 @@ assert.deepStrictEqual([ 1, 2, NaN, 4 ], [ 1, 2, NaN, 4 ]);
 {
   const boxedString = new String('test');
   const boxedSymbol = Object(Symbol());
+
+  const fakeBoxedSymbol = {};
+  Object.setPrototypeOf(fakeBoxedSymbol, Symbol.prototype);
+  Object.defineProperty(
+    fakeBoxedSymbol,
+    Symbol.toStringTag,
+    { enumerable: false, value: 'Symbol' }
+  );
+
   assertNotDeepOrStrict(new Boolean(true), Object(false));
   assertNotDeepOrStrict(Object(true), new Number(1));
   assertNotDeepOrStrict(new Number(2), new Number(1));
   assertNotDeepOrStrict(boxedSymbol, Object(Symbol()));
   assertNotDeepOrStrict(boxedSymbol, {});
+  assertNotDeepOrStrict(boxedSymbol, fakeBoxedSymbol);
   assertDeepAndStrictEqual(boxedSymbol, boxedSymbol);
   assertDeepAndStrictEqual(Object(true), Object(true));
   assertDeepAndStrictEqual(Object(2), Object(2));
@@ -618,6 +627,7 @@ assert.deepStrictEqual([ 1, 2, NaN, 4 ], [ 1, 2, NaN, 4 ]);
   assertNotDeepOrStrict(boxedString, Object('test'));
   boxedSymbol.slow = true;
   assertNotDeepOrStrict(boxedSymbol, {});
+  assertNotDeepOrStrict(boxedSymbol, fakeBoxedSymbol);
 }
 
 // Minus zero


### PR DESCRIPTION
I discovered this bug while perusing the code, to try to bring the npm `deep-equal` package into sync with node's.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
  * note: the related tests have passed; i didn't run the full suite
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added (n/a)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
