### PR TITLE
stream: cleanup use of _readableState.ended

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -303,7 +303,7 @@ class Http2ServerRequest extends Readable {
 
   get complete() {
     return this[kAborted] ||
-           this._readableState.ended ||
+           this.readableEnded ||
            this[kState].closed ||
            this[kStream].destroyed;
   }

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -207,11 +207,11 @@ class Worker extends EventEmitter {
 
     const { stdout, stderr } = this[kParentSideStdio];
 
-    if (!stdout._readableState.ended) {
+    if (!stdout.readableEnded) {
       debug(`[${threadId}] explicitly closes stdout for ${this.threadId}`);
       stdout.push(null);
     }
-    if (!stderr._readableState.ended) {
+    if (!stderr.readableEnded) {
       debug(`[${threadId}] explicitly closes stderr for ${this.threadId}`);
       stderr.push(null);
     }

--- a/lib/net.js
+++ b/lib/net.js
@@ -422,7 +422,7 @@ function afterShutdown(status) {
   if (self.destroyed)
     return;
 
-  if (!self.readable || self._readableState.ended) {
+  if (!self.readable || self.readableEnded) {
     debug('readableState ended, destroying');
     self.destroy();
   }

--- a/test/parallel/test-stream-readable-ended.js
+++ b/test/parallel/test-stream-readable-ended.js
@@ -31,3 +31,16 @@ const assert = require('assert');
     assert.strictEqual(readable.readableEnded, false);
   }));
 }
+
+// Verifies no `error` triggered on multiple .push(null) invocations
+{
+  const readable = new Readable();
+
+  readable.on('readable', () => { readable.read(); });
+  readable.on('error', common.mustNotCall());
+  readable.on('end', common.mustCall());
+
+  readable.push('a');
+  readable.push(null);
+  readable.push(null);
+}


### PR DESCRIPTION
Replaces references to Readable stream's internal state 
`_readableState.ended` with `readableEnded`.

One thing to highlight that readable stream internally (L#[216](https://github.com/nodejs/node/blob/master/lib/_stream_readable.js#L216)) 
sets the `readableEnded` property using `_readableState.endEmitted` and 
not `_readableState.ended`. The files changed in this PR used 
`_readableState.ended` state.

Although all existing tests pass and it seems correct to rely on the 
`_readableState.endEmitted` to know when the stream ended, please 
suggest if this could be a potential issue.

cc:  @addaleax @mcollina 

Refs: #[445](https://github.com/nodejs/node/issues/445)

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
