### PR TITLE
stream: lazy allocate

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -51,7 +51,8 @@ Object.setPrototypeOf(Readable, Stream);
 const { errorOrDestroy } = destroyImpl;
 const kProxyEvents = ['error', 'close', 'destroy', 'pause', 'resume'];
 
-const kPipes = Symbol('kPipes')
+const kPipes = Symbol('kPipes');
+const kBuffer = Symbol('kBuffer');
 
 function prependListener(emitter, event, fn) {
   // Sadly this is not cacheable as some libraries bundle their own
@@ -97,7 +98,7 @@ function ReadableState(options, stream, isDuplex) {
   // A linked list is used to store data chunks instead of an array because the
   // linked list can remove elements from the beginning faster than
   // array.shift()
-  this.buffer = new BufferList();
+  this[kBuffer] = null;
   this.length = 0;
   this[kPipes] = null;
   this.flowing = null;
@@ -164,8 +165,21 @@ Object.defineProperty(ReadableState.prototype, 'pipes', {
     }
     return this[kPipes];
   },
-  set (val) {
+  set(val) {
     this[kPipes] = val;
+  }
+});
+
+// Legacy getter/setter for `buffer`
+Object.defineProperty(ReadableState.prototype, 'buffer', {
+  get() {
+    if (!this[kBuffer]) {
+      this[kBuffer] = new BufferList();
+    }
+    return this[kBuffer];
+  },
+  set(val) {
+    this[kBuffer] = val;
   }
 });
 
@@ -315,12 +329,15 @@ function addChunk(stream, state, chunk, addToFront) {
     state.awaitDrain = 0;
     stream.emit('data', chunk);
   } else {
+    if (!state[kBuffer]) {
+      state[kBuffer] = new BufferList();
+    }
     // Update the buffer info.
     state.length += state.objectMode ? 1 : chunk.length;
     if (addToFront)
-      state.buffer.unshift(chunk);
+      state[kBuffer].unshift(chunk);
     else
-      state.buffer.push(chunk);
+      state[kBuffer].push(chunk);
 
     if (state.needReadable)
       emitReadable(stream);
@@ -353,6 +370,9 @@ Readable.prototype.setEncoding = function(enc) {
   this._readableState.encoding = this._readableState.decoder.encoding;
 
   const buffer = this._readableState.buffer;
+  if (!buffer) {
+    return this;
+  }
   // Iterate over current buffer to convert already stored Buffers:
   let content = '';
   for (const data of buffer) {
@@ -541,9 +561,13 @@ function onEofChunk(stream, state) {
   debug('onEofChunk');
   if (state.ended) return;
   if (state.decoder) {
+    if (!state[kBuffer]) {
+      state[kBuffer] = new BufferList();
+    }
+
     var chunk = state.decoder.end();
     if (chunk && chunk.length) {
-      state.buffer.push(chunk);
+      state[kBuffer].push(chunk);
       state.length += state.objectMode ? 1 : chunk.length;
     }
   }
@@ -1121,21 +1145,24 @@ function fromList(n, state) {
   if (state.length === 0)
     return null;
 
+  // Check state.buffer for test compat.
+  const buffer = state[kBuffer] || state.buffer;
+
   var ret;
   if (state.objectMode)
-    ret = state.buffer.shift();
+    ret = buffer.shift();
   else if (!n || n >= state.length) {
     // Read it all, truncate the list
     if (state.decoder)
-      ret = state.buffer.join('');
-    else if (state.buffer.length === 1)
-      ret = state.buffer.first();
+      ret = buffer.join('');
+    else if (buffer.length === 1)
+      ret = buffer.first();
     else
-      ret = state.buffer.concat(state.length);
-    state.buffer.clear();
+      ret = buffer.concat(state.length);
+    buffer.clear();
   } else {
     // read part of list
-    ret = state.buffer.consume(n, state.decoder);
+    ret = buffer.consume(n, state.decoder);
   }
 
   return ret;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -51,6 +51,8 @@ Object.setPrototypeOf(Readable, Stream);
 const { errorOrDestroy } = destroyImpl;
 const kProxyEvents = ['error', 'close', 'destroy', 'pause', 'resume'];
 
+const kPipes = Symbol('kPipes')
+
 function prependListener(emitter, event, fn) {
   // Sadly this is not cacheable as some libraries bundle their own
   // event emitter implementation with them.
@@ -97,7 +99,7 @@ function ReadableState(options, stream, isDuplex) {
   // array.shift()
   this.buffer = new BufferList();
   this.length = 0;
-  this.pipes = [];
+  this[kPipes] = null;
   this.flowing = null;
   this.ended = false;
   this.endEmitted = false;
@@ -150,7 +152,20 @@ function ReadableState(options, stream, isDuplex) {
 // Legacy getter for `pipesCount`
 Object.defineProperty(ReadableState.prototype, 'pipesCount', {
   get() {
-    return this.pipes.length;
+    return this.pipes ? this.pipes.length : 0;
+  }
+});
+
+// Legacy getter/setter for `pipes`
+Object.defineProperty(ReadableState.prototype, 'pipes', {
+  get() {
+    if (!this[kPipes]) {
+      this[kPipes] = [];
+    }
+    return this[kPipes];
+  },
+  set (val) {
+    this[kPipes] = val;
   }
 });
 
@@ -647,8 +662,13 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   const src = this;
   const state = this._readableState;
 
-  state.pipes.push(dest);
-  debug('pipe count=%d opts=%j', state.pipes.length, pipeOpts);
+  if (!state[kPipes]) {
+    state[kPipes] = [];
+  }
+  const pipes = state[kPipes];
+
+  pipes.push(dest);
+  debug('pipe count=%d opts=%j', pipes.length, pipeOpts);
 
   const doEnd = (!pipeOpts || pipeOpts.end !== false) &&
               dest !== process.stdout &&
@@ -714,11 +734,12 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     const ret = dest.write(chunk);
     debug('dest.write', ret);
     if (ret === false) {
+      const pipes = state[kPipes];
       // If the user unpiped during `dest.write()`, it is possible
       // to get stuck in a permanently paused state if that write
       // also returned false.
       // => Check whether `dest` is still a piping destination.
-      if (state.pipes.length > 0 && state.pipes.includes(dest) && !cleanedUp) {
+      if (pipes && pipes.includes(dest) && !cleanedUp) {
         debug('false write response, pause', state.awaitDrain);
         state.awaitDrain++;
       }
@@ -788,13 +809,13 @@ Readable.prototype.unpipe = function(dest) {
   const unpipeInfo = { hasUnpiped: false };
 
   // If we're not piping anywhere, then do nothing.
-  if (state.pipes.length === 0)
+  if (!state[kPipes])
     return this;
 
   if (!dest) {
     // remove all.
-    var dests = state.pipes;
-    state.pipes = [];
+    const dests = state[kPipes];
+    state[kPipes] = null;
     state.flowing = false;
 
     for (var i = 0; i < dests.length; i++)
@@ -803,13 +824,16 @@ Readable.prototype.unpipe = function(dest) {
   }
 
   // Try to find the right one.
-  const index = state.pipes.indexOf(dest);
+  const index = state[kPipes].indexOf(dest);
   if (index === -1)
     return this;
 
-  state.pipes.splice(index, 1);
-  if (state.pipes.length === 0)
+  if (state[kPipes].length > 1) {
+    state[kPipes].splice(index, 1);
+  } else {
+    state[kPipes] = null;
     state.flowing = false;
+  }
 
   dest.emit('unpipe', this, unpipeInfo);
 


### PR DESCRIPTION
Lazy allocate potentially unused state objects.

```js
 streams/creation.js kind='duplex' n=1000000           ***      5.57 %       ±1.65% ±2.21% ±2.89%
 streams/creation.js kind='readable' n=1000000         ***      6.55 %       ±2.70% ±3.60% ±4.70%
 streams/creation.js kind='transform' n=1000000        ***      2.51 %       ±1.41% ±1.88% ±2.45%
 streams/creation.js kind='writable' n=1000000                  0.04 %       ±1.60% ±2.13% ±2.79%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
