### PR TITLE
repl: declare for initial expression in the for loop, instead of hoisting and re-using

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1089,7 +1089,7 @@ function complete(line, callback) {
   var completions;
   // List of completion lists, one for each inheritance "level"
   var completionGroups = [];
-  var completeOn, i, group, c;
+  var completeOn, group, c;
 
   // REPL commands (e.g. ".break").
   var filter;
@@ -1112,7 +1112,7 @@ function complete(line, callback) {
     completeOn = match[1];
     var subdir = match[2] || '';
     filter = match[1];
-    var dir, files, f, name, base, ext, abs, subfiles, s, isDirectory;
+    var dir, files, name, base, ext, abs, subfiles, isDirectory;
     group = [];
     let paths = [];
 
@@ -1126,14 +1126,14 @@ function complete(line, callback) {
       paths = module.paths.concat(CJSModule.globalPaths);
     }
 
-    for (i = 0; i < paths.length; i++) {
+    for (let i = 0; i < paths.length; i++) {
       dir = path.resolve(paths[i], subdir);
       try {
         files = fs.readdirSync(dir);
       } catch {
         continue;
       }
-      for (f = 0; f < files.length; f++) {
+      for (let f = 0; f < files.length; f++) {
         name = files[f];
         ext = path.extname(name);
         base = name.slice(0, -ext.length);
@@ -1154,7 +1154,7 @@ function complete(line, callback) {
           } catch {
             continue;
           }
-          for (s = 0; s < subfiles.length; s++) {
+          for (let s = 0; s < subfiles.length; s++) {
             if (indexRe.test(subfiles[s])) {
               group.push(subdir + name);
             }
@@ -1291,7 +1291,7 @@ function complete(line, callback) {
           }
 
           if (memberGroups.length) {
-            for (i = 0; i < memberGroups.length; i++) {
+            for (let i = 0; i < memberGroups.length; i++) {
               completionGroups.push(
                 memberGroups[i].map((member) => `${expr}.${member}`));
             }
@@ -1316,7 +1316,7 @@ function complete(line, callback) {
     // Filter, sort (within each group), uniq and merge the completion groups.
     if (completionGroups.length && filter) {
       var newCompletionGroups = [];
-      for (i = 0; i < completionGroups.length; i++) {
+      for (let i = 0; i < completionGroups.length; i++) {
         group = completionGroups[i]
           .filter((elem) => elem.indexOf(filter) === 0);
         if (group.length) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1332,7 +1332,7 @@ function complete(line, callback) {
       // Completion group 0 is the "closest"
       // (least far up the inheritance chain)
       // so we put its completions last: to be closest in the REPL.
-      for (i = 0; i < completionGroups.length; i++) {
+      for (let i = 0; i < completionGroups.length; i++) {
         group = completionGroups[i];
         group.sort();
         for (var j = group.length - 1; j >= 0; j--) {


### PR DESCRIPTION
There was a for loop that had an initial Expression that wasn't using let/var,  this adds a `let` to it


I also noticed that this module uses var instead of let/const.  I saw in another issue,https://github.com/nodejs/node/issues/28009#issuecomment-497981115 , the reasoning for why they haven't been updated yet.  But since i am touching this file, I would like to try to do the conversion for this file.  If someone else agrees i can push another commit with those updates,  if not,  then i'll just keep this PR as is

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
