### PR TITLE
http: make sure end is always emitted with keepalive connections 

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -618,8 +618,6 @@ function resOnFinish(req, res, socket, state, server) {
   assert(state.incoming.length === 0 || state.incoming[0] === req);
 
   state.incoming.shift();
-  // Reset the .incoming property so that the request object can be gc'ed.
-  if (socket.parser) socket.parser.incoming = null;
 
   // If the user never called req.read(), and didn't pipe() or
   // .resume() or .on('data'), then we call req._dump() so that the

--- a/test/parallel/test-http-server-keepalive-end.js
+++ b/test/parallel/test-http-server-keepalive-end.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common');
+const { createServer } = require('http');
+const { connect } = require('net');
+
+const server = createServer(common.mustCall((req, res) => {
+  req.on('end', common.mustCall());
+  res.end('hello world');
+}));
+
+server.unref();
+
+server.listen(0, common.mustCall(() => {
+
+  const client = connect(server.address().port);
+
+  const req = [
+    'POST / HTTP/1.1',
+    `Host: localhost:${server.address().port}`,
+    'Connection: keep-alive',
+    'Content-Length: 11',
+    '',
+    'hello world',
+    ''
+  ].join('\r\n');
+
+  client.end(req);
+}));


### PR DESCRIPTION
Unfortunately 779a05d introduced a regression in 12.8.0, making the [autocannon](http://npm.im/autocannon) test failing on Node 12. This PR reverts 779a05d and adds a test to ensure that we do not regress again.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
