### PR TITLE
crypto: remove guard against fixed OpenSSL bug

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4806,14 +4806,6 @@ void Hash::HashDigest(const FunctionCallbackInfo<Value>& args) {
     encoding = ParseEncoding(env->isolate(), args[0], BUFFER);
   }
 
-  // TODO(tniessen): SHA3_squeeze does not work for zero-length outputs on all
-  // platforms and will cause a segmentation fault if called. This workaround
-  // causes hash.digest() to correctly return an empty buffer / string.
-  // See https://github.com/openssl/openssl/issues/9431.
-  if (!hash->has_md_ && hash->md_len_ == 0) {
-    hash->has_md_ = true;
-  }
-
   if (!hash->has_md_) {
     // Some hash algorithms such as SHA3 do not support calling
     // EVP_DigestFinal_ex more than once, however, Hash._flush


### PR DESCRIPTION
This guard used to prevent segfaults caused by a bug in OpenSSL, but this was fixed in OpenSSL 1.1.1d.

Refs: https://github.com/openssl/openssl/pull/9433
Refs: https://github.com/openssl/openssl/issues/9431

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
