### PR TITLE
docs: remove replaceme placeholder

### DIFF
--- a/tools/doc/README.md
+++ b/tools/doc/README.md
@@ -35,7 +35,7 @@ A description of the function.
 
 ## module.someNewFunction(x)
 <!-- YAML
-added: REPLACEME
+added: v0.10.0
 -->
 
 * `x` {string} The description of the string.


### PR DESCRIPTION
There seem to be quite a few CI failures looking like this:

```
TypeError: Cannot create property 'changes' on string 'REPLACEME'
14:15:34     at Object.extractAndParseYAML (/data/iojs/build/workspace/node-test-commit-linuxone/nodes/rhel72-s390x/tools/doc/common.js:41:16)
14:15:34     at /data/iojs/build/workspace/node-test-commit-linuxone/nodes/rhel72-s390x/tools/doc/json.js:99:33
14:15:34     at Array.forEach (<anonymous>)
14:15:34     at doSection (/data/iojs/build/workspace/node-test-commit-linuxone/nodes/rhel72-s390x/tools/doc/json.js:84:13)
14:15:34     at doSection (/data/iojs/build/workspace/node-test-commit-linuxone/nodes/rhel72-s390x/tools/doc/json.js:200:9)
14:15:34     at doSection (/data/iojs/build/workspace/node-test-commit-linuxone/nodes/rhel72-s390x/tools/doc/json.js:200:9)
14:15:34     at /data/iojs/build/workspace/node-test-commit-linuxone/nodes/rhel72-s390x/tools/doc/json.js:58:7
14:15:34     at wrapped (/data/iojs/build/workspace/node-test-commit-linuxone/nodes/rhel72-s390x/tools/doc/node_modules/trough/wrap.js:25:19)
14:15:34     at next (/data/iojs/build/workspace/node-test-commit-linuxone/nodes/rhel72-s390x/tools/doc/node_modules/trough/index.js:58:24)
```

This removes the only instance of `REPLACEME` I could find in the docs, to see if that fixes things.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
