### PR TITLE
doc: add missing extends Http2Session

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -620,6 +620,8 @@ instance's underlying [`net.Socket`].
 added: v8.4.0
 -->
 
+* Extends: {Http2Session}
+
 #### serverhttp2session.altsvc(alt, originOrStream)
 <!-- YAML
 added: v9.4.0
@@ -741,6 +743,8 @@ server.on('stream', (stream) => {
 <!-- YAML
 added: v8.4.0
 -->
+
+* Extends: {Http2Session}
 
 #### Event: 'altsvc'
 <!-- YAML


### PR DESCRIPTION
adds missing extends Http2Session for ClientHttp2Session and ServerHttp2Session

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
