### PR TITLE
stream: don't emit drain if ended

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -470,15 +470,17 @@ function onwrite(stream, er) {
     }
 
     if (sync) {
-      process.nextTick(afterWrite, stream, state, finished, cb);
+      process.nextTick(afterWrite, stream, state, cb);
     } else {
-      afterWrite(stream, state, finished, cb);
+      afterWrite(stream, state, cb);
     }
   }
 }
 
-function afterWrite(stream, state, finished, cb) {
-  if (!finished && state.length === 0 && state.needDrain) {
+function afterWrite(stream, state, cb) {
+  const needDrain = !state.ending && !stream.destroyed && state.length === 0 &&
+    state.needDrain;
+  if (needDrain) {
     state.needDrain = false;
     stream.emit('drain');
   }

--- a/test/parallel/test-stream-write-drain.js
+++ b/test/parallel/test-stream-write-drain.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../common');
+const { Writable } = require('stream');
+
+// Don't emit 'drain' if ended
+
+const w = new Writable({
+  write(data, enc, cb) {
+    process.nextTick(cb);
+  },
+  highWaterMark: 1
+});
+
+w.on('drain', common.mustNotCall());
+w.write('asd');
+w.end();


### PR DESCRIPTION
Don't emit `'drain'` if the stream has been ended. `'drain'` should only be emitted if the stream wants more data.

See, https://nodejs.org/api/stream.html#stream_event_drain.
> the 'drain' event will be emitted when it is appropriate to resume writing data to the stream.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

NOTE TO SELF: After this is merged look into emitting `'drain'` after `state.length < hwm` instead of `state.length === 0`.