### PR TITLE
http2: optimize the altsvc Max bytes limit, define and use constants

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -161,6 +161,7 @@ function debugSessionObj(session, message, ...args) {
 const kMaxFrameSize = (2 ** 24) - 1;
 const kMaxInt = (2 ** 32) - 1;
 const kMaxStreams = (2 ** 31) - 1;
+const kMaxALTSVC = (2 ** 14) - 2;
 
 // eslint-disable-next-line no-control-regex
 const kQuotedString = /^[\x09\x20-\x5b\x5d-\x7e\x80-\xff]*$/;
@@ -1476,7 +1477,7 @@ class ServerHttp2Session extends Http2Session {
       throw new ERR_INVALID_CHAR('alt');
 
     // Max length permitted for ALTSVC
-    if ((alt.length + (origin !== undefined ? origin.length : 0)) > 16382)
+    if ((alt.length + (origin !== undefined ? origin.length : 0)) > kMaxALTSVC)
       throw new ERR_HTTP2_ALTSVC_LENGTH();
 
     this[kHandle].altsvc(stream, origin || '', alt);
@@ -1508,7 +1509,7 @@ class ServerHttp2Session extends Http2Session {
       len += origin.length;
     }
 
-    if (len > 16382)
+    if (len > kMaxALTSVC)
       throw new ERR_HTTP2_ORIGIN_LENGTH();
 
     this[kHandle].origin(arr, count);


### PR DESCRIPTION
Altsvc Max bytes extracted constant, can better maintain this limit value

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
