### PR TITLE
domain: do not import util for a simple type check

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -206,7 +206,7 @@ Domain.prototype.members = undefined;
 Domain.prototype._errorHandler = function(er) {
   var caught = false;
 
-  if (typeof er === 'object' && er !== null || typeof er === 'function') {
+  if ((typeof er === 'object' && er !== null) || typeof er === 'function') {
     Object.defineProperty(er, 'domain', {
       configurable: true,
       enumerable: false,

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -28,7 +28,6 @@
 
 const { Object, Reflect } = primordials;
 
-const util = require('util');
 const EventEmitter = require('events');
 const {
   ERR_DOMAIN_CALLBACK_NOT_AVAILABLE,
@@ -207,7 +206,7 @@ Domain.prototype.members = undefined;
 Domain.prototype._errorHandler = function(er) {
   var caught = false;
 
-  if (!util.isPrimitive(er)) {
+  if (typeof er === 'object' && er !== null || typeof er === 'function') {
     Object.defineProperty(er, 'domain', {
       configurable: true,
       enumerable: false,


### PR DESCRIPTION
This removes `require('util')` from the `domain` module. There was
only a single simple type check used from the `util` module which
is now inlined instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
