### PR TITLE
doc: clarify stream behaviour

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1801,8 +1801,8 @@ This function MUST NOT be called by application code directly. It should be
 implemented by child classes, and called by the internal `Writable` class
 methods only.
 
-The `writable._writev()` method may be implemented in addition (but not
-instead of) to `writable._write()` in stream implementations that are capable
+The `writable._writev()` method may be implemented in addition to (but not
+instead of) `writable._write()` in stream implementations that are capable
 of processing multiple chunks of data at once. If implemented, the method will
 be called with all chunks of data currently buffered in the write queue.
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1757,7 +1757,7 @@ const myWritable = new Writable({
 * `callback` {Function} Call this function (optionally with an error
   argument) when processing is complete for the supplied chunk.
 
-**All** `Writable` stream implementations must provide a
+All `Writable` stream implementations must provide a
 [`writable._write()`][stream-_write] method to send data to the underlying
 resource.
 


### PR DESCRIPTION
This clarifies some stream behaviour in the documentation

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)