### PR TITLE
readline: support closing dumb terminals

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -816,15 +816,20 @@ function _ttyWriteDumb(s, key) {
   if (this._sawReturnAt && key.name !== 'enter')
     this._sawReturnAt = 0;
 
-  if (key.ctrl && key.name === 'c') {
-    if (this.listenerCount('SIGINT') > 0) {
-      this.emit('SIGINT');
-    } else {
-      // This readline instance is finished
-      this.close();
-    }
+  if (key.ctrl) {
+    if (key.name === 'c') {
+      if (this.listenerCount('SIGINT') > 0) {
+        this.emit('SIGINT');
+      } else {
+        // This readline instance is finished
+        this.close();
+      }
 
-    return;
+      return;
+    } else if (key.name === 'd') {
+      this.close();
+      return;
+    }
   }
 
   switch (key.name) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -823,6 +823,8 @@ function _ttyWriteDumb(s, key) {
       // This readline instance is finished
       this.close();
     }
+
+    return;
   }
 
   switch (key.name) {

--- a/test/pseudo-tty/repl-dumb-tty.js
+++ b/test/pseudo-tty/repl-dumb-tty.js
@@ -1,9 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
 
 process.env.TERM = 'dumb';
 
 const repl = require('repl');
+const ArrayStream = require('../common/arraystream');
 
 repl.start('> ');
 process.stdin.push('console.log("foo")\n');
@@ -13,3 +14,18 @@ process.stdin.push('console.dir({ a: 1 })\n');
 process.stdin.push('{ a: 1 }\n');
 process.stdin.push('\n');
 process.stdin.push('.exit\n');
+
+// Verify Control+D support.
+{
+  const stream = new ArrayStream();
+  const replServer = repl.start({
+    prompt: '> ',
+    terminal: true,
+    input: stream,
+    output: stream,
+    useColors: false
+  });
+
+  replServer.on('close', common.mustCall());
+  replServer.write(null, { ctrl: true, name: 'd' });
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/29111

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
