### PR TITLE
deps: V8: cherry-pick deac757

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/ast/source-range-ast-visitor.cc
+++ b/deps/v8/src/ast/source-range-ast-visitor.cc
@@ -25,6 +25,14 @@ void SourceRangeAstVisitor::VisitBlock(Block* stmt) {
   }
 }
 
+void SourceRangeAstVisitor::VisitSwitchStatement(SwitchStatement* stmt) {
+  AstTraversalVisitor::VisitSwitchStatement(stmt);
+  ZonePtrList<CaseClause>* clauses = stmt->cases();
+  for (CaseClause* clause : *clauses) {
+    MaybeRemoveLastContinuationRange(clause->statements());
+  }
+}
+
 void SourceRangeAstVisitor::VisitFunctionLiteral(FunctionLiteral* expr) {
   AstTraversalVisitor::VisitFunctionLiteral(expr);
   ZonePtrList<Statement>* stmts = expr->body();

--- a/deps/v8/src/ast/source-range-ast-visitor.h
+++ b/deps/v8/src/ast/source-range-ast-visitor.h
@@ -34,6 +34,7 @@ class SourceRangeAstVisitor final
   friend class AstTraversalVisitor<SourceRangeAstVisitor>;
 
   void VisitBlock(Block* stmt);
+  void VisitSwitchStatement(SwitchStatement* stmt);
   void VisitFunctionLiteral(FunctionLiteral* expr);
   bool VisitNode(AstNode* node);
 

--- a/deps/v8/test/mjsunit/code-coverage-block.js
+++ b/deps/v8/test/mjsunit/code-coverage-block.js
@@ -434,8 +434,8 @@ TestCoverage(
 `,
 [{"start":0,"end":399,"count":1},
  {"start":1,"end":351,"count":1},
- {"start":154,"end":204,"count":0},
- {"start":226,"end":350,"count":0}]
+ {"start":154,"end":176,"count":0},
+ {"start":254,"end":276,"count":0}]
 );
 
 TestCoverage(
@@ -464,8 +464,8 @@ TestCoverage(
 `,
 [{"start":0,"end":999,"count":1},
  {"start":1,"end":951,"count":1},
- {"start":152,"end":202,"count":0},
- {"start":285,"end":353,"count":0}]
+ {"start":152,"end":168,"count":0},
+ {"start":287,"end":310,"count":0}]
 );
 
 TestCoverage(
@@ -1050,6 +1050,51 @@ try {                                     // 0500
  {"start":602,"end":616,"count":0},
  {"start":0,"end":201,"count":2},
  {"start":69,"end":153,"count":1}]
+);
+
+TestCoverage(
+"https://crbug.com/v8/9705",
+`
+function f(x) {                           // 0000
+  switch (x) {                            // 0050
+    case 40: nop();                       // 0100
+    case 41: nop(); return 1;             // 0150
+    case 42: nop(); break;                // 0200
+  }                                       // 0250
+  return 3;                               // 0300
+};                                        // 0350
+f(40);                                    // 0400
+f(41);                                    // 0450
+f(42);                                    // 0500
+f(43);                                    // 0550
+`,
+[{"start":0,"end":599,"count":1},
+ {"start":0,"end":351,"count":4},
+ {"start":104,"end":119,"count":1},
+ {"start":154,"end":179,"count":2},
+ {"start":204,"end":226,"count":1},
+ {"start":253,"end":350,"count":2}]
+);
+
+TestCoverage(
+"https://crbug.com/v8/9705",
+`
+function f(x) {                           // 0000
+  switch (x) {                            // 0050
+    case 40: nop();                       // 0100
+    case 41: nop(); return 1;             // 0150
+    case 42: nop(); break;                // 0200
+  }                                       // 0250
+  return 3;                               // 0300
+};                                        // 0350
+f(42);                                    // 0400
+f(43);                                    // 0450
+`,
+[{"start":0,"end":499,"count":1},
+ {"start":0,"end":351,"count":2},
+ {"start":104,"end":119,"count":0},
+ {"start":154,"end":179,"count":0},
+ {"start":204,"end":226,"count":1}]
 );
 
 %DebugToggleBlockCoverage(false);

--- a/deps/v8/test/mjsunit/code-coverage-utils.js
+++ b/deps/v8/test/mjsunit/code-coverage-utils.js
@@ -18,25 +18,40 @@ let gen;
     return undefined;
   };
 
-  function TestCoverageInternal(name, source, expectation, collect_garbage) {
+  function TestCoverageInternal(
+      name, source, expectation, collect_garbage, prettyPrintResults) {
     source = source.trim();
     eval(source);
     if (collect_garbage) %CollectGarbage("collect dead objects");
     var covfefe = GetCoverage(source);
     var stringified_result = JSON.stringify(covfefe);
     var stringified_expectation = JSON.stringify(expectation);
-    if (stringified_result != stringified_expectation) {
-      print(stringified_result.replace(/[}],[{]/g, "},\n {"));
+    const mismatch = stringified_result != stringified_expectation;
+    if (mismatch) {
+      console.log(stringified_result.replace(/[}],[{]/g, "},\n {"));
+    }
+    if (prettyPrintResults) {
+      console.log("=== Coverage Expectation ===")
+      for (const {start,end,count} of expectation) {
+        console.log(`Range [${start}, ${end}) (count: ${count})`);
+        console.log(source.substring(start, end));
+      }
+      console.log("=== Coverage Results ===")
+      for (const {start,end,count} of covfefe) {
+        console.log(`Range [${start}, ${end}) (count: ${count})`);
+        console.log(source.substring(start, end));
+      }
+      console.log("========================")
     }
     assertEquals(stringified_expectation, stringified_result, name + " failed");
   };
 
-  TestCoverage = function(name, source, expectation) {
-    TestCoverageInternal(name, source, expectation, true);
+  TestCoverage = function(name, source, expectation, prettyPrintResults) {
+    TestCoverageInternal(name, source, expectation, true, prettyPrintResults);
   };
 
-  TestCoverageNoGC = function(name, source, expectation) {
-    TestCoverageInternal(name, source, expectation, false);
+  TestCoverageNoGC = function(name, source, expectation, prettyPrintResults) {
+    TestCoverageInternal(name, source, expectation, false, prettyPrintResults);
   };
 
   nop = function() {};


### PR DESCRIPTION
Original commit message:

    [debugger] Fix code coverage for break/return inside switch-case

    Case statements have a list of statements associated with them, but are
    not blocks, and were hence not fixed-up correctly for code coverage.
    This CL also applies the fix-up to the "body" of case statements,
    in this way removing ranges reported as uncovered between the final
    break/return in a case and the next case (or end of function).

    Drive-by: Add optional pretty printing to code coverage test results.

    Change-Id: I5f4002d4e17b7253ed516d99f7c389ab2264be10
    Bug: v8:9705
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1798426
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Reviewed-by: Jakob Gruber <jgruber@chromium.org>
    Commit-Queue: Sigurd Schneider <sigurds@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#63719}

Refs: https://github.com/v8/v8/commit/deac757bc76d207845375340bcea090c774ad9d0

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
