### PR TITLE
src,lib: make ^C print a JS stack trace

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -779,6 +779,13 @@ added: v13.5.0
 Prints a stack trace whenever an environment is exited proactively,
 i.e. invoking `process.exit()`.
 
+### `--trace-sigint`
+<!-- YAML
+added: REPLACEME
+-->
+
+Prints a stack trace on SIGINT.
+
 ### `--trace-sync-io`
 <!-- YAML
 added: v2.1.0
@@ -1122,6 +1129,7 @@ Node.js options that are allowed are:
 * `--trace-event-file-pattern`
 * `--trace-events-enabled`
 * `--trace-exit`
+* `--trace-sigint`
 * `--trace-sync-io`
 * `--trace-tls`
 * `--trace-uncaught`

--- a/doc/node.1
+++ b/doc/node.1
@@ -367,6 +367,8 @@ Enable the collection of trace event tracing information.
 .It Fl -trace-exit
 Prints a stack trace whenever an environment is exited proactively,
 i.e. invoking `process.exit()`.
+.It Fl -trace-sigint
+Prints a stack trace on SIGINT.
 .
 .It Fl -trace-sync-io
 Print a stack trace whenever synchronous I/O is detected after the first turn of the event loop.

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -37,6 +37,9 @@ function prepareMainThreadExecution(expandArgv1 = false) {
 
   setupDebugEnv();
 
+  // Print stack trace on `SIGINT` if option `--trace-sigint` presents.
+  setupStacktracePrinterOnSigint();
+
   // Process initial diagnostic reporting configuration, if present.
   initializeReport();
   initializeReportSignalHandlers();  // Main-thread-only.
@@ -147,6 +150,16 @@ function setupCoverageHooks(dir) {
     return '';
   }
   return coverageDirectory;
+}
+
+function setupStacktracePrinterOnSigint() {
+  if (!getOptionValue('--trace-sigint')) {
+    return;
+  }
+  const { SigintWatchdog } = require('internal/watchdog');
+
+  const watchdog = new SigintWatchdog();
+  watchdog.start();
 }
 
 function initializeReport() {

--- a/lib/internal/watchdog.js
+++ b/lib/internal/watchdog.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const {
+  TraceSigintWatchdog
+} = internalBinding('watchdog');
+
+class SigintWatchdog extends TraceSigintWatchdog {
+  _started = false;
+  _effective = false;
+  _onNewListener = (eve) => {
+    if (eve === 'SIGINT' && this._effective) {
+      super.stop();
+      this._effective = false;
+    }
+  };
+  _onRemoveListener = (eve) => {
+    if (eve === 'SIGINT' && process.listenerCount('SIGINT') === 0 &&
+        !this._effective) {
+      super.start();
+      this._effective = true;
+    }
+  }
+
+  start() {
+    if (this._started) {
+      return;
+    }
+    this._started = true;
+    // Prepend sigint newListener to remove stop watchdog before signal wrap
+    // been activated. Also make sigint removeListener been ran after signal
+    // wrap been stopped.
+    process.prependListener('newListener', this._onNewListener);
+    process.addListener('removeListener', this._onRemoveListener);
+
+    if (process.listenerCount('SIGINT') === 0) {
+      super.start();
+      this._effective = true;
+    }
+  }
+
+  stop() {
+    if (!this._started) {
+      return;
+    }
+    this._started = false;
+    process.removeListener('newListener', this._onNewListener);
+    process.removeListener('removeListener', this._onRemoveListener);
+
+    if (this._effective) {
+      super.stop();
+      this._effective = false;
+    }
+  }
+}
+
+
+module.exports = {
+  SigintWatchdog
+};

--- a/node.gyp
+++ b/node.gyp
@@ -210,6 +210,7 @@
       'lib/internal/vm/module.js',
       'lib/internal/worker.js',
       'lib/internal/worker/io.js',
+      'lib/internal/watchdog.js',
       'lib/internal/streams/lazy_transform.js',
       'lib/internal/streams/async_iterator.js',
       'lib/internal/streams/buffer_list.js',

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -68,6 +68,7 @@ namespace node {
   V(TTYWRAP)                                                                  \
   V(UDPSENDWRAP)                                                              \
   V(UDPWRAP)                                                                  \
+  V(SIGINTWATCHDOG)                                                           \
   V(WORKER)                                                                   \
   V(WRITEWRAP)                                                                \
   V(ZLIB)

--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -81,6 +81,14 @@ void MemoryTracker::TrackFieldWithSize(const char* edge_name,
   if (size > 0) AddNode(GetNodeName(node_name, edge_name), size, edge_name);
 }
 
+void MemoryTracker::TrackInlineFieldWithSize(const char* edge_name,
+                                             size_t size,
+                                             const char* node_name) {
+  if (size > 0) AddNode(GetNodeName(node_name, edge_name), size, edge_name);
+  CHECK(CurrentNode());
+  CurrentNode()->size_ -= size;
+}
+
 void MemoryTracker::TrackField(const char* edge_name,
                                const MemoryRetainer& value,
                                const char* node_name) {
@@ -246,6 +254,12 @@ void MemoryTracker::TrackField(const char* name,
                                const uv_async_t& value,
                                const char* node_name) {
   TrackFieldWithSize(name, sizeof(value), "uv_async_t");
+}
+
+void MemoryTracker::TrackInlineField(const char* name,
+                                     const uv_async_t& value,
+                                     const char* node_name) {
+  TrackInlineFieldWithSize(name, sizeof(value), "uv_async_t");
 }
 
 template <class NativeT, class V8T>

--- a/src/memory_tracker.h
+++ b/src/memory_tracker.h
@@ -135,6 +135,10 @@ class MemoryTracker {
   inline void TrackFieldWithSize(const char* edge_name,
                                  size_t size,
                                  const char* node_name = nullptr);
+  inline void TrackInlineFieldWithSize(const char* edge_name,
+                                       size_t size,
+                                       const char* node_name = nullptr);
+
   // Shortcut to extract the underlying object out of the smart pointer
   template <typename T>
   inline void TrackField(const char* edge_name,
@@ -228,6 +232,9 @@ class MemoryTracker {
   inline void TrackField(const char* edge_name,
                          const uv_async_t& value,
                          const char* node_name = nullptr);
+  inline void TrackInlineField(const char* edge_name,
+                               const uv_async_t& value,
+                               const char* node_name = nullptr);
   template <class NativeT, class V8T>
   inline void TrackField(const char* edge_name,
                          const AliasedBufferBase<NativeT, V8T>& value,

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -87,6 +87,7 @@
   V(v8)                                                                        \
   V(wasi)                                                                      \
   V(worker)                                                                    \
+  V(watchdog)                                                                  \
   V(zlib)
 
 #define NODE_BUILTIN_MODULES(V)                                                \

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -758,6 +758,11 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             &PerProcessOptions::use_largepages,
             kAllowedInEnvironment);
 
+  AddOption("--trace-sigint",
+            "enable printing JavaScript stacktrace on SIGINT",
+            &PerProcessOptions::trace_sigint,
+            kAllowedInEnvironment);
+
   Insert(iop, &PerProcessOptions::get_per_isolate_options);
 }
 

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -237,6 +237,7 @@ class PerProcessOptions : public Options {
 #endif
 #endif
   std::string use_largepages = "off";
+  bool trace_sigint = false;
 
 #ifdef NODE_REPORT
   std::vector<std::string> cmdline;

--- a/test/pseudo-tty/test-trace-sigint-disabled.js
+++ b/test/pseudo-tty/test-trace-sigint-disabled.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const { mustCall } = require('../common');
+const childProcess = require('child_process');
+const assert = require('assert');
+
+if (process.env.CHILD === 'true') {
+  main();
+} else {
+  // Use inherited stdio child process to prevent test tools from determining
+  // the case as crashed from SIGINT
+  const cp = childProcess.spawn(
+    process.execPath,
+    ['--trace-sigint', __filename],
+    {
+      env: { ...process.env, CHILD: 'true' },
+      stdio: 'inherit'
+    });
+  cp.on('exit', mustCall((code, signal) => {
+    assert.strictEqual(signal, null);
+    assert.strictEqual(code, 0);
+  }));
+}
+
+function main() {
+  // Deactivate colors even if the tty does support colors.
+  process.env.NODE_DISABLE_COLORS = '1';
+
+  const noop = mustCall(() => {
+    process.exit(0);
+  });
+  process.on('SIGINT', noop);
+  // Try testing re-add 'SIGINT' listeners
+  process.removeListener('SIGINT', noop);
+  process.on('SIGINT', noop);
+
+  process.kill(process.pid, 'SIGINT');
+  setTimeout(() => { assert.fail('unreachable path'); }, 10 * 1000);
+}

--- a/test/pseudo-tty/test-trace-sigint-on-idle.js
+++ b/test/pseudo-tty/test-trace-sigint-on-idle.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { mustCall } = require('../common');
+const childProcess = require('child_process');
+const assert = require('assert');
+
+if (process.env.CHILD === 'true') {
+  main();
+} else {
+  // Use inherited stdio child process to prevent test tools from determining
+  // the case as crashed from SIGINT
+  const cp = childProcess.spawn(
+    process.execPath,
+    ['--trace-sigint', __filename],
+    {
+      env: { ...process.env, CHILD: 'true' },
+      stdio: 'inherit'
+    });
+  setTimeout(() => cp.kill('SIGINT'), 1 * 1000);
+  cp.on('exit', mustCall((code, signal) => {
+    assert.strictEqual(signal, 'SIGINT');
+    assert.strictEqual(code, null);
+  }));
+}
+
+function main() {
+  // Deactivate colors even if the tty does support colors.
+  process.env.NODE_DISABLE_COLORS = '1';
+  setTimeout(() => {}, 10 * 1000);
+}

--- a/test/pseudo-tty/test-trace-sigint-on-idle.out
+++ b/test/pseudo-tty/test-trace-sigint-on-idle.out
@@ -1,0 +1,1 @@
+KEYBOARD_INTERRUPT: Script execution was interrupted by `SIGINT`

--- a/test/pseudo-tty/test-trace-sigint.js
+++ b/test/pseudo-tty/test-trace-sigint.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { mustCall } = require('../common');
+const childProcess = require('child_process');
+const assert = require('assert');
+
+if (process.env.CHILD === 'true') {
+  main();
+} else {
+  // Use inherited stdio child process to prevent test tools from determining
+  // the case as crashed from SIGINT
+  const cp = childProcess.spawn(
+    process.execPath,
+    ['--trace-sigint', __filename],
+    {
+      env: { ...process.env, CHILD: 'true' },
+      stdio: 'inherit'
+    });
+  cp.on('exit', mustCall((code, signal) => {
+    assert.strictEqual(signal, 'SIGINT');
+    assert.strictEqual(code, null);
+  }));
+}
+
+function main() {
+  // Deactivate colors even if the tty does support colors.
+  process.env.NODE_DISABLE_COLORS = '1';
+  process.kill(process.pid, 'SIGINT');
+  while (true) {}
+}

--- a/test/pseudo-tty/test-trace-sigint.out
+++ b/test/pseudo-tty/test-trace-sigint.out
@@ -1,0 +1,9 @@
+KEYBOARD_INTERRUPT: Script execution was interrupted by `SIGINT`
+    at main (*/test-trace-sigint.js:*)
+    at */test-trace-sigint.js:*
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -51,6 +51,7 @@ const { getSystemErrorName } = require('util');
     delete providers.HTTPCLIENTREQUEST;
     delete providers.HTTPINCOMINGMESSAGE;
     delete providers.ELDHISTOGRAM;
+    delete providers.SIGINTWATCHDOG;
 
     const objKeys = Object.keys(providers);
     if (objKeys.length > 0)


### PR DESCRIPTION
If terminating the process with ctrl-c / SIGINT, prints a JS stack trace leading up to the currently executing code.

The feature would be enabled under option `--trace-sigint`.

Conditions of no stacktrace on sigint:

1. has (an) active sigint listener(s);
2. main thread is idle (i.e. uv polling), a message instead of stacktrace would be printed.

Related: https://github.com/nodejs/node/issues/24937

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
