### PR TITLE
doc: stream error can close stream

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -277,7 +277,9 @@ added: v0.9.4
 The `'error'` event is emitted if an error occurred while writing or piping
 data. The listener callback is passed a single `Error` argument when called.
 
-The stream is not closed when the `'error'` event is emitted.
+The stream is not closed when the `'error'` event is emitted unless the
+[`autoDestroy`][writable-new] option was set to `true` when creating the
+stream.
 
 ##### Event: 'finish'
 <!-- YAML
@@ -2731,4 +2733,5 @@ contain multi-byte characters.
 [stream-write]: #stream_writable_write_chunk_encoding_callback
 [writable-_destroy]: #stream_writable_destroy_err_callback
 [writable-destroy]: #stream_writable_destroy_error
+[writable-new]: #stream_constructor_new_stream_writable_options
 [zlib]: zlib.html


### PR DESCRIPTION
Clarify that `'error'` *can* close the stream if `autoDestroy` is enabled.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
