### PR TITLE
stream: change how the AsyncIteratorPrototype is set up on ReadableStreams

### DIFF
--- a/1
+++ b/1
@@ -1,0 +1,2 @@
+INFORMAZIONI: impossibile trovare file corrispondenti ai 
+criteri di ricerca indicati.

--- a/1
+++ b/1
@@ -1,2 +1,0 @@
-INFORMAZIONI: impossibile trovare file corrispondenti ai 
-criteri di ricerca indicati.

--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -52,77 +52,92 @@ function wrapForNext(lastPromise, iter) {
 const AsyncIteratorPrototype = Object.getPrototypeOf(
   Object.getPrototypeOf(async function* () {}).prototype);
 
-const ReadableStreamAsyncIteratorPrototype = Object.setPrototypeOf({
-  get stream() {
-    return this[kStream];
-  },
+const ReadableStreamAsyncIteratorPrototype = Object.create(AsyncIteratorPrototype, {
+    stream: {
+      get() {
+        return this[kStream];
+      },
+      writable: true,
+      enumerable: true,
+      configurable: true
+    },
 
-  next() {
-    // If we have detected an error in the meanwhile
-    // reject straight away.
-    const error = this[kError];
-    if (error !== null) {
-      return Promise.reject(error);
-    }
-
-    if (this[kEnded]) {
-      return Promise.resolve(createIterResult(undefined, true));
-    }
-
-    if (this[kStream].destroyed) {
-      // We need to defer via nextTick because if .destroy(err) is
-      // called, the error will be emitted via nextTick, and
-      // we cannot guarantee that there is no error lingering around
-      // waiting to be emitted.
-      return new Promise((resolve, reject) => {
-        process.nextTick(() => {
-          if (this[kError]) {
-            reject(this[kError]);
-          } else {
-            resolve(createIterResult(undefined, true));
+    next: {
+      value: function () {
+          // If we have detected an error in the meanwhile
+          // reject straight away.
+          const error = this[kError];
+          if (error !== null) {
+              return Promise.reject(error);
           }
+
+          if (this[kEnded]) {
+              return Promise.resolve(createIterResult(undefined, true));
+          }
+
+          if (this[kStream].destroyed) {
+              // We need to defer via nextTick because if .destroy(err) is
+              // called, the error will be emitted via nextTick, and
+              // we cannot guarantee that there is no error lingering around
+              // waiting to be emitted.
+              return new Promise((resolve, reject) => {
+                  process.nextTick(() => {
+                      if (this[kError]) {
+                          reject(this[kError]);
+                      } else {
+                          resolve(createIterResult(undefined, true));
+                      }
+                  });
+              });
+          }
+
+          // If we have multiple next() calls we will wait for the previous Promise to
+          // finish. This logic is optimized to support for await loops, where next()
+          // is only called once at a time.
+          const lastPromise = this[kLastPromise];
+          let promise;
+
+          if (lastPromise) {
+              promise = new Promise(wrapForNext(lastPromise, this));
+          } else {
+              // Fast path needed to support multiple this.push()
+              // without triggering the next() queue.
+              const data = this[kStream].read();
+              if (data !== null) {
+                  return Promise.resolve(createIterResult(data, false));
+              }
+
+              promise = new Promise(this[kHandlePromise]);
+          }
+
+          this[kLastPromise] = promise;
+
+          return promise;
+      },
+      writable: true,
+      enumerable: true,
+      configurable: true
+    },
+
+    return: {
+      value: function () {
+        return new Promise((resolve, reject) => {
+            const stream = this[kStream];
+            finished(stream, (err) => {
+                if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
+                    reject(err);
+                } else {
+                    resolve(createIterResult(undefined, true));
+                }
+            });
+            stream.destroy();
         });
-      });
+      },
+      writable: true,
+      enumerable: true,
+      configurable: true
     }
-
-    // If we have multiple next() calls we will wait for the previous Promise to
-    // finish. This logic is optimized to support for await loops, where next()
-    // is only called once at a time.
-    const lastPromise = this[kLastPromise];
-    let promise;
-
-    if (lastPromise) {
-      promise = new Promise(wrapForNext(lastPromise, this));
-    } else {
-      // Fast path needed to support multiple this.push()
-      // without triggering the next() queue.
-      const data = this[kStream].read();
-      if (data !== null) {
-        return Promise.resolve(createIterResult(data, false));
-      }
-
-      promise = new Promise(this[kHandlePromise]);
-    }
-
-    this[kLastPromise] = promise;
-
-    return promise;
-  },
-
-  return() {
-    return new Promise((resolve, reject) => {
-      const stream = this[kStream];
-      finished(stream, (err) => {
-        if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
-          reject(err);
-        } else {
-          resolve(createIterResult(undefined, true));
-        }
-      });
-      stream.destroy();
-    });
-  },
-}, AsyncIteratorPrototype);
+});
 
 const createReadableStreamAsyncIterator = (stream) => {
   const iterator = Object.create(ReadableStreamAsyncIteratorPrototype, {

--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -54,90 +54,91 @@ const AsyncIteratorPrototype = Object.getPrototypeOf(
 
 const ReadableStreamAsyncIteratorPrototype = Object.create(
   AsyncIteratorPrototype, {
-  stream: {
-    get() {
-      return this[kStream];
+    stream: {
+      get() {
+        return this[kStream];
+      },
+      enumerable: true,
+      configurable: true
     },
-    enumerable: true,
-    configurable: true
-  },
 
-  next: {
-    value: function() {
-      // If we have detected an error in the meanwhile
-      // reject straight away.
-      const error = this[kError];
-      if (error !== null) {
-        return Promise.reject(error);
-      }
+    next: {
+      value: function() {
+        // If we have detected an error in the meanwhile
+        // reject straight away.
+        const error = this[kError];
+        if (error !== null) {
+          return Promise.reject(error);
+        }
 
-      if (this[kEnded]) {
-        return Promise.resolve(createIterResult(undefined, true));
-      }
+        if (this[kEnded]) {
+          return Promise.resolve(createIterResult(undefined, true));
+        }
 
-      if (this[kStream].destroyed) {
-        // We need to defer via nextTick because if .destroy(err) is
-        // called, the error will be emitted via nextTick, and
-        // we cannot guarantee that there is no error lingering around
-        // waiting to be emitted.
+        if (this[kStream].destroyed) {
+          // We need to defer via nextTick because if .destroy(err) is
+          // called, the error will be emitted via nextTick, and
+          // we cannot guarantee that there is no error lingering around
+          // waiting to be emitted.
+          return new Promise((resolve, reject) => {
+            process.nextTick(() => {
+              if (this[kError]) {
+                reject(this[kError]);
+              } else {
+                resolve(createIterResult(undefined, true));
+              }
+            });
+          });
+        }
+
+        // If we have multiple next() calls we will wait for the previous
+        // Promise to finish. This logic is optimized to support for
+        // await loops, where next() is only called once at a time.
+        const lastPromise = this[kLastPromise];
+        let promise;
+
+        if (lastPromise) {
+          promise = new Promise(wrapForNext(lastPromise, this));
+        } else {
+          // Fast path needed to support multiple this.push()
+          // without triggering the next() queue.
+          const data = this[kStream].read();
+          if (data !== null) {
+            return Promise.resolve(createIterResult(data, false));
+          }
+
+          promise = new Promise(this[kHandlePromise]);
+        }
+
+        this[kLastPromise] = promise;
+
+        return promise;
+      },
+      writable: true,
+      enumerable: true,
+      configurable: true
+    },
+
+    return: {
+      value: function() {
         return new Promise((resolve, reject) => {
-          process.nextTick(() => {
-            if (this[kError]) {
-              reject(this[kError]);
+          const stream = this[kStream];
+          finished(stream, (err) => {
+            if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
+              reject(err);
             } else {
               resolve(createIterResult(undefined, true));
             }
           });
+          stream.destroy();
         });
-      }
-
-      // If we have multiple next() calls we will wait for the previous Promise to
-      // finish. This logic is optimized to support for await loops, where next()
-      // is only called once at a time.
-      const lastPromise = this[kLastPromise];
-      let promise;
-
-      if (lastPromise) {
-        promise = new Promise(wrapForNext(lastPromise, this));
-      } else {
-        // Fast path needed to support multiple this.push()
-        // without triggering the next() queue.
-        const data = this[kStream].read();
-        if (data !== null) {
-          return Promise.resolve(createIterResult(data, false));
-        }
-
-        promise = new Promise(this[kHandlePromise]);
-      }
-
-      this[kLastPromise] = promise;
-
-      return promise;
-    },
-    writable: true,
-    enumerable: true,
-    configurable: true
-  },
-
-  return: {
-    value: function() {
-      return new Promise((resolve, reject) => {
-        const stream = this[kStream];
-        finished(stream, (err) => {
-          if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
-            reject(err);
-          } else {
-            resolve(createIterResult(undefined, true));
-          }
-        });
-        stream.destroy();
-      });
-    },
-    writable: true,
-    enumerable: true,
-    configurable: true
+      },
+      writable: true,
+      enumerable: true,
+      configurable: true
+    }
   }
-});
+);
 
 const createReadableStreamAsyncIterator = (stream) => {
   const iterator = Object.create(ReadableStreamAsyncIteratorPrototype, {

--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -52,91 +52,91 @@ function wrapForNext(lastPromise, iter) {
 const AsyncIteratorPrototype = Object.getPrototypeOf(
   Object.getPrototypeOf(async function* () {}).prototype);
 
-const ReadableStreamAsyncIteratorPrototype = Object.create(AsyncIteratorPrototype, {
-    stream: {
-      get() {
-        return this[kStream];
-      },
-      writable: true,
-      enumerable: true,
-      configurable: true
+const ReadableStreamAsyncIteratorPrototype = Object.create(
+  AsyncIteratorPrototype, {
+  stream: {
+    get() {
+      return this[kStream];
     },
+    enumerable: true,
+    configurable: true
+  },
 
-    next: {
-      value: function () {
-          // If we have detected an error in the meanwhile
-          // reject straight away.
-          const error = this[kError];
-          if (error !== null) {
-              return Promise.reject(error);
-          }
+  next: {
+    value: function() {
+      // If we have detected an error in the meanwhile
+      // reject straight away.
+      const error = this[kError];
+      if (error !== null) {
+        return Promise.reject(error);
+      }
 
-          if (this[kEnded]) {
-              return Promise.resolve(createIterResult(undefined, true));
-          }
+      if (this[kEnded]) {
+        return Promise.resolve(createIterResult(undefined, true));
+      }
 
-          if (this[kStream].destroyed) {
-              // We need to defer via nextTick because if .destroy(err) is
-              // called, the error will be emitted via nextTick, and
-              // we cannot guarantee that there is no error lingering around
-              // waiting to be emitted.
-              return new Promise((resolve, reject) => {
-                  process.nextTick(() => {
-                      if (this[kError]) {
-                          reject(this[kError]);
-                      } else {
-                          resolve(createIterResult(undefined, true));
-                      }
-                  });
-              });
-          }
-
-          // If we have multiple next() calls we will wait for the previous Promise to
-          // finish. This logic is optimized to support for await loops, where next()
-          // is only called once at a time.
-          const lastPromise = this[kLastPromise];
-          let promise;
-
-          if (lastPromise) {
-              promise = new Promise(wrapForNext(lastPromise, this));
-          } else {
-              // Fast path needed to support multiple this.push()
-              // without triggering the next() queue.
-              const data = this[kStream].read();
-              if (data !== null) {
-                  return Promise.resolve(createIterResult(data, false));
-              }
-
-              promise = new Promise(this[kHandlePromise]);
-          }
-
-          this[kLastPromise] = promise;
-
-          return promise;
-      },
-      writable: true,
-      enumerable: true,
-      configurable: true
-    },
-
-    return: {
-      value: function () {
+      if (this[kStream].destroyed) {
+        // We need to defer via nextTick because if .destroy(err) is
+        // called, the error will be emitted via nextTick, and
+        // we cannot guarantee that there is no error lingering around
+        // waiting to be emitted.
         return new Promise((resolve, reject) => {
-            const stream = this[kStream];
-            finished(stream, (err) => {
-                if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
-                    reject(err);
-                } else {
-                    resolve(createIterResult(undefined, true));
-                }
-            });
-            stream.destroy();
+          process.nextTick(() => {
+            if (this[kError]) {
+              reject(this[kError]);
+            } else {
+              resolve(createIterResult(undefined, true));
+            }
+          });
         });
-      },
-      writable: true,
-      enumerable: true,
-      configurable: true
-    }
+      }
+
+      // If we have multiple next() calls we will wait for the previous Promise to
+      // finish. This logic is optimized to support for await loops, where next()
+      // is only called once at a time.
+      const lastPromise = this[kLastPromise];
+      let promise;
+
+      if (lastPromise) {
+        promise = new Promise(wrapForNext(lastPromise, this));
+      } else {
+        // Fast path needed to support multiple this.push()
+        // without triggering the next() queue.
+        const data = this[kStream].read();
+        if (data !== null) {
+          return Promise.resolve(createIterResult(data, false));
+        }
+
+        promise = new Promise(this[kHandlePromise]);
+      }
+
+      this[kLastPromise] = promise;
+
+      return promise;
+    },
+    writable: true,
+    enumerable: true,
+    configurable: true
+  },
+
+  return: {
+    value: function() {
+      return new Promise((resolve, reject) => {
+        const stream = this[kStream];
+        finished(stream, (err) => {
+          if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
+            reject(err);
+          } else {
+            resolve(createIterResult(undefined, true));
+          }
+        });
+        stream.destroy();
+      });
+    },
+    writable: true,
+    enumerable: true,
+    configurable: true
+  }
 });
 
 const createReadableStreamAsyncIterator = (stream) => {


### PR DESCRIPTION
## Object.create vs Object.setPrototypeOf
It's not a good idea changing the `[[Prototype]]` link of an object after having created it.


##### Checklist


- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes: not all because of some not found commands I was not able to make available on windows. But no errors have arisen because of the changes.
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines): did my best :)

