### PR TITLE
events: support EventTarget in `once`

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -703,7 +703,7 @@ added: v11.13.0
 * `name` {string}
 * Returns: {Promise}
 
-Creates a `Promise` that is fulfill when the `EventEmitter` emits the given
+Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected when the `EventEmitter` emits `'error'`.
 The `Promise` will resolve with an array of all the arguments emitted to the
 given event.
@@ -739,7 +739,7 @@ async function run() {
 
 run();
 ```
-
+[WHATWG-EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget)
 [`--trace-warnings`]: cli.html#cli_trace_warnings
 [`EventEmitter.defaultMaxListeners`]: #events_eventemitter_defaultmaxlisteners
 [`domain`]: domain.html
@@ -749,5 +749,4 @@ run();
 [`fs.ReadStream`]: fs.html#fs_class_fs_readstream
 [`net.Server`]: net.html#net_class_net_server
 [`process.on('warning')`]: process.html#process_event_warning
-[WHATWG-EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget)
 [stream]: stream.html

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -703,10 +703,14 @@ added: v11.13.0
 * `name` {string}
 * Returns: {Promise}
 
-Creates a `Promise` that is resolved when the `EventEmitter` emits the given
+Creates a `Promise` that is fulfill when the `EventEmitter` emits the given
 event or that is rejected when the `EventEmitter` emits `'error'`.
 The `Promise` will resolve with an array of all the arguments emitted to the
 given event.
+
+Note: This method is intentionally generic and works with the web platform
+[EventTarget](WHATWG-EventTarget) interface, which have no special
+`'error'` event semantics and do not listen to the `'error'` event.
 
 ```js
 const { once, EventEmitter } = require('events');
@@ -745,4 +749,5 @@ run();
 [`fs.ReadStream`]: fs.html#fs_class_fs_readstream
 [`net.Server`]: net.html#net_class_net_server
 [`process.on('warning')`]: process.html#process_event_warning
+[WHATWG-EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget)
 [stream]: stream.html

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -708,7 +708,7 @@ event or that is rejected when the `EventEmitter` emits `'error'`.
 The `Promise` will resolve with an array of all the arguments emitted to the
 given event.
 
-Note: This method is intentionally generic and works with the web platform
+This method is intentionally generic and works with the web platform
 [EventTarget](WHATWG-EventTarget) interface, which have no special
 `'error'` event semantics and do not listen to the `'error'` event.
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -532,6 +532,5 @@ function once(emitter, name) {
       (...args) => { resolve(args); },
       { once: true }
     );
-    return;
   });
 }

--- a/lib/events.js
+++ b/lib/events.js
@@ -497,7 +497,7 @@ function unwrapListeners(arr) {
 
 function once(emitter, name) {
   return new Promise((resolve, reject) => {
-    if (typeof emitter.addEventListener === 'undefined') {
+    if (typeof emitter.addEventListener !== 'function') {
       const eventListener = (...args) => {
         if (errorListener !== undefined) {
           emitter.removeListener('error', errorListener);
@@ -525,21 +525,13 @@ function once(emitter, name) {
       return;
     }
 
-    if (typeof emitter.addEventListener === 'function') {
-      // EventTarget does not have `error` event semantics like Node
-      // EventEmitters, we do not listen to `error` events here.
-      if (name === 'error') {
-        reject('EventTarget does not have `error` event semantics');
-      }
-
-      emitter.addEventListener(
-        name,
-        (...args) => { resolve(args); },
-        { once: true }
-      );
-      return;
-    }
-
-    throw new ERR_INVALID_ARG_TYPE('emitter', 'EventEmitter', emitter);
+    // EventTarget does not have `error` event semantics like Node
+    // EventEmitters, we do not listen to `error` events here.
+    emitter.addEventListener(
+      name,
+      (...args) => { resolve(args); },
+      { once: true }
+    );
+    return;
   });
 }

--- a/lib/events.js
+++ b/lib/events.js
@@ -497,7 +497,7 @@ function unwrapListeners(arr) {
 
 function once(emitter, name) {
   return new Promise((resolve, reject) => {
-    if (emitter.addEventListener === undefined) {
+    if (typeof emitter.addEventListener === 'undefined') {
       const eventListener = (...args) => {
         if (errorListener !== undefined) {
           emitter.removeListener('error', errorListener);
@@ -528,7 +528,15 @@ function once(emitter, name) {
     if (typeof emitter.addEventListener === 'function') {
       // EventTarget does not have `error` event semantics like Node
       // EventEmitters, we do not listen to `error` events here.
-      emitter.addEventListener(name, resolve, { once: true });
+      if (name === 'error') {
+        reject('EventTarget does not have `error` event semantics');
+      }
+
+      emitter.addEventListener(
+        name,
+        (...args) => { resolve(args); },
+        { once: true }
+      );
       return;
     }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -497,29 +497,41 @@ function unwrapListeners(arr) {
 
 function once(emitter, name) {
   return new Promise((resolve, reject) => {
-    const eventListener = (...args) => {
-      if (errorListener !== undefined) {
-        emitter.removeListener('error', errorListener);
-      }
-      resolve(args);
-    };
-    let errorListener;
-
-    // Adding an error listener is not optional because
-    // if an error is thrown on an event emitter we cannot
-    // guarantee that the actual event we are waiting will
-    // be fired. The result could be a silent way to create
-    // memory or file descriptor leaks, which is something
-    // we should avoid.
-    if (name !== 'error') {
-      errorListener = (err) => {
-        emitter.removeListener(name, eventListener);
-        reject(err);
+    if (emitter.addEventListener === undefined) {
+      const eventListener = (...args) => {
+        if (errorListener !== undefined) {
+          emitter.removeListener('error', errorListener);
+        }
+        resolve(args);
       };
+      let errorListener;
 
-      emitter.once('error', errorListener);
+      // Adding an error listener is not optional because
+      // if an error is thrown on an event emitter we cannot
+      // guarantee that the actual event we are waiting will
+      // be fired. The result could be a silent way to create
+      // memory or file descriptor leaks, which is something
+      // we should avoid.
+      if (name !== 'error') {
+        errorListener = (err) => {
+          emitter.removeListener(name, eventListener);
+          reject(err);
+        };
+
+        emitter.once('error', errorListener);
+      }
+
+      emitter.once(name, eventListener);
+      return;
     }
 
-    emitter.once(name, eventListener);
+    if (typeof emitter.addEventListener === 'function') {
+      // EventTarget does not have `error` event semantics like Node
+      // EventEmitters, we do not listen to `error` events here.
+      emitter.addEventListener(name, resolve, { once: true });
+      return;
+    }
+
+    throw new ERR_INVALID_ARG_TYPE('emitter', 'EventEmitter', emitter);
   });
 }

--- a/lib/events.js
+++ b/lib/events.js
@@ -497,40 +497,40 @@ function unwrapListeners(arr) {
 
 function once(emitter, name) {
   return new Promise((resolve, reject) => {
-    if (typeof emitter.addEventListener !== 'function') {
-      const eventListener = (...args) => {
-        if (errorListener !== undefined) {
-          emitter.removeListener('error', errorListener);
-        }
-        resolve(args);
-      };
-      let errorListener;
-
-      // Adding an error listener is not optional because
-      // if an error is thrown on an event emitter we cannot
-      // guarantee that the actual event we are waiting will
-      // be fired. The result could be a silent way to create
-      // memory or file descriptor leaks, which is something
-      // we should avoid.
-      if (name !== 'error') {
-        errorListener = (err) => {
-          emitter.removeListener(name, eventListener);
-          reject(err);
-        };
-
-        emitter.once('error', errorListener);
-      }
-
-      emitter.once(name, eventListener);
+    if (typeof emitter.addEventListener === 'function') {
+      // EventTarget does not have `error` event semantics like Node
+      // EventEmitters, we do not listen to `error` events here.
+      emitter.addEventListener(
+        name,
+        (...args) => { resolve(args); },
+        { once: true }
+      );
       return;
     }
 
-    // EventTarget does not have `error` event semantics like Node
-    // EventEmitters, we do not listen to `error` events here.
-    emitter.addEventListener(
-      name,
-      (...args) => { resolve(args); },
-      { once: true }
-    );
+    const eventListener = (...args) => {
+      if (errorListener !== undefined) {
+        emitter.removeListener('error', errorListener);
+      }
+      resolve(args);
+    };
+    let errorListener;
+
+    // Adding an error listener is not optional because
+    // if an error is thrown on an event emitter we cannot
+    // guarantee that the actual event we are waiting will
+    // be fired. The result could be a silent way to create
+    // memory or file descriptor leaks, which is something
+    // we should avoid.
+    if (name !== 'error') {
+      errorListener = (err) => {
+        emitter.removeListener(name, eventListener);
+        reject(err);
+      };
+
+      emitter.once('error', errorListener);
+    }
+
+    emitter.once(name, eventListener);
   });
 }

--- a/test/parallel/test-events-once.js
+++ b/test/parallel/test-events-once.js
@@ -84,10 +84,31 @@ async function onceError() {
   strictEqual(ee.listenerCount('myevent'), 0);
 }
 
+async function onceWithEventTarget() {
+  const emitter = new class EventTargetLike extends EventEmitter {
+    addEventListener = common.mustCall(function(name, listener, options) {
+      if (options.once) {
+        this.once(name, listener);
+      } else {
+        this.on(name, listener);
+      }
+    });
+  }();
+
+  process.nextTick(() => {
+    emitter.emit('myevent', 42);
+  });
+  const value = await once(emitter, 'myevent');
+  strictEqual(value, 42);
+  strictEqual(emitter.listenerCount('myevent'), 0);
+
+}
+
 Promise.all([
   onceAnEvent(),
   onceAnEventWithTwoArgs(),
   catchesErrors(),
   stopListeningAfterCatchingError(),
-  onceError()
+  onceError(),
+  onceWithEventTarget()
 ]).then(common.mustCall());


### PR DESCRIPTION
My attempt to add support for EventTarget in the once static method.
This PR follow up https://github.com/nodejs/node/pull/27977

Ping @benjamingr please take a look.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
