### PR TITLE
net: use callback to properly propagate error

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -685,7 +685,7 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
   this._pendingEncoding = '';
 
   if (!this._handle) {
-    this.destroy(new ERR_SOCKET_CLOSED(), cb);
+    cb(new ERR_SOCKET_CLOSED());
     return false;
   }
 


### PR DESCRIPTION
The socket will be destroyed upstream through the proper error
flow.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
