### PR TITLE
fs: update tests for rmdir()

### DIFF
--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -15,9 +15,6 @@ function makeNonEmptyDirectory(depth, files, folders, dirname) {
   fs.writeFileSync(path.join(dirname, 'text.txt'), 'hello', 'utf8');
 
   let options = { flag: 'wx' };
-  if (process.version.match(/^v0\.8/)) {
-    options = 'utf8';
-  }
 
   for (let f = files; f > 0; f--) {
     fs.writeFileSync(path.join(dirname, `f-${depth}-${f}`), '', options);

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -14,7 +14,7 @@ function makeNonEmptyDirectory(depth, files, folders, dirname) {
   fs.mkdirSync(dirname, { recursive: true });
   fs.writeFileSync(path.join(dirname, 'text.txt'), 'hello', 'utf8');
 
-  let options = { flag: 'wx' };
+  const options = { flag: 'wx' };
 
   for (let f = files; f > 0; f--) {
     fs.writeFileSync(path.join(dirname, `f-${depth}-${f}`), '', options);

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -10,34 +10,52 @@ let count = 0;
 
 tmpdir.refresh();
 
-function makeNonEmptyDirectory (depth, files, folders, dirname) {
+function makeNonEmptyDirectory(depth, files, folders, dirname) {
   fs.mkdirSync(dirname, { recursive: true });
   fs.writeFileSync(path.join(dirname, 'text.txt'), 'hello', 'utf8');
 
-  var o = { flag: 'wx' }
-  if (process.version.match(/^v0\.8/))
-    o = 'utf8'
-
-  for (var f = files; f > 0; f--) {
-    fs.writeFileSync(dirname + '/f-' + depth + '-' + f, '', o)
+  let options = { flag: 'wx' };
+  if (process.version.match(/^v0\.8/)) {
+    options = 'utf8';
   }
 
-  // valid symlink
-  fs.symlinkSync('f-' + depth + '-1', dirname + '/link-' + depth + '-good', 'file')
+  for (let f = files; f > 0; f--) {
+    fs.writeFileSync(path.join(dirname, `f-${depth}-${f}`), '', options);
+  }
 
-  // invalid symlink
-  fs.symlinkSync('does-not-exist', dirname + '/link-' + depth + '-bad', 'file')
+  // Valid symlink
+  fs.symlinkSync(
+    `f-${depth}-1`,
+    path.join(dirname, `link-${depth}-good`),
+    'file'
+  );
 
-  // file with a name that looks like a glob
-  fs.writeFileSync(dirname + '/[a-z0-9].txt', '', o)
+  // Invalid symlink
+  fs.symlinkSync(
+    'does-not-exist',
+    path.join(dirname, `link-${depth}-bad`),
+    'file'
+  );
 
-  depth--
-  if (depth <= 0)
-    return dirname;
+  // File with a name that looks like a glob
+  fs.writeFileSync(path.join(dirname, '[a-z0-9].txt'), '', options);
 
-  for (f = folders; f > 0; f--) {
-    fs.mkdirSync(dirname + '/folder-' + depth + '-' + f, { recursive: true });
-    makeNonEmptyDirectory(depth, files, folders, dirname + '/d-' + depth + '-' + f)
+  depth--;
+  if (depth <= 0) {
+    return;
+  }
+
+  for (let f = folders; f > 0; f--) {
+    fs.mkdirSync(
+      path.join(dirname, `folder-${depth}-${f}`),
+      { recursive: true }
+    );
+    makeNonEmptyDirectory(
+      depth,
+      files,
+      folders,
+      path.join(dirname, `d-${depth}-${f}`)
+    );
   }
 }
 

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -10,7 +10,7 @@ let count = 0;
 
 tmpdir.refresh();
 
-function makeNonEmptyDirectory(depth, files, folders, dirname) {
+function makeNonEmptyDirectory(depth, files, folders, dirname, createSymLinks) {
   fs.mkdirSync(dirname, { recursive: true });
   fs.writeFileSync(path.join(dirname, 'text.txt'), 'hello', 'utf8');
 
@@ -20,19 +20,21 @@ function makeNonEmptyDirectory(depth, files, folders, dirname) {
     fs.writeFileSync(path.join(dirname, `f-${depth}-${f}`), '', options);
   }
 
-  // Valid symlink
-  fs.symlinkSync(
-    `f-${depth}-1`,
-    path.join(dirname, `link-${depth}-good`),
-    'file'
-  );
+  if (createSymLinks) {
+    // Valid symlink
+    fs.symlinkSync(
+      `f-${depth}-1`,
+      path.join(dirname, `link-${depth}-good`),
+      'file'
+    );
 
-  // Invalid symlink
-  fs.symlinkSync(
-    'does-not-exist',
-    path.join(dirname, `link-${depth}-bad`),
-    'file'
-  );
+    // Invalid symlink
+    fs.symlinkSync(
+      'does-not-exist',
+      path.join(dirname, `link-${depth}-bad`),
+      'file'
+    );
+  }
 
   // File with a name that looks like a glob
   fs.writeFileSync(path.join(dirname, '[a-z0-9].txt'), '', options);
@@ -51,16 +53,13 @@ function makeNonEmptyDirectory(depth, files, folders, dirname) {
       depth,
       files,
       folders,
-      path.join(dirname, `d-${depth}-${f}`)
+      path.join(dirname, `d-${depth}-${f}`),
+      createSymLinks
     );
   }
 }
 
-// Test the asynchronous version.
-{
-  const dir = `rmdir-recursive-${count}`;
-  makeNonEmptyDirectory(4, 10, 2, dir);
-
+function removeAsync(dir) {
   // Removal should fail without the recursive option.
   fs.rmdir(dir, common.mustCall((err) => {
     assert.strictEqual(err.syscall, 'rmdir');
@@ -87,11 +86,31 @@ function makeNonEmptyDirectory(depth, files, folders, dirname) {
   }));
 }
 
+// Test the asynchronous version
+{
+  // Create a 4-level folder hierarchy including symlinks
+  let dir = `rmdir-recursive-${count}`;
+  makeNonEmptyDirectory(4, 10, 2, dir, true);
+  removeAsync(dir);
+
+  // Create a 2-level folder hierarchy without symlinks
+  count++;
+  dir = `rmdir-recursive-${count}`;
+  makeNonEmptyDirectory(2, 10, 2, dir, false);
+  removeAsync(dir);
+
+  // Create a flat folder including symlinks
+  count++;
+  dir = `rmdir-recursive-${count}`;
+  makeNonEmptyDirectory(1, 10, 2, dir, true);
+  removeAsync(dir);
+}
+
 // Test the synchronous version.
 {
   count++;
   const dir = `rmdir-recursive-${count}`;
-  makeNonEmptyDirectory(4, 10, 2, dir);
+  makeNonEmptyDirectory(4, 10, 2, dir, true);
 
   // Removal should fail without the recursive option set to true.
   common.expectsError(() => {
@@ -115,7 +134,7 @@ function makeNonEmptyDirectory(depth, files, folders, dirname) {
 (async () => {
   count++;
   const dir = `rmdir-recursive-${count}`;
-  makeNonEmptyDirectory(4, 10, 2, dir);
+  makeNonEmptyDirectory(4, 10, 2, dir, true);
 
   // Removal should fail without the recursive option set to true.
   assert.rejects(fs.promises.rmdir(dir), { syscall: 'rmdir' });


### PR DESCRIPTION
Update tests to create more nested folders and files, like [rimraf package tests do](https://github.com/isaacs/rimraf/blob/master/test/fill.js). 
Each test will create 28 nested directories and 210 files. 
It will also create different types of files, like symlinks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
