### PR TITLE
stream: _write optional when _writev

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1761,7 +1761,7 @@ const myWritable = new Writable({
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/29639
-    description: _write is optional when providing _writev.
+    description: _write() is optional when providing _writev().
 -->
 
 * `chunk` {Buffer|string|any} The `Buffer` to be written, converted from the

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1667,8 +1667,8 @@ const myWritable = new Writable({
 The `stream.Writable` class is extended to implement a [`Writable`][] stream.
 
 Custom `Writable` streams *must* call the `new stream.Writable([options])`
-constructor and implement the `writable._write()` method. The
-`writable._writev()` method *may* also be implemented.
+constructor and implement the `writable._write()` and/or `writable._writev()`
+method.
 
 #### Constructor: new stream.Writable([options])
 <!-- YAML
@@ -1770,7 +1770,8 @@ const myWritable = new Writable({
   argument) when processing is complete for the supplied chunk.
 
 All `Writable` stream implementations must provide a
-[`writable._write()`][stream-_write] method to send data to the underlying
+[`writable._write()`][stream-_write] and/or
+[`writable._writev()`][stream-_writev] method to send data to the underlying
 resource.
 
 [`Transform`][] streams provide their own implementation of the
@@ -1813,8 +1814,8 @@ This function MUST NOT be called by application code directly. It should be
 implemented by child classes, and called by the internal `Writable` class
 methods only.
 
-The `writable._writev()` method may be implemented in addition to
-`writable._write()` in stream implementations that are capable of processing
+The `writable._writev()` method may be implemented in addition or alternatively
+to `writable._write()` in stream implementations that are capable of processing
 multiple chunks of data at once. If implemented, the method will be called with
 all chunks of data currently buffered in the write queue.
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1757,6 +1757,12 @@ const myWritable = new Writable({
 ```
 
 #### writable.\_write(chunk, encoding, callback)
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/29639
+    description: _write is optional when providing _writev.
+-->
 
 * `chunk` {Buffer|string|any} The `Buffer` to be written, converted from the
   `string` passed to [`stream.write()`][stream-write]. If the stream's

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -558,7 +558,11 @@ function clearBuffer(stream, state) {
 }
 
 Writable.prototype._write = function(chunk, encoding, cb) {
-  cb(new ERR_METHOD_NOT_IMPLEMENTED('_write()'));
+  if (this._writev) {
+    this._writev([{ chunk, encoding }], cb);
+  } else {
+    cb(new ERR_METHOD_NOT_IMPLEMENTED('_write()'));
+  }
 };
 
 Writable.prototype._writev = null;

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -122,9 +122,9 @@ function test(decode, uncork, multi, next) {
 
 {
   const w = new stream.Writable({
-    writev: function(chunks, cb) {
+    writev: common.mustCall(function(chunks, cb) {
       cb();
-    }
+    })
   });
   w.write('asd', common.mustCall());
 }

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -119,3 +119,12 @@ function test(decode, uncork, multi, next) {
     next();
   });
 }
+
+{
+  const w = new stream.Writable({
+    writev: function(chunks, cb) {
+      cb();
+    }
+  });
+  w.write('asd', common.mustCall());
+}


### PR DESCRIPTION
When implementing _writev, _write should be optional.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
