### PR TITLE
src,n-api: throwing error with napi_pending_exception status

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1489,10 +1489,8 @@ napi_status napi_create_bigint_words(napi_env env,
 
   v8::Local<v8::Context> context = env->context();
 
-  if (word_count > INT_MAX) {
-    napi_throw_range_error(env, nullptr, "Maximum BigInt size exceeded");
-    return napi_set_last_error(env, napi_pending_exception);
-  }
+  THROW_RANGE_ERROR_IF_TRUE(
+      env, word_count > INT_MAX, nullptr, "Maximum BigInt size exceeded");
 
   v8::MaybeLocal<v8::BigInt> b = v8::BigInt::NewFromWords(
       context, sign_bit, word_count, words);
@@ -2483,13 +2481,10 @@ napi_status napi_instanceof(napi_env env,
 
   CHECK_TO_OBJECT(env, context, ctor, constructor);
 
-  if (!ctor->IsFunction()) {
-    napi_throw_type_error(env,
-                          "ERR_NAPI_CONS_FUNCTION",
-                          "Constructor must be a function");
-
-    return napi_set_last_error(env, napi_function_expected);
-  }
+  THROW_TYPE_ERROR_IF_FALSE(env,
+                            ctor->IsFunction(),
+                            "ERR_NAPI_CONS_FUNCTION",
+                            "Constructor must be a function");
 
   napi_status status = napi_generic_failure;
 
@@ -2769,14 +2764,14 @@ napi_status napi_create_dataview(napi_env env,
   RETURN_STATUS_IF_FALSE(env, value->IsArrayBuffer(), napi_invalid_arg);
 
   v8::Local<v8::ArrayBuffer> buffer = value.As<v8::ArrayBuffer>();
-  if (byte_length + byte_offset > buffer->ByteLength()) {
-    napi_throw_range_error(
-        env,
-        "ERR_NAPI_INVALID_DATAVIEW_ARGS",
-        "byte_offset + byte_length should be less than or "
-        "equal to the size in bytes of the array passed in");
-    return napi_set_last_error(env, napi_pending_exception);
-  }
+
+  THROW_RANGE_ERROR_IF_TRUE(
+      env,
+      byte_length + byte_offset > buffer->ByteLength(),
+      "ERR_NAPI_INVALID_DATAVIEW_ARGS",
+      "byte_offset + byte_length should be less than or "
+      "equal to the size in bytes of the array passed in");
+
   v8::Local<v8::DataView> DataView = v8::DataView::New(buffer, byte_offset,
                                                        byte_length);
 

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -140,13 +140,21 @@ napi_status napi_set_last_error(napi_env env, napi_status error_code,
   (!try_catch.HasCaught() ? napi_ok \
                          : napi_set_last_error((env), napi_pending_exception))
 
-#define THROW_RANGE_ERROR_IF_FALSE(env, condition, error, message) \
-  do {                                                             \
-    if (!(condition)) {                                            \
-      napi_throw_range_error((env), (error), (message));           \
-      return napi_set_last_error((env), napi_generic_failure);     \
-    }                                                              \
+#define THROW_XERROR_IF_TRUE(errortype, env, condition, error, message)        \
+  do {                                                                         \
+    if (condition) {                                                           \
+      napi_throw_##errortype##_error((env), (error), (message));               \
+      return napi_set_last_error((env), napi_pending_exception);               \
+    }                                                                          \
   } while (0)
+
+#define THROW_RANGE_ERROR_IF_TRUE(env, condition, error, message)              \
+  THROW_XERROR_IF_TRUE(range, env, condition, error, message)
+#define THROW_RANGE_ERROR_IF_FALSE(env, condition, error, message)             \
+  THROW_XERROR_IF_TRUE(range, env, !(condition), error, message)
+
+#define THROW_TYPE_ERROR_IF_FALSE(env, condition, error, message)              \
+  THROW_XERROR_IF_TRUE(type, env, !(condition), error, message)
 
 namespace v8impl {
 


### PR DESCRIPTION
It should be napi_pending_exception if an JavaScript error is
pending to be handled. Or it might have a great chance to be ignored.
See https://github.com/nodejs/node-addon-api/blob/master/napi-inl.h#L2006-L2013

Related: https://github.com/nodejs/node/pull/29768#issuecomment-537273131

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
