### PR TITLE
Update buffer.md

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -100,7 +100,7 @@ to one of these new APIs.*
 * [`Buffer.from(buffer)`][] returns a new `Buffer` that *contains a copy* of the
   contents of the given `Buffer`.
 * [`Buffer.from(string[, encoding])`][`Buffer.from(string)`] returns a new
-  `Buffer` that *contains a copy* of the provided string.
+  `Buffer` that *contains a copy* of the provided string. (When `'hex'` encoding a string, using odd number of characters may result in an unpredictable behaviour).
 * [`Buffer.alloc(size[, fill[, encoding]])`][`Buffer.alloc()`] returns a new
   initialized `Buffer` of the specified size. This method is slower than
   [`Buffer.allocUnsafe(size)`][`Buffer.allocUnsafe()`] but guarantees that newly

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -100,7 +100,7 @@ to one of these new APIs.*
 * [`Buffer.from(buffer)`][] returns a new `Buffer` that *contains a copy* of the
   contents of the given `Buffer`.
 * [`Buffer.from(string[, encoding])`][`Buffer.from(string)`] returns a new
-  `Buffer` that *contains a copy* of the provided string. (When `'hex'` encoding a string, using odd number of characters may result in an unpredictable behaviour).
+  `Buffer` that *contains a copy* of the provided string.
 * [`Buffer.alloc(size[, fill[, encoding]])`][`Buffer.alloc()`] returns a new
   initialized `Buffer` of the specified size. This method is slower than
   [`Buffer.allocUnsafe(size)`][`Buffer.allocUnsafe()`] but guarantees that newly
@@ -203,7 +203,8 @@ The character encodings currently supported by Node.js include:
 
 * `'binary'` - Alias for `'latin1'`.
 
-* `'hex'` - Encode each byte as two hexadecimal characters.
+* `'hex'` - Encode each byte as two hexadecimal characters. If the number of
+hexadecimal characters is odd, the first incomplete hexadecimal pair is ignored.
 
 Modern Web browsers follow the [WHATWG Encoding Standard][] which aliases
 both `'latin1'` and `'ISO-8859-1'` to `'win-1252'`. This means that while doing


### PR DESCRIPTION
updated Buffer.from(string[, encoding]) in documentation

Documented an issue when hex encoding a string using
Buffer.from(string,  [,encoding]) with an odd number of characters string.

Ref: https://github.com/nodejs/node/issues/29786

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
