### PR TITLE
doc: improve UV_THREADPOOL_SIZE description

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1191,9 +1191,8 @@ on synchronous system APIs. Node.js APIs that use the threadpool are:
 
 - all `fs` APIs, other than the file watcher APIs and those that are explicitly
   synchronous
-- `crypto.pbkdf2()`
-- `crypto.randomBytes()`, unless it is used without a callback
-- `crypto.randomFill()`
+- asynchronous crypto APIs such as `crypto.pbkdf2()`, `crypto.scrypt()`,
+  `crypto.randomBytes()`, `crypto.randomFill()`, `crypto.generateKeyPair()`
 - `dns.lookup()`
 - all `zlib` APIs, other than those that are explicitly synchronous
 


### PR DESCRIPTION
The `UV_THREADPOOL_SIZE` documentation claims that only three `crypto` APIs use the thread pool, which is not true anymore. This commit lists all relevant APIs and rephrases it such that future API additions are included in the documentation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
