### PR TITLE
doc: esm: options for package authors

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -97,6 +97,15 @@ if the nearest parent `package.json` contains `"type": "module"`.
 import './startup.js'; // Loaded as ES module because of package.json
 ```
 
+It is recommended that package authors always include the `"type"` field, even
+in packages where it is unnecessary because all sources are CommonJS (and so
+therefore the default `"type": "commonjs"` is implied) or because there are no
+files ending in `.js` (for example, all files end in `.mjs` or `.cjs` or
+`.wasm`, etc.). Being explicit about the `type` of the package will future-proof
+the package in case Node.js’ default type ever changes, and it will also make
+things easier for build tools and loaders to determine how the files in the
+package should be interpreted.
+
 ### Package Scope and File Extensions
 
 A folder containing a `package.json` file, and all subfolders below that

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -60,7 +60,7 @@ or when referenced by `import` statements within ES module code:
 - Strings passed in as an argument to `--eval` or `--print`, or piped to
   `node` via `STDIN`, with the flag `--input-type=commonjs`.
 
-## <code>package.json</code> <code>"type"</code> field
+### <code>package.json</code> <code>"type"</code> field
 
 Files ending with `.js` or `.mjs`, or lacking any extension,
 will be loaded as ES modules when the nearest parent `package.json` file
@@ -97,7 +97,7 @@ if the nearest parent `package.json` contains `"type": "module"`.
 import './startup.js'; // Loaded as ES module because of package.json
 ```
 
-## Package Scope and File Extensions
+### Package Scope and File Extensions
 
 A folder containing a `package.json` file, and all subfolders below that
 folder down until the next folder containing another `package.json`, is
@@ -156,7 +156,7 @@ package scope:
   extension (since both `.js` and `.cjs` files are treated as CommonJS within a
   `"commonjs"` package scope).
 
-## <code>--input-type</code> flag
+### <code>--input-type</code> flag
 
 Strings passed in as an argument to `--eval` or `--print` (or `-e` or `-p`), or
 piped to `node` via `STDIN`, will be treated as ES modules when the
@@ -174,7 +174,9 @@ For completeness there is also `--input-type=commonjs`, for explicitly running
 string input as CommonJS. This is the default behavior if `--input-type` is
 unspecified.
 
-## Package Entry Points
+## Packages
+
+### Package Entry Points
 
 The `package.json` `"main"` field defines the entry point for a package,
 whether the package is included into CommonJS via `require` or into an ES
@@ -217,7 +219,7 @@ a package would be accessible like `require('pkg')` and `import
 module entry point and legacy users could be informed of the CommonJS entry
 point path, e.g. `require('pkg/commonjs')`.
 
-## Package Exports
+### Package Exports
 
 By default, all subpaths from a package can be imported (`import 'pkg/x.js'`).
 Custom subpath aliasing and encapsulation can be provided through the

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -246,16 +246,16 @@ publishing a package that contains both CommonJS and ES module sources:
    lack support for ES modules.
 
 1. Switch the package `"main"` entry point to an ES module file as part of a
-   semver major version bump. This version and above would only be usable on ES
-   module-supporting versions of Node.js. If the package still contains a
+   breaking change version bump. This version and above would only be usable on
+   ES module-supporting versions of Node.js. If the package still contains a
    CommonJS version, it would be accessible via a path within the package, e.g.
    `require('pkg/commonjs')`; this is essentially the inverse of the previous
    approach. Package consumers who are using CommonJS-only versions of Node.js
    would need to update their code from `require('pkg')` to e.g.
    `require('pkg/commonjs')`.
 
-Of course, a package could also include _only_ CommonJS or ES module sources. An
-existing package could make a semver major bump to an ES module-only version,
+Of course, a package could also include only CommonJS or only ES module sources.
+An existing package could make a semver major bump to an ES module-only version,
 that would only be supported in ES module-supporting versions of Node.js (and
 other runtimes). New packages could be published containing only ES module
 sources, and would be compatible only with ES module-supporting runtimes.
@@ -940,7 +940,6 @@ success!
 
 [CommonJS]: modules.html
 [ECMAScript-modules implementation]: https://github.com/nodejs/modules/blob/master/doc/plan-for-new-modules-implementation.md
-[package exports]: #esm_package_exports
 [ES Module Integration Proposal for Web Assembly]: https://github.com/webassembly/esm-integration
 [Node.js EP for ES Modules]: https://github.com/nodejs/node-eps/blob/master/002-es-modules.md
 [Terminology]: #esm_terminology
@@ -952,5 +951,6 @@ success!
 [`import`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 [`module.createRequire()`]: modules.html#modules_module_createrequire_filename
 [dynamic instantiate hook]: #esm_dynamic_instantiate_hook
+[package exports]: #esm_package_exports
 [special scheme]: https://url.spec.whatwg.org/#special-scheme
 [the official standard format]: https://tc39.github.io/ecma262/#sec-modules


### PR DESCRIPTION
This updates the ECMAScript Modules docs with a few changes agreed in recent modules group meetings:

- Per the 2019-06-19 meeting, we [decided](https://github.com/nodejs/modules/issues/342#issuecomment-503733187) that we want to encourage all package authors to always include the `package.json` `"type"` field, even for CommonJS packages (where `"type": "commonjs"` is implied).

- Per the 2019-08-28 meeting, we [decided](https://github.com/nodejs/modules/issues/371#issuecomment-526349453) that the docs needed more discussion of packages and specifically what options are available for package authors wishing to support both CommonJS and ESM consumers of packages, and both current and older versions of Node.

Regarding the latter, this PR is just a first step; it will need expansion if/when #29494 is merged in, and possibly again later if more improvements are made to better support different module systems or Node runtime versions. For now, though, I think this text is an improvement on the very minimal mention that dual CommonJS/ESM support in packages has currently.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

//cc @nodejs/modules-active-members