### PR TITLE
readline: y in cursorTo is optional

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -487,7 +487,7 @@ function completer(linePartial, callback) {
 }
 ```
 
-## readline.cursorTo(stream, x, y[, callback])
+## readline.cursorTo(stream, x[, y][, callback])
 <!-- YAML
 added: v0.7.7
 changes:

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -145,7 +145,7 @@ added: v0.7.7
 A `number` specifying the number of columns the TTY currently has. This property
 is updated whenever the `'resize'` event is emitted.
 
-### writeStream.cursorTo(x, y[, callback])
+### writeStream.cursorTo(x[, y][, callback])
 <!-- YAML
 added: v0.7.7
 changes:

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -1193,6 +1193,11 @@ function cursorTo(stream, x, y, callback) {
   if (callback !== undefined && typeof callback !== 'function')
     throw new ERR_INVALID_CALLBACK(callback);
 
+  if (typeof y === 'function') {
+    callback = y;
+    y = undefined;
+  }
+
   if (stream == null || (typeof x !== 'number' && typeof y !== 'number')) {
     if (typeof callback === 'function')
       process.nextTick(callback);

--- a/test/parallel/test-readline-csi.js
+++ b/test/parallel/test-readline-csi.js
@@ -134,12 +134,20 @@ assert.strictEqual(readline.cursorTo(writable, 1, 'a'), true);
 assert.strictEqual(writable.data, '\x1b[2G');
 
 writable.data = '';
+assert.strictEqual(readline.cursorTo(writable, 1), true);
+assert.strictEqual(writable.data, '\x1b[2G');
+
+writable.data = '';
 assert.strictEqual(readline.cursorTo(writable, 1, 2), true);
 assert.strictEqual(writable.data, '\x1b[3;2H');
 
 writable.data = '';
 assert.strictEqual(readline.cursorTo(writable, 1, 2, common.mustCall()), true);
 assert.strictEqual(writable.data, '\x1b[3;2H');
+
+writable.data = '';
+assert.strictEqual(readline.cursorTo(writable, 1, common.mustCall()), true);
+assert.strictEqual(writable.data, '\x1b[2G');
 
 // Verify that cursorTo() throws on invalid callback.
 assert.throws(() => {


### PR DESCRIPTION
Parameter `y` in `cursorTo()` is optional and this is also verified by tests but docs don't state this. Besides that if the newly added parameter `callback` is used but no `y` it's quite unhandy. This PR allows to simply omit `y`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
