### PR TITLE
tools: minor `require` consistency changes

### DIFF
--- a/tools/doc/apilinks.js
+++ b/tools/doc/apilinks.js
@@ -18,10 +18,10 @@
 //    `function X(...) {...}`). Over time, we expect to handle more
 //    cases (example: ES2015 class definitions).
 
-const acorn = require('../../deps/acorn/acorn');
 const fs = require('fs');
 const path = require('path');
 const child_process = require('child_process');
+const acorn = require('../../deps/acorn/acorn');
 
 // Run a command, capturing stdout, ignoring errors.
 function execSync(command) {

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -21,9 +21,8 @@
 
 'use strict';
 
-const common = require('./common.js');
 const fs = require('fs');
-const getVersions = require('./versions.js');
+const path = require('path');
 const unified = require('unified');
 const find = require('unist-util-find');
 const visit = require('unist-util-visit');
@@ -31,7 +30,9 @@ const markdown = require('remark-parse');
 const remark2rehype = require('remark-rehype');
 const raw = require('rehype-raw');
 const htmlStringify = require('rehype-stringify');
-const path = require('path');
+
+const common = require('./common.js');
+const getVersions = require('./versions.js');
 const typeParser = require('./type-parser.js');
 
 module.exports = {

--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -22,9 +22,9 @@
 'use strict';
 
 const unified = require('unified');
-const common = require('./common.js');
 const html = require('remark-html');
 const select = require('unist-util-select');
+const common = require('./common.js');
 
 module.exports = { jsonAPI };
 

--- a/tools/doc/versions.js
+++ b/tools/doc/versions.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const https = require('https');
 const { readFileSync } = require('fs');
 const path = require('path');
 const srcRoot = path.join(__dirname, '..', '..');
@@ -14,7 +15,6 @@ const isRelease = () => {
 
 const getUrl = (url) => {
   return new Promise((resolve, reject) => {
-    const https = require('https');
     const request = https.get(url, { timeout: 5000 }, (response) => {
       if (response.statusCode !== 200) {
         reject(new Error(


### PR DESCRIPTION
Move the system packages first and make sure `require` is in the top level.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This is untested, not sure if CI runs these scripts. Also, this was mostly nitpicking after I noticed the `https` require inside `getUrl()` in tools/doc/versions.js.