### PR TITLE
doc: error modes of writable

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -432,7 +432,8 @@ file.end('world!');
 // Writing more now is not allowed!
 ```
 
-[`stream.end()`][stream-end] will error with (in order of precedence):
+[`stream.end()`][stream-end] will call it's callback and emit `'error'`
+with (in order of precedence):
 * `ERR_STREAM_WRITE_AFTER_END` if `chunk` is not nully and
 [`stream.end()`][stream-end] has been called.
 * `ERR_STREAM_DESTROYED` if `chunk` is not nully and
@@ -631,7 +632,8 @@ write('hello', () => {
 
 A `Writable` stream in object mode will always ignore the `encoding` argument.
 
-`stream.write()` will error with (in order of precedence):
+`stream.write()`  will call it's callback and emit `'error'`
+with (in order of precedence):
 * `ERR_STREAM_WRITE_AFTER_END` if [`stream.end()`][stream-end] has been called.
 * `ERR_STREAM_DESTROYED` if [`stream.destroy()`][writable-destroy] has been
   called.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -442,7 +442,7 @@ with (in order of precedence):
  `chunk` is not a `string` when not in `objectMode`.
 * `ERR_STREAM_ALREADY_FINISHED` if
  [`writable.writableFinished`][] is `true`.
-* Any error emitted by the instance through `'error'` before
+* Last error emitted by the instance through `'error'` before
  [`writable.writableFinished`][] is set to `true`.
 
 ##### writable.setDefaultEncoding(encoding)

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -432,7 +432,7 @@ file.end('world!');
 // Writing more now is not allowed!
 ```
 
-[`stream.end()`][stream-end] will call it's callback and emit `'error'`
+[`stream.end()`][stream-end] will call its callback and emit `'error'`
 with (in order of precedence):
 * `ERR_STREAM_WRITE_AFTER_END` if `chunk` is not nully and
 [`stream.end()`][stream-end] has been called.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -639,7 +639,7 @@ with (in order of precedence):
   called.
 * `ERR_STREAM_NULL_VALUES` if `chunk` is `null`.
 * `ERR_INVALID_ARG_TYPE` if `chunk` is not a `string` when not in `objectMode`.
-* Any error forwarded by `writable._write()`.
+* Any error forwarded from `writable._write()` or `writable._writev()`.
 
 ### Readable Streams
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -435,15 +435,15 @@ file.end('world!');
 [`stream.end()`][stream-end] will call its callback and emit `'error'`
 with (in order of precedence):
 * `ERR_STREAM_WRITE_AFTER_END` if `chunk` is not nully and
-[`stream.end()`][stream-end] has been called.
+ [`stream.end()`][stream-end] has been called.
 * `ERR_STREAM_DESTROYED` if `chunk` is not nully and
-[`stream.destroy()`][writable-destroy] has been called.
+ [`stream.destroy()`][writable-destroy] has been called.
 * `ERR_INVALID_ARG_TYPE` if `chunk` is not nully and
-`chunk` is not a `string` when not in `objectMode`.
+ `chunk` is not a `string` when not in `objectMode`.
 * `ERR_STREAM_ALREADY_FINISHED` if
-[`writable.writableFinished`][] is `true`.
+ [`writable.writableFinished`][] is `true`.
 * Any error emitted by the instance through `'error'` before
-[`writable.writableFinished`][] is set to `true`.
+ [`writable.writableFinished`][] is set to `true`.
 
 ##### writable.setDefaultEncoding(encoding)
 <!-- YAML
@@ -632,7 +632,7 @@ write('hello', () => {
 
 A `Writable` stream in object mode will always ignore the `encoding` argument.
 
-`stream.write()`  will call it's callback and emit `'error'`
+[`stream.write()`][stream-write] will call its callback and emit `'error'`
 with (in order of precedence):
 * `ERR_STREAM_WRITE_AFTER_END` if [`stream.end()`][stream-end] has been called.
 * `ERR_STREAM_DESTROYED` if [`stream.destroy()`][writable-destroy] has been

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -633,7 +633,8 @@ A `Writable` stream in object mode will always ignore the `encoding` argument.
 
 `stream.write()` will error with (in order of precedence):
 * `ERR_STREAM_WRITE_AFTER_END` if [`stream.end()`][stream-end] has been called.
-* `ERR_STREAM_DESTROYED` if [`stream.destroy()`][writable-destroy] has been called.
+* `ERR_STREAM_DESTROYED` if [`stream.destroy()`][writable-destroy] has been
+  called.
 * `ERR_STREAM_NULL_VALUES` if `chunk` is `null`.
 * `ERR_INVALID_ARG_TYPE` if `chunk` is not a `string` when not in `objectMode`.
 * Any error forwarded by `writable._write()`.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -436,13 +436,13 @@ file.end('world!');
 * `ERR_STREAM_WRITE_AFTER_END` if `chunk` is not nully and
 [`stream.end()`][stream-end] has been called.
 * `ERR_STREAM_DESTROYED` if `chunk` is not nully and
-[`stream.destroy()`][stream-destroy] has been called.
+[`stream.destroy()`][writable-destroy] has been called.
 * `ERR_INVALID_ARG_TYPE` if `chunk` is not nully and
 `chunk` is not a `string` when not in `objectMode`.
 * `ERR_STREAM_ALREADY_FINISHED` if
-[`writable.writableFinished`][].
+[`writable.writableFinished`][] is `true`.
 * Any error emitted by the instance through `'error'` before
-[`writable.writableFinished`][].
+[`writable.writableFinished`][] is set to `true`.
 
 ##### writable.setDefaultEncoding(encoding)
 <!-- YAML
@@ -633,7 +633,7 @@ A `Writable` stream in object mode will always ignore the `encoding` argument.
 
 `stream.write()` will error with (in order of precedence):
 * `ERR_STREAM_WRITE_AFTER_END` if [`stream.end()`][stream-end] has been called.
-* `ERR_STREAM_DESTROYED` if [`stream.destroy()`][stream-destroy] has been called.
+* `ERR_STREAM_DESTROYED` if [`stream.destroy()`][writable-destroy] has been called.
 * `ERR_STREAM_NULL_VALUES` if `chunk` is `null`.
 * `ERR_INVALID_ARG_TYPE` if `chunk` is not a `string` when not in `objectMode`.
 * Any error forwarded by `writable._write()`.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -432,6 +432,18 @@ file.end('world!');
 // Writing more now is not allowed!
 ```
 
+[`stream.end()`][stream-end] will error with (in order of precedence):
+* `ERR_STREAM_WRITE_AFTER_END` if `chunk` is not nully and
+[`stream.end()`][stream-end] has been called.
+* `ERR_STREAM_DESTROYED` if `chunk` is not nully and
+[`stream.destroy()`][stream-destroy] has been called.
+* `ERR_INVALID_ARG_TYPE` if `chunk` is not nully and
+`chunk` is not a `string` when not in `objectMode`.
+* `ERR_STREAM_ALREADY_FINISHED` if
+[`writable.writableFinished`][].
+* Any error emitted by the instance through `'error'` before
+[`writable.writableFinished`][].
+
 ##### writable.setDefaultEncoding(encoding)
 <!-- YAML
 added: v0.11.15
@@ -618,6 +630,13 @@ write('hello', () => {
 ```
 
 A `Writable` stream in object mode will always ignore the `encoding` argument.
+
+`stream.write()` will error with (in order of precedence):
+* `ERR_STREAM_WRITE_AFTER_END` if [`stream.end()`][stream-end] has been called.
+* `ERR_STREAM_DESTROYED` if [`stream.destroy()`][stream-destroy] has been called.
+* `ERR_STREAM_NULL_VALUES` if `chunk` is `null`.
+* `ERR_INVALID_ARG_TYPE` if `chunk` is not a `string` when not in `objectMode`.
+* Any error forwarded by `writable._write()`.
 
 ### Readable Streams
 


### PR DESCRIPTION
Documents the error modes of `Writable`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
