### PR TITLE
src: fix compiler warning in inspector_profiler.cc

### DIFF
--- a/src/inspector_profiler.cc
+++ b/src/inspector_profiler.cc
@@ -229,7 +229,7 @@ void V8CoverageConnection::WriteProfile(Local<String> message) {
   // Avoid writing to disk if no source-map data:
   if (!source_map_cache_v->IsUndefined()) {
     profile->Set(context, FIXED_ONE_BYTE_STRING(isolate, "source-map-cache"),
-                source_map_cache_v);
+                source_map_cache_v).ToChecked();
   }
 
   Local<String> result_s;


### PR DESCRIPTION
Currently, the following compiler warnings is generated:
```console
../src/inspector_profiler.cc:231:5: warning:
ignoring return value of function declared with 'warn_unused_result'
attribute [-Wunused-result]
profile->Set(context, FIXED_ONE_BYTE_STRING(isolate, "source-map-cache")
^~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```
This commit adds a .ToChecked() call to avoid the warning.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
