### PR TITLE
stream: read refactor

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -383,17 +383,9 @@ function howMuchToRead(n, state) {
     else
       return state.length;
   }
-  // If we're asking for more than the current hwm, then raise the hwm.
-  if (n > state.highWaterMark)
-    state.highWaterMark = computeNewHighWaterMark(n);
   if (n <= state.length)
     return n;
-  // Don't have enough
-  if (!state.ended) {
-    state.needReadable = true;
-    return 0;
-  }
-  return state.length;
+  return state.ended ? state.length : 0;
 }
 
 // You can override either this method, or the async _read(n) below.
@@ -408,6 +400,10 @@ Readable.prototype.read = function(n) {
   }
   const state = this._readableState;
   const nOrig = n;
+
+  // If we're asking for more than the current hwm, then raise the hwm.
+  if (n > state.highWaterMark)
+    state.highWaterMark = computeNewHighWaterMark(n);
 
   if (n !== 0)
     state.emittedReadable = false;


### PR DESCRIPTION
This slightly refactors `read` by moving side effects out of `howMuchToRead`.

We don't actually have to set `state.needReadable = true;` in `howMuchToRead` since `read` handles `0` return as `needReadable`.

```js
 streams/readable-bigunevenread.js n=1000          *      8.80 %       ±7.47% ±9.94% ±12.94%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
