### PR TITLE
doc: async_hooks.createHook resolvePromise option

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -89,6 +89,7 @@ added: v8.1.0
   * `before` {Function} The [`before` callback][].
   * `after` {Function} The [`after` callback][].
   * `destroy` {Function} The [`destroy` callback][].
+  * `promiseResolve` {Function} The [`promiseResolve` callback][].
 * Returns: {AsyncHook} Instance used for disabling and enabling hooks
 
 Registers functions to be called for different lifetime events of each async
@@ -685,6 +686,7 @@ never be called.
 [`before` callback]: #async_hooks_before_asyncid
 [`destroy` callback]: #async_hooks_destroy_asyncid
 [`init` callback]: #async_hooks_init_asyncid_type_triggerasyncid_resource
+[`promiseResolve` callback]: #async_hooks_promiseresolve_asyncid
 [Hook Callbacks]: #async_hooks_hook_callbacks
 [PromiseHooks]: https://docs.google.com/document/d/1rda3yKGHimKIhg5YeoAmCOtyURgsbTH_qaYR79FELlk/edit
 [`Worker`]: worker_threads.html#worker_threads_class_worker


### PR DESCRIPTION
Document the `resolvePromise` option to `async_hooks.createHook()`.

This seems to have been overlooked in commit b605b15346 ("async_hooks:
support promise resolve hook") from September 2017.

It is documented elsewhere in the async_hooks API documentation, except
where you actually pass it in.