### PR TITLE
stream: improve read() performance further

### DIFF
--- a/lib/internal/streams/buffer_list.js
+++ b/lib/internal/streams/buffer_list.js
@@ -71,19 +71,19 @@ module.exports = class BufferList {
 
   // Consumes a specified amount of bytes or characters from the buffered data.
   consume(n, hasStrings) {
-    var ret;
-    if (n < this.head.data.length) {
+    const data = this.head.data;
+    if (n < data.length) {
       // `slice` is the same for buffers and strings.
-      ret = this.head.data.slice(0, n);
-      this.head.data = this.head.data.slice(n);
-    } else if (n === this.head.data.length) {
-      // First chunk is a perfect match.
-      ret = this.shift();
-    } else {
-      // Result spans more than one buffer.
-      ret = hasStrings ? this._getString(n) : this._getBuffer(n);
+      const slice = data.slice(0, n);
+      this.head.data = data.slice(n);
+      return slice;
     }
-    return ret;
+    if (n === data.length) {
+      // First chunk is a perfect match.
+      return this.shift();
+    }
+    // Result spans more than one buffer.
+    return hasStrings ? this._getString(n) : this._getBuffer(n);
   }
 
   first() {


### PR DESCRIPTION
Results:

```
                                                        confidence improvement accuracy (*)    (**)   (***)
 streams/readable-unevenread.js n=1000                        ***      7.38 %       ±1.31%  ±1.75%  ±2.27%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
