### PR TITLE
perf_hooks: remove not exist entries from inspect

### DIFF
--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -205,15 +205,7 @@ class PerformanceNodeTiming extends PerformanceEntry {
       bootstrapComplete: this.bootstrapComplete,
       environment: this.environment,
       loopStart: this.loopStart,
-      loopExit: this.loopExit,
-      thirdPartyMainStart: this.thirdPartyMainStart,
-      thirdPartyMainEnd: this.thirdPartyMainEnd,
-      clusterSetupStart: this.clusterSetupStart,
-      clusterSetupEnd: this.clusterSetupEnd,
-      moduleLoadStart: this.moduleLoadStart,
-      moduleLoadEnd: this.moduleLoadEnd,
-      preloadModuleLoadStart: this.preloadModuleLoadStart,
-      preloadModuleLoadEnd: this.preloadModuleLoadEnd
+      loopExit: this.loopExit
     };
   }
 }

--- a/test/parallel/test-trace-events-bootstrap.js
+++ b/test/parallel/test-trace-events-bootstrap.js
@@ -12,15 +12,7 @@ const names = [
   'v8Start',
   'loopStart',
   'loopExit',
-  'bootstrapComplete',
-  'thirdPartyMainStart',
-  'thirdPartyMainEnd',
-  'clusterSetupStart',
-  'clusterSetupEnd',
-  'moduleLoadStart',
-  'moduleLoadEnd',
-  'preloadModulesLoadStart',
-  'preloadModulesLoadEnd'
+  'bootstrapComplete'
 ];
 
 if (process.argv[2] === 'child') {


### PR DESCRIPTION
Some of the milestones was removed in PR #21247 but entries not removed
from function for inspect PerformanceNodeTiming.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
