### PR TITLE
tools: consistent perms of signed release files

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -144,6 +144,7 @@ function sign {
 
     if [ "X${yorn}" == "Xy" ]; then
       scp ${customsshkey} ${tmpdir}/${shafile} ${tmpdir}/${shafile}.asc ${tmpdir}/${shafile}.sig ${webuser}@${webhost}:${shadir}/
+      ssh ${customsshkey} ${webuser}@${webhost} chmod 644 ${shadir}/${shafile}.asc ${shadir}/${shafile}.sig
       break
     fi
   done


### PR DESCRIPTION
Fixes: https://github.com/nodejs/build/issues/1904

v12.9.1 went out with .sig and .asc files mode 600 so were `403 Forbidden`. I believe this is because file permissions are simply copied from what they were when the releaser makes the signature files. All other files in the release directory are already 644 just prior to signing and uploading signed files: https://github.com/nodejs/build/blob/f95ffc8d7d9930f1bc9505b016fdd84711916759/setup/www/tools/promote/_resha.sh#L25-L26

This is only testable by a releaser so I'd appreciate the next person doing a release to run this copy of tools/release.sh rather than the one currently on master & v12.x. Once we confirm the release is 👍 we can merge this and make sure it's on all active release branches. @nodejs/releasers.