### PR TITLE
Preliminary WSL support

### DIFF
--- a/deps/npm/bin/npm
+++ b/deps/npm/bin/npm
@@ -2,12 +2,16 @@
 (set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
 
 basedir=`dirname "$0"`
+isexe=0
 
 case `uname` in
     *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
 esac
 
 NODE_EXE="$basedir/node.exe"
+if [ -x "$NODE_EXE" ]; then
+  isexe=1
+fi
 if ! [ -x "$NODE_EXE" ]; then
   NODE_EXE="$basedir/node"
 fi
@@ -33,5 +37,9 @@ case `uname` in
     fi
     ;;
 esac
+
+if [ isexe==1 ] && [ -f "/bin/wslpath" ]; then # normalize back to Windows path
+  NPM_CLI_JS=`wslpath -w "$NPM_CLI_JS"`
+fi
 
 "$NODE_EXE" "$NPM_CLI_JS" "$@"


### PR DESCRIPTION
This preliminary fix supports running `npm` installed on Windows within Windows Subsystem for Linux.

However, for the fix to take effect, it is required that the end of line character in and only in the `npm` file be `\n` even when installed on Windows.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
