### PR TITLE
build: add Python 3 tests to Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,3 +87,17 @@ jobs:
         - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
             bash -x tools/lint-pr-commit-message.sh ${TRAVIS_PULL_REQUEST};
           fi
+
+    - name: "Python 3 is EXPERIMENTAL"
+      language: node_js
+      node_js: "node"
+      install:
+        - pyenv global 3.7.1
+        - make lint-py-build || true
+      script:
+        - NODE=$(which node) make lint lint-py
+        - python3.7 ./configure.py
+        - NODE=$(which node) make test
+
+  allow_failures:
+    - name: "Python 3 is EXPERIMENTAL"

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,8 @@ jobs:
       node_js: "node"
       install:
         - pyenv global 3.7.1
-        - make lint-py-build || true
+        - python3.7 -m pip install --upgrade pip
+        - make lint-py-build
       script:
         - NODE=$(which node) make lint lint-py
         - python3.7 ./configure.py


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Based on the lessons learned in #29193, this pull request adds Travis CI test suite named __Python 3 is EXPERIMENTAL__.  These tests are run in __allow_failures__ mode on Python 3.7.1 and they bypasses the Python version checks in __./configure__ by directly running __./configure.py__.