### PR TITLE
src: do not crash when accessing empty WeakRefs

### DIFF
--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -191,14 +191,16 @@ class WeakReference : public BaseObject {
 
   static void IncRef(const FunctionCallbackInfo<Value>& args) {
     WeakReference* weak_ref = Unwrap<WeakReference>(args.Holder());
-    if (weak_ref->reference_count_ == 0) weak_ref->target_.ClearWeak();
     weak_ref->reference_count_++;
+    if (weak_ref->target_.IsEmpty()) return;
+    if (weak_ref->reference_count_ == 1) weak_ref->target_.ClearWeak();
   }
 
   static void DecRef(const FunctionCallbackInfo<Value>& args) {
     WeakReference* weak_ref = Unwrap<WeakReference>(args.Holder());
     CHECK_GE(weak_ref->reference_count_, 1);
     weak_ref->reference_count_--;
+    if (weak_ref->target_.IsEmpty()) return;
     if (weak_ref->reference_count_ == 0) weak_ref->target_.SetWeak();
   }
 


### PR DESCRIPTION
Making `.incRef()` and `.decRef()` fail silently leads to better error
messages when trying to access the underlying value (as opposed to
crashing inside these methods).

Refs: https://github.com/nodejs/node/pull/25461#issuecomment-524481482

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
