### PR TITLE
crypto: use byteLength in timingSafeEqual

### DIFF
--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -78,7 +78,7 @@ function timingSafeEqual(buf1, buf2) {
     throw new ERR_INVALID_ARG_TYPE('buf2',
                                    ['Buffer', 'TypedArray', 'DataView'], buf2);
   }
-  if (buf1.length !== buf2.length) {
+  if (buf1.byteLength !== buf2.byteLength) {
     throw new ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH();
   }
   return _timingSafeEqual(buf1, buf2);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -755,7 +755,7 @@ E('ERR_CRYPTO_SCRYPT_NOT_SUPPORTED', 'Scrypt algorithm not supported', Error);
 // Switch to TypeError. The current implementation does not seem right.
 E('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign', Error);
 E('ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
-  'Input buffers must have the same byteLength', RangeError);
+  'Input buffers must have the same number of bytes', RangeError);
 E('ERR_DNS_SET_SERVERS_FAILED', 'c-ares failed to set servers: "%s" [%s]',
   Error);
 E('ERR_DOMAIN_CALLBACK_NOT_AVAILABLE',

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -755,7 +755,7 @@ E('ERR_CRYPTO_SCRYPT_NOT_SUPPORTED', 'Scrypt algorithm not supported', Error);
 // Switch to TypeError. The current implementation does not seem right.
 E('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign', Error);
 E('ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
-  'Input buffers must have the same length', RangeError);
+  'Input buffers must have the same byteLength', RangeError);
 E('ERR_DNS_SET_SERVERS_FAILED', 'c-ares failed to set servers: "%s" [%s]',
   Error);
 E('ERR_DOMAIN_CALLBACK_NOT_AVAILABLE',

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -755,7 +755,7 @@ E('ERR_CRYPTO_SCRYPT_NOT_SUPPORTED', 'Scrypt algorithm not supported', Error);
 // Switch to TypeError. The current implementation does not seem right.
 E('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign', Error);
 E('ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
-  'Input buffers must have the same number of bytes', RangeError);
+  'Input buffers must have the same byte length', RangeError);
 E('ERR_DNS_SET_SERVERS_FAILED', 'c-ares failed to set servers: "%s" [%s]',
   Error);
 E('ERR_DOMAIN_CALLBACK_NOT_AVAILABLE',

--- a/test/sequential/test-crypto-timing-safe-equal.js
+++ b/test/sequential/test-crypto-timing-safe-equal.js
@@ -37,7 +37,7 @@ common.expectsError(
   {
     code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
     type: RangeError,
-    message: 'Input buffers must have the same number of bytes'
+    message: 'Input buffers must have the same byte length'
   }
 );
 

--- a/test/sequential/test-crypto-timing-safe-equal.js
+++ b/test/sequential/test-crypto-timing-safe-equal.js
@@ -19,105 +19,17 @@ assert.strictEqual(
 );
 
 {
-  const ab32 = new ArrayBuffer(32);
-  const dv32 = new DataView(ab32);
-  dv32.setUint32(0, 1);
-  dv32.setUint32(4, 1, true);
-  dv32.setBigUint64(8, 1n);
-  dv32.setBigUint64(16, 1n, true);
-  dv32.setUint16(24, 1);
-  dv32.setUint16(26, 1, true);
-  dv32.setUint8(28, 1);
-  dv32.setUint8(29, 1);
+  // Test TypedArrays with different lengths but equal byteLengths.
+  const buf = crypto.randomBytes(16).buffer;
+  const a1 = new Uint8Array(buf);
+  const a2 = new Uint16Array(buf);
+  const a3 = new Uint32Array(buf);
 
-  // 'should consider equal buffers to be equal'
-  assert.strictEqual(
-    crypto.timingSafeEqual(Buffer.from(ab32), dv32),
-    true
-  );
-  assert.strictEqual(
-    crypto.timingSafeEqual(new Uint32Array(ab32), dv32),
-    true
-  );
-  assert.strictEqual(
-    crypto.timingSafeEqual(
-      new Uint8Array(ab32, 0, 16),
-      Buffer.from(ab32, 0, 16)
-    ),
-    true
-  );
-  assert.strictEqual(
-    crypto.timingSafeEqual(
-      new Uint32Array(ab32, 0, 8),
-      Buffer.of(0, 0, 0, 1, // 4
-                1, 0, 0, 0, // 8
-                0, 0, 0, 0, 0, 0, 0, 1, // 16
-                1, 0, 0, 0, 0, 0, 0, 0, // 24
-                0, 1, // 26
-                1, 0, // 28
-                1, 1, // 30
-                0, 0) // 32
-    ),
-    true
-  );
-
-  // 'should consider unequal buffer views to be unequal'
-  assert.strictEqual(
-    crypto.timingSafeEqual(
-      new Uint32Array(ab32, 16, 4),
-      Buffer.from(ab32, 0, 16)
-    ),
-    false
-  );
-  assert.strictEqual(
-    crypto.timingSafeEqual(
-      new Uint8Array(ab32, 0, 16),
-      Buffer.from(ab32, 16, 16)
-    ),
-    false
-  );
-  assert.strictEqual(
-    crypto.timingSafeEqual(
-      new Uint32Array(ab32, 0, 8),
-      Buffer.of(0, 0, 0, 1, // 4
-                1, 0, 0, 0, // 8
-                0, 0, 0, 0, 0, 0, 0, 1, // 16
-                1, 0, 0, 0, 0, 0, 0, 0, // 24
-                0, 1, // 26
-                1, 0, // 28
-                1, 1, // 30
-                0, 1) // 32
-    ),
-    false
-  );
-  // 'buffers with differing byteLength must throw an equal length error'
-  common.expectsError(
-    () => crypto.timingSafeEqual(Buffer.from(ab32, 0, 8),
-                                 Buffer.from(ab32, 0, 9)),
-    {
-      code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
-      type: RangeError,
-      message: 'Input buffers must have the same number of bytes'
+  for (const left of [a1, a2, a3]) {
+    for (const right of [a1, a2, a3]) {
+      assert.strictEqual(crypto.timingSafeEqual(left, right), true);
     }
-  );
-  common.expectsError(
-    () => crypto.timingSafeEqual(
-      new Uint32Array(ab32, 0, 8), // 32
-      Buffer.of(0, 0, 0, 1, // 4
-                1, 0, 0, 0, // 8
-                0, 0, 0, 0, 0, 0, 0, 1, // 16
-                1, 0, 0, 0, 0, 0, 0, 0, // 24
-                0, 1, // 26
-                1, 0, // 28
-                1, 1, // 30
-                0) // 31
-    ),
-    {
-      code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
-      type: RangeError,
-      message: 'Input buffers must have the same number of bytes'
-    }
-  );
+  }
 }
 
 common.expectsError(

--- a/test/sequential/test-crypto-timing-safe-equal.js
+++ b/test/sequential/test-crypto-timing-safe-equal.js
@@ -18,12 +18,114 @@ assert.strictEqual(
   false
 );
 
+{
+  const ab32 = new ArrayBuffer(32);
+  const dv32 = new DataView(ab32);
+  dv32.setUint32(0, 1);
+  dv32.setUint32(4, 1, true);
+  dv32.setBigUint64(8, 1n);
+  dv32.setBigUint64(16, 1n, true);
+  dv32.setUint16(24, 1);
+  dv32.setUint16(26, 1, true);
+  dv32.setUint8(28, 1);
+  dv32.setUint8(29, 1);
+
+  // 'should consider equal buffers to be equal'
+  assert.strictEqual(
+    crypto.timingSafeEqual(Buffer.from(ab32), dv32),
+    true
+  );
+  assert.strictEqual(
+    crypto.timingSafeEqual(new Uint32Array(ab32), dv32),
+    true
+  );
+  assert.strictEqual(
+    crypto.timingSafeEqual(
+      new Uint8Array(ab32, 0, 16),
+      Buffer.from(ab32, 0, 16)
+    ),
+    true
+  );
+  assert.strictEqual(
+    crypto.timingSafeEqual(
+      new Uint32Array(ab32, 0, 8),
+      Buffer.of(0, 0, 0, 1, // 4
+                1, 0, 0, 0, // 8
+                0, 0, 0, 0, 0, 0, 0, 1, // 16
+                1, 0, 0, 0, 0, 0, 0, 0, // 24
+                0, 1, // 26
+                1, 0, // 28
+                1, 1, // 30
+                0, 0) // 32
+    ),
+    true
+  );
+
+  // 'should consider unequal buffer views to be unequal'
+  assert.strictEqual(
+    crypto.timingSafeEqual(
+      new Uint32Array(ab32, 16, 4),
+      Buffer.from(ab32, 0, 16)
+    ),
+    false
+  );
+  assert.strictEqual(
+    crypto.timingSafeEqual(
+      new Uint8Array(ab32, 0, 16),
+      Buffer.from(ab32, 16, 16)
+    ),
+    false
+  );
+  assert.strictEqual(
+    crypto.timingSafeEqual(
+      new Uint32Array(ab32, 0, 8),
+      Buffer.of(0, 0, 0, 1, // 4
+                1, 0, 0, 0, // 8
+                0, 0, 0, 0, 0, 0, 0, 1, // 16
+                1, 0, 0, 0, 0, 0, 0, 0, // 24
+                0, 1, // 26
+                1, 0, // 28
+                1, 1, // 30
+                0, 1) // 32
+    ),
+    false
+  );
+  // 'buffers with differing byteLength must throw an equal length error'
+  common.expectsError(
+    () => crypto.timingSafeEqual(Buffer.from(ab32, 0, 8),
+                                 Buffer.from(ab32, 0, 9)),
+    {
+      code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
+      type: RangeError,
+      message: 'Input buffers must have the same byteLength'
+    }
+  );
+  common.expectsError(
+    () => crypto.timingSafeEqual(
+      new Uint32Array(ab32, 0, 8), // 32
+      Buffer.of(0, 0, 0, 1, // 4
+                1, 0, 0, 0, // 8
+                0, 0, 0, 0, 0, 0, 0, 1, // 16
+                1, 0, 0, 0, 0, 0, 0, 0, // 24
+                0, 1, // 26
+                1, 0, // 28
+                1, 1, // 30
+                0) // 31
+    ),
+    {
+      code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
+      type: RangeError,
+      message: 'Input buffers must have the same byteLength'
+    }
+  );
+}
+
 common.expectsError(
   () => crypto.timingSafeEqual(Buffer.from([1, 2, 3]), Buffer.from([1, 2])),
   {
     code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
     type: RangeError,
-    message: 'Input buffers must have the same length'
+    message: 'Input buffers must have the same byteLength'
   }
 );
 

--- a/test/sequential/test-crypto-timing-safe-equal.js
+++ b/test/sequential/test-crypto-timing-safe-equal.js
@@ -97,7 +97,7 @@ assert.strictEqual(
     {
       code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
       type: RangeError,
-      message: 'Input buffers must have the same byteLength'
+      message: 'Input buffers must have the same number of bytes'
     }
   );
   common.expectsError(
@@ -115,7 +115,7 @@ assert.strictEqual(
     {
       code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
       type: RangeError,
-      message: 'Input buffers must have the same byteLength'
+      message: 'Input buffers must have the same number of bytes'
     }
   );
 }
@@ -125,7 +125,7 @@ common.expectsError(
   {
     code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
     type: RangeError,
-    message: 'Input buffers must have the same byteLength'
+    message: 'Input buffers must have the same number of bytes'
   }
 );
 


### PR DESCRIPTION
This is a revival of https://github.com/nodejs/node/pull/23341 which has shown no activity since last year. I fixed the branch, changed the error description as suggested by @jasnell in https://github.com/nodejs/node/pull/23341#discussion_r235443728, and simplified the test case.

cc @nodejs/crypto

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
