### PR TITLE
src: make ELDHistogram a HandleWrap

### DIFF
--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -34,6 +34,7 @@ namespace node {
 #define NODE_ASYNC_NON_CRYPTO_PROVIDER_TYPES(V)                               \
   V(NONE)                                                                     \
   V(DNSCHANNEL)                                                               \
+  V(ELDHISTOGRAM)                                                             \
   V(FILEHANDLE)                                                               \
   V(FILEHANDLECLOSEREQ)                                                       \
   V(FSEVENTWRAP)                                                              \

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -126,15 +126,14 @@ void HandleWrap::OnClose(uv_handle_t* handle) {
   HandleScope scope(env->isolate());
   Context::Scope context_scope(env->context());
 
-  // The wrap object should still be there.
-  CHECK_EQ(wrap->persistent().IsEmpty(), false);
   CHECK_EQ(wrap->state_, kClosing);
 
   wrap->state_ = kClosed;
 
   wrap->OnClose();
 
-  if (wrap->object()->Has(env->context(), env->handle_onclose_symbol())
+  if (!wrap->persistent().IsEmpty() &&
+      wrap->object()->Has(env->context(), env->handle_onclose_symbol())
       .FromMaybe(false)) {
     wrap->MakeCallback(env->handle_onclose_symbol(), 0, nullptr);
   }

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -84,6 +84,17 @@ void HandleWrap::Close(Local<Value> close_callback) {
 }
 
 
+void HandleWrap::MakeWeak() {
+  persistent().SetWeak(
+      this,
+      [](const v8::WeakCallbackInfo<HandleWrap>& data) {
+        HandleWrap* handle_wrap = data.GetParameter();
+        handle_wrap->persistent().Reset();
+        handle_wrap->Close();
+      }, v8::WeakCallbackType::kParameter);
+}
+
+
 void HandleWrap::MarkAsInitialized() {
   env()->handle_wrap_queue()->PushBack(this);
   state_ = kInitialized;

--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -76,6 +76,8 @@ class HandleWrap : public AsyncWrap {
   static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
       Environment* env);
 
+  void MakeWeak();  // This hides BaseObject::MakeWeak()
+
  protected:
   HandleWrap(Environment* env,
              v8::Local<v8::Object> object,

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -123,13 +123,11 @@ class GCPerformanceEntry : public PerformanceEntry {
   PerformanceGCKind gckind_;
 };
 
-class ELDHistogram : public BaseObject, public Histogram {
+class ELDHistogram : public HandleWrap, public Histogram {
  public:
   ELDHistogram(Environment* env,
                Local<Object> wrap,
                int32_t resolution);
-
-  ~ELDHistogram() override;
 
   bool RecordDelta();
   bool Enable();
@@ -149,13 +147,13 @@ class ELDHistogram : public BaseObject, public Histogram {
   SET_SELF_SIZE(ELDHistogram)
 
  private:
-  void CloseTimer();
+  static void DelayIntervalCallback(uv_timer_t* req);
 
   bool enabled_ = false;
   int32_t resolution_ = 0;
   int64_t exceeds_ = 0;
   uint64_t prev_ = 0;
-  uv_timer_t* timer_;
+  uv_timer_t timer_;
 };
 
 }  // namespace performance

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -50,6 +50,7 @@ const { getSystemErrorName } = require('util');
     delete providers.KEYPAIRGENREQUEST;
     delete providers.HTTPCLIENTREQUEST;
     delete providers.HTTPINCOMINGMESSAGE;
+    delete providers.ELDHISTOGRAM;
 
     const objKeys = Object.keys(providers);
     if (objKeys.length > 0)


### PR DESCRIPTION
This simplifies the implementation of ELDHistogram a bit,
and more generally allows us to have weak JS references
associated with `HandleWrap`s.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
