### PR TITLE
esm: make dynamic import work in the REPL

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -279,6 +279,12 @@ function REPLServer(prompt,
   }
 
   function defaultEval(code, context, file, cb) {
+    const { getOptionValue } = require('internal/options');
+    const experimentalModules = getOptionValue('--experimental-modules');
+    const asyncESM = experimentalModules ?
+      require('internal/process/esm_loader') :
+      null;
+
     let result, script, wrappedErr;
     let err = null;
     let wrappedCmd = false;
@@ -312,6 +318,12 @@ function REPLServer(prompt,
     if (code === '\n')
       return cb(null);
 
+    let pwd;
+    try {
+      const { pathToFileURL } = require('url');
+      pwd = pathToFileURL(process.cwd()).href;
+    } catch {
+    }
     while (true) {
       try {
         if (!/^\s*$/.test(code) &&
@@ -322,7 +334,12 @@ function REPLServer(prompt,
         }
         script = vm.createScript(code, {
           filename: file,
-          displayErrors: true
+          displayErrors: true,
+          importModuleDynamically: experimentalModules ?
+            async (specifier) => {
+              return (await asyncESM.loaderPromise).import(specifier, pwd);
+            } :
+            undefined
         });
       } catch (e) {
         debug('parse error %j', code, e);

--- a/test/es-module/test-esm-repl.js
+++ b/test/es-module/test-esm-repl.js
@@ -1,0 +1,19 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { spawn } = require('child_process');
+
+const child = spawn(process.execPath, [
+  '--experimental-modules',
+  '--interactive'
+]);
+child.stdin.end(`
+import('fs').then(
+  ns => ns.default === require('fs') ? 0 : 1,
+  _ => 2
+).then(process.exit)
+`);
+
+child.on('exit', (code) => {
+  assert.strictEqual(code, 0);
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This ensures that `import("fs")` will work in the REPL with `--experimental-modules`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
