### PR TITLE
http2: no crash on stream listener removal w/ destroyed session

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -426,23 +426,27 @@ function sessionListenerRemoved(name) {
 // Also keep track of listeners for the Http2Stream instances, as some events
 // are emitted on those objects.
 function streamListenerAdded(name) {
+  const session = this[kSession];
+  if (!session) return;
   switch (name) {
     case 'priority':
-      this[kSession][kNativeFields][kSessionPriorityListenerCount]++;
+      session[kNativeFields][kSessionPriorityListenerCount]++;
       break;
     case 'frameError':
-      this[kSession][kNativeFields][kSessionFrameErrorListenerCount]++;
+      session[kNativeFields][kSessionFrameErrorListenerCount]++;
       break;
   }
 }
 
 function streamListenerRemoved(name) {
+  const session = this[kSession];
+  if (!session) return;
   switch (name) {
     case 'priority':
-      this[kSession][kNativeFields][kSessionPriorityListenerCount]--;
+      session[kNativeFields][kSessionPriorityListenerCount]--;
       break;
     case 'frameError':
-      this[kSession][kNativeFields][kSessionFrameErrorListenerCount]--;
+      session[kNativeFields][kSessionFrameErrorListenerCount]--;
       break;
   }
 }

--- a/test/parallel/test-http2-stream-removelisteners-after-close.js
+++ b/test/parallel/test-http2-stream-removelisteners-after-close.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+// Regression test for https://github.com/nodejs/node/issues/29457:
+// HTTP/2 stream event listeners can be added and removed after the
+// session has been destroyed.
+
+const server = http2.createServer((req, res) => {
+  res.end('Hi!\n');
+});
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const headers = { ':path': '/' };
+  const req = client.request(headers);
+
+  req.on('close', common.mustCall(() => {
+    req.removeAllListeners();
+    req.on('priority', common.mustNotCall());
+    server.close();
+  }));
+
+  req.on('priority', common.mustNotCall());
+  req.on('error', common.mustCall());
+
+  client.destroy();
+}));


### PR DESCRIPTION
Do not crash when the session is no longer available.

Fixes: https://github.com/nodejs/node/issues/29457

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
