### PR TITLE
stream: 'error' should be emitted asynchronously

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -309,7 +309,7 @@ Writable.prototype.write = function(chunk, encoding, cb) {
   } else if (state.destroyed) {
     const err = new ERR_STREAM_DESTROYED('write');
     process.nextTick(cb, err);
-    errorOrDestroy(this, err);
+    errorOrDestroy(this, err, true);
   } else if (isBuf || validChunk(this, state, chunk, cb)) {
     state.pendingcb++;
     ret = writeOrBuffer(this, state, isBuf, chunk, encoding, cb);

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -107,7 +107,7 @@ function undestroy() {
   }
 }
 
-function errorOrDestroy(stream, err) {
+function errorOrDestroy(stream, err, tick) {
   // We have tests that rely on errors being emitted
   // in the same tick, so changing this is semver major.
   // For now when you opt-in to autoDestroy we allow
@@ -123,8 +123,13 @@ function errorOrDestroy(stream, err) {
 
   if ((r && r.autoDestroy) || (w && w.autoDestroy))
     stream.destroy(err);
-  else if (needError(stream, err))
-    stream.emit('error', err);
+  else if (needError(stream, err)) {
+    if (tick) {
+      process.nextTick(emitErrorNT, stream, err);
+    } else {
+      stream.emit('error', err);
+    }
+  }
 }
 
 


### PR DESCRIPTION
`errorOrDestroy` emits `'error'` synchronously due to [compat reasons](https://github.com/nodejs/node/blob/master/lib/internal/streams/destroy.js#L111). However, it should be possible to use correct async behaviour for new code.

Fixes: https://github.com/nodejs/node/pull/29741

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
