### PR TITLE
`qs.stringify` behavior on `undefined` and `null`

### DIFF
--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -119,7 +119,7 @@ given `obj` by iterating through the object's "own properties".
 
 It serializes the following types of values passed in `obj`:
 {string|number|boolean|string[]|number[]|boolean[]}
-Any other input values will be coerced to empty strings.
+Any other input values (including {null} and {undefined}) will be coerced to empty strings.
 
 ```js
 querystring.stringify({ foo: 'bar', baz: ['qux', 'quux'], corge: '' });


### PR DESCRIPTION
Related to issue #28916

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
