### PR TITLE
fs: reuse stream.open code

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -102,10 +102,15 @@ function ReadStream(path, options) {
     }
   }
 
+  this.once('ready', () => {
+    // Start the flow of data.
+    this.read();
+  });
+
   if (typeof this.fd !== 'number')
     this.open();
 
-  this.on('end', function() {
+  this.on('end', () => {
     if (this.autoClose) {
       this.destroy();
     }
@@ -127,8 +132,6 @@ ReadStream.prototype.open = function() {
     this.fd = fd;
     this.emit('open', fd);
     this.emit('ready');
-    // Start the flow of data.
-    this.read();
   });
 };
 
@@ -280,22 +283,7 @@ WriteStream.prototype._final = function(callback) {
   callback();
 };
 
-WriteStream.prototype.open = function() {
-  fs.open(this.path, this.flags, this.mode, (er, fd) => {
-    if (er) {
-      if (this.autoClose) {
-        this.destroy();
-      }
-      this.emit('error', er);
-      return;
-    }
-
-    this.fd = fd;
-    this.emit('open', fd);
-    this.emit('ready');
-  });
-};
-
+WriteStream.prototype.open = ReadStream.prototype.open;
 
 WriteStream.prototype._write = function(data, encoding, cb) {
   if (!(data instanceof Buffer)) {


### PR DESCRIPTION
Avoid code duplication. Re-use `open()` implementattion.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
