### PR TITLE
crypto: use BoringSSL-compatible flag getter

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4600,7 +4600,7 @@ bool Hash::HashInit(const char* hash_type, Maybe<unsigned int> xof_md_len) {
   if (xof_md_len.IsJust() && xof_md_len.FromJust() != md_len_) {
     // This is a little hack to cause createHash to fail when an incorrect
     // hashSize option was passed for a non-XOF hash function.
-    if ((EVP_MD_meth_get_flags(md) & EVP_MD_FLAG_XOF) == 0) {
+    if ((EVP_MD_flags(md) & EVP_MD_FLAG_XOF) == 0) {
       EVPerr(EVP_F_EVP_DIGESTFINALXOF, EVP_R_NOT_XOF_OR_INVALID_LENGTH);
       return false;
     }


### PR DESCRIPTION
This PR changes `HashInit` to return the md flags via [`EVP_MD_flags()`](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1c/crypto/evp/evp_lib.c#L322-L325) instead of [`EVP_MD_meth_get_flags()`](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1c/crypto/evp/evp_lib.c#L417-L420).

In OpenSSL `1.1.1c`, which Node.js bundles at present, these functions are implemented in precisely the same way (see linked implementations above), with the primary difference being that `EVP_MD_flags()` is exposed by BoringSSL whereas `EVP_MD_meth_get_flags()` is not.

This allows Electron to reduce its patch surface while changing no behavior in Node.js.

cc @tniessen 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
