### PR TITLE
Accept Python 3 on Windows

### DIFF
--- a/tools/msvs/find_python.cmd
+++ b/tools/msvs/find_python.cmd
@@ -1,6 +1,8 @@
 @IF NOT DEFINED DEBUG_HELPER @ECHO OFF
+
 echo Looking for Python 2.x
-SETLOCAL
+setlocal enabledelayedexpansion
+
 :: If python.exe is in %Path%, just validate
 FOR /F "delims=" %%a IN ('where python.exe 2^> NUL') DO (
   SET need_path=0
@@ -11,32 +13,36 @@ FOR /F "delims=" %%a IN ('where python.exe 2^> NUL') DO (
 :: Query the 3 locations mentioned in PEP 514 for a python2 InstallPath
 FOR %%K IN ( "HKCU\Software", "HKLM\SOFTWARE", "HKLM\Software\Wow6432Node") DO (
   SET need_path=1
-  CALL :find-main-branch %%K
+  CALL :find-versions-v2 %%K
   :: If validate returns 0 just jump to the end
   IF NOT ERRORLEVEL 1 GOTO :validate
 )
+
 goto :no-python
 
-:: Helper subroutine to handle quotes in %1
-:find-main-branch
-SET main_key="%~1\Python\PythonCore"
-REG QUERY %main_key% /s 2> NUL | findstr "2." | findstr InstallPath > NUL 2> NUL
-IF NOT ERRORLEVEL 1 CALL :find-key %main_key%
-EXIT /B
 
-:: Query registry sub-tree for InstallPath
-:find-key
-FOR /F "delims=" %%a IN ('REG QUERY %1 /s 2^> NUL ^| findstr "2." ^| findstr InstallPath') DO IF NOT ERRORLEVEL 1 CALL :find-path %%a
-EXIT /B
-
-:: Parse the value of %1 as the path for python.exe
-:find-path
-FOR /F "tokens=3*" %%a IN ('REG QUERY %1 /ve') DO (
-  SET pt=%%a
-  IF NOT ERRORLEVEL 1 SET p=%pt%
-  EXIT /B 0
+:: Find Python 2 installations in a registry location
+:find-versions-v2
+for /f "delims=" %%a in ('reg query "%~1\Python\PythonCore" /f * /k 2^> nul ^| findstr /r ^^HK ^| findstr "\\2\."') do (
+  call :read-installpath %%a
+  if not errorlevel 1 exit /b 0
 )
-EXIT /B 1
+exit /b 1
+
+:: Read the InstallPath of a given Environment Key to %p%
+:: https://www.python.org/dev/peps/pep-0514/#installpath
+:read-installpath
+:: %%a will receive token 3
+:: %%b will receive *, corresponding to token 4 and all after
+for /f "skip=2 tokens=3*" %%a in ('reg query "%1\InstallPath" /ve /t REG_SZ 2^> nul') do (
+  set "head=%%a"
+  set "tail=%%b"
+  set "p=!head!"
+  if not "!tail!"=="" set "p=!head! !tail!"
+  exit /b 0
+)
+exit /b 1
+
 
 :: Check if %p% holds a path to a real python2 executable
 :validate

--- a/tools/msvs/find_python.cmd
+++ b/tools/msvs/find_python.cmd
@@ -1,29 +1,57 @@
 @IF NOT DEFINED DEBUG_HELPER @ECHO OFF
 
-echo Looking for Python 2.x
+echo Looking for Python
 setlocal enabledelayedexpansion
 
-:: If python.exe is in %Path%, just validate
+:: To remove the preference for Python 2, but still support it, just remove
+:: the 5 blocks marked with "Python 2:" and the support warnings
+
+:: Python 2: If python.exe is in %Path%, use if it's Python 2
 FOR /F "delims=" %%a IN ('where python.exe 2^> NUL') DO (
   SET need_path=0
   SET p=%%~dpa
-  IF NOT ERRORLEVEL 1 GOTO :validate
+  CALL :validate-v2
+  IF NOT ERRORLEVEL 1 GOTO :found-python2
+  GOTO :done-path-v2
 )
+:done-path-v2
 
-:: Query the 3 locations mentioned in PEP 514 for a python2 InstallPath
+:: Python 2: Query the 3 locations mentioned in PEP 514 for a python2 InstallPath
 FOR %%K IN ( "HKCU\Software", "HKLM\SOFTWARE", "HKLM\Software\Wow6432Node") DO (
   SET need_path=1
   CALL :find-versions-v2 %%K
-  :: If validate returns 0 just jump to the end
-  IF NOT ERRORLEVEL 1 GOTO :validate
+  IF NOT ERRORLEVEL 1 CALL :validate-v2
+  IF NOT ERRORLEVEL 1 GOTO :found-python2
+)
+
+:: Use python.exe if in %PATH%
+set need_path=0
+for /f "delims=" %%a in ('where python.exe 2^> nul') do (
+  set p=%%~dpa
+  goto :found-python
+)
+
+:: Query the 3 locations mentioned in PEP 514 for a Python InstallPath
+set need_path=1
+for %%k in ( "HKCU\Software", "HKLM\SOFTWARE", "HKLM\Software\Wow6432Node") do (
+  call :find-versions %%k
+  if not errorlevel 1 goto :found-python
 )
 
 goto :no-python
 
 
-:: Find Python 2 installations in a registry location
+:: Python 2: Find Python 2 installations in a registry location
 :find-versions-v2
 for /f "delims=" %%a in ('reg query "%~1\Python\PythonCore" /f * /k 2^> nul ^| findstr /r ^^HK ^| findstr "\\2\."') do (
+  call :read-installpath %%a
+  if not errorlevel 1 exit /b 0
+)
+exit /b 1
+
+:: Find Python installations in a registry location
+:find-versions
+for /f "delims=" %%a in ('reg query "%~1\Python\PythonCore" /f * /k 2^> nul ^| findstr /r ^^HK') do (
   call :read-installpath %%a
   if not errorlevel 1 exit /b 0
 )
@@ -44,22 +72,37 @@ for /f "skip=2 tokens=3*" %%a in ('reg query "%1\InstallPath" /ve /t REG_SZ 2^> 
 exit /b 1
 
 
-:: Check if %p% holds a path to a real python2 executable
-:validate
-IF NOT EXIST "%p%python.exe" goto :no-python
+:: Python 2: Check if %p% holds a path to a real python2 executable
+:validate-v2
+IF NOT EXIST "%p%\python.exe" EXIT /B 1
 :: Check if %p% is python2
-"%p%python.exe" -V 2>&1 | findstr /R "^Python.2.*" > NUL
-IF ERRORLEVEL 1 goto :no-python2
-:: We can wrap it up
-ENDLOCAL & SET pt=%p%& SET need_path_ext=%need_path%
-SET VCBUILD_PYTHON_LOCATION=%pt%python.exe
-IF %need_path_ext%==1 SET Path=%Path%;%pt%
-SET need_path_ext=
+"%p%\python.exe" -V 2>&1 | findstr /R "^Python.2.*" > NUL
 EXIT /B %ERRORLEVEL%
 
-:no-python2
-echo Python found in %p%, but it is not v2.x.
-exit /B 1
+
+:: Python 2:
+:found-python2
+echo Python 2 found in %p%\python.exe
+set pyver=2
+goto :done
+
+:found-python
+echo Python found in %p%\python.exe
+echo WARNING: Python 3 is not yet fully supported, to avoid issues Python 2 should be installed.
+set pyver=3
+goto :done
+
+:done
+endlocal ^
+  & set "pt=%p%" ^
+  & set "need_path_ext=%need_path%" ^
+  & set "VCBUILD_PYTHON_VERSION=%pyver%"
+set "VCBUILD_PYTHON_LOCATION=%pt%\python.exe"
+if %need_path_ext%==1 set "PATH=%pt%;%PATH%"
+set "pt="
+set "need_path_ext="
+exit /b 0
+
 :no-python
 echo Could not find Python.
-exit /B 1
+exit /b 1

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -689,6 +689,9 @@ goto exit
 
 :create-msvs-files-failed
 echo Failed to create vc project files.
+if %VCBUILD_PYTHON_VERSION%==3 (
+  echo Python 3 is not yet fully supported, to avoid issues Python 2 should be installed.
+)
 del .used_configure_flags
 goto exit
 


### PR DESCRIPTION
This loosely depends on https://github.com/nodejs/node/pull/25878. Doesn't make much sense without it, but doesn't break either.

This allows Python 3 to be used, but only if it is the only Python version installed. https://github.com/nodejs/node/pull/25878 does this for `configure`, this PR does for `vcbuild`.

If Python 3 is being used and `configure` fails, a warning is displayed.

cc @nodejs/platform-windows @nodejs/python @cclauss 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
