### PR TITLE
deps: V8: cherry-pick 35c6d4d

### DIFF
--- a/deps/v8/third_party/inspector_protocol/code_generator.py
+++ b/deps/v8/third_party/inspector_protocol/code_generator.py
@@ -43,6 +43,9 @@ def read_config():
       items = [(k, os.path.join(output_base, v) if k == "output" else v)
                for (k, v) in items]
       keys, values = list(zip(*items))
+      # 'async' is a keyword since Python 3.7.
+      # Avoid namedtuple(rename=True) for compatibility with Python 2.X.
+      keys = tuple('async_' if k == 'async' else k for k in keys)
       return collections.namedtuple('X', keys)(*values)
     return json.loads(data, object_hook=json_object_hook)
 
@@ -555,7 +558,7 @@ class Protocol(object):
     if not self.config.protocol.options:
       return False
     return self.check_options(self.config.protocol.options, domain, command,
-                              "async", None, False)
+                              "async_", None, False)
 
   def is_exported(self, domain, name):
     if not self.config.protocol.options:

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -573,8 +573,14 @@ The resolve hook returns the resolved file URL and module format for a
 given module specifier and parent file URL:
 
 ```js
-const baseURL = new URL(`${process.cwd()}/`, 'file://');
+import { URL, pathToFileURL } from 'url';
+const baseURL = pathToFileURL(process.cwd()).href;
 
+/**
+ * @param {string} specifier
+ * @param {string} parentModuleURL
+ * @param {function} defaultResolver
+ */
 export async function resolve(specifier,
                               parentModuleURL = baseURL,
                               defaultResolver) {
@@ -612,13 +618,21 @@ be written:
 import path from 'path';
 import process from 'process';
 import Module from 'module';
+import { URL, pathToFileURL } from 'url';
 
 const builtins = Module.builtinModules;
 const JS_EXTENSIONS = new Set(['.js', '.mjs']);
 
-const baseURL = new URL(`${process.cwd()}/`, 'file://');
+const baseURL = pathToFileURL(process.cwd()).href;
 
-export function resolve(specifier, parentModuleURL = baseURL, defaultResolve) {
+/**
+ * @param {string} specifier
+ * @param {string} parentModuleURL
+ * @param {function} defaultResolver
+ */
+export async function resolve(specifier,
+                              parentModuleURL = baseURL,
+                              defaultResolver) {
   if (builtins.includes(specifier)) {
     return {
       url: specifier,
@@ -627,7 +641,7 @@ export function resolve(specifier, parentModuleURL = baseURL, defaultResolve) {
   }
   if (/^\.{0,2}[/]/.test(specifier) !== true && !specifier.startsWith('file:')) {
     // For node_modules support:
-    // return defaultResolve(specifier, parentModuleURL);
+    // return defaultResolver(specifier, parentModuleURL);
     throw new Error(
       `imports must begin with '/', './', or '../'; '${specifier}' does not`);
   }


### PR DESCRIPTION
Original commit message:

    Make code generator python3.7 compatible (async keyword).

    Change-Id: Ifcd8b8cb1de60a007c7bbd4564d7869e83cb7109

Fixes: https://github.com/nodejs/node/issues/29548
Refs:
- https://github.com/nodejs/node/pull/29520
- https://github.com/nodejs/node/pull/29340
- https://chromium-review.googlesource.com/c/deps/inspector_protocol/+/1781351
- https://chromium.googlesource.com/deps/inspector_protocol/+/35c6d4d0d80b42d81bd00bcb1eb2b1093c80ed0a

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
