### PR TITLE
stream: allow throwing from _read

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1855,10 +1855,7 @@ or write buffered data before a stream ends.
 It is recommended that errors occurring during the processing of the
 `writable._write()` and `writable._writev()` methods are reported by invoking
 the callback and passing the error as the first argument. This will cause an
-`'error'` event to be emitted by the `Writable`. Throwing an `Error` from within
-`writable._write()` can result in unexpected and inconsistent behavior depending
-on how the stream is being used. Using the callback ensures consistent and
-predictable handling of errors.
+`'error'` event to be emitted by the `Writable`.
 
 If a `Readable` stream pipes into a `Writable` stream when `Writable` emits an
 error, the `Readable` stream will be unpiped.
@@ -2129,30 +2126,6 @@ implementers, and only from within the `readable._read()` method.
 For streams not operating in object mode, if the `chunk` parameter of
 `readable.push()` is `undefined`, it will be treated as empty string or
 buffer. See [`readable.push('')`][] for more information.
-
-#### Errors While Reading
-
-It is recommended that errors occurring during the processing of the
-`readable._read()` method are emitted using the `'error'` event rather than
-being thrown. Throwing an `Error` from within `readable._read()` can result in
-unexpected and inconsistent behavior depending on whether the stream is
-operating in flowing or paused mode. Using the `'error'` event ensures
-consistent and predictable handling of errors.
-
-<!-- eslint-disable no-useless-return -->
-```js
-const { Readable } = require('stream');
-
-const myReadable = new Readable({
-  read(size) {
-    if (checkSomeErrorCondition()) {
-      process.nextTick(() => this.emit('error', err));
-      return;
-    }
-    // Do some work.
-  }
-});
-```
 
 #### An Example Counting Stream
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -499,8 +499,13 @@ Readable.prototype.read = function(n) {
     // If the length is currently zero, then we *need* a readable event.
     if (state.length === 0)
       state.needReadable = true;
-    // Call internal read method
-    this._read(state.highWaterMark);
+    try {
+      // Call internal read method
+      this._read(state.highWaterMark);
+    } catch (err) {
+      process.nextTick(errorOrDestroy, this, err);
+      return null;
+    }
     state.sync = false;
     // If _read pushed data synchronously, then `reading` will be false,
     // and we need to re-evaluate how much data we can return to the user.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -503,6 +503,7 @@ Readable.prototype.read = function(n) {
       // Call internal read method
       this._read(state.highWaterMark);
     } catch (err) {
+      // errorOrDestroy emits 'error' synchronously.
       process.nextTick(errorOrDestroy, this, err);
       return null;
     }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -163,6 +163,10 @@ function WritableState(options, stream, isDuplex) {
   const corkReq = { next: null, entry: null, finish: undefined };
   corkReq.finish = onCorkedFinish.bind(undefined, corkReq, this);
   this.corkedRequestsFree = corkReq;
+
+  // Should caught errors be thrown synchronously or emitted
+  // through 'error' events asynchronously.
+  this.syncError = !!options.syncError;
 }
 
 WritableState.prototype.getBuffer = function getBuffer() {
@@ -430,6 +434,9 @@ function doWrite(stream, state, writev, len, chunk, encoding, cb) {
       else
         stream._write(chunk, encoding, state.onwrite);
     } catch (err) {
+      if (state.syncError) {
+        throw err;
+      }
       state.onwrite(err);
     }
   }
@@ -636,6 +643,9 @@ function callFinal(stream, state) {
     });
   } catch (err) {
     state.pendingcb--;
+    if (state.syncError) {
+      throw err;
+    }
     errorOrDestroy(stream, err);
   }
 }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -421,12 +421,18 @@ function doWrite(stream, state, writev, len, chunk, encoding, cb) {
   state.writecb = cb;
   state.writing = true;
   state.sync = true;
-  if (state.destroyed)
+  if (state.destroyed) {
     state.onwrite(new ERR_STREAM_DESTROYED('write'));
-  else if (writev)
-    stream._writev(chunk, state.onwrite);
-  else
-    stream._write(chunk, encoding, state.onwrite);
+  } else {
+    try {
+      if (writev)
+        stream._writev(chunk, state.onwrite);
+      else
+        stream._write(chunk, encoding, state.onwrite);
+    } catch (err) {
+      state.onwrite(err);
+    }
+  }
   state.sync = false;
 }
 
@@ -617,16 +623,21 @@ function needFinish(state) {
           !state.writing);
 }
 function callFinal(stream, state) {
-  stream._final((err) => {
+  try {
+    stream._final((err) => {
+      state.pendingcb--;
+      if (err) {
+        errorOrDestroy(stream, err);
+      } else {
+        state.prefinished = true;
+        stream.emit('prefinish');
+        finishMaybe(stream, state);
+      }
+    });
+  } catch (err) {
     state.pendingcb--;
-    if (err) {
-      errorOrDestroy(stream, err);
-    } else {
-      state.prefinished = true;
-      stream.emit('prefinish');
-      finishMaybe(stream, state);
-    }
-  });
+    errorOrDestroy(stream, err);
+  }
 }
 function prefinish(stream, state) {
   if (!state.prefinished && !state.finalCalled) {

--- a/lib/internal/fs/sync_write_stream.js
+++ b/lib/internal/fs/sync_write_stream.js
@@ -6,7 +6,7 @@ const { Writable } = require('stream');
 const { closeSync, writeSync } = require('fs');
 
 function SyncWriteStream(fd, options) {
-  Writable.call(this, { autoDestroy: true });
+  Writable.call(this, { autoDestroy: true, syncError: true });
 
   options = options || {};
 

--- a/test/parallel/test-stream-readable-throw.js
+++ b/test/parallel/test-stream-readable-throw.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const common = require('../common');
+const { Readable } = require('stream');
+const assert = require('assert');
+
+{
+  const readable = new Readable({ autoDestroy: false });
+
+  readable._read = () => {
+    throw new Error();
+  };
+  readable.on('error', common.mustCall());
+  readable.on('close', common.mustNotCall());
+  readable.resume();
+}
+
+{
+  const readable = new Readable({ autoDestroy: true });
+
+  readable._read = () => {
+    throw new Error();
+  };
+  readable.on('error', common.mustCall());
+  readable.on('close', common.mustCall());
+  readable.resume();
+}
+
+{
+  const readable = new Readable({ autoDestroy: true });
+
+  readable._read = () => {
+    throw new Error();
+  };
+  readable.on('error', common.mustCall());
+  readable.on('close', common.mustCall());
+  assert.strictEqual(readable.read(), null);
+}

--- a/test/parallel/test-stream-writable-throw.js
+++ b/test/parallel/test-stream-writable-throw.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const common = require('../common');
+const { Writable } = require('stream');
+const assert = require('assert');
+
+{
+  const writable = new Writable({ autoDestroy: false });
+
+  writable._write = () => {
+    throw new Error();
+  };
+  writable.on('error', common.mustCall());
+  writable.on('close', common.mustNotCall());
+  writable.write('asd');
+}
+
+{
+  const writable = new Writable({ autoDestroy: true });
+
+  writable._write = () => {
+    throw new Error();
+  };
+  writable.on('error', common.mustCall());
+  writable.on('close', common.mustCall());
+  writable.write('asd');
+}
+
+{
+  const writable = new Writable({ autoDestroy: false });
+
+  writable._final = () => {
+    throw new Error();
+  };
+  writable.on('error', common.mustCall());
+  writable.on('close', common.mustNotCall());
+  writable.end('asd');
+}
+
+{
+  const writable = new Writable({ autoDestroy: true });
+
+  writable._final = () => {
+    throw new Error();
+  };
+  writable.on('error', common.mustCall());
+  writable.on('close', common.mustCall());
+  writable.end('asd');
+}


### PR DESCRIPTION
`_read` is a sync api and should handle errors accordingly.
Furthermore, userland does not have access to errorOrDestroy
and will often implement error handling incorrectly or not
at all.

`_write`, `_writev`, `_final` should never throw. However, if
they do the error case should be predictable.

In order to maintain compatibility with `SyncWriteStream` a `syncError` option is added for `Writable` in order to allow errors to be thrown synchronously to the caller.

Furthermore, userland does not have access to `errorOrDestroy`
and will often implement error handling incorrectly or not
at all.

try/catch should be fast since V8 turbofan.

A follow up to this PR would be to fix an (existing) bug where `destroy` is not called on `SyncWriteStream` on error even though it is `autoDestroy: true`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
