### PR TITLE
tls: honor pauseOnConnect option

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -412,6 +412,7 @@ function TLSSocket(socket, opts) {
     handle: this._wrapHandle(wrap),
     allowHalfOpen: socket ? socket.allowHalfOpen : tlsOptions.allowHalfOpen,
     pauseOnCreate: tlsOptions.pauseOnConnect,
+    // readable only needed if pauseOnCreate will be handled
     readable: tlsOptions.pauseOnConnect,
     writable: false
   });

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -411,7 +411,8 @@ function TLSSocket(socket, opts) {
   net.Socket.call(this, {
     handle: this._wrapHandle(wrap),
     allowHalfOpen: socket ? socket.allowHalfOpen : tlsOptions.allowHalfOpen,
-    readable: false,
+    pauseOnCreate: tlsOptions.pauseOnConnect,
+    readable: tlsOptions.pauseOnConnect,
     writable: false
   });
 
@@ -925,7 +926,8 @@ function tlsConnectionListener(rawSocket) {
     handshakeTimeout: this[kHandshakeTimeout],
     ALPNProtocols: this.ALPNProtocols,
     SNICallback: this[kSNICallback] || SNICallback,
-    enableTrace: this[kEnableTrace]
+    enableTrace: this[kEnableTrace],
+    pauseOnConnect: this.pauseOnConnect,
   });
 
   socket.on('secure', onServerSocketSecure);

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -412,7 +412,7 @@ function TLSSocket(socket, opts) {
     handle: this._wrapHandle(wrap),
     allowHalfOpen: socket ? socket.allowHalfOpen : tlsOptions.allowHalfOpen,
     pauseOnCreate: tlsOptions.pauseOnConnect,
-    // readable only needed if pauseOnCreate will be handled
+    // The readable flag is only needed if pauseOnCreate will be handled.
     readable: tlsOptions.pauseOnConnect,
     writable: false
   });

--- a/test/parallel/test-tls-server-parent-constructor-options.js
+++ b/test/parallel/test-tls-server-parent-constructor-options.js
@@ -19,9 +19,11 @@ const options = {
 {
   const server = tls.createServer(options, common.mustCall((socket) => {
     assert.strictEqual(socket.allowHalfOpen, false);
+    assert.strictEqual(socket.isPaused(), false);
   }));
 
   assert.strictEqual(server.allowHalfOpen, false);
+  assert.strictEqual(server.pauseOnConnect, false);
 
   server.listen(0, common.mustCall(() => {
     const socket = tls.connect({
@@ -40,13 +42,16 @@ const options = {
 {
   const server = tls.createServer({
     allowHalfOpen: true,
+    pauseOnConnect: true,
     ...options
   }, common.mustCall((socket) => {
     assert.strictEqual(socket.allowHalfOpen, true);
+    assert.strictEqual(socket.isPaused(), true);
     socket.on('end', socket.end);
   }));
 
   assert.strictEqual(server.allowHalfOpen, true);
+  assert.strictEqual(server.pauseOnConnect, true);
 
   server.listen(0, common.mustCall(() => {
     const socket = tls.connect({


### PR DESCRIPTION
`pauseOnConnect` is now passed along to the net.Socket constructor from
the tls.Socket constructor. The `readable` flag must match the value of
`pauseOnConnect`. Tests were added to cover all available net.Server
options when used in the tls.Server constructor.

Fixes: https://github.com/nodejs/node/issues/29620
Refs: https://github.com/nodejs/node/pull/27665

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

---

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
