### PR TITLE
console: display timeEnd with suitable time unit

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -544,7 +544,7 @@ function formatTime(ms) {
     unit = 's';
   }
 
-  return value.toFixed(3) * 1 + unit;
+  return value.toFixed(3) + unit;
 }
 
 const keyKey = 'Key';

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -518,10 +518,25 @@ function timeLogImpl(self, name, label, data) {
   }
   const duration = process.hrtime(time);
   const ms = duration[0] * 1000 + duration[1] / 1e6;
+
+  let value = ms;
+  let unit = 'ms';
+
+  if (ms >= 3600000) {
+    value = ms / 3600000;
+    unit = 'h';
+  } else if (ms >= 60000) {
+    value = ms / 60000;
+    unit = 'min';
+  } else if (ms >= 1000) {
+    value = ms / 1000;
+    unit = 's';
+  }
+
   if (data === undefined) {
-    self.log('%s: %sms', label, ms.toFixed(3));
+    self.log('%s: %s%s', label, value.toFixed(3), unit);
   } else {
-    self.log('%s: %sms', label, ms.toFixed(3), ...data);
+    self.log('%s: %s%s', label, value.toFixed(3), unit, ...data);
   }
   return true;
 }

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -520,7 +520,7 @@ function timeLogImpl(self, name, label, data) {
   const ms = duration[0] * 1000 + duration[1] / 1e6;
 
   const formatted = formatTime(ms);
-  
+
   if (data === undefined) {
     self.log('%s: %s', label, formatted);
   } else {

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -32,6 +32,10 @@ const kTraceBegin = 'b'.charCodeAt(0);
 const kTraceEnd = 'e'.charCodeAt(0);
 const kTraceInstant = 'n'.charCodeAt(0);
 
+const kSecond = 1000;
+const kMinute = 60 * kSecond;
+const kHour = 60 * kMinute;
+
 const {
   isArray: ArrayIsArray,
   from: ArrayFrom,
@@ -533,14 +537,14 @@ function formatTime(ms) {
   let value = ms;
   let unit = 'ms';
 
-  if (ms >= 3600000) {
-    value = ms / 3600000;
+  if (ms >= kHour) {
+    value = ms / kHour;
     unit = 'h';
-  } else if (ms >= 60000) {
-    value = ms / 60000;
+  } else if (ms >= kMinute) {
+    value = ms / kMinute;
     unit = 'min';
-  } else if (ms >= 1000) {
-    value = ms / 1000;
+  } else if (ms >= kSecond) {
+    value = ms / kSecond;
     unit = 's';
   }
 

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -519,6 +519,17 @@ function timeLogImpl(self, name, label, data) {
   const duration = process.hrtime(time);
   const ms = duration[0] * 1000 + duration[1] / 1e6;
 
+  const formatted = formatTime(ms);
+  
+  if (data === undefined) {
+    self.log('%s: %s', label, formatted);
+  } else {
+    self.log('%s: %s', label, formatted, ...data);
+  }
+  return true;
+}
+
+function formatTime(ms) {
   let value = ms;
   let unit = 'ms';
 
@@ -533,12 +544,7 @@ function timeLogImpl(self, name, label, data) {
     unit = 's';
   }
 
-  if (data === undefined) {
-    self.log('%s: %s%s', label, value.toFixed(3), unit);
-  } else {
-    self.log('%s: %s%s', label, value.toFixed(3), unit, ...data);
-  }
-  return true;
+  return value.toFixed(3) * 1 + unit;
 }
 
 const keyKey = 'Key';
@@ -562,5 +568,6 @@ Console.prototype.groupCollapsed = Console.prototype.group;
 module.exports = {
   Console,
   kBindStreamsLazy,
-  kBindProperties
+  kBindProperties,
+  formatTime // exported for tests
 };

--- a/test/parallel/test-console-formatTime.js
+++ b/test/parallel/test-console-formatTime.js
@@ -1,0 +1,13 @@
+// Flags: --expose-internals
+const { formatTime } = require('internal/console/constructor');
+const assert = require('assert');
+
+const test1 = formatTime(100);
+const test2 = formatTime(1500);
+const test3 = formatTime(60300);
+const test4 = formatTime(4000000);
+
+assert.strictEqual(test1, '100ms');
+assert.strictEqual(test2, '1.5s');
+assert.strictEqual(test3, '1.005min')
+assert.strictEqual(test4, '1.111h')

--- a/test/parallel/test-console-formatTime.js
+++ b/test/parallel/test-console-formatTime.js
@@ -7,7 +7,7 @@ const test2 = formatTime(1500);
 const test3 = formatTime(60300);
 const test4 = formatTime(4000000);
 
-assert.strictEqual(test1, '100ms');
-assert.strictEqual(test2, '1.5s');
+assert.strictEqual(test1, '100.000ms');
+assert.strictEqual(test2, '1.500s');
 assert.strictEqual(test3, '1.005min')
 assert.strictEqual(test4, '1.111h')

--- a/test/parallel/test-console-formatTime.js
+++ b/test/parallel/test-console-formatTime.js
@@ -1,4 +1,6 @@
+'use strict';
 // Flags: --expose-internals
+require('../common');
 const { formatTime } = require('internal/console/constructor');
 const assert = require('assert');
 
@@ -9,5 +11,5 @@ const test4 = formatTime(4000000);
 
 assert.strictEqual(test1, '100.000ms');
 assert.strictEqual(test2, '1.500s');
-assert.strictEqual(test3, '1.005min')
-assert.strictEqual(test4, '1.111h')
+assert.strictEqual(test3, '1.005min');
+assert.strictEqual(test4, '1.111h');

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -245,6 +245,7 @@ assert.strictEqual(strings.shift(), 'inspect inspect\n');
 assert.ok(strings[0].includes('foo: { bar: { baz:'));
 assert.ok(strings[0].includes('quux'));
 assert.ok(strings.shift().includes('quux: true'));
+
 assert.ok(/^label: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
 assert.ok(/^__proto__: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
 assert.ok(/^constructor: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -245,25 +245,24 @@ assert.strictEqual(strings.shift(), 'inspect inspect\n');
 assert.ok(strings[0].includes('foo: { bar: { baz:'));
 assert.ok(strings[0].includes('quux'));
 assert.ok(strings.shift().includes('quux: true'));
-
-assert.ok(/^label: \d+\.\d{3}ms$/.test(strings.shift().trim()));
-assert.ok(/^__proto__: \d+\.\d{3}ms$/.test(strings.shift().trim()));
-assert.ok(/^constructor: \d+\.\d{3}ms$/.test(strings.shift().trim()));
-assert.ok(/^hasOwnProperty: \d+\.\d{3}ms$/.test(strings.shift().trim()));
+assert.ok(/^label: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^__proto__: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^constructor: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^hasOwnProperty: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
 
 // Verify that console.time() coerces label values to strings as expected
-assert.ok(/^: \d+\.\d{3}ms$/.test(strings.shift().trim()));
-assert.ok(/^\[object Object\]: \d+\.\d{3}ms$/.test(strings.shift().trim()));
-assert.ok(/^\[object Object\]: \d+\.\d{3}ms$/.test(strings.shift().trim()));
-assert.ok(/^null: \d+\.\d{3}ms$/.test(strings.shift().trim()));
-assert.ok(/^default: \d+\.\d{3}ms$/.test(strings.shift().trim()));
-assert.ok(/^default: \d+\.\d{3}ms$/.test(strings.shift().trim()));
-assert.ok(/^NaN: \d+\.\d{3}ms$/.test(strings.shift().trim()));
+assert.ok(/^: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^\[object Object\]: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^\[object Object\]: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^null: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^default: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^default: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^NaN: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
 
-assert.ok(/^log1: \d+\.\d{3}ms$/.test(strings.shift().trim()));
-assert.ok(/^log1: \d+\.\d{3}ms test$/.test(strings.shift().trim()));
-assert.ok(/^log1: \d+\.\d{3}ms {} \[ 1, 2, 3 ]$/.test(strings.shift().trim()));
-assert.ok(/^log1: \d+\.\d{3}ms$/.test(strings.shift().trim()));
+assert.ok(/^log1: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^log1: \d+\.\d{3}(ms|s|min|h) test$/.test(strings.shift().trim()));
+assert.ok(/^log1: \d+\.\d{3}(ms|s|min|h) {} \[ 1, 2, 3 ]$/.test(strings.shift().trim()));
+assert.ok(/^log1: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
 
 // Make sure that we checked all strings
 assert.strictEqual(strings.length, 0);


### PR DESCRIPTION
When timeEnd function is called, display result with a suitable
time unit instead of a big amount of milliseconds.

Refs: https://github.com/nodejs/node/issues/29099

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
