### PR TITLE
http: symbol naming convention

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -40,7 +40,7 @@ const Agent = require('_http_agent');
 const { Buffer } = require('buffer');
 const { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
 const { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
-const { outHeadersKey, ondrain } = require('internal/http');
+const { kOutHeaders, ondrain } = require('internal/http');
 const { connResetException, codes } = require('internal/errors');
 const {
   ERR_HTTP_HEADERS_SENT,
@@ -253,7 +253,7 @@ function ClientRequest(input, options, cb) {
       }
 
       this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n',
-                        this[outHeadersKey]);
+                        this[kOutHeaders]);
     }
   } else {
     this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n',
@@ -308,7 +308,7 @@ ClientRequest.prototype._implicitHeader = function _implicitHeader() {
     throw new ERR_HTTP_HEADERS_SENT('render');
   }
   this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n',
-                    this[outHeadersKey]);
+                    this[kOutHeaders]);
 };
 
 ClientRequest.prototype.abort = function abort() {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -27,7 +27,7 @@ const { getDefaultHighWaterMark } = require('internal/streams/state');
 const assert = require('internal/assert');
 const Stream = require('stream');
 const internalUtil = require('internal/util');
-const { outHeadersKey, utcDate } = require('internal/http');
+const { kOutHeaders, utcDate } = require('internal/http');
 const { Buffer } = require('buffer');
 const common = require('_http_common');
 const checkIsHttpToken = common._checkIsHttpToken;
@@ -104,7 +104,7 @@ function OutgoingMessage() {
   this.socket = null;
   this.connection = null;
   this._header = null;
-  this[outHeadersKey] = null;
+  this[kOutHeaders] = null;
 
   this._onPendingData = noopPendingOutput;
 }
@@ -145,9 +145,9 @@ Object.defineProperty(OutgoingMessage.prototype, '_headers', {
   }, 'OutgoingMessage.prototype._headers is deprecated', 'DEP0066'),
   set: internalUtil.deprecate(function(val) {
     if (val == null) {
-      this[outHeadersKey] = null;
+      this[kOutHeaders] = null;
     } else if (typeof val === 'object') {
-      const headers = this[outHeadersKey] = Object.create(null);
+      const headers = this[kOutHeaders] = Object.create(null);
       const keys = Object.keys(val);
       for (var i = 0; i < keys.length; ++i) {
         const name = keys[i];
@@ -159,7 +159,7 @@ Object.defineProperty(OutgoingMessage.prototype, '_headers', {
 
 Object.defineProperty(OutgoingMessage.prototype, '_headerNames', {
   get: internalUtil.deprecate(function() {
-    const headers = this[outHeadersKey];
+    const headers = this[kOutHeaders];
     if (headers !== null) {
       const out = Object.create(null);
       const keys = Object.keys(headers);
@@ -174,7 +174,7 @@ Object.defineProperty(OutgoingMessage.prototype, '_headerNames', {
   }, 'OutgoingMessage.prototype._headerNames is deprecated', 'DEP0066'),
   set: internalUtil.deprecate(function(val) {
     if (typeof val === 'object' && val !== null) {
-      const headers = this[outHeadersKey];
+      const headers = this[kOutHeaders];
       if (!headers)
         return;
       const keys = Object.keys(val);
@@ -193,7 +193,7 @@ OutgoingMessage.prototype._renderHeaders = function _renderHeaders() {
     throw new ERR_HTTP_HEADERS_SENT('render');
   }
 
-  const headersMap = this[outHeadersKey];
+  const headersMap = this[kOutHeaders];
   const headers = {};
 
   if (headersMap !== null) {
@@ -316,7 +316,7 @@ function _storeHeader(firstLine, headers) {
   };
 
   if (headers) {
-    if (headers === this[outHeadersKey]) {
+    if (headers === this[kOutHeaders]) {
       for (const key in headers) {
         const entry = headers[key];
         processHeader(this, state, entry[0], entry[1], false);
@@ -486,9 +486,9 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
   validateHeaderName(name);
   validateHeaderValue(name, value);
 
-  let headers = this[outHeadersKey];
+  let headers = this[kOutHeaders];
   if (headers === null)
-    this[outHeadersKey] = headers = Object.create(null);
+    this[kOutHeaders] = headers = Object.create(null);
 
   headers[name.toLowerCase()] = [name, value];
 };
@@ -497,7 +497,7 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
 OutgoingMessage.prototype.getHeader = function getHeader(name) {
   validateString(name, 'name');
 
-  const headers = this[outHeadersKey];
+  const headers = this[kOutHeaders];
   if (headers === null)
     return;
 
@@ -508,13 +508,13 @@ OutgoingMessage.prototype.getHeader = function getHeader(name) {
 
 // Returns an array of the names of the current outgoing headers.
 OutgoingMessage.prototype.getHeaderNames = function getHeaderNames() {
-  return this[outHeadersKey] !== null ? Object.keys(this[outHeadersKey]) : [];
+  return this[kOutHeaders] !== null ? Object.keys(this[kOutHeaders]) : [];
 };
 
 
 // Returns a shallow copy of the current outgoing headers.
 OutgoingMessage.prototype.getHeaders = function getHeaders() {
-  const headers = this[outHeadersKey];
+  const headers = this[kOutHeaders];
   const ret = Object.create(null);
   if (headers) {
     const keys = Object.keys(headers);
@@ -530,8 +530,8 @@ OutgoingMessage.prototype.getHeaders = function getHeaders() {
 
 OutgoingMessage.prototype.hasHeader = function hasHeader(name) {
   validateString(name, 'name');
-  return this[outHeadersKey] !== null &&
-    !!this[outHeadersKey][name.toLowerCase()];
+  return this[kOutHeaders] !== null &&
+    !!this[kOutHeaders][name.toLowerCase()];
 };
 
 
@@ -559,8 +559,8 @@ OutgoingMessage.prototype.removeHeader = function removeHeader(name) {
       break;
   }
 
-  if (this[outHeadersKey] !== null) {
-    delete this[outHeadersKey][key];
+  if (this[kOutHeaders] !== null) {
+    delete this[kOutHeaders][key];
   }
 };
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -40,7 +40,7 @@ const {
 } = require('_http_common');
 const { OutgoingMessage } = require('_http_outgoing');
 const {
-  outHeadersKey,
+  kOutHeaders,
   ondrain,
   nowDate,
   emitStatistics
@@ -252,7 +252,7 @@ function writeHead(statusCode, reason, obj) {
   this.statusCode = statusCode;
 
   var headers;
-  if (this[outHeadersKey]) {
+  if (this[kOutHeaders]) {
     // Slow-case: when progressive API and header fields are passed.
     var k;
     if (obj) {
@@ -266,7 +266,7 @@ function writeHead(statusCode, reason, obj) {
       throw new ERR_HTTP_HEADERS_SENT('render');
     }
     // Only progressive api is used
-    headers = this[outHeadersKey];
+    headers = this[kOutHeaders];
   } else {
     // Only writeHead() called
     headers = obj;

--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -49,7 +49,7 @@ function emitStatistics(statistics) {
 }
 
 module.exports = {
-  outHeadersKey: Symbol('outHeadersKey'),
+  kOutHeaders: Symbol('kOutHeaders'),
   ondrain,
   nowDate,
   utcDate,

--- a/test/parallel/test-http-correct-hostname.js
+++ b/test/parallel/test-http-correct-hostname.js
@@ -5,7 +5,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const { outHeadersKey } = require('internal/http');
+const { kOutHeaders } = require('internal/http');
 
 const http = require('http');
 const modules = { http };
@@ -20,7 +20,7 @@ Object.keys(modules).forEach((module) => {
     `${module}.request should not connect to ${module}://example.com%60x.example.com`
   );
   const req = modules[module].request(`${module}://example.com%60x.example.com`, doNotCall);
-  assert.deepStrictEqual(req[outHeadersKey].host, [
+  assert.deepStrictEqual(req[kOutHeaders].host, [
     'Host',
     'example.com`x.example.com',
   ]);

--- a/test/parallel/test-http-outgoing-internal-headers.js
+++ b/test/parallel/test-http-outgoing-internal-headers.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const { outHeadersKey } = require('internal/http');
+const { kOutHeaders } = require('internal/http');
 const { OutgoingMessage } = require('http');
 
 const warn = 'OutgoingMessage.prototype._headers is deprecated';
@@ -25,7 +25,7 @@ common.expectWarning('DeprecationWarning', warn, 'DEP0066');
   };
 
   assert.deepStrictEqual(
-    Object.entries(outgoingMessage[outHeadersKey]),
+    Object.entries(outgoingMessage[kOutHeaders]),
     Object.entries({
       host: ['host', 'risingstack.com'],
       origin: ['Origin', 'localhost']

--- a/test/parallel/test-http-outgoing-renderHeaders.js
+++ b/test/parallel/test-http-outgoing-renderHeaders.js
@@ -4,7 +4,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const outHeadersKey = require('internal/http').outHeadersKey;
+const kOutHeaders = require('internal/http').kOutHeaders;
 const http = require('http');
 const OutgoingMessage = http.OutgoingMessage;
 
@@ -23,7 +23,7 @@ const OutgoingMessage = http.OutgoingMessage;
 
 {
   const outgoingMessage = new OutgoingMessage();
-  outgoingMessage[outHeadersKey] = null;
+  outgoingMessage[kOutHeaders] = null;
   const result = outgoingMessage._renderHeaders();
   assert.deepStrictEqual(result, {});
 }
@@ -31,14 +31,14 @@ const OutgoingMessage = http.OutgoingMessage;
 
 {
   const outgoingMessage = new OutgoingMessage();
-  outgoingMessage[outHeadersKey] = {};
+  outgoingMessage[kOutHeaders] = {};
   const result = outgoingMessage._renderHeaders();
   assert.deepStrictEqual(result, {});
 }
 
 {
   const outgoingMessage = new OutgoingMessage();
-  outgoingMessage[outHeadersKey] = {
+  outgoingMessage[kOutHeaders] = {
     host: ['host', 'nodejs.org'],
     origin: ['Origin', 'localhost']
   };


### PR DESCRIPTION
Follow the naming convention for symbols.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
