### PR TITLE
stream: don't emit error after close

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -126,6 +126,9 @@ function ReadableState(options, stream, isDuplex) {
   // Has it been destroyed
   this.destroyed = false;
 
+  // When 'close' is emitted
+  this.closed = false;
+
   // Crypto is kind of old and crusty.  Historically, its default string
   // encoding is 'binary' so we have to make this configurable.
   // Everything else in the universe uses 'utf8', though.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -92,6 +92,9 @@ function WritableState(options, stream, isDuplex) {
   // Has it been destroyed
   this.destroyed = false;
 
+  // When 'close' is emitted
+  this.closed = false;
+
   // Should we decode strings into buffers before passing to _write?
   // this is here so that some node-core streams can optimize string
   // handling at a lower level.

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -220,6 +220,12 @@ function closeFsStream(stream, cb, err) {
     er = er || err;
     cb(er);
     stream.closed = true;
+    if (stream._writableState) {
+      stream._writableState.closed = true;
+    }
+    if (stream._readableState) {
+      stream._readableState.closed = true;
+    }
     if (!er)
       stream.emit('close');
   });

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -7,10 +7,13 @@ function destroy(err, cb) {
   const writableDestroyed = this._writableState &&
     this._writableState.destroyed;
 
+  const closed = (this._writableState && this._writableState.closed) ||
+    (this._readableState && this._readableState.closed);
+
   if (readableDestroyed || writableDestroyed) {
     if (cb) {
       cb(err);
-    } else if (err) {
+    } else if (err && !closed) {
       if (!this._writableState) {
         process.nextTick(emitErrorNT, this, err);
       } else if (!this._writableState.errorEmitted) {
@@ -61,6 +64,12 @@ function emitErrorAndCloseNT(self, err) {
 }
 
 function emitCloseNT(self) {
+  if (self._writableState) {
+    self._writableState.closed = true;
+  }
+  if (self._readableState) {
+    self._readableState.closed = true;
+  }
   if (self._writableState && !self._writableState.emitClose)
     return;
   if (self._readableState && !self._readableState.emitClose)
@@ -70,6 +79,7 @@ function emitCloseNT(self) {
 
 function undestroy() {
   if (this._readableState) {
+    this._readableState.closed = false;
     this._readableState.destroyed = false;
     this._readableState.reading = false;
     this._readableState.ended = false;
@@ -77,6 +87,7 @@ function undestroy() {
   }
 
   if (this._writableState) {
+    this._writableState.closed = false;
     this._writableState.destroyed = false;
     this._writableState.ended = false;
     this._writableState.ending = false;
@@ -100,6 +111,10 @@ function errorOrDestroy(stream, err) {
 
   const rState = stream._readableState;
   const wState = stream._writableState;
+
+  if (stream.closed) {
+    return;
+  }
 
   if ((rState && rState.autoDestroy) || (wState && wState.autoDestroy))
     stream.destroy(err);

--- a/test/parallel/test-file-write-stream.js
+++ b/test/parallel/test-file-write-stream.js
@@ -65,17 +65,11 @@ file
     assert.strictEqual(file.bytesWritten, EXPECTED.length * 2);
 
     callbacks.close++;
-    common.expectsError(
-      () => {
-        console.error('write after end should not be allowed');
-        file.write('should not work anymore');
-      },
-      {
-        code: 'ERR_STREAM_WRITE_AFTER_END',
-        type: Error,
-        message: 'write after end'
-      }
-    );
+    file.write('should not work anymore', common.expectsError({
+      code: 'ERR_STREAM_WRITE_AFTER_END',
+      type: Error,
+      message: 'write after end'
+    }));
 
     fs.unlinkSync(fn);
   });

--- a/test/parallel/test-file-write-stream2.js
+++ b/test/parallel/test-file-write-stream2.js
@@ -33,7 +33,7 @@ const filepath = path.join(tmpdir.path, 'write.txt');
 
 const EXPECTED = '012345678910';
 
-const cb_expected = 'write open drain write drain close error ';
+const cb_expected = 'write open drain write drain close';
 let cb_occurred = '';
 
 let countDrains = 0;
@@ -90,7 +90,7 @@ file.on('drain', function() {
 });
 
 file.on('close', function() {
-  cb_occurred += 'close ';
+  cb_occurred += 'close';
   assert.strictEqual(file.bytesWritten, EXPECTED.length * 2);
   file.write('should not work anymore');
 });

--- a/test/parallel/test-http2-server-stream-session-destroy.js
+++ b/test/parallel/test-http2-server-stream-session-destroy.js
@@ -34,12 +34,11 @@ server.on('stream', common.mustCall((stream) => {
       type: Error
     }
   );
-  stream.on('error', common.expectsError({
+  assert.strictEqual(stream.write('data', common.expectsError({
     type: Error,
     code: 'ERR_STREAM_WRITE_AFTER_END',
     message: 'write after end'
-  }));
-  assert.strictEqual(stream.write('data'), false);
+  })), false);
 }));
 
 server.listen(0, common.mustCall(() => {


### PR DESCRIPTION
- Don't emit `'error'` after `'close'`. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
