### PR TITLE
stream: don't deadlock duplexpair

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2060,7 +2060,9 @@ when `_read()` is called again after it has stopped should it resume pushing
 additional data onto the queue.
 
 Once the `readable._read()` method has been called, it will not be called again
-until the [`readable.push()`][stream-push] method is called.
+until more data is pushed through the [`readable.push()`][stream-push] method.
+Empty data such as empty buffers and strings will not cause `readable._read()`
+to be called.
 
 The `size` argument is advisory. For implementations where a "read" is a
 single operation that returns data can use the `size` argument to determine how

--- a/lib/internal/streams/duplexpair.js
+++ b/lib/internal/streams/duplexpair.js
@@ -20,10 +20,10 @@ class DuplexSocket extends Duplex {
   }
 
   _write(chunk, encoding, callback) {
-    this[kOtherSide].push(chunk);
-    if (!this[kOtherSide].readableLength) {
+    if (chunk.length === 0) {
       process.nextTick(callback);
     } else {
+      this[kOtherSide].push(chunk);
       this[kOtherSide][kCallback] = callback;
     }
   }

--- a/lib/internal/streams/duplexpair.js
+++ b/lib/internal/streams/duplexpair.js
@@ -20,8 +20,12 @@ class DuplexSocket extends Duplex {
   }
 
   _write(chunk, encoding, callback) {
-    this[kOtherSide][kCallback] = callback;
     this[kOtherSide].push(chunk);
+    if (!this[kOtherSide].readableLength) {
+      process.nextTick(callback);
+    } else {
+      this[kOtherSide][kCallback] = callback;
+    }
   }
 
   _final(callback) {

--- a/test/common/duplexpair.js
+++ b/test/common/duplexpair.js
@@ -24,8 +24,12 @@ class DuplexSocket extends Duplex {
   _write(chunk, encoding, callback) {
     assert.notStrictEqual(this[kOtherSide], null);
     assert.strictEqual(this[kOtherSide][kCallback], null);
-    this[kOtherSide][kCallback] = callback;
     this[kOtherSide].push(chunk);
+    if (!this[kOtherSide].readableLength) {
+      process.nextTick(callback);
+    } else {
+      this[kOtherSide][kCallback] = callback;
+    }
   }
 
   _final(callback) {

--- a/test/common/duplexpair.js
+++ b/test/common/duplexpair.js
@@ -24,10 +24,10 @@ class DuplexSocket extends Duplex {
   _write(chunk, encoding, callback) {
     assert.notStrictEqual(this[kOtherSide], null);
     assert.strictEqual(this[kOtherSide][kCallback], null);
-    this[kOtherSide].push(chunk);
-    if (!this[kOtherSide].readableLength) {
+    if (chunk.length === 0) {
       process.nextTick(callback);
     } else {
+      this[kOtherSide].push(chunk);
       this[kOtherSide][kCallback] = callback;
     }
   }


### PR DESCRIPTION
 If nothing is buffered then _read will not be called and the callback will not invoked, effectivly deadlocking.

Fixes: https://github.com/nodejs/node/issues/29758
Refs: https://github.com/nodejs/node/pull/29649

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
