### PR TITLE
Patches to help build node as a shared library for Android

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -156,8 +156,8 @@
             'ldflags': [ '-Wl,-bbigtoc' ],
           }],
           ['OS == "android"', {
-            'cflags': [ '-fPIE' ],
-            'ldflags': [ '-fPIE', '-pie' ]
+            'cflags': [ '-fPIC' ],
+            'ldflags': [ '-fPIC' ]
           }],
         ],
         'msvs_settings': {
@@ -216,8 +216,8 @@
             ],
           },],
           ['OS == "android"', {
-            'cflags': [ '-fPIE' ],
-            'ldflags': [ '-fPIE', '-pie' ]
+            'cflags': [ '-fPIC' ],
+            'ldflags': [ '-fPIC' ]
           }],
         ],
         'msvs_settings': {

--- a/configure.py
+++ b/configure.py
@@ -1103,14 +1103,17 @@ def configure_node(o):
   o['variables']['node_shared'] = b(options.shared)
   node_module_version = getmoduleversion.get_version()
 
-  if sys.platform == 'darwin':
+  if options.dest_os == 'android':
+    shlib_suffix = 'so'
+  elif sys.platform == 'darwin':
     shlib_suffix = '%s.dylib'
   elif sys.platform.startswith('aix'):
     shlib_suffix = '%s.a'
   else:
     shlib_suffix = 'so.%s'
+  if '%s' in shlib_suffix:
+    shlib_suffix %= node_module_version
 
-  shlib_suffix %= node_module_version
   o['variables']['node_module_version'] = int(node_module_version)
   o['variables']['shlib_suffix'] = shlib_suffix
 

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -10,6 +10,10 @@
 #include "node_v8_platform-inl.h"
 #include "util-inl.h"
 
+#ifdef __ANDROID__
+#include <android/log.h>
+#endif
+
 namespace node {
 
 using errors::TryCatchScope;
@@ -413,6 +417,8 @@ void PrintErrorString(const char* format, ...) {
   // Don't include the null character in the output
   CHECK_GT(n, 0);
   WriteConsoleW(stderr_handle, wbuf.data(), n - 1, nullptr, nullptr);
+#elif defined(__ANDROID__)
+  __android_log_vprint(ANDROID_LOG_ERROR, "nodejs", format, ap);
 #else
   vfprintf(stderr, format, ap);
 #endif


### PR DESCRIPTION
Hello! I maintain an Android app that uses nodejs as a library. These patches have been necessary to build.
The patches are tested on the 8.x branch, which we're using currently. They did not rebase cleanly on master because the corresponding core was moved around, but I think they are small enough they should be correct.

I hope the patches are generally useful. I would love to have them upstream, so I can move away from 8.x