### PR TITLE
stream: _writeAfterEnd

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1793,13 +1793,13 @@ user programs.
 #### writable.\_writeAfterEnd(callback)
 
 * `callback` {Function} A callback function (optionally with an error
-  argument) to override the default `ERR_WRITE_AFTER_END` error.
+  argument) to override the default `ERR_STREAM_WRITE_AFTER_END` error.
 
 This function MUST NOT be called by application code directly. It should be
 implemented by child classes, and called by the internal `Writable` class
 methods only.
 
-The `writable._writeAfterEnd()` method may be implemented in order to perfom
+The `writable._writeAfterEnd()` method may be implemented in order to perform
 extra error handling when [`writable.write()`][stream-write] is called after
 [`writable.end()`][stream-end] and also to optionally override the default
 error with a more descriptive error.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1790,6 +1790,20 @@ The `writable._write()` method is prefixed with an underscore because it is
 internal to the class that defines it, and should never be called directly by
 user programs.
 
+#### writable.\_writeAfterEnd(callback)
+
+* `callback` {Function} A callback function (optionally with an error
+  argument) to override the default `ERR_WRITE_AFTER_END` error.
+
+This function MUST NOT be called by application code directly. It should be
+implemented by child classes, and called by the internal `Writable` class
+methods only.
+
+The `writable._writeAfterEnd()` method may be implemented in order to perfom
+extra error handling when [`writable.write()`][stream-write] is called after
+[`writable.end()`][stream-end] and also to optionally override the default
+error with a more descriptive error.
+
 #### writable.\_writev(chunks, callback)
 
 * `chunks` {Object[]} The chunks to be written. Each chunk has following

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -248,10 +248,18 @@ Writable.prototype.pipe = function() {
 
 
 function writeAfterEnd(stream, cb) {
-  const er = new ERR_STREAM_WRITE_AFTER_END();
-  // TODO: defer error events consistently everywhere, not just the cb
-  errorOrDestroy(stream, er);
-  process.nextTick(cb, er);
+  // TODO: defer error events consistently everywhere, not just the cb.
+  if (typeof stream._writeAfterEnd === 'function') {
+    stream._writeAfterEnd((err) => {
+      const er = err || new ERR_STREAM_WRITE_AFTER_END();
+      errorOrDestroy(stream, er);
+      process.nextTick(cb, er);
+    });
+  } else {
+    const er = new ERR_STREAM_WRITE_AFTER_END();
+    errorOrDestroy(stream, er);
+    process.nextTick(cb, er);
+  }
 }
 
 // Checks that a user-supplied chunk is valid, especially for the particular

--- a/lib/net.js
+++ b/lib/net.js
@@ -397,22 +397,13 @@ function afterShutdown(status) {
 // Provide a better error message when we call end() as a result
 // of the other side sending a FIN.  The standard 'write after end'
 // is overly vague, and makes it seem like the user's code is to blame.
-function writeAfterFIN(chunk, encoding, cb) {
-  if (typeof encoding === 'function') {
-    cb = encoding;
-    encoding = null;
-  }
-
+Socket.prototype._writeAfterEnd = function(cb) {
   // eslint-disable-next-line no-restricted-syntax
   const er = new Error('This socket has been ended by the other party');
   er.code = 'EPIPE';
-  process.nextTick(emitErrorNT, this, er);
-  if (typeof cb === 'function') {
-    defaultTriggerAsyncIdScope(this[async_id_symbol], process.nextTick, cb, er);
-  }
+  defaultTriggerAsyncIdScope(this[async_id_symbol], process.nextTick, cb, er);
+};
 
-  return false;
-}
 
 Socket.prototype.setTimeout = setStreamTimeout;
 
@@ -541,10 +532,8 @@ Socket.prototype.end = function(data, encoding, callback) {
 
 // Called when the 'end' event is emitted.
 function onReadableStreamEnd() {
-  if (!this.allowHalfOpen) {
-    this.write = writeAfterFIN;
-    if (this.writable)
-      this.end();
+  if (!this.allowHalfOpen && this.writable) {
+    this.end();
   }
 
   if (!this.destroyed && !this.writable && !this.writableLength)

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -458,3 +458,29 @@ const helloWorldBuffer = Buffer.from('hello world');
   w.write(Buffer.allocUnsafe(1));
   w.end(Buffer.allocUnsafe(0));
 }
+
+{
+  // Verify that _writeAfterEnd overrides error.
+  const d = new D();
+  d.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'custom error');
+  }));
+  d._writeAfterEnd = function(cb) {
+    process.nextTick(cb, new Error('custom error'));
+  };
+  d.end();
+  d.write('hello');
+}
+
+{
+  // Verify that _writeAfterEnd overrides error.
+  const w = new W();
+  w.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'custom error');
+  }));
+  w._writeAfterEnd = function(cb) {
+    process.nextTick(cb, new Error('custom error'));
+  };
+  w.end();
+  w.write('hello');
+}


### PR DESCRIPTION
Allow stream implementors to override write after end
errors, similar to how it's done for net.Socket. Removed
net.Socket special case with generic solution.

Pulled out from https://github.com/nodejs/node/pull/29179 per request.

Refs: https://github.com/nodejs/node/issues/29068

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
