### PR TITLE
worker: prevent event loop starvation through MessagePorts

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -604,11 +604,25 @@ void MessagePort::OnMessage() {
   HandleScope handle_scope(env()->isolate());
   Local<Context> context = object(env()->isolate())->CreationContext();
 
+  ssize_t processing_limit;
+  {
+    Mutex::ScopedLock(data_->mutex_);
+    processing_limit = data_->incoming_messages_.size();
+  }
+
   // data_ can only ever be modified by the owner thread, so no need to lock.
   // However, the message port may be transferred while it is processing
   // messages, so we need to check that this handle still owns its `data_` field
   // on every iteration.
   while (data_) {
+    if (--processing_limit < 0) {
+      // Prevent event loop starvation by only processing those messages without
+      // interruption that were already present when the OnMessage() call was
+      // first triggered.
+      TriggerAsync();
+      return;
+    }
+
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(context);
 

--- a/test/parallel/test-worker-message-port-close-while-receiving.js
+++ b/test/parallel/test-worker-message-port-close-while-receiving.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+
+const { MessageChannel } = require('worker_threads');
+
+// Make sure that closing a message port while receiving messages on it does
+// not stop messages that are already in the queue from being emitted.
+
+const { port1, port2 } = new MessageChannel();
+
+port1.on('message', common.mustCall(() => {
+  port1.close();
+}, 2));
+port2.postMessage('foo');
+port2.postMessage('bar');

--- a/test/parallel/test-worker-message-port-infinite-message-loop.js
+++ b/test/parallel/test-worker-message-port-infinite-message-loop.js
@@ -24,4 +24,6 @@ port1.on('message', () => {
 
 port2.postMessage(0);
 
+// This is part of the test -- the event loop should be available and not stall
+// out due to the recursive .postMessage() calls.
 setTimeout(common.mustCall(), 0);

--- a/test/parallel/test-worker-message-port-infinite-message-loop.js
+++ b/test/parallel/test-worker-message-port-infinite-message-loop.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const { MessageChannel } = require('worker_threads');
+
+// Make sure that an infinite asynchronous .on('message')/postMessage loop
+// does not lead to a stack overflow and does not starve the event loop.
+// We schedule timeouts both from before the the .on('message') handler and
+// inside of it, which both should run.
+
+const { port1, port2 } = new MessageChannel();
+let count = 0;
+port1.on('message', () => {
+  if (count === 0) {
+    setTimeout(common.mustCall(() => {
+      port1.close();
+    }), 0);
+  }
+
+  port2.postMessage(0);
+  assert(count++ < 10000, `hit ${count} loop iterations`);
+});
+
+port2.postMessage(0);
+
+setTimeout(common.mustCall(), 0);


### PR DESCRIPTION
This is a re-do of https://github.com/nodejs/node/pull/28030 that also respects another web platform test (that messages that are queued before a .close() call are also emitted).

---

Limit the number of messages processed without interruption on a
given `MessagePort` to prevent event loop starvation, but still
make sure that all messages are emitted that were already in the
queue when emitting began.

This aligns the behaviour better with the web.

Refs: https://github.com/nodejs/node/pull/28030

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
