### PR TITLE
src: print exceptions from PromiseRejectCallback

### DIFF
--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -10,6 +10,7 @@
 
 namespace node {
 
+using errors::TryCatchScope;
 using v8::Array;
 using v8::Context;
 using v8::Function;
@@ -111,8 +112,17 @@ void PromiseRejectCallback(PromiseRejectMessage message) {
   }
 
   Local<Value> args[] = { type, promise, value };
+
+  // V8 does not expect this callback to have a scheduled exceptions once it
+  // returns, so we print them out in a best effort to do something about it
+  // without failing silently and without crashing the process.
+  TryCatchScope try_catch(env);
   USE(callback->Call(
       env->context(), Undefined(isolate), arraysize(args), args));
+  if (try_catch.HasCaught() && !try_catch.HasTerminated()) {
+    fprintf(stderr, "Exception in PromiseRejectCallback:\n");
+    PrintCaughtException(isolate, env->context(), try_catch);
+  }
 }
 
 static void SetPromiseRejectCallback(

--- a/test/parallel/test-async-wrap-pop-id-during-load.js
+++ b/test/parallel/test-async-wrap-pop-id-during-load.js
@@ -23,4 +23,4 @@ assert.strictEqual(ret.status, 0,
                    `EXIT CODE: ${ret.status}, STDERR:\n${ret.stderr}`);
 const stderr = ret.stderr.toString('utf8', 0, 2048);
 assert.ok(!/async.*hook/i.test(stderr));
-assert.ok(stderr.includes('UnhandledPromiseRejectionWarning: Error'), stderr);
+assert.ok(stderr.includes('Maximum call stack size exceeded'), stderr);

--- a/test/parallel/test-promise-reject-callback-exception.js
+++ b/test/parallel/test-promise-reject-callback-exception.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const path = require('path');
@@ -21,11 +21,11 @@ for (const NODE_V8_COVERAGE of ['', tmpdir.path]) {
                             { env: { ...process.env, NODE_V8_COVERAGE } });
 
   assert(stdout.toString('utf8')
-      .startsWith('RangeError: Maximum call stack size exceeded'),
-      `stdout: <${stdout}>`);
+         .startsWith('RangeError: Maximum call stack size exceeded'),
+         `stdout: <${stdout}>`);
   assert(stderr.toString('utf8')
-      .startsWith('Exception in PromiseRejectCallback'),
-      `stderr: <${stderr}>`);
+         .startsWith('Exception in PromiseRejectCallback'),
+         `stderr: <${stderr}>`);
   assert.strictEqual(status, 0);
   assert.strictEqual(signal, null);
 }

--- a/test/parallel/test-promise-reject-callback-exception.js
+++ b/test/parallel/test-promise-reject-callback-exception.js
@@ -15,6 +15,10 @@ tmpdir.refresh();
 // was enabled, it resulted in a hard crash.
 
 for (const NODE_V8_COVERAGE of ['', tmpdir.path]) {
+  // NODE_V8_COVERAGE does not work without the inspector.
+  // Refs: https://github.com/nodejs/node/issues/29542
+  if (!process.features.inspector && NODE_V8_COVERAGE !== '') continue;
+
   const { status, signal, stdout, stderr } =
     child_process.spawnSync(process.execPath,
                             [path.join(__dirname, 'test-ttywrap-stack.js')],

--- a/test/parallel/test-promise-reject-callback-exception.js
+++ b/test/parallel/test-promise-reject-callback-exception.js
@@ -1,0 +1,31 @@
+'use strict';
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const path = require('path');
+const child_process = require('child_process');
+
+tmpdir.refresh();
+
+// Tests that exceptions from the PromiseRejectCallback are printed to stderr
+// when they occur as a best-effort way of handling them, and that calling
+// `console.log()` works after that. Earlier, the latter did not work because
+// of the exception left lying around by the PromiseRejectCallback when its JS
+// part exceeded the call stack limit, and when the inspector/built-in coverage
+// was enabled, it resulted in a hard crash.
+
+for (const NODE_V8_COVERAGE of ['', tmpdir.path]) {
+  const { status, signal, stdout, stderr } =
+    child_process.spawnSync(process.execPath,
+                            [path.join(__dirname, 'test-ttywrap-stack.js')],
+                            { env: { ...process.env, NODE_V8_COVERAGE } });
+
+  assert(stdout.toString('utf8')
+      .startsWith('RangeError: Maximum call stack size exceeded'),
+      `stdout: <${stdout}>`);
+  assert(stderr.toString('utf8')
+      .startsWith('Exception in PromiseRejectCallback'),
+      `stderr: <${stderr}>`);
+  assert.strictEqual(status, 0);
+  assert.strictEqual(signal, null);
+}


### PR DESCRIPTION
Previously, leaving the exception lying around would leave the JS
engine in an invalid state, as it was not expecting exceptions to
be thrown from the C++ `PromiseRejectCallback`, and lead to hard
crashes under some conditions (e.g. with coverage enabled).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
