### PR TITLE
event: improve performance of EventEmitter.emit

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const { Math, Object, Reflect } = primordials;
+const apply = Reflect.apply;
 
 var spliceOne;
 
@@ -206,12 +207,12 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
     return false;
 
   if (typeof handler === 'function') {
-    Reflect.apply(handler, this, args);
+    apply(handler, this, args);
   } else {
     const len = handler.length;
     const listeners = arrayClone(handler, len);
     for (var i = 0; i < len; ++i)
-      Reflect.apply(listeners[i], this, args);
+      apply(listeners[i], this, args);
   }
 
   return true;


### PR DESCRIPTION
This restore some performance we lost when we introduced primordialias.
Improvements are up to +100%.

<details>

```
                                                     confidence improvement accuracy (*)   (**)  (***)
 events/ee-add-remove.js n=1000000                                   0.18 %       ±0.51% ±0.68% ±0.88%
 events/ee-emit.js listeners=1 argc=0 n=2000000             ***     43.53 %       ±1.04% ±1.40% ±1.84%
 events/ee-emit.js listeners=1 argc=10 n=2000000            ***     26.47 %       ±1.61% ±2.14% ±2.79%
 events/ee-emit.js listeners=1 argc=2 n=2000000             ***     22.94 %       ±1.02% ±1.38% ±1.82%
 events/ee-emit.js listeners=1 argc=4 n=2000000             ***     24.83 %       ±2.27% ±3.04% ±3.99%
 events/ee-emit.js listeners=10 argc=0 n=2000000            ***    111.71 %       ±1.43% ±1.91% ±2.50%
 events/ee-emit.js listeners=10 argc=10 n=2000000           ***     29.13 %       ±1.76% ±2.34% ±3.05%
 events/ee-emit.js listeners=10 argc=2 n=2000000            ***     27.52 %       ±1.60% ±2.13% ±2.78%
 events/ee-emit.js listeners=10 argc=4 n=2000000            ***     31.05 %       ±2.91% ±3.92% ±5.19%
 events/ee-emit.js listeners=5 argc=0 n=2000000             ***     73.72 %       ±0.98% ±1.31% ±1.72%
 events/ee-emit.js listeners=5 argc=10 n=2000000            ***     28.93 %       ±1.68% ±2.24% ±2.92%
 events/ee-emit.js listeners=5 argc=2 n=2000000             ***     28.53 %       ±1.71% ±2.30% ±3.03%
 events/ee-emit.js listeners=5 argc=4 n=2000000             ***     28.88 %       ±0.78% ±1.04% ±1.35%
 events/ee-listener-count-on-prototype.js n=50000000                 0.73 %       ±0.81% ±1.08% ±1.41%
 events/ee-listeners-many.js n=5000000                               0.52 %       ±1.13% ±1.51% ±1.96%
 events/ee-listeners.js n=5000000                                   -0.68 %       ±2.06% ±2.77% ±3.66%
 events/ee-once.js argc=0 n=20000000                        ***     14.97 %       ±3.18% ±4.23% ±5.51%
 events/ee-once.js argc=1 n=20000000                        ***      8.85 %       ±1.30% ±1.75% ±2.29%
 events/ee-once.js argc=4 n=20000000                        ***      8.55 %       ±1.10% ±1.47% ±1.91%
 events/ee-once.js argc=5 n=20000000                        ***      7.37 %       ±1.10% ±1.46% ±1.90
```

</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
