### PR TITLE
console: update time formatting

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -3,7 +3,7 @@
 // The Console constructor is not actually used to construct the global
 // console. It's exported for backwards compatibility.
 
-const { Object, ObjectPrototype, Reflect } = primordials;
+const { Object, ObjectPrototype, Reflect, Math } = primordials;
 
 const { trace } = internalBinding('trace_events');
 const {
@@ -534,21 +534,44 @@ function timeLogImpl(self, name, label, data) {
 }
 
 function formatTime(ms) {
-  let value = ms;
-  let unit = 'ms';
+  let end = 3;
+  const values = [];
 
   if (ms >= kHour) {
-    value = ms / kHour;
-    unit = 'h';
-  } else if (ms >= kMinute) {
-    value = ms / kMinute;
-    unit = 'min';
-  } else if (ms >= kSecond) {
-    value = ms / kSecond;
-    unit = 's';
+    end = -1;
+    values.push(`${Math.floor(ms / kHour)}h`);
+    ms = Math.floor(ms % kHour);
+  }
+  if (ms >= kMinute) {
+    if (end === 3) {
+      end = 0;
+    }
+    values.push(`${Math.floor(ms / kMinute)}min`);
+    ms = ms % kMinute;
+  }
+  if (ms >= kSecond) {
+    if (end === -1) {
+      values.push(`${String(Number((ms / kSecond).toFixed(1)))}s`);
+    } else {
+      values.push(`${Math.floor(ms / kSecond)}s`);
+      if (end === 3) {
+        end = 1;
+      }
+    }
+    ms = ms % kSecond;
+  }
+  if (end !== -1) {
+    values.push(`${String(Number(ms.toFixed(end)))}ms`);
   }
 
-  return value.toFixed(3) + unit;
+  let res = values.pop();
+  if (values.length) {
+    res = `${values.pop()} and ${res}`;
+  }
+  while (values.length !== 0) {
+    res = `${values.pop()}, ${res}`;
+  }
+  return res;
 }
 
 const keyKey = 'Key';

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -533,45 +533,38 @@ function timeLogImpl(self, name, label, data) {
   return true;
 }
 
+function pad(value) {
+  return `${value}`.padStart(2, '0');
+}
+
 function formatTime(ms) {
-  let end = 3;
-  const values = [];
+  let hours = 0;
+  let minutes = 0;
+  let seconds = 0;
 
-  if (ms >= kHour) {
-    end = -1;
-    values.push(`${Math.floor(ms / kHour)}h`);
-    ms = Math.floor(ms % kHour);
-  }
-  if (ms >= kMinute) {
-    if (end === 3) {
-      end = 0;
-    }
-    values.push(`${Math.floor(ms / kMinute)}min`);
-    ms = ms % kMinute;
-  }
   if (ms >= kSecond) {
-    if (end === -1) {
-      values.push(`${String(Number((ms / kSecond).toFixed(1)))}s`);
-    } else {
-      values.push(`${Math.floor(ms / kSecond)}s`);
-      if (end === 3) {
-        end = 1;
+    if (ms >= kMinute) {
+      if (ms >= kHour) {
+        hours = Math.floor(ms / kHour);
+        ms = ms % kHour;
       }
+      minutes = Math.floor(ms / kMinute);
+      ms = ms % kMinute;
     }
-    ms = ms % kSecond;
-  }
-  if (end !== -1) {
-    values.push(`${String(Number(ms.toFixed(end)))}ms`);
+    seconds = ms / kSecond;
   }
 
-  let res = values.pop();
-  if (values.length) {
-    res = `${values.pop()} and ${res}`;
+  if (hours !== 0 || minutes !== 0) {
+    [seconds, ms] = seconds.toFixed(3).split('.');
+    const res = hours !== 0 ? `${hours}:${pad(minutes)}` : minutes;
+    return `${res}:${pad(seconds)}.${ms} (${hours !== 0 ? 'h:m' : ''}m:ss.mmm)`;
   }
-  while (values.length !== 0) {
-    res = `${values.pop()}, ${res}`;
+
+  if (seconds !== 0) {
+    return `${seconds.toFixed(3)}s`;
   }
-  return res;
+
+  return `${Number(ms.toFixed(3))}ms`;
 }
 
 const keyKey = 'Key';

--- a/test/parallel/test-console-formatTime.js
+++ b/test/parallel/test-console-formatTime.js
@@ -4,12 +4,10 @@ require('../common');
 const { formatTime } = require('internal/console/constructor');
 const assert = require('assert');
 
-const test1 = formatTime(100);
-const test2 = formatTime(1500);
-const test3 = formatTime(60300);
-const test4 = formatTime(4000000);
-
-assert.strictEqual(test1, '100.000ms');
-assert.strictEqual(test2, '1.500s');
-assert.strictEqual(test3, '1.005min');
-assert.strictEqual(test4, '1.111h');
+assert.strictEqual(formatTime(100.0096), '100.01ms');
+assert.strictEqual(formatTime(100.0115), '100.011ms');
+assert.strictEqual(formatTime(1500.04), '1s and 500ms');
+assert.strictEqual(formatTime(1500.056), '1s and 500.1ms');
+assert.strictEqual(formatTime(60300.3), '1min and 300ms');
+assert.strictEqual(formatTime(4000457.4), '1h, 6min and 40.5s');
+assert.strictEqual(formatTime(3601017.4), '1h and 1s');

--- a/test/parallel/test-console-formatTime.js
+++ b/test/parallel/test-console-formatTime.js
@@ -6,8 +6,9 @@ const assert = require('assert');
 
 assert.strictEqual(formatTime(100.0096), '100.01ms');
 assert.strictEqual(formatTime(100.0115), '100.011ms');
-assert.strictEqual(formatTime(1500.04), '1s and 500ms');
-assert.strictEqual(formatTime(1500.056), '1s and 500.1ms');
-assert.strictEqual(formatTime(60300.3), '1min and 300ms');
-assert.strictEqual(formatTime(4000457.4), '1h, 6min and 40.5s');
-assert.strictEqual(formatTime(3601017.4), '1h and 1s');
+assert.strictEqual(formatTime(1500.04), '1.500s');
+assert.strictEqual(formatTime(1000.056), '1.000s');
+assert.strictEqual(formatTime(60300.3), '1:00.300 (m:ss.mmm)');
+assert.strictEqual(formatTime(4000457.4), '1:06:40.457 (h:mm:ss.mmm)');
+assert.strictEqual(formatTime(3601310.4), '1:00:01.310 (h:mm:ss.mmm)');
+assert.strictEqual(formatTime(3213601017.6), '892:40:01.018 (h:mm:ss.mmm)');

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -246,24 +246,24 @@ assert.ok(strings[0].includes('foo: { bar: { baz:'));
 assert.ok(strings[0].includes('quux'));
 assert.ok(strings.shift().includes('quux: true'));
 
-assert.ok(/^label: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
-assert.ok(/^__proto__: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
-assert.ok(/^constructor: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
-assert.ok(/^hasOwnProperty: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^label: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
+assert.ok(/^__proto__: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
+assert.ok(/^constructor: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
+assert.ok(/^hasOwnProperty: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
 
 // Verify that console.time() coerces label values to strings as expected
-assert.ok(/^: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
-assert.ok(/^\[object Object\]: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
-assert.ok(/^\[object Object\]: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
-assert.ok(/^null: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
-assert.ok(/^default: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
-assert.ok(/^default: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
-assert.ok(/^NaN: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
+assert.ok(/^\[object Object\]: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
+assert.ok(/^\[object Object\]: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
+assert.ok(/^null: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
+assert.ok(/^default: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
+assert.ok(/^default: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
+assert.ok(/^NaN: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
 
-assert.ok(/^log1: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
-assert.ok(/^log1: \d+\.\d{3}(ms|s|min|h) test$/.test(strings.shift().trim()));
-assert.ok(/^log1: \d+\.\d{3}(ms|s|min|h) {} \[ 1, 2, 3 ]$/.test(strings.shift().trim()));
-assert.ok(/^log1: \d+\.\d{3}(ms|s|min|h)$/.test(strings.shift().trim()));
+assert.ok(/^log1: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
+assert.ok(/^log1: \d+(\.\d{1,3})?(ms|s) test$/.test(strings.shift().trim()));
+assert.ok(/^log1: \d+(\.\d{1,3})?(ms|s) {} \[ 1, 2, 3 ]$/.test(strings.shift().trim()));
+assert.ok(/^log1: \d+(\.\d{1,3})?(ms|s)$/.test(strings.shift().trim()));
 
 // Make sure that we checked all strings
 assert.strictEqual(strings.length, 0);


### PR DESCRIPTION
This improves the readability of the `console.timeEnd()` output
while keeping a higher output's precision in multiple cases.

Instead of e.g. '1.005min' it will print '1min and 300ms'.

It also rounds full numbers (e.g., `1.1` instead of `1.100`). It would also be possible to always print seconds and milliseconds as one value, since that's easy to read. This just seemed even clearer and more straight forward.

This relies on a semver-major commit (#29251). As long as it lands together with the other commit, it should be fine to land this as a patch instead of being semver-major itself.

I requested the reviewers from the former commit to also review this PR.
CC @Xstoudi

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
