### PR TITLE
console,util: revert #23162

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -185,6 +185,10 @@ property take precedence over `--trace-deprecation` and
 <!-- YAML
 added: v0.5.3
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/29592
+    description: The output string's formatting will again dependent on the type
+                 of the first argument.
   - version: v12.11.0
     pr-url: https://github.com/nodejs/node/pull/29606
     description: The `%c` specifier is ignored now.
@@ -217,10 +221,11 @@ changes:
 * `...args` {any}
 * Returns: {string} The formatted string
 
-The `util.format()` method returns a formatted string using the first argument
-as a `printf`-like format string which can contain zero or more format
-specifiers. Each specifier is replaced with the converted value from the
-corresponding argument. Supported specifiers are:
+If the first argument `format` is a string and `args` is not empty, the
+`util.format()` method returns a formatted string using the first argument as a
+`printf`-like format string which can contain zero or more format specifiers.
+Each specifier is replaced with the converted value from the corresponding
+argument. Supported specifiers are:
 
 * `%s` - `String` will be used to convert all values except `BigInt`, `Object`
   and `-0`. `BigInt` values will be represented with an `n` and Objects that
@@ -251,32 +256,36 @@ util.format('%s:%s', 'foo');
 // Returns: 'foo:%s'
 ```
 
-Values that are not part of the format string are formatted using
-`util.inspect()` if their type is not `string`.
-
-If there are more arguments passed to the `util.format()` method than the
-number of specifiers, the extra arguments are concatenated to the returned
-string, separated by spaces:
+If there are more arguments than the number of specifiers, the extra arguments
+are concatenated to the returned string, separated by spaces:
 
 ```js
 util.format('%s:%s', 'foo', 'bar', 'baz');
 // Returns: 'foo:bar baz'
 ```
 
-If the first argument does not contain a valid format specifier, `util.format()`
-returns a string that is the concatenation of all arguments separated by spaces:
+Values that are not consumed by the format string are formatted using
+`util.inspect()` if their type is not `string`:
 
 ```js
-util.format(1, 2, 3);
-// Returns: '1 2 3'
+util.format('string', 5n, 'string');
+// Returns 'string 5n string'
 ```
 
-If only one argument is passed to `util.format()`, it is returned as it is
-without any formatting:
+All values are formatted using `util.inspect()`, if the first argument's type is
+not `string`:
 
 ```js
-util.format('%% %s');
-// Returns: '%% %s'
+util.format(5n, 'string \n line 1', [1]);
+// Returns: "5n 'string \\n line 1' [ 1 ]"
+```
+
+If only a single argument of type `string` is passed to `util.format()`, it is
+returned as it is without any formatting:
+
+```js
+util.format('%% %s \n line 2');
+// Returns: '%% %s \n line 2'
 ```
 
 `util.format()` is a synchronous method that is intended as a debugging tool.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -181,7 +181,7 @@ The `--throw-deprecation` command line flag and `process.throwDeprecation`
 property take precedence over `--trace-deprecation` and
 `process.traceDeprecation`.
 
-## util.format(format\[, ...args\])
+## util.format(\[format\]\[, ...args\])
 <!-- YAML
 added: v0.5.3
 changes:
@@ -214,6 +214,8 @@ changes:
 -->
 
 * `format` {string} A `printf`-like format string.
+* `...args` {any}
+* Returns: {string} The formatted string
 
 The `util.format()` method returns a formatted string using the first argument
 as a `printf`-like format string which can contain zero or more format
@@ -241,7 +243,6 @@ corresponding argument. Supported specifiers are:
 * `%c` - `CSS`. This specifier is currently ignored, and will skip any CSS
   passed in.
 * `%%` - single percent sign (`'%'`). This does not consume an argument.
-* Returns: {string} The formatted string
 
 If a specifier does not have a corresponding argument, it is not replaced:
 
@@ -282,13 +283,15 @@ util.format('%% %s');
 Some input values can have a significant performance overhead that can block the
 event loop. Use this function with care and never in a hot code path.
 
-## util.formatWithOptions(inspectOptions, format\[, ...args\])
+## util.formatWithOptions(inspectOptions\[, format\]\[, ...args\])
 <!-- YAML
 added: v10.0.0
 -->
 
 * `inspectOptions` {Object}
 * `format` {string}
+* `...args` {any}
+* Returns: {string}
 
 This function is identical to [`util.format()`][], except in that it takes
 an `inspectOptions` argument which specifies options that are passed along to

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -188,21 +188,16 @@ changes:
   - version: v12.11.0
     pr-url: https://github.com/nodejs/node/pull/29606
     description: The `%c` specifier is ignored now.
+  - version: v12.0.0
+    pr-url: https://github.com/nodejs/node/pull/23162
+    description: The output string's formatting is no longer dependent on the
+                 type of the first argument. This change removes previously
+                 present quotes from strings that were being output when the
+                 first argument was not a string.
   - version: v11.4.0
     pr-url: https://github.com/nodejs/node/pull/23708
     description: The `%d`, `%f` and `%i` specifiers now support Symbols
                  properly.
-  - version: v12.0.0
-    pr-url: https://github.com/nodejs/node/pull/23162
-    description: The `format` argument is now only taken as such if it actually
-                 contains format specifiers.
-  - version: v12.0.0
-    pr-url: https://github.com/nodejs/node/pull/23162
-    description: If the `format` argument is not a format string, the output
-                 string's formatting is no longer dependent on the type of the
-                 first argument. This change removes previously present quotes
-                 from strings that were being output when the first argument
-                 was not a string.
   - version: v11.4.0
     pr-url: https://github.com/nodejs/node/pull/24806
     description: The `%o` specifier's `depth` has default depth of 4 again.

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1700,7 +1700,11 @@ function formatWithOptionsInternal(inspectOptions, ...args) {
   while (a < args.length) {
     const value = args[a];
     str += join;
-    str += typeof value !== 'string' ? inspect(value, inspectOptions) : value;
+    if (typeof value !== 'string' || typeof first !== 'string') {
+      str += inspect(value, inspectOptions);
+    } else {
+      str += value;
+    }
     join = ' ';
     a++;
   }

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -367,17 +367,17 @@ Object.setPrototypeOf(BadCustomError, Error);
 assert.strictEqual(util.format(new BadCustomError('foo')),
                    '[BadCustomError: foo]');
 
-// The format of arguments should not depend on type of the first argument
+// The argument formatting depends on the type of the first argument.
 assert.strictEqual(util.format('1', '1'), '1 1');
-assert.strictEqual(util.format(1, '1'), '1 1');
+assert.strictEqual(util.format(1, '1'), "1 '1'");
 assert.strictEqual(util.format('1', 1), '1 1');
 assert.strictEqual(util.format(1, -0), '1 -0');
 assert.strictEqual(util.format('1', () => {}), '1 [Function (anonymous)]');
 assert.strictEqual(util.format(1, () => {}), '1 [Function (anonymous)]');
 assert.strictEqual(util.format('1', "'"), "1 '");
-assert.strictEqual(util.format(1, "'"), "1 '");
+assert.strictEqual(util.format(1, "'"), '1 "\'"');
 assert.strictEqual(util.format('1', 'number'), '1 number');
-assert.strictEqual(util.format(1, 'number'), '1 number');
+assert.strictEqual(util.format(1, 'number'), "1 'number'");
 assert.strictEqual(util.format(5n), '5n');
 assert.strictEqual(util.format(5n, 5n), '5n 5n');
 
@@ -393,7 +393,15 @@ assert.strictEqual(
     '\u001b[33m1\u001b[39m ' +
     '\u001b[33m5n\u001b[39m ' +
     '\u001b[1mnull\u001b[22m ' +
-    'foobar'
+    "\u001b[32m'foobar'\u001b[39m"
+);
+
+assert.strictEqual(
+  util.formatWithOptions(
+    { colors: true },
+    'string', true, 'foobar'
+  ),
+  'string \u001b[33mtrue\u001b[39m foobar'
 );
 
 assert.strictEqual(


### PR DESCRIPTION
_Edit by @Fishrock123: issue description at https://github.com/nodejs/node/pull/29592#issuecomment-540761073_

-----

This reverts #23162 so that `util.format()` works as before.

Both TSC members (@addaleax and @jasnell) who gave their LG to the original PR seem to be in favor of reverting to the old behavior. I therefore went ahead and opened this PR.

I requested the review of all people being involved in #29539 to take a look at this.

Refs: #29539

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
