### PR TITLE
buffer: add Buffer.createView() to create a new buffer that shares ArrayBuffer with another ArrayBufferView

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -223,6 +223,35 @@ Buffer.from = function from(value, encodingOrOffset, length) {
   );
 };
 
+/**
+ * Like Buffer.from(), but it creates a view of an ArrayBuffer
+ * or the underlying ArrayBuffer in an ArrayBufferView.
+ *
+ * Buffer.createView(arrayBufferView[, byteOffset[, length]])
+ * Buffer.createView(arrayBuffer[, byteOffset[, length]])
+ */
+Buffer.createView = function createView(value, offset, length) {
+  if (isArrayBufferView(value)) {
+    const offsetForBuffer = value.byteOffset +
+      (offset !== undefined ? Number(offset) : 0);
+    return fromArrayBuffer(
+      value.buffer,
+      offsetForBuffer,
+      length !== undefined ? length : value.byteLength,
+    );
+  }
+
+  if (isAnyArrayBuffer(value)) {
+    return fromArrayBuffer(value, offset, length);
+  }
+
+  throw new ERR_INVALID_ARG_TYPE(
+    'first argument',
+    ['ArrayBuffer', 'ArrayBufferView', 'Buffer'],
+    value
+  );
+};
+
 // Identical to the built-in %TypedArray%.of(), but avoids using the deprecated
 // Buffer() constructor. Must use arrow function syntax to avoid automatically
 // adding a `prototype` property and making the function a constructor.

--- a/test/parallel/test-buffer-create-view.js
+++ b/test/parallel/test-buffer-create-view.js
@@ -1,0 +1,24 @@
+'use strict';
+
+require('../common');
+const { deepStrictEqual, strictEqual, throws } = require('assert');
+
+const b = Buffer.from([99, 1, 2, 3, 100]).subarray(1, 4);
+
+deepStrictEqual(Buffer.createView(b), b);
+strictEqual(Buffer.createView(b).buffer, b.buffer);
+
+[
+  [{}, 'object'],
+  [[0, 1, 2, 3], 'object'],
+  ['foo', 'string'],
+].forEach(([input, actualType]) => {
+  const errObj = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The first argument must be one of type ' +
+             'ArrayBuffer, ArrayBufferView, or Buffer. ' +
+             `Received type ${actualType}`
+  };
+  throws(() => Buffer.createView(input), errObj);
+});


### PR DESCRIPTION
This is a proposal for a new method `Buffer.createView()`, although its name could be changed.

*This is not ready to merge because of missing docs and tests, but rather I've made this PR for discussion.*

### Rationale

When users convert ArrayBufferView (e.g. typed arrays and buffer itself) to Buffer, there are typical mistakes about handling underlying ArrayBuffer.:

* A mistake on `Buffer.from(arrayBufferView)` that copies the underlying ArrayBuffer of `arrayBufferView` which might be unexpectedly slow
* A mistake on `Buffer.from(arrayBufferView.buffer)`  that creates a view of the underlying ArrayBuffer without `offset` and `length` parameters

So this PR creates a new method `Buffer.createView(arrayBufferView)`:

```js
const bytes = someMethodToCreateUint8Array();
// The same as `Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)`
const buffer = Buffer.createView(bytes);

// It requires no temporary variable:
const buffer = Buffer.createView(someMethodToCreateUint8Array());
```

And also `Buffer.createView(arrayBuffer)` is provided as the same semantics of the current `Buffer.from(arrayBuffer)` to clarify that it is just a view of `arrayBuffer`.

I think `Buffer.from(arrayBuffer)` should be deprecated because it is extremely confusing, and ECMA-262's typed arrays have no such overload, anyway. However, it is not directly related to this PR.

refs: https://github.com/nodejs/node/issues/28725

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added **NOT YET**
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
