### PR TITLE
doc: simply wording in n-api doc

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -549,7 +549,7 @@ typedef void (*napi_async_execute_callback)(napi_env env, void* data);
 ```
 
 Implementations of this function must avoid making N-API calls
-that result in the execution of JavaScript or interaction with
+that execute JavaScript or interact with
 JavaScript objects. Any code that needs to make N-API
 calls should be in the `napi_async_complete_callback` instead.
 Do not use the `napi_env` parameter as it will likely

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -548,12 +548,12 @@ operations. Callback functions must satisfy the following signature:
 typedef void (*napi_async_execute_callback)(napi_env env, void* data);
 ```
 
-Implementations of this type of function should avoid making any N-API calls
-that could result in the execution of JavaScript or interaction with
-JavaScript objects. Most often, any code that needs to make N-API
-calls should be made in `napi_async_complete_callback` instead.
-Avoid using the `napi_env` parameter in the execute callback as
-it will likely execute JavaScript.
+Implementations of this function must avoid making N-API calls
+that result in the execution of JavaScript or interaction with
+JavaScript objects. Any code that needs to make N-API
+calls should be in the `napi_async_complete_callback` instead.
+Do not use the `napi_env` parameter as it will likely
+result in execution of JavaScript.
 
 #### napi_async_complete_callback
 <!-- YAML

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -550,7 +550,7 @@ typedef void (*napi_async_execute_callback)(napi_env env, void* data);
 
 Implementations of this function must avoid making N-API calls
 that execute JavaScript or interact with
-JavaScript objects. Any code that needs to make N-API
+JavaScript objects.  N-API
 calls should be in the `napi_async_complete_callback` instead.
 Do not use the `napi_env` parameter as it will likely
 result in execution of JavaScript.


### PR DESCRIPTION
Simplify/clarify wording documenting n-api execute
callback.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
