### PR TITLE
lib: fs.rmdir should accept null/undefined in options

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -541,7 +541,13 @@ const validateRmdirOptions = hideStackFrames((options) => {
   if (options === null || typeof options !== 'object')
     throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
 
-  options = { ...defaultRmdirOptions, ...options };
+  const definedValueOnly = Object.assign({}, options);
+  Object.entries(definedValueOnly).forEach((kv) => {
+    const [key, value] = kv;
+    if (typeof value === 'undefined' || value === null)
+      delete definedValueOnly[key];
+  });
+  options = { ...defaultRmdirOptions, ...definedValueOnly };
 
   if (typeof options.recursive !== 'boolean')
     throw new ERR_INVALID_ARG_TYPE('recursive', 'boolean', options.recursive);

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -102,10 +102,16 @@ function makeNonEmptyDirectory() {
     maxBusyTries: 5,
     recursive: true
   };
+  const nullOrUndefine = {
+    emfileWait: null,
+    maxBusyTries: undefined,
+    recursive: undefined
+  };
 
   assert.deepStrictEqual(validateRmdirOptions(), defaults);
   assert.deepStrictEqual(validateRmdirOptions({}), defaults);
   assert.deepStrictEqual(validateRmdirOptions(modified), modified);
+  assert.deepStrictEqual(validateRmdirOptions(nullOrUndefine), defaults);
   assert.deepStrictEqual(validateRmdirOptions({
     maxBusyTries: 99
   }), {


### PR DESCRIPTION
[From the documentation](https://github.com/nodejs/node/blob/24011de9071fcd092fab29719d3fa8269a95288a/doc/api/fs.md#fsrmdirpath-options-callback
), all fields for options for `fs.rmdir` are optional.
However, if `undefined` or `null` is given, it throws error.
I think it is inconsistent with other APIs which accept `undefined` or `null` and use default values as fallback.

##### Checklist
- [x] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
