### PR TITLE
stream: don't deadlock on aborted stream

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -82,12 +82,17 @@ function eos(stream, opts, callback) {
     stream.on('close', onlegacyfinish);
   }
 
+  if (typeof stream.aborted === 'boolean') {
+    stream.on('aborted', onclose);
+  }
+
   stream.on('end', onend);
   stream.on('finish', onfinish);
   if (opts.error !== false) stream.on('error', onerror);
   stream.on('close', onclose);
 
   return function() {
+    stream.removeListener('aborted', onclose);
     stream.removeListener('complete', onfinish);
     stream.removeListener('abort', onclose);
     stream.removeListener('request', onrequest);

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -82,6 +82,7 @@ function eos(stream, opts, callback) {
     stream.on('close', onlegacyfinish);
   }
 
+  // Not all streams will emit 'close' after 'aborted'.
   if (typeof stream.aborted === 'boolean') {
     stream.on('aborted', onclose);
   }

--- a/test/parallel/test-http-client-finished.js
+++ b/test/parallel/test-http-client-finished.js
@@ -4,20 +4,20 @@ const http = require('http');
 const { finished } = require('stream')
 
 {
-  // abort before finished
+  // Test abort before finished.
 
   const server = http.createServer(function(req, res) {
-    res.write('asd')
+    res.write('asd');
   });
 
   server.listen(0, common.mustCall(function() {
-    const req = http.request({
+    http.request({
       port: this.address().port
     })
     .on('response', res => {
-      res.on('readable', () => (
-        res.destroy()
-      ));
+      res.on('readable', () => {
+        res.destroy();
+      });
       finished(res, common.mustCall(() => {
         server.close();
       }));

--- a/test/parallel/test-http-client-finished.js
+++ b/test/parallel/test-http-client-finished.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
 const http = require('http');
-const { finished } = require('stream')
+const { finished } = require('stream');
 
 {
   // Test abort before finished.
@@ -14,7 +14,7 @@ const { finished } = require('stream')
     http.request({
       port: this.address().port
     })
-    .on('response', res => {
+    .on('response', (res) => {
       res.on('readable', () => {
         res.destroy();
       });

--- a/test/parallel/test-http-client-finished.js
+++ b/test/parallel/test-http-client-finished.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const { finished } = require('stream')
+
+{
+  // abort before finished
+
+  const server = http.createServer(function(req, res) {
+    res.write('asd')
+  });
+
+  server.listen(0, common.mustCall(function() {
+    const req = http.request({
+      port: this.address().port
+    })
+    .on('response', res => {
+      res.on('readable', () => (
+        res.destroy()
+      ));
+      finished(res, common.mustCall(() => {
+        server.close();
+      }));
+    })
+    .end();
+  }));
+}


### PR DESCRIPTION
Not all streams (e.g. http.ClientRequest) will always emit `'close'` after `'aborted'`.

Noticed this while fixing some stuff in fastify. I think the root issue will be fixed by https://github.com/nodejs/node/pull/27984. But I still think it's a good idea to have this fix/workaround in the npm stream-readable package for older node versions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
