### PR TITLE
http2: remove security revert flags

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -151,9 +151,6 @@ Http2Options::Http2Options(Environment* env, nghttp2_session_type type) {
         buffer[IDX_OPTIONS_PEER_MAX_CONCURRENT_STREAMS]);
   }
 
-  if (IsReverted(SECURITY_REVERT_CVE_2019_9512))
-    nghttp2_option_set_max_outbound_ack(options_, 10000);
-
   // The padding strategy sets the mechanism by which we determine how much
   // additional frame padding to apply to DATA and HEADERS frames. Currently
   // this is set on a per-session basis, but eventually we may switch to
@@ -945,10 +942,8 @@ int Http2Session::OnBeginHeadersCallback(nghttp2_session* handle,
     if (UNLIKELY(!session->CanAddStream() ||
                  Http2Stream::New(session, id, frame->headers.cat) ==
                      nullptr)) {
-      if (session->rejected_stream_count_++ > 100 &&
-          !IsReverted(SECURITY_REVERT_CVE_2019_9514)) {
+      if (session->rejected_stream_count_++ > 100)
         return NGHTTP2_ERR_CALLBACK_FAILURE;
-      }
       // Too many concurrent streams being opened
       nghttp2_submit_rst_stream(**session, NGHTTP2_FLAG_NONE, id,
                                 NGHTTP2_ENHANCE_YOUR_CALM);
@@ -1039,10 +1034,8 @@ int Http2Session::OnInvalidFrame(nghttp2_session* handle,
   Http2Session* session = static_cast<Http2Session*>(user_data);
 
   Debug(session, "invalid frame received, code: %d", lib_error_code);
-  if (session->invalid_frame_count_++ > 1000 &&
-      !IsReverted(SECURITY_REVERT_CVE_2019_9514)) {
+  if (session->invalid_frame_count_++ > 1000)
     return 1;
-  }
 
   // If the error is fatal or if error code is ERR_STREAM_CLOSED... emit error
   if (nghttp2_is_fatal(lib_error_code) ||
@@ -1412,8 +1405,7 @@ int Http2Session::HandleDataFrame(const nghttp2_frame* frame) {
 
   if (!stream->IsDestroyed() && frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
     stream->EmitRead(UV_EOF);
-  } else if (frame->hd.length == 0 &&
-           !IsReverted(SECURITY_REVERT_CVE_2019_9518)) {
+  } else if (frame->hd.length == 0) {
     return 1;  // Consider 0-length frame without END_STREAM an error.
   }
   return 0;
@@ -2298,9 +2290,7 @@ bool Http2Stream::AddHeader(nghttp2_rcbuf* name,
   if (this->statistics_.first_header == 0)
     this->statistics_.first_header = uv_hrtime();
   size_t name_len = nghttp2_rcbuf_get_buf(name).len;
-  if (name_len == 0 && !IsReverted(SECURITY_REVERT_CVE_2019_9516)) {
-    return true;  // Ignore headers with empty names.
-  }
+  if (name_len == 0) return true;  // Ignore headers with empty names.
   size_t value_len = nghttp2_rcbuf_get_buf(value).len;
   size_t length = name_len + value_len + 32;
   // A header can only be added if we have not exceeded the maximum number

--- a/src/node_revert.h
+++ b/src/node_revert.h
@@ -16,13 +16,7 @@
 namespace node {
 
 #define SECURITY_REVERSIONS(XX)                                            \
-  XX(CVE_2019_9512, "CVE-2019-9512", "HTTP/2 Ping/Settings Flood")         \
-  XX(CVE_2019_9514, "CVE-2019-9514", "HTTP/2 Reset Flood")                 \
-  XX(CVE_2019_9516, "CVE-2019-9516", "HTTP/2 0-Length Headers Leak")       \
-  XX(CVE_2019_9518, "CVE-2019-9518", "HTTP/2 Empty DATA Frame Flooding")   \
 //  XX(CVE_2016_PEND, "CVE-2016-PEND", "Vulnerability Title")
-  // TODO(addaleax): Remove all of the above before Node.js 13 as the comment
-  // at the start of the file indicates.
 
 enum reversion {
 #define V(code, ...) SECURITY_REVERT_##code,


### PR DESCRIPTION
As the comment in `node_revert.h` indicates, the master branch should
not provide security revert flags.

Refs: https://github.com/nodejs/node/pull/29122

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
