### PR TITLE
dns: update lookupService() first arg name

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -164,13 +164,12 @@ function onlookupservice(err, hostname, service) {
 }
 
 
-// lookupService(address, port, callback)
-function lookupService(hostname, port, callback) {
+function lookupService(address, port, callback) {
   if (arguments.length !== 3)
-    throw new ERR_MISSING_ARGS('hostname', 'port', 'callback');
+    throw new ERR_MISSING_ARGS('address', 'port', 'callback');
 
-  if (isIP(hostname) === 0)
-    throw new ERR_INVALID_OPT_VALUE('hostname', hostname);
+  if (isIP(address) === 0)
+    throw new ERR_INVALID_OPT_VALUE('address', address);
 
   if (!isLegalPort(port))
     throw new ERR_SOCKET_BAD_PORT(port);
@@ -182,12 +181,12 @@ function lookupService(hostname, port, callback) {
 
   const req = new GetNameInfoReqWrap();
   req.callback = callback;
-  req.hostname = hostname;
+  req.hostname = address;
   req.port = port;
   req.oncomplete = onlookupservice;
 
-  const err = cares.getnameinfo(req, hostname, port);
-  if (err) throw dnsException(err, 'getnameinfo', hostname);
+  const err = cares.getnameinfo(req, address, port);
+  if (err) throw dnsException(err, 'getnameinfo', address);
   return req;
 }
 

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -151,17 +151,17 @@ function createLookupServicePromise(hostname, port) {
   });
 }
 
-function lookupService(hostname, port) {
+function lookupService(address, port) {
   if (arguments.length !== 2)
-    throw new ERR_MISSING_ARGS('hostname', 'port');
+    throw new ERR_MISSING_ARGS('address', 'port');
 
-  if (isIP(hostname) === 0)
-    throw new ERR_INVALID_OPT_VALUE('hostname', hostname);
+  if (isIP(address) === 0)
+    throw new ERR_INVALID_OPT_VALUE('address', address);
 
   if (!isLegalPort(port))
     throw new ERR_SOCKET_BAD_PORT(port);
 
-  return createLookupServicePromise(hostname, +port);
+  return createLookupServicePromise(address, +port);
 }
 
 

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -265,29 +265,29 @@ dns.lookup('', {
   const err = {
     code: 'ERR_MISSING_ARGS',
     type: TypeError,
-    message: 'The "hostname", "port", and "callback" arguments must be ' +
+    message: 'The "address", "port", and "callback" arguments must be ' +
     'specified'
   };
 
   common.expectsError(() => dns.lookupService('0.0.0.0'), err);
-  err.message = 'The "hostname" and "port" arguments must be specified';
+  err.message = 'The "address" and "port" arguments must be specified';
   common.expectsError(() => dnsPromises.lookupService('0.0.0.0'), err);
 }
 
 {
-  const invalidHost = 'fasdfdsaf';
+  const invalidAddress = 'fasdfdsaf';
   const err = {
     code: 'ERR_INVALID_OPT_VALUE',
     type: TypeError,
-    message: `The value "${invalidHost}" is invalid for option "hostname"`
+    message: `The value "${invalidAddress}" is invalid for option "address"`
   };
 
   common.expectsError(() => {
-    dnsPromises.lookupService(invalidHost, 0);
+    dnsPromises.lookupService(invalidAddress, 0);
   }, err);
 
   common.expectsError(() => {
-    dns.lookupService(invalidHost, 0, common.mustNotCall());
+    dns.lookupService(invalidAddress, 0, common.mustNotCall());
   }, err);
 }
 


### PR DESCRIPTION
The first argument to `lookupService()` should be an IP address, and is named `"address"` in the documentation. This commit updates the code to match the documentation and provide less confusing errors.

Fixes: https://github.com/nodejs/node/issues/29039

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
