### PR TITLE
stream: don't call _read after destroy()

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -420,6 +420,11 @@ Readable.prototype.read = function(n) {
     n = parseInt(n, 10);
   }
   const state = this._readableState;
+
+  if (state.destroyed) {
+    return;
+  }
+
   const nOrig = n;
 
   // If we're asking for more than the current hwm, then raise the hwm.
@@ -643,7 +648,7 @@ function maybeReadMore_(stream, state) {
   //   called push() with new data. In this case we skip performing more
   //   read()s. The execution ends in this method again after the _read() ends
   //   up calling push() with more data.
-  while (!state.reading && !state.ended &&
+  while (!state.reading && !state.ended && !state.destroyed &&
          (state.length < state.highWaterMark ||
           (state.flowing && state.length === 0))) {
     const len = state.length;
@@ -976,6 +981,12 @@ function resume(stream, state) {
 
 function resume_(stream, state) {
   debug('resume', state.reading);
+
+  if (state.destroyed) {
+    state.resumeScheduled = false;
+    return;
+  }
+
   if (!state.reading) {
     stream.read(0);
   }

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -189,3 +189,12 @@ const assert = require('assert');
   read.push('hi');
   read.on('data', common.mustNotCall());
 }
+
+{
+  const read = new Readable({
+    read: common.mustNotCall(function() {})
+  });
+  read.destroy();
+  assert.strictEqual(read.destroyed, true);
+  read.read();
+}

--- a/test/parallel/test-stream-transform-destroy.js
+++ b/test/parallel/test-stream-transform-destroy.js
@@ -95,35 +95,6 @@ const assert = require('assert');
   const transform = new Transform({
     transform(chunk, enc, cb) {}
   });
-  transform.resume();
-
-  transform._destroy = common.mustCall(function(err, cb) {
-    assert.strictEqual(err, null);
-    process.nextTick(() => {
-      this.push(null);
-      this.end();
-      cb();
-    });
-  }, 1);
-
-  const fail = common.mustNotCall('no event');
-
-  transform.on('finish', fail);
-  transform.on('end', fail);
-  transform.on('close', common.mustCall());
-
-  transform.destroy();
-
-  transform.removeListener('end', fail);
-  transform.removeListener('finish', fail);
-  transform.on('end', common.mustCall());
-  transform.on('finish', common.mustCall());
-}
-
-{
-  const transform = new Transform({
-    transform(chunk, enc, cb) {}
-  });
 
   const expected = new Error('kaboom');
 


### PR DESCRIPTION
Stop flowing once destroyed.

Currently stream implementation MUST check for `destroyed` inside `_read`. 

Found this while investigating a suspicious  `destroyed` conditional in `fs` streams.

This is semver major unfortunately. The existing behaviour is to flush the readable and invoke `end` after `destroy()`. See updated tests.

If preferable I can make a less breaking version of this (instead of or as an intermediate?) that just makes sure `_read` is not called after `destroy()`. Though it does not fully "correct" the behaviour.

Refs: #29477

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
