### PR TITLE
stream: Readable.off

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -914,6 +914,7 @@ Readable.prototype.removeListener = function(ev, fn) {
 
   return res;
 };
+Readable.prototype.off = Readable.prototype.removeListener;
 
 Readable.prototype.removeAllListeners = function(ev) {
   const res = Stream.prototype.removeAllListeners.apply(this, arguments);

--- a/test/parallel/test-stream-readable-readable-then-resume.js
+++ b/test/parallel/test-stream-readable-readable-then-resume.js
@@ -2,6 +2,7 @@
 
 const common = require('../common');
 const { Readable } = require('stream');
+const assert = require('assert');
 
 // This test verifies that a stream could be resumed after
 // removing the readable event in the same tick
@@ -24,6 +25,7 @@ function check(s) {
   const readableListener = common.mustNotCall();
   s.on('readable', readableListener);
   s.on('end', common.mustCall());
+  assert.strictEqual(s.removeListener, s.off);
   s.removeListener('readable', readableListener);
   s.resume();
 }


### PR DESCRIPTION
We have special logic in removeListener() which must apply
to off() as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
