### PR TITLE
assert: add checkPrototype option for assert.deepStrictEqual()

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -261,10 +261,13 @@ parameter is undefined, a default error message is assigned. If the `message`
 parameter is an instance of an [`Error`][] then it will be thrown instead of the
 `AssertionError`.
 
-## assert.deepStrictEqual(actual, expected[, message])
+## assert.deepStrictEqual(actual, expected[, options])
 <!-- YAML
 added: v1.2.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/NNNNN
+    description: Added `checkPrototype` option.
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15169
     description: Enumerable symbol properties are now compared.
@@ -291,11 +294,22 @@ changes:
 -->
 * `actual` {any}
 * `expected` {any}
-* `message` {string|Error}
+* `options` {Object|string|Error}
+  * `checkPrototype` {boolean} Whether to check that `actual` and `expected`
+    have the same prototype. **Default:** `true`
+  * `error` {Error} Error to throw if `actual` and `expected` are not deep
+    equal. **Default:** `AssertionError`
+  * `message` {string} Message to use to replace the generated default message.
+    Ignored if `error` is specified.
 
 Tests for deep equality between the `actual` and `expected` parameters.
-"Deep" equality means that the enumerable "own" properties of child objects
-are recursively evaluated also by the following rules.
+
+If `options` is a string, it is the value of the `message` option.
+
+If `options` is an `Error` object, then it is the value of the `error` option.
+
+Enumerable "own" properties of child objects are recursively evaluated by the
+following rules.
 
 ### Comparison details
 
@@ -407,12 +421,6 @@ assert.deepStrictEqual(weakMap1, weakMap3);
 // -   unequal: true
 //   }
 ```
-
-If the values are not equal, an `AssertionError` is thrown with a `message`
-property set equal to the value of the `message` parameter. If the `message`
-parameter is undefined, a default error message is assigned. If the `message`
-parameter is an instance of an [`Error`][] then it will be thrown instead of the
-`AssertionError`.
 
 ## assert.doesNotReject(asyncFn[, error][, message])
 <!-- YAML
@@ -1278,7 +1286,7 @@ second argument. This might lead to difficult-to-spot errors.
 [`WeakMap`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
 [`WeakSet`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
 [`assert.deepEqual()`]: #assert_assert_deepequal_actual_expected_message
-[`assert.deepStrictEqual()`]: #assert_assert_deepstrictequal_actual_expected_message
+[`assert.deepStrictEqual()`]: #assert_assert_deepstrictequal_actual_expected_options
 [`assert.doesNotThrow()`]: #assert_assert_doesnotthrow_fn_error_message
 [`assert.notDeepStrictEqual()`]: #assert_assert_notdeepstrictequal_actual_expected_message
 [`assert.notStrictEqual()`]: #assert_assert_notstrictequal_actual_expected_message

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2210,7 +2210,7 @@ util.log('Timestamped message.');
 [`WeakMap`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
 [`WeakSet`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
 [`WebAssembly.Module`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
-[`assert.deepStrictEqual()`]: assert.html#assert_assert_deepstrictequal_actual_expected_message
+[`assert.deepStrictEqual()`]: assert.html#assert_assert_deepstrictequal_actual_expected_options
 [`console.error()`]: console.html#console_console_error_data_args
 [`target` and `handler`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#Terminology
 [`tty.hasColors()`]: tty.html#tty_writestream_hascolors_count_env

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -452,21 +452,29 @@ assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
 };
 /* eslint-enable */
 
-assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
-  if (arguments.length < 2) {
-    throw new ERR_MISSING_ARGS('actual', 'expected');
-  }
-  if (isDeepEqual === undefined) lazyLoadComparison();
-  if (!isDeepStrictEqual(actual, expected)) {
-    innerFail({
-      actual,
-      expected,
-      message,
-      operator: 'deepStrictEqual',
-      stackStartFn: deepStrictEqual
-    });
-  }
-};
+assert.deepStrictEqual =
+  function deepStrictEqual(actual, expected,
+                           options = { checkPrototype: true }) {
+    if (arguments.length < 2) {
+      throw new ERR_MISSING_ARGS('actual', 'expected');
+    }
+    if (isDeepEqual === undefined) lazyLoadComparison();
+    if (!isDeepStrictEqual(actual, expected, options)) {
+      let message;
+      if (typeof options === 'string' || options instanceof Error) {
+        message = options;
+      } else {
+        message = options.error || options.message;
+      }
+      innerFail({
+        actual,
+        expected,
+        message,
+        operator: 'deepStrictEqual',
+        stackStartFn: deepStrictEqual
+      });
+    }
+  };
 
 assert.notDeepStrictEqual = notDeepStrictEqual;
 function notDeepStrictEqual(actual, expected, message) {

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -42,9 +42,6 @@ const {
   }
 } = internalBinding('util');
 
-const kStrict = true;
-const kLoose = false;
-
 const kNoIterator = 0;
 const kIsArray = 1;
 const kIsSet = 2;
@@ -124,16 +121,16 @@ function isEqualBoxedPrimitive(val1, val2) {
 // a) The same built-in type tags
 // b) The same prototypes.
 
-function innerDeepEqual(val1, val2, strict, memos) {
+function innerDeepEqual(val1, val2, options, memos) {
   // All identical values are equivalent, as determined by ===.
   if (val1 === val2) {
     if (val1 !== 0)
       return true;
-    return strict ? Object.is(val1, val2) : true;
+    return options.strict ? Object.is(val1, val2) : true;
   }
 
   // Check more closely if val1 and val2 are equal.
-  if (strict) {
+  if (options.strict) {
     if (typeof val1 !== 'object') {
       return typeof val1 === 'number' && Number.isNaN(val1) &&
         Number.isNaN(val2);
@@ -141,8 +138,10 @@ function innerDeepEqual(val1, val2, strict, memos) {
     if (typeof val2 !== 'object' || val1 === null || val2 === null) {
       return false;
     }
-    if (Object.getPrototypeOf(val1) !== Object.getPrototypeOf(val2)) {
-      return false;
+    if (options.checkPrototype) {
+      if (Object.getPrototypeOf(val1) !== Object.getPrototypeOf(val2)) {
+        return false;
+      }
     }
   } else {
     if (val1 === null || typeof val1 !== 'object') {
@@ -167,16 +166,17 @@ function innerDeepEqual(val1, val2, strict, memos) {
     if (val1.length !== val2.length) {
       return false;
     }
-    const filter = strict ? ONLY_ENUMERABLE : ONLY_ENUMERABLE | SKIP_SYMBOLS;
+    const filter = options.strict ?
+      ONLY_ENUMERABLE : ONLY_ENUMERABLE | SKIP_SYMBOLS;
     const keys1 = getOwnNonIndexProperties(val1, filter);
     const keys2 = getOwnNonIndexProperties(val2, filter);
     if (keys1.length !== keys2.length) {
       return false;
     }
-    return keyCheck(val1, val2, strict, memos, kIsArray, keys1);
+    return keyCheck(val1, val2, options, memos, kIsArray, keys1);
   }
   if (val1Tag === '[object Object]') {
-    return keyCheck(val1, val2, strict, memos, kNoIterator);
+    return keyCheck(val1, val2, options, memos, kNoIterator);
   }
   if (isDate(val1)) {
     if (DatePrototype.getTime(val1) !== DatePrototype.getTime(val2)) {
@@ -193,7 +193,7 @@ function innerDeepEqual(val1, val2, strict, memos) {
       return false;
     }
   } else if (isArrayBufferView(val1)) {
-    if (!strict && (isFloat32Array(val1) || isFloat64Array(val1))) {
+    if (!options.strict && (isFloat32Array(val1) || isFloat64Array(val1))) {
       if (!areSimilarFloatArrays(val1, val2)) {
         return false;
       }
@@ -203,23 +203,24 @@ function innerDeepEqual(val1, val2, strict, memos) {
     // Buffer.compare returns true, so val1.length === val2.length. If they both
     // only contain numeric keys, we don't need to exam further than checking
     // the symbols.
-    const filter = strict ? ONLY_ENUMERABLE : ONLY_ENUMERABLE | SKIP_SYMBOLS;
+    const filter = options.strict ?
+      ONLY_ENUMERABLE : ONLY_ENUMERABLE | SKIP_SYMBOLS;
     const keys1 = getOwnNonIndexProperties(val1, filter);
     const keys2 = getOwnNonIndexProperties(val2, filter);
     if (keys1.length !== keys2.length) {
       return false;
     }
-    return keyCheck(val1, val2, strict, memos, kNoIterator, keys1);
+    return keyCheck(val1, val2, options, memos, kNoIterator, keys1);
   } else if (isSet(val1)) {
     if (!isSet(val2) || val1.size !== val2.size) {
       return false;
     }
-    return keyCheck(val1, val2, strict, memos, kIsSet);
+    return keyCheck(val1, val2, options, memos, kIsSet);
   } else if (isMap(val1)) {
     if (!isMap(val2) || val1.size !== val2.size) {
       return false;
     }
-    return keyCheck(val1, val2, strict, memos, kIsMap);
+    return keyCheck(val1, val2, options, memos, kIsMap);
   } else if (isAnyArrayBuffer(val1)) {
     if (!areEqualArrayBuffers(val1, val2)) {
       return false;
@@ -229,14 +230,14 @@ function innerDeepEqual(val1, val2, strict, memos) {
     !isEqualBoxedPrimitive(val1, val2)) {
     return false;
   }
-  return keyCheck(val1, val2, strict, memos, kNoIterator);
+  return keyCheck(val1, val2, options, memos, kNoIterator);
 }
 
 function getEnumerables(val, keys) {
   return keys.filter((k) => propertyIsEnumerable(val, k));
 }
 
-function keyCheck(val1, val2, strict, memos, iterationType, aKeys) {
+function keyCheck(val1, val2, options, memos, iterationType, aKeys) {
   // For all remaining Object pairs, including Array, objects and Maps,
   // equivalence is determined by having:
   // a) The same number of owned enumerable properties
@@ -262,7 +263,7 @@ function keyCheck(val1, val2, strict, memos, iterationType, aKeys) {
     }
   }
 
-  if (strict && arguments.length === 5) {
+  if (options.strict && arguments.length === 5) {
     const symbolKeysA = Object.getOwnPropertySymbols(val1);
     if (symbolKeysA.length !== 0) {
       let count = 0;
@@ -323,7 +324,7 @@ function keyCheck(val1, val2, strict, memos, iterationType, aKeys) {
   memos.val1.set(val1, memos.position);
   memos.val2.set(val2, memos.position);
 
-  const areEq = objEquiv(val1, val2, strict, aKeys, memos, iterationType);
+  const areEq = objEquiv(val1, val2, options, aKeys, memos, iterationType);
 
   memos.val1.delete(val1);
   memos.val2.delete(val2);
@@ -331,10 +332,10 @@ function keyCheck(val1, val2, strict, memos, iterationType, aKeys) {
   return areEq;
 }
 
-function setHasEqualElement(set, val1, strict, memo) {
+function setHasEqualElement(set, val1, options, memo) {
   // Go looking.
   for (const val2 of set) {
-    if (innerDeepEqual(val1, val2, strict, memo)) {
+    if (innerDeepEqual(val1, val2, options, memo)) {
       // Remove the matching element to make sure we do not check that again.
       set.delete(val2);
       return true;
@@ -390,7 +391,7 @@ function mapMightHaveLoosePrim(a, b, prim, item, memo) {
   return !a.has(altValue) && innerDeepEqual(item, curB, false, memo);
 }
 
-function setEquiv(a, b, strict, memo) {
+function setEquiv(a, b, options, memo) {
   // This is a lazily initiated Set of entries which have to be compared
   // pairwise.
   let set = null;
@@ -408,7 +409,7 @@ function setEquiv(a, b, strict, memo) {
       // O(n log n) complexity we have to copy these values in a new set first.
       set.add(val);
     } else if (!b.has(val)) {
-      if (strict)
+      if (options.strict)
         return false;
 
       // Fast path to detect missing string, symbol, undefined and null values.
@@ -428,11 +429,11 @@ function setEquiv(a, b, strict, memo) {
       // We have to check if a primitive value is already
       // matching and only if it's not, go hunting for it.
       if (typeof val === 'object' && val !== null) {
-        if (!setHasEqualElement(set, val, strict, memo))
+        if (!setHasEqualElement(set, val, options, memo))
           return false;
-      } else if (!strict &&
+      } else if (!options.strict &&
                  !a.has(val) &&
-                 !setHasEqualElement(set, val, strict, memo)) {
+                 !setHasEqualElement(set, val, options, memo)) {
         return false;
       }
     }
@@ -442,13 +443,13 @@ function setEquiv(a, b, strict, memo) {
   return true;
 }
 
-function mapHasEqualEntry(set, map, key1, item1, strict, memo) {
+function mapHasEqualEntry(set, map, key1, item1, options, memo) {
   // To be able to handle cases like:
   //   Map([[{}, 'a'], [{}, 'b']]) vs Map([[{}, 'b'], [{}, 'a']])
   // ... we need to consider *all* matching keys, not just the first we find.
   for (const key2 of set) {
-    if (innerDeepEqual(key1, key2, strict, memo) &&
-      innerDeepEqual(item1, map.get(key2), strict, memo)) {
+    if (innerDeepEqual(key1, key2, options, memo) &&
+      innerDeepEqual(item1, map.get(key2), options, memo)) {
       set.delete(key2);
       return true;
     }
@@ -457,7 +458,7 @@ function mapHasEqualEntry(set, map, key1, item1, strict, memo) {
   return false;
 }
 
-function mapEquiv(a, b, strict, memo) {
+function mapEquiv(a, b, options, memo) {
   let set = null;
 
   for (const [key, item1] of a) {
@@ -471,8 +472,8 @@ function mapEquiv(a, b, strict, memo) {
       // almost all possible cases.
       const item2 = b.get(key);
       if ((item2 === undefined && !b.has(key) ||
-          !innerDeepEqual(item1, item2, strict, memo))) {
-        if (strict)
+          !innerDeepEqual(item1, item2, options, memo))) {
+        if (options.strict)
           return false;
         // Fast path to detect missing string, symbol, undefined and null
         // keys.
@@ -489,9 +490,9 @@ function mapEquiv(a, b, strict, memo) {
   if (set !== null) {
     for (const [key, item] of b) {
       if (typeof key === 'object' && key !== null) {
-        if (!mapHasEqualEntry(set, a, key, item, strict, memo))
+        if (!mapHasEqualEntry(set, a, key, item, options, memo))
           return false;
-      } else if (!strict &&
+      } else if (!options.strict &&
                  (!a.has(key) ||
                    !innerDeepEqual(a.get(key), item, false, memo)) &&
                  !mapHasEqualEntry(set, a, key, item, false, memo)) {
@@ -504,24 +505,24 @@ function mapEquiv(a, b, strict, memo) {
   return true;
 }
 
-function objEquiv(a, b, strict, keys, memos, iterationType) {
+function objEquiv(a, b, options, keys, memos, iterationType) {
   // Sets and maps don't have their entries accessible via normal object
   // properties.
   let i = 0;
 
   if (iterationType === kIsSet) {
-    if (!setEquiv(a, b, strict, memos)) {
+    if (!setEquiv(a, b, options, memos)) {
       return false;
     }
   } else if (iterationType === kIsMap) {
-    if (!mapEquiv(a, b, strict, memos)) {
+    if (!mapEquiv(a, b, options, memos)) {
       return false;
     }
   } else if (iterationType === kIsArray) {
     for (; i < a.length; i++) {
       if (hasOwnProperty(a, i)) {
         if (!hasOwnProperty(b, i) ||
-            !innerDeepEqual(a[i], b[i], strict, memos)) {
+            !innerDeepEqual(a[i], b[i], options, memos)) {
           return false;
         }
       } else if (hasOwnProperty(b, i)) {
@@ -532,7 +533,7 @@ function objEquiv(a, b, strict, keys, memos, iterationType) {
         for (; i < keysA.length; i++) {
           const key = keysA[i];
           if (!hasOwnProperty(b, key) ||
-              !innerDeepEqual(a[key], b[key], strict, memos)) {
+              !innerDeepEqual(a[key], b[key], options, memos)) {
             return false;
           }
         }
@@ -548,7 +549,7 @@ function objEquiv(a, b, strict, keys, memos, iterationType) {
   // Possibly expensive deep test:
   for (i = 0; i < keys.length; i++) {
     const key = keys[i];
-    if (!innerDeepEqual(a[key], b[key], strict, memos)) {
+    if (!innerDeepEqual(a[key], b[key], options, memos)) {
       return false;
     }
   }
@@ -556,11 +557,12 @@ function objEquiv(a, b, strict, keys, memos, iterationType) {
 }
 
 function isDeepEqual(val1, val2) {
-  return innerDeepEqual(val1, val2, kLoose);
+  return innerDeepEqual(val1, val2, { strict: false });
 }
 
-function isDeepStrictEqual(val1, val2) {
-  return innerDeepEqual(val1, val2, kStrict);
+function isDeepStrictEqual(val1, val2, options = { checkPrototype: true }) {
+  return innerDeepEqual(
+    val1, val2, { strict: true, checkPrototype: options.checkPrototype });
 }
 
 module.exports = {

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -55,6 +55,7 @@ assert.throws(
              '- Buffer [Uint8Array] [\n    120,\n...\n    122,\n    10\n  ]'
   }
 );
+assert.deepStrictEqual(arr, buf, { checkPrototype: false });
 assert.deepEqual(arr, buf);
 
 {
@@ -1122,4 +1123,42 @@ assert.throws(
 
   // The descriptor is not compared.
   assertDeepAndStrictEqual(a, { a: 5 });
+}
+
+// Test `message` option.
+{
+  assert.throws(
+    () => { assert.deepStrictEqual('a', 'b', { message: 'fhqwhgads' }); },
+    { code: 'ERR_ASSERTION', name: 'AssertionError', message: 'fhqwhgads' }
+  );
+}
+
+// Test `error` option.
+{
+  assert.throws(
+    () => {
+      assert.deepStrictEqual('a', 'b', { error: new Error('fhqwhgads') });
+    }, new Error('fhqwhgads'));
+}
+
+// Test that the `message` option ignored if the `error` options is supplied.
+{
+  assert.throws(
+    () => {
+      assert.deepStrictEqual(
+        'a', 'b', { error: new Error('fhqwhgads'), message: 'come on' }
+      );
+    }, new Error('fhqwhgads'));
+}
+
+// Test `checkPrototype` option.
+{
+  // `obj1` and `obj2` have different prototypes.
+  const obj1 = {};
+  const obj2 = Object.create(obj1);
+  assert.throws(() => {
+    assert.deepStrictEqual(obj1, obj2, { checkPrototype: true });
+  }, { code: 'ERR_ASSERTION', name: 'AssertionError' });
+
+  assert.deepStrictEqual(obj1, obj2, { checkPrototype: false });
 }


### PR DESCRIPTION
Allow usage of assert.deepStrictEqual() without prototype checks.

Refs: https://github.com/nodejs/node/pull/28011

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
