### PR TITLE
stream: make sure readable is called on empty chunk followed by eof

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -271,12 +271,12 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
       er = chunkInvalid(state, chunk);
     if (er) {
       errorOrDestroy(stream, er);
-    } else {
+    } else if (state.objectMode || chunk && chunk.length > 0) {
       if (typeof chunk !== 'string' &&
           !state.objectMode &&
           // Do not use Object.getPrototypeOf as it is slower since V8 7.3.
           !(chunk instanceof Buffer)) {
-        chunk = chunk ? Stream._uint8ArrayToBuffer(chunk) : Buffer.alloc(0);
+        chunk = Stream._uint8ArrayToBuffer(chunk);
       }
 
       if (addToFront) {
@@ -292,9 +292,19 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
         state.reading = false;
         if (state.decoder && !encoding) {
           chunk = state.decoder.write(chunk);
+          if (state.objectMode || chunk.length !== 0)
+            addChunk(stream, state, chunk, false);
+          else
+            maybeReadMore(stream, state);
+        } else {
+          addChunk(stream, state, chunk, false);
         }
-        addChunk(stream, state, chunk, false);
       }
+    } else if (!addToFront) {
+      state.reading = false;
+      if (state.needReadable)
+        emitReadable(stream);
+      maybeReadMore(stream, state);
     }
   }
 
@@ -306,27 +316,22 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
 }
 
 function addChunk(stream, state, chunk, addToFront) {
-  const len = state.objectMode ? 1 : chunk.length;
   if (state.flowing && state.length === 0 && !state.sync) {
-    if (len) {
-      // Use the guard to avoid creating `Set()` repeatedly
-      // when we have multiple pipes.
-      if (state.multiAwaitDrain) {
-        state.awaitDrainWriters.clear();
-      } else {
-        state.awaitDrainWriters = null;
-      }
-      stream.emit('data', chunk);
+    // Use the guard to avoid creating `Set()` repeatedly
+    // when we have multiple pipes.
+    if (state.multiAwaitDrain) {
+      state.awaitDrainWriters.clear();
+    } else {
+      state.awaitDrainWriters = null;
     }
+    stream.emit('data', chunk);
   } else {
-    if (len) {
-      // Update the buffer info.
-      state.length += len;
-      if (addToFront)
-        state.buffer.unshift(chunk);
-      else
-        state.buffer.push(chunk);
-    }
+    // Update the buffer info.
+    state.length += state.objectMode ? 1 : chunk.length;
+    if (addToFront)
+      state.buffer.unshift(chunk);
+    else
+      state.buffer.push(chunk);
 
     if (state.needReadable)
       emitReadable(stream);

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -271,12 +271,12 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
       er = chunkInvalid(state, chunk);
     if (er) {
       errorOrDestroy(stream, er);
-    } else if (state.objectMode || chunk && chunk.length > 0) {
+    } else {
       if (typeof chunk !== 'string' &&
           !state.objectMode &&
           // Do not use Object.getPrototypeOf as it is slower since V8 7.3.
           !(chunk instanceof Buffer)) {
-        chunk = Stream._uint8ArrayToBuffer(chunk);
+        chunk = chunk ? Stream._uint8ArrayToBuffer(chunk) : Buffer.alloc(0);
       }
 
       if (addToFront) {
@@ -292,17 +292,9 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
         state.reading = false;
         if (state.decoder && !encoding) {
           chunk = state.decoder.write(chunk);
-          if (state.objectMode || chunk.length !== 0)
-            addChunk(stream, state, chunk, false);
-          else
-            maybeReadMore(stream, state);
-        } else {
-          addChunk(stream, state, chunk, false);
         }
+        addChunk(stream, state, chunk, false);
       }
-    } else if (!addToFront) {
-      state.reading = false;
-      maybeReadMore(stream, state);
     }
   }
 
@@ -314,22 +306,27 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
 }
 
 function addChunk(stream, state, chunk, addToFront) {
+  const len = state.objectMode ? 1 : chunk.length;
   if (state.flowing && state.length === 0 && !state.sync) {
-    // Use the guard to avoid creating `Set()` repeatedly
-    // when we have multiple pipes.
-    if (state.multiAwaitDrain) {
-      state.awaitDrainWriters.clear();
-    } else {
-      state.awaitDrainWriters = null;
+    if (len) {
+      // Use the guard to avoid creating `Set()` repeatedly
+      // when we have multiple pipes.
+      if (state.multiAwaitDrain) {
+        state.awaitDrainWriters.clear();
+      } else {
+        state.awaitDrainWriters = null;
+      }
+      stream.emit('data', chunk);
     }
-    stream.emit('data', chunk);
   } else {
-    // Update the buffer info.
-    state.length += state.objectMode ? 1 : chunk.length;
-    if (addToFront)
-      state.buffer.unshift(chunk);
-    else
-      state.buffer.push(chunk);
+    if (len) {
+      // Update the buffer info.
+      state.length += len;
+      if (addToFront)
+        state.buffer.unshift(chunk);
+      else
+        state.buffer.push(chunk);
+    }
 
     if (state.needReadable)
       emitReadable(stream);
@@ -593,8 +590,11 @@ function emitReadable_(stream) {
   debug('emitReadable_', state.destroyed, state.length, state.ended);
   if (!state.destroyed && (state.length || state.ended)) {
     stream.emit('readable');
-    state.emittedReadable = false;
   }
+
+  // Reset emittedReadable once it is safe to schedule another
+  // emitReadable.
+  state.emittedReadable = false;
 
   // The stream needs another readable event if
   // 1. It is not flowing, as the flow mechanism will take

--- a/test/parallel/test-stream-duplex-empty-chunk.js
+++ b/test/parallel/test-stream-duplex-empty-chunk.js
@@ -9,6 +9,7 @@ serverSide.resume();
 serverSide.on('end', function(buf) {
   serverSide.write('out');
   serverSide.write('');
+  serverSide.write('');
   serverSide.end();
 });
 

--- a/test/parallel/test-stream-duplex-empty-chunk.js
+++ b/test/parallel/test-stream-duplex-empty-chunk.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../common');
+const makeDuplexPair = require('../common/duplexpair');
+
+const { clientSide, serverSide } = makeDuplexPair();
+
+serverSide.resume();
+serverSide.on('end', function(buf) {
+  serverSide.write('out');
+  serverSide.write('');
+  serverSide.end();
+});
+
+clientSide.end();
+
+clientSide.on('data', common.mustCall());
+clientSide.on('end', common.mustCall());

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -44,7 +44,7 @@ class TestReader extends R {
 }
 
 const reader = new TestReader();
-setImmediate(function() {
+process.nextTick(function() {
   assert.strictEqual(ondataCalled, 1);
   console.log('ok');
   reader.push(null);


### PR DESCRIPTION
An empty chunk should be treated like any other chunk and trigger the corresponding read logic.

Fixes: https://github.com/nodejs/node/issues/29758

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
