### PR TITLE
child_process: document the -pid/killpg feature

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1071,7 +1071,14 @@ be delivered to that process instead which can have unexpected results.
 While the function is called `kill`, the signal delivered to the child process
 may not actually terminate the process.
 
-See kill(2) for reference.
+On Unix-like systems, the function calls kill(2) with the pid and the signal(7)
+given. See the manual pages for reference. On Windows, a subset of these
+signals are supported via emulation.
+
+On System V-compatible systems, a negative pid causes the process group with
+the corresponding id to be killed. In combination with [`options.detached`]
+the function can exert limited control on child processes of child processes.
+This feature is not available on Windows.
 
 On Linux, child processes of child processes will not be terminated
 when attempting to kill their parent. This is likely to happen when running a


### PR DESCRIPTION
People talk about it a lot but it always requires digging to find out.
Why not mention it explicitly?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
