### PR TITLE
stream: eof & pipeline compat

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1525,6 +1525,11 @@ Especially useful in error handling scenarios where a stream is destroyed
 prematurely (like an aborted HTTP request), and will not emit `'end'`
 or `'finish'`.
 
+`stream.finished()` will error with `ERR_STREAM_PREMATURE_CLOSE` if:
+* `Writable` emits `'close'` before `'finish'` and
+[`writable.writableFinished`][].
+* `Readable` emits `'close'` before `'end'` and [`readable.readableEnded`][].
+
 The `finished` API is promisify-able as well;
 
 ```js
@@ -1646,6 +1651,10 @@ run().catch(console.error);
 `stream.pipeline()` will call `stream.destroy(err)` on all streams except:
 * `Readable` streams which have emitted `'end'` or `'close'`.
 * `Writable` streams which have emitted `'finish'` or `'close'`.
+
+If any `Writable` or `Readable` stream emits `'close'` without being able to
+fully flush or drain, `stream.pipeline()` will error with
+`ERR_STREAM_PREMATURE_CLOSE`.
 
 `stream.pipeline()` leaves dangling event listeners on the streams
 after the `callback` has been invoked. In the case of reuse of streams after
@@ -2865,6 +2874,7 @@ contain multi-byte characters.
 [`process.stdout`]: process.html#process_process_stdout
 [`readable._read()`]: #stream_readable_read_size_1
 [`readable.push('')`]: #stream_readable_push
+[`readable.readableEnded`]: #stream_readable_readableended
 [`readable.setEncoding()`]: #stream_readable_setencoding_encoding
 [`stream.Readable.from()`]: #stream_stream_readable_from_iterable_options
 [`stream.cork()`]: #stream_writable_cork

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -147,6 +147,8 @@ function ReadableState(options, stream, isDuplex) {
   // Indicates whether the stream has errored.
   this.errored = false;
 
+  this.closed = false;
+
   // Crypto is kind of old and crusty.  Historically, its default string
   // encoding is 'binary' so we have to make this configurable.
   // Everything else in the universe uses 'utf8', though.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -175,6 +175,8 @@ function WritableState(options, stream, isDuplex) {
   // is disabled we need a way to tell whether the stream has failed.
   this.errored = false;
 
+  this.closed = false;
+
   // Count buffered requests
   this.bufferedRequestCount = 0;
 

--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -122,16 +122,6 @@ const ReadableStreamAsyncIteratorPrototype = ObjectSetPrototypeOf({
   return() {
     return new Promise((resolve, reject) => {
       const stream = this[kStream];
-
-      // TODO(ronag): Remove this check once finished() handles
-      // already ended and/or destroyed streams.
-      const ended = stream.destroyed || stream.readableEnded ||
-        (stream._readableState && stream._readableState.endEmitted);
-      if (ended) {
-        resolve(createIterResult(undefined, true));
-        return;
-      }
-
       finished(stream, (err) => {
         if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
           reject(err);

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -73,6 +73,13 @@ function emitCloseNT(self) {
   const r = self._readableState;
   const w = self._writableState;
 
+  if (w) {
+    w.closed = true;
+  }
+  if (r) {
+    r.closed = true;
+  }
+
   if ((w && w.emitClose) || (r && r.emitClose)) {
     self.emit('close');
   }
@@ -103,6 +110,7 @@ function undestroy() {
   if (r) {
     r.destroyed = false;
     r.errored = false;
+    r.closed = false;
     r.reading = false;
     r.ended = false;
     r.endEmitted = false;
@@ -112,6 +120,7 @@ function undestroy() {
   if (w) {
     w.destroyed = false;
     w.errored = false;
+    w.closed = false;
     w.ended = false;
     w.ending = false;
     w.finalCalled = false;

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -69,15 +69,13 @@ function eos(stream, opts, callback) {
   };
 
   const onfinish = () => {
-    writable = false;
     writableFinished = true;
-    if (!readable) callback.call(stream);
+    if (!readable || readableEnded) callback.call(stream);
   };
 
   const onend = () => {
-    readable = false;
     readableEnded = true;
-    if (!writable) callback.call(stream);
+    if (!writable || writableFinished) callback.call(stream);
   };
 
   const onclose = () => {

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -79,10 +79,24 @@ function eos(stream, opts, callback) {
   };
 
   const onclose = () => {
-    if (readable && !readableEnded) {
-      callback.call(stream, new ERR_STREAM_PREMATURE_CLOSE());
-    } else if (writable && !writableFinished) {
-      callback.call(stream, new ERR_STREAM_PREMATURE_CLOSE());
+    if (readable) {
+      const ended = (stream._readableState &&
+        stream._readableState.endEmitted) || stream.readableEnded;
+      if (!ended && !readableEnded) {
+        callback.call(stream, new ERR_STREAM_PREMATURE_CLOSE());
+      } else if (!readableEnded) {
+        // Compat. Stream has ended but haven't emitted 'end'.
+        callback.call(stream);
+      }
+    } else if (writable) {
+      const finished = (stream._writableState &&
+        stream._writableState.finished) || stream.writableFinished;
+      if (!finished && !writableFinished) {
+        callback.call(stream, new ERR_STREAM_PREMATURE_CLOSE());
+      } else if (!writableFinished) {
+        // Compat. Stream has finished but haven't emitted 'finish'.
+        callback.call(stream);
+      }
     }
   };
 

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -44,16 +44,25 @@ function eos(stream, opts, callback) {
     callback.call(stream, err);
   };
 
-  let writableFinished = stream.writableFinished ||
-    (stream._writableState && stream._writableState.finished);
-  let readableEnded = stream.readableEnded ||
-    (stream._readableState && stream._readableState.endEmitted);
+  const w = stream._writableState;
+  const r = stream._readableState;
 
-  if (writableFinished || readableEnded || stream.destroyed ||
-      stream.aborted) {
+  let writableFinished = stream.writableFinished || (w && w.finished);
+  let readableEnded = stream.readableEnded || (r && r.endEmitted);
+
+  const errorEmitted = (w && w.errorEmitted) || (r && r.errorEmitted);
+  const closed = (w && w.closed) || (r && r.closed);
+
+  if (writableFinished || readableEnded || errorEmitted || closed) {
+    // TODO(ronag): rethrow if errorEmitted?
+    // TODO(ronag): premature close if closed but not
+    // errored, finished or ended?
+
+    // Swallow any error past this point.
     if (opts.error !== false) stream.on('error', onerror);
-    // A destroy(err) call emits error in nextTick.
+
     process.nextTick(callback.bind(stream));
+
     return () => {
       stream.removeListener('error', onerror);
     };

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -28,6 +28,25 @@ function eos(stream, opts, callback) {
 
   callback = once(callback);
 
+  const onerror = (err) => {
+    callback.call(stream, err);
+  };
+
+  let writableFinished = stream.writableFinished ||
+    (stream._writableState && stream._writableState.finished);
+  let readableEnded = stream.readableEnded ||
+    (stream._readableState && stream._readableState.endEmitted);
+
+  if (writableFinished || readableEnded || stream.destroyed ||
+      stream.aborted) {
+    if (opts.error !== false) stream.on('error', onerror);
+    // A destroy(err) call emits error in nextTick.
+    process.nextTick(callback.bind(stream));
+    return () => {
+      stream.removeListener('error', onerror);
+    };
+  }
+
   let readable = opts.readable || (opts.readable !== false && stream.readable);
   let writable = opts.writable || (opts.writable !== false && stream.writable);
 
@@ -35,36 +54,23 @@ function eos(stream, opts, callback) {
     if (!stream.writable) onfinish();
   };
 
-  let writableEnded = stream._writableState && stream._writableState.finished;
   const onfinish = () => {
     writable = false;
-    writableEnded = true;
+    writableFinished = true;
     if (!readable) callback.call(stream);
   };
 
-  let readableEnded = stream.readableEnded ||
-    (stream._readableState && stream._readableState.endEmitted);
   const onend = () => {
     readable = false;
     readableEnded = true;
     if (!writable) callback.call(stream);
   };
 
-  const onerror = (err) => {
-    callback.call(stream, err);
-  };
-
   const onclose = () => {
-    let err;
     if (readable && !readableEnded) {
-      if (!stream._readableState || !stream._readableState.ended)
-        err = new ERR_STREAM_PREMATURE_CLOSE();
-      return callback.call(stream, err);
-    }
-    if (writable && !writableEnded) {
-      if (!stream._writableState || !stream._writableState.ended)
-        err = new ERR_STREAM_PREMATURE_CLOSE();
-      return callback.call(stream, err);
+      callback.call(stream, new ERR_STREAM_PREMATURE_CLOSE());
+    } else if (writable && !writableFinished) {
+      callback.call(stream, new ERR_STREAM_PREMATURE_CLOSE());
     }
   };
 

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -13,6 +13,18 @@ function isRequest(stream) {
   return stream.setHeader && typeof stream.abort === 'function';
 }
 
+function isReadable(stream) {
+  return typeof stream.readable === 'boolean' ||
+    typeof stream.readableEnded === 'boolean' ||
+    !!stream._readableState;
+}
+
+function isWritable(stream) {
+  return typeof stream.writable === 'boolean' ||
+    typeof stream.writableEnded === 'boolean' ||
+    !!stream._writableState;
+}
+
 function eos(stream, opts, callback) {
   if (arguments.length === 2) {
     callback = opts;
@@ -47,8 +59,10 @@ function eos(stream, opts, callback) {
     };
   }
 
-  let readable = opts.readable || (opts.readable !== false && stream.readable);
-  let writable = opts.writable || (opts.writable !== false && stream.writable);
+  const readable = opts.readable ||
+    (opts.readable !== false && isReadable(stream));
+  const writable = opts.writable ||
+    (opts.writable !== false && isWritable(stream));
 
   const onlegacyfinish = () => {
     if (!stream.writable) onfinish();

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -46,6 +46,29 @@ function destroyer(stream, reading, writing, callback) {
 
   if (eos === undefined) eos = require('internal/streams/end-of-stream');
   eos(stream, { readable: reading, writable: writing }, (err) => {
+    if (
+      err &&
+      err.code === 'ERR_STREAM_PREMATURE_CLOSE' &&
+      reading &&
+      (stream._readableState && stream._readableState.ended)
+    ) {
+      // Some readable streams will emit 'close' before 'end'. However, since
+      // this is on the readable side 'end' should still be emitted if the
+      // stream has been ended and no error emitted. This should be allowed in
+      // favor of backwards compatibility. Since the stream is piped to a
+      // destination this should not result in any observable difference.
+      // We don't need to check if this is a writable premature close since
+      // eos will only fail with premature close on the reading side for
+      // duplex streams.
+      stream
+        .on('end', () => {
+          closed = true;
+          callback();
+        })
+        .on('error', callback);
+      return;
+    }
+
     if (err) return callback(err);
     closed = true;
     callback();

--- a/test/parallel/test-http-client-finished.js
+++ b/test/parallel/test-http-client-finished.js
@@ -25,3 +25,109 @@ const { finished } = require('stream');
     .end();
   }));
 }
+
+{
+  // Test abort before finished.
+
+  const server = http.createServer(function(req, res) {
+  });
+
+  server.listen(0, common.mustCall(function() {
+    const req = http.request({
+      port: this.address().port
+    }, common.mustNotCall());
+    req.abort();
+    finished(req, common.mustCall(() => {
+      server.close();
+    }));
+  }));
+}
+
+{
+  // Test abort after request.
+
+  const server = http.createServer(function(req, res) {
+  });
+
+  server.listen(0, common.mustCall(function() {
+    const req = http.request({
+      port: this.address().port
+    }).end();
+    finished(req, (err) => {
+      common.expectsError({
+        type: Error,
+        code: 'ERR_STREAM_PREMATURE_CLOSE'
+      })(err);
+      finished(req, common.mustCall(() => {
+        server.close();
+      }));
+    });
+    req.abort();
+  }));
+}
+
+{
+  // Test abort before end.
+
+  const server = http.createServer(function(req, res) {
+    res.write('test');
+  });
+
+  server.listen(0, common.mustCall(function() {
+    const req = http.request({
+      port: this.address().port
+    }).on('response', common.mustCall((res) => {
+      req.abort();
+      finished(res, common.mustCall(() => {
+        finished(res, common.mustCall(() => {
+          server.close();
+        }));
+      }));
+    })).end();
+  }));
+}
+
+{
+  // Test destroy before end.
+
+  const server = http.createServer(function(req, res) {
+    res.write('test');
+  });
+
+  server.listen(0, common.mustCall(function() {
+    http.request({
+      port: this.address().port
+    }).on('response', common.mustCall((res) => {
+      // TODO(ronag): Bug? Won't emit 'close' unless read.
+      res.on('data', () => {});
+      res.destroy();
+      finished(res, common.mustCall(() => {
+        finished(res, common.mustCall(() => {
+          server.close();
+        }));
+      }));
+    })).end();
+  }));
+}
+
+{
+  // Test finish after end.
+
+  const server = http.createServer(function(req, res) {
+    res.end('asd');
+  });
+
+  server.listen(0, common.mustCall(function() {
+    http.request({
+      port: this.address().port
+    }).on('response', common.mustCall((res) => {
+      // TODO(ronag): Bug? Won't emit 'close' unless read.
+      res.on('data', () => {});
+      finished(res, common.mustCall(() => {
+        finished(res, common.mustCall(() => {
+          server.close();
+        }));
+      }));
+    })).end();
+  }));
+}

--- a/test/parallel/test-http-client-finished.js
+++ b/test/parallel/test-http-client-finished.js
@@ -55,7 +55,7 @@ const { finished } = require('stream');
     }).end();
     finished(req, (err) => {
       common.expectsError({
-        type: Error,
+        name: 'Error',
         code: 'ERR_STREAM_PREMATURE_CLOSE'
       })(err);
       finished(req, common.mustCall(() => {

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -197,10 +197,14 @@ const { promisify } = require('util');
 {
   // Completed if readable-like is ended before.
 
+  let ticked = false;
   const streamLike = new EE();
   streamLike.readableEnded = true;
   streamLike.readable = true;
-  finished(streamLike, common.mustCall());
+  finished(streamLike, common.mustCall(() => {
+    assert.strictEqual(ticked, true);
+  }));
+  ticked = true;
 }
 
 {
@@ -213,42 +217,6 @@ const { promisify } = require('util');
     code: 'ERR_STREAM_PREMATURE_CLOSE'
   }));
   streamLike.emit('close');
-}
-
-{
-  // Completed if writable-like is destroyed before.
-
-  const streamLike = new EE();
-  streamLike.destroyed = true;
-  streamLike.writable = true;
-  finished(streamLike, common.mustCall());
-}
-
-{
-  // Completed if readable-like is aborted before.
-
-  const streamLike = new EE();
-  streamLike.destroyed = true;
-  streamLike.readable = true;
-  finished(streamLike, common.mustCall());
-}
-
-{
-  // Completed if writable-like is aborted before.
-
-  const streamLike = new EE();
-  streamLike.aborted = true;
-  streamLike.writable = true;
-  finished(streamLike, common.mustCall());
-}
-
-{
-  // Completed if readable-like is aborted before.
-
-  const streamLike = new EE();
-  streamLike.aborted = true;
-  streamLike.readable = true;
-  finished(streamLike, common.mustCall());
 }
 
 {

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -273,27 +273,26 @@ const { promisify } = require('util');
 }
 
 {
-  // Premature close if stream never emitted 'finish'
-  // even if writableFinished says something else.
+  // No error if stream never emitted 'end'
+  // even if readableEnded says something else.
 
   const streamLike = new EE();
   streamLike.writable = true;
-  finished(streamLike, common.expectsError({
-    code: 'ERR_STREAM_PREMATURE_CLOSE'
+  finished(streamLike, common.mustCall((err) => {
+    assert.strictEqual(err, undefined);
   }));
   streamLike.writableFinished = true;
   streamLike.emit('close');
 }
 
-
 {
-  // Premature close if stream never emitted 'end'
-  // even if readableEnded says something else.
+  // No error if stream never emitted 'finished'
+  // even if writableFinished says something else.
 
   const streamLike = new EE();
   streamLike.readable = true;
-  finished(streamLike, common.expectsError({
-    code: 'ERR_STREAM_PREMATURE_CLOSE'
+  finished(streamLike, common.mustCall((err) => {
+    assert.strictEqual(err, undefined);
   }));
   streamLike.readableEnded = true;
   streamLike.emit('close');

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -912,4 +912,35 @@ const { promisify } = require('util');
   }, common.mustCall((err) => {
     assert.strictEqual(err.message, 'kaboom');
   }));
+  // Make sure 'close' before 'end' finishes without error
+  // if readable has received eof.
+  // Ref: https://github.com/nodejs/node/issues/29699
+  const r = new Readable();
+  const w = new Writable({
+    write(chunk, encoding, cb) {
+      cb();
+    }
+  });
+  pipeline(r, w, (err) => {
+    assert.strictEqual(err, undefined);
+  });
+  r.push(null);
+  r.destroy();
+}
+
+{
+  // Make sure 'close' before 'end' finishes without error
+  // if readable has received eof.
+  // Ref: https://github.com/nodejs/node/issues/29699
+  const r = new Readable();
+  const w = new Writable({
+    write(chunk, encoding, cb) {
+      cb();
+    }
+  });
+  pipeline(r, w, (err) => {
+    assert.strictEqual(err, undefined);
+  });
+  r.push(null);
+  r.emit('close');
 }


### PR DESCRIPTION
Some broken streams might emit 'close' before 'end' or 'finish'. However, if they have actually been ended or finished, this should not result in a premature close error.

This fixes #29699 while still maintaining what could be considered correct behaviour. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
