### PR TITLE
build,win: fix Python detection on localized OS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 test/fixtures/* -text
 vcbuild.bat text eol=crlf
+tools/msvs/find_python.cmd text eol=crlf

--- a/tools/msvs/find_python.cmd
+++ b/tools/msvs/find_python.cmd
@@ -60,14 +60,16 @@ exit /b 1
 :: Read the InstallPath of a given Environment Key to %p%
 :: https://www.python.org/dev/peps/pep-0514/#installpath
 :read-installpath
-:: %%a will receive token 3
-:: %%b will receive *, corresponding to token 4 and all after
-for /f "skip=2 tokens=3*" %%a in ('reg query "%1\InstallPath" /ve /t REG_SZ 2^> nul') do (
-  set "head=%%a"
-  set "tail=%%b"
-  set "p=!head!"
-  if not "!tail!"=="" set "p=!head! !tail!"
-  exit /b 0
+:: %%a will receive everything before ), might have spaces depending on language
+:: %%b will receive *, corresponding to everything after )
+:: %%c will receive REG_SZ
+:: %%d will receive the path, including spaces
+for /f "skip=2 tokens=1* delims=)" %%a in ('reg query "%1\InstallPath" /ve /t REG_SZ 2^> nul') do (
+  for /f "tokens=1*" %%c in ("%%b") do (
+    if not "%%c"=="REG_SZ" exit /b 1
+    set "p=%%d"
+    exit /b 0
+  )
 )
 exit /b 1
 


### PR DESCRIPTION
This code previously assumed the default value was always printed to the console by reg.exe as `(default)`, but this is not true on localized versions of Windows and can contain spaces.

Fixes: https://github.com/nodejs/node/issues/29417

cc @targos @nodejs/platform-windows 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
