### PR TITLE
doc: add KeyObject to type

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1736,7 +1736,7 @@ changes:
 -->
 
 * `algorithm` {string}
-* `key` {string | Buffer | TypedArray | DataView}
+* `key` {string | Buffer | TypedArray | DataView | KeyObject}
 * `iv` {string | Buffer | TypedArray | DataView | null}
 * `options` {Object} [`stream.transform` options][]
 * Returns: {Decipher}


### PR DESCRIPTION
>  The key may optionally be a KeyObject of type secret

It is written in description, but not in type. 

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
