### PR TITLE
lib: remove the use of util.isFunction

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -20,7 +20,6 @@ if (!hasInspector)
 
 const EventEmitter = require('events');
 const { validateString } = require('internal/validators');
-const util = require('util');
 const { isMainThread } = require('worker_threads');
 
 const {
@@ -86,7 +85,7 @@ class Session extends EventEmitter {
 
   post(method, params, callback) {
     validateString(method, 'method');
-    if (!callback && util.isFunction(params)) {
+    if (!callback && typeof params === 'function') {
       callback = params;
       params = null;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

see https://nodejs.org/dist/latest-v12.x/docs/api/util.html#util_util_isfunction_object

`util.isFunction` has deprecated.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)