### PR TITLE
doc: unify place of stability notes

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -623,14 +623,14 @@ changes:
                  deprecated and emits a warning.
 -->
 
+> Stability: 0 - Deprecated: Use `assert.fail([message])` or other assert
+> functions instead.
+
 * `actual` {any}
 * `expected` {any}
 * `message` {string|Error}
 * `operator` {string} **Default:** `'!='`
 * `stackStartFn` {Function} **Default:** `assert.fail`
-
-> Stability: 0 - Deprecated: Use `assert.fail([message])` or other assert
-> functions instead.
 
 If `message` is falsy, the error message is set as the values of `actual` and
 `expected` separated by the provided `operator`. If just the two `actual` and

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -229,10 +229,10 @@ added: v0.9.12
 deprecated: v4.0.0
 -->
 
+> Stability: 0 - Deprecated: Use [`emitter.listenerCount()`][] instead.
+
 * `emitter` {EventEmitter} The emitter to query
 * `eventName` {string|symbol} The event name
-
-> Stability: 0 - Deprecated: Use [`emitter.listenerCount()`][] instead.
 
 A class method that returns the number of listeners for the given `eventName`
 registered on the given `emitter`.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1169,9 +1169,9 @@ added: v0.3.0
 deprecated: REPLACEME
 -->
 
-* {net.Socket}
-
 > Stability: 0 - Deprecated. Use [`response.socket`][].
+
+* {net.Socket}
 
 See [`response.socket`][].
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -970,11 +970,11 @@ added: v10.12.0
 deprecated: v12.2.0
 -->
 
+> Stability: 0 - Deprecated: Please use [`createRequire()`][] instead.
+
 * `filename` {string} Filename to be used to construct the relative require
   function.
 * Returns: {require} Require function
-
-> Stability: 0 - Deprecated: Please use [`createRequire()`][] instead.
 
 ```js
 const { createRequireFromPath } = require('module');

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -482,11 +482,11 @@ added: v0.8.9
 deprecated: v9.0.0
 -->
 
+> Stability: 0 - Deprecated.
+
 * `keyword` {string} the potential keyword to parse and execute
 * `rest` {any} any parameters to the keyword command
 * Returns: {boolean}
-
-> Stability: 0 - Deprecated.
 
 An internal method used to parse and execute `REPLServer` keywords.
 Returns `true` if `keyword` is a valid keyword, otherwise `false`.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1769,10 +1769,10 @@ added: v0.7.5
 deprecated: v6.0.0
 -->
 
+> Stability: 0 - Deprecated: Use [`Object.assign()`] instead.
+
 * `target` {Object}
 * `source` {Object}
-
-> Stability: 0 - Deprecated: Use [`Object.assign()`] instead.
 
 The `util._extend()` method was never intended to be used outside of internal
 Node.js modules. The community found and used it anyway.


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

In most cases, stability note is the first info in a doc section after YAML. This PR makes it consistent across all docs, as this info seems the most relevant for a reader.