### PR TITLE
build: add full Python 3 tests to Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,18 @@ language: cpp
 env:
   global:
     - PYTHON2_VERSION="2.7.15"
-    - PYTHON3_VERSION="3.6.7"  # "3.7.1" after #29326 us fixed
+    - PYTHON3_VERSION="3.6.7"  # "3.7.1" after #29326 is fixed
+    - PYTHON2_CACHE=$HOME/.ccache/py${PYTHON2_VERSION}
+    - PYTHON3_CACHE=$HOME/.ccache/py${PYTHON3_VERSION}
+cache:
+  ccache: true
+  directories:
+    - ${PYTHON2_CACHE}
+    - ${PYTHON3_CACHE}
 jobs:
   include:
     - stage: "Compile"
       name: "Compile V8 (py2)"
-      cache:
-        ccache: true
-        directories:
-          - $HOME/.ccache/py${PYTHON2_VERSION}
       addons:
         apt:
           sources:
@@ -31,11 +34,6 @@ jobs:
         - make -j2 -C out V=1 v8
 
     - name: "Compile V8 (py3)"
-      cache:
-        ccache: true
-        directories:
-          - $HOME/.ccache/py${PYTHON3_VERSION}
-
       addons:
         apt:
           sources:
@@ -50,11 +48,6 @@ jobs:
         - make -j2 -C out V=1 v8
 
     - name: "Compile Node.js (py2)"
-      cache:
-        ccache: true
-        directories:
-          - $HOME/.ccache/py${PYTHON2_VERSION}
-
       addons:
         apt:
           sources:
@@ -66,16 +59,10 @@ jobs:
         - pyenv global ${PYTHON2_VERSION}
         - ./configure
         - make -j2 V=1
-        - mkdir -p $HOME/.ccache/py${PYTHON2_VERSION}
-        - cp out/Release/node $HOME/.ccache/py${PYTHON2_VERSION}
-        - cp out/Release/cctest $HOME/.ccache/py${PYTHON2_VERSION}
-        - ls -lr $HOME/.ccache
+        - cp out/Release/node ${PYTHON2_CACHE}
+        - cp out/Release/cctest ${PYTHON2_CACHE}
 
     - name: "Compile Node.js (py3)"
-      cache:
-        ccache: true
-        directories:
-          - $HOME/.ccache/py${PYTHON3_VERSION}
       addons:
         apt:
           sources:
@@ -88,50 +75,36 @@ jobs:
         # - ./configure  # workaround pending #25878
         - python3 configure.py
         - make -j2 V=1
-        - mkdir -p $HOME/.ccache/py${PYTHON3_VERSION}
-        - cp out/Release/node $HOME/.ccache/py${PYTHON3_VERSION}
-        - cp out/Release/cctest $HOME/.ccache/py${PYTHON3_VERSION}
-        - ls -lr $HOME/.ccache
+        - cp out/Release/node ${PYTHON3_CACHE}
+        - cp out/Release/cctest ${PYTHON3_CACHE}
 
     - stage: "Tests"
       name: "Test JS Suites (py2)"
-      cache:
-        ccache: true
-        directories:
-          - $HOME/.ccache/py${PYTHON2_VERSION}
       install:
         - mkdir -p out/Release
-        - cp $HOME/.ccache/py${PYTHON2_VERSION}/node out/Release/node
+        - cp ${PYTHON2_CACHE}/node out/Release/node
       script:
         - pyenv global ${PYTHON2_VERSION}
         - python tools/test.py -j 2 -p dots --report --mode=release --flaky-tests=dontcare default
 
     - name: "Test JS Suites (py3)"
-      cache:
-        ccache: true
-        directories:
-          - $HOME/.ccache/py${PYTHON3_VERSION}
       install:
         - mkdir -p out/Release
-        - cp $HOME/.ccache/py${PYTHON3_VERSION}/node out/Release/node
+        - cp ${PYTHON3_CACHE}/node out/Release/node
       script:
         - pyenv global ${PYTHON3_VERSION}
         - python tools/test.py -j 2 -p dots --report --mode=release --flaky-tests=dontcare default
 
     - name: "Test C++ Suites (py2)"
-      cache:
-        ccache: true
-        directories:
-          - $HOME/.ccache/py${PYTHON2_VERSION}
       install:
         - export CCACHE_NOSTATS=1
         - export CCACHE_SLOPPINESS="file_macro,include_file_mtime,include_file_ctime,time_macros,file_stat_matches"
         - export CC='ccache gcc'
         - export CXX='ccache g++'
         - mkdir -p out/Release
-        - cp $HOME/.ccache/py${PYTHON2_VERSION}/node out/Release/node
+        - cp ${PYTHON2_CACHE}/node out/Release/node
         - ln -fs out/Release/node node
-        - cp $HOME/.ccache/py${PYTHON2_VERSION}/cctest out/Release/cctest
+        - cp ${PYTHON2_CACHE}/cctest out/Release/cctest
         - touch config.gypi
       script:
         - pyenv global ${PYTHON2_VERSION}
@@ -140,19 +113,15 @@ jobs:
         - python tools/test.py -j 2 -p dots --report --mode=release --flaky-tests=dontcare addons js-native-api node-api
 
     - name: "Test C++ Suites (py3)"
-      cache:
-        ccache: true
-        directories:
-          - $HOME/.ccache/py${PYTHON3_VERSION}
       install:
         - export CCACHE_NOSTATS=1
         - export CCACHE_SLOPPINESS="file_macro,include_file_mtime,include_file_ctime,time_macros,file_stat_matches"
         - export CC='ccache gcc'
         - export CXX='ccache g++'
         - mkdir -p out/Release
-        - cp $HOME/.ccache/py${PYTHON3_VERSION}/node out/Release/node
+        - cp ${PYTHON3_CACHE}/node out/Release/node
         - ln -fs out/Release/node node
-        - cp $HOME/.ccache/py${PYTHON3_VERSION}/cctest out/Release/cctest
+        - cp ${PYTHON3_CACHE}/cctest out/Release/cctest
         - touch config.gypi
       script:
         - pyenv global ${PYTHON3_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ env:
   global:
     - PYTHON2_VERSION="2.7.15"
     - PYTHON3_VERSION="3.6.7"  # "3.7.1" after #29326 us fixed
-cache:
-    directories:
-     - $HOME/.rvm/
 jobs:
   include:
     - stage: "Compile"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
       name: "Compile V8 (py2)"
       addons:
         apt:
+          update: true
           sources:
             - ubuntu-toolchain-r-test
           packages:
@@ -36,6 +37,7 @@ jobs:
     - name: "Compile V8 (py3)"
       addons:
         apt:
+          update: true
           sources:
             - ubuntu-toolchain-r-test
           packages:
@@ -50,6 +52,7 @@ jobs:
     - name: "Compile Node.js (py2)"
       addons:
         apt:
+          update: true
           sources:
             - ubuntu-toolchain-r-test
           packages:
@@ -65,6 +68,7 @@ jobs:
     - name: "Compile Node.js (py3)"
       addons:
         apt:
+          update: true
           sources:
             - ubuntu-toolchain-r-test
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,19 @@ os: linux
 language: cpp
 env:
   global:
-    - PYTHON_VERSION="2.7.15"
+    - PYTHON2_VERSION="2.7.15"
+    - PYTHON3_VERSION="3.6.7"  # "3.7.1" after #29326 us fixed
+cache:
+    directories:
+     - $HOME/.rvm/
 jobs:
   include:
     - stage: "Compile"
-      name: "Compile V8"
-      cache: ccache
+      name: "Compile V8 (py2)"
+      cache:
+        ccache: true
+        directories:
+          - $HOME/.ccache/py${PYTHON2_VERSION}
       addons:
         apt:
           sources:
@@ -22,12 +29,16 @@ jobs:
             - g++-6
       install: *ccache-setup-steps
       script:
-        - pyenv global ${PYTHON_VERSION}
+        - pyenv global ${PYTHON2_VERSION}
         - ./configure
         - make -j2 -C out V=1 v8
 
-    - name: "Compile Node.js"
-      cache: ccache
+    - name: "Compile V8 (py3)"
+      cache:
+        ccache: true
+        directories:
+          - $HOME/.ccache/py${PYTHON3_VERSION}
+
       addons:
         apt:
           sources:
@@ -36,45 +47,136 @@ jobs:
             - g++-6
       install: *ccache-setup-steps
       script:
-        - pyenv global ${PYTHON_VERSION}
+        - pyenv global ${PYTHON3_VERSION}
+        # - ./configure  # workaround pending #25878
+        - python3 configure.py
+        - make -j2 -C out V=1 v8
+
+    - name: "Compile Node.js (py2)"
+      cache:
+        ccache: true
+        directories:
+          - $HOME/.ccache/py${PYTHON2_VERSION}
+
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      install: *ccache-setup-steps
+      script:
+        - pyenv global ${PYTHON2_VERSION}
         - ./configure
         - make -j2 V=1
-        - cp out/Release/node /home/travis/.ccache
-        - cp out/Release/cctest /home/travis/.ccache
+        - mkdir -p $HOME/.ccache/py${PYTHON2_VERSION}
+        - cp out/Release/node $HOME/.ccache/py${PYTHON2_VERSION}
+        - cp out/Release/cctest $HOME/.ccache/py${PYTHON2_VERSION}
+        - ls -lr $HOME/.ccache
+
+    - name: "Compile Node.js (py3)"
+      cache:
+        ccache: true
+        directories:
+          - $HOME/.ccache/py${PYTHON3_VERSION}
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      install: *ccache-setup-steps
+      script:
+        - pyenv global ${PYTHON3_VERSION}
+        # - ./configure  # workaround pending #25878
+        - python3 configure.py
+        - make -j2 V=1
+        - mkdir -p $HOME/.ccache/py${PYTHON3_VERSION}
+        - cp out/Release/node $HOME/.ccache/py${PYTHON3_VERSION}
+        - cp out/Release/cctest $HOME/.ccache/py${PYTHON3_VERSION}
+        - ls -lr $HOME/.ccache
 
     - stage: "Tests"
-      name: "Test JS Suites"
-      cache: ccache
+      name: "Test JS Suites (py2)"
+      cache:
+        ccache: true
+        directories:
+          - $HOME/.ccache/py${PYTHON2_VERSION}
       install:
         - mkdir -p out/Release
-        - cp /home/travis/.ccache/node out/Release/node
+        - cp $HOME/.ccache/py${PYTHON2_VERSION}/node out/Release/node
       script:
-        - pyenv global ${PYTHON_VERSION}
+        - pyenv global ${PYTHON2_VERSION}
         - python tools/test.py -j 2 -p dots --report --mode=release --flaky-tests=dontcare default
 
-    - name: "Test C++ Suites"
-      cache: ccache
+    - name: "Test JS Suites (py3)"
+      cache:
+        ccache: true
+        directories:
+          - $HOME/.ccache/py${PYTHON3_VERSION}
+      install:
+        - mkdir -p out/Release
+        - cp $HOME/.ccache/py${PYTHON3_VERSION}/node out/Release/node
+      script:
+        - pyenv global ${PYTHON3_VERSION}
+        - python tools/test.py -j 2 -p dots --report --mode=release --flaky-tests=dontcare default
+
+    - name: "Test C++ Suites (py2)"
+      cache:
+        ccache: true
+        directories:
+          - $HOME/.ccache/py${PYTHON2_VERSION}
       install:
         - export CCACHE_NOSTATS=1
         - export CCACHE_SLOPPINESS="file_macro,include_file_mtime,include_file_ctime,time_macros,file_stat_matches"
         - export CC='ccache gcc'
         - export CXX='ccache g++'
         - mkdir -p out/Release
-        - cp /home/travis/.ccache/node out/Release/node
+        - cp $HOME/.ccache/py${PYTHON2_VERSION}/node out/Release/node
         - ln -fs out/Release/node node
-        - cp /home/travis/.ccache/cctest out/Release/cctest
+        - cp $HOME/.ccache/py${PYTHON2_VERSION}/cctest out/Release/cctest
         - touch config.gypi
       script:
-        - pyenv global ${PYTHON_VERSION}
+        - pyenv global ${PYTHON2_VERSION}
         - out/Release/cctest
         - make -j1 V=1 test/addons/.buildstamp test/js-native-api/.buildstamp test/node-api/.buildstamp
         - python tools/test.py -j 2 -p dots --report --mode=release --flaky-tests=dontcare addons js-native-api node-api
 
-    - name: "Linter"
+    - name: "Test C++ Suites (py3)"
+      cache:
+        ccache: true
+        directories:
+          - $HOME/.ccache/py${PYTHON3_VERSION}
+      install:
+        - export CCACHE_NOSTATS=1
+        - export CCACHE_SLOPPINESS="file_macro,include_file_mtime,include_file_ctime,time_macros,file_stat_matches"
+        - export CC='ccache gcc'
+        - export CXX='ccache g++'
+        - mkdir -p out/Release
+        - cp $HOME/.ccache/py${PYTHON3_VERSION}/node out/Release/node
+        - ln -fs out/Release/node node
+        - cp $HOME/.ccache/py${PYTHON3_VERSION}/cctest out/Release/cctest
+        - touch config.gypi
+      script:
+        - pyenv global ${PYTHON3_VERSION}
+        - out/Release/cctest
+        - make -j1 V=1 test/addons/.buildstamp test/js-native-api/.buildstamp test/node-api/.buildstamp
+        - python tools/test.py -j 2 -p dots --report --mode=release --flaky-tests=dontcare addons js-native-api node-api
+
+    - name: "Linter (py2)"
       language: node_js
       node_js: "node"
       install:
-        - pyenv global ${PYTHON_VERSION}
+        - pyenv global ${PYTHON2_VERSION}
+        - make lint-py-build || true
+      script:
+        - NODE=$(which node) make lint lint-py
+
+    - name: "Linter (py3)"
+      language: node_js
+      node_js: "node"
+      install:
+        - pyenv global ${PYTHON3_VERSION}
         - make lint-py-build || true
       script:
         - NODE=$(which node) make lint lint-py
@@ -88,30 +190,5 @@ jobs:
             bash -x tools/lint-pr-commit-message.sh ${TRAVIS_PULL_REQUEST};
           fi
 
-    - name: "Python 3 is EXPERIMENTAL (Py36)"
-      language: node_js
-      node_js: "node"
-      install:
-        - pyenv global 3.6.7
-        - python3.6 -m pip install --upgrade pip
-        - make lint-py-build
-      script:
-        - NODE=$(which node) make lint lint-py
-        - python3.6 ./configure.py
-        - NODE=$(which node) make test
-
-    - name: "Python 3 is EXPERIMENTAL (Py37)"
-      language: node_js
-      node_js: "node"
-      install:
-        - pyenv global 3.7.1
-        - python3.7 -m pip install --upgrade pip
-        - make lint-py-build
-      script:
-        - NODE=$(which node) make lint lint-py
-        - python3.7 ./configure.py
-        - NODE=$(which node) make test
-
   allow_failures:
-    - name: "Python 3 is EXPERIMENTAL (Py36)"
-    - name: "Python 3 is EXPERIMENTAL (Py37)"
+    - name: "Test C++ Suites (py3)"  # allow_failures pending #29246


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
This PR significantly reduces our Travis CI build times and provides better test coverage.

Remove the former, incomplete Travis CI runs on Python 3.6 and 3.7 and replace them with the full 5 stage pipeline running on both Python 2.7 and 3.6.

The Python 3.6 tests pass all runs except __Test C++ Suites (py3)__ as discussed in #29246 and the Python 3.6 run can be replaced with a Python 3.7 run when #29346 or similar has landed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
