### PR TITLE
tools: update paths in v8_external_snapshot.gypi

### DIFF
--- a/tools/v8_gypfiles/v8_external_snapshot.gypi
+++ b/tools/v8_gypfiles/v8_external_snapshot.gypi
@@ -1,4 +1,3 @@
-# Keeping this separate since Node.js does use it
 {
   'targets': [
     {
@@ -36,8 +35,8 @@
             'v8_base',
           ],
           'sources': [
-            '<(V8_ROOT)/src/setup-isolate-deserialize.cc',
-            '<(V8_ROOT)/src/snapshot/embedded-empty.cc',
+            '<(V8_ROOT)/src/init/setup-isolate-deserialize.cc',
+            '<(V8_ROOT)/src/snapshot/embedded/embedded-empty.cc',
             '<(V8_ROOT)/src/snapshot/natives-external.cc',
             '<(V8_ROOT)/src/snapshot/snapshot-external.cc',
             '<(embedded_builtins_snapshot_src)',


### PR DESCRIPTION
Update the paths to source files in v8_external_snapshot.gypi this was
broken and went unnoticed since this target is never really built by
default.

Fixes: https://github.com/nodejs/node/issues/28964

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

/cc @refack @gengjiawen 

I'm not sure how relevant this is and if CI can even check for this. Maybe we should consider just removing this target at some point?