### PR TITLE
n-api: set the 'length' property of functions

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3990,18 +3990,18 @@ napi_create_function_with_length(napi_env env,
                                  napi_value* result);
 ```
 
-- `[in] env`: The environment that the API is invoked under.
-- `[in] utf8Name`: The name of the function encoded as UTF8. This is visible
+* `[in] env`: The environment that the API is invoked under.
+* `[in] utf8Name`: The name of the function encoded as UTF8. This is visible
 within JavaScript as the new function object's `name` property.
-- `[in] length`: The length of the `utf8name` in bytes, or
+* `[in] length`: The length of the `utf8name` in bytes, or
 `NAPI_AUTO_LENGTH` if it is null-terminated.
-- `[in] cb`: The native function which should be called when this function
+* `[in] cb`: The native function which should be called when this function
 object is invoked.
-- `[in] arguments_length`: The number of arguments passed to the native
-  function.
-- `[in] data`: User-provided data context. This will be passed back into the
+* `[in] arguments_length`: The number of arguments that will be passed to
+function.
+* `[in] data`: User-provided data context. This will be passed back into the
 function when invoked later.
-- `[out] result`: `napi_value` representing the JavaScript function object for
+* `[out] result`: `napi_value` representing the JavaScript function object for
 the newly created function.
 
 Returns `napi_ok` if the API succeeded.
@@ -4009,13 +4009,6 @@ Returns `napi_ok` if the API succeeded.
 This API allows an add-on author to create a function object in native code.
 This is the primary mechanism to allow calling *into* the add-on's native code
 *from* JavaScript.
-
-The newly created function is not automatically visible from script after this
-call. Instead, a property must be explicitly set on any object that is visible
-to JavaScript, in order for the function to be accessible from script.
-
-The string passed to `require()` is the name of the target in `binding.gyp`
-responsible for creating the `.node` file.
 
 Any non-`NULL` data which is passed to this API via the `data` parameter can
 be associated with the resulting JavaScript function (which is returned in the
@@ -4261,37 +4254,37 @@ napi_define_class_with_length(napi_env env,
                               napi_value* result);
 ```
 
- - `[in] env`: The environment that the API is invoked under.
- - `[in] utf8name`: Name of the JavaScript constructor function; this is
+* `[in] env`: The environment that the API is invoked under.
+* `[in] utf8name`: Name of the JavaScript constructor function; this is
    not required to be the same as the C++ class name, though it is recommended
    for clarity.
- - `[in] length`: The length of the `utf8name` in bytes, or `NAPI_AUTO_LENGTH`
+* `[in] length`: The length of the `utf8name` in bytes, or `NAPI_AUTO_LENGTH`
 if it is null-terminated.
- - `[in] constructor`: Callback function that handles constructing instances
-   of the class. (This should be a static method on the class, not an actual
-   C++ constructor function.)
- - `[in] arguments_length`: The number of arguments passed to the native
-   function that is the constructor of the class.
- - `[in] data`: Optional data to be passed to the constructor callback as
-   the `data` property of the callback info.
- - `[in] property_count`: Number of items in the `properties` array argument.
- - `[in] properties`: Array of property descriptors describing static and
-   instance data properties, accessors, and methods on the class
-   See `napi_property_descriptor`.
- - `[out] result`: A `napi_value` representing the constructor function for
-   the class.
+* `[in] constructor`: Callback function that handles constructing instances of
+ the class. (This should be a static method on the class, not an actual C++
+ constructor function.)
+* `[in] arguments_length`: The number of arguments that will be passed to
+function.
+* `[in] data`: Optional data to be passed to the constructor callback as the
+`data` property of the callback info.
+* `[in] property_count`: Number of items in the `properties` array argument.
+* `[in] properties`: Array of property descriptors describing static and
+instance data properties, accessors, and methods on the class. See
+`napi_property_descriptor`.
+* `[out] result`: A `napi_value` representing the constructor function for the
+class.
 
 Returns `napi_ok` if the API succeeded.
 
 Defines a JavaScript class that corresponds to a C++ class, including:
- - A JavaScript constructor function that has the class name and invokes the
-   provided C++ constructor callback.
- - Properties on the constructor function corresponding to _static_ data
-   properties, accessors, and methods of the C++ class (defined by
-   property descriptors with the `napi_static` attribute).
- - Properties on the constructor function's `prototype` object corresponding to
-   _non-static_ data properties, accessors, and methods of the C++ class
-   (defined by property descriptors without the `napi_static` attribute).
+* A JavaScript constructor function that has the class name and invokes the
+provided C++ constructor callback.
+* Properties on the constructor function corresponding to _static_ data
+properties, accessors, and methods of the C++ class (defined by property
+descriptors with the `napi_static` attribute).
+* Properties on the constructor function's `prototype` object corresponding to
+_non-static_ data properties, accessors, and methods of the C++ class (defined
+by property descriptors without the `napi_static` attribute).
 
 The C++ constructor callback should be a static method on the class that calls
 the actual class constructor, then wraps the new C++ instance in a JavaScript
@@ -5393,7 +5386,6 @@ This API may only be called from the main thread.
 [`napi_create_async_work`]: #n_api_napi_create_async_work
 [`napi_create_error`]: #n_api_napi_create_error
 [`napi_create_external_arraybuffer`]: #n_api_napi_create_external_arraybuffer
-[`napi_create_function`]: #n_api_napi_create_function
 [`napi_create_range_error`]: #n_api_napi_create_range_error
 [`napi_create_reference`]: #n_api_napi_create_reference
 [`napi_create_type_error`]: #n_api_napi_create_type_error

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3978,7 +3978,7 @@ Language Specification.
 > Stability: 1 - Experimental
 
 <!-- YAML
-added: v12.9.2
+added: REPLACEME
 -->
 ```C
 napi_create_function_with_length(napi_env env,
@@ -4246,7 +4246,7 @@ the JavaScript function and the data to [`napi_add_finalizer`][].
 > Stability: 1 - Experimental
 
 <!-- YAML
-added: v12.9.2
+added: REPLACEME
 -->
 ```C
 napi_status

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3973,6 +3973,59 @@ passing both the JavaScript function and the data to [`napi_add_finalizer`][].
 JavaScript `Function`s are described in [Section 19.2][] of the ECMAScript
 Language Specification.
 
+### napi_create_function_with_length
+
+> Stability: 1 - Experimental
+
+<!-- YAML
+added: v12.9.2
+-->
+```C
+napi_create_function_with_length(napi_env env,
+                                 const char* utf8name,
+                                 size_t length,
+                                 napi_callback cb,
+                                 size_t arguments_length,
+                                 void* data,
+                                 napi_value* result);
+```
+
+- `[in] env`: The environment that the API is invoked under.
+- `[in] utf8Name`: The name of the function encoded as UTF8. This is visible
+within JavaScript as the new function object's `name` property.
+- `[in] length`: The length of the `utf8name` in bytes, or
+`NAPI_AUTO_LENGTH` if it is null-terminated.
+- `[in] cb`: The native function which should be called when this function
+object is invoked.
+- `[in] arguments_length`: The number of arguments passed to the native
+  function.
+- `[in] data`: User-provided data context. This will be passed back into the
+function when invoked later.
+- `[out] result`: `napi_value` representing the JavaScript function object for
+the newly created function.
+
+Returns `napi_ok` if the API succeeded.
+
+This API allows an add-on author to create a function object in native code.
+This is the primary mechanism to allow calling *into* the add-on's native code
+*from* JavaScript.
+
+The newly created function is not automatically visible from script after this
+call. Instead, a property must be explicitly set on any object that is visible
+to JavaScript, in order for the function to be accessible from script.
+
+The string passed to `require()` is the name of the target in `binding.gyp`
+responsible for creating the `.node` file.
+
+Any non-`NULL` data which is passed to this API via the `data` parameter can
+be associated with the resulting JavaScript function (which is returned in the
+`result` parameter) and freed whenever the function is garbage-collected by
+passing both the JavaScript function and the data to [`napi_add_finalizer`][].
+
+JavaScript `Function`s are described in
+[Section 19.2](https://tc39.github.io/ecma262/#sec-function-objects)
+of the ECMAScript Language Specification.
+
 ### napi_get_cb_info
 <!-- YAML
 added: v8.0.0
@@ -4170,6 +4223,75 @@ Defines a JavaScript class that corresponds to a C++ class, including:
 * Properties on the constructor function's `prototype` object corresponding to
   _non-static_ data properties, accessors, and methods of the C++ class
   (defined by property descriptors without the `napi_static` attribute).
+
+The C++ constructor callback should be a static method on the class that calls
+the actual class constructor, then wraps the new C++ instance in a JavaScript
+object, and returns the wrapper object. See `napi_wrap()` for details.
+
+The JavaScript constructor function returned from [`napi_define_class`][] is
+often saved and used later, to construct new instances of the class from native
+code, and/or check whether provided values are instances of the class. In that
+case, to prevent the function value from being garbage-collected, create a
+persistent reference to it using [`napi_create_reference`][] and ensure the
+reference count is kept >= 1.
+
+Any non-`NULL` data which is passed to this API via the `data` parameter or via
+the `data` field of the `napi_property_descriptor` array items can be associated
+with the resulting JavaScript constructor (which is returned in the `result`
+parameter) and freed whenever the class is garbage-collected by passing both
+the JavaScript function and the data to [`napi_add_finalizer`][].
+
+### napi_define_class_with_length
+
+> Stability: 1 - Experimental
+
+<!-- YAML
+added: v12.9.2
+-->
+```C
+napi_status
+napi_define_class_with_length(napi_env env,
+                              const char* utf8name,
+                              size_t length,
+                              napi_callback constructor,
+                              size_t arguments_length,
+                              void* data,
+                              size_t property_count,
+                              const napi_property_descriptor* properties,
+                              napi_value* result);
+```
+
+ - `[in] env`: The environment that the API is invoked under.
+ - `[in] utf8name`: Name of the JavaScript constructor function; this is
+   not required to be the same as the C++ class name, though it is recommended
+   for clarity.
+ - `[in] length`: The length of the `utf8name` in bytes, or `NAPI_AUTO_LENGTH`
+if it is null-terminated.
+ - `[in] constructor`: Callback function that handles constructing instances
+   of the class. (This should be a static method on the class, not an actual
+   C++ constructor function.)
+ - `[in] arguments_length`: The number of arguments passed to the native
+   function that is the constructor of the class.
+ - `[in] data`: Optional data to be passed to the constructor callback as
+   the `data` property of the callback info.
+ - `[in] property_count`: Number of items in the `properties` array argument.
+ - `[in] properties`: Array of property descriptors describing static and
+   instance data properties, accessors, and methods on the class
+   See `napi_property_descriptor`.
+ - `[out] result`: A `napi_value` representing the constructor function for
+   the class.
+
+Returns `napi_ok` if the API succeeded.
+
+Defines a JavaScript class that corresponds to a C++ class, including:
+ - A JavaScript constructor function that has the class name and invokes the
+   provided C++ constructor callback.
+ - Properties on the constructor function corresponding to _static_ data
+   properties, accessors, and methods of the C++ class (defined by
+   property descriptors with the `napi_static` attribute).
+ - Properties on the constructor function's `prototype` object corresponding to
+   _non-static_ data properties, accessors, and methods of the C++ class
+   (defined by property descriptors without the `napi_static` attribute).
 
 The C++ constructor callback should be a static method on the class that calls
 the actual class constructor, then wraps the new C++ instance in a JavaScript
@@ -5271,6 +5393,7 @@ This API may only be called from the main thread.
 [`napi_create_async_work`]: #n_api_napi_create_async_work
 [`napi_create_error`]: #n_api_napi_create_error
 [`napi_create_external_arraybuffer`]: #n_api_napi_create_external_arraybuffer
+[`napi_create_function`]: #n_api_napi_create_function
 [`napi_create_range_error`]: #n_api_napi_create_range_error
 [`napi_create_reference`]: #n_api_napi_create_reference
 [`napi_create_type_error`]: #n_api_napi_create_type_error

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -89,6 +89,13 @@ NAPI_EXTERN napi_status napi_create_string_utf16(napi_env env,
 NAPI_EXTERN napi_status napi_create_symbol(napi_env env,
                                            napi_value description,
                                            napi_value* result);
+NAPI_EXTERN napi_status napi_create_function_with_length(napi_env env,
+                                             const char* utf8name,
+                                             size_t length,
+                                             napi_callback cb,
+                                             size_t params,
+                                             void* data,
+                                             napi_value* result);
 NAPI_EXTERN napi_status napi_create_function(napi_env env,
                                              const char* utf8name,
                                              size_t length,
@@ -271,6 +278,16 @@ NAPI_EXTERN napi_status napi_get_cb_info(
 NAPI_EXTERN napi_status napi_get_new_target(napi_env env,
                                             napi_callback_info cbinfo,
                                             napi_value* result);
+NAPI_EXTERN napi_status
+napi_define_class_with_length(napi_env env,
+                  const char* utf8name,
+                  size_t length,
+                  napi_callback constructor,
+                  size_t params,
+                  void* data,
+                  size_t property_count,
+                  const napi_property_descriptor* properties,
+                  napi_value* result);
 NAPI_EXTERN napi_status
 napi_define_class(napi_env env,
                   const char* utf8name,

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -89,13 +89,6 @@ NAPI_EXTERN napi_status napi_create_string_utf16(napi_env env,
 NAPI_EXTERN napi_status napi_create_symbol(napi_env env,
                                            napi_value description,
                                            napi_value* result);
-NAPI_EXTERN napi_status napi_create_function_with_length(napi_env env,
-                                             const char* utf8name,
-                                             size_t length,
-                                             napi_callback cb,
-                                             size_t params,
-                                             void* data,
-                                             napi_value* result);
 NAPI_EXTERN napi_status napi_create_function(napi_env env,
                                              const char* utf8name,
                                              size_t length,
@@ -278,16 +271,6 @@ NAPI_EXTERN napi_status napi_get_cb_info(
 NAPI_EXTERN napi_status napi_get_new_target(napi_env env,
                                             napi_callback_info cbinfo,
                                             napi_value* result);
-NAPI_EXTERN napi_status
-napi_define_class_with_length(napi_env env,
-                  const char* utf8name,
-                  size_t length,
-                  napi_callback constructor,
-                  size_t params,
-                  void* data,
-                  size_t property_count,
-                  const napi_property_descriptor* properties,
-                  napi_value* result);
 NAPI_EXTERN napi_status
 napi_define_class(napi_env env,
                   const char* utf8name,
@@ -472,7 +455,7 @@ NAPI_EXTERN napi_status napi_adjust_external_memory(napi_env env,
 
 #if NAPI_VERSION >= 5
 
-// Dates
+// Date
 NAPI_EXTERN napi_status napi_create_date(napi_env env,
                                          double time,
                                          napi_value* result);
@@ -535,6 +518,26 @@ NAPI_EXTERN napi_status napi_get_instance_data(napi_env env,
 // ArrayBuffer detaching
 NAPI_EXTERN napi_status napi_detach_arraybuffer(napi_env env,
                                                 napi_value arraybuffer);
+// Function
+NAPI_EXTERN napi_status napi_create_function_with_length(napi_env env,
+                                             const char* utf8name,
+                                             size_t length,
+                                             napi_callback cb,
+                                             size_t arguments_length,
+                                             void* data,
+                                             napi_value* result);
+
+// Class
+NAPI_EXTERN napi_status
+napi_define_class_with_length(napi_env env,
+                  const char* utf8name,
+                  size_t length,
+                  napi_callback constructor,
+                  size_t arguments_length,
+                  void* data,
+                  size_t property_count,
+                  const napi_property_descriptor* properties,
+                  napi_value* result);
 #endif  // NAPI_EXPERIMENTAL
 
 EXTERN_C_END

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -704,7 +704,7 @@ napi_status napi_create_function_with_length(napi_env env,
                                  const char* utf8name,
                                  size_t length,
                                  napi_callback cb,
-                                 size_t params,
+                                 size_t arguments_length,
                                  void* callback_data,
                                  napi_value* result) {
   NAPI_PREAMBLE(env);
@@ -724,7 +724,7 @@ napi_status napi_create_function_with_length(napi_env env,
       v8::Function::New(context,
                         v8impl::FunctionCallbackWrapper::Invoke,
                         cbdata,
-                        params);
+                        arguments_length);
   CHECK_MAYBE_EMPTY(env, maybe_function, napi_generic_failure);
 
   return_value = scope.Escape(maybe_function.ToLocalChecked());
@@ -759,7 +759,7 @@ napi_status napi_define_class_with_length(napi_env env,
                               const char* utf8name,
                               size_t length,
                               napi_callback constructor,
-                              size_t params,
+                              size_t arguments_length,
                               void* callback_data,
                               size_t property_count,
                               const napi_property_descriptor* properties,
@@ -786,7 +786,7 @@ napi_status napi_define_class_with_length(napi_env env,
       v8impl::FunctionCallbackWrapper::Invoke,
       cbdata,
       signature,
-      params);
+      arguments_length);
 
   v8::Local<v8::String> name_string;
   CHECK_NEW_FROM_UTF8_LEN(env, name_string, utf8name, length);


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/28196

In this PR I added two new functions:
- `napi_create_function_with_length`
- `napi_define_class_with_length`

Both of these functions accept a parameter called `params` that represents the number  of parameters passed to the native callback function and it is used to set the `length` property.

@nodejs/n-api  This is a WIP PR and I want some feedback about this work after that I will continue adding tests and documentation.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
