### PR TITLE
esm: globals should be wrapped to stay in sync with ESM

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Object, SafeWeakMap } = primordials;
+const { NativeModule } = require('internal/bootstrap/loaders');
 
 const { getOptionValue } = require('internal/options');
 const { Buffer } = require('buffer');
@@ -369,6 +370,11 @@ function initializeCJSLoader() {
 }
 
 function initializeESMLoader() {
+  // proxify the global process to keep in sync with ESM
+  const mod = NativeModule.map.get('process');
+  mod.compileForPublicLoader(true);
+  globalThis.process = mod.exports;
+
   // Create this WeakMap in js-land because V8 has no C++ API for WeakMap.
   internalBinding('module_wrap').callbackMap = new SafeWeakMap();
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This fixes the behavior of the builtin module proxy for `process` so that `test/parallel/test-global-setters.js` works even when ESM is turned on via `--experimental-modules` by changing the global to use the `Proxy` form that ESM creates for named export syncing.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
