### PR TITLE
fs: add default options for stat, fstat, and lstat

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -796,7 +796,7 @@ function readdirSync(path, options) {
   return options.withFileTypes ? getDirents(path, result) : result;
 }
 
-function fstat(fd, options, callback) {
+function fstat(fd, options = { bigint: false }, callback) {
   if (typeof options === 'function') {
     callback = options;
     options = {};
@@ -807,7 +807,7 @@ function fstat(fd, options, callback) {
   binding.fstat(fd, options.bigint, req);
 }
 
-function lstat(path, options, callback) {
+function lstat(path, options = { bigint: false }, callback) {
   if (typeof options === 'function') {
     callback = options;
     options = {};
@@ -819,7 +819,7 @@ function lstat(path, options, callback) {
   binding.lstat(pathModule.toNamespacedPath(path), options.bigint, req);
 }
 
-function stat(path, options, callback) {
+function stat(path, options = { bigint: false }, callback) {
   if (typeof options === 'function') {
     callback = options;
     options = {};

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -154,3 +154,14 @@ fs.stat(__filename, common.mustCall(function(err, s) {
     }
   );
 });
+
+// Should not throw an error
+fs.stat(__filename, undefined, common.mustCall(() => {}));
+
+fs.open(__filename, 'r', undefined, common.mustCall((err, fd) => {
+  // Should not throw an error
+  fs.fstat(fd, undefined, common.mustCall(() => {}));
+}));
+
+// Should not throw an error
+fs.lstat(__filename, undefined, common.mustCall(() => {}));


### PR DESCRIPTION
Add default options to the function signatures for fs.stat, fs.fstat, and fs.lstat.

This allows a library to pass undefined to get the default options.

Fixes: https://github.com/nodejs/node/issues/29113

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
