### PR TITLE
doc: fix type of atime/mtime of fs.unlinkSync

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2086,8 +2086,8 @@ changes:
 -->
 
 * `fd` {integer}
-* `atime` {integer}
-* `mtime` {integer}
+* `atime` {number|string|Date}
+* `mtime` {number|string|Date}
 
 Synchronous version of [`fs.futimes()`][]. Returns `undefined`.
 


### PR DESCRIPTION
It seems that `fs.unlinkSync` accepts `number`, `Date` or `string` as same as `fs.unlink`
https://github.com/nodejs/node/blob/3a2e75d9a5c31d20e429d505b82dd182e33f459a/lib/fs.js#L1177-L1196

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)



