### PR TITLE
worker: make terminate() resolve for unref’ed Workers

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -226,6 +226,8 @@ class Worker extends EventEmitter {
   terminate(callback) {
     debug(`[${threadId}] terminates Worker with ID ${this.threadId}`);
 
+    this.ref();
+
     if (typeof callback === 'function') {
       process.emitWarning(
         'Passing a callback to worker.terminate() is deprecated. ' +

--- a/test/parallel/test-worker-terminate-unrefed.js
+++ b/test/parallel/test-worker-terminate-unrefed.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../common');
+const { once } = require('events');
+const { Worker } = require('worker_threads');
+
+// Test that calling worker.terminate() on an unref()’ed Worker instance
+// still resolves the returned Promise.
+
+async function test() {
+  const worker = new Worker('setTimeout(() => {}, 1000000);', { eval: true });
+  await once(worker, 'online');
+  worker.unref();
+  await worker.terminate();
+}
+
+test().then(common.mustCall());


### PR DESCRIPTION
Once `worker.terminate()` is called, the Worker instance will be
destroyed as soon as possible anyway, so in order to make
the Promise returned by `worker.terminate()` resolve always,
it should be okay to just call `.ref()` on it and keep the main
event loop alive temporarily.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
