### PR TITLE
process: deprecate process._tickCallback

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2530,10 +2530,11 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/29671
     description: Runtime deprecation.
 -->
-Type: Documentation-only (supports [`--pending-deprecation`][])
+Type: Runtime
 
 The `process._tickCallback` property was never documented as
-an officially supported API.
+an officially supported API. Please use `process.runNextTicks`
+instead.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2519,8 +2519,8 @@ Type: Documentation-only
 Prefer [`response.socket`][] over [`response.connection`][] and
 [`request.socket`][] over [`request.connection`][].
 
-<a id="DEP0134"></a>
-### DEP0134: process._tickCallback
+<a id="DEP0XXX"></a>
+### DEP0XXX: process._tickCallback
 <!-- YAML
 changes:
   - version: REPLACEME

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2527,7 +2527,7 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/29781
     description: Documentation-only deprecation.
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/
+    pr-url: https://github.com/nodejs/node/pull/29671
     description: Runtime deprecation.
 -->
 Type: Documentation-only (supports [`--pending-deprecation`][])

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2519,16 +2519,16 @@ Type: Documentation-only
 Prefer [`response.socket`][] over [`response.connection`][] and
 [`request.socket`][] over [`request.connection`][].
 
-<a id="DEP0XXX"></a>
-### DEP0XXX: process._tickCallback
+<a id="DEP0134"></a>
+### DEP0134: process._tickCallback
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/29781
-    description: Documentation-only deprecation.
-  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/29671
     description: Runtime deprecation.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/29781
+    description: Documentation-only deprecation.
 -->
 Type: Runtime
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2526,6 +2526,9 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/29781
     description: Documentation-only deprecation.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/
+    description: Runtime deprecation.
 -->
 Type: Documentation-only (supports [`--pending-deprecation`][])
 

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -281,10 +281,12 @@ process.emitWarning = emitWarning;
   const { nextTick, runNextTicks } = setupTaskQueue();
   process.nextTick = nextTick;
   // Used to emulate a tick manually in the JS land.
-  // A better name for this function would be `runNextTicks` but
-  // it has been exposed to the process object so we keep this legacy name
-  // TODO(joyeecheung): either remove it or make it public
-  process._tickCallback = runNextTicks;
+  process.runNextTicks = runNextTicks;
+  process._tickCallback = deprecate(
+    runNextTicks,
+    'process._tickCallback is deprecated. ',
+    'DEP0134');
+
 
   const { getTimerCallbacks } = require('internal/timers');
   const { setupTimers } = internalBinding('timers');

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -284,7 +284,8 @@ process.emitWarning = emitWarning;
   process.runNextTicks = runNextTicks;
   process._tickCallback = deprecate(
     runNextTicks,
-    'process._tickCallback is deprecated. ',
+    'process._tickCallback is deprecated. ' +
+    'Please use `process.runNextTicks` instead.',
     'DEP0134');
 
 

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -271,10 +271,6 @@ function initializeDeprecations() {
     process.binding = deprecate(process.binding,
                                 'process.binding() is deprecated. ' +
                                 'Please use public APIs instead.', 'DEP0111');
-
-    process._tickCallback = deprecate(process._tickCallback,
-                                      'process._tickCallback() is deprecated',
-                                      'DEP0134');
   }
 
   // Create global.process and global.Buffer as getters so that we have a


### PR DESCRIPTION
This comment:

> // A better name for this function would be `runNextTicks` but
  // it has been exposed to the process object so we keep this legacy name
  // TODO(joyeecheung): either remove it or make it public

suggests that the `process._tickCallback` isn't the correct name for this function, but since it is exposed on the process object, it needs to stay, and that it should be removed(or made public).

This PR  deprecates the `process._tickCallback` funciton as well as adding the more appropriately named `process.runNextTicks to the process object.


While this PR does both, deprecate and make the renamed function public, I am open to changing this to just deprecate and not add a new, possibly unneeded function to the process object.


I am also looking for some guidance on where a test for a change like this should be added


ping @joyeecheung 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
