### PR TITLE
Cleanup stream private state writable emit close

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -489,6 +489,15 @@ added: v11.4.0
 
 Is `true` if it is safe to call [`writable.write()`][stream-write].
 
+##### writable.writableEmitClose
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+Getter for the property `writableEmitClose` of a given `Writable` stream.
+
 ##### writable.writableFinished
 <!-- YAML
 added: v12.6.0

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -496,7 +496,7 @@ added: REPLACEME
 
 * {boolean}
 
-Getter for the property `writableEmitClose` of a given `Writable` stream.
+Getter for the property `emitClose` of a given `Writable` stream.
 
 ##### writable.writableFinished
 <!-- YAML

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -708,6 +708,13 @@ Object.defineProperty(Writable.prototype, 'destroyed', {
   }
 });
 
+Object.defineProperty(Writable.prototype, 'writableEmitClose', {
+  enumerable: false,
+  get() {
+    return this._writableState ? this._writableState.emitClose : false;
+  }
+});
+
 Object.defineProperty(Writable.prototype, 'writableObjectMode', {
   enumerable: false,
   get() {

--- a/lib/internal/process/stdio.js
+++ b/lib/internal/process/stdio.js
@@ -11,7 +11,7 @@ function dummyDestroy(err, cb) {
   // are not going to do it twice.
   // The 'close' event is needed so that finished and
   // pipeline work correctly.
-  if (!this._writableState.emitClose) {
+  if (!this.writableEmitClose) {
     process.nextTick(() => {
       this.emit('close');
     });

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -445,3 +445,11 @@ class TestWriter extends EE {
   const w = new W({ objectMode: true });
   assert.strictEqual(w.writableObjectMode, true);
 }
+
+{
+  // Verify writableEmitClose property
+  assert(W.prototype.hasOwnProperty('writableEmitClose'));
+
+  const w = new W({ emitClose: false });
+  assert.strictEqual(w.writableEmitClose, false);
+}


### PR DESCRIPTION
Adds a public writableEmitClose property and replaces references to ._writableState.emitClose 
Refs: https://github.com/nodejs/node/issues/445
cc: @mcollina

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]
