### PR TITLE
stream: simplify isUint8Array helper

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -21,8 +21,6 @@
 
 'use strict';
 
-const { Object } = primordials;
-
 const { Buffer } = require('buffer');
 const pipeline = require('internal/streams/pipeline');
 const eos = require('internal/streams/end-of-stream');
@@ -43,27 +41,7 @@ Stream.finished = eos;
 // Backwards-compat with node 0.4.x
 Stream.Stream = Stream;
 
-// Internal utilities
-try {
-  const types = require('internal/util/types');
-  if (types && typeof types.isUint8Array === 'function') {
-    Stream._isUint8Array = types.isUint8Array;
-  } else {
-    // This throws for Node < 4.2.0 because there's no util binding and
-    // returns undefined for Node < 7.4.0.
-    // Please do not convert process.binding() to internalBinding() here.
-    // This is for compatibility with older versions when loaded as
-    // readable-stream.
-    Stream._isUint8Array = process.binding('util').isUint8Array;
-  }
-} catch (e) { // eslint-disable-line no-unused-vars
-}
-
-if (!Stream._isUint8Array) {
-  Stream._isUint8Array = function _isUint8Array(obj) {
-    return Object.prototype.toString.call(obj) === '[object Uint8Array]';
-  };
-}
+Stream._isUint8Array = require('internal/util/types').isUint8Array;
 
 const version = process.version.substr(1).split('.');
 if (version[0] === 0 && version[1] < 12) {


### PR DESCRIPTION
The fallback code is no longer used when exporting to readable-stream.

Refs: https://github.com/nodejs/node/pull/29475

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
