### PR TITLE
fs: use fs.writev

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -3,10 +3,6 @@
 const { Math, Object } = primordials;
 
 const {
-  FSReqCallback,
-  writeBuffers
-} = internalBinding('fs');
-const {
   ERR_INVALID_ARG_TYPE,
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
@@ -325,18 +321,6 @@ WriteStream.prototype._write = function(data, encoding, cb) {
 };
 
 
-function writev(fd, chunks, position, callback) {
-  function wrapper(err, written) {
-    // Retain a reference to chunks so that they can't be GC'ed too soon.
-    callback(err, written || 0, chunks);
-  }
-
-  const req = new FSReqCallback();
-  req.oncomplete = wrapper;
-  writeBuffers(fd, chunks, position, req);
-}
-
-
 WriteStream.prototype._writev = function(data, cb) {
   if (typeof this.fd !== 'number') {
     return this.once('open', function() {
@@ -356,7 +340,7 @@ WriteStream.prototype._writev = function(data, cb) {
     size += chunk.length;
   }
 
-  writev(this.fd, chunks, this.pos, function(er, bytes) {
+  fs.writev(this.fd, chunks, this.pos, function(er, bytes) {
     if (er) {
       self.destroy();
       return cb(er);


### PR DESCRIPTION
Avoid using internal API in fs implementation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
