### PR TITLE
stream: always invoke end(cb) callback

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -606,6 +606,11 @@ Writable.prototype.end = function(chunk, encoding, cb) {
   else if (typeof cb === 'function') {
     if (!state.finished) {
       this.once('finish', cb);
+      this.once('error', (err) => {
+        if (!state.finished) {
+          cb(err);
+        }
+      });
     } else {
       cb(new ERR_STREAM_ALREADY_FINISHED('end'));
     }
@@ -682,10 +687,16 @@ function endWritable(stream, state, cb) {
   state.ending = true;
   finishMaybe(stream, state);
   if (cb) {
-    if (state.finished)
+    if (state.finished) {
       process.nextTick(cb);
-    else
+    } else {
       stream.once('finish', cb);
+      stream.once('error', (err) => {
+        if (!state.finished) {
+          cb(err);
+        }
+      });
+    }
   }
   state.ended = true;
   stream.writable = false;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -602,9 +602,9 @@ Writable.prototype.end = function(chunk, encoding, cb) {
   }
 
   // Ignore unnecessary end() calls.
-  if (!state.ending)
+  if (!state.ending) {
     endWritable(this, state, cb);
-  else if (typeof cb === 'function') {
+  } else if (typeof cb === 'function') {
     if (!state.finished) {
       onFinished(this, state, cb);
     } else {
@@ -683,12 +683,10 @@ function endWritable(stream, state, cb) {
   state.ending = true;
   finishMaybe(stream, state);
   if (cb) {
-    if (state.finished) {
-      // TODO(ronag): finished before end should be an error.
+    if (state.finished)
       process.nextTick(cb);
-    } else {
+    else
       onFinished(stream, state, cb);
-    }
   }
   state.ended = true;
   stream.writable = false;
@@ -709,6 +707,14 @@ function onCorkedFinish(corkReq, state, err) {
 }
 
 function onFinished(stream, state, cb) {
+  if (state.destroyed && state.errorEmitted) {
+    // TODO(ronag): Backwards compat. Should be moved to end() without
+    // errorEmitted check and with errorOrDestroy.
+    const err = new ERR_STREAM_DESTROYED('end');
+    process.nextTick(cb, err);
+    return;
+  }
+
   function onerror(err) {
     stream.removeListener('finish', onfinish);
     stream.removeListener('error', onerror);

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -722,8 +722,8 @@ function onFinished(stream, state, cb) {
     stream.removeListener('error', onerror);
     cb();
   }
-  stream.once('finish', onfinish);
-  stream.once('error', onerror);
+  stream.on('finish', onfinish);
+  stream.on('error', onerror);
 }
 
 Object.defineProperty(Writable.prototype, 'destroyed', {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -709,7 +709,7 @@ function onCorkedFinish(corkReq, state, err) {
 }
 
 function onFinished(stream, state, cb) {
-  function onerror (err) {
+  function onerror(err) {
     stream.removeListener('finish', onfinish);
     stream.removeListener('error', onerror);
     cb(err);
@@ -717,7 +717,7 @@ function onFinished(stream, state, cb) {
       stream.emit('error', err);
     }
   }
-  function onfinish () {
+  function onfinish() {
     stream.removeListener('finish', onfinish);
     stream.removeListener('error', onerror);
     cb();

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -30,7 +30,6 @@ const { Object } = primordials;
 module.exports = Writable;
 Writable.WritableState = WritableState;
 
-const EE = require('events');
 const internalUtil = require('internal/util');
 const Stream = require('stream');
 const { Buffer } = require('buffer');
@@ -719,7 +718,7 @@ function onFinished(stream, state, cb) {
     stream.removeListener('finish', onfinish);
     stream.removeListener('error', onerror);
     cb(err);
-    if (EE.listenerCount(stream, 'error') === 0) {
+    if (stream.listenerCount('error') === 0) {
       stream.emit('error', err);
     }
   }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -30,6 +30,7 @@ const { Object } = primordials;
 module.exports = Writable;
 Writable.WritableState = WritableState;
 
+const EE = require('events');
 const internalUtil = require('internal/util');
 const Stream = require('stream');
 const { Buffer } = require('buffer');
@@ -605,12 +606,7 @@ Writable.prototype.end = function(chunk, encoding, cb) {
     endWritable(this, state, cb);
   else if (typeof cb === 'function') {
     if (!state.finished) {
-      this.once('finish', cb);
-      this.once('error', (err) => {
-        if (!state.finished) {
-          cb(err);
-        }
-      });
+      onFinished(this, state, cb);
     } else {
       cb(new ERR_STREAM_ALREADY_FINISHED('end'));
     }
@@ -688,14 +684,10 @@ function endWritable(stream, state, cb) {
   finishMaybe(stream, state);
   if (cb) {
     if (state.finished) {
+      // TODO(ronag): finished before end should be an error.
       process.nextTick(cb);
     } else {
-      stream.once('finish', cb);
-      stream.once('error', (err) => {
-        if (!state.finished) {
-          cb(err);
-        }
-      });
+      onFinished(stream, state, cb);
     }
   }
   state.ended = true;
@@ -714,6 +706,24 @@ function onCorkedFinish(corkReq, state, err) {
 
   // Reuse the free corkReq.
   state.corkedRequestsFree.next = corkReq;
+}
+
+function onFinished(stream, state, cb) {
+  function onerror (err) {
+    stream.removeListener('finish', onfinish);
+    stream.removeListener('error', onerror);
+    cb(err);
+    if (EE.listenerCount(stream, 'error') === 0) {
+      stream.emit('error', err);
+    }
+  }
+  function onfinish () {
+    stream.removeListener('finish', onfinish);
+    stream.removeListener('error', onerror);
+    cb();
+  }
+  stream.once('finish', onfinish);
+  stream.once('error', onerror);
 }
 
 Object.defineProperty(Writable.prototype, 'destroyed', {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -727,7 +727,7 @@ function onFinished(stream, state, cb) {
     stream.removeListener('error', onerror);
     cb();
   }
-  stream.prependListener('finish', onfinish);
+  stream.on('finish', onfinish);
   stream.prependListener('error', onerror);
 }
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -727,8 +727,8 @@ function onFinished(stream, state, cb) {
     stream.removeListener('error', onerror);
     cb();
   }
-  stream.on('finish', onfinish);
-  stream.on('error', onerror);
+  stream.prependListener('finish', onfinish);
+  stream.prependListener('error', onerror);
 }
 
 Object.defineProperty(Writable.prototype, 'destroyed', {

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -292,3 +292,39 @@ const assert = require('assert');
   }));
   write.uncork();
 }
+
+{
+  // Call end(cb) after error & destroy
+
+  const write = new Writable({
+    write(chunk, enc, cb) { cb(new Error('asd')); }
+  });
+  write.on('error', common.mustCall(() => {
+    write.destroy();
+    let ticked = false;
+    write.end(common.mustCall((err) => {
+      assert.strictEqual(ticked, true);
+      assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+    }));
+    ticked = true;
+  }));
+  write.write('asd');
+}
+
+{
+  // Call end(cb) after finish & destroy
+
+  const write = new Writable({
+    write(chunk, enc, cb) { cb(); }
+  });
+  write.on('finish', common.mustCall(() => {
+    write.destroy();
+    let ticked = false;
+    write.end(common.mustCall((err) => {
+      assert.strictEqual(ticked, false);
+      assert.strictEqual(err.code, 'ERR_STREAM_ALREADY_FINISHED');
+    }));
+    ticked = true;
+  }));
+  write.end();
+}

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -328,3 +328,19 @@ const assert = require('assert');
   }));
   write.end();
 }
+
+{
+  // Call end(cb) after error & destroy and don't trigger
+  // unhandled exception.
+
+  const write = new Writable({
+    write(chunk, enc, cb) { process.nextTick(cb); }
+  });
+  write.once('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'asd');
+  }));
+  write.end('asd', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'asd');
+  }));
+  write.destroy(new Error('asd'));
+}

--- a/test/parallel/test-stream-writable-end-cb-error.js
+++ b/test/parallel/test-stream-writable-end-cb-error.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const stream = require('stream');
+
+{
+  // Invoke end callback on failure.
+  const writable = new stream.Writable();
+
+  writable._write = (chunk, encoding, cb) => {
+    process.nextTick(cb, new Error('kaboom'));
+  };
+
+  writable.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'kaboom');
+  }));
+  writable.write('asd');
+  writable.end(common.mustCall((err) => {
+    assert.strictEqual(err.message, 'kaboom');
+  }));
+  writable.end(common.mustCall((err) => {
+    assert.strictEqual(err.message, 'kaboom');
+  }));
+}
+
+{
+  // Don't invoke end callback twice
+  const writable = new stream.Writable();
+
+  writable._write = (chunk, encoding, cb) => {
+    process.nextTick(cb);
+  };
+
+  let called = false;
+  writable.end('asd', common.mustCall((err) => {
+    called = true;
+    assert.strictEqual(err, undefined);
+  }));
+
+  writable.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'kaboom');
+  }));
+  writable.on('finish', common.mustCall(() => {
+    assert.strictEqual(called, true);
+    writable.emit('error', new Error('kaboom'));
+  }));
+}

--- a/test/parallel/test-stream-writable-end-cb-uncaugth.js
+++ b/test/parallel/test-stream-writable-end-cb-uncaugth.js
@@ -14,8 +14,8 @@ writable._write = (chunk, encoding, cb) => {
   cb();
 };
 writable._final = (cb) => {
-  cb(new Error('kaboom'))
-}
+  cb(new Error('kaboom'));
+};
 
 writable.write('asd');
 writable.end(common.mustCall((err) => {

--- a/test/parallel/test-stream-writable-end-cb-uncaugth.js
+++ b/test/parallel/test-stream-writable-end-cb-uncaugth.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const stream = require('stream');
+
+process.on('uncaughtException', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'kaboom');
+}));
+
+const writable = new stream.Writable();
+
+writable._write = (chunk, encoding, cb) => {
+  cb();
+};
+writable._final = (cb) => {
+  cb(new Error('kaboom'))
+}
+
+writable.write('asd');
+writable.end(common.mustCall((err) => {
+  assert.strictEqual(err.message, 'kaboom');
+}));


### PR DESCRIPTION
Ensure that the callback passed into end() is always invoked in order to avoid bug such as deadlock the user.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
