### PR TITLE
src: disconnect inspector before exiting out of fatal exception

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -978,7 +978,9 @@ void TriggerUncaughtException(Isolate* isolate,
 
   // Now we are certain that the exception is fatal.
   ReportFatalException(env, error, message, EnhanceFatalException::kEnhance);
-  WaitForInspectorDisconnect(env);
+#if HAVE_INSPECTOR
+  profiler::EndStartedProfilers(env);
+#endif
 
   // If the global uncaught exception handler sets process.exitCode,
   // exit with that code. Otherwise, exit with 1.

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -978,6 +978,7 @@ void TriggerUncaughtException(Isolate* isolate,
 
   // Now we are certain that the exception is fatal.
   ReportFatalException(env, error, message, EnhanceFatalException::kEnhance);
+  WaitForInspectorDisconnect(env);
 
   // If the global uncaught exception handler sets process.exitCode,
   // exit with that code. Otherwise, exit with 1.

--- a/test/fixtures/v8-coverage/throw.js
+++ b/test/fixtures/v8-coverage/throw.js
@@ -1,0 +1,7 @@
+const a = 99;
+if (true) {
+  const b = 101;
+} else {
+  const c = 102;
+}
+throw new Error('test');

--- a/test/parallel/test-v8-coverage.js
+++ b/test/parallel/test-v8-coverage.js
@@ -39,6 +39,24 @@ function nextdir() {
 {
   const coverageDirectory = path.join(tmpdir.path, nextdir());
   const output = spawnSync(process.execPath, [
+    require.resolve('../fixtures/v8-coverage/throw')
+  ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
+  if (output.status !== 1) {
+    console.log(output.stderr.toString());
+  }
+  assert.strictEqual(output.status, 1);
+  const fixtureCoverage = getFixtureCoverage('throw.js', coverageDirectory);
+  assert.ok(fixtureCoverage, 'coverage not found for file');
+  // First branch executed.
+  assert.strictEqual(fixtureCoverage.functions[0].ranges[0].count, 1);
+  // Second branch did not execute.
+  assert.strictEqual(fixtureCoverage.functions[0].ranges[1].count, 0);
+}
+
+// Outputs coverage when process.exit(1) exits process.
+{
+  const coverageDirectory = path.join(tmpdir.path, nextdir());
+  const output = spawnSync(process.execPath, [
     require.resolve('../fixtures/v8-coverage/exit-1')
   ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
   if (output.status !== 1) {

--- a/test/parallel/test-v8-coverage.js
+++ b/test/parallel/test-v8-coverage.js
@@ -35,7 +35,7 @@ function nextdir() {
   assert.strictEqual(fixtureCoverage.functions[0].ranges[1].count, 0);
 }
 
-// Outputs coverage when process.exit(1) exits process.
+// Outputs coverage when error is thrown in first tick.
 {
   const coverageDirectory = path.join(tmpdir.path, nextdir());
   const output = spawnSync(process.execPath, [


### PR DESCRIPTION
So that coverage, .etc are properly written in case of a normal
fatal exception.

Fixes: https://github.com/nodejs/node/issues/29570

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
