### PR TITLE
build: move tooltest to before jstest target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,13 +313,13 @@ coverage-run-js:
 .PHONY: test
 # This does not run tests of third-party libraries inside deps.
 test: all ## Runs default tests, linters, and builds docs.
+	$(MAKE) -s tooltest
 	$(MAKE) -s test-doc
 	$(MAKE) -s build-addons
 	$(MAKE) -s build-js-native-api-tests
 	$(MAKE) -s build-node-api-tests
 	$(MAKE) -s cctest
 	$(MAKE) -s jstest
-	$(MAKE) -s tooltest
 
 .PHONY: test-only
 test-only: all  ## For a quick test, does not run linter or build docs.


### PR DESCRIPTION
This commit moves the tooltest target to come before the jstest target
to make the console output consistent with it was before I introduced
the tooltest target.

Currently the output looks like this which is might give the impression
that only one test was run:
```console
/Applications/Xcode.app/Contents/Developer/usr/bin/make -s tooltest
.
----------------------------------------------------------------------
Ran 1 test in 0.000s
```
Compared to the usual:
```console
[03:58|% 100|+ 2739|-   0]: Done
```

@nodejs/build-files 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
