### PR TITLE
http2: send out pending data earlier

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1186,7 +1186,10 @@ int Http2Session::OnDataChunkReceived(nghttp2_session* handle,
       stream->inbound_consumed_data_while_paused_ += avail;
 
     // If we have a gathered a lot of data for output, try sending it now.
-    if (session->outgoing_length_ > 4096) session->SendPendingData();
+    if (session->outgoing_length_ > 4096 ||
+        stream->available_outbound_length_ > 4096) {
+      session->SendPendingData();
+    }
   } while (len != 0);
 
   // If we are currently waiting for a write operation to finish, we should


### PR DESCRIPTION
If there’s a lot of data waiting on a given stream, send
it out early, if possible. This helps trigger the backpressure
mechanism introduced in 8a4a1931b8b98 at a better time.

(Will look into writing tests for this.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
