### PR TITLE
repl: add autocomplete support for fs.promises

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -988,6 +988,7 @@ ArrayStream.prototype.resume = function() {};
 ArrayStream.prototype.write = function() {};
 
 const requireRE = /\brequire\s*\(['"](([\w@./-]+\/)?(?:[\w@./-]*))/;
+const fsAutoCompleteRE = /fs(?:\.promises)?\.\s*[a-z][a-zA-Z]+\(\s*["'](.*)/;
 const simpleExpressionRE =
     /(?:[a-zA-Z_$](?:\w|\$)*\.)*[a-zA-Z_$](?:\w|\$)*\.?$/;
 
@@ -1156,7 +1157,7 @@ function complete(line, callback) {
     }
 
     completionGroupsLoaded();
-  } else if (match = line.match(/fs\.\s*[a-z][a-zA-Z]+\(\s*["'](.*)/)) {
+  } else if (match = line.match(fsAutoCompleteRE)) {
 
     let filePath = match[1];
     let fileList;

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -402,37 +402,39 @@ testMe.complete('obj.', common.mustCall((error, data) => {
   putIn.run(['.clear']);
   process.chdir(__dirname);
 
-  const readFileSync = 'fs.readFileSync("';
-  const fixturePath = `${readFileSync}../fixtures/test-repl-tab-completion`;
+  const readFileSyncs = ['fs.readFileSync("', 'fs.promises.readFileSync("'];
   if (!common.isWindows) {
-    testMe.complete(fixturePath, common.mustCall((err, data) => {
-      assert.strictEqual(err, null);
-      assert.ok(data[0][0].includes('.hiddenfiles'));
-      assert.ok(data[0][1].includes('hellorandom.txt'));
-      assert.ok(data[0][2].includes('helloworld.js'));
-    }));
+    readFileSyncs.forEach((readFileSync) => {
+      const fixturePath = `${readFileSync}../fixtures/test-repl-tab-completion`;
+      testMe.complete(fixturePath, common.mustCall((err, data) => {
+        assert.strictEqual(err, null);
+        assert.ok(data[0][0].includes('.hiddenfiles'));
+        assert.ok(data[0][1].includes('hellorandom.txt'));
+        assert.ok(data[0][2].includes('helloworld.js'));
+      }));
 
-    testMe.complete(`${fixturePath}/hello`,
-                    common.mustCall((err, data) => {
-                      assert.strictEqual(err, null);
-                      assert.ok(data[0][0].includes('hellorandom.txt'));
-                      assert.ok(data[0][1].includes('helloworld.js'));
-                    })
-    );
+      testMe.complete(`${fixturePath}/hello`,
+                      common.mustCall((err, data) => {
+                        assert.strictEqual(err, null);
+                        assert.ok(data[0][0].includes('hellorandom.txt'));
+                        assert.ok(data[0][1].includes('helloworld.js'));
+                      })
+      );
 
-    testMe.complete(`${fixturePath}/.h`,
-                    common.mustCall((err, data) => {
-                      assert.strictEqual(err, null);
-                      assert.ok(data[0][0].includes('.hiddenfiles'));
-                    })
-    );
+      testMe.complete(`${fixturePath}/.h`,
+                      common.mustCall((err, data) => {
+                        assert.strictEqual(err, null);
+                        assert.ok(data[0][0].includes('.hiddenfiles'));
+                      })
+      );
 
-    testMe.complete(`${readFileSync}./xxxRandom/random`,
-                    common.mustCall((err, data) => {
-                      assert.strictEqual(err, null);
-                      assert.strictEqual(data[0].length, 0);
-                    })
-    );
+      testMe.complete(`${readFileSync}./xxxRandom/random`,
+                      common.mustCall((err, data) => {
+                        assert.strictEqual(err, null);
+                        assert.strictEqual(data[0].length, 0);
+                      })
+      );
+    });
   }
 }
 


### PR DESCRIPTION
Follow up of this https://github.com/nodejs/node/pull/26648. Adding support for `fs.promises` also updated the test files. 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
