### PR TITLE
fs: validate writev fds consistently

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -625,7 +625,7 @@ function writev(fd, buffers, position, callback) {
     callback(err, written || 0, buffers);
   }
 
-  validateUint32(fd, 'fd');
+  validateInt32(fd, 'fd', 0);
 
   if (!isBuffersArray(buffers)) {
     throw new ERR_INVALID_ARG_TYPE('buffers', 'ArrayBufferView[]', buffers);
@@ -650,7 +650,7 @@ Object.defineProperty(writev, internalUtil.customPromisifyArgs, {
 // fs.writevSync(fd, buffers[, position]);
 function writevSync(fd, buffers, position) {
 
-  validateUint32(fd, 'fd');
+  validateInt32(fd, 'fd', 0);
   const ctx = {};
 
   if (!isBuffersArray(buffers)) {


### PR DESCRIPTION
This commit updates the recently added writev methods to validate file descriptors like the other fs methods do.

Refs: https://github.com/nodejs/node/pull/25925

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
