### PR TITLE
doc: update Http2ServerRequest extends Readable

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2628,13 +2628,12 @@ HTTP/2.
 added: v8.4.0
 -->
 
+* Extends: {stream.Readable}
+
 A `Http2ServerRequest` object is created by [`http2.Server`][] or
 [`http2.SecureServer`][] and passed as the first argument to the
 [`'request'`][] event. It may be used to access a request status, headers, and
 data.
-
-It implements the [Readable Stream][] interface, as well as the
-following additional events, methods, and properties.
 
 #### Event: 'aborted'
 <!-- YAML
@@ -3468,7 +3467,6 @@ following additional properties:
 [RFC 7838]: https://tools.ietf.org/html/rfc7838
 [RFC 8336]: https://tools.ietf.org/html/rfc8336
 [RFC 8441]: https://tools.ietf.org/html/rfc8441
-[Readable Stream]: stream.html#stream_class_stream_readable
 [`'checkContinue'`]: #http2_event_checkcontinue
 [`'connect'`]: #http2_event_connect
 [`'request'`]: #http2_event_request


### PR DESCRIPTION
This PR also removes the redundant statement explained by "extends stream.Readable"

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
