### PR TITLE
stream: unpipe once

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -737,8 +737,11 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   // However, don't suppress the throwing behavior for this.
   function onerror(er) {
     debug('onerror', er);
-    unpipe();
+    dest.removeListener('finish', onfinish);
+    dest.removeListener('close', onclose);
     dest.removeListener('error', onerror);
+    unpipe();
+
     if (EE.listenerCount(dest, 'error') === 0)
       errorOrDestroy(dest, er);
   }
@@ -749,11 +752,13 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   // Both close and finish should trigger unpipe, but only once.
   function onclose() {
     dest.removeListener('finish', onfinish);
+    dest.removeListener('error', onerror);
     unpipe();
   }
   dest.once('close', onclose);
   function onfinish() {
     debug('onfinish');
+    dest.removeListener('error', onerror);
     dest.removeListener('close', onclose);
     unpipe();
   }

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -692,8 +692,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     }
     dest.removeListener('error', onerror);
     dest.removeListener('unpipe', onunpipe);
-    src.removeListener('end', onend);
-    src.removeListener('end', unpipe);
+    src.removeListener('end', endFn);
     src.removeListener('data', ondata);
 
     cleanedUp = true;


### PR DESCRIPTION
Depending on stream implementation `unpipe` could be called twice.

Also a minor optimizattion on removing the `end` listener.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
