### PR TITLE
perf_hooks: improve http2 import

### DIFF
--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -92,11 +92,12 @@ const IDX_SESSION_STATS_DATA_SENT = 6;
 const IDX_SESSION_STATS_DATA_RECEIVED = 7;
 const IDX_SESSION_STATS_MAX_CONCURRENT_STREAMS = 8;
 
+let http2;
 let sessionStats;
 let streamStats;
 
 function collectHttp2Stats(entry) {
-  const http2 = internalBinding('http2');
+  if (http2 === undefined) http2 = internalBinding('http2');
   switch (entry.name) {
     case 'Http2Stream':
       if (streamStats === undefined)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Nearly ~119ns for each `collectHttp2Stats` call.

`const http2 = internalBinding('http2');` => `20001: 36.200362ms`
`if (http2 === undefined) http2 = internalBinding('http2');` => `20001: 33.814263ms`
`(36.200362 - 33.814263) * 1e6 / 20001 = 119`

Same lazy `require` in `net` module: https://github.com/nodejs/node/blob/v12.9.1/lib/net.js#L940

Benchmarked with:
```js
const http2 = require('http2')
const perf_hooks = require('perf_hooks')

let firstImport = true
let sum = 0
let cnt = 0
process.once('beforeExit', () => console.log(`${cnt}: ${sum.toFixed(6)}ms`))

const obs = new perf_hooks.PerformanceObserver((items) => {
  const entry = items.getEntries()[0]
  if (entry.entryType !== 'measure') return

  if (firstImport) {
    firstImport = false
    return
  }

  sum += entry.duration
  cnt += 1
})
obs.observe({ entryTypes: ['measure', 'http2'] })

const server = http2.createServer({}, (req, res) => res.end('ok')).listen(8000)
server.once('listening', async () => {
  const client = http2.connect('http://localhost:8000')
  await Promise.all(new Array(1e4).fill(null).map(() => {
    return new Promise((resolve) => client.request().on('data', () => {}).once('close', resolve).end())
  }))

  client.close()
  server.close()
})
```

Code in `perf_hooks.js` was changed to:
```js
  performance.mark('collectHttp2StatsImportStart');
  // const http2 = internalBinding('http2');
  if (http2 === undefined) http2 = internalBinding('http2');
  performance.mark('collectHttp2StatsImportEnd');
  performance.measure('collectHttp2Stats', 'collectHttp2StatsImportStart', 'collectHttp2StatsImportEnd');
```