### PR TITLE
crypto: don't expose OpenSSL internals

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -713,7 +713,7 @@ class PublicKeyCipher {
   static bool Cipher(Environment* env,
                      const ManagedEVPPKey& pkey,
                      int padding,
-                     const char* oaep_hash,
+                     const EVP_MD* digest,
                      const unsigned char* data,
                      int len,
                      AllocatedBuffer* out);

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -42,6 +42,7 @@ void PrintErrorString(const char* format, ...);
   V(ERR_CONSTRUCT_CALL_REQUIRED, TypeError)                                  \
   V(ERR_CONSTRUCT_CALL_INVALID, TypeError)                                   \
   V(ERR_INVALID_ARG_VALUE, TypeError)                                        \
+  V(ERR_OSSL_EVP_INVALID_DIGEST, Error)                                      \
   V(ERR_INVALID_ARG_TYPE, TypeError)                                         \
   V(ERR_INVALID_MODULE_SPECIFIER, TypeError)                                 \
   V(ERR_INVALID_PACKAGE_CONFIG, SyntaxError)                                 \
@@ -89,6 +90,7 @@ void PrintErrorString(const char* format, ...);
   V(ERR_CONSTRUCT_CALL_REQUIRED, "Cannot call constructor without `new`")    \
   V(ERR_INVALID_TRANSFER_OBJECT, "Found invalid object in transferList")     \
   V(ERR_MEMORY_ALLOCATION_FAILED, "Failed to allocate memory")               \
+  V(ERR_OSSL_EVP_INVALID_DIGEST, "Invalid digest used")                      \
   V(ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST,                               \
     "MessagePort was found in message but not listed in transferList")       \
   V(ERR_MISSING_PLATFORM_FOR_WORKER,                                         \


### PR DESCRIPTION
https://github.com/nodejs/node/pull/28335 extended RSA-OAEP support with `oaepHash`, which works perfectly fine for OpenSSL but unfortunately is a bespoke internal for BoringSSL, and so fails to compile in Electron as BoringSSL does not expose `EVP_PKEY_OP_TYPE_CRYPT` or `EVP_PKEY_CTRL_RSA_OAEP_MD`.

OpenSSL has a macro `EVP_PKEY_CTX_set_rsa_oaep_md` that accomplished the selfsame purpose as [documented](https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_ctrl.html), and which this PR switches to in order to allow BoringSSL compilation.

Passing a bad or null digest to this new macro returns an error like `ERR_OSSL_BAD_DECODE` and as such the error i've added to `node_errors` allows for a thrown error that retains the previous context.

cc @tniessen @ryzokuken 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
