### PR TITLE
stream: improve destroy readability

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -2,19 +2,20 @@
 
 // Undocumented cb() API, needed for core, not for public API
 function destroy(err, cb) {
-  const readableDestroyed = this._readableState &&
-    this._readableState.destroyed;
-  const writableDestroyed = this._writableState &&
-    this._writableState.destroyed;
+  const r = this._readableState;
+  const w = this._writableState;
+
+  const readableDestroyed = r && r.destroyed;
+  const writableDestroyed = w && w.destroyed;
 
   if (readableDestroyed || writableDestroyed) {
     if (cb) {
       cb(err);
     } else if (err) {
-      if (!this._writableState) {
+      if (!w) {
         process.nextTick(emitErrorNT, this, err);
-      } else if (!this._writableState.errorEmitted) {
-        this._writableState.errorEmitted = true;
+      } else if (!w.errorEmitted) {
+        w.errorEmitted = true;
         process.nextTick(emitErrorNT, this, err);
       }
     }
@@ -25,21 +26,21 @@ function destroy(err, cb) {
   // We set destroyed to true before firing error callbacks in order
   // to make it re-entrance safe in case destroy() is called within callbacks
 
-  if (this._readableState) {
-    this._readableState.destroyed = true;
+  if (r) {
+    r.destroyed = true;
   }
 
   // If this is a duplex stream mark the writable part as destroyed as well
-  if (this._writableState) {
-    this._writableState.destroyed = true;
+  if (w) {
+    w.destroyed = true;
   }
 
   this._destroy(err || null, (err) => {
     if (!cb && err) {
-      if (!this._writableState) {
+      if (!w) {
         process.nextTick(emitErrorAndCloseNT, this, err);
-      } else if (!this._writableState.errorEmitted) {
-        this._writableState.errorEmitted = true;
+      } else if (!w.errorEmitted) {
+        w.errorEmitted = true;
         process.nextTick(emitErrorAndCloseNT, this, err);
       } else {
         process.nextTick(emitCloseNT, this);
@@ -61,29 +62,35 @@ function emitErrorAndCloseNT(self, err) {
 }
 
 function emitCloseNT(self) {
-  if (self._writableState && !self._writableState.emitClose)
+  const r = self._readableState;
+  const w = self._writableState;
+
+  if (w && !w.emitClose)
     return;
-  if (self._readableState && !self._readableState.emitClose)
+  if (r && !r.emitClose)
     return;
   self.emit('close');
 }
 
 function undestroy() {
-  if (this._readableState) {
-    this._readableState.destroyed = false;
-    this._readableState.reading = false;
-    this._readableState.ended = false;
-    this._readableState.endEmitted = false;
+  const r = this._readableState;
+  const w = this._writableState;
+
+  if (r) {
+    r.destroyed = false;
+    r.reading = false;
+    r.ended = false;
+    r.endEmitted = false;
   }
 
-  if (this._writableState) {
-    this._writableState.destroyed = false;
-    this._writableState.ended = false;
-    this._writableState.ending = false;
-    this._writableState.finalCalled = false;
-    this._writableState.prefinished = false;
-    this._writableState.finished = false;
-    this._writableState.errorEmitted = false;
+  if (w) {
+    w.destroyed = false;
+    w.ended = false;
+    w.ending = false;
+    w.finalCalled = false;
+    w.prefinished = false;
+    w.finished = false;
+    w.errorEmitted = false;
   }
 }
 
@@ -98,10 +105,10 @@ function errorOrDestroy(stream, err) {
   // the error to be emitted nextTick. In a future
   // semver major update we should change the default to this.
 
-  const rState = stream._readableState;
-  const wState = stream._writableState;
+  const r = stream._readableState;
+  const w = stream._writableState;
 
-  if ((rState && rState.autoDestroy) || (wState && wState.autoDestroy))
+  if ((r && r.autoDestroy) || (w && w.autoDestroy))
     stream.destroy(err);
   else
     stream.emit('error', err);


### PR DESCRIPTION
Purely cosmetic. I have changes pending here where it becomes unreadable with long names.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
