### PR TITLE
doc: change the 'txt' to 'console' for a command

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -133,7 +133,7 @@ performance. Use of the `--zero-fill-buffers` option is recommended only when
 necessary to enforce that newly allocated `Buffer` instances cannot contain old
 data that is potentially sensitive.
 
-```txt
+```console
 $ node --zero-fill-buffers
 > Buffer.allocUnsafe(5);
 <Buffer 00 00 00 00 00>

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -41,7 +41,7 @@ if (cluster.isMaster) {
 
 Running Node.js will now share port 8000 between the workers:
 
-```txt
+```console
 $ node server.js
 Master 3596 is running
 Worker 4324 started

--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -11,7 +11,7 @@ Node.js includes an out-of-process debugging utility accessible via a
 with the `inspect` argument followed by the path to the script to debug; a
 prompt will be displayed indicating successful launch of the debugger:
 
-```txt
+```console
 $ node inspect myscript.js
 < Debugger listening on ws://127.0.0.1:9229/80e7a814-7cd3-49fb-921a-2e02228cd5ba
 < For help, see: https://nodejs.org/en/docs/inspector
@@ -42,7 +42,7 @@ console.log('hello');
 
 Once the debugger is run, a breakpoint will occur at line 3:
 
-```txt
+```console
 $ node inspect myscript.js
 < Debugger listening on ws://127.0.0.1:9229/80e7a814-7cd3-49fb-921a-2e02228cd5ba
 < For help, see: https://nodejs.org/en/docs/inspector
@@ -124,7 +124,7 @@ on line 1
 It is also possible to set a breakpoint in a file (module) that
 is not loaded yet:
 
-```txt
+```console
 $ node inspect main.js
 < Debugger listening on ws://127.0.0.1:9229/4e3db158-9791-4274-8909-914f7facf3bd
 < For help, see: https://nodejs.org/en/docs/inspector
@@ -183,7 +183,7 @@ e.g. `--inspect=9222` will accept DevTools connections on port 9222.
 To break on the first line of the application code, pass the `--inspect-brk`
 flag instead of `--inspect`.
 
-```txt
+```console
 $ node --inspect index.js
 Debugger listening on 127.0.0.1:9229.
 To start debugging, open the following URL in Chrome:

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -85,7 +85,7 @@ variable:
 Omitting the callback function on asynchronous fs functions is deprecated and
 may result in an error being thrown in the future.
 
-```txt
+```console
 $ cat script.js
 function bad() {
   require('fs').readFile('/');

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1861,7 +1861,7 @@ Then `request.url` will be:
 To parse the url into its parts `require('url').parse(request.url)`
 can be used:
 
-```txt
+```console
 $ node
 > require('url').parse('/status?name=ryan')
 Url {
@@ -1883,7 +1883,7 @@ To extract the parameters from the query string, the
 `require('querystring').parse` function can be used, or
 `true` can be passed as the second argument to `require('url').parse`:
 
-```txt
+```console
 $ node
 > require('url').parse('/status?name=ryan', true)
 Url {

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2919,7 +2919,7 @@ To extract the parameters from the query string, the
 `require('querystring').parse` function can be used, or
 `true` can be passed as the second argument to `require('url').parse`.
 
-```txt
+```console
 $ node
 > require('url').parse('/status?name=ryan', true)
 Url {

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -330,7 +330,7 @@ provided to the `a.js` module.
 By the time `main.js` has loaded both modules, they're both finished.
 The output of this program would thus be:
 
-```txt
+```console
 $ node main.js
 main starting
 a starting

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -374,7 +374,7 @@ command-line option can be used to suppress the default console output but the
 The following example illustrates the warning that is printed to `stderr` when
 too many listeners have been added to an event:
 
-```txt
+```console
 $ node
 > events.defaultMaxListeners = 1;
 > process.on('foo', () => {});
@@ -386,7 +386,7 @@ detected. 2 foo listeners added. Use emitter.setMaxListeners() to increase limit
 In contrast, the following example turns off the default warning output and
 adds a custom handler to the `'warning'` event:
 
-```txt
+```console
 $ node --no-warnings
 > const p = process.on('warning', (warning) => console.warn('Do not do that!'));
 > events.defaultMaxListeners = 1;

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -438,7 +438,7 @@ replServer.defineCommand('saybye', function saybye() {
 
 The new commands can then be used from within the REPL instance:
 
-```txt
+```console
 > .sayhello Node.js User
 Hello, Node.js User!
 > .saybye

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -900,7 +900,7 @@ rr.on('end', () => {
 
 The output of running this script is:
 
-```txt
+```console
 $ node test.js
 readable: null
 end


### PR DESCRIPTION
This is the document formation, because `node` is a command to be
executed, we should reguard it as a command prompt instead of a command
txt type. Notice that if this is a pure txt file of command, it should be something
like what we see in 'doc/api/tracing.md (L39-41)'.

----
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)