### PR TITLE
util: validate formatWithOptions inspectOptions

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1542,11 +1542,6 @@ function reduceToSingleString(
   return `${braces[0]}${ln}${join(output, `,\n${indentation}  `)} ${braces[1]}`;
 }
 
-function format(...args) {
-  return formatWithOptions(undefined, ...args);
-}
-
-
 const firstErrorLine = (error) => error.message.split('\n')[0];
 let CIRCULAR_ERROR_MESSAGE;
 function tryStringify(arg) {
@@ -1569,7 +1564,19 @@ function tryStringify(arg) {
   }
 }
 
+function format(...args) {
+  return formatWithOptionsInternal(undefined, ...args);
+}
+
 function formatWithOptions(inspectOptions, ...args) {
+  if (typeof inspectOptions !== 'object' || inspectOptions === null) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'inspectOptions', 'object', inspectOptions);
+  }
+  return formatWithOptionsInternal(inspectOptions, ...args);
+}
+
+function formatWithOptionsInternal(inspectOptions, ...args) {
   const first = args[0];
   let a = 0;
   let str = '';

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -408,3 +408,20 @@ assert.strictEqual(
   ),
   '[ 1, [Object] ]'
 );
+
+[
+  undefined,
+  null,
+  false,
+  5n,
+  5,
+  'test',
+  Symbol()
+].forEach((invalidOptions) => {
+  assert.throws(() => {
+    util.formatWithOptions(invalidOptions, { a: true });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: /"inspectOptions".+object/
+  });
+});


### PR DESCRIPTION
This makes sure that the `inspectOptions` are validated. This could
otherwise cause confusion.

Fixes: https://github.com/nodejs/node/issues/29726

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
