### PR TITLE
src: fix closing weak `HandleWrap`s on GC

### DIFF
--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -72,11 +72,11 @@ void HandleWrap::Close(Local<Value> close_callback) {
   if (state_ != kInitialized)
     return;
 
-  CHECK_EQ(false, persistent().IsEmpty());
   uv_close(handle_, OnClose);
   state_ = kClosing;
 
-  if (!close_callback.IsEmpty() && close_callback->IsFunction()) {
+  if (!close_callback.IsEmpty() && close_callback->IsFunction() &&
+      !persistent().IsEmpty()) {
     object()->Set(env()->context(),
                   env()->handle_onclose_symbol(),
                   close_callback).Check();

--- a/test/sequential/test-performance-eventloopdelay.js
+++ b/test/sequential/test-performance-eventloopdelay.js
@@ -1,3 +1,4 @@
+// Flags: --expose-gc
 'use strict';
 
 const common = require('../common');
@@ -97,3 +98,5 @@ const {
   }
   spinAWhile();
 }
+
+process.on('exit', global.gc);

--- a/test/sequential/test-performance-eventloopdelay.js
+++ b/test/sequential/test-performance-eventloopdelay.js
@@ -99,4 +99,6 @@ const {
   spinAWhile();
 }
 
+// Make sure that the histogram instances can be garbage-collected without
+// and not just implictly destroyed when the Environment is torn down.
 process.on('exit', global.gc);


### PR DESCRIPTION
In 0af62aae07ccbb3783030367ffe4, this was overlooked, with it
possibly leading to hard crashes.

Thanks to @bcoe for pointing me to this as the cause of the failure in https://ci.nodejs.org/job/node-test-commit-freebsd/nodes=freebsd11-x64/28455/console.

Refs: https://github.com/nodejs/node/pull/29317

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
