### PR TITLE
stream: deprecate destroySoon

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2500,6 +2500,19 @@ Type: Runtime
 Passing a callback to [`worker.terminate()`][] is deprecated. Use the returned
 `Promise` instead, or a listener to the worker’s `'exit'` event.
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: stream.destroySoon()
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/29065
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+`stream.destroySoon()` is an unused internal API.
+
 [`--http-parser=legacy`]: cli.html#cli_http_parser_library
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -591,11 +591,12 @@ function responseKeepAlive(res, req) {
 
   if (!req.shouldKeepAlive) {
     if (socket.writable) {
-      debug('AGENT socket.destroySoon()');
-      if (typeof socket.destroySoon === 'function')
-        socket.destroySoon();
+      socket.end();
+
+      if (socket.writableFinished)
+        socket.destroy();
       else
-        socket.end();
+        socket.once('finish', socket.destroy);
     }
     assert(!socket.writable);
   } else {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -635,11 +635,13 @@ function resOnFinish(req, res, socket, state, server) {
   process.nextTick(emitCloseNT, res);
 
   if (res._last) {
-    if (typeof socket.destroySoon === 'function') {
-      socket.destroySoon();
-    } else {
+    if (socket.writable)
       socket.end();
-    }
+
+    if (socket.writableFinished)
+      socket.destroy();
+    else
+      socket.once('finish', socket.destroy);
   } else if (state.outgoing.length === 0) {
     if (server.keepAliveTimeout && typeof socket.setTimeout === 'function') {
       socket.setTimeout(server.keepAliveTimeout);

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -10,6 +10,7 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
+const internalUtil = require('internal/util');
 const { validateNumber } = require('internal/validators');
 const fs = require('fs');
 const { Buffer } = require('buffer');
@@ -393,7 +394,9 @@ WriteStream.prototype.close = function(cb) {
 };
 
 // There is no shutdown() for files.
-WriteStream.prototype.destroySoon = WriteStream.prototype.end;
+WriteStream.prototype.destroySoon = internalUtil.deprecate(
+  WriteStream.prototype.end,
+  'WriteStream.prototype.destroySoon is deprecated', 'DEP0XXX');
 
 Object.defineProperty(WriteStream.prototype, 'pending', {
   get() { return this.fd === null; },

--- a/lib/internal/fs/sync_write_stream.js
+++ b/lib/internal/fs/sync_write_stream.js
@@ -4,6 +4,7 @@ const { Object } = primordials;
 
 const { Writable } = require('stream');
 const { closeSync, writeSync } = require('fs');
+const internalUtil = require('internal/util');
 
 function SyncWriteStream(fd, options) {
   Writable.call(this, { autoDestroy: true });
@@ -35,7 +36,8 @@ SyncWriteStream.prototype._destroy = function(err, cb) {
   cb(err);
 };
 
-SyncWriteStream.prototype.destroySoon =
-  SyncWriteStream.prototype.destroy;
+SyncWriteStream.prototype.destroySoon = internalUtil.deprecate(
+  SyncWriteStream.prototype.destroy,
+  'SyncWriteStream.prototype.destroySoon is deprecated', 'DEP0XXX');
 
 module.exports = SyncWriteStream;

--- a/lib/internal/process/stdio.js
+++ b/lib/internal/process/stdio.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { guessHandleType } = internalBinding('util');
+const internalUtil = require('internal/util');
 exports.getMainThreadStdio = getMainThreadStdio;
 
 function dummyDestroy(err, cb) {
@@ -26,7 +27,9 @@ function getMainThreadStdio() {
   function getStdout() {
     if (stdout) return stdout;
     stdout = createWritableStdioStream(1);
-    stdout.destroySoon = stdout.destroy;
+    stdout.destroySoon = internalUtil.deprecate(
+      stdout.destroy,
+      'stdout.destroySoon is deprecated', 'DEP0XXX');
     // Override _destroy so that the fd is never actually closed.
     stdout._destroy = dummyDestroy;
     if (stdout.isTTY) {
@@ -38,7 +41,9 @@ function getMainThreadStdio() {
   function getStderr() {
     if (stderr) return stderr;
     stderr = createWritableStdioStream(2);
-    stderr.destroySoon = stderr.destroy;
+    stderr.destroySoon = internalUtil.deprecate(
+      stderr.destroy,
+      'stderr.destroySoon is deprecated', 'DEP0XXX');
     // Override _destroy so that the fd is never actually closed.
     stderr._destroy = dummyDestroy;
     if (stderr.isTTY) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -552,7 +552,7 @@ function onReadableStreamEnd() {
 }
 
 
-Socket.prototype.destroySoon = function() {
+Socket.prototype.destroySoon = deprecate(function() {
   if (this.writable)
     this.end();
 
@@ -560,7 +560,7 @@ Socket.prototype.destroySoon = function() {
     this.destroy();
   else
     this.once('finish', this.destroy);
-};
+}, 'Socket.prototype.destroySoon is deprecated', 'DEP0XXX');
 
 
 Socket.prototype._destroy = function(exception, cb) {

--- a/test/parallel/test-http-client-readable.js
+++ b/test/parallel/test-http-client-readable.js
@@ -47,7 +47,7 @@ class FakeAgent extends http.Agent {
       cb();
     };
 
-    s.destroy = s.destroySoon = function() {
+    s.destroy = function() {
       this.writable = false;
     };
 

--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -50,16 +50,6 @@ const filename = path.join(tmpdir.path, 'sync-write-stream.txt');
   assert.strictEqual(stream.fd, null);
 }
 
-// Verify that the stream will unset the fd after destroySoon().
-{
-  const fd = fs.openSync(filename, 'w');
-  const stream = new SyncWriteStream(fd);
-
-  stream.on('close', common.mustCall());
-  assert.strictEqual(stream.destroySoon(), stream);
-  assert.strictEqual(stream.fd, null);
-}
-
 // Verify that calling end() will also destroy the stream.
 {
   const fd = fs.openSync(filename, 'w');

--- a/test/parallel/test-tls-client-destroy-soon.js
+++ b/test/parallel/test-tls-client-destroy-soon.js
@@ -42,7 +42,6 @@ const big = Buffer.alloc(2 * 1024 * 1024, 'Y');
 // create server
 const server = tls.createServer(options, common.mustCall(function(socket) {
   socket.end(big);
-  socket.destroySoon();
 }));
 
 // start listening

--- a/test/sequential/test-net-response-size.js
+++ b/test/sequential/test-net-response-size.js
@@ -69,7 +69,7 @@ if (process.argv[2] === 'server') {
 
       client.write(alittle);
 
-      client.destroySoon();
+      client.end();
     });
   });
 }


### PR DESCRIPTION
Deprecate unnecessary/unused/legacy `destroySoon` API.

Refs: #29062

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
