### PR TITLE
events: add/removeListener should call on/off

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -734,7 +734,8 @@ run();
 [`EventEmitter.defaultMaxListeners`]: #events_eventemitter_defaultmaxlisteners
 [`domain`]: domain.html
 [`emitter.listenerCount()`]: #events_emitter_listenercount_eventname
-[`emitter.removeListener()`]: #events_emitter_removelistener_eventname_listener
+[`emitter.on()`]: #events_emitter_on_eventname_listener
+[`emitter.off()`]: #events_emitter_off_eventname_listener
 [`emitter.setMaxListeners(n)`]: #events_emitter_setmaxlisteners_n
 [`fs.ReadStream`]: fs.html#fs_class_fs_readstream
 [`net.Server`]: net.html#net_class_net_server

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -292,33 +292,8 @@ added: v0.1.26
 * `listener` {Function}
 * Returns: {EventEmitter}
 
-Adds the `listener` function to the end of the listeners array for the
-event named `eventName`. No checks are made to see if the `listener` has
-already been added. Multiple calls passing the same combination of `eventName`
-and `listener` will result in the `listener` being added, and called, multiple
-times.
-
-```js
-server.addListener('connection', (stream) => {
-  console.log('someone connected!');
-});
-```
-
-Returns a reference to the `EventEmitter`, so that calls can be chained.
-
-By default, event listeners are invoked in the order they are added. The
-`emitter.prependListener()` method can be used as an alternative to add the
-event listener to the beginning of the listeners array.
-
-```js
-const myEE = new EventEmitter();
-myEE.addListener('foo', () => console.log('a'));
-myEE.prependListener('foo', () => console.log('b'));
-myEE.emit('foo');
-// Prints:
-//   b
-//   a
-```
+This function is implemented by calling [`emitter.on()`][].
+When overriding, override [`emitter.on()`][].
 
 ### emitter.emit(eventName[, ...args])
 <!-- YAML
@@ -442,8 +417,8 @@ added: v10.0.0
 * `listener` {Function}
 * Returns: {EventEmitter}
 
-Calls [`emitter.removeListener()`][]. When overriding, override
-[`emitter.removeListener()`][].
+This function is implemented by calling [`emitter.removeListener()`][].
+When overriding, override [`emitter.removeListener()`][].
 
 ### emitter.on(eventName, listener)
 <!-- YAML
@@ -454,8 +429,33 @@ added: v0.1.101
 * `listener` {Function} The callback function
 * Returns: {EventEmitter}
 
-Calls [`emitter.addListener()`][]. When overriding, override
-[`emitter.addListener()`][].
+Adds the `listener` function to the end of the listeners array for the
+event named `eventName`. No checks are made to see if the `listener` has
+already been added. Multiple calls passing the same combination of `eventName`
+and `listener` will result in the `listener` being added, and called, multiple
+times.
+
+```js
+server.on('connection', (stream) => {
+  console.log('someone connected!');
+});
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+By default, event listeners are invoked in the order they are added. The
+`emitter.prependListener()` method can be used as an alternative to add the
+event listener to the beginning of the listeners array.
+
+```js
+const myEE = new EventEmitter();
+myEE.on('foo', () => console.log('a'));
+myEE.prependListener('foo', () => console.log('b'));
+myEE.emit('foo');
+// Prints:
+//   b
+//   a
+```
 
 ### emitter.once(eventName, listener)
 <!-- YAML

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -290,8 +290,35 @@ added: v0.1.26
 -->
 * `eventName` {string|symbol}
 * `listener` {Function}
+* Returns: {EventEmitter}
 
-Alias for `emitter.on(eventName, listener)`.
+Adds the `listener` function to the end of the listeners array for the
+event named `eventName`. No checks are made to see if the `listener` has
+already been added. Multiple calls passing the same combination of `eventName`
+and `listener` will result in the `listener` being added, and called, multiple
+times.
+
+```js
+server.addListener('connection', (stream) => {
+  console.log('someone connected!');
+});
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+By default, event listeners are invoked in the order they are added. The
+`emitter.prependListener()` method can be used as an alternative to add the
+event listener to the beginning of the listeners array.
+
+```js
+const myEE = new EventEmitter();
+myEE.addListener('foo', () => console.log('a'));
+myEE.prependListener('foo', () => console.log('b'));
+myEE.emit('foo');
+// Prints:
+//   b
+//   a
+```
 
 ### emitter.emit(eventName[, ...args])
 <!-- YAML
@@ -415,7 +442,8 @@ added: v10.0.0
 * `listener` {Function}
 * Returns: {EventEmitter}
 
-Alias for [`emitter.removeListener()`][].
+Calls [`emitter.removeListener()`][]. When overriding, override
+[`emitter.removeListener()`][].
 
 ### emitter.on(eventName, listener)
 <!-- YAML
@@ -426,33 +454,8 @@ added: v0.1.101
 * `listener` {Function} The callback function
 * Returns: {EventEmitter}
 
-Adds the `listener` function to the end of the listeners array for the
-event named `eventName`. No checks are made to see if the `listener` has
-already been added. Multiple calls passing the same combination of `eventName`
-and `listener` will result in the `listener` being added, and called, multiple
-times.
-
-```js
-server.on('connection', (stream) => {
-  console.log('someone connected!');
-});
-```
-
-Returns a reference to the `EventEmitter`, so that calls can be chained.
-
-By default, event listeners are invoked in the order they are added. The
-`emitter.prependListener()` method can be used as an alternative to add the
-event listener to the beginning of the listeners array.
-
-```js
-const myEE = new EventEmitter();
-myEE.on('foo', () => console.log('a'));
-myEE.prependListener('foo', () => console.log('b'));
-myEE.emit('foo');
-// Prints:
-//   b
-//   a
-```
+Calls [`emitter.addListener()`][]. When overriding, override
+[`emitter.addListener()`][].
 
 ### emitter.once(eventName, listener)
 <!-- YAML

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -417,86 +417,8 @@ added: v10.0.0
 * `listener` {Function}
 * Returns: {EventEmitter}
 
-Removes the specified `listener` from the listener array for the event named
-`eventName`.
-
-```js
-const callback = (stream) => {
-  console.log('someone connected!');
-};
-server.on('connection', callback);
-// ...
-server.off('connection', callback);
-```
-
-`off()` will remove, at most, one instance of a listener from the
-listener array. If any single listener has been added multiple times to the
-listener array for the specified `eventName`, then `off()` must be
-called multiple times to remove each instance.
-
-Once an event has been emitted, all listeners attached to it at the
-time of emitting will be called in order. This implies that any
-`off()` or `removeAllListeners()` calls *after* emitting and
-*before* the last listener finishes execution will not remove them from
-`emit()` in progress. Subsequent events will behave as expected.
-
-```js
-const myEmitter = new MyEmitter();
-
-const callbackA = () => {
-  console.log('A');
-  myEmitter.off('event', callbackB);
-};
-
-const callbackB = () => {
-  console.log('B');
-};
-
-myEmitter.on('event', callbackA);
-
-myEmitter.on('event', callbackB);
-
-// callbackA removes listener callbackB but it will still be called.
-// Internal listener array at time of emit [callbackA, callbackB]
-myEmitter.emit('event');
-// Prints:
-//   A
-//   B
-
-// callbackB is now removed.
-// Internal listener array [callbackA]
-myEmitter.emit('event');
-// Prints:
-//   A
-```
-
-Because listeners are managed using an internal array, calling this will
-change the position indices of any listener registered *after* the listener
-being removed. This will not impact the order in which listeners are called,
-but it means that any copies of the listener array as returned by
-the `emitter.listeners()` method will need to be recreated.
-
-When a single function has been added as a handler multiple times for a single
-event (as in the example below), `off()` will remove the most
-recently added instance. In the example the `once('ping')`
-listener is removed:
-
-```js
-const ee = new EventEmitter();
-
-function pong() {
-  console.log('pong');
-}
-
-ee.on('ping', pong);
-ee.once('ping', pong);
-ee.off('ping', pong);
-
-ee.emit('ping');
-ee.emit('ping');
-```
-
-Returns a reference to the `EventEmitter`, so that calls can be chained.
+This function is implemented by calling [`emitter.removeListener()`][].
+When overriding, override [`emitter.removeListener()`][].
 
 ### emitter.on(eventName, listener)
 <!-- YAML
@@ -636,8 +558,86 @@ added: v0.1.26
 * `listener` {Function}
 * Returns: {EventEmitter}
 
-This function is implemented by calling [`emitter.off()`][].
-When overriding, override [`emitter.off()`][].
+Removes the specified `listener` from the listener array for the event named
+`eventName`.
+
+```js
+const callback = (stream) => {
+  console.log('someone connected!');
+};
+server.on('connection', callback);
+// ...
+server.removeListener('connection', callback);
+```
+
+`removeListener()` will remove, at most, one instance of a listener from the
+listener array. If any single listener has been added multiple times to the
+listener array for the specified `eventName`, then `removeListener()` must be
+called multiple times to remove each instance.
+
+Once an event has been emitted, all listeners attached to it at the
+time of emitting will be called in order. This implies that any
+`removeListener()` or `removeAllListeners()` calls *after* emitting and
+*before* the last listener finishes execution will not remove them from
+`emit()` in progress. Subsequent events will behave as expected.
+
+```js
+const myEmitter = new MyEmitter();
+
+const callbackA = () => {
+  console.log('A');
+  myEmitter.removeListener('event', callbackB);
+};
+
+const callbackB = () => {
+  console.log('B');
+};
+
+myEmitter.on('event', callbackA);
+
+myEmitter.on('event', callbackB);
+
+// callbackA removes listener callbackB but it will still be called.
+// Internal listener array at time of emit [callbackA, callbackB]
+myEmitter.emit('event');
+// Prints:
+//   A
+//   B
+
+// callbackB is now removed.
+// Internal listener array [callbackA]
+myEmitter.emit('event');
+// Prints:
+//   A
+```
+
+Because listeners are managed using an internal array, calling this will
+change the position indices of any listener registered *after* the listener
+being removed. This will not impact the order in which listeners are called,
+but it means that any copies of the listener array as returned by
+the `emitter.listeners()` method will need to be recreated.
+
+When a single function has been added as a handler multiple times for a single
+event (as in the example below), `removeListener()` will remove the most
+recently added instance. In the example the `once('ping')`
+listener is removed:
+
+```js
+const ee = new EventEmitter();
+
+function pong() {
+  console.log('pong');
+}
+
+ee.on('ping', pong);
+ee.once('ping', pong);
+ee.removeListener('ping', pong);
+
+ee.emit('ping');
+ee.emit('ping');
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
 
 ### emitter.setMaxListeners(n)
 <!-- YAML
@@ -734,8 +734,7 @@ run();
 [`EventEmitter.defaultMaxListeners`]: #events_eventemitter_defaultmaxlisteners
 [`domain`]: domain.html
 [`emitter.listenerCount()`]: #events_emitter_listenercount_eventname
-[`emitter.on()`]: #events_emitter_on_eventname_listener
-[`emitter.off()`]: #events_emitter_off_eventname_listener
+[`emitter.removeListener()`]: #events_emitter_removelistener_eventname_listener
 [`emitter.setMaxListeners(n)`]: #events_emitter_setmaxlisteners_n
 [`fs.ReadStream`]: fs.html#fs_class_fs_readstream
 [`net.Server`]: net.html#net_class_net_server

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -417,8 +417,86 @@ added: v10.0.0
 * `listener` {Function}
 * Returns: {EventEmitter}
 
-This function is implemented by calling [`emitter.removeListener()`][].
-When overriding, override [`emitter.removeListener()`][].
+Removes the specified `listener` from the listener array for the event named
+`eventName`.
+
+```js
+const callback = (stream) => {
+  console.log('someone connected!');
+};
+server.on('connection', callback);
+// ...
+server.off('connection', callback);
+```
+
+`off()` will remove, at most, one instance of a listener from the
+listener array. If any single listener has been added multiple times to the
+listener array for the specified `eventName`, then `off()` must be
+called multiple times to remove each instance.
+
+Once an event has been emitted, all listeners attached to it at the
+time of emitting will be called in order. This implies that any
+`off()` or `removeAllListeners()` calls *after* emitting and
+*before* the last listener finishes execution will not remove them from
+`emit()` in progress. Subsequent events will behave as expected.
+
+```js
+const myEmitter = new MyEmitter();
+
+const callbackA = () => {
+  console.log('A');
+  myEmitter.off('event', callbackB);
+};
+
+const callbackB = () => {
+  console.log('B');
+};
+
+myEmitter.on('event', callbackA);
+
+myEmitter.on('event', callbackB);
+
+// callbackA removes listener callbackB but it will still be called.
+// Internal listener array at time of emit [callbackA, callbackB]
+myEmitter.emit('event');
+// Prints:
+//   A
+//   B
+
+// callbackB is now removed.
+// Internal listener array [callbackA]
+myEmitter.emit('event');
+// Prints:
+//   A
+```
+
+Because listeners are managed using an internal array, calling this will
+change the position indices of any listener registered *after* the listener
+being removed. This will not impact the order in which listeners are called,
+but it means that any copies of the listener array as returned by
+the `emitter.listeners()` method will need to be recreated.
+
+When a single function has been added as a handler multiple times for a single
+event (as in the example below), `off()` will remove the most
+recently added instance. In the example the `once('ping')`
+listener is removed:
+
+```js
+const ee = new EventEmitter();
+
+function pong() {
+  console.log('pong');
+}
+
+ee.on('ping', pong);
+ee.once('ping', pong);
+ee.off('ping', pong);
+
+ee.emit('ping');
+ee.emit('ping');
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
 
 ### emitter.on(eventName, listener)
 <!-- YAML
@@ -558,86 +636,8 @@ added: v0.1.26
 * `listener` {Function}
 * Returns: {EventEmitter}
 
-Removes the specified `listener` from the listener array for the event named
-`eventName`.
-
-```js
-const callback = (stream) => {
-  console.log('someone connected!');
-};
-server.on('connection', callback);
-// ...
-server.removeListener('connection', callback);
-```
-
-`removeListener()` will remove, at most, one instance of a listener from the
-listener array. If any single listener has been added multiple times to the
-listener array for the specified `eventName`, then `removeListener()` must be
-called multiple times to remove each instance.
-
-Once an event has been emitted, all listeners attached to it at the
-time of emitting will be called in order. This implies that any
-`removeListener()` or `removeAllListeners()` calls *after* emitting and
-*before* the last listener finishes execution will not remove them from
-`emit()` in progress. Subsequent events will behave as expected.
-
-```js
-const myEmitter = new MyEmitter();
-
-const callbackA = () => {
-  console.log('A');
-  myEmitter.removeListener('event', callbackB);
-};
-
-const callbackB = () => {
-  console.log('B');
-};
-
-myEmitter.on('event', callbackA);
-
-myEmitter.on('event', callbackB);
-
-// callbackA removes listener callbackB but it will still be called.
-// Internal listener array at time of emit [callbackA, callbackB]
-myEmitter.emit('event');
-// Prints:
-//   A
-//   B
-
-// callbackB is now removed.
-// Internal listener array [callbackA]
-myEmitter.emit('event');
-// Prints:
-//   A
-```
-
-Because listeners are managed using an internal array, calling this will
-change the position indices of any listener registered *after* the listener
-being removed. This will not impact the order in which listeners are called,
-but it means that any copies of the listener array as returned by
-the `emitter.listeners()` method will need to be recreated.
-
-When a single function has been added as a handler multiple times for a single
-event (as in the example below), `removeListener()` will remove the most
-recently added instance. In the example the `once('ping')`
-listener is removed:
-
-```js
-const ee = new EventEmitter();
-
-function pong() {
-  console.log('pong');
-}
-
-ee.on('ping', pong);
-ee.once('ping', pong);
-ee.removeListener('ping', pong);
-
-ee.emit('ping');
-ee.emit('ping');
-```
-
-Returns a reference to the `EventEmitter`, so that calls can be chained.
+This function is implemented by calling [`emitter.off()`][].
+When overriding, override [`emitter.off()`][].
 
 ### emitter.setMaxListeners(n)
 <!-- YAML

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -421,7 +421,6 @@ function connectionListenerInternal(server, socket) {
 
   // Overrides to unconsume on `data`, `readable` listeners
   socket.on = generateSocketListenerWrapper('on');
-  socket.addListener = generateSocketListenerWrapper('addListener');
   socket.prependListener = generateSocketListenerWrapper('prependListener');
 
   // We only consume the socket if it has never been consumed before.
@@ -792,7 +791,6 @@ function generateSocketListenerWrapper(originalFnName) {
     const res = net.Socket.prototype[originalFnName].call(this, ev, fn);
     if (!this.parser) {
       this.on = net.Socket.prototype.on;
-      this.addListener = net.Socket.prototype.addListener;
       this.prependListener = net.Socket.prototype.prependListener;
       return res;
     }

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -897,10 +897,9 @@ Readable.prototype.on = function(ev, fn) {
 
   return res;
 };
-Readable.prototype.addListener = Readable.prototype.on;
 
-Readable.prototype.removeListener = function(ev, fn) {
-  const res = Stream.prototype.removeListener.call(this, ev, fn);
+Readable.prototype.off = function(ev, fn) {
+  const res = Stream.prototype.off.call(this, ev, fn);
 
   if (ev === 'readable') {
     // We need to check if there is someone still listening to

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -898,8 +898,8 @@ Readable.prototype.on = function(ev, fn) {
   return res;
 };
 
-Readable.prototype.off = function(ev, fn) {
-  const res = Stream.prototype.off.call(this, ev, fn);
+Readable.prototype.removeListener = function(ev, fn) {
+  const res = Stream.prototype.removeListener.call(this, ev, fn);
 
   if (ev === 'readable') {
     // We need to check if there is someone still listening to

--- a/lib/events.js
+++ b/lib/events.js
@@ -380,9 +380,10 @@ EventEmitter.prototype.off =
       return this;
     };
 
-EventEmitter.prototype.removeListener = function removeListener(type, listener) {
-  return this.off(type, listener);
-};
+EventEmitter.prototype.removeListener =
+    function removeListener(type, listener) {
+      return this.off(type, listener);
+    };
 
 EventEmitter.prototype.removeAllListeners =
     function removeAllListeners(type) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -280,11 +280,11 @@ function _addListener(target, type, listener, prepend) {
 }
 
 EventEmitter.prototype.addListener = function addListener(type, listener) {
-  return _addListener(this, type, listener, false);
+  return this.on(type, listener);
 };
 
 EventEmitter.prototype.on = function(type, listener) {
-  this.addListener(type, listener);
+  return _addListener(this, type, listener, false);
 };
 
 EventEmitter.prototype.prependListener =
@@ -381,7 +381,7 @@ EventEmitter.prototype.removeListener =
     };
 
 EventEmitter.prototype.off = function(type, listener) {
-  this.removeListener(type, listener);
+  return this.removeListener(type, listener);
 };
 
 EventEmitter.prototype.removeAllListeners =

--- a/lib/events.js
+++ b/lib/events.js
@@ -283,7 +283,7 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
   return this.on(type, listener);
 };
 
-EventEmitter.prototype.on = function(type, listener) {
+EventEmitter.prototype.on = function on(type, listener) {
   return _addListener(this, type, listener, false);
 };
 
@@ -380,7 +380,7 @@ EventEmitter.prototype.off =
       return this;
     };
 
-EventEmitter.prototype.removeListener = function(type, listener) {
+EventEmitter.prototype.removeListener = function removeListener(type, listener) {
   return this.off(type, listener);
 };
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -326,8 +326,8 @@ EventEmitter.prototype.prependOnceListener =
     };
 
 // Emits a 'removeListener' event if and only if the listener was removed.
-EventEmitter.prototype.off =
-    function off(type, listener) {
+EventEmitter.prototype.removeListener =
+    function removeListener(type, listener) {
       let originalListener;
 
       checkListener(listener);
@@ -380,9 +380,9 @@ EventEmitter.prototype.off =
       return this;
     };
 
-EventEmitter.prototype.removeListener =
-    function removeListener(type, listener) {
-      return this.off(type, listener);
+EventEmitter.prototype.off =
+    function off(type, listener) {
+      return this.removeListener(type, listener);
     };
 
 EventEmitter.prototype.removeAllListeners =

--- a/lib/events.js
+++ b/lib/events.js
@@ -283,7 +283,9 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
   return _addListener(this, type, listener, false);
 };
 
-EventEmitter.prototype.on = EventEmitter.prototype.addListener;
+EventEmitter.prototype.on = function (type, listener) {
+  this.addListener(type, listener);
+}
 
 EventEmitter.prototype.prependListener =
     function prependListener(type, listener) {
@@ -378,7 +380,9 @@ EventEmitter.prototype.removeListener =
       return this;
     };
 
-EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+EventEmitter.prototype.off = function (type, listener) {
+  this.removeListener(type, listener);
+}
 
 EventEmitter.prototype.removeAllListeners =
     function removeAllListeners(type) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -283,9 +283,9 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
   return _addListener(this, type, listener, false);
 };
 
-EventEmitter.prototype.on = function (type, listener) {
+EventEmitter.prototype.on = function(type, listener) {
   this.addListener(type, listener);
-}
+};
 
 EventEmitter.prototype.prependListener =
     function prependListener(type, listener) {
@@ -380,9 +380,9 @@ EventEmitter.prototype.removeListener =
       return this;
     };
 
-EventEmitter.prototype.off = function (type, listener) {
+EventEmitter.prototype.off = function(type, listener) {
   this.removeListener(type, listener);
-}
+};
 
 EventEmitter.prototype.removeAllListeners =
     function removeAllListeners(type) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -326,8 +326,8 @@ EventEmitter.prototype.prependOnceListener =
     };
 
 // Emits a 'removeListener' event if and only if the listener was removed.
-EventEmitter.prototype.removeListener =
-    function removeListener(type, listener) {
+EventEmitter.prototype.off =
+    function off(type, listener) {
       let originalListener;
 
       checkListener(listener);
@@ -380,8 +380,8 @@ EventEmitter.prototype.removeListener =
       return this;
     };
 
-EventEmitter.prototype.off = function(type, listener) {
-  return this.removeListener(type, listener);
+EventEmitter.prototype.removeListener = function(type, listener) {
+  return this.off(type, listener);
 };
 
 EventEmitter.prototype.removeAllListeners =

--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -29,9 +29,6 @@ const EventEmitter = require('events');
   const events_new_listener_emitted = [];
   const listeners_new_listener_emitted = [];
 
-  // Sanity check
-  assert.strictEqual(ee.addListener, ee.on);
-
   ee.on('newListener', function(event, listener) {
     // Don't track newListener listeners.
     if (event === 'newListener')

--- a/test/parallel/test-event-emitter-method-names.js
+++ b/test/parallel/test-event-emitter-method-names.js
@@ -26,10 +26,9 @@ const events = require('events');
 
 const E = events.EventEmitter.prototype;
 assert.strictEqual(E.constructor.name, 'EventEmitter');
-assert.strictEqual(E.on, E.addListener);  // Same method.
-assert.strictEqual(E.off, E.removeListener);  // Same method.
+
 Object.getOwnPropertyNames(E).forEach(function(name) {
-  if (name === 'constructor' || name === 'on' || name === 'off') return;
+  if (name === 'constructor') return;
   if (typeof E[name] !== 'function') return;
   assert.strictEqual(E[name].name, name);
 });

--- a/test/parallel/test-events-override.js
+++ b/test/parallel/test-events-override.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+const { once, EventEmitter: EE } = require('events');
+const { strictEqual, deepStrictEqual } = require('assert');
+
+{
+  const e = new EE();
+  e.addListener = common.mustCall();
+  e.on('test', () => {});
+}
+
+{
+  const e = new EE();
+  e.removeListener = common.mustCall();
+  e.off('test', () => {});
+}

--- a/test/parallel/test-events-override.js
+++ b/test/parallel/test-events-override.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const common = require('../common');
-const { once, EventEmitter: EE } = require('events');
-const { strictEqual, deepStrictEqual } = require('assert');
+const { EventEmitter: EE } = require('events');
 
 {
   const e = new EE();

--- a/test/parallel/test-events-override.js
+++ b/test/parallel/test-events-override.js
@@ -11,6 +11,6 @@ const { EventEmitter: EE } = require('events');
 
 {
   const e = new EE();
-  e.off = common.mustCall();
-  e.removeListener('test', () => {});
+  e.removeListener = common.mustCall();
+  e.off('test', () => {});
 }

--- a/test/parallel/test-events-override.js
+++ b/test/parallel/test-events-override.js
@@ -5,12 +5,12 @@ const { EventEmitter: EE } = require('events');
 
 {
   const e = new EE();
-  e.addListener = common.mustCall();
-  e.on('test', () => {});
+  e.on = common.mustCall();
+  e.addListener('test', () => {});
 }
 
 {
   const e = new EE();
-  e.removeListener = common.mustCall();
-  e.off('test', () => {});
+  e.off = common.mustCall();
+  e.removeListener('test', () => {});
 }


### PR DESCRIPTION
Previously these used alias which caused surprising behaviour
when trying to override add/removeListener, e.g. Readable.

This resolves this by making on/off actually call the
corresponding function through the prototype chain.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
