### PR TITLE
doc: fix some signatures of .end() methods

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1175,7 +1175,7 @@ deprecated: REPLACEME
 
 See [`response.socket`][].
 
-### response.end([data][, encoding][, callback])
+### response.end([data[, encoding]][, callback])
 <!-- YAML
 added: v0.1.90
 changes:

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3006,7 +3006,7 @@ deprecated: REPLACEME
 
 See [`response.socket`][].
 
-#### response.end([data][, encoding][, callback])
+#### response.end([data[, encoding]][, callback])
 <!-- YAML
 added: v8.4.0
 changes:

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -394,7 +394,7 @@ added: v8.0.0
 
 Is `true` after [`writable.destroy()`][writable-destroy] has been called.
 
-##### writable.end([chunk][, encoding][, callback])
+##### writable.end([chunk[, encoding]][, callback])
 <!-- YAML
 added: v0.9.4
 changes:


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

In `.end()` methods, an optional `encoding` parameter makes sense only if the `data` (`chunk`) parameter is provided.