### PR TITLE
crypto: add support for IEEE-P1363 DSA signatures

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1405,6 +1405,7 @@ changes:
 -->
 
 * `privateKey` {Object | string | Buffer | KeyObject}
+  * `dsaEncoding` {string}
   * `padding` {integer}
   * `saltLength` {integer}
 * `outputEncoding` {string} The [encoding][] of the return value.
@@ -1417,6 +1418,10 @@ If `privateKey` is not a [`KeyObject`][], this function behaves as if
 `privateKey` had been passed to [`crypto.createPrivateKey()`][]. If it is an
 object, the following additional properties can be passed:
 
+* `dsaEncoding` {string} For DSA and ECDSA, this option specifies the
+  format of the generated signature. It can be one of the following:
+  * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
+  * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
 * `padding` {integer} Optional padding value for RSA, one of the following:
   * `crypto.constants.RSA_PKCS1_PADDING` (default)
   * `crypto.constants.RSA_PKCS1_PSS_PADDING`
@@ -1513,6 +1518,7 @@ changes:
 -->
 
 * `object` {Object | string | Buffer | KeyObject}
+  * `dsaEncoding` {string}
   * `padding` {integer}
   * `saltLength` {integer}
 * `signature` {string | Buffer | TypedArray | DataView}
@@ -1526,6 +1532,10 @@ If `object` is not a [`KeyObject`][], this function behaves as if
 `object` had been passed to [`crypto.createPublicKey()`][]. If it is an
 object, the following additional properties can be passed:
 
+* `dsaEncoding` {string} For DSA and ECDSA, this option specifies the
+  format of the generated signature. It can be one of the following:
+  * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
+  * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
 * `padding` {integer} Optional padding value for RSA, one of the following:
   * `crypto.constants.RSA_PKCS1_PADDING` (default)
   * `crypto.constants.RSA_PKCS1_PSS_PADDING`
@@ -2891,6 +2901,10 @@ If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
 passed to [`crypto.createPrivateKey()`][]. If it is an object, the following
 additional properties can be passed:
 
+* `dsaEncoding` {string} For DSA and ECDSA, this option specifies the
+  format of the generated signature. It can be one of the following:
+  * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
+  * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
 * `padding` {integer} Optional padding value for RSA, one of the following:
   * `crypto.constants.RSA_PKCS1_PADDING` (default)
   * `crypto.constants.RSA_PKCS1_PSS_PADDING`
@@ -2944,6 +2958,10 @@ If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
 passed to [`crypto.createPublicKey()`][]. If it is an object, the following
 additional properties can be passed:
 
+* `dsaEncoding` {string} For DSA and ECDSA, this option specifies the
+  format of the generated signature. It can be one of the following:
+  * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
+  * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
 * `padding` {integer} Optional padding value for RSA, one of the following:
   * `crypto.constants.RSA_PKCS1_PADDING` (default)
   * `crypto.constants.RSA_PKCS1_PSS_PADDING`

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -11,6 +11,8 @@ const { validateString } = require('internal/validators');
 const {
   Sign: _Sign,
   Verify: _Verify,
+  kSigEncDER,
+  kSigEncP1363,
   signOneShot: _signOneShot,
   verifyOneShot: _verifyOneShot
 } = internalBinding('crypto');
@@ -59,6 +61,20 @@ function getSaltLength(options) {
   return getIntOption('saltLength', options);
 }
 
+function getDSASignatureEncoding(options) {
+  if (typeof options === 'object') {
+    const { dsaEncoding = 'der' } = options;
+    if (dsaEncoding === 'der')
+      return kSigEncDER;
+    else if (dsaEncoding === 'ieee-p1363')
+      return kSigEncP1363;
+    else
+      throw new ERR_INVALID_OPT_VALUE('dsaEncoding', dsaEncoding);
+  }
+
+  return kSigEncDER;
+}
+
 function getIntOption(name, options) {
   const value = options[name];
   if (value !== undefined) {
@@ -81,8 +97,11 @@ Sign.prototype.sign = function sign(options, encoding) {
   const rsaPadding = getPadding(options);
   const pssSaltLength = getSaltLength(options);
 
+  // Options specific to (EC)DSA
+  const dsaSigEnc = getDSASignatureEncoding(options);
+
   const ret = this[kHandle].sign(data, format, type, passphrase, rsaPadding,
-                                 pssSaltLength);
+                                 pssSaltLength, dsaSigEnc);
 
   encoding = encoding || getDefaultEncoding();
   if (encoding && encoding !== 'buffer')
@@ -117,8 +136,11 @@ function signOneShot(algorithm, data, key) {
   const rsaPadding = getPadding(key);
   const pssSaltLength = getSaltLength(key);
 
+  // Options specific to (EC)DSA
+  const dsaSigEnc = getDSASignatureEncoding(key);
+
   return _signOneShot(keyData, keyFormat, keyType, keyPassphrase, data,
-                      algorithm, rsaPadding, pssSaltLength);
+                      algorithm, rsaPadding, pssSaltLength, dsaSigEnc);
 }
 
 function Verify(algorithm, options) {
@@ -149,13 +171,15 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
 
   // Options specific to RSA
   const rsaPadding = getPadding(options);
-
   const pssSaltLength = getSaltLength(options);
+
+  // Options specific to (EC)DSA
+  const dsaSigEnc = getDSASignatureEncoding(options);
 
   signature = getArrayBufferView(signature, 'signature', sigEncoding);
 
   return this[kHandle].verify(data, format, type, passphrase, signature,
-                              rsaPadding, pssSaltLength);
+                              rsaPadding, pssSaltLength, dsaSigEnc);
 };
 
 function verifyOneShot(algorithm, data, key, signature) {
@@ -181,6 +205,9 @@ function verifyOneShot(algorithm, data, key, signature) {
   const rsaPadding = getPadding(key);
   const pssSaltLength = getSaltLength(key);
 
+  // Options specific to (EC)DSA
+  const dsaSigEnc = getDSASignatureEncoding(key);
+
   if (!isArrayBufferView(signature)) {
     throw new ERR_INVALID_ARG_TYPE(
       'signature',
@@ -190,7 +217,7 @@ function verifyOneShot(algorithm, data, key, signature) {
   }
 
   return _verifyOneShot(keyData, keyFormat, keyType, keyPassphrase, signature,
-                        data, algorithm, rsaPadding, pssSaltLength);
+                        data, algorithm, rsaPadding, pssSaltLength, dsaSigEnc);
 }
 
 module.exports = {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5053,6 +5053,8 @@ static AllocatedBuffer ConvertSignatureToP1363(Environment* env,
   CHECK_EQ(n, BN_bn2binpad(r, data, n));
   CHECK_EQ(n, BN_bn2binpad(s, data + n, n));
 
+  ECDSA_SIG_free(asn1_sig);
+
   return buf;
 }
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -326,6 +326,13 @@ class ByteSource {
   const char* get() const;
   size_t size() const;
 
+  inline operator bool() const {
+    return data_ != nullptr;
+  }
+
+  static ByteSource Allocated(char* data, size_t size);
+  static ByteSource Foreign(const char* data, size_t size);
+
   static ByteSource FromStringOrBuffer(Environment* env,
                                        v8::Local<v8::Value> value);
 
@@ -350,9 +357,6 @@ class ByteSource {
   size_t size_ = 0;
 
   ByteSource(const char* data, char* allocated_data, size_t size);
-
-  static ByteSource Allocated(char* data, size_t size);
-  static ByteSource Foreign(const char* data, size_t size);
 };
 
 enum PKEncodingType {
@@ -628,7 +632,8 @@ class SignBase : public BaseObject {
     kSignNotInitialised,
     kSignUpdate,
     kSignPrivateKey,
-    kSignPublicKey
+    kSignPublicKey,
+    kSignMalformedSignature
   } Error;
 
   SignBase(Environment* env, v8::Local<v8::Object> wrap)
@@ -649,6 +654,10 @@ class SignBase : public BaseObject {
   EVPMDPointer mdctx_;
 };
 
+enum DSASigEnc {
+  kSigEncDER, kSigEncP1363
+};
+
 class Sign : public SignBase {
  public:
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
@@ -666,7 +675,8 @@ class Sign : public SignBase {
   SignResult SignFinal(
       const ManagedEVPPKey& pkey,
       int padding,
-      const v8::Maybe<int>& saltlen);
+      const v8::Maybe<int>& saltlen,
+      DSASigEnc dsa_sig_enc);
 
  protected:
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -538,6 +538,22 @@ common.expectsError(
     }
   }
 
+  // Test verifying externally signed messages.
+  const extSig = Buffer.from('494c18ab5c8a62a72aea5041966902bcfa229821af2bf65' +
+                             '0b5b4870d1fe6aebeaed9460c62210693b5b0a300033823' +
+                             '33d9529c8abd8c5948940af944828be16c', 'hex');
+  for (const ok of [true, false]) {
+    assert.strictEqual(
+      crypto.verify('sha256', data, {
+        key: fixtures.readKey('ec-key.pem'),
+        dsaEncoding: 'ieee-p1363'
+      }, extSig),
+      ok
+    );
+
+    extSig[Math.floor(Math.random() * extSig.length)] ^= 1;
+  }
+
   // Non-(EC)DSA keys should ignore the option.
   const sig = crypto.sign('sha1', data, {
     key: keyPem,


### PR DESCRIPTION
This patch adds support for "IEEE-P1363 signatures" for DSA and ECDSA. If you are thinking "What is that and why doesn't it have a proper name?", you are right to think that.

Currently, OpenSSL produces ASN.1 signatures which are encoded as DER, basically encoding a `SEQUENCE` of two `INTEGER` components, `r` and `s`. That works nicely and is supported by most crypto APIs including OpenSSL, pycryptodome, Crypto++, JCE, and BouncyCastle. Except, of course, WebCrypto (and .NET).

WebCrypto (and .NET) use an alternative signature format that does not have a name as far as I can tell. It was, however, suggested in IEEE P1363 in 2000, so it is not an entirely new invention, and some frameworks such as Crypto++ and pycryptodome support it. It is stupidly simple, basically just the concatenation of `r` and `s` after some padding.

The conversion can also be done in JavaScript and it isn't difficult, an example implementation is in https://github.com/nodejs/webcrypto/pull/18, but since it involves some simple DER / ASN.1 parsing, it would be convenient and more efficient to put it into core. There are other frameworks that support both formats, e.g., pycryptodome and Crypto++.

After giving this a lot of thought, I have a slight preference towards adding this to core, but I would be happy to be convinced of the opposite. And I am totally open to other names for the format than `ieee-p1363`.

cc @nodejs/crypto @nodejs/security-wg @panva

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
- [x] test case with externally generated data (e.g., using WebCrypto)
