### PR TITLE
v8 Synthetic Modules Implementation

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -150,8 +150,7 @@ function NativeModule(id) {
   this.filename = `${id}.js`;
   this.id = id;
   this.exports = {};
-  this.reflect = undefined;
-  this.esmFacade = undefined;
+  this.module = undefined;
   this.exportKeys = undefined;
   this.loaded = false;
   this.loading = false;
@@ -240,16 +239,18 @@ NativeModule.prototype.getURL = function() {
 };
 
 NativeModule.prototype.getESMFacade = function() {
-  if (this.esmFacade) return this.esmFacade;
-  const createDynamicModule = nativeModuleRequire(
-    'internal/modules/esm/create_dynamic_module');
+  if (this.module) return this.module;
+  const { ModuleWrap } = internalBinding('module_wrap');
   const url = this.getURL();
-  return this.esmFacade = createDynamicModule(
-    [], [...this.exportKeys, 'default'], url, (reflect) => {
-      this.reflect = reflect;
-      this.syncExports();
-      reflect.exports.default.set(this.exports);
-    });
+  const nativeModule = this;
+  this.module = new ModuleWrap(function() {
+    nativeModule.syncExports();
+    this.setExport('default', nativeModule.exports);
+  }, [...this.exportKeys, 'default'], url);
+  // Ensure immediate sync execution to capture exports now
+  this.module.instantiate();
+  this.module.evaluate(-1, false);
+  return this.module;
 };
 
 // Provide named exports for all builtin libraries so that the libraries
@@ -258,13 +259,12 @@ NativeModule.prototype.getESMFacade = function() {
 // called so that APMs and other behavior are supported.
 NativeModule.prototype.syncExports = function() {
   const names = this.exportKeys;
-  if (this.reflect) {
+  if (this.module) {
     for (let i = 0; i < names.length; i++) {
       const exportName = names[i];
       if (exportName === 'default') continue;
-      this.reflect.exports[exportName].set(
-        getOwn(this.exports, exportName, this.exports)
-      );
+      this.module.setExport(exportName,
+                            getOwn(this.exports, exportName, this.exports));
     }
   }
 };

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -74,9 +74,7 @@ const experimentalExports = getOptionValue('--experimental-exports');
 
 module.exports = { wrapSafe, Module };
 
-let asyncESM;
-let ModuleJob;
-let createDynamicModule;
+let asyncESM, ModuleJob, ModuleWrap, kInstantiated;
 
 const {
   CHAR_FORWARD_SLASH,
@@ -819,21 +817,18 @@ Module.prototype.load = function(filename) {
     const module = ESMLoader.moduleMap.get(url);
     // Create module entry at load time to snapshot exports correctly
     const exports = this.exports;
-    if (module !== undefined) { // Called from cjs translator
-      if (module.reflect) {
-        module.reflect.onReady((reflect) => {
-          reflect.exports.default.set(exports);
-        });
-      }
+    // Called from cjs translator
+    if (module !== undefined && module.module !== undefined) {
+      if (module.module.getStatus() >= kInstantiated)
+        module.module.setExport('default', exports);
     } else { // preemptively cache
       ESMLoader.moduleMap.set(
         url,
-        new ModuleJob(ESMLoader, url, async () => {
-          return createDynamicModule(
-            [], ['default'], url, (reflect) => {
-              reflect.exports.default.set(exports);
-            });
-        })
+        new ModuleJob(ESMLoader, url, () =>
+          new ModuleWrap(function() {
+            this.setExport('default', exports);
+          }, ['default'], url)
+        )
       );
     }
   }
@@ -1150,6 +1145,5 @@ Module.Module = Module;
 if (experimentalModules) {
   asyncESM = require('internal/process/esm_loader');
   ModuleJob = require('internal/modules/esm/module_job');
-  createDynamicModule = require(
-    'internal/modules/esm/create_dynamic_module');
+  ({ ModuleWrap, kInstantiated } = internalBinding('module_wrap'));
 }

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -117,12 +117,7 @@ class Loader {
     source,
     url = pathToFileURL(`${process.cwd()}/[eval${++this.evalIndex}]`).href
   ) {
-    const evalInstance = async (url) => {
-      return {
-        module: new ModuleWrap(source, url),
-        reflect: undefined
-      };
-    };
+    const evalInstance = (url) => new ModuleWrap(source, url);
     const job = new ModuleJob(this, url, evalInstance, false);
     this.moduleMap.set(url, job);
     const { module, result } = await job.run();

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -165,7 +165,7 @@ class Loader {
         return createDynamicModule([], exports, url, (reflect) => {
           debug(`Loading dynamic ${url}`);
           execute(reflect.exports);
-        });
+        }).module;
       };
     } else {
       if (!translators.has(format))

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -30,19 +30,17 @@ class ModuleJob {
     // onto `this` by `link()` below once it has been resolved.
     this.modulePromise = moduleProvider.call(loader, url, isMain);
     this.module = undefined;
-    this.reflect = undefined;
 
     // Wait for the ModuleWrap instance being linked with all dependencies.
     const link = async () => {
-      ({ module: this.module,
-         reflect: this.reflect } = await this.modulePromise);
+      this.module = await this.modulePromise;
       assert(this.module instanceof ModuleWrap);
 
       const dependencyJobs = [];
       const promises = this.module.link(async (specifier) => {
         const jobPromise = this.loader.getModuleJob(specifier, url);
         dependencyJobs.push(jobPromise);
-        return (await (await jobPromise).modulePromise).module;
+        return (await jobPromise).modulePromise;
       });
 
       if (promises !== undefined)

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -32,6 +32,8 @@ const {
 const readFileAsync = promisify(fs.readFile);
 const JsonParse = JSON.parse;
 const { maybeCacheSourceMap } = require('internal/source_map/source_map_cache');
+const moduleWrap = internalBinding('module_wrap');
+const { ModuleWrap } = moduleWrap;
 
 const debug = debuglog('esm');
 
@@ -77,22 +79,18 @@ translators.set('module', async function moduleStrategy(url) {
   const source = `${await getSource(url)}`;
   maybeCacheSourceMap(url, source);
   debug(`Translating StandardModule ${url}`);
-  const { ModuleWrap, callbackMap } = internalBinding('module_wrap');
   const module = new ModuleWrap(source, url);
-  callbackMap.set(module, {
+  moduleWrap.callbackMap.set(module, {
     initializeImportMeta,
     importModuleDynamically,
   });
-  return {
-    module,
-    reflect: undefined,
-  };
+  return module;
 });
 
 // Strategy for loading a node-style CommonJS module
 const isWindows = process.platform === 'win32';
 const winSepRegEx = /\//g;
-translators.set('commonjs', async function commonjsStrategy(url, isMain) {
+translators.set('commonjs', function commonjsStrategy(url, isMain) {
   debug(`Translating CJSModule ${url}`);
   const pathname = internalURLModule.fileURLToPath(new URL(url));
   const cached = this.cjsCache.get(url);
@@ -105,17 +103,17 @@ translators.set('commonjs', async function commonjsStrategy(url, isMain) {
   ];
   if (module && module.loaded) {
     const exports = module.exports;
-    return createDynamicModule([], ['default'], url, (reflect) => {
-      reflect.exports.default.set(exports);
-    });
+    return new ModuleWrap(function() {
+      this.setExport('default', exports);
+    }, ['default'], url);
   }
-  return createDynamicModule([], ['default'], url, () => {
+  return new ModuleWrap(function() {
     debug(`Loading CJSModule ${url}`);
     // We don't care about the return val of _load here because Module#load
     // will handle it for us by checking the loader registry and filling the
     // exports like above
     CJSModule._load(pathname, undefined, isMain);
-  });
+  }, ['default'], url);
 });
 
 // Strategy for loading a node builtin CommonJS module that isn't
@@ -145,9 +143,9 @@ translators.set('json', async function jsonStrategy(url) {
     module = CJSModule._cache[modulePath];
     if (module && module.loaded) {
       const exports = module.exports;
-      return createDynamicModule([], ['default'], url, (reflect) => {
-        reflect.exports.default.set(exports);
-      });
+      return new ModuleWrap(function() {
+        this.setExport('default', exports);
+      }, ['default'], url);
     }
   }
   const content = `${await getSource(url)}`;
@@ -158,9 +156,9 @@ translators.set('json', async function jsonStrategy(url) {
     module = CJSModule._cache[modulePath];
     if (module && module.loaded) {
       const exports = module.exports;
-      return createDynamicModule(['default'], url, (reflect) => {
-        reflect.exports.default.set(exports);
-      });
+      return new ModuleWrap(function() {
+        this.setExport('default', exports);
+      }, ['default'], url);
     }
   }
   try {
@@ -180,10 +178,10 @@ translators.set('json', async function jsonStrategy(url) {
   if (pathname) {
     CJSModule._cache[modulePath] = module;
   }
-  return createDynamicModule([], ['default'], url, (reflect) => {
+  return new ModuleWrap(function() {
     debug(`Parsing JSONModule ${url}`);
-    reflect.exports.default.set(module.exports);
-  });
+    this.setExport('default', module.exports);
+  }, ['default'], url);
 });
 
 // Strategy for loading a wasm module
@@ -206,5 +204,5 @@ translators.set('wasm', async function(url) {
     const { exports } = new WebAssembly.Instance(compiled, reflect.imports);
     for (const expt of Object.keys(exports))
       reflect.exports[expt].set(exports[expt]);
-  });
+  }).module;
 });

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -69,12 +69,19 @@ class ModuleWrap : public BaseObject {
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetInitializeImportMetaObjectCallback(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+  static v8::MaybeLocal<v8::Value> SyntheticModuleEvaluationStepsCallback(
+      v8::Local<v8::Context> context, v8::Local<v8::Module> module);
+  static void SetSyntheticExport(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
   static v8::MaybeLocal<v8::Module> ResolveCallback(
       v8::Local<v8::Context> context,
       v8::Local<v8::String> specifier,
       v8::Local<v8::Module> referrer);
   static ModuleWrap* GetFromModule(node::Environment*, v8::Local<v8::Module>);
 
+  v8::Global<v8::Function> synthetic_evaluation_steps_;
+  bool synthetic_ = false;
   v8::Global<v8::Module> module_;
   v8::Global<v8::String> url_;
   bool linked_ = false;


### PR DESCRIPTION
This updates uses of `createDynamicModule` to instead use a new `ModuleWrap` signature for creating v8 Synthetic Module Records instead.

We still need to retain `createDynamicModule` for WASM due to imports and for the dynamic loader due to the exact behaviours, but these uses will likely be phased out over time anyway.

This PR is based on top of https://github.com/nodejs/node/pull/29737, so should merge after that. This is also prerequisite to the unflagging, as discussed in https://github.com/nodejs/modules/issues/394.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
