### PR TITLE
src: rename --security-reverts to ...-revert

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -640,7 +640,12 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             &PerProcessOptions::debug_arraybuffer_allocations,
             kAllowedInEnvironment);
 
+
+  // 12.x renamed this inadvertently, so alias it for consistency within the
+  // release line, while using the original name for consistency with older
+  // release lines.
   AddOption("--security-revert", "", &PerProcessOptions::security_reverts);
+  AddAlias("--security-reverts", "--security-revert");
   AddOption("--completion-bash",
             "print source-able bash completion script",
             &PerProcessOptions::print_bash_completion);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -640,7 +640,7 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             &PerProcessOptions::debug_arraybuffer_allocations,
             kAllowedInEnvironment);
 
-  AddOption("--security-reverts", "", &PerProcessOptions::security_reverts);
+  AddOption("--security-revert", "", &PerProcessOptions::security_reverts);
   AddOption("--completion-bash",
             "print source-able bash completion script",
             &PerProcessOptions::print_bash_completion);

--- a/test/parallel/test-security-revert-unknown.js
+++ b/test/parallel/test-security-revert-unknown.js
@@ -5,7 +5,7 @@ const { spawnSync } = require('child_process');
 const os = require('os');
 
 const { signal, status, output } =
-  spawnSync(process.execPath, ['--security-reverts=not-a-cve']);
+  spawnSync(process.execPath, ['--security-revert=not-a-cve']);
 assert.strictEqual(signal, null);
 assert.strictEqual(status, 12);
 assert.strictEqual(


### PR DESCRIPTION
It was called --security-revert prior to 12.x, but changed in
https://github.com/nodejs/node/pull/22490.

See:
https://github.com/nodejs/nodejs.org/pull/2412#issuecomment-521739752

@addaleax good idea?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
