### PR TITLE
deps: V8: cherry-pick 597f885

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     ##### V8 defaults for Node.js #####
 


### PR DESCRIPTION
This backports @schuay's fix in V8 that addresses missing function coverage.

## The Bug

This bug only occurred on certain OSes, and manifested itself as follows:

1. A function's coverage information can be tracked multiple times in memory (I don't believe we've figured out the root cause of this yet).
1. If you have < `N` functions in your script file, functions with coverage information are listed first. 
1. as soon as you have > `N` functions in a script file, sorting swaps and, due to an optimization, all block coverage is dropped for a function (because we see that the function itself has no coverage).

## The Fix

We now sort functions before applying the optimization of dropping block coverage.

This is difficult to write tests for, because it appears to be architecture dependent but @shuay has been able to confirm the patch (@shuay I don't suppose I could also get you to test against this branch). 

see: https://github.com/nodejs/node/issues/27566