### PR TITLE
http: remove redundant condition

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -267,7 +267,7 @@ function _writeRaw(data, encoding, callback) {
     encoding = null;
   }
 
-  if (conn && conn._httpMessage === this && conn.writable && !conn.destroyed) {
+  if (conn && conn._httpMessage === this && conn.writable) {
     // There might be pending data in the this.output buffer.
     if (this.outputData.length) {
       this._flushOutput(conn);


### PR DESCRIPTION
`conn.destroyed` is guaranteed to be `false` because a previous `if`
statement already handles the case where `conn && conn.destroyed`
evaluates to `true` returning `false` in that case.

https://github.com/nodejs/node/blob/83495e778319603c3ed61e31d37dc9715df14329/lib/_http_outgoing.js#L259-L263

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
