### PR TITLE
lib: consolidate lazyErrmapGet()

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -327,7 +327,7 @@ function lazyUv() {
   return uvBinding;
 }
 
-function lazyErrmapGet(name) {
+function uvErrmapGet(name) {
   uvBinding = lazyUv();
   if (!uvBinding.errmap) {
     uvBinding.errmap = uvBinding.getErrorMap();
@@ -346,7 +346,7 @@ function lazyErrmapGet(name) {
  * @returns {Error}
  */
 function uvException(ctx) {
-  const [ code, uvmsg ] = lazyErrmapGet(ctx.errno);
+  const [ code, uvmsg ] = uvErrmapGet(ctx.errno);
   let message = `${code}: ${ctx.message || uvmsg}, ${ctx.syscall}`;
 
   let path;
@@ -404,7 +404,7 @@ function uvException(ctx) {
  * @returns {Error}
  */
 function uvExceptionWithHostPort(err, syscall, address, port) {
-  const [ code, uvmsg ] = lazyErrmapGet(err);
+  const [ code, uvmsg ] = uvErrmapGet(err);
   const message = `${syscall} ${code}: ${uvmsg}`;
   let details = '';
 
@@ -671,6 +671,7 @@ module.exports = {
   hideStackFrames,
   isStackOverflowError,
   connResetException,
+  uvErrmapGet,
   uvException,
   uvExceptionWithHostPort,
   SystemError,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const { Object, Reflect } = primordials;
-
 const {
-  ERR_INVALID_ARG_TYPE,
-  ERR_NO_CRYPTO,
-  ERR_UNKNOWN_SIGNAL
-} = require('internal/errors').codes;
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+    ERR_NO_CRYPTO,
+    ERR_UNKNOWN_SIGNAL
+  },
+  uvErrmapGet
+} = require('internal/errors');
 const { signals } = internalBinding('constants').os;
 const {
   getHiddenValue,
@@ -244,19 +246,8 @@ function getConstructorOf(obj) {
   return null;
 }
 
-let uvBinding;
-function lazyErrmapGet(name) {
-  if (!uvBinding) {
-    uvBinding = internalBinding('uv');
-  }
-  if (!uvBinding.errmap) {
-    uvBinding.errmap = uvBinding.getErrorMap();
-  }
-  return uvBinding.errmap.get(name);
-}
-
 function getSystemErrorName(err) {
-  const entry = lazyErrmapGet(err);
+  const entry = uvErrmapGet(err);
   return entry ? entry[0] : `Unknown system error ${err}`;
 }
 


### PR DESCRIPTION
There are currently two implementations of this function. This commit removes the redundancy, and removes "lazy" from the name.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
