### PR TITLE
test: deflake test-tls-passphrase

### DIFF
--- a/test/parallel/test-tls-passphrase.js
+++ b/test/parallel/test-tls-passphrase.js
@@ -37,6 +37,10 @@ assert(Buffer.isBuffer(cert));
 assert.strictEqual(typeof passKey.toString(), 'string');
 assert.strictEqual(typeof cert.toString(), 'string');
 
+function onSecureConnect() {
+  return common.mustCall(function() { this.end(); });
+}
+
 const server = tls.Server({
   key: passKey,
   passphrase: 'password',
@@ -44,8 +48,6 @@ const server = tls.Server({
   ca: [cert],
   requestCert: true,
   rejectUnauthorized: true
-}, function(s) {
-  s.end();
 });
 
 server.listen(0, common.mustCall(function() {
@@ -56,14 +58,14 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'password',
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: rawKey,
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
@@ -71,7 +73,7 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   // Buffer[]
   tls.connect({
@@ -80,14 +82,14 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'password',
     cert: [cert],
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: [rawKey],
     cert: [cert],
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
@@ -95,7 +97,7 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: [cert],
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   // string
   tls.connect({
@@ -104,14 +106,14 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'password',
     cert: cert.toString(),
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: rawKey.toString(),
     cert: cert.toString(),
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
@@ -119,7 +121,7 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: cert.toString(),
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   // String[]
   tls.connect({
@@ -128,14 +130,14 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'password',
     cert: [cert.toString()],
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: [rawKey.toString()],
     cert: [cert.toString()],
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
@@ -143,7 +145,7 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: [cert.toString()],
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   // Object[]
   tls.connect({
@@ -151,7 +153,7 @@ server.listen(0, common.mustCall(function() {
     key: [{ pem: passKey, passphrase: 'password' }],
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
@@ -159,7 +161,7 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
@@ -167,28 +169,28 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'password',
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: [{ pem: passKey.toString(), passphrase: 'password' }],
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: [{ pem: rawKey, passphrase: 'ignored' }],
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: [{ pem: rawKey.toString(), passphrase: 'ignored' }],
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
@@ -196,7 +198,7 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
@@ -204,21 +206,21 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: [{ pem: rawKey }],
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: [{ pem: rawKey.toString() }],
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall());
+  }, onSecureConnect());
 })).unref();
 
 const errMessagePassword = /bad decrypt/;


### PR DESCRIPTION
Move `socket.end()` to client.

Fixes: https://github.com/nodejs/node/issues/28111
Refs: https://github.com/nodejs/node/pull/27569

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
