### PR TITLE
src: discard remaining foreground tasks on platform shutdown

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -279,8 +279,13 @@ void PerIsolatePlatformData::Shutdown() {
   if (flush_tasks_ == nullptr)
     return;
 
-  CHECK_NULL(foreground_delayed_tasks_.Pop());
-  CHECK_NULL(foreground_tasks_.Pop());
+  // While there should be no V8 tasks in the queues at this point, it is
+  // possible that Node.js-internal tasks from e.g. the inspector are still
+  // lying around. We clear these queues and ignore the return value,
+  // effectively deleting the tasks instead of running them.
+  foreground_delayed_tasks_.PopAll();
+  foreground_tasks_.PopAll();
+
   CancelPendingDelayedTasks();
 
   ShutdownCbList* copy = new ShutdownCbList(std::move(shutdown_callbacks_));


### PR DESCRIPTION
While V8 itself should not have any remaining tasks on the queue
during platform shutdown, our inspector implementation may do so.
Thus, the checks verifying that no tasks are queued at that point
makes some of the inspector tasks flaky.
Remove the checks and replace them by explicitly destroying all
tasks that are left.

Refs: https://github.com/nodejs/node/pull/25653
Refs: https://github.com/nodejs/node/pull/28870#issuecomment-531908090

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
