### PR TITLE
lib: add Timer/Immediate to promisifyed setTimer/setImmediate

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -151,8 +151,9 @@ next event loop iteration.
 
 If `callback` is not a function, a [`TypeError`][] will be thrown.
 
-This method has a custom variant for promises that is available using
-[`util.promisify()`][]:
+If this method is invoked as its [`util.promisify()`][]ed version, it returns a
+Promise. The created `Immediate` is attached to the Promise as a `immediate`
+property.
 
 ```js
 const util = require('util');
@@ -170,6 +171,13 @@ async function timerExample() {
   console.log('After I/O callbacks');
 }
 timerExample();
+
+// You can access the immediate on promise.immediate
+const promise = setImmediatePromise();
+promise.then(() => {
+  // This callback is never called because the Immediate is cleared
+});
+clearImmediate(promise.immediate);
 ```
 
 ### setInterval(callback, delay[, ...args])
@@ -213,8 +221,9 @@ will be set to `1`. Non-integer delays are truncated to an integer.
 
 If `callback` is not a function, a [`TypeError`][] will be thrown.
 
-This method has a custom variant for promises that is available using
-[`util.promisify()`][]:
+If this method is invoked as its [`util.promisify()`][]ed version, it returns a
+Promise. The created `Timeout` is attached to the Promise as a `timeout`
+property.
 
 ```js
 const util = require('util');
@@ -224,6 +233,12 @@ setTimeoutPromise(40, 'foobar').then((value) => {
   // value === 'foobar' (passing values is optional)
   // This is executed after about 40 milliseconds.
 });
+
+const promise = setTimeoutPromise(40, 'foobar');
+promise.then((value) => {
+  // This is never executed because the timeout is cleared
+});
+clearTimeout(promise.timeout);
 ```
 
 ## Cancelling Timers

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -147,9 +147,11 @@ function setTimeout(callback, after, arg1, arg2, arg3) {
 
 setTimeout[customPromisify] = function(after, value) {
   const args = value !== undefined ? [value] : value;
-  return new Promise((resolve) => {
-    active(new Timeout(resolve, after, args, false));
-  });
+  let resolve;
+  const promise = new Promise((res) => resolve = res);
+  promise.timeout = new Timeout(resolve, after, args, false);
+  active(promise.timeout);
+  return promise;
 };
 
 function clearTimeout(timer) {
@@ -272,7 +274,10 @@ function setImmediate(callback, arg1, arg2, arg3) {
 }
 
 setImmediate[customPromisify] = function(value) {
-  return new Promise((resolve) => new Immediate(resolve, [value]));
+  let resolve;
+  const promise = new Promise((res) => resolve = res);
+  promise.immediate = new Immediate(resolve, [value]);
+  return promise;
 };
 
 function clearImmediate(immediate) {

--- a/test/parallel/test-timer-immediate-async-cleared.js
+++ b/test/parallel/test-timer-immediate-async-cleared.js
@@ -1,0 +1,10 @@
+'use strict';
+const { mustNotCall } = require('../common');
+const { promisify } = require('util');
+
+const setImmediateAsync = promisify(setImmediate);
+
+const expected = ['foo', 'bar', 'baz'];
+const promise = setImmediateAsync(...expected);
+promise.then(() => mustNotCall('expected immediate to be cleared'));
+clearImmediate(promise.immediate);

--- a/test/parallel/test-timer-immediate-async.js
+++ b/test/parallel/test-timer-immediate-async.js
@@ -1,0 +1,12 @@
+'use strict';
+require('../common');
+const { strictEqual } = require('assert');
+const { promisify } = require('util');
+
+const setImmediateAsync = promisify(setImmediate);
+
+const expected = ['foo', 'bar', 'baz'];
+// N.B. the promisified version of setImmediate will resolve with the _first_
+// value, not an array of all values.
+setImmediateAsync(...expected)
+  .then((actual) => strictEqual(actual, expected[0]));

--- a/test/parallel/test-timer-timeout-async-cleared.js
+++ b/test/parallel/test-timer-timeout-async-cleared.js
@@ -1,0 +1,10 @@
+'use strict';
+const { mustNotCall } = require('../common');
+const { promisify } = require('util');
+
+const setTimeoutAsync = promisify(setTimeout);
+
+const expected = ['foo', 'bar', 'baz'];
+const promise = setTimeoutAsync(10, ...expected);
+promise.then(() => mustNotCall('expected timeout to be cleared'));
+clearTimeout(promise.timeout);

--- a/test/parallel/test-timer-timeout-async.js
+++ b/test/parallel/test-timer-timeout-async.js
@@ -1,0 +1,12 @@
+'use strict';
+require('../common');
+const { strictEqual } = require('assert');
+const { promisify } = require('util');
+
+const setTimeoutAsync = promisify(setTimeout);
+
+const expected = ['foo', 'bar', 'baz'];
+// N.B. the promisified version of setTimeout will resolve with the _first_
+// value, not an array of all values.
+setTimeoutAsync(10, ...expected)
+  .then((actual) => strictEqual(actual, expected[0]));


### PR DESCRIPTION
The current implementation of the promisified setTimeout and
setImmediate does not make the Timeout or Immediate available, so they
cannot be canceled or unreffed.

The docs and code follow the pattern established by child_process
- lib/child_process.js#L150-L171
- doc/api/child_process.md#L217-L222

There are two issues with this implementation
 - it conflicts with `timeout` or `immediate` properties that exist or may exist on other promise implementations or future promise implementations. Looks like bluebird promises include a `.timeout` method. http://bluebirdjs.com/docs/api/timeout.html
 - if the timeout/immediate is cleared the promise will never settle.
   - this issue could be addressed by a special case in the Timer or Immediate class
   - alternatively we could add `clearTimeout()` or `clearImmediate()` properties that clears the timer and rejects the promise. I can't currently think of a use case for calling unref, unref, or refresh on a promised timer so it may not be necessary to expose the whole timer instance.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
