### PR TITLE
stream: writable write emit all errors async

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1851,7 +1851,8 @@ methods only.
 The `callback` method must be called to signal either that the write completed
 successfully or failed with an error. The first argument passed to the
 `callback` must be the `Error` object if the call failed or `null` if the
-write succeeded.
+write succeeded. The `callback` method will always be called asynchronously and
+before `'error'` is emitted.
 
 All calls to `writable.write()` that occur between the time `writable._write()`
 is called and the `callback` is called will cause the written data to be

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -265,14 +265,6 @@ Writable.prototype.pipe = function() {
   errorOrDestroy(this, new ERR_STREAM_CANNOT_PIPE());
 };
 
-
-function writeAfterEnd(stream, cb) {
-  const er = new ERR_STREAM_WRITE_AFTER_END();
-  // TODO: defer error events consistently everywhere, not just the cb
-  errorOrDestroy(stream, er);
-  process.nextTick(cb, er);
-}
-
 // Checks that a user-supplied chunk is valid, especially for the particular
 // mode the stream is in. Currently this means that `null` is never accepted
 // and undefined/non-string values are only allowed in object mode.
@@ -285,8 +277,8 @@ function validChunk(stream, state, chunk, cb) {
     er = new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
   }
   if (er) {
-    errorOrDestroy(stream, er);
     process.nextTick(cb, er);
+    errorOrDestroy(stream, er, true);
     return false;
   }
   return true;
@@ -316,11 +308,13 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     cb = nop;
 
   if (state.ending) {
-    writeAfterEnd(this, cb);
+    const err = new ERR_STREAM_WRITE_AFTER_END();
+    process.nextTick(cb, err);
+    errorOrDestroy(this, err, true);
   } else if (state.destroyed) {
     const err = new ERR_STREAM_DESTROYED('write');
     process.nextTick(cb, err);
-    errorOrDestroy(this, err);
+    errorOrDestroy(this, err, true);
   } else if (isBuf || validChunk(this, state, chunk, cb)) {
     state.pendingcb++;
     ret = writeOrBuffer(this, state, chunk, encoding, cb);
@@ -656,15 +650,25 @@ Writable.prototype.end = function(chunk, encoding, cb) {
     this.uncork();
   }
 
+  if (typeof cb !== 'function')
+    cb = nop;
+
   // Ignore unnecessary end() calls.
-  if (!state.ending) {
+  // TODO(ronag): Compat. Allow end() after destroy().
+  if (!state.errored && !state.ending) {
     endWritable(this, state, cb);
-  } else if (typeof cb === 'function') {
-    if (!state.finished) {
-      onFinished(this, state, cb);
-    } else {
-      cb(new ERR_STREAM_ALREADY_FINISHED('end'));
-    }
+  } else if (state.finished) {
+    const err = new ERR_STREAM_ALREADY_FINISHED('end');
+    process.nextTick(cb, err);
+    // TODO(ronag): Compat. Don't error the stream.
+    // errorOrDestroy(this, err, true);
+  } else if (state.destroyed) {
+    const err = new ERR_STREAM_DESTROYED('end');
+    process.nextTick(cb, err);
+    // TODO(ronag): Compat. Don't error the stream.
+    // errorOrDestroy(this, err, true);
+  } else if (cb !== nop) {
+    onFinished(this, state, cb);
   }
 
   return this;
@@ -749,7 +753,7 @@ function finish(stream, state) {
 function endWritable(stream, state, cb) {
   state.ending = true;
   finishMaybe(stream, state, true);
-  if (cb) {
+  if (cb !== nop) {
     if (state.finished)
       process.nextTick(cb);
     else
@@ -774,14 +778,6 @@ function onCorkedFinish(corkReq, state, err) {
 }
 
 function onFinished(stream, state, cb) {
-  if (state.destroyed && state.errorEmitted) {
-    // TODO(ronag): Backwards compat. Should be moved to end() without
-    // errorEmitted check and with errorOrDestroy.
-    const err = new ERR_STREAM_DESTROYED('end');
-    process.nextTick(cb, err);
-    return;
-  }
-
   function onerror(err) {
     stream.removeListener('finish', onfinish);
     stream.removeListener('error', onerror);

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -610,7 +610,7 @@ Writable.prototype._write = function(chunk, encoding, cb) {
   if (this._writev) {
     this._writev([{ chunk, encoding }], cb);
   } else {
-    cb(new ERR_METHOD_NOT_IMPLEMENTED('_write()'));
+    process.nextTick(cb, new ERR_METHOD_NOT_IMPLEMENTED('_write()'));
   }
 };
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -265,25 +265,6 @@ Writable.prototype.pipe = function() {
   errorOrDestroy(this, new ERR_STREAM_CANNOT_PIPE());
 };
 
-// Checks that a user-supplied chunk is valid, especially for the particular
-// mode the stream is in. Currently this means that `null` is never accepted
-// and undefined/non-string values are only allowed in object mode.
-function validChunk(stream, state, chunk, cb) {
-  var er;
-
-  if (chunk === null) {
-    er = new ERR_STREAM_NULL_VALUES();
-  } else if (typeof chunk !== 'string' && !state.objectMode) {
-    er = new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
-  }
-  if (er) {
-    process.nextTick(cb, er);
-    errorOrDestroy(stream, er, true);
-    return false;
-  }
-  return true;
-}
-
 Writable.prototype.write = function(chunk, encoding, cb) {
   const state = this._writableState;
   var ret = false;
@@ -307,17 +288,23 @@ Writable.prototype.write = function(chunk, encoding, cb) {
   if (typeof cb !== 'function')
     cb = nop;
 
+  let err;
   if (state.ending) {
-    const err = new ERR_STREAM_WRITE_AFTER_END();
-    process.nextTick(cb, err);
-    errorOrDestroy(this, err, true);
+    err = new ERR_STREAM_WRITE_AFTER_END();
   } else if (state.destroyed) {
-    const err = new ERR_STREAM_DESTROYED('write');
-    process.nextTick(cb, err);
-    errorOrDestroy(this, err, true);
-  } else if (isBuf || validChunk(this, state, chunk, cb)) {
+    err = new ERR_STREAM_DESTROYED('write');
+  } else if (chunk === null) {
+    err = new ERR_STREAM_NULL_VALUES();
+  } else if (!isBuf && typeof chunk !== 'string' && !state.objectMode) {
+    err = new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
+  } else {
     state.pendingcb++;
     ret = writeOrBuffer(this, state, chunk, encoding, cb);
+  }
+
+  if (err) {
+    process.nextTick(cb, err);
+    errorOrDestroy(this, err, true);
   }
 
   return ret;

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -119,7 +119,7 @@ function undestroy() {
   }
 }
 
-function errorOrDestroy(stream, err) {
+function errorOrDestroy(stream, err, sync) {
   // We have tests that rely on errors being emitted
   // in the same tick, so changing this is semver major.
   // For now when you opt-in to autoDestroy we allow
@@ -138,7 +138,12 @@ function errorOrDestroy(stream, err) {
     if (r) {
       r.errored = true;
     }
-    emitErrorNT(stream, err);
+
+    if (sync) {
+      process.nextTick(emitErrorNT, stream, err);
+    } else {
+      emitErrorNT(stream, err);
+    }
   }
 }
 

--- a/test/parallel/test-child-process-server-close.js
+++ b/test/parallel/test-child-process-server-close.js
@@ -32,7 +32,7 @@ const server = net.createServer((conn) => {
   }));
 }).listen(common.PIPE, () => {
   const client = net.connect(common.PIPE, common.mustCall());
-  client.on('data', () => {
+  client.once('data', () => {
     client.end(() => {
       server.close();
     });

--- a/test/parallel/test-file-write-stream.js
+++ b/test/parallel/test-file-write-stream.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const path = require('path');
@@ -46,9 +46,6 @@ file
     callbacks.open++;
     assert.strictEqual(typeof fd, 'number');
   })
-  .on('error', function(err) {
-    throw err;
-  })
   .on('drain', function() {
     console.error('drain!', callbacks.drain);
     callbacks.drain++;
@@ -65,17 +62,13 @@ file
     assert.strictEqual(file.bytesWritten, EXPECTED.length * 2);
 
     callbacks.close++;
-    assert.throws(
-      () => {
-        console.error('write after end should not be allowed');
-        file.write('should not work anymore');
-      },
-      {
-        code: 'ERR_STREAM_WRITE_AFTER_END',
-        name: 'Error',
-        message: 'write after end'
-      }
-    );
+    console.error('write after end should not be allowed');
+    file.write('should not work anymore');
+    file.on('error', common.expectsError({
+      code: 'ERR_STREAM_WRITE_AFTER_END',
+      name: 'Error',
+      message: 'write after end'
+    }));
 
     fs.unlinkSync(fn);
   });

--- a/test/parallel/test-net-socket-write-error.js
+++ b/test/parallel/test-net-socket-write-error.js
@@ -9,11 +9,11 @@ function connectToServer() {
   const client = net.createConnection(this.address().port, () => {
     client.write(1337, common.expectsError({
       code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
+      name: 'TypeError'
     }));
     client.on('error', common.expectsError({
       code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
+      name: 'TypeError'
     }));
 
     client.destroy();

--- a/test/parallel/test-net-socket-write-error.js
+++ b/test/parallel/test-net-socket-write-error.js
@@ -1,18 +1,20 @@
 'use strict';
 
-require('../common');
-const assert = require('assert');
+const common = require('../common');
 const net = require('net');
 
 const server = net.createServer().listen(0, connectToServer);
 
 function connectToServer() {
   const client = net.createConnection(this.address().port, () => {
-    assert.throws(() => client.write(1337),
-                  {
-                    code: 'ERR_INVALID_ARG_TYPE',
-                    name: 'TypeError'
-                  });
+    client.write(1337, common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    }));
+    client.on('error', common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    }));
 
     client.destroy();
   })

--- a/test/parallel/test-net-write-arguments.js
+++ b/test/parallel/test-net-write-arguments.js
@@ -1,17 +1,21 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const net = require('net');
 
 const socket = net.Stream({ highWaterMark: 0 });
 
 // Make sure that anything besides a buffer or a string throws.
-assert.throws(() => socket.write(null),
-              {
-                code: 'ERR_STREAM_NULL_VALUES',
-                name: 'TypeError',
-                message: 'May not write null values to stream'
-              });
+socket.write(null, common.expectsError({
+  code: 'ERR_STREAM_NULL_VALUES',
+  type: TypeError,
+  message: 'May not write null values to stream'
+}));
+socket.on('error', common.expectsError({
+  code: 'ERR_STREAM_NULL_VALUES',
+  type: TypeError,
+  message: 'May not write null values to stream'
+}));
+
 [
   true,
   false,

--- a/test/parallel/test-net-write-arguments.js
+++ b/test/parallel/test-net-write-arguments.js
@@ -7,12 +7,12 @@ const socket = net.Stream({ highWaterMark: 0 });
 // Make sure that anything besides a buffer or a string throws.
 socket.write(null, common.expectsError({
   code: 'ERR_STREAM_NULL_VALUES',
-  type: TypeError,
+  name: 'TypeError',
   message: 'May not write null values to stream'
 }));
 socket.on('error', common.expectsError({
   code: 'ERR_STREAM_NULL_VALUES',
-  type: TypeError,
+  name: 'TypeError',
   message: 'May not write null values to stream'
 }));
 

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -341,7 +341,7 @@ const assert = require('assert');
     write.destroy();
     let ticked = false;
     write.end(common.mustCall((err) => {
-      assert.strictEqual(ticked, false);
+      assert.strictEqual(ticked, true);
       assert.strictEqual(err.code, 'ERR_STREAM_ALREADY_FINISHED');
     }));
     ticked = true;

--- a/test/parallel/test-stream-writable-end-multiple.js
+++ b/test/parallel/test-stream-writable-end-multiple.js
@@ -6,7 +6,6 @@ const assert = require('assert');
 const stream = require('stream');
 
 const writable = new stream.Writable();
-
 writable._write = (chunk, encoding, cb) => {
   setTimeout(() => cb(), 10);
 };
@@ -14,7 +13,10 @@ writable._write = (chunk, encoding, cb) => {
 writable.end('testing ended state', common.mustCall());
 writable.end(common.mustCall());
 writable.on('finish', common.mustCall(() => {
+  let ticked = false;
   writable.end(common.mustCall((err) => {
+    assert.strictEqual(ticked, true);
     assert.strictEqual(err.code, 'ERR_STREAM_ALREADY_FINISHED');
   }));
+  ticked = true;
 }));

--- a/test/parallel/test-stream-writable-null.js
+++ b/test/parallel/test-stream-writable-null.js
@@ -26,27 +26,14 @@ class MyWritable extends stream.Writable {
   m.write(null, assert);
 }
 
-<<<<<<< HEAD
-assert.throws(
-  () => {
-    const m = new MyWritable();
-    m.write(false, (err) => assert.ok(err));
-  },
-  {
-    code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError'
-  }
-);
-=======
 {
   const m = new MyWritable();
   m.write(false, (err) => assert.ok(err));
   m.on('error', common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError
+    name: 'TypeError'
   }));
 }
->>>>>>> stream: 'error' should be emitted asynchronously
 
 { // Should not throw.
   const m = new MyWritable().on('error', assert);

--- a/test/parallel/test-stream-writable-null.js
+++ b/test/parallel/test-stream-writable-null.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const stream = require('stream');
@@ -11,23 +11,22 @@ class MyWritable extends stream.Writable {
   }
 }
 
-assert.throws(
-  () => {
-    const m = new MyWritable({ objectMode: true });
-    m.write(null, (err) => assert.ok(err));
-  },
-  {
+{
+  const m = new MyWritable({ objectMode: true });
+  m.write(null, (err) => assert.ok(err));
+  m.on('error', common.expectsError({
     code: 'ERR_STREAM_NULL_VALUES',
     name: 'TypeError',
     message: 'May not write null values to stream'
-  }
-);
+  }));
+}
 
 { // Should not throw.
   const m = new MyWritable({ objectMode: true }).on('error', assert);
   m.write(null, assert);
 }
 
+<<<<<<< HEAD
 assert.throws(
   () => {
     const m = new MyWritable();
@@ -38,6 +37,16 @@ assert.throws(
     name: 'TypeError'
   }
 );
+=======
+{
+  const m = new MyWritable();
+  m.write(false, (err) => assert.ok(err));
+  m.on('error', common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError
+  }));
+}
+>>>>>>> stream: 'error' should be emitted asynchronously
 
 { // Should not throw.
   const m = new MyWritable().on('error', assert);

--- a/test/parallel/test-zlib-object-write.js
+++ b/test/parallel/test-zlib-object-write.js
@@ -1,11 +1,12 @@
 'use strict';
 
-require('../common');
-const assert = require('assert');
+const common = require('../common');
 const { Gunzip } = require('zlib');
 
 const gunzip = new Gunzip({ objectMode: true });
-assert.throws(
-  () => gunzip.write({}),
-  TypeError
-);
+gunzip.write({}, common.expectsError({
+  type: TypeError
+}));
+gunzip.on('error', common.expectsError({
+  type: TypeError
+}));

--- a/test/parallel/test-zlib-object-write.js
+++ b/test/parallel/test-zlib-object-write.js
@@ -5,8 +5,8 @@ const { Gunzip } = require('zlib');
 
 const gunzip = new Gunzip({ objectMode: true });
 gunzip.write({}, common.expectsError({
-  type: TypeError
+  name: 'TypeError'
 }));
 gunzip.on('error', common.expectsError({
-  type: TypeError
+  name: 'TypeError'
 }));

--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -21,18 +21,19 @@
 
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const zlib = require('zlib');
 
 zlib.gzip('hello', common.mustCall(function(err, out) {
   const unzip = zlib.createGunzip();
   unzip.close(common.mustCall());
-  assert.throws(
-    () => unzip.write(out),
-    {
-      code: 'ERR_STREAM_DESTROYED',
-      name: 'Error',
-      message: 'Cannot call write after a stream was destroyed'
-    }
-  );
+  unzip.write(out, common.expectsError({
+    code: 'ERR_STREAM_DESTROYED',
+    type: Error,
+    message: 'Cannot call write after a stream was destroyed'
+  }));
+  unzip.on('error', common.expectsError({
+    code: 'ERR_STREAM_DESTROYED',
+    type: Error,
+    message: 'Cannot call write after a stream was destroyed'
+  }));
 }));

--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -28,12 +28,12 @@ zlib.gzip('hello', common.mustCall(function(err, out) {
   unzip.close(common.mustCall());
   unzip.write(out, common.expectsError({
     code: 'ERR_STREAM_DESTROYED',
-    type: Error,
+    name: 'Error',
     message: 'Cannot call write after a stream was destroyed'
   }));
   unzip.on('error', common.expectsError({
     code: 'ERR_STREAM_DESTROYED',
-    type: Error,
+    name: 'Error',
     message: 'Cannot call write after a stream was destroyed'
   }));
 }));


### PR DESCRIPTION
Currently `write` sometimes throws/emits synchronously and sometimes asynchronously. Also, the callback is sometimes called before and sometimes after the `'error'`.

This PR brings consistency in "correctly" emitting all errors in `write` asynchronously after the callback.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
