### PR TITLE
doc: fix type of atime/mtime

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2086,8 +2086,8 @@ changes:
 -->
 
 * `fd` {integer}
-* `atime` {integer}
-* `mtime` {integer}
+* `atime` {number|string|Date}
+* `mtime` {number|string|Date}
 
 Synchronous version of [`fs.futimes()`][]. Returns `undefined`.
 
@@ -3462,8 +3462,8 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `atime` {integer}
-* `mtime` {integer}
+* `atime` {number|string|Date}
+* `mtime` {number|string|Date}
 
 Returns `undefined`.
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2064,8 +2064,8 @@ changes:
 -->
 
 * `fd` {integer}
-* `atime` {number|string|Date}
-* `mtime` {number|string|Date}
+* `atime` {integer|string|Date}
+* `mtime` {integer|string|Date}
 * `callback` {Function}
   * `err` {Error}
 
@@ -2086,8 +2086,8 @@ changes:
 -->
 
 * `fd` {integer}
-* `atime` {number|string|Date}
-* `mtime` {number|string|Date}
+* `atime` {integer|string|Date}
+* `mtime` {integer|string|Date}
 
 Synchronous version of [`fs.futimes()`][]. Returns `undefined`.
 
@@ -3429,8 +3429,8 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `atime` {number|string|Date}
-* `mtime` {number|string|Date}
+* `atime` {integer|string|Date}
+* `mtime` {integer|string|Date}
 * `callback` {Function}
   * `err` {Error}
 
@@ -3462,8 +3462,8 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `atime` {number|string|Date}
-* `mtime` {number|string|Date}
+* `atime` {integer|string|Date}
+* `mtime` {integer|string|Date}
 
 Returns `undefined`.
 
@@ -4233,8 +4233,8 @@ The last three bytes are null bytes (`'\0'`), to compensate the over-truncation.
 added: v10.0.0
 -->
 
-* `atime` {number|string|Date}
-* `mtime` {number|string|Date}
+* `atime` {integer|string|Date}
+* `mtime` {integer|string|Date}
 * Returns: {Promise}
 
 Change the file system timestamps of the object referenced by the `FileHandle`
@@ -4839,8 +4839,8 @@ added: v10.0.0
 -->
 
 * `path` {string|Buffer|URL}
-* `atime` {number|string|Date}
-* `mtime` {number|string|Date}
+* `atime` {integer|string|Date}
+* `mtime` {integer|string|Date}
 * Returns: {Promise}
 
 Change the file system timestamps of the object referenced by `path` then

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2064,8 +2064,8 @@ changes:
 -->
 
 * `fd` {integer}
-* `atime` {integer|string|Date}
-* `mtime` {integer|string|Date}
+* `atime` {number|string|Date}
+* `mtime` {number|string|Date}
 * `callback` {Function}
   * `err` {Error}
 
@@ -2086,8 +2086,8 @@ changes:
 -->
 
 * `fd` {integer}
-* `atime` {integer|string|Date}
-* `mtime` {integer|string|Date}
+* `atime` {number|string|Date}
+* `mtime` {number|string|Date}
 
 Synchronous version of [`fs.futimes()`][]. Returns `undefined`.
 
@@ -3429,8 +3429,8 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `atime` {integer|string|Date}
-* `mtime` {integer|string|Date}
+* `atime` {number|string|Date}
+* `mtime` {number|string|Date}
 * `callback` {Function}
   * `err` {Error}
 
@@ -3462,8 +3462,8 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `atime` {integer|string|Date}
-* `mtime` {integer|string|Date}
+* `atime` {number|string|Date}
+* `mtime` {number|string|Date}
 
 Returns `undefined`.
 
@@ -4233,8 +4233,8 @@ The last three bytes are null bytes (`'\0'`), to compensate the over-truncation.
 added: v10.0.0
 -->
 
-* `atime` {integer|string|Date}
-* `mtime` {integer|string|Date}
+* `atime` {number|string|Date}
+* `mtime` {number|string|Date}
 * Returns: {Promise}
 
 Change the file system timestamps of the object referenced by the `FileHandle`
@@ -4839,8 +4839,8 @@ added: v10.0.0
 -->
 
 * `path` {string|Buffer|URL}
-* `atime` {integer|string|Date}
-* `mtime` {integer|string|Date}
+* `atime` {number|string|Date}
+* `mtime` {number|string|Date}
 * Returns: {Promise}
 
 Change the file system timestamps of the object referenced by `path` then


### PR DESCRIPTION
It seems that `fs.unlinkSync` and `fs.utimesSync` can accept `number`, `Date` or `string` as same as `fs.unlink` and `fs.utimes`.

https://github.com/nodejs/node/blob/3a2e75d9a5c31d20e429d505b82dd182e33f459a/lib/fs.js#L1177-L1196

https://github.com/nodejs/node/blob/3a2e75d9a5c31d20e429d505b82dd182e33f459a/lib/fs.js#L1189-L1206

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)



