### PR TITLE
buffer: consolidate encoding parsing

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -907,7 +907,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   }
 
   throw new ERR_INVALID_ARG_TYPE(
-    'value', ['string', 'Buffer', 'Uint8Array'], val
+    'value', ['number', 'string', 'Buffer', 'Uint8Array'], val
   );
 }
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -60,6 +60,8 @@ const {
 const {
   inspect: utilInspect
 } = require('internal/util/inspect');
+const { encodings } = internalBinding('string_decoder');
+
 
 const {
   codes: {
@@ -108,6 +110,10 @@ let poolSize, poolOffset, allocPool;
 // |zeroFill| can be undefined when running inside an isolate where we
 // do not own the ArrayBuffer allocator.  Zero fill is always on in that case.
 const zeroFill = bindingZeroFill || [0];
+
+const encodingsMap = Object.create(null);
+for (let i = 0; i < encodings.length; ++i)
+  encodingsMap[encodings[i]] = i;
 
 function createUnsafeBuffer(size) {
   zeroFill[0] = 0;
@@ -376,28 +382,16 @@ function allocate(size) {
   return createUnsafeBuffer(size);
 }
 
-function fromString(string, encoding) {
-  let length;
-  if (typeof encoding !== 'string' || encoding.length === 0) {
-    if (string.length === 0)
-      return new FastBuffer();
-    encoding = 'utf8';
-    length = byteLengthUtf8(string);
-  } else {
-    length = byteLength(string, encoding, true);
-    if (length === -1)
-      throw new ERR_UNKNOWN_ENCODING(encoding);
-    if (string.length === 0)
-      return new FastBuffer();
-  }
+function fromStringFast(string, ops) {
+  const length = ops.byteLength(string);
 
   if (length >= (Buffer.poolSize >>> 1))
-    return createFromString(string, encoding);
+    return createFromString(string, ops.encodingVal);
 
   if (length > (poolSize - poolOffset))
     createPool();
   let b = new FastBuffer(allocPool, poolOffset, length);
-  const actual = b.write(string, encoding);
+  const actual = ops.write(b, string, 0, length);
   if (actual !== length) {
     // byteLength() may overestimate. That's a rare case, though.
     b = new FastBuffer(allocPool, poolOffset, actual);
@@ -405,6 +399,23 @@ function fromString(string, encoding) {
   poolOffset += actual;
   alignPool();
   return b;
+}
+
+function fromString(string, encoding) {
+  let ops;
+  if (typeof encoding !== 'string' || encoding.length === 0) {
+    if (string.length === 0)
+      return new FastBuffer();
+    ops = encodingOps.utf8;
+    encoding = undefined;
+  } else {
+    ops = getEncodingOps(encoding);
+    if (ops === undefined)
+      throw new ERR_UNKNOWN_ENCODING(encoding);
+    if (string.length === 0)
+      return new FastBuffer();
+  }
+  return fromStringFast(string, ops);
 }
 
 function fromArrayLike(obj) {
@@ -553,6 +564,126 @@ function base64ByteLength(str, bytes) {
   return (bytes * 3) >>> 2;
 }
 
+const encodingOps = {
+  utf8: {
+    encoding: 'utf8',
+    encodingVal: encodingsMap.utf8,
+    byteLength: byteLengthUtf8,
+    write: (buf, string, offset, len) => buf.utf8Write(string, offset, len),
+    slice: (buf, start, end) => buf.utf8Slice(start, end),
+    indexOf: (buf, val, byteOffset, dir) =>
+      indexOfString(buf, val, byteOffset, encodingsMap.utf8, dir)
+  },
+  ucs2: {
+    encoding: 'ucs2',
+    encodingVal: encodingsMap.utf16le,
+    byteLength: (string) => string.length * 2,
+    write: (buf, string, offset, len) => buf.ucs2Write(string, offset, len),
+    slice: (buf, start, end) => buf.ucs2Slice(start, end),
+    indexOf: (buf, val, byteOffset, dir) =>
+      indexOfString(buf, val, byteOffset, encodingsMap.utf16le, dir)
+  },
+  utf16le: {
+    encoding: 'utf16le',
+    encodingVal: encodingsMap.utf16le,
+    byteLength: (string) => string.length * 2,
+    write: (buf, string, offset, len) => buf.ucs2Write(string, offset, len),
+    slice: (buf, start, end) => buf.ucs2Slice(start, end),
+    indexOf: (buf, val, byteOffset, dir) =>
+      indexOfString(buf, val, byteOffset, encodingsMap.utf16le, dir)
+  },
+  latin1: {
+    encoding: 'latin1',
+    encodingVal: encodingsMap.latin1,
+    byteLength: (string) => string.length,
+    write: (buf, string, offset, len) => buf.latin1Write(string, offset, len),
+    slice: (buf, start, end) => buf.latin1Slice(start, end),
+    indexOf: (buf, val, byteOffset, dir) =>
+      indexOfString(buf, val, byteOffset, encodingsMap.latin1, dir)
+  },
+  ascii: {
+    encoding: 'ascii',
+    encodingVal: encodingsMap.ascii,
+    byteLength: (string) => string.length,
+    write: (buf, string, offset, len) => buf.asciiWrite(string, offset, len),
+    slice: (buf, start, end) => buf.asciiSlice(start, end),
+    indexOf: (buf, val, byteOffset, dir) =>
+      indexOfBuffer(buf,
+                    fromStringFast(val, encodingOps.ascii),
+                    byteOffset,
+                    encodingsMap.ascii,
+                    dir)
+  },
+  base64: {
+    encoding: 'base64',
+    encodingVal: encodingsMap.base64,
+    byteLength: (string) => base64ByteLength(string, string.length),
+    write: (buf, string, offset, len) => buf.base64Write(string, offset, len),
+    slice: (buf, start, end) => buf.base64Slice(start, end),
+    indexOf: (buf, val, byteOffset, dir) =>
+      indexOfBuffer(buf,
+                    fromStringFast(val, encodingOps.base64),
+                    byteOffset,
+                    encodingsMap.base64,
+                    dir)
+  },
+  hex: {
+    encoding: 'hex',
+    encodingVal: encodingsMap.hex,
+    byteLength: (string) => string.length >>> 1,
+    write: (buf, string, offset, len) => buf.hexWrite(string, offset, len),
+    slice: (buf, start, end) => buf.hexSlice(start, end),
+    indexOf: (buf, val, byteOffset, dir) =>
+      indexOfBuffer(buf,
+                    fromStringFast(val, encodingOps.hex),
+                    byteOffset,
+                    encodingsMap.hex,
+                    dir)
+  }
+};
+function getEncodingOps(encoding) {
+  encoding += '';
+  switch (encoding.length) {
+    case 4:
+      if (encoding === 'utf8') return encodingOps.utf8;
+      if (encoding === 'ucs2') return encodingOps.ucs2;
+      encoding = encoding.toLowerCase();
+      if (encoding === 'utf8') return encodingOps.utf8;
+      if (encoding === 'ucs2') return encodingOps.ucs2;
+      break;
+    case 5:
+      if (encoding === 'utf-8') return encodingOps.utf8;
+      if (encoding === 'ascii') return encodingOps.ascii;
+      if (encoding === 'ucs-2') return encodingOps.ucs2;
+      encoding = encoding.toLowerCase();
+      if (encoding === 'utf-8') return encodingOps.utf8;
+      if (encoding === 'ascii') return encodingOps.ascii;
+      if (encoding === 'ucs-2') return encodingOps.ucs2;
+      break;
+    case 7:
+      if (encoding === 'utf16le' || encoding.toLowerCase() === 'utf16le')
+        return encodingOps.utf16le;
+      break;
+    case 8:
+      if (encoding === 'utf-16le' || encoding.toLowerCase() === 'utf-16le')
+        return encodingOps.utf16le;
+      break;
+    case 6:
+      if (encoding === 'latin1' || encoding === 'binary')
+        return encodingOps.latin1;
+      if (encoding === 'base64') return encodingOps.base64;
+      encoding = encoding.toLowerCase();
+      if (encoding === 'latin1' || encoding === 'binary')
+        return encodingOps.latin1;
+      if (encoding === 'base64') return encodingOps.base64;
+      break;
+    case 3:
+      if (encoding === 'hex' || encoding.toLowerCase() === 'hex')
+        return encodingOps.hex;
+      break;
+  }
+}
+
 function byteLength(string, encoding) {
   if (typeof string !== 'string') {
     if (isArrayBufferView(string) || isAnyArrayBuffer(string)) {
@@ -572,45 +703,10 @@ function byteLength(string, encoding) {
   if (!encoding)
     return (mustMatch ? -1 : byteLengthUtf8(string));
 
-  encoding += '';
-  switch (encoding.length) {
-    case 4:
-      if (encoding === 'utf8') return byteLengthUtf8(string);
-      if (encoding === 'ucs2') return len * 2;
-      encoding = encoding.toLowerCase();
-      if (encoding === 'utf8') return byteLengthUtf8(string);
-      if (encoding === 'ucs2') return len * 2;
-      break;
-    case 5:
-      if (encoding === 'utf-8') return byteLengthUtf8(string);
-      if (encoding === 'ascii') return len;
-      if (encoding === 'ucs-2') return len * 2;
-      encoding = encoding.toLowerCase();
-      if (encoding === 'utf-8') return byteLengthUtf8(string);
-      if (encoding === 'ascii') return len;
-      if (encoding === 'ucs-2') return len * 2;
-      break;
-    case 7:
-      if (encoding === 'utf16le' || encoding.toLowerCase() === 'utf16le')
-        return len * 2;
-      break;
-    case 8:
-      if (encoding === 'utf-16le' || encoding.toLowerCase() === 'utf-16le')
-        return len * 2;
-      break;
-    case 6:
-      if (encoding === 'latin1' || encoding === 'binary') return len;
-      if (encoding === 'base64') return base64ByteLength(string, len);
-      encoding = encoding.toLowerCase();
-      if (encoding === 'latin1' || encoding === 'binary') return len;
-      if (encoding === 'base64') return base64ByteLength(string, len);
-      break;
-    case 3:
-      if (encoding === 'hex' || encoding.toLowerCase() === 'hex')
-        return len >>> 1;
-      break;
-  }
-  return (mustMatch ? -1 : byteLengthUtf8(string));
+  const ops = getEncodingOps(encoding);
+  if (ops === undefined)
+    return (mustMatch ? -1 : byteLengthUtf8(string));
+  return ops.byteLength(string);
 }
 
 Buffer.byteLength = byteLength;
@@ -632,51 +728,6 @@ Object.defineProperty(Buffer.prototype, 'offset', {
     return this.byteOffset;
   }
 });
-
-function stringSlice(buf, encoding, start, end) {
-  if (encoding === undefined) return buf.utf8Slice(start, end);
-  encoding += '';
-  switch (encoding.length) {
-    case 4:
-      if (encoding === 'utf8') return buf.utf8Slice(start, end);
-      if (encoding === 'ucs2') return buf.ucs2Slice(start, end);
-      encoding = encoding.toLowerCase();
-      if (encoding === 'utf8') return buf.utf8Slice(start, end);
-      if (encoding === 'ucs2') return buf.ucs2Slice(start, end);
-      break;
-    case 5:
-      if (encoding === 'utf-8') return buf.utf8Slice(start, end);
-      if (encoding === 'ascii') return buf.asciiSlice(start, end);
-      if (encoding === 'ucs-2') return buf.ucs2Slice(start, end);
-      encoding = encoding.toLowerCase();
-      if (encoding === 'utf-8') return buf.utf8Slice(start, end);
-      if (encoding === 'ascii') return buf.asciiSlice(start, end);
-      if (encoding === 'ucs-2') return buf.ucs2Slice(start, end);
-      break;
-    case 6:
-      if (encoding === 'latin1' || encoding === 'binary')
-        return buf.latin1Slice(start, end);
-      if (encoding === 'base64') return buf.base64Slice(start, end);
-      encoding = encoding.toLowerCase();
-      if (encoding === 'latin1' || encoding === 'binary')
-        return buf.latin1Slice(start, end);
-      if (encoding === 'base64') return buf.base64Slice(start, end);
-      break;
-    case 3:
-      if (encoding === 'hex' || encoding.toLowerCase() === 'hex')
-        return buf.hexSlice(start, end);
-      break;
-    case 7:
-      if (encoding === 'utf16le' || encoding.toLowerCase() === 'utf16le')
-        return buf.ucs2Slice(start, end);
-      break;
-    case 8:
-      if (encoding === 'utf-16le' || encoding.toLowerCase() === 'utf-16le')
-        return buf.ucs2Slice(start, end);
-      break;
-  }
-  throw new ERR_UNKNOWN_ENCODING(encoding);
-}
 
 Buffer.prototype.copy =
   function copy(target, targetStart, sourceStart, sourceEnd) {
@@ -708,7 +759,15 @@ Buffer.prototype.toString = function toString(encoding, start, end) {
 
   if (end <= start)
     return '';
-  return stringSlice(this, encoding, start, end);
+
+  if (encoding === undefined)
+    return this.utf8Slice(start, end);
+
+  const ops = getEncodingOps(encoding);
+  if (ops === undefined)
+    throw new ERR_UNKNOWN_ENCODING(encoding);
+
+  return ops.slice(this, start, end);
 };
 
 Buffer.prototype.equals = function equals(otherBuffer) {
@@ -826,51 +885,30 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   }
   dir = !!dir;  // Cast to bool.
 
-  if (typeof val === 'string') {
-    if (encoding === undefined) {
-      return indexOfString(buffer, val, byteOffset, encoding, dir);
-    }
-    return slowIndexOf(buffer, val, byteOffset, encoding, dir);
-  } else if (isUint8Array(val)) {
-    return indexOfBuffer(buffer, val, byteOffset, encoding, dir);
-  } else if (typeof val === 'number') {
+  if (typeof val === 'number')
     return indexOfNumber(buffer, val >>> 0, byteOffset, dir);
+
+  let ops;
+  if (encoding === undefined)
+    ops = encodingOps.utf8;
+  else
+    ops = getEncodingOps(encoding);
+
+  if (typeof val === 'string') {
+    if (ops === undefined)
+      throw new ERR_UNKNOWN_ENCODING(encoding);
+    return ops.indexOf(buffer, val, byteOffset, dir);
+  }
+
+  if (isUint8Array(val)) {
+    const encodingVal =
+      (ops === undefined ? encodingsMap.utf8 : ops.encodingVal);
+    return indexOfBuffer(buffer, val, byteOffset, encodingVal, dir);
   }
 
   throw new ERR_INVALID_ARG_TYPE(
     'value', ['string', 'Buffer', 'Uint8Array'], val
   );
-}
-
-function slowIndexOf(buffer, val, byteOffset, encoding, dir) {
-  let loweredCase = false;
-  for (;;) {
-    switch (encoding) {
-      case 'utf8':
-      case 'utf-8':
-      case 'ucs2':
-      case 'ucs-2':
-      case 'utf16le':
-      case 'utf-16le':
-      case 'latin1':
-      case 'binary':
-        return indexOfString(buffer, val, byteOffset, encoding, dir);
-
-      case 'base64':
-      case 'ascii':
-      case 'hex':
-        return indexOfBuffer(
-          buffer, Buffer.from(val, encoding), byteOffset, encoding, dir);
-
-      default:
-        if (loweredCase) {
-          throw new ERR_UNKNOWN_ENCODING(encoding);
-        }
-
-        encoding = ('' + encoding).toLowerCase();
-        loweredCase = true;
-    }
-  }
 }
 
 Buffer.prototype.indexOf = function indexOf(val, byteOffset, encoding) {
@@ -985,49 +1023,10 @@ Buffer.prototype.write = function write(string, offset, length, encoding) {
   if (!encoding)
     return this.utf8Write(string, offset, length);
 
-  encoding += '';
-  switch (encoding.length) {
-    case 4:
-      if (encoding === 'utf8') return this.utf8Write(string, offset, length);
-      if (encoding === 'ucs2') return this.ucs2Write(string, offset, length);
-      encoding = encoding.toLowerCase();
-      if (encoding === 'utf8') return this.utf8Write(string, offset, length);
-      if (encoding === 'ucs2') return this.ucs2Write(string, offset, length);
-      break;
-    case 5:
-      if (encoding === 'utf-8') return this.utf8Write(string, offset, length);
-      if (encoding === 'ascii') return this.asciiWrite(string, offset, length);
-      if (encoding === 'ucs-2') return this.ucs2Write(string, offset, length);
-      encoding = encoding.toLowerCase();
-      if (encoding === 'utf-8') return this.utf8Write(string, offset, length);
-      if (encoding === 'ascii') return this.asciiWrite(string, offset, length);
-      if (encoding === 'ucs-2') return this.ucs2Write(string, offset, length);
-      break;
-    case 7:
-      if (encoding === 'utf16le' || encoding.toLowerCase() === 'utf16le')
-        return this.ucs2Write(string, offset, length);
-      break;
-    case 8:
-      if (encoding === 'utf-16le' || encoding.toLowerCase() === 'utf-16le')
-        return this.ucs2Write(string, offset, length);
-      break;
-    case 6:
-      if (encoding === 'latin1' || encoding === 'binary')
-        return this.latin1Write(string, offset, length);
-      if (encoding === 'base64')
-        return this.base64Write(string, offset, length);
-      encoding = encoding.toLowerCase();
-      if (encoding === 'latin1' || encoding === 'binary')
-        return this.latin1Write(string, offset, length);
-      if (encoding === 'base64')
-        return this.base64Write(string, offset, length);
-      break;
-    case 3:
-      if (encoding === 'hex' || encoding.toLowerCase() === 'hex')
-        return this.hexWrite(string, offset, length);
-      break;
-  }
-  throw new ERR_UNKNOWN_ENCODING(encoding);
+  const ops = getEncodingOps(encoding);
+  if (ops === undefined)
+    throw new ERR_UNKNOWN_ENCODING(encoding);
+  return ops.write(this, string, offset, length);
 };
 
 Buffer.prototype.toJSON = function toJSON() {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -63,6 +63,7 @@ using v8::Context;
 using v8::EscapableHandleScope;
 using v8::FunctionCallbackInfo;
 using v8::Global;
+using v8::Int32;
 using v8::Integer;
 using v8::Isolate;
 using v8::Just;
@@ -446,11 +447,9 @@ namespace {
 
 void CreateFromString(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsString());
-  CHECK(args[1]->IsString());
+  CHECK(args[1]->IsInt32());
 
-  enum encoding enc = ParseEncoding(args.GetIsolate(),
-                                    args[1].As<String>(),
-                                    UTF8);
+  enum encoding enc = static_cast<enum encoding>(args[1].As<Int32>()->Value());
   Local<Object> buf;
   if (New(args.GetIsolate(), args[0].As<String>(), enc).ToLocal(&buf))
     args.GetReturnValue().Set(buf);
@@ -786,9 +785,10 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
 
   CHECK(args[1]->IsString());
   CHECK(args[2]->IsNumber());
+  CHECK(args[3]->IsInt32());
   CHECK(args[4]->IsBoolean());
 
-  enum encoding enc = ParseEncoding(isolate, args[3], UTF8);
+  enum encoding enc = static_cast<enum encoding>(args[3].As<Int32>()->Value());
 
   THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
   ArrayBufferViewContents<char> buffer(args[0]);
@@ -900,11 +900,10 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
 void IndexOfBuffer(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsObject());
   CHECK(args[2]->IsNumber());
+  CHECK(args[3]->IsInt32());
   CHECK(args[4]->IsBoolean());
 
-  enum encoding enc = ParseEncoding(args.GetIsolate(),
-                                    args[3],
-                                    UTF8);
+  enum encoding enc = static_cast<enum encoding>(args[3].As<Int32>()->Value());
 
   THROW_AND_RETURN_UNLESS_BUFFER(Environment::GetCurrent(args), args[0]);
   THROW_AND_RETURN_UNLESS_BUFFER(Environment::GetCurrent(args), args[1]);

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -22,6 +22,7 @@ const expectedModules = new Set([
   'Internal Binding native_module',
   'Internal Binding options',
   'Internal Binding process_methods',
+  'Internal Binding string_decoder',
   'Internal Binding task_queue',
   'Internal Binding timers',
   'Internal Binding trace_events',

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -282,7 +282,7 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "value" argument must be one of type string, ' +
+      message: 'The "value" argument must be one of type number, string, ' +
                `Buffer, or Uint8Array. Received type ${typeof val}`
     }
   );

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -357,7 +357,7 @@ assert.strictEqual(Buffer.from('aaaaa').indexOf('b', 'ucs2'), -1);
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "value" argument must be one of type string, ' +
+      message: 'The "value" argument must be one of type number, string, ' +
                `Buffer, or Uint8Array. Received type ${typeof val}`
     }
   );


### PR DESCRIPTION
This consolidates encoding parsing for `buffer` at both the JS and C++ levels (only `fill()` still parses the encoding twice). Doing so not only cleans things up but also improves performance in some cases.

Various relevant benchmark results:

```
                                                                                                   confidence improvement accuracy (*)   (**)  (***)
 buffers/buffer-bytelength.js n=10000000 len=16 encoding='base64'                                          *      4.03 %       ±3.40% ±4.53% ±5.90%
 buffers/buffer-bytelength.js n=10000000 len=16 encoding='buffer'                                        ***     17.47 %       ±1.09% ±1.46% ±1.90%
 buffers/buffer-bytelength.js n=10000000 len=16 encoding='utf8'                                          ***     14.05 %       ±2.17% ±2.92% ±3.87%

 buffers/buffer-tostring.js n=10000000 len=64 args=0 encoding='ascii'                                    ***      1.05 %       ±0.58% ±0.78% ±1.03%
 buffers/buffer-tostring.js n=10000000 len=64 args=0 encoding='hex'                                      ***      2.09 %       ±0.76% ±1.02% ±1.34%
 buffers/buffer-tostring.js n=10000000 len=64 args=0 encoding='latin1'                                   ***      1.30 %       ±0.49% ±0.65% ±0.85%
 buffers/buffer-tostring.js n=10000000 len=64 args=0 encoding='utf8'                                     ***      2.31 %       ±0.98% ±1.31% ±1.72%
 buffers/buffer-tostring.js n=10000000 len=64 args=1 encoding='ascii'                                    ***      8.75 %       ±1.22% ±1.64% ±2.17%
 buffers/buffer-tostring.js n=10000000 len=64 args=1 encoding='hex'                                      ***      5.16 %       ±0.71% ±0.94% ±1.23%
 buffers/buffer-tostring.js n=10000000 len=64 args=1 encoding='latin1'                                   ***      7.52 %       ±1.41% ±1.88% ±2.46%
 buffers/buffer-tostring.js n=10000000 len=64 args=1 encoding='UCS-2'                                    ***      7.93 %       ±1.40% ±1.86% ±2.43%
 buffers/buffer-tostring.js n=10000000 len=64 args=1 encoding='utf8'                                     ***      9.29 %       ±1.19% ±1.60% ±2.11%
 buffers/buffer-tostring.js n=10000000 len=64 args=3 encoding='ascii'                                    ***      9.34 %       ±0.89% ±1.19% ±1.57%
 buffers/buffer-tostring.js n=10000000 len=64 args=3 encoding='hex'                                      ***      4.83 %       ±0.60% ±0.80% ±1.04%
 buffers/buffer-tostring.js n=10000000 len=64 args=3 encoding='latin1'                                   ***     10.68 %       ±1.50% ±2.01% ±2.66%
 buffers/buffer-tostring.js n=10000000 len=64 args=3 encoding='UCS-2'                                    ***      4.50 %       ±1.19% ±1.58% ±2.07%
 buffers/buffer-tostring.js n=10000000 len=64 args=3 encoding='utf8'                                     ***      9.86 %       ±0.84% ±1.12% ±1.48%

 buffers/buffer-write-string.js n=10000000 len=2048 args='' encoding=''                                   **      1.87 %       ±1.20% ±1.60% ±2.09%
 buffers/buffer-write-string.js n=10000000 len=2048 args='' encoding='ascii'                             ***      8.84 %       ±2.47% ±3.30% ±4.31%
 buffers/buffer-write-string.js n=10000000 len=2048 args='' encoding='hex'                               ***      1.24 %       ±0.56% ±0.75% ±0.98%
 buffers/buffer-write-string.js n=10000000 len=2048 args='' encoding='latin1'                            ***      8.56 %       ±1.02% ±1.36% ±1.77%
 buffers/buffer-write-string.js n=10000000 len=2048 args='' encoding='utf16le'                           ***      5.39 %       ±0.68% ±0.91% ±1.18%
 buffers/buffer-write-string.js n=10000000 len=2048 args='' encoding='utf8'                              ***      2.59 %       ±1.09% ±1.45% ±1.89%

 buffers/buffer-from.js n=4000000 len=100 source='string'                                                ***      3.36 %       ±1.69% ±2.24% ±2.92%

 buffers/buffer-indexof.js n=100000 type='buffer' encoding='ucs2' search='@'                             ***     13.54 %       ±4.29% ±5.71% ±7.43%
 buffers/buffer-indexof.js n=100000 type='buffer' encoding='ucs2' search='</i> to the Caterpillar'         *      0.57 %       ±0.48% ±0.63% ±0.82%
 buffers/buffer-indexof.js n=100000 type='buffer' encoding='ucs2' search='aaaaaaaaaaaaaaaaa'               *      0.44 %       ±0.43% ±0.58% ±0.75%
 buffers/buffer-indexof.js n=100000 type='buffer' encoding='ucs2' search='Alice'                         ***     18.63 %       ±4.71% ±6.27% ±8.16%
 buffers/buffer-indexof.js n=100000 type='buffer' encoding='ucs2' search='Gryphon'                       ***      3.35 %       ±1.91% ±2.55% ±3.31%
 buffers/buffer-indexof.js n=100000 type='buffer' encoding='ucs2' search='neighbouring pool'               *      0.48 %       ±0.46% ±0.61% ±0.80%
 buffers/buffer-indexof.js n=100000 type='buffer' encoding='ucs2' search='SQ'                            ***      3.65 %       ±1.69% ±2.25% ±2.92%
 buffers/buffer-indexof.js n=100000 type='buffer' encoding='utf8' search='@'                             ***     16.95 %       ±3.99% ±5.31% ±6.92%
 buffers/buffer-indexof.js n=100000 type='buffer' encoding='utf8' search='Alice'                         ***     18.55 %       ±5.48% ±7.30% ±9.52%
 buffers/buffer-indexof.js n=100000 type='buffer' encoding='utf8' search='Gryphon'                        **      3.03 %       ±1.78% ±2.36% ±3.08%
 buffers/buffer-indexof.js n=100000 type='buffer' encoding='utf8' search='Ou est ma chatte?'               *      0.78 %       ±0.66% ±0.88% ±1.14%
 buffers/buffer-indexof.js n=100000 type='string' encoding='ucs2' search='@'                             ***     14.38 %       ±5.38% ±7.16% ±9.32%
 buffers/buffer-indexof.js n=100000 type='string' encoding='ucs2' search='Alice'                         ***     27.09 %       ±5.71% ±7.60% ±9.91%
 buffers/buffer-indexof.js n=100000 type='string' encoding='ucs2' search='SQ'                            ***      3.63 %       ±2.07% ±2.75% ±3.58%
 buffers/buffer-indexof.js n=100000 type='string' encoding='utf8' search='@'                             ***     12.08 %       ±4.53% ±6.03% ±7.85%
 buffers/buffer-indexof.js n=100000 type='string' encoding='utf8' search='Alice'                         ***     15.36 %       ±5.71% ±7.60% ±9.90%
 buffers/buffer-indexof.js n=100000 type='string' encoding='utf8' search='Gryphon'                         *      1.88 %       ±1.87% ±2.48% ±3.23%
 buffers/buffer-indexof.js n=100000 type='string' encoding='utf8' search='Ou est ma chatte?'               *      0.88 %       ±0.78% ±1.04% ±1.36%
 buffers/buffer-indexof.js n=100000 type='string' encoding='utf8' search='SQ'                              *      3.60 %       ±3.04% ±4.04% ±5.27%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
