### PR TITLE
console: minor timeLogImpl() refactor

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -310,9 +310,9 @@ const consoleMethods = {
   timeEnd(label = 'default') {
     // Coerces everything other than Symbol to a string
     label = `${label}`;
-    const hasWarned = timeLogImpl(this, 'timeEnd', label);
+    const found = timeLogImpl(this, 'timeEnd', label);
     trace(kTraceEnd, kTraceConsoleCategory, `time::${label}`, 0);
-    if (!hasWarned) {
+    if (found) {
       this._times.delete(label);
     }
   },
@@ -509,12 +509,12 @@ const consoleMethods = {
   },
 };
 
-// Returns true if label was not found
+// Returns true if label was found
 function timeLogImpl(self, name, label, data) {
   const time = self._times.get(label);
-  if (!time) {
+  if (time === undefined) {
     process.emitWarning(`No such label '${label}' for console.${name}()`);
-    return true;
+    return false;
   }
   const duration = process.hrtime(time);
   const ms = duration[0] * 1000 + duration[1] / 1e6;
@@ -523,7 +523,7 @@ function timeLogImpl(self, name, label, data) {
   } else {
     self.log('%s: %sms', label, ms.toFixed(3), ...data);
   }
-  return false;
+  return true;
 }
 
 const keyKey = 'Key';


### PR DESCRIPTION
This commit does two things:

- Reverses the boolean value returned by `timeLogImpl()`. The new values make more sense semantically (IMO anyway), and save a a single NOT operation.
- Explicitly check for `undefined` when calling `_times.get()` instead of coercing the value.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
