### PR TITLE
test: skip test-fs-access if root

### DIFF
--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -5,6 +5,9 @@
 // and the errors thrown from these APIs include the desired properties
 
 const common = require('../common');
+if (!common.isWindows && process.getuid() === 0)
+  common.skip('as this test should not be run as `root`');
+
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION
Currently, if this test is run as the root user the following
failure will occur:
```console
=== release test-fs-access ===
Path: parallel/test-fs-access
(node:46733) internal/test/binding: These APIs are for internal testing
only. Do not use them.
Can't clean tmpdir: /root/node/test/.tmp.522
Files blocking: [ 'read_only_file', 'read_write_file' ]

/root/node/test/common/tmpdir.js:136
    throw e;
    ^

Error: EACCES: permission denied, rmdir '/root/node/test/.tmp.522'
    at Object.rmdirSync (fs.js:693:3)
    at rmdirSync (/root/node/test/common/tmpdir.js:72:8)
    at rimrafSync (/root/node/test/common/tmpdir.js:41:7)
    at process.onexit (/root/node/test/common/tmpdir.js:121:5)
    at process.emit (events.js:214:15) {
  errno: -13,
  syscall: 'rmdir',
  code: 'EACCES',
  path: '/root/node/test/.tmp.522'
}
Command: ./node --expose-internals test/parallel/test-fs-access.js
```
This commit adds a root user check and skips this test if running as the
user root.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
