### PR TITLE
stream: remove ambigious code

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -59,9 +59,9 @@ function eos(stream, opts, callback) {
     };
   }
 
-  let readable = opts.readable ||
+  const readable = opts.readable ||
     (opts.readable !== false && isReadable(stream));
-  let writable = opts.writable ||
+  const writable = opts.writable ||
     (opts.writable !== false && isWritable(stream));
 
   const onlegacyfinish = () => {
@@ -69,13 +69,11 @@ function eos(stream, opts, callback) {
   };
 
   const onfinish = () => {
-    writable = false;
     writableFinished = true;
     if (!readable) callback.call(stream);
   };
 
   const onend = () => {
-    readable = false;
     readableEnded = true;
     if (!writable) callback.call(stream);
   };


### PR DESCRIPTION
This cleans up some ambiguous code. I don't believe this actually causes any observable change of behaviour.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
