### PR TITLE
doc: Add Documentation Deprecation for process._tickCallback

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2526,7 +2526,7 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/29781
     description: Documentation-only deprecation.
 -->
-Type: Documentation-only
+Type: Documentation-only (supports [`--pending-deprecation`][])
 
 The `process._tickCallback` property was never documented as
 an officially supported API.

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2531,7 +2531,6 @@ Type: Documentation-only
 The `process._tickCallback` property was never documented as
 an officially supported API.
 
-
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2523,7 +2523,7 @@ Prefer [`response.socket`][] over [`response.connection`] and
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull
+    pr-url: https://github.com/nodejs/node/pull/29781
     description: Documentation-only deprecation.
 -->
 Type: Documentation-only

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2518,6 +2518,20 @@ Type: Documentation-only
 Prefer [`response.socket`][] over [`response.connection`] and
 [`request.socket`][] over [`request.connection`].
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: process._tickCallback
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull
+    description: Documentation-only deprecation.
+-->
+Type: Documentation-only
+
+The `process._tickCallback` property was never documented as
+an officially supported API.
+
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -271,6 +271,10 @@ function initializeDeprecations() {
     process.binding = deprecate(process.binding,
                                 'process.binding() is deprecated. ' +
                                 'Please use public APIs instead.', 'DEP0111');
+
+    process._tickCallback = deprecate(process._tickCallback,
+                                      'process._tickCallback() is deprecated',
+                                      'DEP0XXX');
   }
 
   // Create global.process and global.Buffer as getters so that we have a


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Related to https://github.com/nodejs/node/pull/29671.

This starts the documentation deprecation of `process._tickCallback`

It was suggested that `--pending-deprecation` could be enabled for this, however, i'm not really sure how to get the value of the `--pending-deprecation` flag. I've looked at previous commits that do this, but the way they do it, doesn't seem to work in the file that this deprecation needs to happen in.  So any guidance there would be great.

Since this API was never documented in the process docs,  i didn't add any docs there.  If someone feels strongly that docs should be added(and label as deprecated),  then i'm open to that.

A remaining question is if this API should be replaced by the suggestion in the other PR, #29671 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
