### PR TITLE
build: hard code doctool in test-doc target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -604,7 +604,7 @@ test-doc: doc-only ## Builds, lints, and verifies the docs.
 		echo "Skipping test-doc (no crypto)"; \
 	else \
 		$(MAKE) lint; \
-		$(PYTHON) tools/test.py $(PARALLEL_ARGS) $(CI_DOC); \
+		$(PYTHON) tools/test.py $(PARALLEL_ARGS) doctool; \
 	fi
 
 test-known-issues: all


### PR DESCRIPTION
This commit removes the usage of the `CI_DOC` variable in the `test-doc`
recipe and specifies the `doctool` argument to tools/test.py explicitly.

The motivation for this is that the build is taking longer time and
this is mostly due to tests being run twice as the CI_DOC
variable will be empty in most cases (when not using --without-ssl).

This change was introduced with/after Commit
9039af83a33af870a074463a0e8d79a0cb95d14c ("build: skip test-ci doc
targets if no crypto") and while I though it might make sense to change
the setting of CI_DOC I not sure about the implications that might have
to our CI environment. It currently looks like this:
```makefile
ifeq ($(node_use_openssl), false)
        CI_DOC := doctool
else
        CI_DOC =
endif
```
Which is setting CI_DOC to doctool if there is no crypto support which
not available. But perhaps this should be be the other way around,
changing the order or updating condition to be true.

@nodejs/build @nodejs/build-files 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
