### PR TITLE
deps: define OPENSSLDIR and ENGINESDIR explicitly

### DIFF
--- a/deps/openssl/openssl.gypi
+++ b/deps/openssl/openssl.gypi
@@ -1274,6 +1274,8 @@
       'MK1MF_BUILD',
       'WIN32_LEAN_AND_MEAN',
       'OPENSSL_SYSNAME_WIN32',
+      'ENGINESDIR="C:\\\Program\ Files\\\Common\ Files\\\SSL"',
+      'OPENSSLDIR="C:\\\Program\ Files\\\Common\ Files\\\SSL"',
     ],
     'openssl_default_libraries_win': [
       '-lgdi32.lib',


### PR DESCRIPTION
According to CVE-2019-1552(*), it is encouraged to change `OPENSSLDIR` from the default of /usr/local/ssl to a privileged directory on Windows. "C:\Program Files\Common Files\SSL" is set as it is the default path in OpenSSL-1.1.1.

This is also described in https://github.com/openssl/openssl/commit/d333ebaf9c77332754a9d5e111e2f53e1de54fdd for the forthcoming release of OpenSSL-1.0.2t.

It breaks the compatibility of the `OPENSSLDIR` path with the previous v8 LTS releases. For v8 LTS will be ended after 4 months and its severity is LOW, I do not mind if this is not fixed.

(*) https://www.openssl.org/news/secadv/20190730.txt

Fixes: https://github.com/nodejs/node/issues/29445

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
