### PR TITLE
doc: return type is number

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1195,8 +1195,8 @@ Provides miscellaneous information about the current state of the
     for this `Http2Stream` without receiving a `WINDOW_UPDATE`.
   * `state` {number} A flag indicating the low-level current state of the
     `Http2Stream` as determined by `nghttp2`.
-  * `localClose` {number} `true` if this `Http2Stream` has been closed locally.
-  * `remoteClose` {number} `true` if this `Http2Stream` has been closed
+  * `localClose` {number} `1` if this `Http2Stream` has been closed locally.
+  * `remoteClose` {number} `1` if this `Http2Stream` has been closed
     remotely.
   * `sumDependencyWeight` {number} The sum weight of all `Http2Stream`
     instances that depend on this `Http2Stream` as specified using


### PR DESCRIPTION
https://github.com/nodejs/node/blob/88ef086e39cd055a1cdc6720981f50e4791fb90f/test/parallel/test-http2-session-stream-state.js#L22-L23
Type of  `localClose` and `remoteClose` are `number`, so I think `1` is valid instead of `true`.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
