### PR TITLE
stream: properties cleanup

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -69,40 +69,24 @@ function Duplex(options) {
 }
 
 Object.defineProperty(Duplex.prototype, 'writableHighWaterMark', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
   get() {
     return this._writableState.highWaterMark;
   }
 });
 
 Object.defineProperty(Duplex.prototype, 'writableBuffer', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
   get: function() {
     return this._writableState.getBuffer();
   }
 });
 
 Object.defineProperty(Duplex.prototype, 'writableLength', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
   get() {
     return this._writableState.length;
   }
 });
 
 Object.defineProperty(Duplex.prototype, 'writableFinished', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
   get() {
     return this._writableState.finished;
   }
@@ -124,10 +108,6 @@ function onEndNT(self) {
 }
 
 Object.defineProperty(Duplex.prototype, 'destroyed', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
   get() {
     return this._readableState.destroyed && this._writableState.destroyed;
   },

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -75,7 +75,7 @@ Object.defineProperty(Duplex.prototype, 'writableHighWaterMark', {
 });
 
 Object.defineProperty(Duplex.prototype, 'writableBuffer', {
-  get: function() {
+  get() {
     return this._writableState.getBuffer();
   }
 });

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -84,7 +84,7 @@ Object.defineProperty(Duplex.prototype, 'writableBuffer', {
   // userland will fail
   enumerable: false,
   get: function() {
-    return this._writableState && this._writableState.getBuffer();
+    return this._writableState.getBuffer();
   }
 });
 
@@ -129,20 +129,9 @@ Object.defineProperty(Duplex.prototype, 'destroyed', {
   // userland will fail
   enumerable: false,
   get() {
-    if (this._readableState === undefined ||
-        this._writableState === undefined) {
-      return false;
-    }
     return this._readableState.destroyed && this._writableState.destroyed;
   },
   set(value) {
-    // We ignore the value if the stream
-    // has not been initialized yet
-    if (this._readableState === undefined ||
-        this._writableState === undefined) {
-      return;
-    }
-
     // Backward compatibility, the user is explicitly
     // managing destroyed
     this._readableState.destroyed = value;

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -92,6 +92,19 @@ Object.defineProperty(Duplex.prototype, 'writableFinished', {
   }
 });
 
+Object.defineProperty(Duplex.prototype, 'destroyed', {
+  get() {
+    return this._readableState.destroyed && this._writableState.destroyed;
+  },
+  set(value) {
+    // Backward compatibility, the user is explicitly
+    // managing destroyed
+    this._readableState.destroyed = value;
+    this._writableState.destroyed = value;
+  }
+});
+
+
 // The no-half-open enforcer
 function onend() {
   // If the writable side ended, then we're ok.
@@ -106,15 +119,3 @@ function onend() {
 function onEndNT(self) {
   self.end();
 }
-
-Object.defineProperty(Duplex.prototype, 'destroyed', {
-  get() {
-    return this._readableState.destroyed && this._writableState.destroyed;
-  },
-  set(value) {
-    // Backward compatibility, the user is explicitly
-    // managing destroyed
-    this._readableState.destroyed = value;
-    this._writableState.destroyed = value;
-  }
-});

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -179,23 +179,11 @@ function Readable(options) {
 }
 
 Object.defineProperty(Readable.prototype, 'destroyed', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
   enumerable: false,
   get() {
-    if (this._readableState === undefined) {
-      return false;
-    }
     return this._readableState.destroyed;
   },
   set(value) {
-    // We ignore the value if the stream
-    // has not been initialized yet
-    if (!this._readableState) {
-      return;
-    }
-
     // Backward compatibility, the user is explicitly
     // managing destroyed
     this._readableState.destroyed = value;
@@ -1028,9 +1016,6 @@ Readable.prototype[Symbol.asyncIterator] = function() {
 };
 
 Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
   enumerable: false,
   get: function() {
     return this._readableState.highWaterMark;
@@ -1038,27 +1023,19 @@ Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
 });
 
 Object.defineProperty(Readable.prototype, 'readableBuffer', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
   enumerable: false,
   get: function() {
-    return this._readableState && this._readableState.buffer;
+    return this._readableState.buffer;
   }
 });
 
 Object.defineProperty(Readable.prototype, 'readableFlowing', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
   enumerable: false,
   get: function() {
     return this._readableState.flowing;
   },
   set: function(state) {
-    if (this._readableState) {
-      this._readableState.flowing = state;
-    }
+    this._readableState.flowing = state;
   }
 });
 
@@ -1066,9 +1043,6 @@ Object.defineProperty(Readable.prototype, 'readableFlowing', {
 Readable._fromList = fromList;
 
 Object.defineProperty(Readable.prototype, 'readableLength', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
   enumerable: false,
   get() {
     return this._readableState.length;
@@ -1078,14 +1052,14 @@ Object.defineProperty(Readable.prototype, 'readableLength', {
 Object.defineProperty(Readable.prototype, 'readableObjectMode', {
   enumerable: false,
   get() {
-    return this._readableState ? this._readableState.objectMode : false;
+    return this._readableState.objectMode;
   }
 });
 
 Object.defineProperty(Readable.prototype, 'readableEncoding', {
   enumerable: false,
   get() {
-    return this._readableState ? this._readableState.encoding : null;
+    return this._readableState.encoding;
   }
 });
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -178,6 +178,9 @@ function Readable(options) {
   Stream.call(this);
 }
 
+// Exposed for testing purposes only.
+Readable._fromList = fromList;
+
 Object.defineProperty(Readable.prototype, 'destroyed', {
   get() {
     return this._readableState.destroyed;
@@ -186,6 +189,45 @@ Object.defineProperty(Readable.prototype, 'destroyed', {
     // Backward compatibility, the user is explicitly
     // managing destroyed
     this._readableState.destroyed = value;
+  }
+});
+
+Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
+  get: function() {
+    return this._readableState.highWaterMark;
+  }
+});
+
+Object.defineProperty(Readable.prototype, 'readableBuffer', {
+  get: function() {
+    return this._readableState.buffer;
+  }
+});
+
+Object.defineProperty(Readable.prototype, 'readableFlowing', {
+  get: function() {
+    return this._readableState.flowing;
+  },
+  set: function(state) {
+    this._readableState.flowing = state;
+  }
+});
+
+Object.defineProperty(Readable.prototype, 'readableLength', {
+  get() {
+    return this._readableState.length;
+  }
+});
+
+Object.defineProperty(Readable.prototype, 'readableObjectMode', {
+  get() {
+    return this._readableState.objectMode;
+  }
+});
+
+Object.defineProperty(Readable.prototype, 'readableEncoding', {
+  get() {
+    return this._readableState.encoding;
   }
 });
 
@@ -1013,48 +1055,6 @@ Readable.prototype[Symbol.asyncIterator] = function() {
   }
   return createReadableStreamAsyncIterator(this);
 };
-
-Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
-  get: function() {
-    return this._readableState.highWaterMark;
-  }
-});
-
-Object.defineProperty(Readable.prototype, 'readableBuffer', {
-  get: function() {
-    return this._readableState.buffer;
-  }
-});
-
-Object.defineProperty(Readable.prototype, 'readableFlowing', {
-  get: function() {
-    return this._readableState.flowing;
-  },
-  set: function(state) {
-    this._readableState.flowing = state;
-  }
-});
-
-// Exposed for testing purposes only.
-Readable._fromList = fromList;
-
-Object.defineProperty(Readable.prototype, 'readableLength', {
-  get() {
-    return this._readableState.length;
-  }
-});
-
-Object.defineProperty(Readable.prototype, 'readableObjectMode', {
-  get() {
-    return this._readableState.objectMode;
-  }
-});
-
-Object.defineProperty(Readable.prototype, 'readableEncoding', {
-  get() {
-    return this._readableState.encoding;
-  }
-});
 
 // Pluck off n bytes from an array of buffers.
 // Length is the combined lengths of all the buffers in the list.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -179,7 +179,6 @@ function Readable(options) {
 }
 
 Object.defineProperty(Readable.prototype, 'destroyed', {
-  enumerable: false,
   get() {
     return this._readableState.destroyed;
   },
@@ -1016,21 +1015,18 @@ Readable.prototype[Symbol.asyncIterator] = function() {
 };
 
 Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
-  enumerable: false,
   get: function() {
     return this._readableState.highWaterMark;
   }
 });
 
 Object.defineProperty(Readable.prototype, 'readableBuffer', {
-  enumerable: false,
   get: function() {
     return this._readableState.buffer;
   }
 });
 
 Object.defineProperty(Readable.prototype, 'readableFlowing', {
-  enumerable: false,
   get: function() {
     return this._readableState.flowing;
   },
@@ -1043,21 +1039,18 @@ Object.defineProperty(Readable.prototype, 'readableFlowing', {
 Readable._fromList = fromList;
 
 Object.defineProperty(Readable.prototype, 'readableLength', {
-  enumerable: false,
   get() {
     return this._readableState.length;
   }
 });
 
 Object.defineProperty(Readable.prototype, 'readableObjectMode', {
-  enumerable: false,
   get() {
     return this._readableState.objectMode;
   }
 });
 
 Object.defineProperty(Readable.prototype, 'readableEncoding', {
-  enumerable: false,
   get() {
     return this._readableState.encoding;
   }

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -193,22 +193,22 @@ Object.defineProperty(Readable.prototype, 'destroyed', {
 });
 
 Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
-  get: function() {
+  get() {
     return this._readableState.highWaterMark;
   }
 });
 
 Object.defineProperty(Readable.prototype, 'readableBuffer', {
-  get: function() {
+  get() {
     return this._readableState.buffer;
   }
 });
 
 Object.defineProperty(Readable.prototype, 'readableFlowing', {
-  get: function() {
+  get() {
     return this._readableState.flowing;
   },
-  set: function(state) {
+  set(state) {
     this._readableState.flowing = state;
   }
 });

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -334,7 +334,6 @@ Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
 };
 
 Object.defineProperty(Writable.prototype, 'writableBuffer', {
-  enumerable: false,
   get: function() {
     return this._writableState.getBuffer();
   }
@@ -350,7 +349,6 @@ function decodeChunk(state, chunk, encoding) {
 }
 
 Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
-  enumerable: false,
   get: function() {
     return this._writableState.highWaterMark;
   }
@@ -593,7 +591,6 @@ Object.defineProperty(Writable.prototype, 'writableLength', {
   // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
-  enumerable: false,
   get() {
     return this._writableState.length;
   }
@@ -679,7 +676,6 @@ function onCorkedFinish(corkReq, state, err) {
 }
 
 Object.defineProperty(Writable.prototype, 'destroyed', {
-  enumerable: false,
   get() {
     return this._writableState.destroyed;
   },
@@ -691,14 +687,12 @@ Object.defineProperty(Writable.prototype, 'destroyed', {
 });
 
 Object.defineProperty(Writable.prototype, 'writableObjectMode', {
-  enumerable: false,
   get() {
     return this._writableState.objectMode;
   }
 });
 
 Object.defineProperty(Writable.prototype, 'writableFinished', {
-  enumerable: false,
   get() {
     return this._writableState.finished;
   }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -164,6 +164,13 @@ function WritableState(options, stream, isDuplex) {
   this.corkedRequestsFree = corkReq;
 }
 
+Object.defineProperty(WritableState.prototype, 'buffer', {
+  get: internalUtil.deprecate(function writableStateBufferGetter() {
+    return this.getBuffer();
+  }, '_writableState.buffer is deprecated. Use _writableState.getBuffer ' +
+     'instead.', 'DEP0003')
+});
+
 WritableState.prototype.getBuffer = function getBuffer() {
   var current = this.bufferedRequest;
   const out = [];
@@ -173,13 +180,6 @@ WritableState.prototype.getBuffer = function getBuffer() {
   }
   return out;
 };
-
-Object.defineProperty(WritableState.prototype, 'buffer', {
-  get: internalUtil.deprecate(function writableStateBufferGetter() {
-    return this.getBuffer();
-  }, '_writableState.buffer is deprecated. Use _writableState.getBuffer ' +
-     'instead.', 'DEP0003')
-});
 
 // Test _writableState for inheritance to account for Duplex streams,
 // whose prototype chain only points to Readable.
@@ -239,6 +239,41 @@ function Writable(options) {
 
   Stream.call(this);
 }
+
+Object.defineProperty(Writable.prototype, 'destroyed', {
+  get() {
+    return this._writableState.destroyed;
+  },
+  set(value) {
+    // Backward compatibility, the user is explicitly
+    // managing destroyed
+    this._writableState.destroyed = value;
+  }
+});
+
+Object.defineProperty(Writable.prototype, 'writableObjectMode', {
+  get() {
+    return this._writableState.objectMode;
+  }
+});
+
+Object.defineProperty(Writable.prototype, 'writableFinished', {
+  get() {
+    return this._writableState.finished;
+  }
+});
+
+Object.defineProperty(Writable.prototype, 'writableBuffer', {
+  get: function() {
+    return this._writableState.getBuffer();
+  }
+});
+
+Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
+  get: function() {
+    return this._writableState.highWaterMark;
+  }
+});
 
 // Otherwise people can pipe Writable streams, which is just wrong.
 Writable.prototype.pipe = function() {
@@ -333,12 +368,6 @@ Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
   return this;
 };
 
-Object.defineProperty(Writable.prototype, 'writableBuffer', {
-  get: function() {
-    return this._writableState.getBuffer();
-  }
-});
-
 function decodeChunk(state, chunk, encoding) {
   if (!state.objectMode &&
       state.decodeStrings !== false &&
@@ -347,12 +376,6 @@ function decodeChunk(state, chunk, encoding) {
   }
   return chunk;
 }
-
-Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
-  get: function() {
-    return this._writableState.highWaterMark;
-  }
-});
 
 // If we're already writing something, then just put this
 // in the queue, and wait our turn.  Otherwise, call _write
@@ -674,29 +697,6 @@ function onCorkedFinish(corkReq, state, err) {
   // Reuse the free corkReq.
   state.corkedRequestsFree.next = corkReq;
 }
-
-Object.defineProperty(Writable.prototype, 'destroyed', {
-  get() {
-    return this._writableState.destroyed;
-  },
-  set(value) {
-    // Backward compatibility, the user is explicitly
-    // managing destroyed
-    this._writableState.destroyed = value;
-  }
-});
-
-Object.defineProperty(Writable.prototype, 'writableObjectMode', {
-  get() {
-    return this._writableState.objectMode;
-  }
-});
-
-Object.defineProperty(Writable.prototype, 'writableFinished', {
-  get() {
-    return this._writableState.finished;
-  }
-});
 
 Writable.prototype.destroy = destroyImpl.destroy;
 Writable.prototype._undestroy = destroyImpl.undestroy;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -264,13 +264,13 @@ Object.defineProperty(Writable.prototype, 'writableFinished', {
 });
 
 Object.defineProperty(Writable.prototype, 'writableBuffer', {
-  get: function() {
+  get() {
     return this._writableState.getBuffer();
   }
 });
 
 Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
-  get: function() {
+  get() {
     return this._writableState.highWaterMark;
   }
 });

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -334,12 +334,9 @@ Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
 };
 
 Object.defineProperty(Writable.prototype, 'writableBuffer', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
   enumerable: false,
   get: function() {
-    return this._writableState && this._writableState.getBuffer();
+    return this._writableState.getBuffer();
   }
 });
 
@@ -353,9 +350,6 @@ function decodeChunk(state, chunk, encoding) {
 }
 
 Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
   enumerable: false,
   get: function() {
     return this._writableState.highWaterMark;
@@ -685,23 +679,11 @@ function onCorkedFinish(corkReq, state, err) {
 }
 
 Object.defineProperty(Writable.prototype, 'destroyed', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
   enumerable: false,
   get() {
-    if (this._writableState === undefined) {
-      return false;
-    }
     return this._writableState.destroyed;
   },
   set(value) {
-    // We ignore the value if the stream
-    // has not been initialized yet
-    if (!this._writableState) {
-      return;
-    }
-
     // Backward compatibility, the user is explicitly
     // managing destroyed
     this._writableState.destroyed = value;
@@ -711,14 +693,11 @@ Object.defineProperty(Writable.prototype, 'destroyed', {
 Object.defineProperty(Writable.prototype, 'writableObjectMode', {
   enumerable: false,
   get() {
-    return this._writableState ? this._writableState.objectMode : false;
+    return this._writableState.objectMode;
   }
 });
 
 Object.defineProperty(Writable.prototype, 'writableFinished', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
   enumerable: false,
   get() {
     return this._writableState.finished;

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -184,9 +184,10 @@ const assert = require('assert');
 
 {
   function MyDuplex() {
-    assert.strictEqual(this.destroyed, false);
-    this.destroyed = false;
     Duplex.call(this);
+    assert.strictEqual(this.destroyed, false);
+    this.destroyed = true;
+    assert.strictEqual(this.destroyed, true);
   }
 
   Object.setPrototypeOf(MyDuplex.prototype, Duplex.prototype);

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -154,9 +154,10 @@ const assert = require('assert');
 
 {
   function MyReadable() {
-    assert.strictEqual(this.destroyed, false);
-    this.destroyed = false;
     Readable.call(this);
+    assert.strictEqual(this.destroyed, false);
+    this.destroyed = true;
+    assert.strictEqual(this.destroyed, true);
   }
 
   Object.setPrototypeOf(MyReadable.prototype, Readable.prototype);

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -193,9 +193,10 @@ const assert = require('assert');
 
 {
   function MyWritable() {
-    assert.strictEqual(this.destroyed, false);
-    this.destroyed = false;
     Writable.call(this);
+    assert.strictEqual(this.destroyed, false);
+    this.destroyed = true;
+    assert.strictEqual(this.destroyed, true);
   }
 
   Object.setPrototypeOf(MyWritable.prototype, Writable.prototype);


### PR DESCRIPTION
- Streams are always initialized. Remove redundant checks. 
- `enumerable` is false by default so there is no reason to explicitly set it.
- prefer `method() {}` over `method: function() {}`
- move properties directly after constructor

Refs: https://github.com/nodejs/node/issues/28967, https://github.com/nodejs/node/issues/28991

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
