### PR TITLE
stream: pipe lazy drain

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -676,12 +676,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     dest.end();
   }
 
-  // When the dest drains, it reduces the awaitDrain counter
-  // on the source.  This would be more elegant with a .once()
-  // handler in flow(), but adding and removing repeatedly is
-  // too slow.
-  const ondrain = pipeOnDrain(src);
-  dest.on('drain', ondrain);
+  let ondrain;
 
   var cleanedUp = false;
   function cleanup() {
@@ -689,7 +684,9 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     // Cleanup event handlers once the pipe is broken
     dest.removeListener('close', onclose);
     dest.removeListener('finish', onfinish);
-    dest.removeListener('drain', ondrain);
+    if (ondrain) {
+      dest.removeListener('drain', ondrain);
+    }
     dest.removeListener('error', onerror);
     dest.removeListener('unpipe', onunpipe);
     src.removeListener('end', onend);
@@ -703,7 +700,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     // flowing again.
     // So, if this is awaiting a drain, then we just call it now.
     // If we don't know, then assume that we are waiting for one.
-    if (state.awaitDrain &&
+    if (ondrain && state.awaitDrain &&
         (!dest._writableState || dest._writableState.needDrain))
       ondrain();
   }
@@ -721,6 +718,14 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
       if (state.pipes.length > 0 && state.pipes.includes(dest) && !cleanedUp) {
         debug('false write response, pause', state.awaitDrain);
         state.awaitDrain++;
+      }
+      if (!ondrain) {
+        // When the dest drains, it reduces the awaitDrain counter
+        // on the source.  This would be more elegant with a .once()
+        // handler in flow(), but adding and removing repeatedly is
+        // too slow.
+        ondrain = pipeOnDrain(src);
+        dest.on('drain', ondrain);
       }
       src.pause();
     }

--- a/test/parallel/test-stream2-readable-legacy-drain.js
+++ b/test/parallel/test-stream2-readable-legacy-drain.js
@@ -52,11 +52,4 @@ function drain() {
 
 w.end = common.mustCall();
 
-// Just for kicks, let's mess with the drain count.
-// This verifies that even if it gets negative in the
-// pipe() cleanup function, we'll still function properly.
-r.on('readable', function() {
-  w.emit('drain');
-});
-
 r.pipe(w);


### PR DESCRIPTION
Slight optimization. Don't allocate and register the drain function for fast consumers.

Related https://github.com/nodejs/node/pull/29087

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

NOTE TO SELF: After this has been merged, look into removing unnecessary `onclose`.