### PR TITLE
http: outgoing cork

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1231,6 +1231,13 @@ deprecated: v13.0.0
 
 See [`response.socket`][].
 
+### response.cork()
+<!-- YAML
+added: REPLACEME
+-->
+
+See [`writable.cork()`][].
+
 ### response.end(\[data\[, encoding\]\]\[, callback\])
 <!-- YAML
 added: v0.1.90
@@ -1515,6 +1522,13 @@ response.statusMessage = 'Not found';
 
 After response header was sent to the client, this property indicates the
 status message which was sent out.
+
+### response.uncork()
+<!-- YAML
+added: REPLACEME
+-->
+
+See [`writable.uncork()`][].
 
 ### response.writableEnded
 <!-- YAML
@@ -2356,3 +2370,5 @@ not abort the request or do anything besides add a `'timeout'` event.
 [`socket.unref()`]: net.html#net_socket_unref
 [`url.parse()`]: url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
 [`HPE_HEADER_OVERFLOW`]: errors.html#errors_hpe_header_overflow
+[`writable.cork()`]: stream.html#stream_writable_cork
+[`writable.uncork()`]: stream.html#stream_writable_uncork

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -56,6 +56,8 @@ const { validateString } = require('internal/validators');
 const HIGH_WATER_MARK = getDefaultHighWaterMark();
 const { CRLF, debug } = common;
 
+const kCorked = Symbol('corked');
+
 const RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
 const RE_TE_CHUNKED = common.chunkExpression;
 
@@ -99,6 +101,7 @@ function OutgoingMessage() {
 
   this.finished = false;
   this._headerSent = false;
+  this[kCorked] = 0;
 
   this.socket = null;
   this._header = null;
@@ -134,6 +137,13 @@ Object.defineProperty(OutgoingMessage.prototype, 'writableLength', {
 Object.defineProperty(OutgoingMessage.prototype, 'writableHighWaterMark', {
   get() {
     return this.socket ? this.socket.writableHighWaterMark : HIGH_WATER_MARK;
+  }
+});
+
+Object.defineProperty(OutgoingMessage.prototype, 'writableCorked', {
+  get() {
+    const corked = this.socket ? this.socket.writableCorked : 0;
+    return corked + this[kCorked];
   }
 });
 
@@ -213,6 +223,21 @@ OutgoingMessage.prototype._renderHeaders = function _renderHeaders() {
   return headers;
 };
 
+OutgoingMessage.prototype.cork = function() {
+  if (this.socket) {
+    this.socket.cork();
+  } else {
+    this[kCorked]++;
+  }
+};
+
+OutgoingMessage.prototype.uncork = function() {
+  if (this.socket) {
+    this.socket.uncork();
+  } else if (this[kCorked]) {
+    this[kCorked]--;
+  }
+};
 
 OutgoingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
 
@@ -710,7 +735,10 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     return this;
   }
 
-  var uncork;
+  if (this.socket) {
+    this.socket.cork();
+  }
+
   if (chunk) {
     if (typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
       throw new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
@@ -720,10 +748,6 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
         this._contentLength = Buffer.byteLength(chunk, encoding);
       else
         this._contentLength = chunk.length;
-    }
-    if (this.socket) {
-      this.socket.cork();
-      uncork = true;
     }
     write_(this, chunk, encoding, null, true);
   } else if (!this._header) {
@@ -743,8 +767,12 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     this._send('', 'latin1', finish);
   }
 
-  if (uncork)
+  if (this.socket) {
+    // Fully uncork connection on end().
+    this.socket._writableState.corked = 1;
     this.socket.uncork();
+  }
+  this[kCorked] = 0;
 
   this.finished = true;
 
@@ -805,6 +833,11 @@ OutgoingMessage.prototype._flush = function _flush() {
 };
 
 OutgoingMessage.prototype._flushOutput = function _flushOutput(socket) {
+  while (this[kCorked]) {
+    this[kCorked]--;
+    socket.cork();
+  }
+
   const outputLength = this.outputData.length;
   if (outputLength <= 0)
     return undefined;

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -108,6 +108,16 @@ Object.defineProperty(Duplex.prototype, 'writableFinished', {
   }
 });
 
+Object.defineProperty(Duplex.prototype, 'writableCorked', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get() {
+    return this._writableState ? this._writableState.corked : 0;
+  }
+});
+
 Object.defineProperty(Duplex.prototype, 'writableEnded', {
   // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -503,6 +503,10 @@ class Http2ServerResponse extends Stream {
     return this[kState].statusCode;
   }
 
+  get writableCorked() {
+    return this[kStream].writableCorked;
+  }
+
   set statusCode(code) {
     code |= 0;
     if (code >= 100 && code < 200)
@@ -625,6 +629,14 @@ class Http2ServerResponse extends Stream {
     this[kBeginSend]();
 
     return this;
+  }
+
+  cork() {
+    this[kStream].cork();
+  }
+
+  uncork() {
+    this[kStream].uncork();
   }
 
   write(chunk, encoding, cb) {

--- a/test/parallel/test-http-response-cork.js
+++ b/test/parallel/test-http-response-cork.js
@@ -1,0 +1,33 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+
+const server = http.createServer((req, res) => {
+  let corked = false;
+  const originalWrite = res.socket.write;
+  res.socket.write = common.mustCall((...args) => {
+    assert.strictEqual(corked, false);
+    return originalWrite.call(res.socket, ...args);
+  }, 5);
+  corked = true;
+  res.cork();
+  assert.strictEqual(res.writableCorked, res.socket.writableCorked);
+  res.cork();
+  assert.strictEqual(res.writableCorked, res.socket.writableCorked);
+  res.writeHead(200, { 'a-header': 'a-header-value' });
+  res.uncork();
+  assert.strictEqual(res.writableCorked, res.socket.writableCorked);
+  corked = false;
+  res.end('asd');
+  assert.strictEqual(res.writableCorked, res.socket.writableCorked);
+});
+
+server.listen(0, () => {
+  http.get({ port: server.address().port }, (res) => {
+    res.on('data', common.mustCall());
+    res.on('end', common.mustCall(() => {
+      server.close();
+    }));
+  });
+});


### PR DESCRIPTION
Implements cork/uncork on `OutgoingMessage` to make it more streamlike.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
