### PR TITLE
worker: don't use two-arg NewIsolate

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -116,7 +116,10 @@ class WorkerThreadData {
     : w_(w) {
     CHECK_EQ(uv_loop_init(&loop_), 0);
 
-    Isolate* isolate = NewIsolate(w->array_buffer_allocator_.get(), &loop_);
+    Isolate* isolate = NewIsolate(
+        w->array_buffer_allocator_.get(),
+        &loop_,
+        w->platform_);
     CHECK_NOT_NULL(isolate);
 
     {


### PR DESCRIPTION
Electron creates and initializes the V8 platform ourselves, and so need to build with `NODE_USE_V8_PLATFORM` set to `false` and as a result were unable to use `worker_threads`.

This PR fixes this problem by swapping the two-arg call to NewIsolate present in `NodeWorkerData` for the three-arg version.

Before, the two-arg version calls the three-arg version with `GetMainThreadMultiIsolatePlatform()`, which is implemented with `per_process::v8_platform.Platform()`. That returns `nullptr` when `NODE_USE_V8_PLATFORM` set to `false`, and causes a bad access crash.

cc @joyeecheung @addaleax 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
