### PR TITLE
src: fix ValidateDSAParameters when fips is enabled

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4883,8 +4883,8 @@ static AllocatedBuffer Node_SignFinal(Environment* env,
 static inline bool ValidateDSAParameters(EVP_PKEY* key) {
 #ifdef NODE_FIPS_MODE
   /* Validate DSA2 parameters from FIPS 186-4 */
-  if (FIPS_mode() && EVP_PKEY_DSA == EVP_PKEY_base_id(pkey.get())) {
-    DSA* dsa = EVP_PKEY_get0_DSA(pkey.get());
+  if (FIPS_mode() && EVP_PKEY_DSA == EVP_PKEY_base_id(key)) {
+    DSA* dsa = EVP_PKEY_get0_DSA(key);
     const BIGNUM* p;
     DSA_get0_pqg(dsa, &p, nullptr, nullptr);
     size_t L = BN_num_bits(p);
@@ -4895,7 +4895,7 @@ static inline bool ValidateDSAParameters(EVP_PKEY* key) {
     return (L == 1024 && N == 160) ||
            (L == 2048 && N == 224) ||
            (L == 2048 && N == 256) ||
-           (L == 3072 && N == 256)
+           (L == 3072 && N == 256);
   }
 #endif  // NODE_FIPS_MODE
 


### PR DESCRIPTION
Currently, the following compilation errors are generated when
configuring `--openssl-is-fips`:
```console
../src/node_crypto.cc: In function ‘bool
node::crypto::ValidateDSAParameters(EVP_PKEY*)’:
../src/node_crypto.cc:4886:55: error: ‘pkey’ was not declared in this
scope
   if (FIPS_mode() && EVP_PKEY_DSA == EVP_PKEY_base_id(pkey.get())) {
                                                       ^~~~
../src/node_crypto.cc:4886:55: note: suggested alternative: ‘key’
   if (FIPS_mode() && EVP_PKEY_DSA == EVP_PKEY_base_id(pkey.get())) {
                                                       ^~~~
                                                       key
../src/node_crypto.cc:4898:35: error: expected ‘;’ before ‘}’ token
            (L == 3072 && N == 256)
                                   ^
                                   ;
   }
```
This commit fixes the errors, and after this compilation is successful.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
