### PR TITLE
errors: make sure all Node.js errors show their properties

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -12,8 +12,6 @@
 
 const { Object, Math } = primordials;
 
-const kCode = Symbol('code');
-const kInfo = Symbol('info');
 const messages = new Map();
 const codes = {};
 
@@ -107,75 +105,80 @@ class SystemError extends Error {
       writable: true,
       configurable: true
     });
-    Object.defineProperty(this, kInfo, {
-      configurable: false,
-      enumerable: false,
-      value: context
-    });
-    Object.defineProperty(this, kCode, {
-      configurable: true,
-      enumerable: false,
-      value: key,
-      writable: true
-    });
     addCodeToName(this, 'SystemError', key);
-  }
 
-  get code() {
-    return this[kCode];
-  }
+    this.code = key;
 
-  set code(value) {
-    Object.defineProperty(this, 'code', {
-      configurable: true,
+    Object.defineProperty(this, 'info', {
+      value: context,
       enumerable: true,
-      value,
-      writable: true
+      configurable: true,
+      writable: false
     });
-  }
 
-  get info() {
-    return this[kInfo];
-  }
+    Object.defineProperty(this, 'errno', {
+      get() {
+        return context.errno;
+      },
+      set: (value) => {
+        context.errno = value;
+      },
+      enumerable: true,
+      configurable: true
+    });
 
-  get errno() {
-    return this[kInfo].errno;
-  }
+    Object.defineProperty(this, 'syscall', {
+      get() {
+        return context.syscall;
+      },
+      set: (value) => {
+        context.syscall = value;
+      },
+      enumerable: true,
+      configurable: true
+    });
 
-  set errno(val) {
-    this[kInfo].errno = val;
-  }
+    if (context.path !== undefined) {
+      Object.defineProperty(this, 'path', {
+        get() {
+          return context.path != null ?
+            context.path.toString() : context.path;
+        },
+        set: (value) => {
+          context.path = value ?
+            lazyBuffer().from(value.toString()) : undefined;
+        },
+        enumerable: true,
+        configurable: true
+      });
+    }
 
-  get syscall() {
-    return this[kInfo].syscall;
-  }
-
-  set syscall(val) {
-    this[kInfo].syscall = val;
-  }
-
-  get path() {
-    return this[kInfo].path !== undefined ?
-      this[kInfo].path.toString() : undefined;
-  }
-
-  set path(val) {
-    this[kInfo].path = val ?
-      lazyBuffer().from(val.toString()) : undefined;
-  }
-
-  get dest() {
-    return this[kInfo].path !== undefined ?
-      this[kInfo].dest.toString() : undefined;
-  }
-
-  set dest(val) {
-    this[kInfo].dest = val ?
-      lazyBuffer().from(val.toString()) : undefined;
+    if (context.dest !== undefined) {
+      Object.defineProperty(this, 'dest', {
+        get() {
+          return context.dest != null ?
+            context.dest.toString() : context.dest;
+        },
+        set: (value) => {
+          context.dest = value ?
+            lazyBuffer().from(value.toString()) : undefined;
+        },
+        enumerable: true,
+        configurable: true
+      });
+    }
   }
 
   toString() {
     return `${this.name} [${this.code}]: ${this.message}`;
+  }
+
+  [Symbol.for('nodejs.util.inspect.custom')](recurseTimes, ctx) {
+    return lazyInternalUtilInspect().inspect(this, {
+      ...ctx,
+      getters: true,
+      customInspect: false
+    });
   }
 }
 
@@ -207,19 +210,7 @@ function makeNodeErrorWithCode(Base, key) {
         configurable: true
       });
       addCodeToName(this, super.name, key);
-    }
-
-    get code() {
-      return key;
-    }
-
-    set code(value) {
-      Object.defineProperty(this, 'code', {
-        configurable: true,
-        enumerable: true,
-        value,
-        writable: true
-      });
+      this.code = key;
     }
 
     toString() {
@@ -380,7 +371,6 @@ function uvException(ctx) {
     err[prop] = ctx[prop];
   }
 
-  // TODO(BridgeAR): Show the `code` property as part of the stack.
   err.code = code;
   if (path) {
     err.path = path;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -139,6 +139,11 @@ class SystemError extends Error {
     });
 
     if (context.path !== undefined) {
+      // TODO(BridgeAR): Investigate why and when the `.toString()` was
+      // introduced. The `path` and `dest` properties in the context seem to
+      // always be of type string. We should probably just remove the
+      // `.toString()` and `Buffer.from()` operations and set the value on the
+      // context as the user did.
       Object.defineProperty(this, 'path', {
         get() {
           return context.path != null ?

--- a/test/message/internal_assert.out
+++ b/test/message/internal_assert.out
@@ -12,4 +12,6 @@ Please open an issue with this stack trace at https://github.com/nodejs/node/iss
     at *
     at *
     at *
-    at *
+    at * {
+  code: 'ERR_INTERNAL_ASSERTION'
+}

--- a/test/message/internal_assert_fail.out
+++ b/test/message/internal_assert_fail.out
@@ -13,4 +13,6 @@ Please open an issue with this stack trace at https://github.com/nodejs/node/iss
     at *
     at *
     at *
-    at *
+    at * {
+  code: 'ERR_INTERNAL_ASSERTION'
+}

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -82,9 +82,9 @@ common.expectsError(() => {
 {
   const myError = new errors.codes.TEST_ERROR_1('foo');
   assert.strictEqual(myError.code, 'TEST_ERROR_1');
-  assert.strictEqual(myError.hasOwnProperty('code'), false);
+  assert.strictEqual(myError.hasOwnProperty('code'), true);
   assert.strictEqual(myError.hasOwnProperty('name'), false);
-  assert.deepStrictEqual(Object.keys(myError), []);
+  assert.deepStrictEqual(Object.keys(myError), ['code']);
   const initialName = myError.name;
   myError.code = 'FHQWHGADS';
   assert.strictEqual(myError.code, 'FHQWHGADS');
@@ -99,11 +99,11 @@ common.expectsError(() => {
 // browser. Note that `name` becomes enumerable after being assigned.
 {
   const myError = new errors.codes.TEST_ERROR_1('foo');
-  assert.deepStrictEqual(Object.keys(myError), []);
+  assert.deepStrictEqual(Object.keys(myError), ['code']);
   const initialToString = myError.toString();
 
   myError.name = 'Fhqwhgads';
-  assert.deepStrictEqual(Object.keys(myError), ['name']);
+  assert.deepStrictEqual(Object.keys(myError), ['code', 'name']);
   assert.notStrictEqual(myError.toString(), initialToString);
 }
 
@@ -114,7 +114,7 @@ common.expectsError(() => {
   let initialConsoleLog = '';
   hijackStdout((data) => { initialConsoleLog += data; });
   const myError = new errors.codes.TEST_ERROR_1('foo');
-  assert.deepStrictEqual(Object.keys(myError), []);
+  assert.deepStrictEqual(Object.keys(myError), ['code']);
   const initialToString = myError.toString();
   console.log(myError);
   assert.notStrictEqual(initialConsoleLog, '');
@@ -124,7 +124,7 @@ common.expectsError(() => {
   let subsequentConsoleLog = '';
   hijackStdout((data) => { subsequentConsoleLog += data; });
   myError.message = 'Fhqwhgads';
-  assert.deepStrictEqual(Object.keys(myError), []);
+  assert.deepStrictEqual(Object.keys(myError), ['code']);
   assert.notStrictEqual(myError.toString(), initialToString);
   console.log(myError);
   assert.strictEqual(subsequentConsoleLog, initialConsoleLog);

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -161,8 +161,10 @@ async function ctrlCTest() {
   ]), [
     'await timeout(100000)\r',
     'Thrown:',
-    'Error [ERR_SCRIPT_EXECUTION_INTERRUPTED]: ' +
-      'Script execution was interrupted by `SIGINT`',
+    '[Error [ERR_SCRIPT_EXECUTION_INTERRUPTED]: ' +
+      'Script execution was interrupted by `SIGINT`] {',
+    "  code: 'ERR_SCRIPT_EXECUTION_INTERRUPTED'",
+    '}',
     PROMPT
   ]);
 }


### PR DESCRIPTION
This improves Node.js errors by always showing the attached properties
when inspecting such an error. This applies especially to SystemError.
It did often not show any properties but now all properties will be
visible.
This is done in a mainly backwards compatible way. Instead of using
prototype getters and setters, the property is now set directly on the
error.

Note: the custom inspect function is necessary for the SystemError to keep the old getter/setter behavior intact .

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
