### PR TITLE
Remove misleading paragraph about the Legacy URL API

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -21,10 +21,6 @@ The `url` module provides two APIs for working with URLs: a legacy API that is
 Node.js specific, and a newer API that implements the same
 [WHATWG URL Standard][] used by web browsers.
 
-While the Legacy API has not been deprecated, it is maintained solely for
-backwards compatibility with existing applications. New application code
-should use the WHATWG API.
-
 A comparison between the WHATWG and Legacy APIs is provided below. Above the URL
 `'http://user:pass@sub.example.com:8080/p/a/t/h?query=string#hash'`, properties
 of an object returned by the legacy `url.parse()` are shown. Below it are


### PR DESCRIPTION
As far as I could tell, the Legacy URL API is in fact deprecated, see [Legacy URL API](https://nodejs.org/api/url.html#url_legacy_url_api) and [DEP0116](https://nodejs.org/api/deprecations.html#deprecations_dep0116_legacy_url_api).

##### Checklist

✓ documentation is changed or added
✓ commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)