### PR TITLE
stream: inline onwritedrain

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -478,21 +478,13 @@ function onwrite(stream, er) {
 }
 
 function afterWrite(stream, state, finished, cb) {
-  if (!finished)
-    onwriteDrain(stream, state);
-  state.pendingcb--;
-  cb();
-  finishMaybe(stream, state);
-}
-
-// Must force callback to be called on nextTick, so that we don't
-// emit 'drain' before the write() consumer gets the 'false' return
-// value, and has a chance to attach a 'drain' listener.
-function onwriteDrain(stream, state) {
-  if (state.length === 0 && state.needDrain) {
+  if (!finished && state.length === 0 && state.needDrain) {
     state.needDrain = false;
     stream.emit('drain');
   }
+  state.pendingcb--;
+  cb();
+  finishMaybe(stream, state);
 }
 
 // If there's something in the buffer waiting, then process it


### PR DESCRIPTION
Just a minor cleanup. Inline and simplify onwritedrain. Also remove comment that seems to be outdated/invalid.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
