### PR TITLE
src: reset inspector brk for node bootstrap js

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -214,7 +214,7 @@ MaybeLocal<Value> ExecuteBootstrapper(Environment* env,
                                       std::vector<Local<String>>* parameters,
                                       std::vector<Local<Value>>* arguments) {
 #if HAVE_INSPECTOR
-  InspectorPauseResetter paus_resetter{env->inspector_agent()};
+  InspectorPauseResetter pause_resetter{env->inspector_agent()};
 #endif
   EscapableHandleScope scope(env->isolate());
   MaybeLocal<Function> maybe_fn =


### PR DESCRIPTION
This commit suggests that after calling a node bootstrap js function and
`--inspect-brk-node` was specified, that the inspector should pause again
on the next node internal bootstrap function.

The motivation for this is that when debugging with `--inspect-brk-node`
it will break/pause on the first JavaScript function, but when continuing
it will stop in the user defined function and not in the other node
internal bootstrap js functions.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
