### PR TITLE
doc: remove the suffix number of the anchor link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 * [Code of Conduct](#code-of-conduct)
 * [Issues](#issues)
 * [Pull Requests](#pull-requests)
-* [Developer's Certificate of Origin 1.1](#developers-certificate-of-origin-11)
+* [Developer's Certificate of Origin 1.1](#developers-certificate-of-origin)
 
 ## [Code of Conduct](./doc/guides/contributing/coc.md)
 


### PR DESCRIPTION
Remove the number '11' as the suffix anchor id for the 'Developer's Certificate of Origin 1.1'.

Ref: https://github.com/nodejs/node/pull/6257

---
- [X] make -j4 test (UNIX), or vcbuild test (Windows) passes
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows commit guidelines