### PR TITLE
n-api: add `napi_detach_arraybuffer`

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -371,6 +371,8 @@ typedef enum {
   napi_closing,
   napi_bigint_expected,
   napi_date_expected,
+  napi_arraybuffer_expected,
+  napi_detachable_arraybuffer_expected,
 } napi_status;
 ```
 
@@ -3148,6 +3150,30 @@ Returns `napi_ok` if the API succeeded.
 This API represents the invocation of the Strict Equality algorithm as
 defined in [Section 7.2.14][] of the ECMAScript Language Specification.
 
+### napi_detach_arraybuffer
+<!-- YAML
+added: REPLACEME
+-->
+
+```C
+napi_status napi_detach_arraybuffer(napi_env env,
+                                    napi_value arraybuffer)
+```
+
+* `[in] env`: The environment that the API is invoked under.
+* `[in] arraybuffer`: The JavaScript `ArrayBuffer` to be detached.
+
+Returns `napi_ok` if the API succeeded. If a non-detachable `ArrayBuffer` is
+passed in it returns `napi_detachable_arraybuffer_expected`.
+
+Generally, an `ArrayBuffer` is non-detachable if it has been detached before.
+The engine may impose additional conditions on whether an `ArrayBuffer` is
+detachable. For example, V8 requires that the `ArrayBuffer` be external,
+that is, created with [`napi_create_external_arraybuffer`][].
+
+This API represents the invocation of the `ArrayBuffer` detach operation as
+defined in [Section 24.1.1.3][] of the ECMAScript Language Specification.
+
 ## Working with JavaScript Properties
 
 N-API exposes a set of APIs to get and set properties on JavaScript
@@ -5144,6 +5170,7 @@ This API may only be called from the main thread.
 [Section 22.1.4.1]: https://tc39.github.io/ecma262/#sec-properties-of-array-instances-length
 [Section 22.2]: https://tc39.github.io/ecma262/#sec-typedarray-objects
 [Section 24.1]: https://tc39.github.io/ecma262/#sec-arraybuffer-objects
+[Section 24.1.1.3]: https://tc39.es/ecma262/#sec-detacharraybuffer
 [Section 24.3]: https://tc39.github.io/ecma262/#sec-dataview-objects
 [Section 25.4]: https://tc39.github.io/ecma262/#sec-promise-objects
 [`Number.MIN_SAFE_INTEGER`]: https://tc39.github.io/ecma262/#sec-number.min_safe_integer

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -514,6 +514,10 @@ NAPI_EXTERN napi_status napi_set_instance_data(napi_env env,
 
 NAPI_EXTERN napi_status napi_get_instance_data(napi_env env,
                                                void** data);
+
+// ArrayBuffer detaching
+NAPI_EXTERN napi_status napi_detach_arraybuffer(napi_env env,
+                                                napi_value arraybuffer);
 #endif  // NAPI_EXPERIMENTAL
 
 EXTERN_C_END

--- a/src/js_native_api_types.h
+++ b/src/js_native_api_types.h
@@ -80,6 +80,8 @@ typedef enum {
   napi_closing,
   napi_bigint_expected,
   napi_date_expected,
+  napi_arraybuffer_expected,
+  napi_detachable_arraybuffer_expected,
 } napi_status;
 // Note: when adding a new enum value to `napi_status`, please also update
 // `const int last_status` in `napi_get_last_error_info()' definition,

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -665,6 +665,8 @@ const char* error_messages[] = {nullptr,
                                 "Thread-safe function handle is closing",
                                 "A bigint was expected",
                                 "A date was expected",
+                                "An arraybuffer was expected",
+                                "A detachable arraybuffer was expected",
 };
 
 napi_status napi_get_last_error_info(napi_env env,
@@ -676,7 +678,7 @@ napi_status napi_get_last_error_info(napi_env env,
   // message in the `napi_status` enum each time a new error message is added.
   // We don't have a napi_status_last as this would result in an ABI
   // change each time a message was added.
-  const int last_status = napi_date_expected;
+  const int last_status = napi_detachable_arraybuffer_expected;
 
   static_assert(
       NAPI_ARRAYSIZE(error_messages) == last_status + 1,
@@ -2994,6 +2996,25 @@ napi_status napi_get_instance_data(napi_env env,
   CHECK_ARG(env, data);
 
   *data = env->instance_data.data;
+
+  return napi_clear_last_error(env);
+}
+
+napi_status napi_detach_arraybuffer(napi_env env, napi_value arraybuffer) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, arraybuffer);
+
+  v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(arraybuffer);
+  RETURN_STATUS_IF_FALSE(
+      env, value->IsArrayBuffer(), napi_arraybuffer_expected);
+
+  v8::Local<v8::ArrayBuffer> it = value.As<v8::ArrayBuffer>();
+  RETURN_STATUS_IF_FALSE(
+      env, it->IsExternal(), napi_detachable_arraybuffer_expected);
+  RETURN_STATUS_IF_FALSE(
+      env, it->IsDetachable(), napi_detachable_arraybuffer_expected);
+
+  it->Detach();
 
   return napi_clear_last_error(env);
 }

--- a/test/js-native-api/test_typedarray/test.js
+++ b/test/js-native-api/test_typedarray/test.js
@@ -74,3 +74,21 @@ nonByteArrayTypes.forEach((currentType) => {
     console.log(`start of offset ${currentType}`);
   }, RangeError);
 });
+
+// Test detaching
+arrayTypes.forEach((currentType) => {
+  const buffer = Reflect.construct(currentType, [8]);
+  assert.throws(
+    () => test_typedarray.Detach(buffer),
+    /A detachable arraybuffer was expected/);
+});
+{
+  const buffer = test_typedarray.External();
+  assert.ok(externalResult instanceof Int8Array);
+  assert.strictEqual(externalResult.length, 3);
+  assert.strictEqual(externalResult.byteLength, 3);
+  test_typedarray.Detach(buffer);
+  assert.ok(externalResult instanceof Int8Array);
+  assert.strictEqual(buffer.length, 0);
+  assert.strictEqual(buffer.byteLength, 0);
+}

--- a/test/js-native-api/test_typedarray/test_typedarray.c
+++ b/test/js-native-api/test_typedarray/test_typedarray.c
@@ -1,3 +1,4 @@
+#define NAPI_EXPERIMENTAL
 #include <js_native_api.h>
 #include <string.h>
 #include "../common.h"
@@ -165,12 +166,30 @@ static napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
   return output_array;
 }
 
+static napi_value Detach(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments.");
+
+  bool is_typedarray;
+  NAPI_CALL(env, napi_is_typedarray(env, args[0], &is_typedarray));
+  NAPI_ASSERT(env, is_typedarray, "Wrong type of arguments. Expects a typedarray as first argument.");
+
+  napi_value arraybuffer;
+  NAPI_CALL(env, napi_get_typedarray_info(env, args[0], NULL, NULL, NULL, &arraybuffer, NULL));
+  NAPI_CALL(env, napi_detach_arraybuffer(env, arraybuffer));
+
+  return NULL;
+}
+
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("Multiply", Multiply),
     DECLARE_NAPI_PROPERTY("External", External),
     DECLARE_NAPI_PROPERTY("CreateTypedArray", CreateTypedArray),
+    DECLARE_NAPI_PROPERTY("Detach", Detach),
   };
 
   NAPI_CALL(env, napi_define_properties(


### PR DESCRIPTION
As ArrayBuffer#detach is an ecma spec operation ([Section 24.1.1.3](https://tc39.es/ecma262/#sec-detacharraybuffer)), it might be good to have it in N-API.

Fixes https://github.com/nodejs/node/issues/29674

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
