### PR TITLE
stream: readable throw unhandled error

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -777,8 +777,13 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     debug('onerror', er);
     unpipe();
     dest.removeListener('error', onerror);
-    if (EE.listenerCount(dest, 'error') === 0)
-      errorOrDestroy(dest, er);
+    if (EE.listenerCount(dest, 'error') === 0) {
+      if (!dest.destroyed) {
+        errorOrDestroy(dest, er);
+      } else {
+        dest.emit('error', er);
+      }
+    }
   }
 
   // Make sure our error handler is attached before userland ones.

--- a/test/parallel/test-stream-pipe-error-unhandled.js
+++ b/test/parallel/test-stream-pipe-error-unhandled.js
@@ -8,7 +8,7 @@ process.on('uncaughtException', common.mustCall((err) => {
 }));
 
 const r = new Readable({
-  read () {
+  read() {
     this.push('asd');
   }
 });

--- a/test/parallel/test-stream-pipe-error-unhandled.js
+++ b/test/parallel/test-stream-pipe-error-unhandled.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Readable, Writable } = require('stream');
+
+process.on('uncaughtException', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'asd');
+}));
+
+const r = new Readable({
+  read () {
+    this.push('asd');
+  }
+});
+const w = new Writable({
+  autoDestroy: true,
+  write() {}
+});
+
+r.pipe(w);
+w.destroy(new Error('asd'));


### PR DESCRIPTION
If autoDestroy then we should still throw on unhandled errors.

Currently, since autoDestroy will only emit error once, will cause the error not to end up as unhandled.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
