### PR TITLE
module: avoid passing unnecessary loop reference

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -462,7 +462,7 @@ std::string ReadFile(uv_file file) {
   uv_buf_t buf = uv_buf_init(buffer_memory, sizeof(buffer_memory));
 
   do {
-    const int r = uv_fs_read(uv_default_loop(),
+    const int r = uv_fs_read(nullptr,
                              &req,
                              file,
                              &buf,


### PR DESCRIPTION
It's a sync request, which doesn't require the loop parameter to be set.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
