### PR TITLE
tools: fix mixup with bytes.decode() and str.encode()

### DIFF
--- a/tools/v8_gypfiles/GN-scraper.py
+++ b/tools/v8_gypfiles/GN-scraper.py
@@ -7,8 +7,8 @@ PLAIN_SOURCE_RE = re.compile('\s*"([^/$].+)"\s*')
 def DoMain(args):
   gn_filename, pattern = args
   src_root = os.path.dirname(gn_filename)
-  with open(gn_filename, 'r') as gn_file:
-    gn_content = gn_file.read().encode('utf-8')
+  with open(gn_filename, 'rb') as gn_file:
+    gn_content = gn_file.read().decode('utf-8')
 
   scraper_re = re.compile(pattern + r'\[([^\]]+)', re.DOTALL)
   matches = scraper_re.search(gn_content)


### PR DESCRIPTION
We want to read a bytes file and decode the contents as utf-8 so we can compare against a utf-8 pattern.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
