### PR TITLE
fs: deprecate file stream open

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2518,6 +2518,22 @@ Type: Documentation-only
 Prefer [`response.socket`][] over [`response.connection`] and
 [`request.socket`][] over [`request.connection`].
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: `WriteStream.open()` and `ReadStream.open()` are internal
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/29061
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+[`WriteStream.open()`][] and [`ReadStream.open()`][] are undocumented internal
+APIs that do not make sense to use in userland. File streams should always be
+opened through the constructor or by passing a file descriptor in options.
+
+[`--http-parser=legacy`]: cli.html#cli_http_parser_library
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
@@ -2528,10 +2544,12 @@ Prefer [`response.socket`][] over [`response.connection`] and
 [`Decipher`]: crypto.html#crypto_class_decipher
 [`EventEmitter.listenerCount(emitter, eventName)`]: events.html#events_eventemitter_listenercount_emitter_eventname
 [`REPLServer.clearBufferedCommand()`]: repl.html#repl_replserver_clearbufferedcommand
+[`ReadStream.open()`]: fs.html#fs_class_fs_readstream
 [`Server.connections`]: net.html#net_server_connections
 [`Server.getConnections()`]: net.html#net_server_getconnections_callback
 [`Server.listen({fd: <number>})`]: net.html#net_server_listen_handle_backlog_callback
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
+[`WriteStream.open()`]: fs.html#fs_class_fs_writestream
 [`assert`]: assert.html
 [`asyncResource.runInAsyncScope()`]: async_hooks.html#async_hooks_asyncresource_runinasyncscope_fn_thisarg_args
 [`child_process`]: child_process.html

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2531,10 +2531,9 @@ Type: Runtime
 
 [`WriteStream.open()`][] and [`ReadStream.open()`][] are undocumented internal
 APIs that do not make sense to use in userland. File streams should always be
-opened through their corresponding factory methods or by passing a file
-descriptor in options.
+opened through their corresponding factory methods [`fs.createWriteStream()`][]
+and [`fs.createReadStream()`][]) or by passing a file descriptor in options.
 
-[`--http-parser=legacy`]: cli.html#cli_http_parser_library
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
@@ -2573,6 +2572,8 @@ descriptor in options.
 [`ecdh.setPublicKey()`]: crypto.html#crypto_ecdh_setpublickey_publickey_encoding
 [`emitter.listenerCount(eventName)`]: events.html#events_emitter_listenercount_eventname
 [`fs.access()`]: fs.html#fs_fs_access_path_mode_callback
+[`fs.createReadStream()`]: fs.html#fs_fs_createreadstream_path_options
+[`fs.createWriteStream()`]: fs.html#fs_fs_createwritestream_path_options
 [`fs.exists(path, callback)`]: fs.html#fs_fs_exists_path_callback
 [`fs.lchmod(path, mode, callback)`]: fs.html#fs_fs_lchmod_path_mode_callback
 [`fs.lchmodSync(path, mode)`]: fs.html#fs_fs_lchmodsync_path_mode

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2531,7 +2531,8 @@ Type: Runtime
 
 [`WriteStream.open()`][] and [`ReadStream.open()`][] are undocumented internal
 APIs that do not make sense to use in userland. File streams should always be
-opened through the constructor or by passing a file descriptor in options.
+opened through their corresponding factory methods or by passing a file
+descriptor in options.
 
 [`--http-parser=legacy`]: cli.html#cli_http_parser_library
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -5,6 +5,7 @@ const { Math, Object } = primordials;
 const {
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
+const internalUtil = require('internal/util');
 const { validateNumber } = require('internal/validators');
 const fs = require('fs');
 const { Buffer } = require('buffer');
@@ -100,7 +101,7 @@ function ReadStream(path, options) {
   }
 
   if (typeof this.fd !== 'number')
-    this.open();
+    _openReadFs(this);
 
   this.on('end', function() {
     if (this.autoClose) {
@@ -111,23 +112,34 @@ function ReadStream(path, options) {
 Object.setPrototypeOf(ReadStream.prototype, Readable.prototype);
 Object.setPrototypeOf(ReadStream, Readable);
 
-ReadStream.prototype.open = function() {
-  fs.open(this.path, this.flags, this.mode, (er, fd) => {
+const openReadFs = internalUtil.deprecate(function() {
+  _openReadFs(this);
+}, 'ReadStream.prototype.open() is deprecated', 'DEP0XXX');
+ReadStream.prototype.open = openReadFs;
+
+function _openReadFs(stream) {
+  // Backwards compat for overriden open.
+  if (stream.open !== openReadFs) {
+    stream.open();
+    return;
+  }
+
+  fs.open(stream.path, stream.flags, stream.mode, (er, fd) => {
     if (er) {
-      if (this.autoClose) {
-        this.destroy();
+      if (stream.autoClose) {
+        stream.destroy();
       }
-      this.emit('error', er);
+      stream.emit('error', er);
       return;
     }
 
-    this.fd = fd;
-    this.emit('open', fd);
-    this.emit('ready');
+    stream.fd = fd;
+    stream.emit('open', fd);
+    stream.emit('ready');
     // Start the flow of data.
-    this.read();
+    stream.read();
   });
-};
+}
 
 ReadStream.prototype._read = function(n) {
   if (typeof this.fd !== 'number') {
@@ -266,7 +278,7 @@ function WriteStream(path, options) {
     this.setDefaultEncoding(options.encoding);
 
   if (typeof this.fd !== 'number')
-    this.open();
+    _openWriteFs(this);
 }
 Object.setPrototypeOf(WriteStream.prototype, Writable.prototype);
 Object.setPrototypeOf(WriteStream, Writable);
@@ -279,21 +291,32 @@ WriteStream.prototype._final = function(callback) {
   callback();
 };
 
-WriteStream.prototype.open = function() {
-  fs.open(this.path, this.flags, this.mode, (er, fd) => {
+const openWriteFs = internalUtil.deprecate(function() {
+  _openWriteFs(this);
+}, 'WriteStream.prototype.open() is deprecated', 'DEP0XXX');
+WriteStream.prototype.open = openWriteFs;
+
+function _openWriteFs(stream) {
+  // Backwards compat for overriden open.
+  if (stream.open !== openWriteFs) {
+    stream.open();
+    return;
+  }
+
+  fs.open(stream.path, stream.flags, stream.mode, (er, fd) => {
     if (er) {
-      if (this.autoClose) {
-        this.destroy();
+      if (stream.autoClose) {
+        stream.destroy();
       }
-      this.emit('error', er);
+      stream.emit('error', er);
       return;
     }
 
-    this.fd = fd;
-    this.emit('open', fd);
-    this.emit('ready');
+    stream.fd = fd;
+    stream.emit('open', fd);
+    stream.emit('ready');
   });
-};
+}
 
 
 WriteStream.prototype._write = function(data, encoding, cb) {

--- a/test/parallel/test-fs-read-stream-patch-open.js
+++ b/test/parallel/test-fs-read-stream-patch-open.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+const fs = require('fs');
+
+common.expectWarning(
+  'DeprecationWarning',
+  'ReadStream.prototype.open() is deprecated', 'DEP0XXX');
+const s = fs.createReadStream('asd')
+  // We don't care about errors in this test.
+  .on('error', () => {});
+s.open();
+
+// Allow overriding open().
+fs.ReadStream.prototype.open = common.mustCall();
+fs.createReadStream('asd');

--- a/test/parallel/test-fs-write-stream-patch-open.js
+++ b/test/parallel/test-fs-write-stream-patch-open.js
@@ -28,7 +28,6 @@ common.expectWarning(
   'WriteStream.prototype.open() is deprecated', 'DEP0XXX');
 const s = fs.createWriteStream(`${tmpdir.path}/out`);
 s.open();
-s.destroy();
 
 // Allow overriding open().
 fs.WriteStream.prototype.open = common.mustCall();

--- a/test/parallel/test-fs-write-stream-patch-open.js
+++ b/test/parallel/test-fs-write-stream-patch-open.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const fs = require('fs');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+common.expectWarning(
+  'DeprecationWarning',
+  'WriteStream.prototype.open() is deprecated', 'DEP0XXX');
+const s = fs.createWriteStream(`${tmpdir.path}/out`);
+s.open();
+s.destroy();
+
+// Allow overriding open().
+fs.WriteStream.prototype.open = common.mustCall();
+fs.createWriteStream('asd');


### PR DESCRIPTION
`stream.open()` should not be used by users. 

Refs: https://github.com/nodejs/node/issues/29050.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
