### PR TITLE
fs: unecessary argument validation

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -3,7 +3,6 @@
 const { Math, Object } = primordials;
 
 const {
-  ERR_INVALID_ARG_TYPE,
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
 const { validateNumber } = require('internal/validators');
@@ -238,6 +237,9 @@ function WriteStream(path, options) {
 
   options = copyObject(getOptions(options, {}));
 
+  // Only buffers are supported.
+  options.decodeStrings = true;
+
   // For backwards compat do not emit close on destroy.
   if (options.emitClose === undefined) {
     options.emitClose = false;
@@ -298,11 +300,6 @@ WriteStream.prototype.open = function() {
 
 
 WriteStream.prototype._write = function(data, encoding, cb) {
-  if (!(data instanceof Buffer)) {
-    const err = new ERR_INVALID_ARG_TYPE('data', 'Buffer', data);
-    return this.emit('error', err);
-  }
-
   if (typeof this.fd !== 'number') {
     return this.once('open', function() {
       this._write(data, encoding, cb);

--- a/test/parallel/test-fs-write-stream.js
+++ b/test/parallel/test-fs-write-stream.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
@@ -49,19 +49,6 @@ tmpdir.refresh();
   stream.on('drain', function() {
     assert.fail('\'drain\' event must not be emitted before ' +
                 'stream.write() has been called at least once.');
-  });
-  stream.destroy();
-}
-
-// Throws if data is not of type Buffer.
-{
-  const stream = fs.createWriteStream(file);
-  common.expectsError(() => {
-    stream._write(42, null, function() {});
-  }, {
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: 'The "data" argument must be of type Buffer. Received type number'
   });
   stream.destroy();
 }

--- a/test/parallel/test-fs-write-stream.js
+++ b/test/parallel/test-fs-write-stream.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
@@ -50,5 +50,19 @@ tmpdir.refresh();
     assert.fail('\'drain\' event must not be emitted before ' +
                 'stream.write() has been called at least once.');
   });
+  stream.destroy();
+}
+
+// Throws if data is not of type Buffer.
+{
+  const stream = fs.createWriteStream(file);
+  stream.on('error', common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError
+  }));
+  stream.write(42, null, common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError
+  }));
   stream.destroy();
 }


### PR DESCRIPTION
`Writable` already assures that only `Buffer`'s are passed to `_write`. Also this is not the "correct" way to handle errors inside `_write`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
