### PR TITLE
http: remove listeners from free sockets

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -601,6 +601,8 @@ function responseKeepAlive(req) {
   }
   socket.removeListener('close', socketCloseListener);
   socket.removeListener('error', socketErrorListener);
+  socket.removeListener('data', socketOnData);
+  socket.removeListener('end', socketOnEnd);
   socket.once('error', freeSocketErrorListener);
   // There are cases where _handle === null. Avoid those. Passing null to
   // nextTick() will call getDefaultTriggerAsyncId() to retrieve the id.

--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -150,6 +150,8 @@ function checkListeners(socket) {
     socket.off('free', callback);
     socket.off('close', callback);
   });
+  assert.strictEqual(socket.listenerCount('error'), 1);
+  assert.strictEqual(socket.listenerCount('end'), 2);
   socket.once('free', callback);
   socket.once('close', callback);
 }

--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -137,9 +137,19 @@ server.listen(0, common.mustCall(() => {
 
 // Check for listener leaks when reusing sockets.
 function checkListeners(socket) {
-  assert.strictEqual(socket.listenerCount('data'), 1);
-  assert.strictEqual(socket.listenerCount('drain'), 1);
-  assert.strictEqual(socket.listenerCount('error'), 1);
-  // Sockets have onReadableStreamEnd.
-  assert.strictEqual(socket.listenerCount('end'), 2);
+  const callback = common.mustCall(() => {
+    if (!socket.destroyed) {
+      assert.strictEqual(socket.listenerCount('data'), 0);
+      assert.strictEqual(socket.listenerCount('drain'), 0);
+      // Sockets have freeSocketErrorListener.
+      assert.strictEqual(socket.listenerCount('error'), 1);
+      // Sockets have onReadableStreamEnd.
+      assert.strictEqual(socket.listenerCount('end'), 1);
+    }
+
+    socket.off('free', callback);
+    socket.off('close', callback);
+  });
+  socket.once('free', callback);
+  socket.once('close', callback);
 }


### PR DESCRIPTION
This is a continuation on https://github.com/nodejs/node/pull/29245 made in a separate PR to make #29245 easier to fast track if desired.

Some more listener cleanup when sockets are detached from the request object and moved into the socket pool.

I'm not sure, but this looks like it might actually be a bug?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
