### PR TITLE
[v10.x] backport #26599 (process: add --unhandled-rejections flag)

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -401,6 +401,23 @@ added: v2.4.0
 
 Track heap object allocations for heap snapshots.
 
+### `--unhandled-rejections=mode`
+<!-- YAML
+added: REPLACEME
+-->
+
+By default all unhandled rejections trigger a warning plus a deprecation warning
+for the very first unhandled rejection in case no [`unhandledRejection`][] hook
+is used.
+
+Using this flag allows to change what should happen when an unhandled rejection
+occurs. One of three modes can be chosen:
+
+* `strict`: Raise the unhandled rejection as an uncaught exception.
+* `warn`: Always trigger a warning, no matter if the [`unhandledRejection`][]
+  hook is set or not but do not print the deprecation warning.
+* `none`: Silence all warnings.
+
 ### `--use-bundled-ca`, `--use-openssl-ca`
 <!-- YAML
 added: v6.11.0
@@ -614,6 +631,7 @@ Node.js options that are allowed are:
 - `--trace-sync-io`
 - `--trace-warnings`
 - `--track-heap-objects`
+- `--unhandled-rejections`
 - `--use-bundled-ca`
 - `--use-openssl-ca`
 - `--v8-pool-size`
@@ -773,6 +791,7 @@ greater than `4` (its current default value). For more information, see the
 [`Buffer`]: buffer.html#buffer_class_buffer
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
+[`unhandledRejection`]: process.html#process_event_unhandledrejection
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
 [REPL]: repl.html
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage

--- a/doc/node.1
+++ b/doc/node.1
@@ -218,6 +218,9 @@ Print stack traces for process warnings (including deprecations).
 .It Fl -track-heap-objects
 Track heap object allocations for heap snapshots.
 .
+.It Fl --unhandled-rejections=mode
+Define the behavior for unhandled rejections. Can be one of `strict` (raise an error), `warn` (enforce warnings) or `none` (silence warnings).
+.
 .It Fl -use-bundled-ca , Fl -use-openssl-ca
 Use bundled Mozilla CA store as supplied by current Node.js version or use OpenSSL's default CA store.
 The default store is selectable at build-time.

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -486,14 +486,15 @@
       emitAfter
     } = NativeModule.require('internal/async_hooks');
 
-    process._fatalException = (er) => {
+    process._fatalException = (er, fromPromise) => {
       // It's possible that defaultTriggerAsyncId was set for a constructor
       // call that threw and was never cleared. So clear it now.
       clearDefaultTriggerAsyncId();
 
+      const type = fromPromise ? 'unhandledRejection' : 'uncaughtException';
       if (exceptionHandlerState.captureFn !== null) {
         exceptionHandlerState.captureFn(er);
-      } else if (!process.emit('uncaughtException', er)) {
+      } else if (!process.emit('uncaughtException', er, type)) {
         // If someone handled it, then great.  otherwise, die in C++ land
         // since that means that we'll exit the process, emit the 'exit' event.
         try {

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -11,11 +11,24 @@ let lastPromiseId = 0;
 exports.setup = setupPromises;
 
 function setupPromises(_setupPromises) {
-  _setupPromises(handler, promiseRejectEvents);
+  _setupPromises(promiseRejectHandler, promiseRejectEvents);
   return emitPromiseRejectionWarnings;
 }
 
-function handler(type, promise, reason) {
+const states = {
+  none: 0,
+  warn: 1,
+  strict: 2,
+  default: 3
+};
+
+let state;
+
+function promiseRejectHandler(type, promise, reason) {
+  if (state === undefined) {
+    const { getOptionValue } = require('internal/options');
+    state = states[getOptionValue('--unhandled-rejections') || 'default'];
+  }
   switch (type) {
     case promiseRejectEvents.kPromiseRejectWithNoHandler:
       return unhandledRejection(promise, reason);
@@ -42,6 +55,7 @@ function unhandledRejection(promise, reason) {
     uid: ++lastPromiseId,
     warned: false
   });
+  // This causes the promise to be referenced at least for one tick.
   pendingUnhandledRejections.push(promise);
   return true;
 }
@@ -67,14 +81,16 @@ function handledRejection(promise) {
 
 const unhandledRejectionErrName = 'UnhandledPromiseRejectionWarning';
 function emitWarning(uid, reason) {
-  // eslint-disable-next-line no-restricted-syntax
-  const warning = new Error(
+  if (state === states.none) {
+    return;
+  }
+  const warning = getError(
+    unhandledRejectionErrName,
     'Unhandled promise rejection. This error originated either by ' +
-    'throwing inside of an async function without a catch block, ' +
-    'or by rejecting a promise which was not handled with .catch(). ' +
-    `(rejection id: ${uid})`
+      'throwing inside of an async function without a catch block, ' +
+      'or by rejecting a promise which was not handled with .catch(). ' +
+      `(rejection id: ${uid})`
   );
-  warning.name = unhandledRejectionErrName;
   try {
     if (reason instanceof Error) {
       warning.stack = reason.stack;
@@ -90,7 +106,7 @@ function emitWarning(uid, reason) {
 
 let deprecationWarned = false;
 function emitDeprecationWarning() {
-  if (!deprecationWarned) {
+  if (state === states.default && !deprecationWarned) {
     deprecationWarned = true;
     process.emitWarning(
       'Unhandled promise rejections are deprecated. In the future, ' +
@@ -113,14 +129,56 @@ function emitPromiseRejectionWarnings() {
   while (len--) {
     const promise = pendingUnhandledRejections.shift();
     const promiseInfo = maybeUnhandledPromises.get(promise);
-    if (promiseInfo !== undefined) {
-      promiseInfo.warned = true;
-      const { reason, uid } = promiseInfo;
-      if (!process.emit('unhandledRejection', reason, promise)) {
-        emitWarning(uid, reason);
-      }
-      maybeScheduledTicks = true;
+    if (promiseInfo === undefined) {
+      continue;
     }
+    promiseInfo.warned = true;
+    const { reason, uid } = promiseInfo;
+    if (state === states.strict) {
+      fatalException(reason);
+    }
+    if (!process.emit('unhandledRejection', reason, promise) ||
+        // Always warn in case the user requested it.
+        state === states.warn) {
+      emitWarning(uid, reason);
+    }
+    maybeScheduledTicks = true;
   }
   return maybeScheduledTicks || pendingUnhandledRejections.length !== 0;
+}
+
+function getError(name, message) {
+  // Reset the stack to prevent any overhead.
+  const tmp = Error.stackTraceLimit;
+  Error.stackTraceLimit = 0;
+  // eslint-disable-next-line no-restricted-syntax
+  const err = new Error(message);
+  Error.stackTraceLimit = tmp;
+  Object.defineProperty(err, 'name', {
+    value: name,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  });
+  return err;
+}
+
+function fatalException(reason) {
+  let err;
+  if (reason instanceof Error) {
+    err = reason;
+  } else {
+    err = getError(
+      'UnhandledPromiseRejection',
+      'This error originated either by ' +
+        'throwing inside of an async function without a catch block, ' +
+        'or by rejecting a promise which was not handled with .catch().' +
+        ` The promise rejected with the reason "${safeToString(reason)}".`
+    );
+    err.code = 'ERR_UNHANDLED_REJECTION';
+  }
+
+  if (!process._fatalException(err, true /* fromPromise */)) {
+    throw err;
+  }
 }

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -479,11 +479,11 @@ function setupChild(evalScript) {
   originalFatalException = process._fatalException;
   process._fatalException = fatalException;
 
-  function fatalException(error) {
+  function fatalException(error, fromPromise) {
     debug(`[${threadId}] gets fatal exception`);
     let caught = false;
     try {
-      caught = originalFatalException.call(this, error);
+      caught = originalFatalException.call(this, error, fromPromise);
     } catch (e) {
       error = e;
     }

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -489,23 +489,25 @@ function setupChild(evalScript) {
     }
     debug(`[${threadId}] fatal exception caught = ${caught}`);
 
-    if (!caught) {
-      let serialized;
-      try {
-        serialized = serializeError(error);
-      } catch {}
-      debug(`[${threadId}] fatal exception serialized = ${!!serialized}`);
-      if (serialized)
-        port.postMessage({
-          type: messageTypes.ERROR_MESSAGE,
-          error: serialized
-        });
-      else
-        port.postMessage({ type: messageTypes.COULD_NOT_SERIALIZE_ERROR });
-      clearAsyncIdStack();
-
-      process.exit();
+    if (caught) {
+      return true;
     }
+
+    let serialized;
+    try {
+      serialized = serializeError(error);
+    } catch {}
+    debug(`[${threadId}] fatal exception serialized = ${!!serialized}`);
+    if (serialized)
+      port.postMessage({
+        type: messageTypes.ERROR_MESSAGE,
+        error: serialized
+      });
+    else
+      port.postMessage({ type: messageTypes.COULD_NOT_SERIALIZE_ERROR });
+    clearAsyncIdStack();
+
+    process.exit();
   }
 }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -39,6 +39,14 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
   if (syntax_check_only && has_eval_string) {
     errors->push_back("either --check or --eval can be used, not both");
   }
+
+  if (!unhandled_rejections.empty() &&
+      unhandled_rejections != "strict" &&
+      unhandled_rejections != "warn" &&
+      unhandled_rejections != "none") {
+    errors->push_back("invalid value for --unhandled-rejections");
+  }
+
   debug_options->CheckOptions(errors);
 }
 
@@ -154,6 +162,11 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--trace-warnings",
             "show stack traces on process warnings",
             &EnvironmentOptions::trace_warnings,
+            kAllowedInEnvironment);
+  AddOption("--unhandled-rejections",
+            "define unhandled rejections behavior. Options are 'strict' (raise "
+            "an error), 'warn' (enforce warnings) or 'none' (silence warnings)",
+            &EnvironmentOptions::unhandled_rejections,
             kAllowedInEnvironment);
 
   AddOption("--check",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -84,6 +84,7 @@ class EnvironmentOptions : public Options {
   bool trace_deprecation = false;
   bool trace_sync_io = false;
   bool trace_warnings = false;
+  std::string unhandled_rejections;
   std::string userland_loader;
 
   bool syntax_check_only = false;

--- a/test/message/promise_always_throw_unhandled.js
+++ b/test/message/promise_always_throw_unhandled.js
@@ -1,0 +1,16 @@
+// Flags: --unhandled-rejections=strict
+'use strict';
+
+require('../common');
+
+// Check that the process will exit on the first unhandled rejection in case the
+// unhandled rejections mode is set to `'strict'`.
+
+const ref1 = new Promise(() => {
+  throw new Error('One');
+});
+
+const ref2 = Promise.reject(new Error('Two'));
+
+// Keep the event loop alive to actually detect the unhandled rejection.
+setTimeout(() => console.log(ref1, ref2), 1000);

--- a/test/message/promise_always_throw_unhandled.out
+++ b/test/message/promise_always_throw_unhandled.out
@@ -1,0 +1,14 @@
+*
+    throw err;
+    ^
+Error: One
+    at *promise_always_throw_unhandled.js:*:*
+    at new Promise (<anonymous>)
+    at Object.<anonymous> (*promise_always_throw_unhandled.js:*:*)
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *

--- a/test/message/unhandled_promise_trace_warnings.out
+++ b/test/message/unhandled_promise_trace_warnings.out
@@ -34,7 +34,7 @@
     at *
 (node:*) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 1)
     at handledRejection (internal/process/promises.js:*)
-    at handler (internal/process/promises.js:*)
+    at promiseRejectHandler (internal/process/promises.js:*)
     at Promise.then *
     at Promise.catch *
     at Immediate.setImmediate (*test*message*unhandled_promise_trace_warnings.js:*)

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -35,6 +35,7 @@ expect('--trace-event-file-pattern {pid}-${rotation}.trace_events', 'B\n');
 // eslint-disable-next-line no-template-curly-in-string
 expect('--trace-event-file-pattern {pid}-${rotation}.trace_events ' +
        '--trace-event-categories node.async_hooks', 'B\n');
+expect('--unhandled-rejections=none', 'B\n');
 
 if (!common.isWindows) {
   expect('--perf-basic-prof', 'B\n');

--- a/test/parallel/test-next-tick-errors.js
+++ b/test/parallel/test-next-tick-errors.js
@@ -61,7 +61,9 @@ testNextTickWith('str');
 testNextTickWith({});
 testNextTickWith([]);
 
-process.on('uncaughtException', function() {
+process.on('uncaughtException', function(err, errorOrigin) {
+  assert.strictEqual(errorOrigin, 'uncaughtException');
+
   if (!exceptionHandled) {
     exceptionHandled = true;
     order.push('B');

--- a/test/parallel/test-process-fatal-exception-tick.js
+++ b/test/parallel/test-process-fatal-exception-tick.js
@@ -12,9 +12,12 @@ if (!common.isMainThread)
 
 let stage = 0;
 
-process.once('uncaughtException', common.expectsError({
-  type: Error,
-  message: 'caughtException'
+process.once('uncaughtException', common.mustCall((err, errorOrigin) => {
+  assert.strictEqual(errorOrigin, 'uncaughtException');
+  common.expectsError({
+    type: Error,
+    message: 'caughtException'
+  })(err);
 }));
 
 setImmediate(() => {

--- a/test/parallel/test-promise-unhandled-error.js
+++ b/test/parallel/test-promise-unhandled-error.js
@@ -1,0 +1,54 @@
+// Flags: --unhandled-rejections=strict
+'use strict';
+
+const common = require('../common');
+const Countdown = require('../common/countdown');
+const assert = require('assert');
+
+common.disableCrashOnUnhandledRejection();
+
+// Verify that unhandled rejections always trigger uncaught exceptions instead
+// of triggering unhandled rejections.
+
+const err1 = new Error('One');
+const err2 = new Error(
+  'This error originated either by throwing ' +
+  'inside of an async function without a catch block, or by rejecting a ' +
+  'promise which was not handled with .catch(). The promise rejected with the' +
+  ' reason "null".'
+);
+err2.code = 'ERR_UNHANDLED_REJECTION';
+Object.defineProperty(err2, 'name', {
+  value: 'UnhandledPromiseRejection',
+  writable: true,
+  configurable: true
+});
+
+const errors = [err1, err2];
+const identical = [true, false];
+
+const ref = new Promise(() => {
+  throw err1;
+});
+// Explicitly reject `null`.
+Promise.reject(null);
+
+process.on('warning', common.mustNotCall('warning'));
+process.on('unhandledRejection', common.mustCall(2));
+process.on('rejectionHandled', common.mustNotCall('rejectionHandled'));
+process.on('exit', assert.strictEqual.bind(null, 0));
+
+const timer = setTimeout(() => console.log(ref), 1000);
+
+const counter = new Countdown(2, () => {
+  clearTimeout(timer);
+});
+
+process.on('uncaughtException', common.mustCall((err, origin) => {
+  counter.dec();
+  assert.strictEqual(origin, 'unhandledRejection', err);
+  const knownError = errors.shift();
+  assert.deepStrictEqual(err, knownError);
+  // Check if the errors are reference equal.
+  assert(identical.shift() ? err === knownError : err !== knownError);
+}, 2));

--- a/test/parallel/test-promise-unhandled-flag.js
+++ b/test/parallel/test-promise-unhandled-flag.js
@@ -1,0 +1,16 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+// Verify that a faulty environment variable throws on bootstrapping.
+// Therefore we do not need any special handling for the child process.
+const child = cp.spawnSync(
+  process.execPath,
+  ['--unhandled-rejections=foobar', __filename]
+);
+
+assert.strictEqual(child.stdout.toString(), '');
+assert(child.stderr.includes(
+  'invalid value for --unhandled-rejections'), child.stderr);

--- a/test/parallel/test-promise-unhandled-silent-no-hook.js
+++ b/test/parallel/test-promise-unhandled-silent-no-hook.js
@@ -1,0 +1,22 @@
+// Flags: --unhandled-rejections=none
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+common.disableCrashOnUnhandledRejection();
+
+// Verify that ignoring unhandled rejection works fine and that no warning is
+// logged even though there is no unhandledRejection hook attached.
+
+new Promise(() => {
+  throw new Error('One');
+});
+
+Promise.reject('test');
+
+process.on('warning', common.mustNotCall('warning'));
+process.on('uncaughtException', common.mustNotCall('uncaughtException'));
+process.on('exit', assert.strictEqual.bind(null, 0));
+
+setTimeout(common.mustCall(), 2);

--- a/test/parallel/test-promise-unhandled-silent.js
+++ b/test/parallel/test-promise-unhandled-silent.js
@@ -1,0 +1,23 @@
+// Flags: --unhandled-rejections=none
+'use strict';
+
+const common = require('../common');
+
+common.disableCrashOnUnhandledRejection();
+
+// Verify that ignoring unhandled rejection works fine and that no warning is
+// logged.
+
+new Promise(() => {
+  throw new Error('One');
+});
+
+Promise.reject('test');
+
+process.on('warning', common.mustNotCall('warning'));
+process.on('uncaughtException', common.mustNotCall('uncaughtException'));
+process.on('rejectionHandled', common.mustNotCall('rejectionHandled'));
+
+process.on('unhandledRejection', common.mustCall(2));
+
+setTimeout(common.mustCall(), 2);

--- a/test/parallel/test-promise-unhandled-warn-no-hook.js
+++ b/test/parallel/test-promise-unhandled-warn-no-hook.js
@@ -1,0 +1,23 @@
+// Flags: --unhandled-rejections=warn
+'use strict';
+
+const common = require('../common');
+
+common.disableCrashOnUnhandledRejection();
+
+// Verify that ignoring unhandled rejection works fine and that no warning is
+// logged.
+
+new Promise(() => {
+  throw new Error('One');
+});
+
+Promise.reject('test');
+
+// Unhandled rejections trigger two warning per rejection. One is the rejection
+// reason and the other is a note where this warning is coming from.
+process.on('warning', common.mustCall(4));
+process.on('uncaughtException', common.mustNotCall('uncaughtException'));
+process.on('rejectionHandled', common.mustNotCall('rejectionHandled'));
+
+setTimeout(common.mustCall(), 2);

--- a/test/parallel/test-promise-unhandled-warn.js
+++ b/test/parallel/test-promise-unhandled-warn.js
@@ -1,0 +1,28 @@
+// Flags: --unhandled-rejections=warn
+'use strict';
+
+const common = require('../common');
+
+common.disableCrashOnUnhandledRejection();
+
+// Verify that ignoring unhandled rejection works fine and that no warning is
+// logged.
+
+new Promise(() => {
+  throw new Error('One');
+});
+
+Promise.reject('test');
+
+// Unhandled rejections trigger two warning per rejection. One is the rejection
+// reason and the other is a note where this warning is coming from.
+process.on('warning', common.mustCall(4));
+process.on('uncaughtException', common.mustNotCall('uncaughtException'));
+process.on('rejectionHandled', common.mustCall(2));
+
+process.on('unhandledRejection', (reason, promise) => {
+  // Handle promises but still warn!
+  promise.catch(() => {});
+});
+
+setTimeout(common.mustCall(), 2);

--- a/test/parallel/test-timers-immediate-queue-throw.js
+++ b/test/parallel/test-timers-immediate-queue-throw.js
@@ -23,8 +23,11 @@ const errObj = {
   message: 'setImmediate Err'
 };
 
-process.once('uncaughtException', common.expectsError(errObj));
-process.once('uncaughtException', () => assert.strictEqual(stage, 0));
+process.once('uncaughtException', common.mustCall((err, errorOrigin) => {
+  assert.strictEqual(errorOrigin, 'uncaughtException');
+  assert.strictEqual(stage, 0);
+  common.expectsError(errObj)(err);
+}));
 
 const d1 = domain.create();
 d1.once('error', common.expectsError(errObj));

--- a/test/parallel/test-timers-unref-throw-then-ref.js
+++ b/test/parallel/test-timers-unref-throw-then-ref.js
@@ -2,8 +2,10 @@
 const common = require('../common');
 const assert = require('assert');
 
-process.once('uncaughtException', common.expectsError({
-  message: 'Timeout Error'
+process.once('uncaughtException', common.mustCall((err) => {
+  common.expectsError({
+    message: 'Timeout Error'
+  })(err);
 }));
 
 let called = false;


### PR DESCRIPTION
Backporting #26599 was not completely trivial, since there where so many changes that required a work around. Functionality wise it should now be identical.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
