### PR TITLE
stream: remove usage of private readableListening

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1143,6 +1143,15 @@ added: v12.3.0
 
 Getter for the property `objectMode` of a given `Readable` stream.
 
+##### readable.readableListening
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+Getter for the property `readableListening` of a given `Readable` stream.
+
 ##### readable.resume()
 <!-- YAML
 added: v0.9.4

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1134,6 +1134,17 @@ This property contains the number of bytes (or objects) in the queue
 ready to be read. The value provides introspection data regarding
 the status of the `highWaterMark`.
 
+##### readable.readableListening
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+This property is a Getter for accessing `_readableState.readableListening`
+value of a given `Readable` stream.
+It indicates if any active listeners exist for the stream.
+
 ##### readable.readableObjectMode
 <!-- YAML
 added: v12.3.0
@@ -1142,15 +1153,6 @@ added: v12.3.0
 * {boolean}
 
 Getter for the property `objectMode` of a given `Readable` stream.
-
-##### readable.readableListening
-<!-- YAML
-added: REPLACEME
--->
-
-* {boolean}
-
-Getter for the property `readableListening` of a given `Readable` stream.
 
 ##### readable.resume()
 <!-- YAML

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1082,6 +1082,13 @@ Object.defineProperty(Readable.prototype, 'readableObjectMode', {
   }
 });
 
+Object.defineProperty(Readable.prototype, 'readableListening', {
+  enumerable: false,
+  get() {
+    return this._readableState ? this._readableState.readableListening : false;
+  }
+});
+
 Object.defineProperty(Readable.prototype, 'readableEncoding', {
   enumerable: false,
   get() {

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -298,7 +298,7 @@ function flushStdio(subprocess) {
     // which data can be read from a stream, e.g. being consumed on the
     // native layer directly as a StreamBase.
     if (!stream || !stream.readable ||
-        stream._readableState.readableListening ||
+        stream.readableListening ||
         stream[kIsUsedAsStdio]) {
       continue;
     }

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -451,6 +451,7 @@ class TestWriter extends EE {
   assert(R.prototype.hasOwnProperty('readableListening'));
 
   const r = new TestReader(5);
+  assert.strictEqual(r.readableListening, false);
   r.addListener('readable', () => {});
   assert.strictEqual(r.readableListening, true);
   r.removeAllListeners();

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -445,3 +445,13 @@ class TestWriter extends EE {
   const w = new W({ objectMode: true });
   assert.strictEqual(w.writableObjectMode, true);
 }
+
+{
+  // Verify readableListening property
+  assert(R.prototype.hasOwnProperty('readableListening'));
+
+  const r = new TestReader(5);
+  r.addListener('readable', () => {});
+  assert.strictEqual(r.readableListening, true);
+  r.removeAllListeners();
+}


### PR DESCRIPTION
Adds a public `readableListening` property and replaces references to `_readableState.readableListening` with it.
Refs: https://github.com/nodejs/node/issues/445
cc: @mcollina

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
