### PR TITLE
add missing sigemptyset() to init sigset_t

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -163,6 +163,7 @@ struct V8Platform v8_platform;
 }  // namespace per_process
 
 #ifdef __POSIX__
+
 void SignalExit(int signo, siginfo_t* info, void* ucontext) {
   ResetStdio();
   raise(signo);
@@ -548,6 +549,7 @@ void TrapWebAssemblyOrContinue(int signo, siginfo_t* info, void* ucontext) {
       struct sigaction sa;
       memset(&sa, 0, sizeof(sa));
       sa.sa_handler = SIG_DFL;
+      sigemptyset(&sa.sa_mask);
       CHECK_EQ(sigaction(signo, &sa, nullptr), 0);
 
       ResetStdio();
@@ -574,8 +576,8 @@ void RegisterSignalHandler(int signal,
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_sigaction = handler;
-  sa.sa_flags = reset_handler ? SA_RESETHAND : 0;
   sigfillset(&sa.sa_mask);
+  sa.sa_flags = reset_handler ? SA_RESETHAND : 0;
   CHECK_EQ(sigaction(signal, &sa, nullptr), 0);
 }
 #endif  // __POSIX__
@@ -623,6 +625,7 @@ inline void PlatformInit() {
   // Restore signal dispositions, the parent process may have changed them.
   struct sigaction act;
   memset(&act, 0, sizeof(act));
+  sigemptyset(&act.sa_mask);
 
   // The hard-coded upper limit is because NSIG is not very reliable; on Linux,
   // it evaluates to 32, 34 or 64, depending on whether RT signals are enabled.
@@ -675,6 +678,7 @@ inline void PlatformInit() {
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sa.sa_sigaction = TrapWebAssemblyOrContinue;
+    sigemptyset(&sa.sa_mask);
     sa.sa_flags = SA_SIGINFO;
     CHECK_EQ(sigaction(SIGSEGV, &sa, nullptr), 0);
   }

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -113,6 +113,7 @@ int main(int argc, char* argv[]) {
     struct sigaction act;
     memset(&act, 0, sizeof(act));
     act.sa_handler = SIG_IGN;
+    sigemptyset(&act.sa_mask);
     sigaction(SIGPIPE, &act, nullptr);
   }
 #endif


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This conforms to posix saying that `sigset_t` cannot be initialized through `memset` but rather `sigemptyset()` or `sigfillset()`
