### PR TITLE
stream: call end(cb) callback after destroy

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -591,8 +591,20 @@ Writable.prototype.end = function(chunk, encoding, cb) {
     encoding = null;
   }
 
-  if (chunk !== null && chunk !== undefined)
+  if (chunk !== null && chunk !== undefined) {
     this.write(chunk, encoding);
+  } else if (state.destroyed) {
+    // TODO(ronag): Condition is for backwards compat.
+    if (state.errorEmitted || state.finished) {
+      const err = new ERR_STREAM_DESTROYED('end');
+      if (typeof cb === 'function') {
+        process.nextTick(cb, err);
+      }
+      // TODO(ronag): Disabled for backwards compat.
+      // errorOrDestroy(this, err, true);
+      return;
+    }
+  }
 
   // .end() fully uncorks
   if (state.corked) {

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -292,3 +292,33 @@ const assert = require('assert');
   }));
   write.uncork();
 }
+
+{
+  // Call end(cb) after error & destroy
+
+  const write = new Writable({
+    write(chunk, enc, cb) { cb(new Error('asd')); }
+  });
+  write.on('error', common.mustCall(() => {
+    write.destroy();
+    write.end(common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+    }));
+  }));
+  write.write('asd');
+}
+
+{
+  // Call end(cb) after finish & destroy
+
+  const write = new Writable({
+    write(chunk, enc, cb) { cb(); }
+  });
+  write.on('finish', common.mustCall(() => {
+    write.destroy();
+    write.end(common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+    }));
+  }));
+  write.end();
+}


### PR DESCRIPTION
Don't deadlock calls to end(cb) after destroy(). This only partly fixes the problem in order to minimize breakage.

This becomes relevant in the future for e.g. deprecating `fileStream.close(cb)` in favor of `fileStream.end(cb)`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
