### PR TITLE
lib: remove the comment of base64 validation

### DIFF
--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -151,8 +151,6 @@ function validateEncoding(data, encoding) {
     throw new ERR_INVALID_ARG_VALUE('encoding', encoding,
                                     `is invalid for data of length ${length}`);
   }
-
-  // TODO(bnoordhuis) Add BASE64 check?
 }
 
 module.exports = {


### PR DESCRIPTION
Since there's a comment about the 'base64' validation needed, and this will result in a breaking change, so this should be removed.

---

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)