### PR TITLE
stream: reset writable and readable on destroy

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -711,7 +711,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   src.on('data', ondata);
   function ondata(chunk) {
     debug('ondata');
-    const ret = dest.write(chunk);
+    const ret = dest.writable !== false && dest.write(chunk);
     debug('dest.write', ret);
     if (ret === false) {
       // If the user unpiped during `dest.write()`, it is possible

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -26,11 +26,13 @@ function destroy(err, cb) {
   // to make it re-entrance safe in case destroy() is called within callbacks
 
   if (this._readableState) {
+    this.readable = false;
     this._readableState.destroyed = true;
   }
 
   // If this is a duplex stream mark the writable part as destroyed as well
   if (this._writableState) {
+    this.writable = false;
     this._writableState.destroyed = true;
   }
 

--- a/test/parallel/test-stream-pipe-flow.js
+++ b/test/parallel/test-stream-pipe-flow.js
@@ -65,3 +65,18 @@ const { Readable, Writable, PassThrough } = require('stream');
   wrapper.resume();
   wrapper.on('end', common.mustCall());
 }
+
+{
+  const rs = new Readable({
+    objectMode: true,
+    read: () => {
+      rs.push({});
+    }
+  });
+
+  const pt = rs
+    .on('data', () => {
+      pt.destroy();
+    })
+    .pipe(new PassThrough({ objectMode: true }));
+}

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -189,3 +189,15 @@ const assert = require('assert');
   read.push('hi');
   read.on('data', common.mustNotCall());
 }
+
+{
+  // Not readable after destroy
+  const read = new Readable({
+    read() {}
+  });
+  assert.strictEqual(read.readable, true);
+  read.destroy();
+  assert.strictEqual(read.readable, false);
+  read._undestroy();
+  assert.strictEqual(read.readable, true);
+}

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -198,6 +198,4 @@ const assert = require('assert');
   assert.strictEqual(read.readable, true);
   read.destroy();
   assert.strictEqual(read.readable, false);
-  read._undestroy();
-  assert.strictEqual(read.readable, true);
 }

--- a/test/parallel/test-stream-transform-destroy.js
+++ b/test/parallel/test-stream-transform-destroy.js
@@ -152,7 +152,4 @@ const assert = require('assert');
   transform.destroy();
   assert.strictEqual(transform.writable, false);
   assert.strictEqual(transform.readable, false);
-  transform._undestroy();
-  assert.strictEqual(transform.writable, true);
-  assert.strictEqual(transform.readable, true);
 }

--- a/test/parallel/test-stream-transform-destroy.js
+++ b/test/parallel/test-stream-transform-destroy.js
@@ -141,3 +141,18 @@ const assert = require('assert');
 
   transform.destroy();
 }
+
+{
+  // Not readable after destroy
+  const transform = new Transform({
+    transform(chunk, enc, cb) {}
+  });
+  assert.strictEqual(transform.writable, true);
+  assert.strictEqual(transform.readable, true);
+  transform.destroy();
+  assert.strictEqual(transform.writable, false);
+  assert.strictEqual(transform.readable, false);
+  transform._undestroy();
+  assert.strictEqual(transform.writable, true);
+  assert.strictEqual(transform.readable, true);
+}

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -232,3 +232,15 @@ const assert = require('assert');
   write._undestroy();
   write.end();
 }
+
+{
+  // Not readable after destroy
+  const write = new Writable({
+    write() {}
+  });
+  assert.strictEqual(write.writable, true);
+  write.destroy();
+  assert.strictEqual(write.writable, false);
+  write._undestroy();
+  assert.strictEqual(write.writable, true);
+}

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -241,6 +241,4 @@ const assert = require('assert');
   assert.strictEqual(write.writable, true);
   write.destroy();
   assert.strictEqual(write.writable, false);
-  write._undestroy();
-  assert.strictEqual(write.writable, true);
 }


### PR DESCRIPTION
- Reset `writable` and `readable` on `destroy()`.
- `pipe()` needs to check `writable`.

Fixes: #29143

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
