### PR TITLE
worker: fix process._fatalException return type

### DIFF
--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -166,26 +166,28 @@ function workerOnGlobalUncaughtException(error, fromPromise) {
   }
   debug(`[${threadId}] uncaught exception handled = ${handled}`);
 
-  if (!handled) {
-    let serialized;
-    try {
-      const { serializeError } = require('internal/error-serdes');
-      serialized = serializeError(error);
-    } catch {}
-    debug(`[${threadId}] uncaught exception serialized = ${!!serialized}`);
-    if (serialized)
-      port.postMessage({
-        type: ERROR_MESSAGE,
-        error: serialized
-      });
-    else
-      port.postMessage({ type: COULD_NOT_SERIALIZE_ERROR });
-
-    const { clearAsyncIdStack } = require('internal/async_hooks');
-    clearAsyncIdStack();
-
-    process.exit();
+  if (handled) {
+    return true;
   }
+
+  let serialized;
+  try {
+    const { serializeError } = require('internal/error-serdes');
+    serialized = serializeError(error);
+  } catch {}
+  debug(`[${threadId}] uncaught exception serialized = ${!!serialized}`);
+  if (serialized)
+    port.postMessage({
+      type: ERROR_MESSAGE,
+      error: serialized
+    });
+  else
+    port.postMessage({ type: COULD_NOT_SERIALIZE_ERROR });
+
+  const { clearAsyncIdStack } = require('internal/async_hooks');
+  clearAsyncIdStack();
+
+  process.exit();
 }
 
 // Patch the global uncaught exception handler so it gets picked up by

--- a/test/parallel/test-worker-non-fatal-uncaught-exception.js
+++ b/test/parallel/test-worker-non-fatal-uncaught-exception.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Check that `process._fatalException()` returns a boolean when run inside a
+// worker.
+
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
+  const w = new Worker(__filename);
+  w.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+  }));
+  return;
+}
+
+process.once('uncaughtException', () => {
+  process.nextTick(() => {
+    assert.strictEqual(res, true);
+  });
+});
+
+const res = process._fatalException(new Error());


### PR DESCRIPTION
This makes sure `process._fatalException()` returns a boolean when
run inside of a worker.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
