### PR TITLE
child_process: remove use of stream private state

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -298,8 +298,7 @@ function flushStdio(subprocess) {
     // which data can be read from a stream, e.g. being consumed on the
     // native layer directly as a StreamBase.
     if (!stream || !stream.readable ||
-        stream._readableState.readableListening ||
-        stream[kIsUsedAsStdio]) {
+      stream[kIsUsedAsStdio]) {
       continue;
     }
     stream.resume();

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -297,8 +297,7 @@ function flushStdio(subprocess) {
     // TODO(addaleax): This doesn't necessarily account for all the ways in
     // which data can be read from a stream, e.g. being consumed on the
     // native layer directly as a StreamBase.
-    if (!stream || !stream.readable ||
-      stream[kIsUsedAsStdio]) {
+    if (!stream || !stream.readable || stream[kIsUsedAsStdio]) {
       continue;
     }
     stream.resume();


### PR DESCRIPTION
In child_process.js [L#301](https://github.com/nodejs/node/blob/master/lib/internal/child_process.js#L301), the state `stream._readableState.readableListening` is used to determine if any paused stdio streams exist, and if so, the  `resume()` method is used to flush it. Checking this state seems unnecessary as the `resume()` method has no effect on the streams subscribed with `readable` event. Also, all existing tests pass even after removing it.  

If this is correct analysis, this PR includes change as part of the issue #445, to remove direct references to internal state of the stream implementation. 

cc:  @addaleax @mcollina
 
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
