### PR TITLE
src: add buildflag to force context-aware addons

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -432,7 +432,7 @@ Silence all process warnings (including deprecations).
 added: REPLACEME
 -->
 
-Disable loading non-context-aware native addons.
+Disable loading native addons that are not [context-aware][].
 
 ### `--openssl-config=file`
 <!-- YAML
@@ -1236,3 +1236,4 @@ greater than `4` (its current default value). For more information, see the
 [experimental ECMAScript Module]: esm.html#esm_resolve_hook
 [libuv threadpool documentation]: http://docs.libuv.org/en/latest/threadpool.html
 [remote code execution]: https://www.owasp.org/index.php/Code_Injection
+[context-aware]: addons.html#addons_context_aware_addons

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -427,6 +427,13 @@ added: v6.0.0
 
 Silence all process warnings (including deprecations).
 
+### `--force-context-aware`
+<!-- YAML
+added: REPLACEME
+-->
+
+Disable loading non-context-aware native addons.
+
 ### `--openssl-config=file`
 <!-- YAML
 added: v6.9.0
@@ -996,6 +1003,7 @@ Node.js options that are allowed are:
 * `--experimental-report`
 * `--experimental-vm-modules`
 * `--experimental-wasm-modules`
+* `--force-context-aware`
 * `--force-fips`
 * `--frozen-intrinsics`
 * `--heapsnapshot-signal`

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1611,6 +1611,11 @@ OpenSSL crypto support.
 An attempt was made to use features that require [ICU][], but Node.js was not
 compiled with ICU support.
 
+<a id="ERR_NON_CONTEXT_AWARE_DISABLED"></a>
+### ERR_NON_CONTEXT_AWARE_DISABLED
+
+A non-context-aware native addon was loaded in a process that disallows them.
+
 <a id="ERR_OUT_OF_RANGE"></a>
 ### ERR_OUT_OF_RANGE
 

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -1,4 +1,5 @@
 #include "node_binding.h"
+#include "node_errors.h"
 #include <atomic>
 #include "env-inl.h"
 #include "node_native_module_env.h"
@@ -463,6 +464,13 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
     }
 
     if (mp != nullptr) {
+      if (mp->nm_context_register_func == nullptr) {
+        if (env->options()->force_context_aware) {
+          dlib->Close();
+          THROW_ERR_NON_CONTEXT_AWARE_DISABLED(env);
+          return false;
+        }
+      }
       mp->nm_dso_handle = dlib->handle_;
       dlib->SaveInGlobalHandleMap(mp);
     } else {

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -52,6 +52,7 @@ void PrintErrorString(const char* format, ...);
   V(ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST, TypeError)                    \
   V(ERR_MISSING_PASSPHRASE, TypeError)                                       \
   V(ERR_MISSING_PLATFORM_FOR_WORKER, Error)                                  \
+  V(ERR_NON_CONTEXT_AWARE_DISABLED, Error)                                   \
   V(ERR_MODULE_NOT_FOUND, Error)                                             \
   V(ERR_OUT_OF_RANGE, RangeError)                                            \
   V(ERR_SCRIPT_EXECUTION_INTERRUPTED, Error)                                 \
@@ -96,6 +97,8 @@ void PrintErrorString(const char* format, ...);
   V(ERR_MISSING_PLATFORM_FOR_WORKER,                                         \
     "The V8 platform used by this instance of Node does not support "        \
     "creating Workers")                                                      \
+  V(ERR_NON_CONTEXT_AWARE_DISABLED,                                          \
+    "Loading non context-aware native modules has been disabled")            \
   V(ERR_SCRIPT_EXECUTION_INTERRUPTED,                                        \
     "Script execution was interrupted by `SIGINT`")                          \
   V(ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER,                         \

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -393,6 +393,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "silence all process warnings",
             &EnvironmentOptions::no_warnings,
             kAllowedInEnvironment);
+  AddOption("--force-context-aware",
+            "disable loading non-context-aware addons",
+            &EnvironmentOptions::force_context_aware,
+            kAllowedInEnvironment);
   AddOption("--pending-deprecation",
             "emit pending deprecation warnings",
             &EnvironmentOptions::pending_deprecation,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -117,6 +117,7 @@ class EnvironmentOptions : public Options {
   bool no_deprecation = false;
   bool no_force_async_hooks_checks = false;
   bool no_warnings = false;
+  bool force_context_aware = false;
   bool pending_deprecation = false;
   bool preserve_symlinks = false;
   bool preserve_symlinks_main = false;

--- a/test/addons/force-context-aware/binding.cc
+++ b/test/addons/force-context-aware/binding.cc
@@ -1,0 +1,6 @@
+#include <node.h>
+#include <v8.h>
+
+void init(v8::Local<v8::Object> exports) {}
+
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/force-context-aware/binding.gyp
+++ b/test/addons/force-context-aware/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ],
+      'includes': ['../common.gypi'],
+    }
+  ]
+}

--- a/test/addons/force-context-aware/index.js
+++ b/test/addons/force-context-aware/index.js
@@ -1,0 +1,4 @@
+'use strict';
+const common = require('../../common');
+
+require(`./build/${common.buildType}/binding`);

--- a/test/addons/force-context-aware/test.js
+++ b/test/addons/force-context-aware/test.js
@@ -1,0 +1,13 @@
+'use strict';
+const common = require('../../common');
+const childProcess = require('child_process');
+const assert = require('assert');
+const path = require('path');
+
+const mod = path.join('test', 'addons', 'force-context-aware', 'index.js');
+
+const execString = `"${process.execPath}" --force-context-aware ./${mod}`;
+childProcess.exec(execString, common.mustCall((err) => {
+  const errMsg = 'Loading non context-aware native modules has been disabled';
+  assert.strictEqual(err.message.includes(errMsg), true);
+}));

--- a/test/addons/zlib-binding/test.js
+++ b/test/addons/zlib-binding/test.js
@@ -1,3 +1,5 @@
+// Flags: --force-context-aware
+
 'use strict';
 
 const common = require('../../common');


### PR DESCRIPTION
This PR adds a new cli flag `--force-context-aware` whose purpose is to prevent usage of native node addons that aren't context aware. In an embedder context, loading native addons ahas always been challenging due to the need to rebuild, to link to the right `node.lib/dll`, and to ensure the NODE_MODULE_VERSION is correct. 

Since Node doesn't let you load multiple instances of a native module in the same process, even in different v8 contexts, this creates a host of problems for multi-process framework like Electron. 

This new flag would allow Electron and other embedders to enforce restrictions more cleanly and prevent unexpected behavior.

More context for embedders can be found here: [#18397](https://github.com/electron/electron/issues/18397)

cc @MarshallOfSound 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
