### PR TITLE
worker: mark as stable

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -2,7 +2,7 @@
 
 <!--introduced_in=v10.5.0-->
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 The `worker_threads` module enables the use of threads that execute JavaScript
 in parallel. To access it:


### PR DESCRIPTION
This feature is not expected to receive breaking changes to its API
and is used in real-world applications.

As discussed at the last collaborator summit (Berlin May 2019),
the `worker_threads` module can be considered stable once our
Web Messaging implementation is compatible with Web Platform Tests.
As of b34f05ecf2014a6a51c455e1bee06586ec81ff83, that is the case.

Fixes: https://github.com/nodejs/node/issues/22940

@nodejs/workers @nodejs/tsc 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
