### PR TITLE
stream: don't emit errors after destroy

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -29,11 +29,8 @@ function destroy(err, cb) {
 
   if ((w && w.destroyed) || (r && r.destroyed)) {
     if (cb) {
-      cb(err);
-    } else if (needError(this, err)) {
-      process.nextTick(emitErrorNT, this, err);
+      cb(err || null);
     }
-
     return this;
   }
 
@@ -47,11 +44,11 @@ function destroy(err, cb) {
     r.destroyed = true;
   }
 
-  this._destroy(err || null, (err) => {
+  this._destroy(err || null, (er) => {
     if (cb) {
-      process.nextTick(emitCloseNT, this);
-      cb(err);
-    } else if (needError(this, err)) {
+      cb(er || null);
+    }
+    if (err && needError(this, er || null)) {
       process.nextTick(emitErrorAndCloseNT, this, err);
     } else {
       process.nextTick(emitCloseNT, this);
@@ -113,6 +110,11 @@ function errorOrDestroy(stream, err) {
 
   const r = stream._readableState;
   const w = stream._writableState;
+
+  // Don't emit errors if already destroyed.
+  if ((w && w.destroyed) || (r && r.destroyed)) {
+    return;
+  }
 
   if ((r && r.autoDestroy) || (w && w.autoDestroy))
     stream.destroy(err);

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -144,9 +144,7 @@ const assert = require('assert');
 
   duplex.on('finish', common.mustNotCall('no finish event'));
   duplex.on('end', common.mustNotCall('no end event'));
-  duplex.on('error', common.mustCall((err) => {
-    assert.strictEqual(err, expected);
-  }));
+  duplex.on('error', common.mustNotCall());
 
   duplex.destroy();
   assert.strictEqual(duplex.destroyed, true);

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -130,9 +130,7 @@ const assert = require('assert');
   });
 
   read.on('end', common.mustNotCall('no end event'));
-  read.on('error', common.mustCall((err) => {
-    assert.strictEqual(err, expected);
-  }));
+  read.on('error', common.mustNotCall());
 
   read.destroy();
   assert.strictEqual(read.destroyed, true);
@@ -175,6 +173,7 @@ const assert = require('assert');
   const expected = new Error('kaboom');
 
   read.on('close', common.mustCall());
+  read.on('error', common.mustCall());
   read.destroy(expected, common.mustCall(function(err) {
     assert.strictEqual(err, expected);
   }));
@@ -188,4 +187,30 @@ const assert = require('assert');
   read.destroy();
   read.push('hi');
   read.on('data', common.mustNotCall());
+}
+
+{
+  const read = new Readable({
+    read() {},
+    destroy: common.mustCall((err, cb) => {
+      cb(new Error('test'));
+    })
+  });
+
+  read.on('error', common.mustNotCall());
+  read.destroy();
+}
+
+{
+  const read = new Readable({
+    read() {},
+    destroy: common.mustCall((err, cb) => {
+      cb(new Error('test'))
+    })
+  });
+
+  read.on('error', common.mustCall(err => {
+    assert.strictEqual(err.message, 'destroyed');
+  }));
+  read.destroy(new Error('destroyed'));
 }

--- a/test/parallel/test-stream-transform-destroy.js
+++ b/test/parallel/test-stream-transform-destroy.js
@@ -135,9 +135,7 @@ const assert = require('assert');
   transform.on('close', common.mustCall());
   transform.on('finish', common.mustNotCall('no finish event'));
   transform.on('end', common.mustNotCall('no end event'));
-  transform.on('error', common.mustCall((err) => {
-    assert.strictEqual(err, expected);
-  }));
+  transform.on('error', common.mustNotCall());
 
   transform.destroy();
 }

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -129,9 +129,7 @@ const assert = require('assert');
 
   write.on('close', common.mustCall());
   write.on('finish', common.mustNotCall('no finish event'));
-  write.on('error', common.mustCall((err) => {
-    assert.strictEqual(err, expected);
-  }));
+  write.on('error', common.mustNotCall());
 
   write.destroy();
   assert.strictEqual(write.destroyed, true);
@@ -163,10 +161,7 @@ const assert = require('assert');
   });
 
   writable.on('close', common.mustCall());
-  writable.on('error', common.expectsError({
-    type: Error,
-    message: 'kaboom 2'
-  }));
+  writable.on('error', common.mustNotCall());
 
   writable.destroy();
   assert.strictEqual(writable.destroyed, true);
@@ -175,7 +170,7 @@ const assert = require('assert');
   // Test case where `writable.destroy()` is called again with an error before
   // the `_destroy()` callback is called.
   writable.destroy(new Error('kaboom 2'));
-  assert.strictEqual(writable._writableState.errorEmitted, true);
+  assert.strictEqual(writable._writableState.errorEmitted, false);
 }
 
 {


### PR DESCRIPTION
This one is probably going to be a bit controversial but please give it a chance. It's the continuation on some related but less controversial PR's (e.g. https://github.com/nodejs/node/pull/29197)

Basically it tries to enforce the following rules:

- Emit **one** error after `destroy(err)`.
- Don't emit any error after `destroy()` (including if `destroy(err)` is called afterwards).
- Always pass error to callback in `destroy(err, cb)` or `destroy(null, cb)`.

The idea is to try to avoid unexpectedly crashing the user's application or emit any unexpected errors (even if the user has error listeners registered). Most users (I believe?) assume that after `destroy()` no more errors will be emitted, i.e. the object is practically "killed".

In the case where an error is explicitly passed to `destroy(err)`, it still makes sense to emit **one** error. Since the user has explicitly passed one.

If the user wants to handle any errors on the no error case they should pass a callback in `destroy(null, cb)`. This would also probably require that the undocumented/internal callback API for `destroy()` is documented.

This is semver-major but I don't believe the chances of it breaking anything are very high.

The tests also need a little more polish (I'll do that if there is interest in going forward with this PR). 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
