### PR TITLE
fs: typo error fixture

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -225,7 +225,7 @@ Object.defineProperty(exists, internalUtil.promisify.custom, {
 
 // fs.existsSync never throws, it only returns true or false.
 // Since fs.existsSync never throws, users have established
-// the expectation that passing invalid arguments to it, even like
+// the expectation to pass invalid arguments to it, even like
 // fs.existsSync(), would only get a false in return, so we cannot signal
 // validation errors to users properly out of compatibility concerns.
 // TODO(joyeecheung): deprecate the never-throw-on-invalid-arguments behavior


### PR DESCRIPTION
'the expectation that passing...' => 'the expectation to pass...'

---
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)