### PR TITLE
worker: fix crash when SharedArrayBuffer outlives creating thread

### DIFF
--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -41,6 +41,7 @@ class Worker : public AsyncWrap {
   SET_SELF_SIZE(Worker)
 
   bool is_stopped() const;
+  std::shared_ptr<ArrayBufferAllocator> array_buffer_allocator();
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CloneParentEnvVars(
@@ -59,6 +60,7 @@ class Worker : public AsyncWrap {
   std::vector<std::string> argv_;
 
   MultiIsolatePlatform* platform_;
+  std::shared_ptr<ArrayBufferAllocator> array_buffer_allocator_;
   v8::Isolate* isolate_ = nullptr;
   bool start_profiler_idle_notifier_;
   uv_thread_t tid_;

--- a/src/sharedarraybuffer_metadata.h
+++ b/src/sharedarraybuffer_metadata.h
@@ -46,7 +46,9 @@ class SharedArrayBufferMetadata
   SharedArrayBufferMetadata(const SharedArrayBufferMetadata&) = delete;
 
  private:
-  explicit SharedArrayBufferMetadata(const v8::SharedArrayBuffer::Contents&);
+  SharedArrayBufferMetadata(
+      const v8::SharedArrayBuffer::Contents&,
+      std::shared_ptr<v8::ArrayBuffer::Allocator>);
 
   // Attach a lifetime tracker object with a reference count to `target`.
   v8::Maybe<bool> AssignToSharedArrayBuffer(
@@ -55,6 +57,7 @@ class SharedArrayBufferMetadata
       v8::Local<v8::SharedArrayBuffer> target);
 
   v8::SharedArrayBuffer::Contents contents_;
+  std::shared_ptr<v8::ArrayBuffer::Allocator> allocator_;
 };
 
 }  // namespace worker

--- a/test/parallel/test-worker-arraybuffer-zerofill.js
+++ b/test/parallel/test-worker-arraybuffer-zerofill.js
@@ -1,0 +1,33 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Make sure that allocating uninitialized ArrayBuffers in one thread does not
+// affect the zero-initialization in other threads.
+
+const w = new Worker(`
+const { parentPort } = require('worker_threads');
+
+function post() {
+  const uint32array = new Uint32Array(64);
+  parentPort.postMessage(uint32array.reduce((a, b) => a + b));
+}
+
+setInterval(post, 0);
+`, { eval: true });
+
+function allocBuffers() {
+  Buffer.allocUnsafe(32 * 1024 * 1024);
+}
+
+const interval = setInterval(allocBuffers, 0);
+
+let messages = 0;
+w.on('message', (sum) => {
+  assert.strictEqual(sum, 0);
+  if (messages++ === 100) {
+    clearInterval(interval);
+    w.terminate();
+  }
+});

--- a/test/parallel/test-worker-sharedarraybuffer-from-worker-thread.js
+++ b/test/parallel/test-worker-sharedarraybuffer-from-worker-thread.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Regression test for https://github.com/nodejs/node/issues/28777
+// Make sure that SharedArrayBuffers created in Worker threads are accessible
+// after the creating thread ended.
+
+const w = new Worker(`
+const { parentPort } = require('worker_threads');
+const sharedArrayBuffer = new SharedArrayBuffer(4);
+parentPort.postMessage(sharedArrayBuffer);
+`, { eval: true });
+
+let sharedArrayBuffer;
+w.once('message', common.mustCall((message) => sharedArrayBuffer = message));
+w.once('exit', common.mustCall(() => {
+  const uint8array = new Uint8Array(sharedArrayBuffer);
+  uint8array[0] = 42;
+  assert.deepStrictEqual(uint8array, new Uint8Array([42, 0, 0, 0]));
+}));


### PR DESCRIPTION
Keep a reference to the `ArrayBuffer::Allocator` alive for at least
as long as a `SharedArrayBuffer` allocated by it lives.

The tests are taken 1:1 from https://github.com/nodejs/node/pull/28788.

Refs: https://github.com/nodejs/node/pull/28788
Fixes: https://github.com/nodejs/node/issues/28777
Fixes: https://github.com/nodejs/node/issues/28773

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
