### PR TITLE
module: allow unrestricted cjs requires

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -812,9 +812,6 @@ Module.prototype.load = function(filename) {
   this.loaded = true;
 
   if (experimentalModules) {
-    const ESMLoader = asyncESM.ESMLoader;
-    const url = `${pathToFileURL(filename)}`;
-    const module = ESMLoader.moduleMap.get(url);
     // Create module entry at load time to snapshot exports correctly
     const ext = path.extname(filename);
     // Only inject modules that are valid in the ES module system
@@ -827,6 +824,9 @@ Module.prototype.load = function(filename) {
         injectIntoESM = false;
     }
     if (injectIntoESM) {
+      const ESMLoader = asyncESM.ESMLoader;
+      const url = `${pathToFileURL(filename)}`;
+      const module = ESMLoader.moduleMap.get(url);
       const exports = this.exports;
       // Called from cjs translator
       if (module !== undefined && module.module !== undefined) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -816,20 +816,32 @@ Module.prototype.load = function(filename) {
     const url = `${pathToFileURL(filename)}`;
     const module = ESMLoader.moduleMap.get(url);
     // Create module entry at load time to snapshot exports correctly
-    const exports = this.exports;
-    // Called from cjs translator
-    if (module !== undefined && module.module !== undefined) {
-      if (module.module.getStatus() >= kInstantiated)
-        module.module.setExport('default', exports);
-    } else { // preemptively cache
-      ESMLoader.moduleMap.set(
-        url,
-        new ModuleJob(ESMLoader, url, () =>
-          new ModuleWrap(function() {
-            this.setExport('default', exports);
-          }, ['default'], url)
-        )
-      );
+    const ext = path.extname(filename);
+    // Only inject modules that are valid in the ES module system
+    let injectIntoESM = ext === '.js' || ext === '.cjs' || ext === '.json' ||
+        ext === '.node';
+    if (ext === '.js') {
+      const pkg = readPackageScope(filename);
+      // Do not inject CJS modules that break module type correctness
+      if (pkg && pkg.type === 'module')
+        injectIntoESM = false;
+    }
+    if (injectIntoESM) {
+      const exports = this.exports;
+      // Called from cjs translator
+      if (module !== undefined && module.module !== undefined) {
+        if (module.module.getStatus() >= kInstantiated)
+          module.module.setExport('default', exports);
+      } else { // preemptively cache
+        ESMLoader.moduleMap.set(
+          url,
+          new ModuleJob(ESMLoader, url, () =>
+            new ModuleWrap(function() {
+              this.setExport('default', exports);
+            }, ['default'], url)
+          )
+        );
+      }
     }
   }
 };
@@ -963,12 +975,6 @@ Module.prototype._compile = function(content, filename) {
 
 // Native extension for .js
 Module._extensions['.js'] = function(module, filename) {
-  if (experimentalModules && filename.endsWith('.js')) {
-    const pkg = readPackageScope(filename);
-    if (pkg && pkg.type === 'module') {
-      throw new ERR_REQUIRE_ESM(filename);
-    }
-  }
   const content = fs.readFileSync(filename, 'utf8');
   module._compile(content, filename);
 };

--- a/test/es-module/test-esm-type-flag-errors.js
+++ b/test/es-module/test-esm-type-flag-errors.js
@@ -24,12 +24,10 @@ expect('', packageWithoutTypeMain, 'package-without-type');
 expect('--input-type=module', packageTypeModuleMain,
        'ERR_INPUT_TYPE_NOT_ALLOWED', true);
 
-try {
+// Verify CommonJS load is attempted but fails on ES module syntax
+assert.throws(() => {
   require('../fixtures/es-modules/package-type-module/index.js');
-} catch (e) {
-  // Verify CommonJS load is attempted but fails on ES module syntax
-  assert(e instanceof SyntaxError);
-}
+}, SyntaxError);
 
 function expect(opt = '', inputFile, want, wantsError = false) {
   // TODO: Remove when --experimental-modules is unflagged

--- a/test/es-module/test-esm-type-flag-errors.js
+++ b/test/es-module/test-esm-type-flag-errors.js
@@ -26,9 +26,9 @@ expect('--input-type=module', packageTypeModuleMain,
 
 try {
   require('../fixtures/es-modules/package-type-module/index.js');
-  assert.fail('Expected CJS to fail loading from type: module package.');
 } catch (e) {
-  assert(e.toString().match(/Error \[ERR_REQUIRE_ESM\]: Must use import to load ES Module:/));
+  // Verify CommonJS load is attempted but fails on ES module syntax
+  assert(e instanceof SyntaxError);
 }
 
 function expect(opt = '', inputFile, want, wantsError = false) {


### PR DESCRIPTION
This implements a follow-up to the issue we had in https://github.com/nodejs/modules/issues/389 with the merge of https://github.com/nodejs/node/pull/29492 and later correction in https://github.com/nodejs/node/pull/29732.

The approach taken is to allow CommonJS modules to `require` any other files, even `.js` files in a `"type": "module"` boundary to ensure maximum backwards compatibility. `require` of `.mjs` files is still not permitted though without manually overridding `require._extensions['.mjs']`. To retain the module format invariants we specifically then do not inject CJS loads into the ESM loader when they break the expected module format, which is the check implemented here.

Technically this allows the module registries to diverge in that we can have the same module path in both the CJS and ESM registries, but meaning different things. Note that only a module not using module syntax or require would cause this though as it would be a failure in either registry otherwise. Because of these syntax restrictions and the top-level main restrictions remaining the same (this only applies from `require()`), the ways this "technical incompleteness" causes real issues is impractically small such that the usability and compatibility benefits seem worth it to me.

I expect this will be somewhat controversial and we will need to add this to the modules agenda though.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
