### PR TITLE
esm: update `example-loader` test fixture & API docs

### DIFF
--- a/test/fixtures/es-module-loaders/example-loader.mjs
+++ b/test/fixtures/es-module-loaders/example-loader.mjs
@@ -1,48 +1,66 @@
-import { default as Module } from 'module';
 import { extname } from 'path';
-import { pathToFileURL } from 'url';
+import { default as Module } from 'module';
+
+const JS_EXTENSIONS = new Set(['.js', '.mjs']);
+const baseURL = new URL('file://');
+baseURL.pathname = process.cwd() + '/';
 
 /**
- * @param {string} specifier
- * @param {!(URL|string|undefined)} parentModuleURL
-//  * param {Function} defaultResolver
- * @returns {Promise<{url: string, format: string}>}
+ * @param {!(string)} specifier
+ * @param {{
+ *   parentURL:!(URL|string|undefined),
+ * }} context
+ * @param {!(Function)} defaultResolve
+ * @returns {{
+ *   url:!(string),
+ * }}
  */
-export async function resolve(
-  specifier,
-  parentModuleURL = undefined
-  // defaultResolver
-) {
-  const JS_EXTENSIONS = new Set(['.js', '.mjs']);
-
-  if (parentModuleURL === undefined) {
-    parentModuleURL = pathToFileURL(process.cwd()).href;
-  }
-
+export function resolve(specifier, { parentURL = baseURL }, defaultResolve) {
   if (Module.builtinModules.includes(specifier)) {
     return {
-      url: 'nodejs:' + specifier
+      url: 'nodejs:' + specifier,
     };
   }
-
-  if (!(specifier.startsWith('file:') || /^\.{1,2}[/]/.test(specifier))) {
+  if (
+    /^\.{1,2}[/]/.test(specifier) !== true &&
+    !specifier.startsWith('file:')
+  ) {
     // For node_modules support:
-    // return defaultResolver(specifier, parentModuleURL);
+    // return defaultResolve(specifier, {parentURL}, defaultResolve);
     throw new Error(
       "Imports must either be URLs or begin with './' or '../'; " +
-      `'${specifier}' satisfied neither of these requirements.`
+        `'${specifier}' satisfied neither of these requirements.`
     );
   }
+  const resolved = new URL(specifier, parentURL);
+  return {
+    url: resolved.href,
+  };
+}
 
-  const resolved = new URL(specifier, parentModuleURL);
-  const ext = extname(resolved.pathname);
-
+/**
+ * @param {!(string)} url
+// * param {!(Object)} context
+// * param {!(Function)} defaultGetFormat
+ * @returns {{
+ *   format:!(string),
+ * }}
+ */
+export function getFormat(url /* , context, defaultGetFormat */) {
+  if (url.startsWith('nodejs:') &&
+    Module.builtinModules.includes(url.slice(7))) {
+    return {
+      format: 'builtin',
+    };
+  }
+  const { pathname } = new URL(url);
+  const ext = extname(pathname);
   if (!JS_EXTENSIONS.has(ext)) {
     throw new Error(
-      `Cannot load file with non-JavaScript file extension ${ext}.`);
+      `Cannot load file with non-JavaScript file extension ${ext}.`
+    );
   }
-
   return {
-    format: 'module'
+    format: 'module',
   };
 }


### PR DESCRIPTION
* [x] Remove importing of `URL` & `process` as is unnecessary (they exist in global scope)
* [x] Correct all type annotations (`param` & `returns`) to be accurate to both TypeScript & Closure
* [x] Fix bare-import check error message to be accurate and grammatically correct
* [x] Update bare-import check to more closely match language used in error message
* [x] Update command that runs the example to be cross-platform
* [x] Prefer use of captialized `{Function}` type annotation over `{function}`
* [x] Update prose regarding the condition in which `parentModuleURL` is `undefined`
* [x] Move assignment of `parentModuleURL` to inside the `resolve` hook function
* [x] ~~Prefer `--experimental-loader` to `--loader`~~ (taken care of in another PR)

Fixes: nodejs/node#29610

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
