### PR TITLE
module: Revert remove experimental status from JSON modules

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -989,6 +989,7 @@ Node.js options that are allowed are:
 * `--enable-fips`
 * `--es-module-specifier-resolution`
 * `--experimental-exports`
+* `--experimental-json-modules`
 * `--experimental-loader`
 * `--experimental-modules`
 * `--experimental-policy`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -156,6 +156,13 @@ added: v12.7.0
 
 Enable experimental resolution using the `exports` field in `package.json`.
 
+### `--experimental-json-modules`
+<!-- YAML
+added: v12.9.0
+-->
+
+Enable experimental JSON support for the ES Module loader.
+
 ### `--experimental-modules`
 <!-- YAML
 added: v8.5.0

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -587,8 +587,8 @@ fs.readFileSync === readFileSync;
 ## Experimental JSON Modules
 
 Currently importing JSON modules are only supported in the `commonjs` mode
-and are loaded using the CJS loader. [WHATWG JSON modules][] are currently
-being standardized, and are experimentally supported by including the
+and are loaded using the CJS loader. [WHATWG JSON modules specification][] are
+still being standardized, and are experimentally supported by including the
 additional flag `--experimental-json-modules` when running Node.js.
 
 When the `--experimental-json-modules` flag is included both the

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -584,11 +584,16 @@ fs.readFileSync = () => Buffer.from('Hello, ESM');
 fs.readFileSync === readFileSync;
 ```
 
-## JSON Modules
+## Experimental JSON Modules
 
-JSON modules follow the [WHATWG JSON modules specification][].
+Currently importing JSON modules are only supported in the `commonjs` mode
+and are loaded using the CJS loader. [WHATWG JSON modules][] are currently
+being standardized, and are experimentally supported by including the
+additional flag `--experimental-json-modules` when running Node.js.
 
-The imported JSON only exposes a `default`. There is no
+When the `--experimental-json-modules` flag is included both the
+`commonjs` and `module` mode will use the new experimental JSON
+loader. The imported JSON only exposes a `default`, there is no
 support for named exports. A cache entry is created in the CommonJS
 cache, to avoid duplication. The same object will be returned in
 CommonJS if the JSON module has already been imported from the
@@ -599,6 +604,14 @@ Assuming an `index.mjs` with
 <!-- eslint-skip -->
 ```js
 import packageConfig from './package.json';
+```
+
+The `--experimental-json-modules` flag is needed for the module
+to work.
+
+```bash
+node --experimental-modules index.mjs # fails
+node --experimental-modules --experimental-json-modules index.mjs # works
 ```
 
 ## Experimental Wasm Modules

--- a/doc/node.1
+++ b/doc/node.1
@@ -108,6 +108,9 @@ Requires Node.js to be built with
 .It Fl -es-module-specifier-resolution
 Select extension resolution algorithm for ES Modules; either 'explicit' (default) or 'node'
 .
+.It Fl -experimental-json-modules
+Enable experimental JSON interop support for the ES Module loader.
+.
 .It Fl -experimental-modules
 Enable experimental ES module support and caching modules.
 .

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -8,6 +8,7 @@ const { getOptionValue } = require('internal/options');
 
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
+const experimentalJsonModules = getOptionValue('--experimental-json-modules');
 const typeFlag = getOptionValue('--input-type');
 const experimentalWasmModules = getOptionValue('--experimental-wasm-modules');
 const { resolve: moduleWrapResolve,
@@ -28,7 +29,6 @@ const extensionFormatMap = {
   '__proto__': null,
   '.cjs': 'commonjs',
   '.js': 'module',
-  '.json': 'json',
   '.mjs': 'module'
 };
 
@@ -36,13 +36,16 @@ const legacyExtensionFormatMap = {
   '__proto__': null,
   '.cjs': 'commonjs',
   '.js': 'commonjs',
-  '.json': 'json',
+  '.json': 'commonjs',
   '.mjs': 'module',
   '.node': 'commonjs'
 };
 
 if (experimentalWasmModules)
   extensionFormatMap['.wasm'] = legacyExtensionFormatMap['.wasm'] = 'wasm';
+
+if (experimentalJsonModules)
+  extensionFormatMap['.json'] = legacyExtensionFormatMap['.json'] = 'json';
 
 function resolve(specifier, parentURL) {
   try {

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -316,6 +316,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--experimental-exports",
             "experimental support for exports in package.json",
             &EnvironmentOptions::experimental_exports,
+            kAllowedInEnvironment);
   AddOption("--experimental-json-modules",
             "experimental JSON interop support for the ES Module loader",
             &EnvironmentOptions::experimental_json_modules,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -135,6 +135,11 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
     }
   }
 
+  if (experimental_json_modules && !experimental_modules) {
+    errors->push_back("--experimental-json-modules requires "
+                      "--experimental-modules be enabled");
+  }
+
   if (experimental_wasm_modules && !experimental_modules) {
     errors->push_back("--experimental-wasm-modules requires "
                       "--experimental-modules be enabled");
@@ -311,6 +316,9 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--experimental-exports",
             "experimental support for exports in package.json",
             &EnvironmentOptions::experimental_exports,
+  AddOption("--experimental-json-modules",
+            "experimental JSON interop support for the ES Module loader",
+            &EnvironmentOptions::experimental_json_modules,
             kAllowedInEnvironment);
   AddOption("--experimental-loader",
             "(with --experimental-modules) use the specified file as a "

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -101,6 +101,7 @@ class EnvironmentOptions : public Options {
  public:
   bool abort_on_uncaught_exception = false;
   bool experimental_exports = false;
+  bool experimental_json_modules = false;
   bool experimental_modules = false;
   std::string es_module_specifier_resolution;
   bool experimental_wasm_modules = false;

--- a/test/es-module/test-esm-json-cache.mjs
+++ b/test/es-module/test-esm-json-cache.mjs
@@ -1,4 +1,4 @@
-// Flags: --experimental-modules
+// Flags: --experimental-modules --experimental-json-modules
 import '../common/index.mjs';
 
 import { strictEqual, deepStrictEqual } from 'assert';

--- a/test/es-module/test-esm-json.mjs
+++ b/test/es-module/test-esm-json.mjs
@@ -1,5 +1,4 @@
-// Flags: --experimental-modules
-
+// Flags: --experimental-modules --experimental-json-modules
 import '../common/index.mjs';
 import { strictEqual } from 'assert';
 


### PR DESCRIPTION
This reverts commit ec8776da6fa77628e12718bb38cee687303d4137 from https://github.com/nodejs/node/pull/27752, adding back the `--experimental-json-modules` flag to reflect the fact that JSON modules are being reverted for web (https://github.com/whatwg/html/pull/4943) and should not be considered a stable feature.

Tracking issue at https://github.com/nodejs/modules/issues/391 with further information.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
