### PR TITLE
build: test Python 3.6 and 3.7 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,19 @@ jobs:
             bash -x tools/lint-pr-commit-message.sh ${TRAVIS_PULL_REQUEST};
           fi
 
-    - name: "Python 3 is EXPERIMENTAL"
+    - name: "Python 3 is EXPERIMENTAL (Py36)"
+      language: node_js
+      node_js: "node"
+      install:
+        - pyenv global 3.6.7
+        - python3.6 -m pip install --upgrade pip
+        - make lint-py-build
+      script:
+        - NODE=$(which node) make lint lint-py
+        - python3.6 ./configure.py
+        - NODE=$(which node) make test
+
+    - name: "Python 3 is EXPERIMENTAL (Py37)"
       language: node_js
       node_js: "node"
       install:
@@ -101,4 +113,5 @@ jobs:
         - NODE=$(which node) make test
 
   allow_failures:
-    - name: "Python 3 is EXPERIMENTAL"
+    - name: "Python 3 is EXPERIMENTAL (Py36)"
+    - name: "Python 3 is EXPERIMENTAL (Py37)"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Add a Python 3.6 experimental run to Travis CI because the Python 3.7 run fails early because __async__ is a reserved word in Python >= 3.7.

__help wanted:__
1. How can we get the Python 3.6 build to complete before timing out?
2. How can we fix the __async__ issue on Python >= 3.7?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
