### PR TITLE
Partially revert "stream: reduce internal usage of public require of util"

### DIFF
--- a/lib/internal/streams/buffer_list.js
+++ b/lib/internal/streams/buffer_list.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Buffer } = require('buffer');
-const { inspect } = require('internal/util/inspect');
+const { inspect } = require('util');
 
 module.exports = class BufferList {
   constructor() {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -45,7 +45,7 @@ Stream.Stream = Stream;
 
 // Internal utilities
 try {
-  const types = require('internal/util/types');
+  const types = require('util').types;
   if (types && typeof types.isUint8Array === 'function') {
     Stream._isUint8Array = types.isUint8Array;
   } else {


### PR DESCRIPTION
This partially reverts commit c97851dcd8c5e96a3601df52edd456922399a80b.

Streams code should ideally require on public APIs as much as possible,
because it is exported as readable-stream.

Refs: https://github.com/nodejs/node/pull/26698
Refs: https://github.com/nodejs/readable-stream/issues/416

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
