### PR TITLE
module: pass full URL to loader for top-level load

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1002,7 +1002,7 @@ Module.runMain = function() {
   // Load the main module--the command line argument.
   if (experimentalModules) {
     asyncESM.loaderPromise.then((loader) => {
-      return loader.import(pathToFileURL(process.argv[1]).pathname);
+      return loader.import(pathToFileURL(process.argv[1]).href);
     })
     .catch((e) => {
       internalBinding('errors').triggerUncaughtException(

--- a/test/fixtures/es-module-loaders/example-loader.mjs
+++ b/test/fixtures/es-module-loaders/example-loader.mjs
@@ -15,11 +15,11 @@ export function resolve(specifier, parentModuleURL = baseURL /*, defaultResolve 
       format: 'builtin'
     };
   }
-  if (/^\.{0,2}[/]/.test(specifier) !== true && !specifier.startsWith('file:')) {
+  if (/^\.{1,2}[/]/.test(specifier) !== true && !specifier.startsWith('file:')) {
     // For node_modules support:
     // return defaultResolve(specifier, parentModuleURL);
     throw new Error(
-      `imports must begin with '/', './', or '../'; '${specifier}' does not`);
+      `imports must be URLs or begin with './', or '../'; '${specifier}' does not`);
   }
   const resolved = new url.URL(specifier, parentModuleURL);
   const ext = path.extname(resolved.pathname);


### PR DESCRIPTION
This passes the full URL for the top-level "runMain" to the ESM loader, instead of the pathname. In addition the existing example loader check of the input path type is adjusted to catch the original issue.

This resolves the issue raised in https://github.com/nodejs/node/issues/29610, where the result of `new URL('/C:\path')` will throw.

It's more of a footgun than an actual bug, since the issue is that the expectation is that the parent URL would be passed (`new URL('/C:\path', pathToFileURL(process.cwd() + path.sep))` works fine), but it seems better to be consistent in the use of file URLs input into the loader.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
