### PR TITLE
tools: make nodedownload.py Python 3 compatible

### DIFF
--- a/tools/configure.d/nodedownload.py
+++ b/tools/configure.d/nodedownload.py
@@ -2,27 +2,29 @@
 # Moved some utilities here from ../../configure
 
 from __future__ import print_function
-import urllib
 import hashlib
 import sys
 import zipfile
 import tarfile
-import fpformat
 import contextlib
+try:
+    from urllib.request import FancyURLopener, URLopener
+except ImportError:
+    from urllib import FancyURLopener, URLopener
 
 def formatSize(amt):
     """Format a size as a string in MB"""
-    return fpformat.fix(amt / 1024000., 1)
+    return "%.1f" % (amt / 1024000.)
 
 def spin(c):
     """print out an ASCII 'spinner' based on the value of counter 'c'"""
     spin = ".:|'"
     return (spin[c % len(spin)])
 
-class ConfigOpener(urllib.FancyURLopener):
+class ConfigOpener(FancyURLopener):
     """fancy opener used by retrievefile. Set a UA"""
     # append to existing version (UA)
-    version = '%s node.js/configure' % urllib.URLopener.version
+    version = '%s node.js/configure' % URLopener.version
 
 def reporthook(count, size, total):
     """internal hook used by retrievefile"""


### PR DESCRIPTION
These changes make __nodedownload.py__ compatible with both Python 2 and Python 3.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
