### PR TITLE
bootstrap: adds exception handling for profiler bootstrap

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -120,8 +120,13 @@ function setupCoverageHooks(dir) {
   const { resolve } = require('path');
   const coverageDirectory = resolve(cwd, dir);
   const { sourceMapCacheToObject } = require('internal/source_map');
-  internalBinding('profiler').setCoverageDirectory(coverageDirectory);
-  internalBinding('profiler').setSourceMapCacheGetter(sourceMapCacheToObject);
+
+  try {
+    internalBinding('profiler').setCoverageDirectory(coverageDirectory);
+    internalBinding('profiler').setSourceMapCacheGetter(sourceMapCacheToObject);
+  } catch {
+    process.emitWarning('Profiler is not enabled.', 'Warning');
+  }
   return coverageDirectory;
 }
 

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -121,10 +121,10 @@ function setupCoverageHooks(dir) {
   const coverageDirectory = resolve(cwd, dir);
   const { sourceMapCacheToObject } = require('internal/source_map');
 
-  try {
+  if (process.features.inspector) {
     internalBinding('profiler').setCoverageDirectory(coverageDirectory);
     internalBinding('profiler').setSourceMapCacheGetter(sourceMapCacheToObject);
-  } catch {
+  } else {
     process.emitWarning('The inspector is disabled, ' +
                         'coverage could not be collected',
                         'Warning');

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -125,7 +125,9 @@ function setupCoverageHooks(dir) {
     internalBinding('profiler').setCoverageDirectory(coverageDirectory);
     internalBinding('profiler').setSourceMapCacheGetter(sourceMapCacheToObject);
   } catch {
-    process.emitWarning('Profiler is not enabled.', 'Warning');
+    process.emitWarning('The inspector is disabled, ' +
+                        'coverage could not be collected',
+                        'Warning');
   }
   return coverageDirectory;
 }

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -128,6 +128,7 @@ function setupCoverageHooks(dir) {
     process.emitWarning('The inspector is disabled, ' +
                         'coverage could not be collected',
                         'Warning');
+    return '';
   }
   return coverageDirectory;
 }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -651,6 +651,12 @@ function skipIfInspectorDisabled() {
   }
 }
 
+function skipIfInspectorEnabled() {
+  if (process.features.inspector) {
+    skip('V8 inspector is enabled');
+  }
+}
+
 function skipIfReportDisabled() {
   if (!process.config.variables.node_report) {
     skip('Diagnostic reporting is disabled');
@@ -783,6 +789,7 @@ module.exports = {
   skipIf32Bits,
   skipIfEslintMissing,
   skipIfInspectorDisabled,
+  skipIfInspectorEnabled,
   skipIfReportDisabled,
   skipIfWorker,
 

--- a/test/fixtures/v8-coverage/subprocess.js
+++ b/test/fixtures/v8-coverage/subprocess.js
@@ -6,3 +6,5 @@ setTimeout(() => {
     const c = 102;
   }
 }, 10);
+
+process.on('warning', console.log);

--- a/test/fixtures/v8-coverage/subprocess.js
+++ b/test/fixtures/v8-coverage/subprocess.js
@@ -6,5 +6,3 @@ setTimeout(() => {
     const c = 102;
   }
 }, 10);
-
-process.on('warning', console.log);

--- a/test/parallel/test-coverage-with-inspector-disabled.js
+++ b/test/parallel/test-coverage-with-inspector-disabled.js
@@ -1,0 +1,23 @@
+'use strict';
+
+require('../common');
+const fixtures = require('../common/fixtures');
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const env = Object.assign({}, process.env, { NODE_V8_COVERAGE: '/foo/bar' });
+const childPath = fixtures.path('v8-coverage/subprocess');
+const { status, stderr } = spawnSync(
+  process.execPath,
+  [childPath],
+  { env: env }
+);
+
+const warningMessage = 'The inspector is disabled, ' +
+                        'coverage could not be collected';
+
+assert.strictEqual(status, 0);
+assert.strictEqual(
+  stderr.toString().includes(`Warning: ${warningMessage}`),
+  true
+);

--- a/test/parallel/test-coverage-with-inspector-disabled.js
+++ b/test/parallel/test-coverage-with-inspector-disabled.js
@@ -1,16 +1,17 @@
 'use strict';
 
-require('../common');
-const fixtures = require('../common/fixtures');
+const common = require('../common');
+common.skipIfInspectorEnabled();
 
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const { spawnSync } = require('child_process');
-const env = Object.assign({}, process.env, { NODE_V8_COVERAGE: '/foo/bar' });
+const env = { ...process.env, NODE_V8_COVERAGE: '/foo/bar' };
 const childPath = fixtures.path('v8-coverage/subprocess');
 const { status, stderr } = spawnSync(
   process.execPath,
   [childPath],
-  { env: env }
+  { env }
 );
 
 const warningMessage = 'The inspector is disabled, ' +


### PR DESCRIPTION
The bootstrapping of profiler failed the script evaluation when inspector is disabled. Adding a try-catch block to handle that and emit a warning.

Fixes:  #29542

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
