### PR TITLE
doc,http: optional callback for setTimeout

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1778,7 +1778,7 @@ added: v0.11.6
 The raw request/response trailer keys and values exactly as they were
 received. Only populated at the `'end'` event.
 
-### message.setTimeout(msecs, callback)
+### message.setTimeout(msecs[, callback])
 <!-- YAML
 added: v0.5.9
 -->


### PR DESCRIPTION
Documents that callback is optional for IncomingMessage setTimeout
https://github.com/nodejs/node/blob/0daec61b9bdefbde1026f0dacb7ee38eb6a91771/lib/_http_incoming.js#L88-L89

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)