### PR TITLE
inspector: update faviconUrl

### DIFF
--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -343,7 +343,7 @@ void InspectorSocketServer::SendListResponse(InspectorSocket* socket,
     response.push_back(std::map<std::string, std::string>());
     std::map<std::string, std::string>& target_map = response.back();
     target_map["description"] = "node.js instance";
-    target_map["faviconUrl"] = "https://nodejs.org/static/favicon.ico";
+    target_map["faviconUrl"] = "https://nodejs.org/static/images/favicons/favicon.ico";
     target_map["id"] = id;
     target_map["title"] = delegate_->GetTargetTitle(id);
     Escape(&target_map["title"]);

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -343,7 +343,8 @@ void InspectorSocketServer::SendListResponse(InspectorSocket* socket,
     response.push_back(std::map<std::string, std::string>());
     std::map<std::string, std::string>& target_map = response.back();
     target_map["description"] = "node.js instance";
-    target_map["faviconUrl"] = "https://nodejs.org/static/images/favicons/favicon.ico";
+    target_map["faviconUrl"] =
+                        "https://nodejs.org/static/images/favicons/favicon.ico";
     target_map["id"] = id;
     target_map["title"] = delegate_->GetTargetTitle(id);
     Escape(&target_map["title"]);


### PR DESCRIPTION
Seeing no icon for the remote target at `chrome://inspect/#devices` when debugging via Chrome DevTools with `--inspect` switch. GET request for the icon is returning 404 status code because of incorrect request URL: https://nodejs.org/static/favicon.ico.
Changed `faviconUrl` at `src/inspector_socket_server.cc` to https://nodejs.org/static/images/favicons/favicon.ico. The reason for all this is icon files being moved in https://github.com/nodejs/nodejs.org/commit/ce04045d507be7cc2f0a0347792f22097bc7422a commit.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
