### PR TITLE
build: add comment to .travis.yml on how to test Py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ x-ccache-setup-steps: &ccache-setup-steps
 
 os: linux
 language: cpp
+# Currently this file can only support one PYTHON_VERSION.
+# To experiment with Python 3, comment out Python 2.7 and uncomment one of the Python 3 versions.
 env:
   global:
     - PYTHON_VERSION="2.7.15"
+    # - PYTHON_VERSION="3.6.7"
+    # - PYTHON_VERSION="3.7.1"
 jobs:
   include:
     - stage: "Compile"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
This PR attempts to fulfill the original intention of #29451

It adds documentation to __.travis.yml__ so that contributors
know how to test Python 3 on Travis CI.

This PR makes no attempt to ensure that those tests pass.

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
