### PR TITLE
lib: introduce no-mixed-operators eslint rule to lib

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -4,6 +4,9 @@ env:
 rules:
   prefer-object-spread: error
   no-buffer-constructor: error
+  no-mixed-operators:
+    - error
+    - groups: [[ "&&", "||" ]]
   no-restricted-globals:
     - error
     - name: JSON

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -144,7 +144,7 @@ function ClientRequest(input, options, cb) {
   }
 
   const defaultPort = options.defaultPort ||
-                    this.agent && this.agent.defaultPort;
+                    (this.agent && this.agent.defaultPort);
 
   const port = options.port = options.port || defaultPort || 80;
   const host = options.host = validateHost(options.hostname, 'hostname') ||

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -271,7 +271,7 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
       er = chunkInvalid(state, chunk);
     if (er) {
       errorOrDestroy(stream, er);
-    } else if (state.objectMode || chunk && chunk.length > 0) {
+    } else if (state.objectMode || (chunk && chunk.length > 0)) {
       if (typeof chunk !== 'string' &&
           !state.objectMode &&
           // Do not use Object.getPrototypeOf as it is slower since V8 7.3.

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -149,8 +149,8 @@ function loadSession(hello) {
 
   if (hello.sessionId.length <= 0 ||
       hello.tlsTicket ||
-      owner.server &&
-      !owner.server.emit('resumeSession', hello.sessionId, onSession)) {
+      (owner.server &&
+      !owner.server.emit('resumeSession', hello.sessionId, onSession))) {
     // Sessions without identifiers can't be resumed.
     // Sessions with tickets can be resumed directly from the ticket, no server
     // session storage is necessary.

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -622,7 +622,7 @@ function expectedException(actual, expected, message, fn) {
       message = 'The error is expected to be an instance of ' +
         `"${expected.name}". Received `;
       if (isError(actual)) {
-        const name = actual.constructor && actual.constructor.name ||
+        const name = (actual.constructor && actual.constructor.name) ||
                      actual.name;
         if (expected.name === name) {
           message += 'an error with identical name but a different prototype.';
@@ -685,9 +685,9 @@ function checkIsPromise(obj) {
   // way. Do not accept thenables that use a function as `obj` and that have no
   // `catch` handler.
   return isPromise(obj) ||
-    obj !== null && typeof obj === 'object' &&
+    (obj !== null && typeof obj === 'object' &&
     typeof obj.then === 'function' &&
-    typeof obj.catch === 'function';
+    typeof obj.catch === 'function');
 }
 
 async function waitForActual(promiseFn) {

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -349,7 +349,7 @@ class AssertionError extends Error {
         // In case "actual" is an object or a function, it should not be
         // reference equal.
         if (operator === 'notStrictEqual' &&
-            (typeof actual === 'object' && actual !== null ||
+            ((typeof actual === 'object' && actual !== null) ||
              typeof actual === 'function')) {
           base = kReadableOperator.notStrictEqualObject;
         }

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -941,7 +941,7 @@ function getValidStdio(stdio, sync) {
 
     if (stdio === 'ignore') {
       acc.push({ type: 'ignore' });
-    } else if (stdio === 'pipe' || typeof stdio === 'number' && stdio < 0) {
+    } else if (stdio === 'pipe' || (typeof stdio === 'number' && stdio < 0)) {
       var a = {
         type: 'pipe',
         readable: i === 0,

--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -100,7 +100,7 @@ cluster._getServer = function(obj, options, cb) {
     cluster.worker.state = 'listening';
     const address = obj.address();
     message.act = 'listening';
-    message.port = address && address.port || options.port;
+    message.port = (address && address.port) || options.port;
     send(message);
   });
 };

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -666,8 +666,8 @@ const fatalExceptionStackEnhancers = {
         colors: defaultColors
       }
     } = lazyInternalUtilInspect();
-    const colors = internalBinding('util').guessHandleType(2) === 'TTY' &&
-                   require('internal/tty').hasColors() ||
+    const colors = (internalBinding('util').guessHandleType(2) === 'TTY' &&
+                   require('internal/tty').hasColors()) ||
                    defaultColors;
     try {
       return inspect(error, { colors });

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -204,9 +204,9 @@ const nullCheck = hideStackFrames((path, propName, throwError = true) => {
   const pathIsUint8Array = isUint8Array(path);
 
   // We can only perform meaningful checks on strings and Uint8Arrays.
-  if (!pathIsString && !pathIsUint8Array ||
-      pathIsString && !path.includes('\u0000') ||
-      pathIsUint8Array && !path.includes(0)) {
+  if ((!pathIsString && !pathIsUint8Array) ||
+      (pathIsString && !path.includes('\u0000')) ||
+      (pathIsUint8Array && !path.includes(0))) {
     return;
   }
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -732,7 +732,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
     if (Array.isArray(options.paths)) {
       const isRelative = request.startsWith('./') ||
           request.startsWith('../') ||
-          (isWindows && request.startsWith('.\\') ||
+          ((isWindows && request.startsWith('.\\')) ||
           request.startsWith('..\\'));
 
       if (isRelative) {

--- a/lib/internal/readline/utils.js
+++ b/lib/internal/readline/utils.js
@@ -108,30 +108,30 @@ if (internalBinding('config').hasIntl) {
       code === 0x2329 || // LEFT-POINTING ANGLE BRACKET
       code === 0x232a || // RIGHT-POINTING ANGLE BRACKET
       // CJK Radicals Supplement .. Enclosed CJK Letters and Months
-      code >= 0x2e80 && code <= 0x3247 && code !== 0x303f ||
+      (code >= 0x2e80 && code <= 0x3247 && code !== 0x303f) ||
       // Enclosed CJK Letters and Months .. CJK Unified Ideographs Extension A
-      code >= 0x3250 && code <= 0x4dbf ||
+      (code >= 0x3250 && code <= 0x4dbf) ||
       // CJK Unified Ideographs .. Yi Radicals
-      code >= 0x4e00 && code <= 0xa4c6 ||
+      (code >= 0x4e00 && code <= 0xa4c6) ||
       // Hangul Jamo Extended-A
-      code >= 0xa960 && code <= 0xa97c ||
+      (code >= 0xa960 && code <= 0xa97c) ||
       // Hangul Syllables
-      code >= 0xac00 && code <= 0xd7a3 ||
+      (code >= 0xac00 && code <= 0xd7a3) ||
       // CJK Compatibility Ideographs
-      code >= 0xf900 && code <= 0xfaff ||
+      (code >= 0xf900 && code <= 0xfaff) ||
       // Vertical Forms
-      code >= 0xfe10 && code <= 0xfe19 ||
+      (code >= 0xfe10 && code <= 0xfe19) ||
       // CJK Compatibility Forms .. Small Form Variants
-      code >= 0xfe30 && code <= 0xfe6b ||
+      (code >= 0xfe30 && code <= 0xfe6b) ||
       // Halfwidth and Fullwidth Forms
-      code >= 0xff01 && code <= 0xff60 ||
-      code >= 0xffe0 && code <= 0xffe6 ||
+      (code >= 0xff01 && code <= 0xff60) ||
+      (code >= 0xffe0 && code <= 0xffe6) ||
       // Kana Supplement
-      code >= 0x1b000 && code <= 0x1b001 ||
+      (code >= 0x1b000 && code <= 0x1b001) ||
       // Enclosed Ideographic Supplement
-      code >= 0x1f200 && code <= 0x1f251 ||
+      (code >= 0x1f200 && code <= 0x1f251) ||
       // CJK Unified Ideographs Extension B .. Tertiary Ideographic Plane
-      code >= 0x20000 && code <= 0x3fffd
+      (code >= 0x20000 && code <= 0x3fffd)
     );
   };
 }

--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -200,7 +200,7 @@ function getColorDepth(env = process.env) {
 
 function hasColors(count, env) {
   if (env === undefined &&
-      (count === undefined || typeof count === 'object' && count !== null)) {
+      (count === undefined || (typeof count === 'object' && count !== null))) {
     env = count;
     count = 16;
   } else {

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1363,7 +1363,7 @@ function pathToFileURL(filepath) {
   // path.resolve strips trailing slashes so we must add them back
   const filePathLast = filepath.charCodeAt(filepath.length - 1);
   if ((filePathLast === CHAR_FORWARD_SLASH ||
-       isWindows && filePathLast === CHAR_BACKWARD_SLASH) &&
+       (isWindows && filePathLast === CHAR_BACKWARD_SLASH)) &&
       resolved[resolved.length - 1] !== path.sep)
     resolved += '/';
   const outURL = new URL('file://');

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -293,9 +293,9 @@ function keyCheck(val1, val2, strict, memos, iterationType, aKeys) {
   }
 
   if (aKeys.length === 0 &&
-      ((iterationType === kNoIterator ||
-        iterationType === kIsArray) && (val1.length === 0 ||
-        val1.size === 0))) {
+      (iterationType === kNoIterator ||
+        (iterationType === kIsArray && val1.length === 0) ||
+        val1.size === 0)) {
     return true;
   }
 

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -293,9 +293,9 @@ function keyCheck(val1, val2, strict, memos, iterationType, aKeys) {
   }
 
   if (aKeys.length === 0 &&
-      (iterationType === kNoIterator ||
-        iterationType === kIsArray && val1.length === 0 ||
-        val1.size === 0)) {
+      ((iterationType === kNoIterator ||
+        iterationType === kIsArray) && (val1.length === 0 ||
+        val1.size === 0))) {
     return true;
   }
 
@@ -383,7 +383,7 @@ function mapMightHaveLoosePrim(a, b, prim, item, memo) {
     return altValue;
   }
   const curB = b.get(altValue);
-  if (curB === undefined && !b.has(altValue) ||
+  if ((curB === undefined && !b.has(altValue)) ||
       !innerDeepEqual(item, curB, false, memo)) {
     return false;
   }
@@ -470,7 +470,7 @@ function mapEquiv(a, b, strict, memo) {
       // By directly retrieving the value we prevent another b.has(key) check in
       // almost all possible cases.
       const item2 = b.get(key);
-      if ((item2 === undefined && !b.has(key) ||
+      if (((item2 === undefined && !b.has(key)) ||
           !innerDeepEqual(item1, item2, strict, memo))) {
         if (strict)
           return false;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -599,10 +599,10 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
   // Only list the tag in case it's non-enumerable / not an own property.
   // Otherwise we'd print this twice.
   if (typeof tag !== 'string' ||
-      tag !== '' &&
+      (tag !== '' &&
       (ctx.showHidden ? hasOwnProperty : propertyIsEnumerable)(
         value, Symbol.toStringTag
-      )) {
+      ))) {
     tag = '';
   }
   let base = '';
@@ -686,7 +686,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
       const prefix = getPrefix(constructor, tag, 'RegExp');
       if (prefix !== 'RegExp ')
         base = `${prefix}${base}`;
-      if (keys.length === 0 || recurseTimes > ctx.depth && ctx.depth !== null)
+      if (keys.length === 0 || (recurseTimes > ctx.depth && ctx.depth !== null))
         return ctx.stylize(base, 'regexp');
     } else if (isDate(value)) {
       // Make dates with properties first say the date
@@ -914,14 +914,14 @@ function formatError(err, constructor, tag, ctx) {
   const name = err.name || 'Error';
   let len = name.length;
   if (constructor === null ||
-      name.endsWith('Error') &&
+      (name.endsWith('Error') &&
       stack.startsWith(name) &&
-      (stack.length === len || stack[len] === ':' || stack[len] === '\n')) {
+      (stack.length === len || stack[len] === ':' || stack[len] === '\n'))) {
     let fallback = 'Error';
     if (constructor === null) {
       const start = stack.match(/^([A-Z][a-z_ A-Z0-9[\]()-]+)(?::|\n {4}at)/) ||
         stack.match(/^([a-z_A-Z0-9-]*Error)$/);
-      fallback = start && start[1] || '';
+      fallback = (start && start[1]) || '';
       len = fallback.length;
       fallback = fallback || 'Error';
     }
@@ -939,7 +939,7 @@ function formatError(err, constructor, tag, ctx) {
     }
   }
   // Ignore the error message if it's contained in the stack.
-  let pos = err.message && stack.indexOf(err.message) || -1;
+  let pos = (err.message && stack.indexOf(err.message)) || -1;
   if (pos !== -1)
     pos += err.message.length;
   // Wrap the error in brackets in case it has no stack trace.
@@ -1419,8 +1419,8 @@ function formatProperty(ctx, value, recurseTimes, key, type) {
     const s = ctx.stylize;
     const sp = 'special';
     if (ctx.getters && (ctx.getters === true ||
-          ctx.getters === 'get' && desc.set === undefined ||
-          ctx.getters === 'set' && desc.set !== undefined)) {
+          (ctx.getters === 'get' && desc.set === undefined) ||
+          (ctx.getters === 'set' && desc.set !== undefined))) {
       try {
         const tmp = value[key];
         ctx.indentationLvl += 2;
@@ -1597,15 +1597,15 @@ function formatWithOptions(inspectOptions, ...args) {
                 let constr;
                 if (typeof tempArg !== 'object' ||
                     tempArg === null ||
-                    typeof tempArg.toString === 'function' &&
+                    (typeof tempArg.toString === 'function' &&
                      // A direct own property.
                      (hasOwnProperty(tempArg, 'toString') ||
                       // A direct own property on the constructor prototype in
                       // case the constructor is not an built-in object.
-                      (constr = tempArg.constructor) &&
+                      ((constr = tempArg.constructor) &&
                       !builtInObjects.has(constr.name) &&
                       constr.prototype &&
-                      hasOwnProperty(constr.prototype, 'toString'))) {
+                      hasOwnProperty(constr.prototype, 'toString'))))) {
                   tempStr = String(tempArg);
                 } else {
                   tempStr = inspect(tempArg, {

--- a/lib/path.js
+++ b/lib/path.js
@@ -44,8 +44,8 @@ function isPosixPathSeparator(code) {
 }
 
 function isWindowsDeviceRoot(code) {
-  return code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z ||
-         code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z;
+  return (code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
+         (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z);
 }
 
 // Resolves . and .. elements in a path with directory names
@@ -155,8 +155,8 @@ const win32 = {
         // Verify that a cwd was found and that it actually points
         // to our drive. If not, default to the drive's root.
         if (path === undefined ||
-            path.slice(0, 2).toLowerCase() !== resolvedDevice.toLowerCase() &&
-            path.charCodeAt(2) === CHAR_BACKWARD_SLASH) {
+            (path.slice(0, 2).toLowerCase() !== resolvedDevice.toLowerCase() &&
+            path.charCodeAt(2) === CHAR_BACKWARD_SLASH)) {
           path = `${resolvedDevice}\\`;
         }
       }
@@ -358,10 +358,10 @@ const win32 = {
     const code = path.charCodeAt(0);
     return isPathSeparator(code) ||
       // Possible device root
-      len > 2 &&
+      (len > 2 &&
       isWindowsDeviceRoot(code) &&
       path.charCodeAt(1) === CHAR_COLON &&
-      isPathSeparator(path.charCodeAt(2));
+      isPathSeparator(path.charCodeAt(2)));
   },
 
   join(...args) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -602,8 +602,8 @@ Interface.prototype._wordRight = function() {
 function charLengthLeft(str, i) {
   if (i <= 0)
     return 0;
-  if (i > 1 && (str.codePointAt(i - 2) >= kUTF16SurrogateThreshold ||
-      str.codePointAt(i - 1) >= kUTF16SurrogateThreshold)) {
+  if ((i > 1 && str.codePointAt(i - 2) >= kUTF16SurrogateThreshold) ||
+      str.codePointAt(i - 1) >= kUTF16SurrogateThreshold) {
     return 2;
   }
   return 1;

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -602,8 +602,8 @@ Interface.prototype._wordRight = function() {
 function charLengthLeft(str, i) {
   if (i <= 0)
     return 0;
-  if (i > 1 && str.codePointAt(i - 2) >= kUTF16SurrogateThreshold ||
-      str.codePointAt(i - 1) >= kUTF16SurrogateThreshold) {
+  if (i > 1 && (str.codePointAt(i - 2) >= kUTF16SurrogateThreshold ||
+      str.codePointAt(i - 1) >= kUTF16SurrogateThreshold)) {
     return 2;
   }
   return 1;

--- a/lib/url.js
+++ b/lib/url.js
@@ -765,13 +765,13 @@ Url.prototype.resolveObject = function resolveObject(relative) {
 
   const isSourceAbs = (result.pathname && result.pathname.charAt(0) === '/');
   const isRelAbs = (
-    relative.host || relative.pathname && relative.pathname.charAt(0) === '/'
+    relative.host || (relative.pathname && relative.pathname.charAt(0) === '/')
   );
   var mustEndAbs = (isRelAbs || isSourceAbs ||
                     (result.host && relative.pathname));
   const removeAllDots = mustEndAbs;
-  var srcPath = result.pathname && result.pathname.split('/') || [];
-  const relPath = relative.pathname && relative.pathname.split('/') || [];
+  var srcPath = (result.pathname && result.pathname.split('/')) || [];
+  const relPath = (relative.pathname && relative.pathname.split('/')) || [];
   const noLeadingSlashes = result.protocol &&
       !slashedProtocol.has(result.protocol);
 
@@ -869,8 +869,8 @@ Url.prototype.resolveObject = function resolveObject(relative) {
   // then it must NOT get a trailing slash.
   var last = srcPath.slice(-1)[0];
   const hasTrailingSlash = (
-    (result.host || relative.host || srcPath.length > 1) &&
-    (last === '.' || last === '..') || last === '');
+    ((result.host || relative.host || srcPath.length > 1) &&
+    (last === '.' || last === '..')) || last === '');
 
   // Strip single dots, resolve double dots to parent dir
   // if the path tries to go above the root, `up` ends up > 0

--- a/lib/util.js
+++ b/lib/util.js
@@ -94,7 +94,7 @@ function isFunction(arg) {
 
 function isPrimitive(arg) {
   return arg === null ||
-         typeof arg !== 'object' && typeof arg !== 'function';
+         (typeof arg !== 'object' && typeof arg !== 'function');
 }
 
 function pad(n) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Introduce `no-mixed-operators` eslint rule to `lib` for better code readability.

Refs: https://github.com/nodejs/node/pull/29825#discussion_r331037473

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
