### PR TITLE
cli: rename --loader to --experimental-loader

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -368,12 +368,13 @@ Specify ways of the inspector web socket url exposure.
 By default inspector websocket url is available in stderr and under `/json/list`
 endpoint on `http://host:port/json/list`.
 
-### `--loader=file`
+### `--experimental-loader=module`
 <!-- YAML
 added: v9.0.0
 -->
 
-Specify the `file` of the custom [experimental ECMAScript Module][] loader.
+Specify the `module` of a custom [experimental ECMAScript Module][] loader.
+`module` may be either a path to a file, or an ECMAScript Module name.
 
 ### `--max-http-header-size=size`
 <!-- YAML
@@ -981,6 +982,7 @@ Node.js options that are allowed are:
 * `--enable-fips`
 * `--es-module-specifier-resolution`
 * `--experimental-exports`
+* `--experimental-loader`
 * `--experimental-modules`
 * `--experimental-policy`
 * `--experimental-repl-await`
@@ -998,7 +1000,6 @@ Node.js options that are allowed are:
 * `--inspect-port`, `--debug-port`
 * `--inspect-publish-uid`
 * `--inspect`
-* `--loader`
 * `--max-http-header-size`
 * `--napi-modules`
 * `--no-deprecation`

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -632,7 +632,7 @@ would provide the exports interface for the instantiation of `module.wasm`.
 <!-- type=misc -->
 
 To customize the default module resolution, loader hooks can optionally be
-provided via a `--loader ./loader-name.mjs` argument to Node.js.
+provided via a `--experimental-loader ./loader-name.mjs` argument to Node.js.
 
 When hooks are used they only apply to ES module loading and not to any
 CommonJS modules loaded.
@@ -731,7 +731,7 @@ export async function resolve(specifier,
 With this loader, running:
 
 ```console
-NODE_OPTIONS='--experimental-modules --loader ./custom-loader.mjs' node x.js
+NODE_OPTIONS='--experimental-modules --experimental-loader ./custom-loader.mjs' node x.js
 ```
 
 would load the module `x.js` as an ES module with relative resolution support

--- a/doc/node.1
+++ b/doc/node.1
@@ -191,9 +191,9 @@ Default is
 V8 Inspector integration allows attaching Chrome DevTools and IDEs to Node.js instances for debugging and profiling.
 It uses the Chrome DevTools Protocol.
 .
-.It Fl -loader Ns = Ns Ar file
+.It Fl -experimental-loader Ns = Ns Ar module
 Specify the
-.Ar file
+.Ar module
 as a custom loader, to load
 .Fl -experimental-modules .
 .

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -400,12 +400,12 @@ function initializeESMLoader() {
     // track of for different ESM modules.
     setInitializeImportMetaObjectCallback(esm.initializeImportMetaObject);
     setImportModuleDynamicallyCallback(esm.importModuleDynamicallyCallback);
-    const userLoader = getOptionValue('--loader');
-    // If --loader is specified, create a loader with user hooks. Otherwise
-    // create the default loader.
+    const userLoader = getOptionValue('--experimental-loader');
+    // If --experimental-loader is specified, create a loader with user hooks.
+    // Otherwise create the default loader.
     if (userLoader) {
       const { emitExperimentalWarning } = require('internal/util');
-      emitExperimentalWarning('--loader');
+      emitExperimentalWarning('--experimental-loader');
     }
     esm.initializeLoader(process.cwd(), userLoader);
   }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -114,7 +114,8 @@ void PerIsolateOptions::CheckOptions(std::vector<std::string>* errors) {
 
 void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
   if (!userland_loader.empty() && !experimental_modules) {
-    errors->push_back("--loader requires --experimental-modules be enabled");
+    errors->push_back("--experimental-loader requires "
+                      "--experimental-modules be enabled");
   }
   if (has_policy_integrity_string && experimental_policy.empty()) {
     errors->push_back("--policy-integrity requires "
@@ -311,6 +312,12 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental support for exports in package.json",
             &EnvironmentOptions::experimental_exports,
             kAllowedInEnvironment);
+  AddOption("--experimental-loader",
+            "(with --experimental-modules) use the specified file as a "
+            "custom loader",
+            &EnvironmentOptions::userland_loader,
+            kAllowedInEnvironment);
+  AddAlias("--loader", "--experimental-loader");
   AddOption("--experimental-modules",
             "experimental ES Module support and caching modules",
             &EnvironmentOptions::experimental_modules,
@@ -362,11 +369,6 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--input-type",
             "set module type for string input",
             &EnvironmentOptions::module_type,
-            kAllowedInEnvironment);
-  AddOption("--loader",
-            "(with --experimental-modules) use the specified file as a "
-            "custom loader",
-            &EnvironmentOptions::userland_loader,
             kAllowedInEnvironment);
   AddOption("--es-module-specifier-resolution",
             "Select extension resolution algorithm for es modules; "

--- a/test/es-module/test-esm-example-loader.js
+++ b/test/es-module/test-esm-example-loader.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/example-loader.mjs
+// Flags: --experimental-modules --experimental-loader ./test/fixtures/es-module-loaders/example-loader.mjs
 /* eslint-disable node-core/require-common-first, node-core/required-modules */
 import assert from 'assert';
 import ok from '../fixtures/es-modules/test-esm-ok.mjs';

--- a/test/es-module/test-esm-loader-dependency.mjs
+++ b/test/es-module/test-esm-loader-dependency.mjs
@@ -1,4 +1,4 @@
-// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-with-dep.mjs
+// Flags: --experimental-modules --experimental-loader ./test/fixtures/es-module-loaders/loader-with-dep.mjs
 /* eslint-disable node-core/require-common-first, node-core/required-modules */
 import '../fixtures/es-modules/test-esm-ok.mjs';
 

--- a/test/es-module/test-esm-loader-invalid-format.mjs
+++ b/test/es-module/test-esm-loader-invalid-format.mjs
@@ -1,4 +1,4 @@
-// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-invalid-format.mjs
+// Flags: --experimental-modules --experimental-loader ./test/fixtures/es-module-loaders/loader-invalid-format.mjs
 import { expectsError, mustCall } from '../common/index.mjs';
 import assert from 'assert';
 

--- a/test/es-module/test-esm-loader-invalid-url.mjs
+++ b/test/es-module/test-esm-loader-invalid-url.mjs
@@ -1,4 +1,4 @@
-// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-invalid-url.mjs
+// Flags: --experimental-modules --experimental-loader ./test/fixtures/es-module-loaders/loader-invalid-url.mjs
 import { expectsError, mustCall } from '../common/index.mjs';
 import assert from 'assert';
 

--- a/test/es-module/test-esm-loader-missing-dynamic-instantiate-hook.mjs
+++ b/test/es-module/test-esm-loader-missing-dynamic-instantiate-hook.mjs
@@ -1,4 +1,4 @@
-// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/missing-dynamic-instantiate-hook.mjs
+// Flags: --experimental-modules --experimental-loader ./test/fixtures/es-module-loaders/missing-dynamic-instantiate-hook.mjs
 import { expectsError } from '../common/index.mjs';
 
 import('test').catch(expectsError({

--- a/test/es-module/test-esm-named-exports.mjs
+++ b/test/es-module/test-esm-named-exports.mjs
@@ -1,4 +1,4 @@
-// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
+// Flags: --experimental-modules --experimental-loader ./test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
 import '../common/index.mjs';
 import { readFile } from 'fs';
 import assert from 'assert';

--- a/test/es-module/test-esm-preserve-symlinks-not-found-plain.mjs
+++ b/test/es-module/test-esm-preserve-symlinks-not-found-plain.mjs
@@ -1,3 +1,3 @@
-// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/not-found-assert-loader.mjs
+// Flags: --experimental-modules --experimental-loader ./test/fixtures/es-module-loaders/not-found-assert-loader.mjs
 /* eslint-disable node-core/require-common-first, node-core/required-modules */
 import './not-found.js';

--- a/test/es-module/test-esm-preserve-symlinks-not-found.mjs
+++ b/test/es-module/test-esm-preserve-symlinks-not-found.mjs
@@ -1,3 +1,3 @@
-// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/not-found-assert-loader.mjs
+// Flags: --experimental-modules --experimental-loader ./test/fixtures/es-module-loaders/not-found-assert-loader.mjs
 /* eslint-disable node-core/require-common-first, node-core/required-modules */
 import './not-found.mjs';

--- a/test/es-module/test-esm-resolve-hook.mjs
+++ b/test/es-module/test-esm-resolve-hook.mjs
@@ -1,4 +1,4 @@
-// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/js-loader.mjs
+// Flags: --experimental-modules --experimental-loader ./test/fixtures/es-module-loaders/js-loader.mjs
 /* eslint-disable node-core/require-common-first, node-core/required-modules */
 import { namedExport } from '../fixtures/es-module-loaders/js-as-esm.js';
 import assert from 'assert';

--- a/test/es-module/test-esm-shared-loader-dep.mjs
+++ b/test/es-module/test-esm-shared-loader-dep.mjs
@@ -1,4 +1,4 @@
-// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-shared-dep.mjs
+// Flags: --experimental-modules --experimental-loader ./test/fixtures/es-module-loaders/loader-shared-dep.mjs
 import { createRequire } from '../common/index.mjs';
 
 import assert from 'assert';

--- a/test/parallel/test-loaders-unknown-builtin-module.mjs
+++ b/test/parallel/test-loaders-unknown-builtin-module.mjs
@@ -1,4 +1,4 @@
-// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-unknown-builtin-module.mjs
+// Flags: --experimental-modules --experimental-loader ./test/fixtures/es-module-loaders/loader-unknown-builtin-module.mjs
 import { expectsError, mustCall } from '../common/index.mjs';
 import assert from 'assert';
 

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -87,6 +87,7 @@ const undocumented = difference(process.allowedNodeEnvironmentFlags,
 assert(undocumented.delete('--debug-arraybuffer-allocations'));
 assert(undocumented.delete('--experimental-worker'));
 assert(undocumented.delete('--no-node-snapshot'));
+assert(undocumented.delete('--loader'));
 
 assert.strictEqual(undocumented.size, 0,
                    'The following options are not documented as allowed in ' +


### PR DESCRIPTION
Renames the `--loader` cli argument to `--experimental-loader`.  This is
to clearly indicate the esm loader feature as experimental even after
esm is no longer experimental.

Also minorly alters the `--experimental-loader` docs to say that the
passed loader can be an esm module.

An alternative to this PR is to leave things unchanged and continue to use `--experimental-modules` to allow the use of `--loader`, even after ECMAScript modules are unflagged. This would reduce the number of different argument schemes a hypothetical script that wraps node would need to try, as discussed here: https://github.com/nodejs/modules/issues/351#issuecomment-535605423

Refs: https://github.com/nodejs/modules/issues/351#issuecomment-535189524

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
