### PR TITLE
test: writable.write arg type

### DIFF
--- a/test/parallel/test-stream-writable-invalid-chunk.js
+++ b/test/parallel/test-stream-writable-invalid-chunk.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const common = require('../common');
+const stream = require('stream');
+
+function testWriteType(val, objectMode, code) {
+  const writable = new stream.Writable({
+    objectMode,
+    write: () => {}
+  });
+  if (!code) {
+    writable.on('error', common.mustNotCall());
+  } else {
+    writable.on('error', common.expectsError({
+      code: code,
+    }));
+  }
+  writable.write(val);
+}
+
+testWriteType([], false, 'ERR_INVALID_ARG_TYPE');
+testWriteType({}, false, 'ERR_INVALID_ARG_TYPE');
+testWriteType(0, false, 'ERR_INVALID_ARG_TYPE');
+testWriteType(true, false, 'ERR_INVALID_ARG_TYPE');
+testWriteType(0.0, false, 'ERR_INVALID_ARG_TYPE');
+testWriteType(undefined, false, 'ERR_INVALID_ARG_TYPE');
+testWriteType(null, false, 'ERR_STREAM_NULL_VALUES');
+
+testWriteType([], true);
+testWriteType({}, true);
+testWriteType(0, true);
+testWriteType(true, true);
+testWriteType(0.0, true);
+testWriteType(undefined, true);
+testWriteType(null, true, 'ERR_STREAM_NULL_VALUES');


### PR DESCRIPTION
Adds some test for passing invalid args to `Writable.write`

This basically ports some test from `Readable.push`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
