### PR TITLE
#29439 added leap second behavior to napi_create_date and napi_get_date_value

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1775,6 +1775,9 @@ napi_status napi_create_date(napi_env env,
 
 Returns `napi_ok` if the API succeeded.
 
+This API does not observe leap seconds; they are ignored, as
+ECMAScript aligns with POSIX time specification.
+
 This API allocates a JavaScript `Date` object.
 
 JavaScript `Date` objects are described in
@@ -2433,6 +2436,9 @@ napi_status napi_get_date_value(napi_env env,
 - `[in] value`: `napi_value` representing a JavaScript `Date`.
 - `[out] result`: Time value as a `double` represented as milliseconds
 since midnight at the beginning of 01 January, 1970 UTC.
+
+This API does not observe leap seconds; they are ignored, as
+ECMAScript aligns with POSIX time specification.
 
 Returns `napi_ok` if the API succeeded. If a non-date `napi_value` is passed
 in it returns `napi_date_expected`.


### PR DESCRIPTION
    doc: added leap second behavior to napi_create_date and napi_get_date_value
    
    napi_create_date and napi_get_date_value ignore leap seconds as per
    ECMAScript spec that follows POSIX spec for time, comments added to the
    documentation where added fo clarify it.
    
    fixes: https://github.com/nodejs/node/issues/29439

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
