### PR TITLE
buffer: improve ERR_BUFFER_OUT_OF_BOUNDS default

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -710,7 +710,7 @@ E('ERR_BUFFER_OUT_OF_BOUNDS',
     if (name) {
       return `"${name}" is outside of buffer bounds`;
     }
-    return 'Attempt to write outside buffer bounds';
+    return 'Attempt to access memory outside buffer bounds';
   }, RangeError);
 E('ERR_BUFFER_TOO_LARGE',
   `Cannot create a Buffer larger than 0x${kMaxLength.toString(16)} bytes`,

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -362,7 +362,7 @@ common.expectsError(() => {
 }, {
   code: 'ERR_BUFFER_OUT_OF_BOUNDS',
   type: RangeError,
-  message: 'Attempt to write outside buffer bounds'
+  message: 'Attempt to access memory outside buffer bounds'
 });
 
 assert.deepStrictEqual(

--- a/test/parallel/test-buffer-read.js
+++ b/test/parallel/test-buffer-read.js
@@ -60,7 +60,7 @@ const OOR_ERROR =
 const OOB_ERROR =
 {
   name: 'RangeError',
-  message: 'Attempt to write outside buffer bounds'
+  message: 'Attempt to access memory outside buffer bounds'
 };
 
 // Attempt to overflow buffers, similar to previous bug in array buffers

--- a/test/parallel/test-buffer-readdouble.js
+++ b/test/parallel/test-buffer-readdouble.js
@@ -127,7 +127,7 @@ assert.strictEqual(buffer.readDoubleLE(0), -Infinity);
     {
       code: 'ERR_BUFFER_OUT_OF_BOUNDS',
       name: 'RangeError',
-      message: 'Attempt to write outside buffer bounds'
+      message: 'Attempt to access memory outside buffer bounds'
     });
 
   [NaN, 1.01].forEach((offset) => {

--- a/test/parallel/test-buffer-readfloat.js
+++ b/test/parallel/test-buffer-readfloat.js
@@ -90,7 +90,7 @@ assert.strictEqual(buffer.readFloatLE(0), -Infinity);
     {
       code: 'ERR_BUFFER_OUT_OF_BOUNDS',
       name: 'RangeError',
-      message: 'Attempt to write outside buffer bounds'
+      message: 'Attempt to access memory outside buffer bounds'
     });
 
   [NaN, 1.01].forEach((offset) => {

--- a/test/parallel/test-buffer-writedouble.js
+++ b/test/parallel/test-buffer-writedouble.js
@@ -99,7 +99,7 @@ assert.ok(Number.isNaN(buffer.readDoubleLE(8)));
       {
         code: 'ERR_BUFFER_OUT_OF_BOUNDS',
         name: 'RangeError',
-        message: 'Attempt to write outside buffer bounds'
+        message: 'Attempt to access memory outside buffer bounds'
       });
 
     ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {

--- a/test/parallel/test-buffer-writefloat.js
+++ b/test/parallel/test-buffer-writefloat.js
@@ -81,7 +81,7 @@ assert.ok(Number.isNaN(buffer.readFloatLE(4)));
       {
         code: 'ERR_BUFFER_OUT_OF_BOUNDS',
         name: 'RangeError',
-        message: 'Attempt to write outside buffer bounds'
+        message: 'Attempt to access memory outside buffer bounds'
       });
 
     ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {


### PR DESCRIPTION
This commit changes the default message used by `ERR_BUFFER_OUT_OF_BOUNDS`. Previously, the default message implied that the problematic was always a write, which is not accurate.

Fixes: https://github.com/nodejs/node/issues/29097

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
