### PR TITLE
test: simplify force-context-aware test

### DIFF
--- a/test/addons/force-context-aware/index.js
+++ b/test/addons/force-context-aware/index.js
@@ -1,4 +1,0 @@
-'use strict';
-const common = require('../../common');
-
-require(`./build/${common.buildType}/binding`);

--- a/test/addons/force-context-aware/test.js
+++ b/test/addons/force-context-aware/test.js
@@ -1,13 +1,8 @@
+// Flags: --force-context-aware
 'use strict';
 const common = require('../../common');
-const childProcess = require('child_process');
 const assert = require('assert');
-const path = require('path');
 
-const mod = path.join('test', 'addons', 'force-context-aware', 'index.js');
-
-const execString = `"${process.execPath}" --force-context-aware ./${mod}`;
-childProcess.exec(execString, common.mustCall((err) => {
-  const errMsg = 'Loading non context-aware native modules has been disabled';
-  assert.strictEqual(err.message.includes(errMsg), true);
-}));
+assert.throws(() => {
+  require(`./build/${common.buildType}/binding`);
+}, /^Error: Loading non context-aware native modules has been disabled$/);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)