### PR TITLE
tools: make code cache and snapshot deterministic 

### DIFF
--- a/test/parallel/test-math-random.js
+++ b/test/parallel/test-math-random.js
@@ -1,0 +1,17 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const results = new Set();
+for (let i = 0; i < 10; i++) {
+  const result = spawnSync(process.execPath, ['-p', 'Math.random()']);
+  assert.strictEqual(result.status, 0);
+  results.add(result.stdout.toString());
+}
+// It's theoretically possible if _very_ unlikely to see some duplicates.
+// Therefore, don't expect that the size of the set is exactly 10 but do
+// assume it's > 1 because if you get 10 duplicates in a row you should
+// go out real quick and buy some lottery tickets, you lucky devil you!
+assert(results.size > 1);

--- a/tools/code_cache/mkcodecache.cc
+++ b/tools/code_cache/mkcodecache.cc
@@ -55,6 +55,9 @@ int main(int argc, char* argv[]) {
     v8::Local<v8::Context> context = v8::Context::New(isolate);
     v8::Context::Scope context_scope(context);
 
+    // The command line flags are part of the code cache's checksum so reset
+    // --random_seed= to its default value before creating the code cache.
+    v8::V8::SetFlagsFromString("--random_seed=0");
     std::string cache = CodeCacheBuilder::Generate(context);
     out << cache;
     out.close();

--- a/tools/code_cache/mkcodecache.cc
+++ b/tools/code_cache/mkcodecache.cc
@@ -26,6 +26,8 @@ int wmain(int argc, wchar_t* argv[]) {
 int main(int argc, char* argv[]) {
 #endif  // _WIN32
 
+  v8::V8::SetFlagsFromString("--random_seed=42");
+
   if (argc < 2) {
     std::cerr << "Usage: " << argv[0] << " <path/to/output.cc>\n";
     return 1;

--- a/tools/snapshot/node_mksnapshot.cc
+++ b/tools/snapshot/node_mksnapshot.cc
@@ -19,6 +19,8 @@ int wmain(int argc, wchar_t* argv[]) {
 int main(int argc, char* argv[]) {
 #endif  // _WIN32
 
+  v8::V8::SetFlagsFromString("--random_seed=42");
+
   if (argc < 2) {
     std::cerr << "Usage: " << argv[0] << " <path/to/output.cc>\n";
     return 1;


### PR DESCRIPTION
Use a fixed random seed to ensure that the generated sources are
identical across runs.

The final node binary still reseeds itself on start-up so there should
be no security implications caused by predictable random numbers (e.g.,
`Math.random()`, ASLR, the hash seed, etc.)

Fixes: https://github.com/nodejs/node/issues/29108