### PR TITLE
doc: fix return type

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1824,7 +1824,7 @@ added: v0.9.3
 -->
 
 * `name` {string}
-* Returns: {DiffieHellman}
+* Returns: {DiffieHellmanGroup}
 
 An alias for [`crypto.getDiffieHellman()`][]
 
@@ -2194,9 +2194,9 @@ added: v0.7.5
 -->
 
 * `groupName` {string}
-* Returns: {DiffieHellman}
+* Returns: {DiffieHellmanGroup}
 
-Creates a predefined `DiffieHellman` key exchange object. The
+Creates a predefined `DiffieHellmanGroup` key exchange object. The
 supported groups are: `'modp1'`, `'modp2'`, `'modp5'` (defined in
 [RFC 2412][], but see [Caveats][]) and `'modp14'`, `'modp15'`,
 `'modp16'`, `'modp17'`, `'modp18'` (defined in [RFC 3526][]). The

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -52,6 +52,7 @@ const customTypesMap = {
   'Cipher': 'crypto.html#crypto_class_cipher',
   'Decipher': 'crypto.html#crypto_class_decipher',
   'DiffieHellman': 'crypto.html#crypto_class_diffiehellman',
+  'DiffieHellmanGroup': 'crypto.html#crypto_class_diffiehellmangroup',
   'ECDH': 'crypto.html#crypto_class_ecdh',
   'Hash': 'crypto.html#crypto_class_hash',
   'Hmac': 'crypto.html#crypto_class_hmac',


### PR DESCRIPTION
IIUC, `crypto.createDiffieHellmanGroup(name)` and its original `crypto.getDiffieHellman(groupName)` will return a instance of [`DiffieHellmanGroup`](https://nodejs.org/api/crypto.html#crypto_class_diffiehellmangroup) which is not a sub type of `DiffieHellman`.

```js
const instnace = crypto.createDiffieHellmanGroup("modp14")

console.log(instnace instanceof crypto.DiffieHellmanGroup)
// true
console.log(instnace instanceof crypto.DiffieHellman)
// false
```

on Node.js v12.10.0.


##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
