### PR TITLE
http: fix event listener leak

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -506,6 +506,7 @@ function socketOnData(d) {
              !statusIsInformational(parser.incoming.statusCode)) {
     socket.removeListener('data', socketOnData);
     socket.removeListener('end', socketOnEnd);
+    socket.removeListener('drain', ondrain);
     freeParser(parser, req, socket);
   }
 }
@@ -613,6 +614,7 @@ function responseKeepAlive(res, req) {
     }
     socket.removeListener('close', socketCloseListener);
     socket.removeListener('error', socketErrorListener);
+    socket.removeListener('drain', ondrain);
     socket.once('error', freeSocketErrorListener);
     // There are cases where _handle === null. Avoid those. Passing null to
     // nextTick() will call getDefaultTriggerAsyncId() to retrieve the id.

--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -52,7 +52,7 @@ function get(path, callback) {
     port: server.address().port,
     agent: agent,
     path: path
-  }, callback).on('socket', checkListeners);
+  }, callback).on('socket', common.mustCall(checkListeners));
 }
 
 function checkDataAndSockets(body) {

--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -52,7 +52,7 @@ function get(path, callback) {
     port: server.address().port,
     agent: agent,
     path: path
-  }, callback);
+  }, callback).on('socket', checkListeners);
 }
 
 function checkDataAndSockets(body) {
@@ -134,3 +134,12 @@ server.listen(0, common.mustCall(() => {
     }));
   }));
 }));
+
+// Check for listener leaks when reusing sockets.
+function checkListeners(socket) {
+  assert.strictEqual(socket.listenerCount('data'), 1);
+  assert.strictEqual(socket.listenerCount('drain'), 1);
+  assert.strictEqual(socket.listenerCount('error'), 1);
+  // Sockets have onReadableStreamEnd.
+  assert.strictEqual(socket.listenerCount('end'), 2);
+}


### PR DESCRIPTION
Alternative to https://github.com/nodejs/node/pull/29244

`'drain'` needs to always to be removed together with `'data'` and `'end'` when detaching the socket.

~~Haven't had time to do a unit test yet.~~

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
