### PR TITLE
test: unskip tests that now pass on AIX

### DIFF
--- a/test/message/message.status
+++ b/test/message/message.status
@@ -17,5 +17,3 @@ prefix message
 [$system==freebsd]
 
 [$system==aix]
-# https://github.com/nodejs/node/pull/28469
-vm_dont_display_syntax_error: SKIP

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -19,8 +19,7 @@ test-http2-large-file: PASS, FLAKY
 [$system==freebsd]
 
 [$system==aix]
-# https://github.com/nodejs/node/pull/28469
-test-async-wrap-getasyncid: SKIP
+# https://github.com/nodejs/node/pull/29054
 test-buffer-creation-regression: SKIP
 
 [$arch==arm]


### PR DESCRIPTION
One skipped test remains, it creates very large Buffer objects,
triggering the AIX OOM to kill node and it's parent processes.

See: https://github.com/nodejs/build/issues/1849#issuecomment-514414165

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
