### PR TITLE
stream: don't call _read after destroy()

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -487,9 +487,10 @@ Readable.prototype.read = function(n) {
     debug('length less than watermark', doRead);
   }
 
-  // However, if we've ended, then there's no point, and if we're already
-  // reading, then it's unnecessary.
-  if (state.ended || state.reading) {
+  // However, if we've ended, then there's no point, if we're already
+  // reading, then it's unnecessary, and if we're destroyed, then it's
+  // not allowed.
+  if (state.ended || state.reading || state.destroyed) {
     doRead = false;
     debug('reading or ended', doRead);
   } else if (doRead) {

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -137,9 +137,6 @@ ReadStream.prototype._read = function(n) {
     });
   }
 
-  if (this.destroyed)
-    return;
-
   if (!pool || pool.length - pool.used < kMinPoolSpace) {
     // Discard the old pool.
     allocNewPool(this.readableHighWaterMark);

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -189,3 +189,12 @@ const assert = require('assert');
   read.push('hi');
   read.on('data', common.mustNotCall());
 }
+
+{
+  const read = new Readable({
+    read: common.mustNotCall(function() {})
+  });
+  read.destroy();
+  assert.strictEqual(read.destroyed, true);
+  read.read();
+}

--- a/test/parallel/test-wrap-js-stream-exceptions.js
+++ b/test/parallel/test-wrap-js-stream-exceptions.js
@@ -10,7 +10,7 @@ process.once('uncaughtException', common.mustCall((err) => {
 }));
 
 const socket = new JSStreamWrap(new Duplex({
-  read: common.mustCall(),
+  read: common.mustNotCall(),
   write: common.mustCall((buffer, data, cb) => {
     throw new Error('exception!');
   })


### PR DESCRIPTION
Partly fixes #29477.

Currently stream implementations MUST check for destroyed inside _read.

Found this while investigating a suspicious `destroyed` conditional in fs streams.

"Full" fix in #29485 but it is way too breaking at this point and needs more updated tests.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
