### PR TITLE
lib: add ASCII fast path to getStringWidth()

### DIFF
--- a/benchmark/misc/getstringwidth.js
+++ b/benchmark/misc/getstringwidth.js
@@ -3,7 +3,7 @@
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  type: ['ascii', 'emojiseq', 'fullwidth'],
+  type: ['ascii', 'mixed', 'emojiseq', 'fullwidth'],
   n: [10e4]
 }, {
   flags: ['--expose-internals']
@@ -14,6 +14,7 @@ function main({ n, type }) {
 
   const str = ({
     ascii: 'foobar'.repeat(100),
+    mixed: 'foo'.repeat(100) + '😀' + 'bar'.repeat(100),
     emojiseq: '👨‍👨‍👧‍👦👨‍👩‍👦‍👦👨‍👩‍👧‍👧👩‍👩‍👧‍👦'.repeat(10),
     fullwidth: '你好'.repeat(150)
   })[type];

--- a/benchmark/misc/getstringwidth.js
+++ b/benchmark/misc/getstringwidth.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  type: ['ascii', 'emojiseq', 'fullwidth'],
+  n: [10e4]
+}, {
+  flags: ['--expose-internals']
+});
+
+function main({ n, type }) {
+  const { getStringWidth } = require('internal/readline/utils');
+
+  const str = ({
+    ascii: 'foobar'.repeat(100),
+    emojiseq: '👨‍👨‍👧‍👦👨‍👩‍👦‍👦👨‍👩‍👧‍👧👩‍👩‍👧‍👦'.repeat(10),
+    fullwidth: '你好'.repeat(150)
+  })[type];
+
+  bench.start();
+  for (let j = 0; j < n; j += 1)
+    getStringWidth(str);
+  bench.end(n);
+}

--- a/lib/internal/readline/utils.js
+++ b/lib/internal/readline/utils.js
@@ -35,10 +35,11 @@ if (internalBinding('config').hasIntl) {
   getStringWidth = function getStringWidth(str, options) {
     options = options || {};
     if (Number.isInteger(str)) {
+      // Provide information about the character with code point 'str'.
       return icu.getStringWidth(
         str,
         Boolean(options.ambiguousAsFullWidth),
-        Boolean(options.expandEmojiSequence)
+        false
       );
     }
     str = stripVTControlCharacters(String(str));

--- a/lib/internal/readline/utils.js
+++ b/lib/internal/readline/utils.js
@@ -34,13 +34,31 @@ if (internalBinding('config').hasIntl) {
   const icu = internalBinding('icu');
   getStringWidth = function getStringWidth(str, options) {
     options = options || {};
-    if (!Number.isInteger(str))
-      str = stripVTControlCharacters(String(str));
-    return icu.getStringWidth(
-      str,
-      Boolean(options.ambiguousAsFullWidth),
-      Boolean(options.expandEmojiSequence)
-    );
+    if (Number.isInteger(str)) {
+      return icu.getStringWidth(
+        str,
+        Boolean(options.ambiguousAsFullWidth),
+        Boolean(options.expandEmojiSequence)
+      );
+    }
+    str = stripVTControlCharacters(String(str));
+    let width = 0;
+    for (let i = 0; i < str.length; i++) {
+      // Try to avoid calling into C++ by first handling the ASCII portion of
+      // the string. If it is fully ASCII, we skip the C++ part.
+      const code = str.charCodeAt(i);
+      if (code < 127) {
+        width += code >= 32;
+        continue;
+      }
+      width += icu.getStringWidth(
+        str.slice(i),
+        Boolean(options.ambiguousAsFullWidth),
+        Boolean(options.expandEmojiSequence)
+      );
+      break;
+    }
+    return width;
   };
   isFullWidthCodePoint =
     function isFullWidthCodePoint(code, options) {

--- a/test/parallel/test-icu-stringwidth.js
+++ b/test/parallel/test-icu-stringwidth.js
@@ -69,3 +69,17 @@ assert.strictEqual(
 
 // Control chars and combining chars are zero
 assert.strictEqual(readline.getStringWidth('\u200E\n\u220A\u20D2'), 1);
+
+// Test that the fast path for ASCII characters yields results consistent
+// with the 'slow' path.
+for (const ambiguousAsFullWidth of [ false, true ]) {
+  for (let i = 0; i < 256; i++) {
+    const char = String.fromCharCode(i);
+    assert.strictEqual(
+      readline.getStringWidth(i, { ambiguousAsFullWidth }),
+      readline.getStringWidth(char, { ambiguousAsFullWidth }));
+    assert.strictEqual(
+      readline.getStringWidth(char + '🎉', { ambiguousAsFullWidth }),
+      readline.getStringWidth(char, { ambiguousAsFullWidth }) + 2);
+  }
+}

--- a/test/parallel/test-icu-stringwidth.js
+++ b/test/parallel/test-icu-stringwidth.js
@@ -81,5 +81,13 @@ for (const ambiguousAsFullWidth of [ false, true ]) {
     assert.strictEqual(
       readline.getStringWidth(char + '🎉', { ambiguousAsFullWidth }),
       readline.getStringWidth(char, { ambiguousAsFullWidth }) + 2);
+
+    if (i < 32 || (i >= 127 && i < 160)) {  // Control character
+      assert.strictEqual(
+        readline.getStringWidth(i, { ambiguousAsFullWidth }), 0);
+    } else if (i < 127) {  // Regular ASCII character
+      assert.strictEqual(
+        readline.getStringWidth(i, { ambiguousAsFullWidth }), 1);
+    }
   }
 }


### PR DESCRIPTION
A lot of strings that are going to be passed to `getStringWidth()`
are ASCII strings, for which the calculation is rather easy and
calling into C++ can be skipped.

                                                       confidence improvement accuracy (*)    (**)   (***)
     misc/getstringwidth.js n=100000 type='ascii'            ***    328.99 %      ±21.73% ±29.25% ±38.77%
     misc/getstringwidth.js n=100000 type='emojiseq'                  2.94 %       ±7.66% ±10.19% ±13.26%
     misc/getstringwidth.js n=100000 type='fullwidth'                 4.70 %       ±5.64%  ±7.50%  ±9.76%

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
