### PR TITLE
doc: change urls directly from 'http' to 'https'

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -501,16 +501,16 @@ $ backtrace
   [Build Tools](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017),
   with the default optional components.
 * Basic Unix tools required for some tests,
-  [Git for Windows](http://git-scm.com/download/win) includes Git Bash
+  [Git for Windows](https://git-scm.com/download/win) includes Git Bash
   and tools which can be included in the global `PATH`.
-* The [NetWide Assembler](http://www.nasm.us/), for OpenSSL assembler modules.
+* The [NetWide Assembler](https://www.nasm.us/), for OpenSSL assembler modules.
   If not installed in the default location, it needs to be manually added
   to `PATH`. A build with the `openssl-no-asm` option does not need this, nor
   does a build targeting ARM64 Windows.
 
 Optional requirements to build the MSI installer package:
 
-* The [WiX Toolset v3.11](http://wixtoolset.org/releases/) and the
+* The [WiX Toolset v3.11](https://wixtoolset.org/releases/) and the
   [Wix Toolset Visual Studio 2017 Extension](https://marketplace.visualstudio.com/items?itemName=RobMensching.WixToolsetVisualStudio2017Extension).
 
 Optional requirements for compiling for Windows 10 on ARM (ARM64):
@@ -527,7 +527,7 @@ Optional requirements for compiling for Windows 10 on ARM (ARM64):
 ##### Option 2: Automated install with Boxstarter
 <a name="boxstarter"></a>
 
-A [Boxstarter](http://boxstarter.org/) script can be used for easy setup of
+A [Boxstarter](https://boxstarter.org/) script can be used for easy setup of
 Windows systems with all the required prerequisites for Node.js development.
 This script will install the following [Chocolatey](https://chocolatey.org/)
 packages:
@@ -541,8 +541,8 @@ packages:
 * [NetWide Assembler](https://chocolatey.org/packages/nasm)
 
 To install Node.js prerequisites using
-[Boxstarter WebLauncher](http://boxstarter.org/WebLauncher), open
-<http://boxstarter.org/package/nr/url?https://raw.githubusercontent.com/nodejs/node/master/tools/bootstrap/windows_boxstarter>
+[Boxstarter WebLauncher](https://boxstarter.org/WebLauncher), open
+<https://boxstarter.org/package/nr/url?https://raw.githubusercontent.com/nodejs/node/master/tools/bootstrap/windows_boxstarter>
 with Internet Explorer or Edge browser on the target machine.
 
 Alternatively, you can use PowerShell. Run those commands from an elevated
@@ -550,7 +550,7 @@ PowerShell terminal:
 
 ```powershell
 Set-ExecutionPolicy Unrestricted -Force
-iex ((New-Object System.Net.WebClient).DownloadString('http://boxstarter.org/bootstrapper.ps1'))
+iex ((New-Object System.Net.WebClient).DownloadString('https://boxstarter.org/bootstrapper.ps1'))
 get-boxstarter -Force
 Install-BoxstarterPackage https://raw.githubusercontent.com/nodejs/node/master/tools/bootstrap/windows_boxstarter -DisableReboots
 ```

--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -65,5 +65,5 @@ See also API documentation structure overview in [doctools README][].
 [Javascript type]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Data_structures_and_types
 [serial commas]: https://en.wikipedia.org/wiki/Serial_comma
 [The New York Times Manual of Style and Usage]: https://en.wikipedia.org/wiki/The_New_York_Times_Manual_of_Style_and_Usage
-[plugin]: http://editorconfig.org/#download
+[plugin]: https://editorconfig.org/#download
 [doctools README]: ../tools/doc/README.md

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -5219,7 +5219,7 @@ the file contents.
 [`URL`]: url.html#url_the_whatwg_url_api
 [`UV_THREADPOOL_SIZE`]: cli.html#cli_uv_threadpool_size_size
 [`WriteStream`]: #fs_class_fs_writestream
-[`event ports`]: http://illumos.org/man/port_create
+[`event ports`]: https://illumos.org/man/port_create
 [`fs.Dirent`]: #fs_class_fs_dirent
 [`fs.FSWatcher`]: #fs_class_fs_fswatcher
 [`fs.Stats`]: #fs_class_fs_stats

--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -163,7 +163,7 @@ use `Refs:`.
 
    Examples:
    - `Fixes: https://github.com/nodejs/node/issues/1337`
-   - `Refs: http://eslint.org/docs/rules/space-in-parens.html`
+   - `Refs: https://eslint.org/docs/rules/space-in-parens.html`
    - `Refs: https://github.com/nodejs/node/pull/3615`
 
 5. If your commit introduces a breaking change (`semver-major`), it should
@@ -180,7 +180,7 @@ things in more detail. Please word-wrap to keep columns to 72 characters or
 less.
 
 Fixes: https://github.com/nodejs/node/issues/1337
-Refs: http://eslint.org/docs/rules/space-in-parens.html
+Refs: https://eslint.org/docs/rules/space-in-parens.html
 ```
 
 If you are new to contributing to Node.js, please try to do your best at

--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -433,7 +433,7 @@ https://coverage.nodejs.org/.
 [Google Test]: https://github.com/google/googletest
 [`common` module]: https://github.com/nodejs/node/blob/master/test/common/README.md
 [all maintained branches]: https://github.com/nodejs/lts
-[node.green]: http://node.green/
+[node.green]: https://node.green/
 [test fixture]: https://github.com/google/googletest/blob/master/googletest/docs/Primer.md#test-fixtures-using-the-same-data-configuration-for-multiple-tests
 [Test Coverage section of the Building guide]: https://github.com/nodejs/node/blob/master/BUILDING.md#running-coverage
 [directory structure overview]: https://github.com/nodejs/node/blob/master/test/README.md#test-directories


### PR DESCRIPTION
There're some URLs with old links, change them together from 'http' to
'https'.

Notice:
1. Since files of CHANGELOG may be generated through tools, I don't
intend to change them together as the history track.
2. All the files in the 'deps' are of 3-rd parties, they will be
overwritten for the next update, so avoid modifications for them.

----

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)