### PR TITLE
net: emit close on unconnected socket

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -660,9 +660,11 @@ Socket.prototype._destroy = function(exception, cb) {
     this._handle.onread = noop;
     this._handle = null;
     this._sockname = null;
+    cb(exception);
+  } else {
+    cb(exception);
+    process.nextTick(emitCloseNT, this);
   }
-
-  cb(exception);
 
   if (this._server) {
     debug('has server');

--- a/test/parallel/test-net-connect-destroy.js
+++ b/test/parallel/test-net-connect-destroy.js
@@ -2,6 +2,6 @@
 const common = require('../common');
 const net = require('net');
 
-const socket = new net.Socket()
+const socket = new net.Socket();
 socket.on('close', common.mustCall());
 socket.destroy();

--- a/test/parallel/test-net-connect-destroy.js
+++ b/test/parallel/test-net-connect-destroy.js
@@ -1,0 +1,7 @@
+'use strict';
+const common = require('../common');
+const net = require('net');
+
+const socket = new net.Socket()
+socket.on('close', common.mustCall());
+socket.destroy();


### PR DESCRIPTION
Socket should always emit 'close'. Regardless whether it has been connected or not.

Probably a minor fix for an edge case.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
