### PR TITLE
events: improve once() performance

### DIFF
--- a/benchmark/events/ee-once.js
+++ b/benchmark/events/ee-once.js
@@ -2,18 +2,54 @@
 const common = require('../common.js');
 const EventEmitter = require('events').EventEmitter;
 
-const bench = common.createBenchmark(main, { n: [2e7] });
+const bench = common.createBenchmark(main, {
+  n: [2e7],
+  argc: [0, 1, 4, 5]
+});
 
-function main({ n }) {
+function main({ n, argc }) {
   const ee = new EventEmitter();
 
   function listener() {}
 
-  bench.start();
-  for (var i = 0; i < n; i += 1) {
-    const dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
-    ee.once(dummy, listener);
-    ee.emit(dummy);
+  switch (argc) {
+    case 0:
+      bench.start();
+      for (let i = 0; i < n; i += 1) {
+        const dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+        ee.once(dummy, listener);
+        ee.emit(dummy);
+      }
+      bench.end(n);
+      break;
+    case 1:
+      bench.start();
+      for (let i = 0; i < n; i += 1) {
+        const dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+        ee.once(dummy, listener);
+        ee.emit(dummy, n);
+      }
+      bench.end(n);
+      break;
+    case 4:
+      bench.start();
+      for (let i = 0; i < n; i += 1) {
+        const dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+        ee.once(dummy, listener);
+        ee.emit(dummy, 'foo', argc, 'bar', false);
+      }
+      bench.end(n);
+      break;
+    case 5:
+      bench.start();
+      for (let i = 0; i < n; i += 1) {
+        const dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+        ee.once(dummy, listener);
+        ee.emit(dummy, true, 7.5, 'foo', null, n);
+      }
+      bench.end(n);
+      break;
+    default:
+      throw new Error('Unsupported argument count');
   }
-  bench.end(n);
 }

--- a/lib/events.js
+++ b/lib/events.js
@@ -290,11 +290,13 @@ EventEmitter.prototype.prependListener =
       return _addListener(this, type, listener, true);
     };
 
-function onceWrapper(...args) {
+function onceWrapper() {
   if (!this.fired) {
     this.target.removeListener(this.type, this.wrapFn);
     this.fired = true;
-    return Reflect.apply(this.listener, this.target, args);
+    if (arguments.length === 0)
+      return this.listener.call(this.target);
+    return this.listener.apply(this.target, arguments);
   }
 }
 


### PR DESCRIPTION
Results:

```
                                      confidence improvement accuracy (*)   (**)  (***)
 events/ee-once.js argc=0 n=20000000        ***     15.46 %       ±3.02% ±4.02% ±5.24%
 events/ee-once.js argc=1 n=20000000        ***     10.71 %       ±3.48% ±4.64% ±6.05%
 events/ee-once.js argc=4 n=20000000        ***     13.51 %       ±2.84% ±3.77% ±4.91%
 events/ee-once.js argc=5 n=20000000        ***     13.72 %       ±4.01% ±5.35% ±6.99%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
