### PR TITLE
stream: limit number of pending writes

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -71,6 +71,11 @@ passed into the stream's constructor. For normal streams, the `highWaterMark`
 option specifies a [total number of bytes][hwm-gotcha]. For streams operating
 in object mode, the `highWaterMark` specifies a total number of objects.
 
+For [`Writable`][] streams the `pendingWaterMark` additionally limits the
+number of pending writes. As each buffered write has a small memory overhead,
+lots of small writes can significantly exceed what is expected from the
+`highWaterMark` if the `pendingWaterMark` value is set too high.
+
 Data is buffered in `Readable` streams when the implementation calls
 [`stream.push(chunk)`][stream-push]. If the consumer of the Stream does not
 call [`stream.read()`][stream-read], the data will sit in the internal
@@ -535,6 +540,17 @@ This property contains the number of bytes (or objects) in the queue
 ready to be written. The value provides introspection data regarding
 the status of the `highWaterMark`.
 
+
+##### writable.writablePending
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+This property contains the number of pending writes. The value provides
+introspection data regarding the status of the `pendingWaterMark`.
+
 ##### writable.writableObjectMode
 <!-- YAML
 added: v12.3.0
@@ -543,6 +559,16 @@ added: v12.3.0
 * {boolean}
 
 Getter for the property `objectMode` of a given `Writable` stream.
+
+##### writable.writablePendingWaterMark
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+Return the value of `pendingWaterMark` passed when constructing this
+`Writable`.
 
 ##### writable.write(chunk[, encoding][, callback])
 <!-- YAML
@@ -573,10 +599,11 @@ occurs, the `callback` *may or may not* be called with the error as its
 first argument. To reliably detect write errors, add a listener for the
 `'error'` event.
 
-The return value is `true` if the internal buffer is less than the
-`highWaterMark` configured when the stream was created after admitting `chunk`.
-If `false` is returned, further attempts to write data to the stream should
-stop until the [`'drain'`][] event is emitted.
+The return value is `true` if the internal buffer size is less than the
+`highWaterMark` and the number of pending writes is less than the
+`pendingWaterMark`, both configured when the stream was created after admitting
+`chunk`. If `false` is returned, further attempts to write data to the stream
+should stop until the [`'drain'`][] event is emitted.
 
 While a stream is not draining, calls to `write()` will buffer `chunk`, and
 return false. Once all currently buffered chunks are drained (accepted for
@@ -1675,6 +1702,9 @@ changes:
   * `highWaterMark` {number} Buffer level when
     [`stream.write()`][stream-write] starts returning `false`. **Default:**
     `16384` (16kb), or `16` for `objectMode` streams.
+  * `pendingWaterMark` {number} Pending level when
+    [`stream.write()`][stream-write] starts returning `false`. **Default:**
+    `1024`, or `16` for `objectMode` streams.
   * `decodeStrings` {boolean} Whether to encode `string`s passed to
     [`stream.write()`][stream-write] to `Buffer`s (with the encoding
     specified in the [`stream.write()`][stream-write] call) before passing
@@ -2212,6 +2242,8 @@ changes:
     of the stream. Has no effect if `highWaterMark` is provided.
   * `writableHighWaterMark` {number} Sets `highWaterMark` for the writable side
     of the stream. Has no effect if `highWaterMark` is provided.
+  * `writablePendingWaterMark` {number} Sets `pendingWaterMark` for the writable side
+    of the stream. Has no effect if `pendingWaterMark` is provided.
 
 <!-- eslint-disable no-useless-constructor -->
 ```js

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -78,6 +78,12 @@ Object.defineProperty(Duplex.prototype, 'writableHighWaterMark', {
   }
 });
 
+Object.defineProperty(Duplex.prototype, 'writablePendingWaterMark', {
+  get() {
+    return this._writableState && this._writableState.pendingWaterMark;
+  }
+});
+
 Object.defineProperty(Duplex.prototype, 'writableBuffer', {
   // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
@@ -95,6 +101,17 @@ Object.defineProperty(Duplex.prototype, 'writableLength', {
   enumerable: false,
   get() {
     return this._writableState && this._writableState.length;
+  }
+});
+
+
+Object.defineProperty(Duplex.prototype, 'writablePending', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get() {
+    return this._writableState && this._writableState.pendingcb;
   }
 });
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -34,7 +34,10 @@ const internalUtil = require('internal/util');
 const Stream = require('stream');
 const { Buffer } = require('buffer');
 const destroyImpl = require('internal/streams/destroy');
-const { getHighWaterMark } = require('internal/streams/state');
+const {
+  getHighWaterMark,
+  getPendingWaterMark
+} = require('internal/streams/state');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_METHOD_NOT_IMPLEMENTED,
@@ -72,11 +75,18 @@ function WritableState(options, stream, isDuplex) {
   if (isDuplex)
     this.objectMode = this.objectMode || !!options.writableObjectMode;
 
-  // The point at which write() starts returning false
+  // The point at which write() starts returning false relative
+  // to buffer length.
   // Note: 0 is a valid value, means that we always return false if
   // the entire buffer is not flushed immediately on write()
   this.highWaterMark = getHighWaterMark(this, options, 'writableHighWaterMark',
                                         isDuplex);
+
+  // The point at which write() starts returning false relative
+  // to number of pending operations.
+  this.pendingWaterMark = getPendingWaterMark(this, options,
+                                              'writablePendingWaterMark',
+                                              isDuplex);
 
   // if _final has been called
   this.finalCalled = false;
@@ -300,7 +310,8 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     writeAfterEnd(this, cb);
   else if (isBuf || validChunk(this, state, chunk, cb)) {
     state.pendingcb++;
-    ret = writeOrBuffer(this, state, isBuf, chunk, encoding, cb);
+    ret = writeOrBuffer(this, state, isBuf, chunk, encoding, cb) &&
+      state.pendingcb < state.pendingWaterMark;
   }
 
   return ret;
@@ -370,6 +381,26 @@ Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
   enumerable: false,
   get: function() {
     return this._writableState && this._writableState.highWaterMark;
+  }
+});
+
+Object.defineProperty(Writable.prototype, 'writablePendingWaterMark', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get: function() {
+    return this._writableState && this._writableState.pendingWaterMark;
+  }
+});
+
+Object.defineProperty(Writable.prototype, 'writablePending', {
+  // Making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get: function() {
+    return this._writableState && this._writableState.pendingcb;
   }
 });
 

--- a/lib/internal/streams/state.js
+++ b/lib/internal/streams/state.js
@@ -27,7 +27,32 @@ function getHighWaterMark(state, options, duplexKey, isDuplex) {
   return getDefaultHighWaterMark(state.objectMode);
 }
 
+function pendingWaterMarkFrom(options, isDuplex, duplexKey) {
+  return options.pendingWaterMark != null ? options.pendingWaterMark :
+    isDuplex ? options[duplexKey] : null;
+}
+
+function getDefaultPendingWaterMark(objectMode) {
+  return objectMode ? 16 : 1024;
+}
+
+function getPendingWaterMark(state, options, duplexKey, isDuplex) {
+  const pwm = pendingWaterMarkFrom(options, isDuplex, duplexKey);
+  if (pwm != null) {
+    if (!Number.isInteger(pwm) || pwm < 0) {
+      const name = isDuplex ? duplexKey : 'pendingWaterMark';
+      throw new ERR_INVALID_OPT_VALUE(name, pwm);
+    }
+    return Math.floor(pwm);
+  }
+
+  // Default value
+  return getDefaultPendingWaterMark(state.objectMode);
+}
+
 module.exports = {
   getHighWaterMark,
-  getDefaultHighWaterMark
+  getPendingWaterMark,
+  getDefaultHighWaterMark,
+  getDefaultPendingWaterMark
 };

--- a/test/parallel/test-stream-writable-write-cb-multiple.js
+++ b/test/parallel/test-stream-writable-write-cb-multiple.js
@@ -1,0 +1,37 @@
+'use strict';
+const common = require('../common');
+const { Writable } = require('stream');
+const assert = require('assert');
+
+// Ensure write cannot be spammed with pending
+// requests.
+
+{
+  // Sync
+  const w = new Writable({
+    write: common.mustCallAtLeast((buf, enc, cb) => {
+      process.nextTick(cb);
+    }, 1)
+  });
+
+  let cnt = 0;
+  while (w.write('a'))
+    cnt++;
+
+  assert.strictEqual(cnt, w.writablePendingWaterMark - 1);
+}
+
+{
+  // Async
+  const w = new Writable({
+    write: common.mustCallAtLeast((buf, enc, cb) => {
+      cb();
+    }, 1)
+  });
+
+  let cnt = 0;
+  while (w.write('a'))
+    cnt++;
+
+  assert.strictEqual(cnt, w.writablePendingWaterMark - 1);
+}


### PR DESCRIPTION
This avoid lots of unexpectedly small writes spams the stream and allocates lots of extra memory due to buffering memory overhead.

As each write op has a small memory overhead, lots of dispatched small writes can significantly exceed what is expected from the `highWaterMark`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
