### PR TITLE
stream: don't emit error after close

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -120,6 +120,8 @@ function ReadableState(options, stream, isDuplex) {
   // True if the error was already emitted and should not be thrown again
   this.errorEmitted = false;
 
+  this.closed = false;
+
   // Should close be emitted on destroy. Defaults to true.
   this.emitClose = options.emitClose !== false;
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -148,6 +148,8 @@ function WritableState(options, stream, isDuplex) {
   // True if the error was already emitted and should not be thrown again
   this.errorEmitted = false;
 
+  this.closed = false;
+
   // Should close be emitted on destroy. Defaults to true.
   this.emitClose = options.emitClose !== false;
 

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -8,6 +8,10 @@ function needError(stream, err) {
   const r = stream._readableState;
   const w = stream._writableState;
 
+  if ((w && w.closed) || (r && r.closed)) {
+    return false;
+  }
+
   if ((w && w.errorEmitted) || (r && r.errorEmitted)) {
     return false;
   }
@@ -55,6 +59,12 @@ function destroy(err, cb) {
       process.nextTick(emitErrorAndCloseNT, this, err);
     } else {
       process.nextTick(emitCloseNT, this);
+    }
+    if (w) {
+      w.closed = true;
+    }
+    if (r) {
+      r.closed = true;
     }
   });
 

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -232,3 +232,35 @@ const assert = require('assert');
   write._undestroy();
   write.end();
 }
+
+{
+  const w = new Writable({
+    write(data, enc, cb) {
+      cb();
+    }
+  });
+
+  w.destroy();
+  w.on('error', common.mustNotCall());
+  w.on('close', common.mustCall(() => {
+    w.write('asd', common.expectsError({ type: Error }));
+  }));
+}
+
+{
+  const w = new Writable({
+    write(data, enc, cb) {
+      cb();
+    },
+    emitClose: false
+  });
+
+  w.on('error', common.mustNotCall());
+  w._destroy = (err, cb) => {
+    process.nextTick(() => {
+      w.write('asd', common.expectsError({ type: Error }));
+    });
+    cb(err);
+  };
+  w.destroy();
+}


### PR DESCRIPTION
We should not emit any further errors after the stream is considered
closed (i.e. after `'close'` has been emitted).

The state property naming a little unfortunate, but nothing we can do about that now. It's still good.

- `.destroyed` means "destroying".
- `.closed` means "destroyed" (**new**).

Similar too `ending` and `ended`. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
