### PR TITLE
tls: add option to override signature algorithms

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -839,7 +839,19 @@ Returns an object containing information on the negotiated cipher suite.
 For example: `{ name: 'AES256-SHA', version: 'TLSv1.2' }`.
 
 See
-[OpenSSL](https://www.openssl.org/docs/man1.1.1/man3/SSL_CIPHER_get_name.html)
+[SSL_CIPHER_get_name](https://www.openssl.org/docs/man1.1.1/man3/SSL_CIPHER_get_name.html)
+for more information.
+
+### tlsSocket.getSharedSigalgs()
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Array} List of signature algorithms shared between the server and
+the client in the order of decreasing preference.
+
+See
+[SSL_get_shared_sigalgs](https://www.openssl.org/docs/man1.1.1/man3/SSL_get_shared_sigalgs.html)
 for more information.
 
 ### tlsSocket.getEphemeralKeyInfo()
@@ -1346,6 +1358,10 @@ argument.
 <!-- YAML
 added: v0.11.13
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/29598
+    description: Added `sigalgs` option to override supported signature
+                 algorithms.
   - version: v12.0.0
     pr-url: https://github.com/nodejs/node/pull/26209
     description: TLSv1.3 support added.
@@ -1406,6 +1422,12 @@ changes:
     order as their private keys in `key`. If the intermediate certificates are
     not provided, the peer will not be able to validate the certificate, and the
     handshake will fail.
+  * `sigalgs` {string}` Colon-separated list of supported signature algorithms.
+    The list can contain digest algorithms (`SHA256`, `MD5` etc.), public key
+    algorithms (`RSA-PSS`, `ECDSA` etc.), combination of both (e.g
+    'RSA+SHA384') or TLS v1.3 scheme names (e.g. `rsa_pss_pss_sha512`).
+    See [OpenSSL man pages](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set1_sigalgs_list.html)
+    for more info.
   * `ciphers` {string} Cipher suite specification, replacing the default. For
     more information, see [modifying the default cipher suite][]. Permitted
     ciphers can be obtained via [`tls.getCiphers()`][]. Cipher names must be

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -153,6 +153,19 @@ exports.createSecureContext = function createSecureContext(options) {
     }
   }
 
+  const sigalgs = options.sigalgs;
+  if (sigalgs !== undefined) {
+    if (typeof sigalgs !== 'string') {
+      throw new ERR_INVALID_ARG_TYPE('options.sigalgs', 'string', sigalgs);
+    }
+
+    if (sigalgs === '') {
+      throw new ERR_INVALID_OPT_VALUE('sigalgs', sigalgs);
+    }
+
+    c.context.setSigalgs(sigalgs);
+  }
+
   if (options.ciphers && typeof options.ciphers !== 'string') {
     throw new ERR_INVALID_ARG_TYPE(
       'options.ciphers', 'string', options.ciphers);

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -859,6 +859,7 @@ function makeSocketMethodProxy(name) {
 
 [
   'getCipher',
+  'getSharedSigalgs',
   'getEphemeralKeyInfo',
   'getFinished',
   'getPeerFinished',
@@ -1113,6 +1114,11 @@ Server.prototype.setSecureContext = function(options) {
   else
     this.crl = undefined;
 
+  if (options.sigalgs !== undefined)
+    this.sigalgs = options.sigalgs;
+  else
+    this.sigalgs = undefined;
+
   if (options.ciphers)
     this.ciphers = options.ciphers;
   else
@@ -1157,6 +1163,7 @@ Server.prototype.setSecureContext = function(options) {
     clientCertEngine: this.clientCertEngine,
     ca: this.ca,
     ciphers: this.ciphers,
+    sigalgs: this.sigalgs,
     ecdhCurve: this.ecdhCurve,
     dhparam: this.dhparam,
     minVersion: this.minVersion,

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -125,6 +125,7 @@ class SecureContext : public BaseObject {
   static void AddRootCerts(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetCipherSuites(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetCiphers(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetSigalgs(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetECDHCurve(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetDHParam(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetOptions(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -250,6 +251,7 @@ class SSLWrap {
   static void IsSessionReused(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void VerifyError(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetCipher(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetSharedSigalgs(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void EndParser(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CertCbDone(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Renegotiate(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/parallel/test-tls-set-sigalgs.js
+++ b/test/parallel/test-tls-set-sigalgs.js
@@ -1,0 +1,74 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto) common.skip('missing crypto');
+const fixtures = require('../common/fixtures');
+
+// Test sigalgs: option for TLS.
+
+const {
+  assert, connect, keys
+} = require(fixtures.path('tls-connect'));
+
+function assert_arrays_equal(left, right) {
+  assert.strictEqual(left.length, right.length);
+  for (let i = 0; i < left.length; i++) {
+    assert.strictEqual(left[i], right[i]);
+  }
+}
+
+function test(csigalgs, ssigalgs, shared_sigalgs, cerr, serr) {
+  assert(shared_sigalgs || serr || cerr, 'test missing any expectations');
+  connect({
+    client: {
+      checkServerIdentity: (servername, cert) => { },
+      ca: `${keys.agent1.cert}\n${keys.agent6.ca}`,
+      cert: keys.agent2.cert,
+      key: keys.agent2.key,
+      sigalgs: csigalgs
+    },
+    server: {
+      cert: keys.agent6.cert,
+      key: keys.agent6.key,
+      ca: keys.agent2.ca,
+      context: {
+        requestCert: true,
+        rejectUnauthorized: true
+      },
+      sigalgs: ssigalgs
+    },
+  }, common.mustCall((err, pair, cleanup) => {
+    if (shared_sigalgs) {
+      assert.ifError(err);
+      assert.ifError(pair.server.err);
+      assert.ifError(pair.client.err);
+      assert(pair.server.conn);
+      assert(pair.client.conn);
+      assert_arrays_equal(pair.server.conn.getSharedSigalgs(), shared_sigalgs);
+    } else {
+      if (serr) {
+        assert(pair.server.err);
+        assert(pair.server.err.code, serr);
+      }
+
+      if (cerr) {
+        assert(pair.client.err);
+        assert(pair.client.err.code, cerr);
+      }
+    }
+
+    return cleanup();
+  }));
+}
+
+// Have shared sigalgs
+test('RSA-PSS+SHA384', 'RSA-PSS+SHA384', ['RSA-PSS+SHA384']);
+test('RSA-PSS+SHA256:RSA-PSS+SHA512:ECDSA+SHA256',
+     'RSA-PSS+SHA256:ECDSA+SHA256',
+     ['RSA-PSS+SHA256', 'ECDSA+SHA256']);
+
+// Do not have shared sigalgs.
+test('RSA-PSS+SHA384', 'ECDSA+SHA256',
+     undefined, 'ECONNRESET', 'ERR_SSL_NO_SHARED_SIGNATURE_ALGORITMS');
+
+test('RSA-PSS+SHA384:ECDSA+SHA256', 'ECDSA+SHA384:RSA-PSS+SHA256',
+     undefined, 'ECONNRESET', 'ERR_SSL_NO_SHARED_SIGNATURE_ALGORITMS');


### PR DESCRIPTION
Passes the list down to SSL_CTX_set1_sigalgs_list.

My use case for this is using crypto hardware that has limited support for different algorithms (e.g. no `RSA-PSS` or no MD hashes) through an OpenSSL engine (enabled in [another PR](https://github.com/nodejs/node/pull/28973)).

Can have other applications like hardening the server by disallowing short hashes, or disabling RSA-PKCS1 even when connecting via tls v1.2.