### PR TITLE
http: use readableEnded and writableEnded

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2606,7 +2606,7 @@ officially supported property.
 [`require.extensions`]: modules.html#modules_require_extensions
 [`request.socket`]: http.html#http_request_socket
 [`request.connection`]: http.html#http_request_connection
-[`request._ended`]: http.html#http_request__ended
+[`request._ended`]: http.html#http_request_ended
 [`response.readableEnded`]: stream.html#stream_readable_readableEnded
 [`response.socket`]: http.html#http_response_socket
 [`response.connection`]: http.html#http_response_connection

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2532,6 +2532,24 @@ Type: Documentation-only (supports [`--pending-deprecation`][])
 The `process._tickCallback` property was never documented as
 an officially supported API.
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: ClientRequest.prototype.\_ended
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/29580
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+The `http` module [`request._ended`][] is deprecated. Use
+the public method [`response.readableEnded`][] on the
+response instead.
+
+The [`request._ended`][] property was never documented as an
+officially supported property.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
@@ -2588,6 +2606,8 @@ an officially supported API.
 [`require.extensions`]: modules.html#modules_require_extensions
 [`request.socket`]: http.html#http_request_socket
 [`request.connection`]: http.html#http_request_connection
+[`request._ended`]: http.html#http_request__ended
+[`response.readableEnded`]: stream.html#stream_readable_readableEnded
 [`response.socket`]: http.html#http_response_socket
 [`response.connection`]: http.html#http_response_connection
 [`script.createCachedData()`]: vm.html#vm_script_createcacheddata

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -25,6 +25,7 @@ const { Object } = primordials;
 
 const net = require('net');
 const url = require('url');
+const util = require('internal/util');
 const assert = require('internal/assert');
 const {
   _checkIsHttpToken: checkIsHttpToken,
@@ -55,6 +56,8 @@ const {
 } = require('internal/dtrace');
 
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
+
+const kEnded = Symbol('kEnded');
 
 function validateHost(host, name) {
   if (host !== null && host !== undefined && typeof host !== 'string') {
@@ -188,7 +191,6 @@ function ClientRequest(input, options, cb) {
     this.useChunkedEncodingByDefault = true;
   }
 
-  this._ended = false;
   this.res = null;
   this.aborted = false;
   this.timeoutCb = null;
@@ -301,6 +303,16 @@ ClientRequest.prototype._finish = function _finish() {
   DTRACE_HTTP_CLIENT_REQUEST(this, this.socket);
   OutgoingMessage.prototype._finish.call(this);
 };
+
+// Backwards compat
+Object.defineProperty(ClientRequest.prototype, '_ended', {
+  get: util.deprecate(() => {
+    return this[kEnded] || Boolean(this.res && this.res.readableEnded);
+  }, 'ClientRequest.prototype._ended is deprecated', 'DEP0XXX'),
+  set: util.deprecate((val) => {
+    this[kEnded] = val;
+  }, 'ClientRequest.prototype._ended is deprecated', 'DEP0XXX')
+});
 
 ClientRequest.prototype._implicitHeader = function _implicitHeader() {
   if (this._header) {
@@ -617,8 +629,6 @@ function responseOnEnd() {
     req.socket.removeListener('timeout', emitRequestTimeout);
   }
 
-  req._ended = true;
-
   if (!req.shouldKeepAlive) {
     const socket = req.socket;
     if (socket.writable) {
@@ -629,20 +639,19 @@ function responseOnEnd() {
         socket.end();
     }
     assert(!socket.writable);
-  } else if (req.finished) {
-    // We can assume `req.finished` means all data has been written since:
+  } else if (req.writableEnded) {
+    // We can assume `req.writableEnded` means all data has been written since:
     // - `'responseOnEnd'` means we have been assigned a socket.
     // - when we have a socket we write directly to it without buffering.
-    // - `req.finished` means `end()` has been called and no further data.
-    //   can be written
     responseKeepAlive(req);
   }
 }
 
 function requestOnPrefinish() {
   const req = this;
+  const res = req.res;
 
-  if (req.shouldKeepAlive && req._ended)
+  if (req.shouldKeepAlive && res.readableEnded)
     responseKeepAlive(req);
 }
 
@@ -756,7 +765,9 @@ function _deferToConnect(method, arguments_, cb) {
 }
 
 ClientRequest.prototype.setTimeout = function setTimeout(msecs, callback) {
-  if (this._ended) {
+  const res = this.res;
+
+  if (res && res.readableEnded) {
     return this;
   }
 


### PR DESCRIPTION
Slightly refactor http client by removing extra prop and instead using standard stream accessors.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
