### PR TITLE
lib: make tick processor detect xcodebuild errors

### DIFF
--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -48,8 +48,15 @@ const os = {
     }
     let out = cp.spawnSync(name, args).stdout.toString();
     // Auto c++filt names, but not [iItT]
-    if (process.platform === 'darwin' && name === 'nm')
+    if (process.platform === 'darwin' && name === 'nm') {
+      // nm prints an error along the lines of "Run xcodebuild -license" and
+      // exits when Xcode hasn't been properly installed or when its license
+      // hasn't been accepted yet. Basically any mention of xcodebuild in
+      // the output means the nm command is non-functional.
+      const match = out.match(/(?:^|\n)([^\n]*xcodebuild[^\n]*)(?:\n|$)/);
+      if (match) throw new Error(match[1]);
       out = macCppfiltNm(out);
+    }
     return out;
   }
 };


### PR DESCRIPTION
`node --prof-process` on macOS calls out to nm(1) to look up C++
symbols. If Xcode hasn't been properly installed or its license
hasn't been accepted yet, it prints out an error and exits.

Before this commit, that error was swallowed and the output of
the tick processor was not showing the C++ entry points.

This commit detects that error message and turns it into an
exception. No regression test because this particular condition
is hard to test for without going to extreme lengths to mock
the output of nm.

Fixes: https://github.com/nodejs/node/issues/29804