### PR TITLE
http: add reusedSocket property on incoming message

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -341,6 +341,7 @@ Agent.prototype.keepSocketAlive = function keepSocketAlive(socket) {
 
 Agent.prototype.reuseSocket = function reuseSocket(socket, req) {
   debug('have free socket');
+  req.reusedSocket = true;
   socket.ref();
 };
 

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -42,6 +42,7 @@ function IncomingMessage(socket) {
   this._readableState.readingMore = true;
 
   this.socket = socket;
+  this.reusedSocket = false;
 
   this.httpVersionMajor = null;
   this.httpVersionMinor = null;


### PR DESCRIPTION
Set reusedSocket property when reusing socket for request, so user can
handle retry base on wether the request is reusing a socket.

Refs: https://github.com/request/request/issues/3131

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
