### PR TITLE
src: fix ESM path resolution on Windows

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -488,7 +488,12 @@ enum DescriptorType {
 // Nothing for the "null" cache entries.
 inline Maybe<uv_file> OpenDescriptor(const std::string& path) {
   uv_fs_t fs_req;
+#ifdef _WIN32
+  std::string pth = "\\\\.\\" + path;
+  uv_file fd = uv_fs_open(nullptr, &fs_req, pth.c_str(), O_RDONLY, 0, nullptr);
+#else
   uv_file fd = uv_fs_open(nullptr, &fs_req, path.c_str(), O_RDONLY, 0, nullptr);
+#endif
   uv_fs_req_cleanup(&fs_req);
   if (fd < 0) return Nothing<uv_file>();
   return Just(fd);

--- a/test/es-module/test-esm-windows.js
+++ b/test/es-module/test-esm-windows.js
@@ -1,0 +1,49 @@
+'use strict';
+
+// Flags: --experimental-modules
+// This test ensures that JavaScript file that includes
+// a reserved Windows word can be loaded as ESM module
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs').promises;
+const path = require('path');
+
+const imp = (file) => {
+  return import(path.relative(__dirname, file).replace(/\\/g, '/'));
+};
+
+(async () => {
+  const tmp = tmpdir.path;
+  await fs.mkdir(tmp).catch(() => {});
+  const rel = (file) => path.join(tmp, file);
+
+  { // Load a single script
+    const file = rel('con.mjs');
+    await fs.writeFile(file, 'export default "ok"');
+    assert.strictEqual((await imp(file)).default, 'ok');
+    await fs.unlink(file);
+  }
+
+  { // Load a module
+    const entry = rel('entry.mjs');
+    const nmDir = rel('node_modules');
+    const mDir = rel('node_modules/con');
+    const pkg = rel('node_modules/con/package.json');
+    const script = rel('node_modules/con/index.mjs');
+
+    await fs.writeFile(entry, 'export {default} from "con"');
+    await fs.mkdir(nmDir);
+    await fs.mkdir(mDir);
+    await fs.writeFile(pkg, '{"main":"index.mjs"}');
+    await fs.writeFile(script, 'export default "ok"');
+
+    assert.strictEqual((await imp(entry)).default, 'ok');
+    await fs.unlink(script);
+    await fs.unlink(pkg);
+    await fs.rmdir(mDir);
+    await fs.rmdir(nmDir);
+    await fs.unlink(entry);
+  }
+})().then(common.mustCall());


### PR DESCRIPTION
Windows has some reserved file names such as `con`, `prn`, `nul`, etc. Such files can be accessed only if the path is prefixed with `\\.\`

Fixes #29572

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)