### PR TITLE
crypto: handle i2d_SSL_SESSION() error return

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2317,11 +2317,12 @@ void SSLWrap<Base>::GetSession(const FunctionCallbackInfo<Value>& args) {
     return;
 
   int slen = i2d_SSL_SESSION(sess, nullptr);
-  CHECK_GT(slen, 0);
+  if (slen <= 0)
+    return;  // Invalid or malformed session.
 
   AllocatedBuffer sbuf = env->AllocateManaged(slen);
   unsigned char* p = reinterpret_cast<unsigned char*>(sbuf.data());
-  i2d_SSL_SESSION(sess, &p);
+  CHECK_LT(0, i2d_SSL_SESSION(sess, &p));
   args.GetReturnValue().Set(sbuf.ToBuffer().ToLocalChecked());
 }
 


### PR DESCRIPTION
i2d_SSL_SESSION() can return a value <= 0 when the session is malformed
or otherwise invalid. Handle that case.

This change comes without a regression test because I couldn't figure
out a good way to generate an existing but invalid session in a timely
fashion.

Fixes: https://github.com/nodejs/node/issues/29202