### PR TITLE
worker: make transfer list behave like web MessagePort

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -211,6 +211,7 @@ constexpr size_t kFsStatsBufferLength =
   V(dns_soa_string, "SOA")                                                     \
   V(dns_srv_string, "SRV")                                                     \
   V(dns_txt_string, "TXT")                                                     \
+  V(done_string, "done")                                                       \
   V(duration_string, "duration")                                               \
   V(emit_warning_string, "emitWarning")                                        \
   V(encoding_string, "encoding")                                               \
@@ -272,6 +273,7 @@ constexpr size_t kFsStatsBufferLength =
   V(modulus_string, "modulus")                                                 \
   V(name_string, "name")                                                       \
   V(netmask_string, "netmask")                                                 \
+  V(next_string, "next")                                                       \
   V(nistcurve_string, "nistCurve")                                             \
   V(nsname_string, "nsname")                                                   \
   V(ocsp_request_string, "OCSPRequest")                                        \
@@ -353,6 +355,7 @@ constexpr size_t kFsStatsBufferLength =
   V(ticketkeycallback_string, "onticketkeycallback")                           \
   V(timeout_string, "timeout")                                                 \
   V(tls_ticket_string, "tlsTicket")                                            \
+  V(transfer_string, "transfer")                                               \
   V(ttl_string, "ttl")                                                         \
   V(type_string, "type")                                                       \
   V(uid_string, "uid")                                                         \

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -14,6 +14,8 @@ namespace worker {
 class MessagePortData;
 class MessagePort;
 
+typedef MaybeStackBuffer<v8::Local<v8::Value>, 8> TransferList;
+
 // Represents a single communication message.
 class Message : public MemoryRetainer {
  public:
@@ -44,7 +46,7 @@ class Message : public MemoryRetainer {
   v8::Maybe<bool> Serialize(Environment* env,
                             v8::Local<v8::Context> context,
                             v8::Local<v8::Value> input,
-                            v8::Local<v8::Value> transfer_list,
+                            const TransferList& transfer_list,
                             v8::Local<v8::Object> source_port =
                                 v8::Local<v8::Object>());
 
@@ -149,7 +151,7 @@ class MessagePort : public HandleWrap {
   // serialized with transfers, then silently discarded.
   v8::Maybe<bool> PostMessage(Environment* env,
                               v8::Local<v8::Value> message,
-                              v8::Local<v8::Value> transfer);
+                              const TransferList& transfer);
 
   // Start processing messages on this port as a receiving end.
   void Start();

--- a/test/parallel/test-worker-message-port-terminate-transfer-list.js
+++ b/test/parallel/test-worker-message-port-terminate-transfer-list.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+
+const { parentPort, MessageChannel, Worker } = require('worker_threads');
+
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
+  const w = new Worker(__filename);
+  w.once('message', common.mustCall(() => {
+    w.once('message', common.mustNotCall());
+    setTimeout(() => w.terminate(), 100);
+  }));
+} else {
+  const { port1 } = new MessageChannel();
+
+  parentPort.postMessage('ready');
+
+  // Make sure we don’t end up running JS after the infinite loop is broken.
+  port1.postMessage({}, {
+    transfer: (function*() { while (true); })()
+  });
+
+  parentPort.postMessage('UNREACHABLE');
+  process.kill(process.pid, 'SIGINT');
+}

--- a/test/parallel/test-worker-message-port.js
+++ b/test/parallel/test-worker-message-port.js
@@ -72,22 +72,81 @@ const { MessageChannel, MessagePort } = require('worker_threads');
 
 {
   const { port1, port2 } = new MessageChannel();
-  port2.on('message', common.mustCall(4));
+  port2.on('message', common.mustCall(6));
   port1.postMessage(1, null);
   port1.postMessage(2, undefined);
   port1.postMessage(3, []);
   port1.postMessage(4, {});
+  port1.postMessage(5, { transfer: undefined });
+  port1.postMessage(6, { transfer: [] });
 
   const err = {
     constructor: TypeError,
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'Optional transferList argument must be an array'
+    message: 'Optional transferList argument must be an iterable'
   };
 
   assert.throws(() => port1.postMessage(5, 0), err);
   assert.throws(() => port1.postMessage(5, false), err);
   assert.throws(() => port1.postMessage(5, 'X'), err);
   assert.throws(() => port1.postMessage(5, Symbol('X')), err);
+
+  const err2 = {
+    constructor: TypeError,
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'Optional options.transfer argument must be an iterable'
+  };
+
+  assert.throws(() => port1.postMessage(5, { transfer: null }), err2);
+  assert.throws(() => port1.postMessage(5, { transfer: 0 }), err2);
+  assert.throws(() => port1.postMessage(5, { transfer: false }), err2);
+  assert.throws(() => port1.postMessage(5, { transfer: {} }), err2);
+  assert.throws(() => port1.postMessage(5, {
+    transfer: { [Symbol.iterator]() { return {}; } }
+  }), err2);
+  assert.throws(() => port1.postMessage(5, {
+    transfer: { [Symbol.iterator]() { return { next: 42 }; } }
+  }), err2);
+  assert.throws(() => port1.postMessage(5, {
+    transfer: { [Symbol.iterator]() { return { next: null }; } }
+  }), err2);
+  port1.close();
+}
+
+{
+  // Make sure these ArrayBuffers end up detached, i.e. are actually being
+  // transferred because the transfer list provides them.
+  const { port1, port2 } = new MessageChannel();
+  port2.on('message', common.mustCall((msg) => {
+    assert.strictEqual(msg.ab.byteLength, 10);
+  }, 4));
+
+  {
+    const ab = new ArrayBuffer(10);
+    port1.postMessage({ ab }, [ ab ]);
+    assert.strictEqual(ab.byteLength, 0);
+  }
+
+  {
+    const ab = new ArrayBuffer(10);
+    port1.postMessage({ ab }, { transfer: [ ab ] });
+    assert.strictEqual(ab.byteLength, 0);
+  }
+
+  {
+    const ab = new ArrayBuffer(10);
+    port1.postMessage({ ab }, (function*() { yield ab; })());
+    assert.strictEqual(ab.byteLength, 0);
+  }
+
+  {
+    const ab = new ArrayBuffer(10);
+    port1.postMessage({ ab }, {
+      transfer: (function*() { yield ab; })()
+    });
+    assert.strictEqual(ab.byteLength, 0);
+  }
+
   port1.close();
 }
 


### PR DESCRIPTION
(The diff is a bit easier to view with whitespace diffing disabled.)

Allow generic iterables as transfer list arguments, as well
as an options object with a `transfer` option, for web compatibility.

Refs: https://github.com/nodejs/node/pull/28033#discussion_r289964991

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
