### PR TITLE
module: move cjs type check behind experimental-modules flag

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -953,7 +953,7 @@ Module.prototype._compile = function(content, filename) {
 
 // Native extension for .js
 Module._extensions['.js'] = function(module, filename) {
-  if (filename.endsWith('.js') && experimentalModules) {
+  if (experimentalModules && filename.endsWith('.js')) {
     const pkg = readPackageScope(filename);
     if (pkg && pkg.type === 'module') {
       throw new ERR_REQUIRE_ESM(filename);

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -953,7 +953,7 @@ Module.prototype._compile = function(content, filename) {
 
 // Native extension for .js
 Module._extensions['.js'] = function(module, filename) {
-  if (filename.endsWith('.js')) {
+  if (filename.endsWith('.js') && experimentalModules) {
     const pkg = readPackageScope(filename);
     if (pkg && pkg.type === 'module') {
       throw new ERR_REQUIRE_ESM(filename);

--- a/test/es-module/test-esm-type-flag-errors.js
+++ b/test/es-module/test-esm-type-flag-errors.js
@@ -1,3 +1,4 @@
+// Flags: --experimental-modules
 'use strict';
 const common = require('../common');
 const assert = require('assert');


### PR DESCRIPTION
This puts the check added in https://github.com/nodejs/node/pull/29492 behind the `--experimental-modules` flag instead of being on by default.

We added this error for require(.js) inside of "type": "module" packages to reduce an edge case hazard but it has caused more compatibility issues itself, for which we need to discuss a way forward.

While we do that, at least restricting the error to `--experimental-modules` usage will avoid unintentional compatibility issues unflagged.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
