### PR TITLE
vm: SourceTextModule refactor

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1984,11 +1984,6 @@ than the parent module. Linked modules must share the same context.
 
 The linker function returned a module for which linking has failed.
 
-<a id="ERR_VM_MODULE_NOT_LINKED"></a>
-### ERR_VM_MODULE_NOT_LINKED
-
-The module must be successfully linked before instantiation.
-
 <a id="ERR_VM_MODULE_NOT_MODULE"></a>
 ### ERR_VM_MODULE_NOT_MODULE
 
@@ -2274,6 +2269,11 @@ removed: v10.0.0
 -->
 
 Used when a given value is out of the accepted range.
+
+<a id="ERR_VM_MODULE_NOT_LINKED"></a>
+### ERR_VM_MODULE_NOT_LINKED
+
+The module must be successfully linked before instantiation.
 
 <a id="ERR_ZLIB_BINDING_CLOSED"></a>
 ### ERR_ZLIB_BINDING_CLOSED

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1211,8 +1211,6 @@ E('ERR_VM_MODULE_DIFFERENT_CONTEXT',
   'Linked modules must use the same context', Error);
 E('ERR_VM_MODULE_LINKING_ERRORED',
   'Linking has already failed for the provided module', Error);
-E('ERR_VM_MODULE_NOT_LINKED',
-  'Module must be linked before it can be instantiated', Error);
 E('ERR_VM_MODULE_NOT_MODULE',
   'Provided module is not an instance of Module', Error);
 E('ERR_VM_MODULE_STATUS', 'Module status %s', Error);

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -127,7 +127,7 @@ class Loader {
     this.moduleMap.set(url, job);
     const { module, result } = await job.run();
     return {
-      namespace: module.namespace(),
+      namespace: module.getNamespace(),
       result
     };
   }
@@ -135,7 +135,7 @@ class Loader {
   async import(specifier, parent) {
     const job = await this.getModuleJob(specifier, parent);
     const { module } = await job.run();
-    return module.namespace();
+    return module.getNamespace();
   }
 
   hook({ resolve, dynamicInstantiate }) {

--- a/lib/internal/vm/source_text_module.js
+++ b/lib/internal/vm/source_text_module.js
@@ -3,14 +3,12 @@
 const { Object, SafePromise } = primordials;
 
 const { isModuleNamespaceObject } = require('internal/util/types');
-const { URL } = require('internal/url');
 const { isContext } = internalBinding('contextify');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_VM_MODULE_ALREADY_LINKED,
   ERR_VM_MODULE_DIFFERENT_CONTEXT,
   ERR_VM_MODULE_LINKING_ERRORED,
-  ERR_VM_MODULE_NOT_LINKED,
   ERR_VM_MODULE_NOT_MODULE,
   ERR_VM_MODULE_STATUS,
 } = require('internal/errors').codes;
@@ -22,7 +20,7 @@ const {
 const {
   validateInt32,
   validateUint32,
-  validateString
+  validateString,
 } = require('internal/validators');
 
 const binding = internalBinding('module_wrap');
@@ -37,29 +35,33 @@ const {
 } = binding;
 
 const STATUS_MAP = {
-  [kUninstantiated]: 'uninstantiated',
-  [kInstantiating]: 'instantiating',
-  [kInstantiated]: 'instantiated',
+  [kUninstantiated]: 'unlinked',
+  [kInstantiating]: 'linking',
+  [kInstantiated]: 'linked',
   [kEvaluating]: 'evaluating',
   [kEvaluated]: 'evaluated',
   [kErrored]: 'errored',
 };
 
 let globalModuleId = 0;
-const perContextModuleId = new WeakMap();
-const wrapMap = new WeakMap();
-const dependencyCacheMap = new WeakMap();
-const linkingStatusMap = new WeakMap();
-// ModuleWrap -> vm.SourceTextModule
-const wrapToModuleMap = new WeakMap();
 const defaultModuleName = 'vm:module';
+const perContextModuleId = new WeakMap();
+const wrapToModuleMap = new WeakMap();
 
-// TODO(devsnek): figure out AbstractModule class or protocol
+const kNoError = Symbol('kNoError');
+
 class SourceTextModule {
-  constructor(src, options = {}) {
+  #wrap;
+  #identifier;
+  #context;
+  #dependencySpecifiers;
+  #statusOverride;
+  #error = kNoError;
+
+  constructor(source, options = {}) {
     emitExperimentalWarning('vm.SourceTextModule');
 
-    validateString(src, 'src');
+    validateString(source, 'source');
     if (typeof options !== 'object' || options === null)
       throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
 
@@ -81,21 +83,6 @@ class SourceTextModule {
       }
     }
 
-    let { url } = options;
-    if (url !== undefined) {
-      validateString(url, 'options.url');
-      url = new URL(url).href;
-    } else if (context === undefined) {
-      url = `${defaultModuleName}(${globalModuleId++})`;
-    } else if (perContextModuleId.has(context)) {
-      const curId = perContextModuleId.get(context);
-      url = `${defaultModuleName}(${curId})`;
-      perContextModuleId.set(context, curId + 1);
-    } else {
-      url = `${defaultModuleName}(0)`;
-      perContextModuleId.set(context, 1);
-    }
-
     validateInt32(lineOffset, 'options.lineOffset');
     validateInt32(columnOffset, 'options.columnOffset');
 
@@ -111,114 +98,167 @@ class SourceTextModule {
         'options.importModuleDynamically', 'function', importModuleDynamically);
     }
 
-    const wrap = new ModuleWrap(src, url, context, lineOffset, columnOffset);
-    wrapMap.set(this, wrap);
-    linkingStatusMap.set(this, 'unlinked');
-    wrapToModuleMap.set(wrap, this);
+    let { identifier } = options;
+    if (identifier !== undefined) {
+      validateString(identifier, 'options.identifier');
+    } else if (context === undefined) {
+      identifier = `${defaultModuleName}(${globalModuleId++})`;
+    } else if (perContextModuleId.has(context)) {
+      const curId = perContextModuleId.get(context);
+      identifier = `${defaultModuleName}(${curId})`;
+      perContextModuleId.set(context, curId + 1);
+    } else {
+      identifier = `${defaultModuleName}(0)`;
+      perContextModuleId.set(context, 1);
+    }
 
-    binding.callbackMap.set(wrap, {
+    this.#wrap = new ModuleWrap(
+      source, identifier, context,
+      lineOffset, columnOffset,
+    );
+    wrapToModuleMap.set(this.#wrap, this);
+    this.#identifier = identifier;
+    this.#context = context;
+
+    binding.callbackMap.set(this.#wrap, {
       initializeImportMeta,
-      importModuleDynamically: importModuleDynamically ? async (...args) => {
-        const m = await importModuleDynamically(...args);
-        if (isModuleNamespaceObject(m)) {
-          return m;
-        }
-        if (!m || !wrapMap.has(m))
-          throw new ERR_VM_MODULE_NOT_MODULE();
-        const childLinkingStatus = linkingStatusMap.get(m);
-        if (childLinkingStatus === 'errored')
-          throw m.error;
-        return m.namespace;
-      } : undefined,
+      importModuleDynamically: importModuleDynamically ?
+        importModuleDynamicallyWrap(importModuleDynamically) :
+        undefined,
     });
-
-    Object.defineProperties(this, {
-      url: { value: url, enumerable: true },
-      context: { value: context, enumerable: true },
-    });
-  }
-
-  get linkingStatus() {
-    return linkingStatusMap.get(this);
   }
 
   get status() {
-    return STATUS_MAP[wrapMap.get(this).getStatus()];
-  }
-
-  get namespace() {
-    const wrap = wrapMap.get(this);
-    if (wrap.getStatus() < kInstantiated)
-      throw new ERR_VM_MODULE_STATUS(
-        'must not be uninstantiated or instantiating'
-      );
-    return wrap.namespace();
-  }
-
-  get dependencySpecifiers() {
-    let deps = dependencyCacheMap.get(this);
-    if (deps !== undefined)
-      return deps;
-
-    deps = wrapMap.get(this).getStaticDependencySpecifiers();
-    Object.freeze(deps);
-    dependencyCacheMap.set(this, deps);
-    return deps;
-  }
-
-  get error() {
-    const wrap = wrapMap.get(this);
-    if (wrap.getStatus() !== kErrored)
-      throw new ERR_VM_MODULE_STATUS('must be errored');
-    return wrap.getError();
-  }
-
-  async link(linker) {
-    if (typeof linker !== 'function')
-      throw new ERR_INVALID_ARG_TYPE('linker', 'function', linker);
-    if (linkingStatusMap.get(this) !== 'unlinked')
-      throw new ERR_VM_MODULE_ALREADY_LINKED();
-    const wrap = wrapMap.get(this);
-    if (wrap.getStatus() !== kUninstantiated)
-      throw new ERR_VM_MODULE_STATUS('must be uninstantiated');
-
-    linkingStatusMap.set(this, 'linking');
-
-    const promises = wrap.link(async (specifier) => {
-      const m = await linker(specifier, this);
-      if (!m || !wrapMap.has(m))
-        throw new ERR_VM_MODULE_NOT_MODULE();
-      if (m.context !== this.context)
-        throw new ERR_VM_MODULE_DIFFERENT_CONTEXT();
-      const childLinkingStatus = linkingStatusMap.get(m);
-      if (childLinkingStatus === 'errored')
-        throw new ERR_VM_MODULE_LINKING_ERRORED();
-      if (childLinkingStatus === 'unlinked')
-        await m.link(linker);
-      return wrapMap.get(m);
-    });
-
     try {
-      if (promises !== undefined)
-        await SafePromise.all(promises);
-      linkingStatusMap.set(this, 'linked');
-    } catch (err) {
-      linkingStatusMap.set(this, 'errored');
-      throw err;
+      this.#error;
+    } catch {
+      throw new ERR_VM_MODULE_NOT_MODULE();
+    }
+    if (this.#error !== kNoError) {
+      return 'errored';
+    }
+    if (this.#statusOverride) {
+      return this.#statusOverride;
+    }
+    return STATUS_MAP[this.#wrap.getStatus()];
+  }
+
+  get identifier() {
+    try {
+      return this.#identifier;
+    } catch {
+      throw new ERR_VM_MODULE_NOT_MODULE();
     }
   }
 
-  instantiate() {
-    const wrap = wrapMap.get(this);
-    const status = wrap.getStatus();
-    if (status === kInstantiating || status === kEvaluating)
-      throw new ERR_VM_MODULE_STATUS('must not be instantiating or evaluating');
-    if (linkingStatusMap.get(this) !== 'linked')
-      throw new ERR_VM_MODULE_NOT_LINKED();
-    wrap.instantiate();
+  get context() {
+    try {
+      return this.#context;
+    } catch {
+      throw new ERR_VM_MODULE_NOT_MODULE();
+    }
   }
 
+  get namespace() {
+    try {
+      this.#wrap;
+    } catch {
+      throw new ERR_VM_MODULE_NOT_MODULE();
+    }
+    if (this.#wrap.getStatus() < kInstantiated) {
+      throw new ERR_VM_MODULE_STATUS('must not be unlinked or linking');
+    }
+    return this.#wrap.getNamespace();
+  }
+
+  get dependencySpecifiers() {
+    try {
+      this.#dependencySpecifiers;
+    } catch {
+      throw new ERR_VM_MODULE_NOT_MODULE();
+    }
+    if (this.#dependencySpecifiers === undefined) {
+      this.#dependencySpecifiers = this.#wrap.getStaticDependencySpecifiers();
+    }
+    return this.#dependencySpecifiers;
+  }
+
+  get error() {
+    try {
+      this.#error;
+    } catch {
+      throw new ERR_VM_MODULE_NOT_MODULE();
+    }
+    if (this.#error !== kNoError) {
+      return this.#error;
+    }
+    if (this.#wrap.getStatus() !== kErrored) {
+      throw new ERR_VM_MODULE_STATUS('must be errored');
+    }
+    return this.#wrap.getError();
+  }
+
+  async link(linker) {
+    try {
+      this.#link;
+    } catch {
+      throw new ERR_VM_MODULE_NOT_MODULE();
+    }
+
+    if (typeof linker !== 'function') {
+      throw new ERR_INVALID_ARG_TYPE('linker', 'function', linker);
+    }
+    if (this.status !== 'unlinked') {
+      throw new ERR_VM_MODULE_ALREADY_LINKED();
+    }
+
+    await this.#link(linker);
+
+    this.#wrap.instantiate();
+  }
+
+  #link = async function(linker) {
+    this.#statusOverride = 'linking';
+
+    const promises = this.#wrap.link(async (identifier) => {
+      const module = await linker(identifier, this);
+      try {
+        module.#wrap;
+      } catch {
+        throw new ERR_VM_MODULE_NOT_MODULE();
+      }
+      if (module.context !== this.context) {
+        throw new ERR_VM_MODULE_DIFFERENT_CONTEXT();
+      }
+      if (module.status === 'errored') {
+        throw new ERR_VM_MODULE_LINKING_ERRORED();
+      }
+      if (module.status === 'unlinked') {
+        await module.#link(linker);
+      }
+      return module.#wrap;
+    });
+
+    try {
+      if (promises !== undefined) {
+        await SafePromise.all(promises);
+      }
+    } catch (e) {
+      this.#error = e;
+      throw e;
+    } finally {
+      this.#statusOverride = undefined;
+    }
+  };
+
+
   async evaluate(options = {}) {
+    try {
+      this.#wrap;
+    } catch {
+      throw new ERR_VM_MODULE_NOT_MODULE();
+    }
+
     if (typeof options !== 'object' || options === null) {
       throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
@@ -229,24 +269,41 @@ class SourceTextModule {
     } else {
       validateUint32(timeout, 'options.timeout', true);
     }
-
     const { breakOnSigint = false } = options;
     if (typeof breakOnSigint !== 'boolean') {
       throw new ERR_INVALID_ARG_TYPE('options.breakOnSigint', 'boolean',
                                      breakOnSigint);
     }
-
-    const wrap = wrapMap.get(this);
-    const status = wrap.getStatus();
+    const status = this.#wrap.getStatus();
     if (status !== kInstantiated &&
         status !== kEvaluated &&
         status !== kErrored) {
       throw new ERR_VM_MODULE_STATUS(
-        'must be one of instantiated, evaluated, and errored'
+        'must be one of linked, evaluated, or errored'
       );
     }
-    const result = wrap.evaluate(timeout, breakOnSigint);
-    return { result, __proto__: null };
+    const result = this.#wrap.evaluate(timeout, breakOnSigint);
+    return { __proto__: null, result };
+  }
+
+  static importModuleDynamicallyWrap(importModuleDynamically) {
+    // Named declaration for function name
+    const importModuleDynamicallyWrapper = async (...args) => {
+      const m = await importModuleDynamically(...args);
+      if (isModuleNamespaceObject(m)) {
+        return m;
+      }
+      try {
+        m.#wrap;
+      } catch {
+        throw new ERR_VM_MODULE_NOT_MODULE();
+      }
+      if (m.status === 'errored') {
+        throw m.error;
+      }
+      return m.namespace;
+    };
+    return importModuleDynamicallyWrapper;
   }
 
   [customInspectSymbol](depth, options) {
@@ -258,16 +315,19 @@ class SourceTextModule {
 
     const o = Object.create({ constructor: ctor });
     o.status = this.status;
-    o.linkingStatus = this.linkingStatus;
-    o.url = this.url;
+    o.identifier = this.identifier;
     o.context = this.context;
     return require('internal/util/inspect').inspect(o, options);
   }
 }
 
+// Declared as static to allow access to #wrap
+const importModuleDynamicallyWrap =
+  SourceTextModule.importModuleDynamicallyWrap;
+delete SourceTextModule.importModuleDynamicallyWrap;
+
 module.exports = {
   SourceTextModule,
   wrapToModuleMap,
-  wrapMap,
-  linkingStatusMap,
+  importModuleDynamicallyWrap,
 };

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -31,10 +31,8 @@ const {
 } = internalBinding('contextify');
 const {
   ERR_INVALID_ARG_TYPE,
-  ERR_VM_MODULE_NOT_MODULE,
 } = require('internal/errors').codes;
 const {
-  isModuleNamespaceObject,
   isArrayBufferView,
 } = require('internal/util/types');
 const {
@@ -100,21 +98,13 @@ class Script extends ContextifyScript {
                                        'function',
                                        importModuleDynamically);
       }
-      const { wrapMap, linkingStatusMap } =
+      const { importModuleDynamicallyWrap } =
         require('internal/vm/source_text_module');
       const { callbackMap } = internalBinding('module_wrap');
-      callbackMap.set(this, { importModuleDynamically: async (...args) => {
-        const m = await importModuleDynamically(...args);
-        if (isModuleNamespaceObject(m)) {
-          return m;
-        }
-        if (!m || !wrapMap.has(m))
-          throw new ERR_VM_MODULE_NOT_MODULE();
-        const childLinkingStatus = linkingStatusMap.get(m);
-        if (childLinkingStatus === 'errored')
-          throw m.error;
-        return m.namespace;
-      } });
+      callbackMap.set(this, {
+        importModuleDynamically:
+          importModuleDynamicallyWrap(importModuleDynamically),
+      });
     }
   }
 

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -57,7 +57,7 @@ class ModuleWrap : public BaseObject {
   static void Link(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Instantiate(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Evaluate(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Namespace(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetNamespace(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetStatus(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetError(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetStaticDependencySpecifiers(

--- a/test/parallel/test-internal-module-wrap.js
+++ b/test/parallel/test-internal-module-wrap.js
@@ -25,5 +25,5 @@ const bar = new ModuleWrap('export const five = 5', 'bar');
   foo.instantiate();
 
   assert.strictEqual(await foo.evaluate(-1, false), 6);
-  assert.strictEqual(foo.namespace().five, 5);
+  assert.strictEqual(foo.getNamespace().five, 5);
 })();

--- a/test/parallel/test-util-inspect-namespace.js
+++ b/test/parallel/test-util-inspect-namespace.js
@@ -11,7 +11,6 @@ const { inspect } = require('util');
 (async () => {
   const m = new SourceTextModule('export const a = 1; export var b = 2');
   await m.link(() => 0);
-  m.instantiate();
   assert.strictEqual(
     inspect(m.namespace),
     '[Module] { a: <uninitialized>, b: undefined }');

--- a/test/parallel/test-util-types.js
+++ b/test/parallel/test-util-types.js
@@ -281,7 +281,6 @@ for (const [ value, _method ] of [
 (async () => {
   const m = new vm.SourceTextModule('');
   await m.link(() => 0);
-  m.instantiate();
   await m.evaluate();
   assert.ok(types.isModuleNamespaceObject(m.namespace));
 })();

--- a/test/parallel/test-vm-module-dynamic-import.js
+++ b/test/parallel/test-vm-module-dynamic-import.js
@@ -10,7 +10,6 @@ const { Script, SourceTextModule, createContext } = require('vm');
 async function testNoCallback() {
   const m = new SourceTextModule('import("foo")', { context: createContext() });
   await m.link(common.mustNotCall());
-  m.instantiate();
   const { result } = await m.evaluate();
   let threw = false;
   try {
@@ -25,7 +24,6 @@ async function testNoCallback() {
 async function test() {
   const foo = new SourceTextModule('export const a = 1;');
   await foo.link(common.mustNotCall());
-  foo.instantiate();
   await foo.evaluate();
 
   {
@@ -50,7 +48,6 @@ async function test() {
       }),
     });
     await m.link(common.mustNotCall());
-    m.instantiate();
     const { result } = await m.evaluate();
     assert.strictEqual(foo.namespace, await result);
   }
@@ -63,7 +60,6 @@ async function testInvalid() {
     }),
   });
   await m.link(common.mustNotCall());
-  m.instantiate();
   const { result } = await m.evaluate();
   await result.catch(common.mustCall((e) => {
     assert.strictEqual(e.code, 'ERR_VM_MODULE_NOT_MODULE');

--- a/test/parallel/test-vm-module-dynamic-namespace.js
+++ b/test/parallel/test-vm-module-dynamic-namespace.js
@@ -1,35 +1,30 @@
 'use strict';
 
-// Flags: --experimental-vm-modules --expose-internals
-//
+// Flags: --experimental-vm-modules
+
 const common = require('../common');
 
 const assert = require('assert');
 
 const { types } = require('util');
-const { SourceTextModule, wrapMap } = require('internal/vm/source_text_module');
-
-const { importModuleDynamicallyCallback } =
-  require('internal/process/esm_loader');
+const { SourceTextModule } = require('vm');
 
 async function getNamespace() {
   const m = new SourceTextModule('');
   await m.link(() => 0);
-  m.instantiate();
   await m.evaluate();
   return m.namespace;
 }
 
 (async () => {
   const namespace = await getNamespace();
-  const m = new SourceTextModule('export const A = "A";', {
+  const m = new SourceTextModule('export const A = "A"; import("");', {
     importModuleDynamically: common.mustCall((specifier, wrap) => {
       return namespace;
     })
   });
   await m.link(() => 0);
-  m.instantiate();
-  await m.evaluate();
-  const ns = await importModuleDynamicallyCallback(wrapMap.get(m));
+  const { result } = await m.evaluate();
+  const ns = await result;
   assert.ok(types.isModuleNamespaceObject(ns));
 })().then(common.mustCall());

--- a/test/parallel/test-vm-module-import-meta.js
+++ b/test/parallel/test-vm-module-import-meta.js
@@ -14,7 +14,6 @@ async function testBasic() {
     })
   });
   await m.link(common.mustNotCall());
-  m.instantiate();
   const { result } = await m.evaluate();
   assert.strictEqual(typeof result, 'object');
   assert.strictEqual(Object.getPrototypeOf(result), null);

--- a/test/parallel/test-vm-module-reevaluate.js
+++ b/test/parallel/test-vm-module-reevaluate.js
@@ -14,7 +14,6 @@ const finished = common.mustCall();
   {
     const m = new SourceTextModule('1');
     await m.link(common.mustNotCall());
-    m.instantiate();
     assert.strictEqual((await m.evaluate()).result, 1);
     assert.strictEqual((await m.evaluate()).result, undefined);
     assert.strictEqual((await m.evaluate()).result, undefined);
@@ -23,7 +22,6 @@ const finished = common.mustCall();
   {
     const m = new SourceTextModule('throw new Error()');
     await m.link(common.mustNotCall());
-    m.instantiate();
 
     let threw = false;
     try {


### PR DESCRIPTION
- Removes redundant `instantiate` method
- Refactors `link` to match the spec linking steps more accurately
- Removes URL validation from SourceTextModule specifiers
- DRYs some dynamic import logic

Closes #29030

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
