### PR TITLE
async_hooks: buffer bootstrap events

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -695,7 +695,7 @@ never be called.
 [`after` callback]: #async_hooks_after_asyncid
 [`before` callback]: #async_hooks_before_asyncid
 [`destroy` callback]: #async_hooks_destroy_asyncid
-[`init` callback]: #async_hooks_init_asyncid_type_triggerasyncid_resource
+[`init` callback]: #async_hooks_init_asyncid_type_triggerasyncid_resource_bootstrap
 [`promiseResolve` callback]: #async_hooks_promiseresolve_asyncid
 [Hook Callbacks]: #async_hooks_hook_callbacks
 [PromiseHooks]: https://docs.google.com/document/d/1rda3yKGHimKIhg5YeoAmCOtyURgsbTH_qaYR79FELlk/edit

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -323,7 +323,7 @@ elaborate to make calling context easier to see.
 let indent = 0;
 const bootstrapIds = new Set();
 async_hooks.createHook({
-  init(asyncId, type, triggerAsyncId, bootstrap) {
+  init(asyncId, type, triggerAsyncId, resource, bootstrap) {
     if (bootstrap) {
       bootstrapIds.add(asyncId);
       return;

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -5152,7 +5152,7 @@ This API may only be called from the main thread.
 [Working with JavaScript Properties]: #n_api_working_with_javascript_properties
 [Working with JavaScript Values - Abstract Operations]: #n_api_working_with_javascript_values_abstract_operations
 [Working with JavaScript Values]: #n_api_working_with_javascript_values
-[`init` hooks]: async_hooks.html#async_hooks_init_asyncid_type_triggerasyncid_resource
+[`init` hooks]: async_hooks.html#async_hooks_init_asyncid_type_triggerasyncid_resource_bootstrap
 [`napi_add_finalizer`]: #n_api_napi_add_finalizer
 [`napi_async_init`]: #n_api_napi_async_init
 [`napi_cancel_async_work`]: #n_api_napi_cancel_async_work

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -28,6 +28,7 @@ const {
   emitAfter,
   emitDestroy,
   initHooksExist,
+  emitBootstrapHooksBuffer
 } = internal_async_hooks;
 
 // Get symbols
@@ -91,6 +92,10 @@ class AsyncHook {
     if (prev_kTotals === 0 && hook_fields[kTotals] > 0) {
       enableHooks();
     }
+
+    // If there are unemitted bootstrap hooks, emit them now.
+    // This only applies during sync execution of user code after bootsrap.
+    emitBootstrapHooksBuffer();
 
     return this;
   }

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -289,6 +289,18 @@ function bufferBootstrapHooks() {
   }
 }
 
+function clearBootstrapHooksBuffer() {
+  if (!bootstrapBuffer)
+    return;
+  if (bootstrapHooks) {
+    stopBootstrapHooksBuffer();
+    process._tickCallback();
+  }
+  const _bootstrapBuffer = bootstrapBuffer;
+  bootstrapBuffer = null;
+  return _bootstrapBuffer;
+}
+
 function stopBootstrapHooksBuffer() {
   if (!bootstrapHooks)
     return;
@@ -302,18 +314,11 @@ function stopBootstrapHooksBuffer() {
   bootstrapHooks = null;
   if (async_hook_fields[kTotals] === 0) {
     disableHooks();
-    // Flush microtasks to ensure disable has run.
-    process._tickCallback();
   }
 }
 
-function clearBootstrapHooksBuffer() {
-  if (bootstrapHooks)
-    stopBootstrapHooksBuffer();
-  bootstrapBuffer = null;
-}
-
 function emitBootstrapHooksBuffer() {
+  const bootstrapBuffer = clearBootstrapHooksBuffer();
   if (!bootstrapBuffer || async_hook_fields[kTotals] === 0) {
     return;
   }
@@ -333,7 +338,6 @@ function emitBootstrapHooksBuffer() {
         break;
     }
   }
-  bootstrapBuffer = null;
 }
 
 let wantPromiseHook = false;

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -125,7 +125,8 @@ function validateAsyncId(asyncId, type) {
 // Used by C++ to call all init() callbacks. Because some state can be setup
 // from C++ there's no need to perform all the same operations as in
 // emitInitScript.
-function emitInitNative(asyncId, type, triggerAsyncId, resource) {
+function emitInitNative(asyncId, type, triggerAsyncId, resource,
+                        bootstrap = false) {
   active_hooks.call_depth += 1;
   // Use a single try/catch for all hooks to avoid setting up one per iteration.
   try {
@@ -133,7 +134,7 @@ function emitInitNative(asyncId, type, triggerAsyncId, resource) {
       if (typeof active_hooks.array[i][init_symbol] === 'function') {
         active_hooks.array[i][init_symbol](
           asyncId, type, triggerAsyncId,
-          resource
+          resource, bootstrap
         );
       }
     }
@@ -231,6 +232,103 @@ function restoreActiveHooks() {
   active_hooks.tmp_fields = null;
 }
 
+// Bootstrap hooks are buffered to emit to userland listeners
+let bootstrapHooks, bootstrapBuffer;
+function bufferBootstrapHooks() {
+  const { getOptionValue } = require('internal/options');
+  if (getOptionValue('--no-force-async-hooks-checks')) {
+    return;
+  }
+  async_hook_fields[kInit]++;
+  async_hook_fields[kBefore]++;
+  async_hook_fields[kAfter]++;
+  async_hook_fields[kDestroy]++;
+  async_hook_fields[kPromiseResolve]++;
+  async_hook_fields[kTotals] += 5;
+  bootstrapHooks = {
+    [init_symbol]: (asyncId, type, triggerAsyncId, resource) => {
+      bootstrapBuffer.push({
+        type: kInit,
+        asyncId,
+        args: [type, triggerAsyncId, resource, true]
+      });
+    },
+    [before_symbol]: (asyncId) => {
+      bootstrapBuffer.push({
+        type: kBefore,
+        asyncId,
+        args: null
+      });
+    },
+    [after_symbol]: (asyncId) => {
+      bootstrapBuffer.push({
+        type: kAfter,
+        asyncId,
+        args: null
+      });
+    },
+    [destroy_symbol]: (asyncId) => {
+      bootstrapBuffer.push({
+        type: kDestroy,
+        asyncId,
+        args: null
+      });
+    },
+    [promise_resolve_symbol]: (asyncId) => {
+      bootstrapBuffer.push({
+        type: kPromiseResolve,
+        asyncId,
+        args: null
+      });
+    }
+  };
+  bootstrapBuffer = [];
+  active_hooks.array.push(bootstrapHooks);
+  if (async_hook_fields[kTotals] === 5) {
+    enableHooks();
+  }
+}
+
+function clearBootstrapHooksBuffer() {
+  if (!bootstrapBuffer)
+    return;
+  async_hook_fields[kInit]--;
+  async_hook_fields[kBefore]--;
+  async_hook_fields[kAfter]--;
+  async_hook_fields[kDestroy]--;
+  async_hook_fields[kPromiseResolve]--;
+  async_hook_fields[kTotals] -= 5;
+  active_hooks.array.splice(active_hooks.array.indexOf(bootstrapHooks), 1);
+  if (async_hook_fields[kTotals] === 0)
+    disableHooks();
+  const _bootstrapBuffer = bootstrapBuffer;
+  bootstrapBuffer = null;
+  bootstrapHooks = null;
+  return _bootstrapBuffer;
+}
+
+function emitBootstrapHooksBuffer() {
+  const bootstrapBuffer = clearBootstrapHooksBuffer();
+  if (!bootstrapBuffer || async_hook_fields[kTotals] === 0) {
+    return;
+  }
+  for (const { type, asyncId, args } of bootstrapBuffer) {
+    switch (type) {
+      case kInit:
+        emitInitNative(asyncId, ...args);
+        break;
+      case kBefore:
+        emitBeforeNative(asyncId);
+        break;
+      case kAfter:
+        emitAfterNative(asyncId);
+        break;
+      case kDestroy:
+        emitDestroyNative(asyncId);
+        break;
+    }
+  }
+}
 
 let wantPromiseHook = false;
 function enableHooks() {
@@ -318,7 +416,8 @@ function destroyHooksExist() {
 }
 
 
-function emitInitScript(asyncId, type, triggerAsyncId, resource) {
+function emitInitScript(asyncId, type, triggerAsyncId, resource,
+                        bootstrap = false) {
   validateAsyncId(asyncId, 'asyncId');
   if (triggerAsyncId !== null)
     validateAsyncId(triggerAsyncId, 'triggerAsyncId');
@@ -338,7 +437,7 @@ function emitInitScript(asyncId, type, triggerAsyncId, resource) {
     triggerAsyncId = getDefaultTriggerAsyncId();
   }
 
-  emitInitNative(asyncId, type, triggerAsyncId, resource);
+  emitInitNative(asyncId, type, triggerAsyncId, resource, bootstrap);
 }
 
 
@@ -468,5 +567,8 @@ module.exports = {
     after: emitAfterNative,
     destroy: emitDestroyNative,
     promise_resolve: emitPromiseResolveNative
-  }
+  },
+  bufferBootstrapHooks,
+  clearBootstrapHooksBuffer,
+  emitBootstrapHooksBuffer
 };

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -299,8 +299,12 @@ function clearBootstrapHooksBuffer() {
   async_hook_fields[kPromiseResolve]--;
   async_hook_fields[kTotals] -= 5;
   active_hooks.array.splice(active_hooks.array.indexOf(bootstrapHooks), 1);
-  if (async_hook_fields[kTotals] === 0)
-    disableHooks();
+  if (async_hook_fields[kTotals] === 0) {
+    async_hook_fields[kCheck] -= 1;
+    wantPromiseHook = false;
+    // No delay, because timing is always carefully managed by the caller.
+    disablePromiseHookIfNecessary();
+  }
   const _bootstrapBuffer = bootstrapBuffer;
   bootstrapBuffer = null;
   bootstrapHooks = null;

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -294,7 +294,6 @@ function clearBootstrapHooksBuffer() {
     return;
   if (bootstrapHooks) {
     stopBootstrapHooksBuffer();
-    process._tickCallback();
   }
   const _bootstrapBuffer = bootstrapBuffer;
   bootstrapBuffer = null;
@@ -314,6 +313,8 @@ function stopBootstrapHooksBuffer() {
   bootstrapHooks = null;
   if (async_hook_fields[kTotals] === 0) {
     disableHooks();
+    // Ensure disable happens immediately and synchronously.
+    process._tickCallback();
   }
 }
 

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -300,10 +300,9 @@ function clearBootstrapHooksBuffer() {
   async_hook_fields[kTotals] -= 5;
   active_hooks.array.splice(active_hooks.array.indexOf(bootstrapHooks), 1);
   if (async_hook_fields[kTotals] === 0) {
-    async_hook_fields[kCheck] -= 1;
-    wantPromiseHook = false;
-    // No delay, because timing is always carefully managed by the caller.
-    disablePromiseHookIfNecessary();
+    disableHooks();
+    // Flush microtasks to ensure disable has run.
+    process._tickCallback();
   }
   const _bootstrapBuffer = bootstrapBuffer;
   bootstrapBuffer = null;

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -289,8 +289,8 @@ function bufferBootstrapHooks() {
   }
 }
 
-function clearBootstrapHooksBuffer() {
-  if (!bootstrapBuffer)
+function stopBootstrapHooksBuffer() {
+  if (!bootstrapHooks)
     return;
   async_hook_fields[kInit]--;
   async_hook_fields[kBefore]--;
@@ -299,19 +299,21 @@ function clearBootstrapHooksBuffer() {
   async_hook_fields[kPromiseResolve]--;
   async_hook_fields[kTotals] -= 5;
   active_hooks.array.splice(active_hooks.array.indexOf(bootstrapHooks), 1);
+  bootstrapHooks = null;
   if (async_hook_fields[kTotals] === 0) {
     disableHooks();
     // Flush microtasks to ensure disable has run.
     process._tickCallback();
   }
-  const _bootstrapBuffer = bootstrapBuffer;
+}
+
+function clearBootstrapHooksBuffer() {
+  if (bootstrapHooks)
+    stopBootstrapHooksBuffer();
   bootstrapBuffer = null;
-  bootstrapHooks = null;
-  return _bootstrapBuffer;
 }
 
 function emitBootstrapHooksBuffer() {
-  const bootstrapBuffer = clearBootstrapHooksBuffer();
   if (!bootstrapBuffer || async_hook_fields[kTotals] === 0) {
     return;
   }
@@ -331,6 +333,7 @@ function emitBootstrapHooksBuffer() {
         break;
     }
   }
+  bootstrapBuffer = null;
 }
 
 let wantPromiseHook = false;
@@ -573,5 +576,6 @@ module.exports = {
   },
   bufferBootstrapHooks,
   clearBootstrapHooksBuffer,
-  emitBootstrapHooksBuffer
+  emitBootstrapHooksBuffer,
+  stopBootstrapHooksBuffer
 };

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -5,6 +5,7 @@ const { Object, SafeWeakMap } = primordials;
 const { getOptionValue } = require('internal/options');
 const { Buffer } = require('buffer');
 const { ERR_MANIFEST_ASSERT_INTEGRITY } = require('internal/errors').codes;
+const { bufferBootstrapHooks } = require('internal/async_hooks');
 
 function prepareMainThreadExecution(expandArgv1 = false) {
   // Patch the process object with legacy properties and normalizations
@@ -31,6 +32,10 @@ function prepareMainThreadExecution(expandArgv1 = false) {
   }
 
   setupDebugEnv();
+
+  // Buffer all async hooks emitted by core bootstrap
+  // to allow user listeners to attach to these
+  bufferBootstrapHooks();
 
   // Only main thread receives signals.
   setupSignalHandlers();

--- a/lib/internal/main/run_main_module.js
+++ b/lib/internal/main/run_main_module.js
@@ -3,29 +3,15 @@
 const {
   prepareMainThreadExecution
 } = require('internal/bootstrap/pre_execution');
-const { getOptionValue } = require('internal/options');
 
 prepareMainThreadExecution(true);
 
-// Load the main module--the command line argument.
-const experimentalModules = getOptionValue('--experimental-modules');
-if (experimentalModules) {
-  const asyncESM = require('internal/process/esm_loader');
-  const { pathToFileURL } = require('internal/url');
-  markBootstrapComplete();
-  asyncESM.loaderPromise.then((loader) => {
-    return loader.import(pathToFileURL(process.argv[1]).href);
-  })
-  .catch((e) => {
-    internalBinding('errors').triggerUncaughtException(
-      e,
-      true /* fromPromise */
-    );
-  });
-} else {
-  const { clearBootstrapHooksBuffer } = require('internal/async_hooks');
-  clearBootstrapHooksBuffer();
-  const CJSModule = require('internal/modules/cjs/loader').Module;
-  markBootstrapComplete();
-  CJSModule._load(process.argv[1], null, true);
-}
+const CJSModule = require('internal/modules/cjs/loader').Module;
+
+markBootstrapComplete();
+
+// Note: this actually tries to run the module as a ESM first if
+// --experimental-modules is on.
+// TODO(joyeecheung): can we move that logic to here? Note that this
+// is an undocumented method available via `require('module').runMain`
+CJSModule.runMain(process.argv[1]);

--- a/lib/internal/main/run_main_module.js
+++ b/lib/internal/main/run_main_module.js
@@ -3,15 +3,29 @@
 const {
   prepareMainThreadExecution
 } = require('internal/bootstrap/pre_execution');
+const { getOptionValue } = require('internal/options');
 
 prepareMainThreadExecution(true);
 
-const CJSModule = require('internal/modules/cjs/loader').Module;
-
-markBootstrapComplete();
-
-// Note: this actually tries to run the module as a ESM first if
-// --experimental-modules is on.
-// TODO(joyeecheung): can we move that logic to here? Note that this
-// is an undocumented method available via `require('module').runMain`
-CJSModule.runMain();
+// Load the main module--the command line argument.
+const experimentalModules = getOptionValue('--experimental-modules');
+if (experimentalModules) {
+  const asyncESM = require('internal/process/esm_loader');
+  const { pathToFileURL } = require('internal/url');
+  markBootstrapComplete();
+  asyncESM.loaderPromise.then((loader) => {
+    return loader.import(pathToFileURL(process.argv[1]).href);
+  })
+  .catch((e) => {
+    internalBinding('errors').triggerUncaughtException(
+      e,
+      true /* fromPromise */
+    );
+  });
+} else {
+  const { clearBootstrapHooksBuffer } = require('internal/async_hooks');
+  clearBootstrapHooksBuffer();
+  const CJSModule = require('internal/modules/cjs/loader').Module;
+  markBootstrapComplete();
+  CJSModule._load(process.argv[1], null, true);
+}

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -140,8 +140,8 @@ port.on('message', (message) => {
       const { evalScript } = require('internal/process/execution');
       evalScript('[worker eval]', filename);
     } else {
-      process.argv[1] = filename; // script filename
-      require('module').runMain();
+      // script filename
+      require('module').runMain(process.argv[1] = filename);
     }
   } else if (message.type === STDIO_PAYLOAD) {
     const { stream, chunk, encoding } = message;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -62,7 +62,7 @@ const manifest = getOptionValue('--experimental-policy') ?
   require('internal/process/policy').manifest :
   null;
 const { compileFunction } = internalBinding('contextify');
-
+const { clearBootstrapHooksBuffer } = require('internal/async_hooks');
 const {
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_OPT_VALUE,
@@ -1005,6 +1005,24 @@ Module._extensions['.node'] = function(module, filename) {
 
 Module._extensions['.mjs'] = function(module, filename) {
   throw new ERR_REQUIRE_ESM(filename);
+};
+
+Module.runMain = function(mainPath) {
+  // Load the main module--the command line argument.
+  if (experimentalModules) {
+    asyncESM.loaderPromise.then((loader) => {
+      return loader.import(pathToFileURL(mainPath).href);
+    })
+    .catch((e) => {
+      internalBinding('errors').triggerUncaughtException(
+        e,
+        true /* fromPromise */
+      );
+    });
+  } else {
+    clearBootstrapHooksBuffer();
+    Module._load(mainPath, null, true);
+  }
 };
 
 function createRequireFromPath(filename) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1007,24 +1007,6 @@ Module._extensions['.mjs'] = function(module, filename) {
   throw new ERR_REQUIRE_ESM(filename);
 };
 
-// Bootstrap main module.
-Module.runMain = function() {
-  // Load the main module--the command line argument.
-  if (experimentalModules) {
-    asyncESM.loaderPromise.then((loader) => {
-      return loader.import(pathToFileURL(process.argv[1]).href);
-    })
-    .catch((e) => {
-      internalBinding('errors').triggerUncaughtException(
-        e,
-        true /* fromPromise */
-      );
-    });
-    return;
-  }
-  Module._load(process.argv[1], null, true);
-};
-
 function createRequireFromPath(filename) {
   // Allow a directory to be passed as the filename
   const trailingSlash =

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -821,10 +821,12 @@ Module.prototype.load = function(filename) {
     if (module !== undefined && module.module !== undefined) {
       if (module.module.getStatus() >= kInstantiated)
         module.module.setExport('default', exports);
-    } else { // preemptively cache
+    } else {
+      // Preemptively cache
+      // We use a function to defer promise creation for async hooks.
       ESMLoader.moduleMap.set(
         url,
-        new ModuleJob(ESMLoader, url, () =>
+        () => new ModuleJob(ESMLoader, url, () =>
           new ModuleWrap(function() {
             this.setExport('default', exports);
           }, ['default'], url)

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -146,6 +146,9 @@ class Loader {
   async getModuleJob(specifier, parentURL) {
     const { url, format } = await this.resolve(specifier, parentURL);
     let job = this.moduleMap.get(url);
+    // CJS injects jobs as functions to defer promise creation for async hooks.
+    if (typeof job === 'function')
+      this.moduleMap.set(url, job = job());
     if (job !== undefined)
       return job;
 

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -11,7 +11,8 @@ const { ModuleWrap } = internalBinding('module_wrap');
 const { decorateErrorStack } = require('internal/util');
 const { getOptionValue } = require('internal/options');
 const assert = require('internal/assert');
-const { clearBootstrapHooksBuffer } = require('internal/async_hooks');
+const { clearBootstrapHooksBuffer, stopBootstrapHooksBuffer } =
+    require('internal/async_hooks');
 const resolvedPromise = SafePromise.resolve();
 
 function noop() {}
@@ -107,13 +108,14 @@ class ModuleJob {
     const module = await this.instantiate();
     const timeout = -1;
     const breakOnSigint = false;
+    if (this.isMain)
+      stopBootstrapHooksBuffer();
     const output = {
       module,
       result: module.evaluate(timeout, breakOnSigint)
     };
-    if (this.isMain) {
+    if (this.isMain)
       clearBootstrapHooksBuffer();
-    }
     return output;
   }
 }

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -11,6 +11,7 @@ const { ModuleWrap } = internalBinding('module_wrap');
 const { decorateErrorStack } = require('internal/util');
 const { getOptionValue } = require('internal/options');
 const assert = require('internal/assert');
+const { clearBootstrapHooksBuffer } = require('internal/async_hooks');
 const resolvedPromise = SafePromise.resolve();
 
 function noop() {}
@@ -106,7 +107,14 @@ class ModuleJob {
     const module = await this.instantiate();
     const timeout = -1;
     const breakOnSigint = false;
-    return { module, result: module.evaluate(timeout, breakOnSigint) };
+    const output = {
+      module,
+      result: module.evaluate(timeout, breakOnSigint)
+    };
+    if (this.isMain) {
+      clearBootstrapHooksBuffer();
+    }
+    return output;
   }
 }
 Object.setPrototypeOf(ModuleJob.prototype, null);

--- a/lib/internal/modules/esm/module_map.js
+++ b/lib/internal/modules/esm/module_map.js
@@ -16,7 +16,7 @@ class ModuleMap extends SafeMap {
   }
   set(url, job) {
     validateString(url, 'url');
-    if (job instanceof ModuleJob !== true) {
+    if (job instanceof ModuleJob !== true && typeof job !== 'function') {
       throw new ERR_INVALID_ARG_TYPE('job', 'ModuleJob', job);
     }
     debug(`Storing ${url} in ModuleMap`);

--- a/test/es-module/test-esm-async-hooks.mjs
+++ b/test/es-module/test-esm-async-hooks.mjs
@@ -1,0 +1,47 @@
+// Flags: --experimental-modules
+import '../common/index.mjs';
+import assert from 'assert';
+import { createHook } from 'async_hooks';
+
+const bootstrapCalls = {};
+const calls = {};
+
+const asyncHook = createHook({ init, before, after, destroy, promiseResolve });
+asyncHook.enable();
+
+function init(asyncId, type, asyncTriggerId, resource, bootstrap) {
+  (bootstrap ? bootstrapCalls : calls)[asyncId] = {
+    init: true
+  };
+}
+
+function before(asyncId) {
+  (bootstrapCalls[asyncId] || calls[asyncId]).before = true;
+}
+
+function after(asyncId) {
+  (bootstrapCalls[asyncId] || calls[asyncId]).after = true;
+}
+
+function destroy(asyncId) {
+  (bootstrapCalls[asyncId] || calls[asyncId]).destroy = true;
+}
+
+function promiseResolve(asyncId) {
+  (bootstrapCalls[asyncId] || calls[asyncId]).promiseResolve = true;
+}
+
+// Ensure all hooks have inits
+assert(Object.values(bootstrapCalls).every(({ init }) => init === true));
+assert(Object.values(calls).every(({ init }) => init === true));
+
+// Ensure we have at least one of each type of callback
+assert(Object.values(bootstrapCalls).some(({ before }) => before === true));
+assert(Object.values(bootstrapCalls).some(({ after }) => after === true));
+assert(Object.values(bootstrapCalls).some(({ destroy }) => destroy === true));
+
+// Wait a tick to see that we have promise resolution
+setTimeout(() => {
+  assert(Object.values(bootstrapCalls).some(({ promiseResolve }) =>
+    promiseResolve === true));
+}, 10);

--- a/test/es-module/test-esm-async-hooks.mjs
+++ b/test/es-module/test-esm-async-hooks.mjs
@@ -7,6 +7,9 @@ const bootstrapCalls = {};
 const calls = {};
 
 const asyncHook = createHook({ init, before, after, destroy, promiseResolve });
+
+// Bootstrap hooks for modules pipeline will trigger sync with this enable
+// call.
 asyncHook.enable();
 
 function init(asyncId, type, asyncTriggerId, resource, bootstrap) {

--- a/test/parallel/test-internal-module-map-asserts.js
+++ b/test/parallel/test-internal-module-map-asserts.js
@@ -12,7 +12,7 @@ const ModuleMap = require('internal/modules/esm/module_map');
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: /^The "url" argument must be of type string/
-  }, 15);
+  }, 12);
 
   const moduleMap = new ModuleMap();
 
@@ -21,7 +21,7 @@ const ModuleMap = require('internal/modules/esm/module_map');
   // but I think it's useless, and was not simple to mock...
   const job = undefined;
 
-  [{}, [], true, 1, () => {}].forEach((value) => {
+  [{}, [], true, 1].forEach((value) => {
     assert.throws(() => moduleMap.get(value), errorReg);
     assert.throws(() => moduleMap.has(value), errorReg);
     assert.throws(() => moduleMap.set(value, job), errorReg);
@@ -34,11 +34,11 @@ const ModuleMap = require('internal/modules/esm/module_map');
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: /^The "job" argument must be of type ModuleJob/
-  }, 5);
+  }, 4);
 
   const moduleMap = new ModuleMap();
 
-  [{}, [], true, 1, () => {}].forEach((value) => {
+  [{}, [], true, 1].forEach((value) => {
     assert.throws(() => moduleMap.set('', value), errorReg);
   });
 }


### PR DESCRIPTION
This provides async_hooks support for an asynchronous Node.js core bootstrap. This is necessary for async_hooks events emitted during the async experimental modules bootstrap to have their init events properly emitted, as userland code can't attach to those otherwise.

The approach taken is to buffer the internal bootstrap async_hooks events, and then re-emit these buffered events as soon as there is an attachment to async_hooks during the initial sync execution of the module execution. As soon as the initial sync execution has completed, the buffer is cleared and async_hooks is disabled if no listeners were attached. When using the `--no-force-async-hooks-checks` flag this buffering is entirely disabled.

A `bootstrap` boolean flag is also provided to the `init` hook to be able to check which async hooks correspond to bootstrap events or not.

This work is a prerequisite to `--experimental-modules` unflagging (as in https://github.com/nodejs/node/pull/29866).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
