### PR TITLE
doc: update Http2ServerResponse extends Stream 

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2938,11 +2938,10 @@ Url {
 added: v8.4.0
 -->
 
+* Extends: {Stream}
+
 This object is created internally by an HTTP server — not by the user. It is
 passed as the second parameter to the [`'request'`][] event.
-
-The response inherits from [Stream][], and additionally implements the
-following:
 
 #### Event: 'close'
 <!-- YAML
@@ -3470,7 +3469,6 @@ following additional properties:
 [RFC 8336]: https://tools.ietf.org/html/rfc8336
 [RFC 8441]: https://tools.ietf.org/html/rfc8441
 [Readable Stream]: stream.html#stream_class_stream_readable
-[Stream]: stream.html#stream_stream
 [`'checkContinue'`]: #http2_event_checkcontinue
 [`'connect'`]: #http2_event_connect
 [`'request'`]: #http2_event_request


### PR DESCRIPTION
also removes the redundant statement explained by "extends Stream"

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
