### PR TITLE
[v10.x] n-api: mark version 5 N-APIs as stable

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1475,8 +1475,6 @@ added: REPLACEME
 napiVersion: 4
 -->
 
-> Stability: 1 - Experimental
-
 ```C
 napi_status napi_create_date(napi_env env,
                              double time,
@@ -2120,8 +2118,6 @@ added: REPLACEME
 napiVersion: 4
 -->
 
-> Stability: 1 - Experimental
-
 ```C
 napi_status napi_get_date_value(napi_env env,
                                 napi_value value,
@@ -2728,8 +2724,6 @@ This API checks if the `Object` passed in is a buffer.
 added: REPLACEME
 napiVersion: 4
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 napi_status napi_is_date(napi_env env, napi_value value, bool* result)
@@ -3821,8 +3815,6 @@ callback was associated with the wrapping, it will no longer be called when the
 JavaScript object becomes garbage-collected.
 
 ### napi_add_finalizer
-
-> Stability: 1 - Experimental
 
 <!-- YAML
 added: v8.0.0

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -10,7 +10,7 @@
 #define NAPI_VERSION 2147483647
 #else
 // The baseline version for N-API
-#define NAPI_VERSION 4
+#define NAPI_VERSION 5
 #endif
 #endif
 
@@ -674,7 +674,7 @@ napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 
 #endif  // NAPI_VERSION >= 4
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 5
 
 // Dates
 NAPI_EXTERN napi_status napi_create_date(napi_env env,
@@ -688,6 +688,18 @@ NAPI_EXTERN napi_status napi_is_date(napi_env env,
 NAPI_EXTERN napi_status napi_get_date_value(napi_env env,
                                             napi_value value,
                                             double* result);
+
+// Add finalizer for pointer
+NAPI_EXTERN napi_status napi_add_finalizer(napi_env env,
+                                           napi_value js_object,
+                                           void* native_object,
+                                           napi_finalize finalize_cb,
+                                           void* finalize_hint,
+                                           napi_ref* result);
+
+#endif  // NAPI_VERSION >= 5
+
+#ifdef NAPI_EXPERIMENTAL
 
 // BigInt
 NAPI_EXTERN napi_status napi_create_bigint_int64(napi_env env,
@@ -714,12 +726,6 @@ NAPI_EXTERN napi_status napi_get_value_bigint_words(napi_env env,
                                                     int* sign_bit,
                                                     size_t* word_count,
                                                     uint64_t* words);
-NAPI_EXTERN napi_status napi_add_finalizer(napi_env env,
-                                           napi_value js_object,
-                                           void* native_object,
-                                           napi_finalize finalize_cb,
-                                           void* finalize_hint,
-                                           napi_ref* result);
 #endif  // NAPI_EXPERIMENTAL
 
 EXTERN_C_END

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -114,6 +114,6 @@
 #define NODE_MODULE_VERSION 64
 
 // the NAPI_VERSION provided by this version of the runtime
-#define NAPI_VERSION  4
+#define NAPI_VERSION  5
 
 #endif  // SRC_NODE_VERSION_H_

--- a/test/addons-napi/test_date/test_date.c
+++ b/test/addons-napi/test_date/test_date.c
@@ -1,5 +1,3 @@
-#define NAPI_EXPERIMENTAL
-
 #include <node_api.h>
 #include "../common.h"
 

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -34,7 +34,7 @@ assert.notStrictEqual(test_general.testGetPrototype(baseObject),
 
 // test version management functions
 // expected version is currently 4
-assert.strictEqual(test_general.testGetVersion(), 4);
+assert.strictEqual(test_general.testGetVersion(), 5);
 
 const [ major, minor, patch, release ] = test_general.testGetNodeVersion();
 assert.strictEqual(process.version.split('-')[0],

--- a/test/addons-napi/test_general/test_general.c
+++ b/test/addons-napi/test_general/test_general.c
@@ -1,4 +1,3 @@
-#define NAPI_EXPERIMENTAL
 #include <node_api.h>
 #include <stdlib.h>
 #include "../common.h"


### PR DESCRIPTION
PR-URL: https://github.com/nodejs/node/pull/29401

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
