### PR TITLE
timers: always set _destroyed

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -544,8 +544,8 @@ function getTimerCallbacks(runNextTicks) {
 
           if (destroyHooksExist() && !timer._destroyed) {
             emitDestroy(timer[async_id_symbol]);
-            timer._destroyed = true;
           }
+          timer._destroyed = true;
         }
       }
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -65,8 +65,8 @@ function unenroll(item) {
       item[async_id_symbol] !== undefined &&
       !item._destroyed) {
     emitDestroy(item[async_id_symbol]);
-    item._destroyed = true;
   }
+  item._destroyed = true;
 
   L.remove(item);
 

--- a/test/parallel/test-timers-destroyed.js
+++ b/test/parallel/test-timers-destroyed.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+// We don't really care about the calling results here.
+// So, this makes the test less fragile.
+const noop = () => {};
+
+const t1 = setTimeout(common.mustNotCall(), 1);
+const t2 = setTimeout(common.mustCall(), 1);
+const i1 = setInterval(common.mustNotCall(), 1);
+const i2 = setInterval(noop, 1);
+i2.unref();
+
+// Keep process alive for i2 to call once due to timer ordering.
+setTimeout(common.mustCall(), 1);
+
+clearTimeout(t1);
+clearInterval(i1);
+
+process.on('exit', () => {
+  assert.strictEqual(t1._destroyed, true);
+  assert.strictEqual(t2._destroyed, true);
+  assert.strictEqual(i1._destroyed, true);
+  assert.strictEqual(i2._destroyed, false);
+});


### PR DESCRIPTION
Required for other potential changes.

This should make it so we can always just check _destroyed to check if a timer has been ended.

I think this was included in some other PR previously, perhaps it wasn't merged or something.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
