### PR TITLE
tools: update ESLint to 6.3.0

### DIFF
--- a/tools/node_modules/eslint/README.md
+++ b/tools/node_modules/eslint/README.md
@@ -1,5 +1,6 @@
 [![NPM version][npm-image]][npm-url]
 [![Build Status](https://dev.azure.com/eslint/eslint/_apis/build/status/eslint.eslint?branchName=master)](https://dev.azure.com/eslint/eslint/_build/latest?definitionId=1&branchName=master)
+[![Build Status](https://github.com/eslint/eslint/workflows/CI/badge.svg)](https://github.com/eslint/eslint/actions)
 [![Downloads][downloads-image]][downloads-url]
 [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=282608)](https://www.bountysource.com/trackers/282608-eslint?utm_source=282608&utm_medium=shield&utm_campaign=TRACKER_BADGE)
 [![Join the chat at https://gitter.im/eslint/eslint](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/eslint/eslint?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/tools/node_modules/eslint/conf/config-schema.js
+++ b/tools/node_modules/eslint/conf/config-schema.js
@@ -21,6 +21,7 @@ const baseConfigProperties = {
     rules: { type: "object" },
     settings: { type: "object" },
     noInlineConfig: { type: "boolean" },
+    reportUnusedDisableDirectives: { type: "boolean" },
 
     ecmaFeatures: { type: "object" } // deprecated; logs a warning when used
 };

--- a/tools/node_modules/eslint/conf/default-cli-options.js
+++ b/tools/node_modules/eslint/conf/default-cli-options.js
@@ -26,6 +26,6 @@ module.exports = {
     cacheFile: ".eslintcache",
     fix: false,
     allowInlineConfig: true,
-    reportUnusedDisableDirectives: false,
+    reportUnusedDisableDirectives: void 0,
     globInputPaths: true
 };

--- a/tools/node_modules/eslint/lib/cli-engine/config-array-factory.js
+++ b/tools/node_modules/eslint/lib/cli-engine/config-array-factory.js
@@ -531,6 +531,7 @@ class ConfigArrayFactory {
             parserOptions,
             plugins: pluginList,
             processor,
+            reportUnusedDisableDirectives,
             root,
             rules,
             settings,
@@ -573,6 +574,7 @@ class ConfigArrayFactory {
             parserOptions,
             plugins,
             processor,
+            reportUnusedDisableDirectives,
             root,
             rules,
             settings

--- a/tools/node_modules/eslint/lib/cli-engine/config-array/config-array.js
+++ b/tools/node_modules/eslint/lib/cli-engine/config-array/config-array.js
@@ -59,6 +59,7 @@ const { ExtractedConfig } = require("./extracted-config");
  * @property {Object|undefined} parserOptions The parser options.
  * @property {Record<string, DependentPlugin>|undefined} plugins The plugin loaders.
  * @property {string|undefined} processor The processor name to refer plugin's processor.
+ * @property {boolean|undefined} reportUnusedDisableDirectives The flag to report unused `eslint-disable` comments.
  * @property {boolean|undefined} root The flag to express root.
  * @property {Record<string, RuleConf>|undefined} rules The rule settings
  * @property {Object|undefined} settings The shared settings.
@@ -255,6 +256,11 @@ function createConfig(instance, indices) {
         if (config.noInlineConfig === void 0 && element.noInlineConfig !== void 0) {
             config.noInlineConfig = element.noInlineConfig;
             config.configNameOfNoInlineConfig = element.name;
+        }
+
+        // Adopt the reportUnusedDisableDirectives which was found at first.
+        if (config.reportUnusedDisableDirectives === void 0 && element.reportUnusedDisableDirectives !== void 0) {
+            config.reportUnusedDisableDirectives = element.reportUnusedDisableDirectives;
         }
 
         // Merge others.

--- a/tools/node_modules/eslint/lib/cli-engine/config-array/extracted-config.js
+++ b/tools/node_modules/eslint/lib/cli-engine/config-array/extracted-config.js
@@ -78,6 +78,12 @@ class ExtractedConfig {
         this.processor = null;
 
         /**
+         * The flag that reports unused `eslint-disable` directive comments.
+         * @type {boolean|undefined}
+         */
+        this.reportUnusedDisableDirectives = void 0;
+
+        /**
          * Rule settings.
          * @type {Record<string, [SeverityConf, ...any[]]>}
          */

--- a/tools/node_modules/eslint/lib/cli-engine/formatters/stylish.js
+++ b/tools/node_modules/eslint/lib/cli-engine/formatters/stylish.js
@@ -96,5 +96,6 @@ module.exports = function(results) {
         }
     }
 
-    return total > 0 ? output : "";
+    // Resets output color, for prevent change on top level
+    return total > 0 ? chalk.reset(output) : "";
 };

--- a/tools/node_modules/eslint/lib/init/config-initializer.js
+++ b/tools/node_modules/eslint/lib/init/config-initializer.js
@@ -120,6 +120,12 @@ function getModulesList(config, installESLint) {
         }
     }
 
+    const parser = config.parser || (config.parserOptions && config.parserOptions.parser);
+
+    if (parser) {
+        modules[parser] = "latest";
+    }
+
     if (installESLint === false) {
         delete modules.eslint;
     } else {
@@ -291,6 +297,20 @@ function processAnswers(answers) {
         config.extends.push("plugin:vue/essential");
     }
 
+    if (answers.typescript) {
+        if (answers.framework === "vue") {
+            config.parserOptions.parser = "@typescript-eslint/parser";
+        } else {
+            config.parser = "@typescript-eslint/parser";
+        }
+
+        if (Array.isArray(config.plugins)) {
+            config.plugins.push("@typescript-eslint");
+        } else {
+            config.plugins = ["@typescript-eslint"];
+        }
+    }
+
     // setup rules based on problems/style enforcement preferences
     if (answers.purpose === "problems") {
         config.extends.unshift("eslint:recommended");
@@ -305,6 +325,9 @@ function processAnswers(answers) {
             config = configureRules(answers, config);
             config = autoconfig.extendFromRecommended(config);
         }
+    }
+    if (answers.typescript && config.extends.includes("eslint:recommended")) {
+        config.extends.push("plugin:@typescript-eslint/eslint-recommended");
     }
 
     // normalize extends
@@ -464,6 +487,12 @@ function promptUser() {
                 { name: "Vue.js", value: "vue" },
                 { name: "None of these", value: "none" }
             ]
+        },
+        {
+            type: "confirm",
+            name: "typescript",
+            message: "Does your project use TypeScript?",
+            default: false
         },
         {
             type: "checkbox",

--- a/tools/node_modules/eslint/lib/init/npm-utils.js
+++ b/tools/node_modules/eslint/lib/init/npm-utils.js
@@ -98,7 +98,7 @@ function fetchPeerDependencies(packageName) {
  *                                        and values are booleans indicating installation.
  */
 function check(packages, opt) {
-    let deps = [];
+    const deps = new Set();
     const pkgJson = (opt) ? findPackageJson(opt.startDir) : findPackageJson();
     let fileJson;
 
@@ -119,14 +119,14 @@ function check(packages, opt) {
         throw error;
     }
 
-    if (opt.devDependencies && typeof fileJson.devDependencies === "object") {
-        deps = deps.concat(Object.keys(fileJson.devDependencies));
-    }
-    if (opt.dependencies && typeof fileJson.dependencies === "object") {
-        deps = deps.concat(Object.keys(fileJson.dependencies));
-    }
+    ["dependencies", "devDependencies"].forEach(key => {
+        if (opt[key] && typeof fileJson[key] === "object") {
+            Object.keys(fileJson[key]).forEach(dep => deps.add(dep));
+        }
+    });
+
     return packages.reduce((status, pkg) => {
-        status[pkg] = deps.indexOf(pkg) !== -1;
+        status[pkg] = deps.has(pkg);
         return status;
     }, {});
 }

--- a/tools/node_modules/eslint/lib/options.js
+++ b/tools/node_modules/eslint/lib/options.js
@@ -192,7 +192,7 @@ module.exports = optionator({
         {
             option: "report-unused-disable-directives",
             type: "Boolean",
-            default: false,
+            default: void 0,
             description: "Adds reported errors for unused eslint-disable directives"
         },
         {

--- a/tools/node_modules/eslint/lib/rules/func-name-matching.js
+++ b/tools/node_modules/eslint/lib/rules/func-name-matching.js
@@ -118,6 +118,7 @@ module.exports = {
                 return false;
             }
             return node.type === "CallExpression" &&
+                node.callee.type === "MemberExpression" &&
                 node.callee.object.name === objName &&
                 node.callee.property.name === funcName;
         }

--- a/tools/node_modules/eslint/lib/rules/function-paren-newline.js
+++ b/tools/node_modules/eslint/lib/rules/function-paren-newline.js
@@ -51,8 +51,8 @@ module.exports = {
             expectedBefore: "Expected newline before ')'.",
             expectedAfter: "Expected newline after '('.",
             expectedBetween: "Expected newline between arguments/params.",
-            unexpectedBefore: "Unexpected newline before '('.",
-            unexpectedAfter: "Unexpected newline after ')'."
+            unexpectedBefore: "Unexpected newline before ')'.",
+            unexpectedAfter: "Unexpected newline after '('."
         }
     },
 

--- a/tools/node_modules/eslint/lib/rules/no-extra-boolean-cast.js
+++ b/tools/node_modules/eslint/lib/rules/no-extra-boolean-cast.js
@@ -102,7 +102,17 @@ module.exports = {
                             if (hasCommentsInside(parent)) {
                                 return null;
                             }
-                            return fixer.replaceText(parent, sourceCode.getText(node.argument));
+
+                            let prefix = "";
+                            const tokenBefore = sourceCode.getTokenBefore(parent);
+                            const firstReplacementToken = sourceCode.getFirstToken(node.argument);
+
+                            if (tokenBefore && tokenBefore.range[1] === parent.range[0] &&
+                                    !astUtils.canTokensBeAdjacent(tokenBefore, firstReplacementToken)) {
+                                prefix = " ";
+                            }
+
+                            return fixer.replaceText(parent, prefix + sourceCode.getText(node.argument));
                         }
                     });
                 }

--- a/tools/node_modules/eslint/lib/rules/no-extra-parens.js
+++ b/tools/node_modules/eslint/lib/rules/no-extra-parens.js
@@ -49,7 +49,8 @@ module.exports = {
                                 nestedBinaryExpressions: { type: "boolean" },
                                 returnAssign: { type: "boolean" },
                                 ignoreJSX: { enum: ["none", "all", "single-line", "multi-line"] },
-                                enforceForArrowConditionals: { type: "boolean" }
+                                enforceForArrowConditionals: { type: "boolean" },
+                                enforceForSequenceExpressions: { type: "boolean" }
                             },
                             additionalProperties: false
                         }
@@ -77,6 +78,8 @@ module.exports = {
         const IGNORE_JSX = ALL_NODES && context.options[1] && context.options[1].ignoreJSX;
         const IGNORE_ARROW_CONDITIONALS = ALL_NODES && context.options[1] &&
             context.options[1].enforceForArrowConditionals === false;
+        const IGNORE_SEQUENCE_EXPRESSIONS = ALL_NODES && context.options[1] &&
+            context.options[1].enforceForSequenceExpressions === false;
 
         const PRECEDENCE_OF_ASSIGNMENT_EXPR = precedence({ type: "AssignmentExpression" });
         const PRECEDENCE_OF_UPDATE_EXPR = precedence({ type: "UpdateExpression" });
@@ -113,6 +116,10 @@ module.exports = {
 
                     // no default
                 }
+            }
+
+            if (node.type === "SequenceExpression" && IGNORE_SEQUENCE_EXPRESSIONS) {
+                return false;
             }
 
             return ALL_NODES || node.type === "FunctionExpression" || node.type === "ArrowFunctionExpression";

--- a/tools/node_modules/eslint/lib/rules/no-self-assign.js
+++ b/tools/node_modules/eslint/lib/rules/no-self-assign.js
@@ -94,9 +94,19 @@ function eachSelfAssignment(left, right, props, report) {
         const end = Math.min(left.elements.length, right.elements.length);
 
         for (let i = 0; i < end; ++i) {
+            const leftElement = left.elements[i];
             const rightElement = right.elements[i];
 
-            eachSelfAssignment(left.elements[i], rightElement, props, report);
+            // Avoid cases such as [...a] = [...a, 1]
+            if (
+                leftElement &&
+                leftElement.type === "RestElement" &&
+                i < right.elements.length - 1
+            ) {
+                break;
+            }
+
+            eachSelfAssignment(leftElement, rightElement, props, report);
 
             // After a spread element, those indices are unknown.
             if (rightElement && rightElement.type === "SpreadElement") {

--- a/tools/node_modules/eslint/lib/rules/yoda.js
+++ b/tools/node_modules/eslint/lib/rules/yoda.js
@@ -274,13 +274,22 @@ module.exports = {
          * @returns {string} A string representation of the node with the sides and operator flipped
          */
         function getFlippedString(node) {
+            const tokenBefore = sourceCode.getTokenBefore(node);
             const operatorToken = sourceCode.getFirstTokenBetween(node.left, node.right, token => token.value === node.operator);
             const textBeforeOperator = sourceCode.getText().slice(sourceCode.getTokenBefore(operatorToken).range[1], operatorToken.range[0]);
             const textAfterOperator = sourceCode.getText().slice(operatorToken.range[1], sourceCode.getTokenAfter(operatorToken).range[0]);
             const leftText = sourceCode.getText().slice(node.range[0], sourceCode.getTokenBefore(operatorToken).range[1]);
-            const rightText = sourceCode.getText().slice(sourceCode.getTokenAfter(operatorToken).range[0], node.range[1]);
+            const firstRightToken = sourceCode.getTokenAfter(operatorToken);
+            const rightText = sourceCode.getText().slice(firstRightToken.range[0], node.range[1]);
 
-            return rightText + textBeforeOperator + OPERATOR_FLIP_MAP[operatorToken.value] + textAfterOperator + leftText;
+            let prefix = "";
+
+            if (tokenBefore && tokenBefore.range[1] === node.range[0] &&
+                    !astUtils.canTokensBeAdjacent(tokenBefore, firstRightToken)) {
+                prefix = " ";
+            }
+
+            return prefix + rightText + textBeforeOperator + OPERATOR_FLIP_MAP[operatorToken.value] + textAfterOperator + leftText;
         }
 
         //--------------------------------------------------------------------------

--- a/tools/node_modules/eslint/lib/shared/types.js
+++ b/tools/node_modules/eslint/lib/shared/types.js
@@ -36,6 +36,7 @@ module.exports = {};
  * @property {ParserOptions} [parserOptions] The parser options.
  * @property {string[]} [plugins] The plugin specifiers.
  * @property {string} [processor] The processor specifier.
+ * @property {boolean|undefined} reportUnusedDisableDirectives The flag to report unused `eslint-disable` comments.
  * @property {boolean} [root] The root flag.
  * @property {Record<string, RuleConf>} [rules] The rule settings.
  * @property {Object} [settings] The shared settings.
@@ -54,6 +55,7 @@ module.exports = {};
  * @property {ParserOptions} [parserOptions] The parser options.
  * @property {string[]} [plugins] The plugin specifiers.
  * @property {string} [processor] The processor specifier.
+ * @property {boolean|undefined} reportUnusedDisableDirectives The flag to report unused `eslint-disable` comments.
  * @property {Record<string, RuleConf>} [rules] The rule settings.
  * @property {Object} [settings] The shared settings.
  */

--- a/tools/node_modules/eslint/package.json
+++ b/tools/node_modules/eslint/package.json
@@ -149,5 +149,5 @@
     "test": "node Makefile.js test",
     "webpack": "node Makefile.js webpack"
   },
-  "version": "6.2.2"
+  "version": "6.3.0"
 }


### PR DESCRIPTION
Update ESLint to 6.3.0

I'm also going to look into adding the new `reportUnusedDisableDirectives` to our configuration. We currently rely on passing the `--report-unused-disable-directives` CLI flag to ESLint in two places. I'm hoping that moving that to the config file could cut the number in half.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)