### PR TITLE
lib: rename validateSafeInteger to validateInteger

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -85,7 +85,7 @@ const {
   isUint32,
   parseMode,
   validateBuffer,
-  validateSafeInteger,
+  validateInteger,
   validateInt32,
   validateUint32
 } = require('internal/validators');
@@ -469,7 +469,7 @@ function read(fd, buffer, offset, length, position, callback) {
   if (offset == null) {
     offset = 0;
   } else {
-    validateSafeInteger(offset, 'offset');
+    validateInteger(offset, 'offset');
   }
 
   length |= 0;
@@ -511,7 +511,7 @@ function readSync(fd, buffer, offset, length, position) {
   if (offset == null) {
     offset = 0;
   } else {
-    validateSafeInteger(offset, 'offset');
+    validateInteger(offset, 'offset');
   }
 
   length |= 0;
@@ -557,7 +557,7 @@ function write(fd, buffer, offset, length, position, callback) {
     if (offset == null || typeof offset === 'function') {
       offset = 0;
     } else {
-      validateSafeInteger(offset, 'offset');
+      validateInteger(offset, 'offset');
     }
     if (typeof length !== 'number')
       length = buffer.length - offset;
@@ -599,7 +599,7 @@ function writeSync(fd, buffer, offset, length, position) {
     if (offset == null) {
       offset = 0;
     } else {
-      validateSafeInteger(offset, 'offset');
+      validateInteger(offset, 'offset');
     }
     if (typeof length !== 'number')
       length = buffer.byteLength - offset;
@@ -698,7 +698,7 @@ function truncate(path, len, callback) {
     len = 0;
   }
 
-  validateSafeInteger(len, 'len');
+  validateInteger(len, 'len');
   callback = maybeCallback(callback);
   fs.open(path, 'r+', (er, fd) => {
     if (er) return callback(er);
@@ -739,7 +739,7 @@ function ftruncate(fd, len = 0, callback) {
     len = 0;
   }
   validateInt32(fd, 'fd', 0);
-  validateSafeInteger(len, 'len');
+  validateInteger(len, 'len');
   len = Math.max(0, len);
   const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
@@ -748,7 +748,7 @@ function ftruncate(fd, len = 0, callback) {
 
 function ftruncateSync(fd, len = 0) {
   validateInt32(fd, 'fd', 0);
-  validateSafeInteger(len, 'len');
+  validateInteger(len, 'len');
   len = Math.max(0, len);
   const ctx = {};
   binding.ftruncate(fd, len, undefined, ctx);

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -3,7 +3,7 @@
 const { AsyncWrap, Providers } = internalBinding('async_wrap');
 const { Buffer } = require('buffer');
 const { scrypt: _scrypt } = internalBinding('crypto');
-const { validateSafeInteger, validateUint32 } = require('internal/validators');
+const { validateInteger, validateUint32 } = require('internal/validators');
 const {
   ERR_CRYPTO_SCRYPT_INVALID_PARAMETER,
   ERR_CRYPTO_SCRYPT_NOT_SUPPORTED,
@@ -108,7 +108,7 @@ function check(password, salt, keylen, options) {
     }
     if (options.maxmem !== undefined) {
       maxmem = options.maxmem;
-      validateSafeInteger(maxmem, 'maxmem', 0);
+      validateInteger(maxmem, 'maxmem', 0);
     }
     if (N === 0) N = defaults.N;
     if (r === 0) r = defaults.r;

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -36,7 +36,7 @@ const {
 const {
   parseMode,
   validateBuffer,
-  validateSafeInteger,
+  validateInteger,
   validateUint32
 } = require('internal/validators');
 const pathModule = require('path');
@@ -209,7 +209,7 @@ async function read(handle, buffer, offset, length, position) {
   if (offset == null) {
     offset = 0;
   } else {
-    validateSafeInteger(offset, 'offset');
+    validateInteger(offset, 'offset');
   }
 
   length |= 0;
@@ -243,7 +243,7 @@ async function write(handle, buffer, offset, length, position) {
     if (offset == null) {
       offset = 0;
     } else {
-      validateSafeInteger(offset, 'offset');
+      validateInteger(offset, 'offset');
     }
     if (typeof length !== 'number')
       length = buffer.length - offset;
@@ -278,7 +278,7 @@ async function truncate(path, len = 0) {
 
 async function ftruncate(handle, len = 0) {
   validateFileHandle(handle);
-  validateSafeInteger(len, 'len');
+  validateInteger(len, 'len');
   len = Math.max(0, len);
   return binding.ftruncate(handle.fd, len, kUsePromises);
 }

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -62,7 +62,7 @@ function parseMode(value, name, def) {
   throw new ERR_INVALID_ARG_VALUE(name, value, modeDesc);
 }
 
-const validateSafeInteger = hideStackFrames(
+const validateInteger = hideStackFrames(
   (value, name, min = MIN_SAFE_INTEGER, max = MAX_SAFE_INTEGER) => {
     if (typeof value !== 'number')
       throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
@@ -161,7 +161,7 @@ module.exports = {
   parseMode,
   validateBuffer,
   validateEncoding,
-  validateSafeInteger,
+  validateInteger,
   validateInt32,
   validateUint32,
   validateString,

--- a/test/parallel/test-validators.js
+++ b/test/parallel/test-validators.js
@@ -1,0 +1,25 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+const {
+  validateInteger
+} = require('internal/validators');
+const { MAX_SAFE_INTEGER, MIN_SAFE_INTEGER } = Number;
+const outOfRangeError = {
+  code: 'ERR_OUT_OF_RANGE',
+  type: RangeError
+};
+
+// validateInteger() defaults to validating safe integers.
+validateInteger(MAX_SAFE_INTEGER, 'foo');
+validateInteger(MIN_SAFE_INTEGER, 'foo');
+common.expectsError(() => {
+  validateInteger(MAX_SAFE_INTEGER + 1, 'foo');
+}, outOfRangeError);
+common.expectsError(() => {
+  validateInteger(MIN_SAFE_INTEGER - 1, 'foo');
+}, outOfRangeError);
+
+// validateInteger() works with unsafe integers.
+validateInteger(MAX_SAFE_INTEGER + 1, 'foo', 0, MAX_SAFE_INTEGER + 1);
+validateInteger(MIN_SAFE_INTEGER - 1, 'foo', MIN_SAFE_INTEGER - 1);


### PR DESCRIPTION
`validateInteger()` was renamed to `validateSafeInteger()` in https://github.com/nodejs/node/pull/26572. However, this function also works with unsafe integers. This commit restores the old name, and adds some basic tests.

Refs: https://github.com/nodejs/node/pull/26572

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
