### PR TITLE
src: check microtasks before running them

### DIFF
--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -12,6 +12,7 @@ using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
+using v8::MicrotasksScope;
 using v8::NewStringType;
 using v8::Object;
 using v8::String;
@@ -100,7 +101,7 @@ void InternalCallbackScope::Close() {
 
   if (!env_->can_call_into_js()) return;
   if (!tick_info->has_tick_scheduled()) {
-    env_->isolate()->RunMicrotasks();
+    MicrotasksScope::PerformCheckpoint(env_->isolate());
   }
 
   // Make sure the stack unwound properly. If there are nested MakeCallback's

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -21,6 +21,7 @@ using v8::kPromiseRejectWithNoHandler;
 using v8::kPromiseResolveAfterResolved;
 using v8::Local;
 using v8::Message;
+using v8::MicrotasksScope;
 using v8::Number;
 using v8::Object;
 using v8::Promise;
@@ -43,7 +44,7 @@ static void EnqueueMicrotask(const FunctionCallbackInfo<Value>& args) {
 bool RunNextTicksNative(Environment* env) {
   TickInfo* tick_info = env->tick_info();
   if (!tick_info->has_tick_scheduled() && !tick_info->has_rejection_to_warn())
-    env->isolate()->RunMicrotasks();
+    MicrotasksScope::PerformCheckpoint(env->isolate());
   if (!tick_info->has_tick_scheduled() && !tick_info->has_rejection_to_warn())
     return true;
 


### PR DESCRIPTION
Refs https://github.com/electron/electron/issues/20013.

Previously, Node.js unilaterally ran microtasks on next tick; since Electron also handles microtask resolution this created an issue whereby the microtask queue would attempt to be pumped while previous tasks were still running.

To address this issue, i've changed the `RunMicrotasks` call to a [`PerformCheckpoint`](https://cs.chromium.org/chromium/src/v8/src/execution/microtask-queue.cc?type=cs&q=PerformCheckpoint&sq=package:chromium&g=0&l=114) call, which adds checks to only run microtasks if none are in progress, and otherwise proceeds normally.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
