### PR TITLE
doc: add missing deprecation number

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2500,8 +2500,8 @@ Type: Runtime
 Passing a callback to [`worker.terminate()`][] is deprecated. Use the returned
 `Promise` instead, or a listener to the worker’s `'exit'` event.
 
-<a id="DEP0XXX"></a>
-### DEP0XXX: http connection
+<a id="DEP0133"></a>
+### DEP0133: http connection
 <!-- YAML
 changes:
   - version: REPLACEME


### PR DESCRIPTION
https://github.com/nodejs/node/pull/29015 landed with the new deprecation listed as `DEP0XXX`. This commit assigns the new deprecation a valid ID.

Refs: https://github.com/nodejs/node/pull/29015

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
