### PR TITLE
degs: fix typo in v8 readme

### DIFF
--- a/deps/v8/README.md
+++ b/deps/v8/README.md
@@ -5,8 +5,8 @@ V8 is Google's open source JavaScript engine.
 
 V8 implements ECMAScript as specified in ECMA-262.
 
-V8 is written in C++ and is used in Google Chrome, the open source
-browser from Google.
+V8 is written in C++ and is used in Chromium, the open source
+version of Google's webbrowser Chrome.
 
 V8 can run standalone, or can be embedded into any C++ application.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passe
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Fixed minor typo/mistake in v8/README.md, Chromium is Google's open source browser, not Chrome.