### PR TITLE
console,util: fix missing recursion end while inspecting prototypes

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -351,7 +351,7 @@ function getEmptyFormatArray() {
   return [];
 }
 
-function getConstructorName(obj, ctx) {
+function getConstructorName(obj, ctx, recurseTimes) {
   let firstProto;
   const tmp = obj;
   while (obj) {
@@ -372,10 +372,23 @@ function getConstructorName(obj, ctx) {
     return null;
   }
 
-  return `${internalGetConstructorName(tmp)} <${inspect(firstProto, {
-    ...ctx,
-    customInspect: false
-  })}>`;
+  const res = internalGetConstructorName(tmp);
+
+  if (recurseTimes > ctx.depth && ctx.depth !== null) {
+    return `${res} <Complex prototype>`;
+  }
+
+  const protoConstr = getConstructorName(firstProto, ctx, recurseTimes + 1);
+
+  if (protoConstr === null) {
+    return `${res} <${inspect(firstProto, {
+      ...ctx,
+      customInspect: false,
+      depth: -1
+    })}>`;
+  }
+
+  return `${res} <${protoConstr}>`;
 }
 
 function getPrefix(constructor, tag, fallback) {
@@ -581,7 +594,7 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
 function formatRaw(ctx, value, recurseTimes, typedArray) {
   let keys;
 
-  const constructor = getConstructorName(value, ctx);
+  const constructor = getConstructorName(value, ctx, recurseTimes);
   let tag = value[Symbol.toStringTag];
   // Only list the tag in case it's non-enumerable / not an own property.
   // Otherwise we'd print this twice.

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2114,6 +2114,21 @@ assert.strictEqual(
     inspect(obj),
     "Array <[Object: null prototype] {}> { '0': 1, '1': 2, '2': 3 }"
   );
+
+  StorageObject.prototype = Object.create(null);
+  Object.setPrototypeOf(StorageObject.prototype, Object.create(null));
+  Object.setPrototypeOf(
+    Object.getPrototypeOf(StorageObject.prototype),
+    Object.create(null)
+  );
+  assert.strictEqual(
+    util.inspect(new StorageObject()),
+    'StorageObject <Object <Object <[Object: null prototype] {}>>> {}'
+  );
+  assert.strictEqual(
+    util.inspect(new StorageObject(), { depth: 1 }),
+    'StorageObject <Object <Object <Complex prototype>>> {}'
+  );
 }
 
 // Check that the fallback always works.


### PR DESCRIPTION
This makes sure prototypes won't be inspected infinitely for some
obscure object creations. The depth is now taken into account and
the recursion ends when the depth limit is reached.

Fixes: #29646

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
