### PR TITLE
stream: unpipe on destroy

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -233,17 +233,15 @@ created with the `emitClose` option.
 ##### Event: 'destroy'
 <!-- YAML
 added: REPLACEME
-changes:
-  - version: v10.0.0
-    pr-url: https://github.com/nodejs/node/pull/29791
 -->
 
 The `'destroy'` event is emitted when the stream is being destroyed. The
 listener callback is passed a single `Error` argument if the stream is
 being destroyed with an error.
 
-Unlike `'close'` and `'error'` is emitted synchronously making it possible
-to immediatly stop interacting with a stream that has been destroyed.
+Unlike `'close'` and `'error'`, the `'destroy'` event is emitted synchronously
+making it possible to immediatly stop interacting with a stream that has been
+destroyed.
 
 ##### Event: 'drain'
 <!-- YAML

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -230,6 +230,21 @@ that no more events will be emitted, and no further computation will occur.
 A [`Writable`][] stream will always emit the `'close'` event if it is
 created with the `emitClose` option.
 
+##### Event: 'destroy'
+<!-- YAML
+added: REPLACEME
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/29791
+-->
+
+The `'destroy'` event is emitted when the stream is being destroyed. The
+listener callback is passed a single `Error` argument if the stream is
+being destroyed with an error.
+
+Unlike `'close'` and `'error'` is emitted synchronously making it possible
+to immediatly stop interacting with a stream that has been destroyed.
+
 ##### Event: 'drain'
 <!-- YAML
 added: v0.9.4

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -782,6 +782,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
       errorOrDestroy(dest, er);
   }
 
+  // If the dest has a pending error, then stop piping into it.
   function ondestroy(err) {
     if (err) {
       unpipe();

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -722,6 +722,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
       dest.removeListener('drain', ondrain);
     }
     dest.removeListener('error', onerror);
+    dest.removeListener('destroy', ondestroy);
     dest.removeListener('unpipe', onunpipe);
     src.removeListener('end', onend);
     src.removeListener('end', unpipe);
@@ -780,6 +781,13 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     if (EE.listenerCount(dest, 'error') === 0)
       errorOrDestroy(dest, er);
   }
+
+  function ondestroy(err) {
+    if (err) {
+      unpipe();
+    }
+  }
+  dest.on('destroy', ondestroy);
 
   // Make sure our error handler is attached before userland ones.
   prependListener(dest, 'error', onerror);

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -51,6 +51,8 @@ function destroy(err, cb) {
     r.destroyed = true;
   }
 
+  this.emit('destroy', err);
+
   this._destroy(err || null, (err) => {
     const emitClose = (w && w.emitClose) || (r && r.emitClose);
     if (cb) {

--- a/test/parallel/test-http2-respond-with-file-connection-abort.js
+++ b/test/parallel/test-http2-respond-with-file-connection-abort.js
@@ -5,7 +5,6 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
-const net = require('net');
 
 const {
   HTTP2_HEADER_CONTENT_TYPE
@@ -25,7 +24,7 @@ server.listen(0, common.mustCall(() => {
 
   req.on('response', common.mustCall(() => {}));
   req.once('data', common.mustCall(() => {
-    net.Socket.prototype.destroy.call(client.socket);
+    client.destroy();
     server.close();
   }));
   req.end();

--- a/test/parallel/test-stream-pipe-destroy-write.js
+++ b/test/parallel/test-stream-pipe-destroy-write.js
@@ -15,7 +15,7 @@ const stream = require('stream');
 
   rs.pipe(ws);
   ws.destroy();
-  ws.on('error', common.mustCall(err => {
+  ws.on('error', common.mustCall((err) => {
     assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
   }));
 }
@@ -32,7 +32,7 @@ const stream = require('stream');
 
   rs.pipe(ws);
   ws.destroy(new Error('asd'));
-  ws.on('error', common.mustCall(err => {
+  ws.on('error', common.mustCall((err) => {
     assert.strictEqual(err.message, 'asd');
   }));
 }

--- a/test/parallel/test-stream-pipe-destroy-write.js
+++ b/test/parallel/test-stream-pipe-destroy-write.js
@@ -1,0 +1,38 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const stream = require('stream');
+
+{
+  const ws = new stream.Writable();
+  const rs = new stream.Readable({ highWaterMark: 16 });
+
+  ws._write = common.mustNotCall();
+
+  rs._read = function() {
+    rs.push('hello world');
+  };
+
+  rs.pipe(ws);
+  ws.destroy();
+  ws.on('error', common.mustCall(err => {
+    assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+  }));
+}
+
+{
+  const ws = new stream.Writable();
+  const rs = new stream.Readable({ highWaterMark: 16 });
+
+  ws.write = common.mustNotCall();
+
+  rs._read = function() {
+    rs.push('hello world');
+  };
+
+  rs.pipe(ws);
+  ws.destroy(new Error('asd'));
+  ws.on('error', common.mustCall(err => {
+    assert.strictEqual(err.message, 'asd');
+  }));
+}


### PR DESCRIPTION
Avoid writing to destination if it has been destroyed. 'close' is emitted asynchronously which can cause another read & write to be performed after destroy() causing a write after destroy error.

Adds a new event `'destroy'` to make this possible.

Fixes: https://github.com/nodejs/node/issues/29790

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
