### PR TITLE
net: explicitly set readable on connect

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -881,6 +881,7 @@ Socket.prototype.connect = function(...args) {
 
   this.connecting = true;
   this.writable = true;
+  this.readable = false;
 
   if (pipe) {
     validateString(path, 'options.path');


### PR DESCRIPTION
I think this works currently by luck? I can't quite see the logic where a socket is re-used/undestroyed and readable is correctly reset to false.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
