### PR TITLE
policy: feature preloadAlways , preloadAllowed

### DIFF
--- a/doc/api/policy.md
+++ b/doc/api/policy.md
@@ -114,6 +114,42 @@ body for the resource which can be useful for local development. It is not
 recommended in production since it would allow unexpected alteration of
 resources to be considered valid.
 
+### Preloading Modules
+
+An application may wish to ensure that some modules run prior to any
+application code. Preloading modules can be enforced.
+
+```json
+{
+  "preloadAlways": ["./polyfills.js"]
+}
+```
+
+The nature of polyfilling and preloading modules means that preloading is done
+prior to any hardening of the global environment. As such, an application may
+limit preloading to a list of well known modules even if they are not always
+preloaded. If set to `true` all resources will be allowed as preloads, this is meant for debugging purposes and ergonomics and is not recommended in production.
+
+```json
+{
+  "preloadAllowed": ["./debug.js"],
+  "preloadAlways": ["./polyfills.js"]
+}
+```
+
+```json
+{
+  "preloadAllowed": ["./debug.js"],
+  "preloadAlways": true
+}
+```
+
+Would allow `./debug.js` to be optionally loaded using means such as `--require`.
+
+```console
+node --require ./debug.js app.js
+```
+
 ### Dependency Redirection
 
 An application may need to ship patched versions of modules or to prevent
@@ -123,7 +159,6 @@ replaced.
 
 ```json
 {
-  "builtins": [],
   "resources": {
     "./app/checked.js": {
       "dependencies": {

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -410,15 +410,25 @@ function initializeFrozenIntrinsics() {
 }
 
 function loadPreloadModules() {
+  const {
+    Module: {
+      _preloadModules
+    },
+  } = require('internal/modules/cjs/loader');
+  const manifest = getOptionValue('--experimental-policy') ?
+    require('internal/process/policy').manifest :
+    null;
   // For user code, we preload modules if `-r` is passed
-  const preloadModules = getOptionValue('--require');
-  if (preloadModules && preloadModules.length > 0) {
-    const {
-      Module: {
-        _preloadModules
-      },
-    } = require('internal/modules/cjs/loader');
-    _preloadModules(preloadModules);
+  const opts = getOptionValue('--require');
+  let preloads;
+  if (manifest) {
+    const manifestPreloads = manifest.preloads();
+    preloads = [ ...manifestPreloads, ...(opts ? opts : []) ];
+  } else {
+    preloads = opts;
+  }
+  if (preloads && preloads.length > 0) {
+    _preloadModules(preloads);
   }
 }
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1100,8 +1100,12 @@ Module._preloadModules = function(requests) {
       throw e;
     }
   }
-  for (var n = 0; n < requests.length; n++)
+  for (var n = 0; n < requests.length; n++) {
+    if (manifest) {
+      manifest.checkPreload(pathToFileURL(path.resolve(requests[n])));
+    }
     parent.require(requests[n]);
+  }
 };
 
 // Backwards compatibility

--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -1,11 +1,15 @@
 'use strict';
 
 const {
+  ArrayPrototype: {
+    includes: ArrayIncludes
+  },
   Map,
   MapPrototype,
   Object,
   RegExpPrototype,
   SafeMap,
+  SafeSet,
   uncurryThis
 } = primordials;
 const {
@@ -13,6 +17,8 @@ const {
 } = require('internal/bootstrap/loaders').NativeModule;
 
 const {
+  ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_ARG_VALUE,
   ERR_MANIFEST_ASSERT_INTEGRITY,
   ERR_MANIFEST_INTEGRITY_MISMATCH,
   ERR_MANIFEST_INVALID_RESOURCE_FIELD,
@@ -22,7 +28,7 @@ const debug = require('internal/util/debuglog').debuglog('policy');
 const SRI = require('internal/policy/sri');
 const crypto = require('crypto');
 const { Buffer } = require('buffer');
-const { URL } = require('internal/url');
+const { URL, fileURLToPath } = require('internal/url');
 const { createHash, timingSafeEqual } = crypto;
 const HashUpdate = uncurryThis(crypto.Hash.prototype.update);
 const HashDigest = uncurryThis(crypto.Hash.prototype.digest);
@@ -54,6 +60,8 @@ function REACTION_LOG(error) {
 class Manifest {
   #integrities = new SafeMap();
   #dependencies = new SafeMap();
+  #preloadAlways = [];
+  #preloadAllowed = null;
   #reaction = null;
   constructor(obj, manifestURL) {
     const integrities = this.#integrities;
@@ -73,6 +81,49 @@ class Manifest {
     }
 
     this.#reaction = reaction;
+    const {
+      preloadAlways = [],
+      preloadAllowed = null
+    } = obj;
+    if (Array.isArray(preloadAlways)) {
+      this.#preloadAlways = Array.from(preloadAlways, (specifier, i) => {
+        if (typeof specifier !== 'string') {
+          throw new ERR_INVALID_ARG_TYPE(
+            `preloadAlways[${i}]`,
+            'string',
+            typeof specifier);
+        }
+        return new URL(specifier, manifestURL).href;
+      });
+    } else if (preloadAlways !== null) {
+      throw new ERR_INVALID_ARG_TYPE(
+        'preloadAlways',
+        ['string[]', 'null'],
+        typeof preloadAlways);
+    }
+    if (preloadAllowed !== true) {
+      if (Array.isArray(preloadAllowed)) {
+        this.#preloadAllowed = new SafeSet(
+          Array.from(preloadAllowed, (specifier, i) => {
+            if (typeof specifier !== 'string') {
+              throw new ERR_INVALID_ARG_TYPE(
+                `preloadAllowed[${i}]`,
+                'string',
+                typeof specifier);
+            }
+            return new URL(specifier, manifestURL).href;
+          })
+        );
+      } else if (preloadAllowed !== null) {
+        throw new ERR_INVALID_ARG_TYPE(
+          'preloadAlways',
+          ['string[]', 'null', 'true'],
+          typeof preloadAllowed);
+      }
+    } else {
+      this.#preloadAllowed = true;
+    }
+
     const manifestEntries = entries(obj.resources);
 
     const parsedURLs = new SafeMap();
@@ -183,6 +234,22 @@ class Manifest {
     Object.freeze(this);
   }
 
+  preloads() {
+    return this.#preloadAlways.map(fileURLToPath);
+  }
+
+  checkPreload(url) {
+    url = `${url}`;
+    if (this.#preloadAllowed === true ||
+      this.#preloadAllowed.has(url) ||
+      ArrayIncludes(this.#preloadAlways, url)) {
+      return;
+    }
+    return this.#reaction(new ERR_INVALID_ARG_VALUE(
+      'preload',
+      url,
+      'is prevented from preloading due to policy'));
+  }
   getRedirector(requester) {
     requester = `${requester}`;
     const dependencies = this.#dependencies;

--- a/test/fixtures/policy-preload/allowed.js
+++ b/test/fixtures/policy-preload/allowed.js
@@ -1,0 +1,2 @@
+'use strict';
+console.log('from allowed.js');

--- a/test/fixtures/policy-preload/always.js
+++ b/test/fixtures/policy-preload/always.js
@@ -1,0 +1,16 @@
+'use strict';
+console.log('from always.js');
+const original = process.binding;
+const allowed = {
+    __proto__: null,
+    'natives': true,
+    'constants': true,
+    'util': true,
+    'tty_wrap': true
+}
+process.binding = function (name, ...args) {
+    if (name in allowed !== true) {
+        throw Error('No such module: ' + name);
+    }
+    return new.target ? new original(name, ...args) : original(name, ...args);
+}

--- a/test/fixtures/policy-preload/banned.js
+++ b/test/fixtures/policy-preload/banned.js
@@ -1,0 +1,3 @@
+'use strict';
+console.log('from banned.js');
+process.exit(42);

--- a/test/fixtures/policy-preload/explodes.js
+++ b/test/fixtures/policy-preload/explodes.js
@@ -1,0 +1,2 @@
+'use strict';
+process.binding('fs');

--- a/test/fixtures/policy-preload/main.js
+++ b/test/fixtures/policy-preload/main.js
@@ -1,0 +1,2 @@
+'use strict';
+console.log('from main.js');

--- a/test/fixtures/policy-preload/policy-allowed-empty.json
+++ b/test/fixtures/policy-preload/policy-allowed-empty.json
@@ -1,0 +1,20 @@
+{
+  "preloadAllowed": [],
+  "resources": {
+    "./allowed.js": {
+      "integrity": "sha512-Iro+V7RY7jsK+n+/KL0pQGfwU7MIth1pixf1GU4rksFMS3LISn+hOKqvMUkYCN5SS2hFeAxd8UANuNt6gccLFQ=="
+    },
+    "./banned.js": {
+      "integrity": "sha512-v4pToTs+xXaA7g6NtBQ1+SM4DCD6aCcDlDl30sw80x93On4tnMIexmblM43JvAkDAOoh8C2E6XTgVBRneRt7RA=="
+    },
+    "./main.js": {
+      "integrity": "sha512-JMUcucB/+nfmPJ55l75Ap2mYv5P/X+1rzKWXb8BOFjzYEvv3wkF0+S83VVei4o8TS0WRQPLkiartevVVrqT1xA=="
+    },
+    "./always.js": {
+      "integrity": "sha512-j7u0vVC57XZWKxJU9PHDsowQlnT65QEoVBPLsT7dRgm9ECvGbHKEubbD7ou0KylAdVsRZTojQmi2PjKPwiRVYw== sha512-gmshpKVaDWywyXkeW+dFdvXAxON5QEqiYL5p5iLe7tSgsvEdlpgSN9o6OpsM2XXyn2GbTchduP5cXio+GkHnzg== sha512-2/HMIvrJwS4ownPhdzGPWfVHp2tn0bqEQVLGCtJ8QzSePDvtyRcJz7asVwzpg6lOH9WDWj3JZbzaf/Sa4+3UjA=="
+    },
+    "./explodes.js": {
+      "integrity": "sha512-+6MYkqfjrQI9Pi8Q9ecClPLU/WhfOcK0nuVd8fSV/xBAEWVIguW9cVbDo69WhkqrXECfVw8sAUVKz6YEOm1LFA== sha512-/VqbBVNx8KqiT6RqLw/pxF4jPYEnPf4DL/6LfBDnvKw8usugQXJ1yPB+zb02ZbW1fI7YzNRjVEBbj+Cq+/04SQ=="
+    }
+  }
+}

--- a/test/fixtures/policy-preload/policy-allowed-null.json
+++ b/test/fixtures/policy-preload/policy-allowed-null.json
@@ -1,0 +1,20 @@
+{
+  "preloadAllowed": null,
+  "resources": {
+    "./allowed.js": {
+      "integrity": "sha512-Iro+V7RY7jsK+n+/KL0pQGfwU7MIth1pixf1GU4rksFMS3LISn+hOKqvMUkYCN5SS2hFeAxd8UANuNt6gccLFQ=="
+    },
+    "./banned.js": {
+      "integrity": "sha512-v4pToTs+xXaA7g6NtBQ1+SM4DCD6aCcDlDl30sw80x93On4tnMIexmblM43JvAkDAOoh8C2E6XTgVBRneRt7RA=="
+    },
+    "./main.js": {
+      "integrity": "sha512-JMUcucB/+nfmPJ55l75Ap2mYv5P/X+1rzKWXb8BOFjzYEvv3wkF0+S83VVei4o8TS0WRQPLkiartevVVrqT1xA=="
+    },
+    "./always.js": {
+      "integrity": "sha512-j7u0vVC57XZWKxJU9PHDsowQlnT65QEoVBPLsT7dRgm9ECvGbHKEubbD7ou0KylAdVsRZTojQmi2PjKPwiRVYw== sha512-gmshpKVaDWywyXkeW+dFdvXAxON5QEqiYL5p5iLe7tSgsvEdlpgSN9o6OpsM2XXyn2GbTchduP5cXio+GkHnzg== sha512-2/HMIvrJwS4ownPhdzGPWfVHp2tn0bqEQVLGCtJ8QzSePDvtyRcJz7asVwzpg6lOH9WDWj3JZbzaf/Sa4+3UjA=="
+    },
+    "./explodes.js": {
+      "integrity": "sha512-+6MYkqfjrQI9Pi8Q9ecClPLU/WhfOcK0nuVd8fSV/xBAEWVIguW9cVbDo69WhkqrXECfVw8sAUVKz6YEOm1LFA== sha512-/VqbBVNx8KqiT6RqLw/pxF4jPYEnPf4DL/6LfBDnvKw8usugQXJ1yPB+zb02ZbW1fI7YzNRjVEBbj+Cq+/04SQ=="
+    }
+  }
+}

--- a/test/fixtures/policy-preload/policy-allowed-true.json
+++ b/test/fixtures/policy-preload/policy-allowed-true.json
@@ -1,0 +1,20 @@
+{
+  "preloadAllowed": true,
+  "resources": {
+    "./allowed.js": {
+      "integrity": "sha512-Iro+V7RY7jsK+n+/KL0pQGfwU7MIth1pixf1GU4rksFMS3LISn+hOKqvMUkYCN5SS2hFeAxd8UANuNt6gccLFQ=="
+    },
+    "./banned.js": {
+      "integrity": "sha512-v4pToTs+xXaA7g6NtBQ1+SM4DCD6aCcDlDl30sw80x93On4tnMIexmblM43JvAkDAOoh8C2E6XTgVBRneRt7RA=="
+    },
+    "./main.js": {
+      "integrity": "sha512-JMUcucB/+nfmPJ55l75Ap2mYv5P/X+1rzKWXb8BOFjzYEvv3wkF0+S83VVei4o8TS0WRQPLkiartevVVrqT1xA=="
+    },
+    "./always.js": {
+      "integrity": "sha512-j7u0vVC57XZWKxJU9PHDsowQlnT65QEoVBPLsT7dRgm9ECvGbHKEubbD7ou0KylAdVsRZTojQmi2PjKPwiRVYw== sha512-gmshpKVaDWywyXkeW+dFdvXAxON5QEqiYL5p5iLe7tSgsvEdlpgSN9o6OpsM2XXyn2GbTchduP5cXio+GkHnzg== sha512-2/HMIvrJwS4ownPhdzGPWfVHp2tn0bqEQVLGCtJ8QzSePDvtyRcJz7asVwzpg6lOH9WDWj3JZbzaf/Sa4+3UjA=="
+    },
+    "./explodes.js": {
+      "integrity": "sha512-+6MYkqfjrQI9Pi8Q9ecClPLU/WhfOcK0nuVd8fSV/xBAEWVIguW9cVbDo69WhkqrXECfVw8sAUVKz6YEOm1LFA== sha512-/VqbBVNx8KqiT6RqLw/pxF4jPYEnPf4DL/6LfBDnvKw8usugQXJ1yPB+zb02ZbW1fI7YzNRjVEBbj+Cq+/04SQ=="
+    }
+  }
+}

--- a/test/fixtures/policy-preload/policy-always-empty.json
+++ b/test/fixtures/policy-preload/policy-always-empty.json
@@ -1,0 +1,20 @@
+{
+  "preloadAlways": [],
+  "resources": {
+    "./allowed.js": {
+      "integrity": "sha512-Iro+V7RY7jsK+n+/KL0pQGfwU7MIth1pixf1GU4rksFMS3LISn+hOKqvMUkYCN5SS2hFeAxd8UANuNt6gccLFQ=="
+    },
+    "./banned.js": {
+      "integrity": "sha512-v4pToTs+xXaA7g6NtBQ1+SM4DCD6aCcDlDl30sw80x93On4tnMIexmblM43JvAkDAOoh8C2E6XTgVBRneRt7RA=="
+    },
+    "./main.js": {
+      "integrity": "sha512-JMUcucB/+nfmPJ55l75Ap2mYv5P/X+1rzKWXb8BOFjzYEvv3wkF0+S83VVei4o8TS0WRQPLkiartevVVrqT1xA=="
+    },
+    "./always.js": {
+      "integrity": "sha512-j7u0vVC57XZWKxJU9PHDsowQlnT65QEoVBPLsT7dRgm9ECvGbHKEubbD7ou0KylAdVsRZTojQmi2PjKPwiRVYw== sha512-gmshpKVaDWywyXkeW+dFdvXAxON5QEqiYL5p5iLe7tSgsvEdlpgSN9o6OpsM2XXyn2GbTchduP5cXio+GkHnzg== sha512-2/HMIvrJwS4ownPhdzGPWfVHp2tn0bqEQVLGCtJ8QzSePDvtyRcJz7asVwzpg6lOH9WDWj3JZbzaf/Sa4+3UjA=="
+    },
+    "./explodes.js": {
+      "integrity": "sha512-+6MYkqfjrQI9Pi8Q9ecClPLU/WhfOcK0nuVd8fSV/xBAEWVIguW9cVbDo69WhkqrXECfVw8sAUVKz6YEOm1LFA== sha512-/VqbBVNx8KqiT6RqLw/pxF4jPYEnPf4DL/6LfBDnvKw8usugQXJ1yPB+zb02ZbW1fI7YzNRjVEBbj+Cq+/04SQ=="
+    }
+  }
+}

--- a/test/fixtures/policy-preload/policy-always-null.json
+++ b/test/fixtures/policy-preload/policy-always-null.json
@@ -1,0 +1,20 @@
+{
+  "preloadAlways": null,
+  "resources": {
+    "./allowed.js": {
+      "integrity": "sha512-Iro+V7RY7jsK+n+/KL0pQGfwU7MIth1pixf1GU4rksFMS3LISn+hOKqvMUkYCN5SS2hFeAxd8UANuNt6gccLFQ=="
+    },
+    "./banned.js": {
+      "integrity": "sha512-v4pToTs+xXaA7g6NtBQ1+SM4DCD6aCcDlDl30sw80x93On4tnMIexmblM43JvAkDAOoh8C2E6XTgVBRneRt7RA=="
+    },
+    "./main.js": {
+      "integrity": "sha512-JMUcucB/+nfmPJ55l75Ap2mYv5P/X+1rzKWXb8BOFjzYEvv3wkF0+S83VVei4o8TS0WRQPLkiartevVVrqT1xA=="
+    },
+    "./always.js": {
+      "integrity": "sha512-j7u0vVC57XZWKxJU9PHDsowQlnT65QEoVBPLsT7dRgm9ECvGbHKEubbD7ou0KylAdVsRZTojQmi2PjKPwiRVYw== sha512-gmshpKVaDWywyXkeW+dFdvXAxON5QEqiYL5p5iLe7tSgsvEdlpgSN9o6OpsM2XXyn2GbTchduP5cXio+GkHnzg== sha512-2/HMIvrJwS4ownPhdzGPWfVHp2tn0bqEQVLGCtJ8QzSePDvtyRcJz7asVwzpg6lOH9WDWj3JZbzaf/Sa4+3UjA=="
+    },
+    "./explodes.js": {
+      "integrity": "sha512-+6MYkqfjrQI9Pi8Q9ecClPLU/WhfOcK0nuVd8fSV/xBAEWVIguW9cVbDo69WhkqrXECfVw8sAUVKz6YEOm1LFA== sha512-/VqbBVNx8KqiT6RqLw/pxF4jPYEnPf4DL/6LfBDnvKw8usugQXJ1yPB+zb02ZbW1fI7YzNRjVEBbj+Cq+/04SQ=="
+    }
+  }
+}

--- a/test/fixtures/policy-preload/policy.json
+++ b/test/fixtures/policy-preload/policy.json
@@ -1,0 +1,26 @@
+{
+  "preloadAlways": [
+    "./always.js"
+  ],
+  "preloadAllowed": [
+    "./allowed.js",
+    "./explodes.js"
+  ],
+  "resources": {
+    "./allowed.js": {
+      "integrity": "sha512-Iro+V7RY7jsK+n+/KL0pQGfwU7MIth1pixf1GU4rksFMS3LISn+hOKqvMUkYCN5SS2hFeAxd8UANuNt6gccLFQ=="
+    },
+    "./banned.js": {
+      "integrity": "sha512-v4pToTs+xXaA7g6NtBQ1+SM4DCD6aCcDlDl30sw80x93On4tnMIexmblM43JvAkDAOoh8C2E6XTgVBRneRt7RA=="
+    },
+    "./main.js": {
+      "integrity": "sha512-JMUcucB/+nfmPJ55l75Ap2mYv5P/X+1rzKWXb8BOFjzYEvv3wkF0+S83VVei4o8TS0WRQPLkiartevVVrqT1xA=="
+    },
+    "./always.js": {
+      "integrity": "sha512-j7u0vVC57XZWKxJU9PHDsowQlnT65QEoVBPLsT7dRgm9ECvGbHKEubbD7ou0KylAdVsRZTojQmi2PjKPwiRVYw== sha512-gmshpKVaDWywyXkeW+dFdvXAxON5QEqiYL5p5iLe7tSgsvEdlpgSN9o6OpsM2XXyn2GbTchduP5cXio+GkHnzg== sha512-2/HMIvrJwS4ownPhdzGPWfVHp2tn0bqEQVLGCtJ8QzSePDvtyRcJz7asVwzpg6lOH9WDWj3JZbzaf/Sa4+3UjA=="
+    },
+    "./explodes.js": {
+      "integrity": "sha512-+6MYkqfjrQI9Pi8Q9ecClPLU/WhfOcK0nuVd8fSV/xBAEWVIguW9cVbDo69WhkqrXECfVw8sAUVKz6YEOm1LFA== sha512-/VqbBVNx8KqiT6RqLw/pxF4jPYEnPf4DL/6LfBDnvKw8usugQXJ1yPB+zb02ZbW1fI7YzNRjVEBbj+Cq+/04SQ=="
+    }
+  }
+}

--- a/test/parallel/test-policy-preload.js
+++ b/test/parallel/test-policy-preload.js
@@ -1,0 +1,162 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const fixtures = require('../common/fixtures');
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const main = fixtures.path('policy-preload', 'main.js');
+const allowed = fixtures.path('policy-preload', 'allowed.js');
+const always = fixtures.path('policy-preload', 'always.js');
+const banned = fixtures.path('policy-preload', 'banned.js');
+const explodes = fixtures.path('policy-preload', 'explodes.js');
+const policy = fixtures.path('policy-preload', 'policy.json');
+const policyAllowedTrue = fixtures.path(
+  'policy-preload',
+  'policy-allowed-true.json');
+const policyAllowedNull = fixtures.path(
+  'policy-preload',
+  'policy-allowed-null.json');
+const policyAllowedEmpty = fixtures.path(
+  'policy-preload',
+  'policy-allowed-empty.json');
+const policyAlwaysEmpty = fixtures.path(
+  'policy-preload',
+  'policy-always-empty.json');
+const policyAlwaysNull = fixtures.path(
+  'policy-preload',
+  'policy-always-null.json');
+{
+  const { status, stdout } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', policy,
+      main,
+    ]
+  );
+  assert.strictEqual(status, 0);
+  assert.strictEqual(`${stdout}`, 'from always.js\nfrom main.js\n');
+}
+{
+  const { status, stdout } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', policy,
+      '--require', allowed,
+      main,
+    ]
+  );
+  assert.strictEqual(status, 0);
+  assert.strictEqual(
+    `${stdout}`,
+    'from always.js\nfrom allowed.js\nfrom main.js\n');
+}
+{
+  const { status } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', policy,
+      '--require', allowed,
+      '--require', explodes,
+      main,
+    ]
+  );
+  assert.strictEqual(status, 1);
+}
+{
+  const { status, stdout } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', policy,
+      '--require', banned,
+      main,
+    ]
+  );
+  assert.strictEqual(status, 1);
+  assert.strictEqual(`${stdout}`, 'from always.js\n');
+}
+{
+  const { status, stdout } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', policy,
+      '--require', banned,
+      '--require', allowed,
+      main,
+    ]
+  );
+  assert.strictEqual(status, 1);
+  assert.strictEqual(`${stdout}`, 'from always.js\n');
+}
+{
+  const { status, stdout } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', policy,
+      '--require', explodes,
+      main,
+    ]
+  );
+  assert.strictEqual(status, 1);
+  assert.strictEqual(`${stdout}`, 'from always.js\n');
+}
+{
+  const { status } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', policyAllowedTrue,
+      '--require', explodes,
+      main,
+    ]
+  );
+  assert.strictEqual(status, 0);
+}
+{
+  const { status } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', policyAllowedEmpty,
+      '--require', always,
+      main,
+    ]
+  );
+  assert.strictEqual(status, 1);
+}
+
+{
+  const { status } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', policyAllowedNull,
+      '--require', always,
+      main,
+    ]
+  );
+  assert.strictEqual(status, 1);
+}
+{
+  const { status } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', policyAlwaysNull,
+      '--require', always,
+      main,
+    ]
+  );
+  assert.strictEqual(status, 1);
+}
+{
+  const { status } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', policyAlwaysEmpty,
+      '--require', always,
+      main,
+    ]
+  );
+  assert.strictEqual(status, 1);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This adds the ability for enforcement of what must be and is allowed to be preloaded. This can be used to harden or instrument globals as needed. It can be used for example to ensure censorship of `process.binding` as can be seen in the test. Currently ESM does not have a way of preloading modules and blocking user code from completing until preloading is finished; this PR likely should not land until an answer of how to determine if something should be preloaded via the ESM loader vs the CJS loader is answered and test is written for them. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
