### PR TITLE
doc: fix process.ppid 'added in' info

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1637,7 +1637,10 @@ Android operating system. However, Android support in Node.js
 
 ## process.ppid
 <!-- YAML
-added: v9.2.0
+added:
+  - v9.2.0
+  - v8.10.0
+  - v6.13.0
 -->
 
 * {integer}


### PR DESCRIPTION
The PR #16839 originally landed in v9.2.0 but was later backported to v8.10.0 and 6.13.0.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)