### PR TITLE
fix fs.read documentation typo read instead of write

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2503,7 +2503,7 @@ changes:
 
 Read data from the file specified by `fd`.
 
-`buffer` is the buffer that the data which was read from the fd will be written to.
+`buffer` is the buffer that the data (read from the fd) will be written to.
 
 `offset` is the offset in the buffer to start writing at.
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2505,7 +2505,7 @@ Read data from the file specified by `fd`.
 
 `buffer` is the buffer that the data which was read from the fd will be written to.
 
-`offset` is the offset in the buffer to start reading from.
+`offset` is the offset in the buffer to start writing at.
 
 `length` is an integer specifying the number of bytes to read.
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2503,7 +2503,7 @@ changes:
 
 Read data from the file specified by `fd`.
 
-`buffer` is the buffer that the data will be read from.
+`buffer` is the buffer that the data which was read from the fd will be written to.
 
 `offset` is the offset in the buffer to start reading from.
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2503,9 +2503,9 @@ changes:
 
 Read data from the file specified by `fd`.
 
-`buffer` is the buffer that the data will be written to.
+`buffer` is the buffer that the data will be reading from.
 
-`offset` is the offset in the buffer to start writing at.
+`offset` is the offset in the buffer to start reading from.
 
 `length` is an integer specifying the number of bytes to read.
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2503,7 +2503,7 @@ changes:
 
 Read data from the file specified by `fd`.
 
-`buffer` is the buffer that the data will be reading from.
+`buffer` is the buffer that the data will be read from.
 
 `offset` is the offset in the buffer to start reading from.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
