### PR TITLE
stdio: use public stream readableFlowing property

### DIFF
--- a/lib/internal/process/stdio.js
+++ b/lib/internal/process/stdio.js
@@ -123,7 +123,7 @@ function getMainThreadStdio() {
     function onpause() {
       if (!stdin._handle)
         return;
-      if (stdin._handle.reading && !stdin._readableState.flowing) {
+      if (stdin._handle.reading && !stdin.readableFlowing) {
         stdin._readableState.reading = false;
         stdin._handle.reading = false;
         stdin._handle.readStop();


### PR DESCRIPTION
A change to avoid using `flowing` property from stream's internal state.
Instead uses the API property `readableFlowing`.

Refs: [#445](https://github.com/nodejs/node/issues/445)

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

