### PR TITLE
http2: compat ERR_STREAM_ALREADY_FINISHED

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -31,7 +31,8 @@ const {
     ERR_HTTP2_STATUS_INVALID,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_CALLBACK,
-    ERR_INVALID_HTTP_TOKEN
+    ERR_INVALID_HTTP_TOKEN,
+    ERR_STREAM_ALREADY_FINISHED
   },
   hideStackFrames
 } = require('internal/errors');
@@ -652,17 +653,28 @@ class Http2ServerResponse extends Stream {
     const stream = this[kStream];
     const state = this[kState];
 
-    if ((state.closed || state.ending) &&
-        state.headRequest === stream.headRequest) {
-      return this;
-    }
-
     if (typeof chunk === 'function') {
       cb = chunk;
       chunk = null;
     } else if (typeof encoding === 'function') {
       cb = encoding;
       encoding = 'utf8';
+    }
+
+    if (this.writableEnded) {
+      if (typeof cb === 'function') {
+        if (!this.finished) {
+          this.on('finish', cb);
+        } else {
+          cb(new ERR_STREAM_ALREADY_FINISHED('end'));
+        }
+      }
+      return this;
+    }
+
+    if ((state.closed || state.ending) &&
+        state.headRequest === stream.headRequest) {
+      return this;
     }
 
     if (chunk !== null && chunk !== undefined)


### PR DESCRIPTION
Make http/2 compat end() match Writable and http/1.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
