### PR TITLE
process: add lineLength to source-map-cache

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1171,8 +1171,9 @@ If found, Source Map data is appended to the top-level key `source-map-cache`
 on the JSON coverage object.
 
 `source-map-cache` is an object with keys representing the files source maps
-were extracted from, and the values include the raw source-map URL
-(in the key `url`) and the parsed Source Map V3 information (in the key `data`).
+were extracted from, and values which include the raw source-map URL
+(in the key `url`), the parsed Source Map V3 information (in the key `data`),
+and the line lengths of the source file (in the key `lineLengths`).
 
 ```json
 {
@@ -1198,7 +1199,13 @@ were extracted from, and the values include the raw source-map URL
         ],
         "mappings": "MAAMA,IACJC,YAAaC",
         "sourceRoot": "./"
-      }
+      },
+      "lineLengths": [
+        13,
+        62,
+        38,
+        27
+      ]
     }
   }
 }

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -25,7 +25,7 @@ function prepareMainThreadExecution(expandArgv1 = false) {
   // prepareStackTrace method, replacing the default in errors.js.
   if (getOptionValue('--enable-source-maps')) {
     const { prepareStackTrace } =
-      require('internal/source_map/source_map_cache');
+      require('internal/source_map/prepare_stack_trace');
     const { setPrepareStackTraceCallback } = internalBinding('errors');
     setPrepareStackTraceCallback(prepareStackTrace);
   }

--- a/lib/internal/source_map/prepare_stack_trace.js
+++ b/lib/internal/source_map/prepare_stack_trace.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const debug = require('internal/util/debuglog').debuglog('source_map');
+const { findSourceMap } = require('internal/source_map/source_map_cache');
+const { overrideStackTrace } = require('internal/errors');
+
+// Create a prettified stacktrace, inserting context from source maps
+// if possible.
+const ErrorToString = Error.prototype.toString; // Capture original toString.
+const prepareStackTrace = (globalThis, error, trace) => {
+  // API for node internals to override error stack formatting
+  // without interfering with userland code.
+  // TODO(bcoe): add support for source-maps to repl.
+  if (overrideStackTrace.has(error)) {
+    const f = overrideStackTrace.get(error);
+    overrideStackTrace.delete(error);
+    return f(error, trace);
+  }
+
+  const { SourceMap } = require('internal/source_map/source_map');
+  const errorString = ErrorToString.call(error);
+
+  if (trace.length === 0) {
+    return errorString;
+  }
+  const preparedTrace = trace.map((t, i) => {
+    let str = i !== 0 ? '\n    at ' : '';
+    str = `${str}${t}`;
+    try {
+      const sourceMap = findSourceMap(t.getFileName(), error);
+      if (sourceMap && sourceMap.data) {
+        const sm = new SourceMap(sourceMap.data);
+        // Source Map V3 lines/columns use zero-based offsets whereas, in
+        // stack traces, they start at 1/1.
+        const [, , url, line, col] =
+                   sm.findEntry(t.getLineNumber() - 1, t.getColumnNumber() - 1);
+        if (url && line !== undefined && col !== undefined) {
+          str +=
+            `\n        -> ${url.replace('file://', '')}:${line + 1}:${col + 1}`;
+        }
+      }
+    } catch (err) {
+      debug(err.stack);
+    }
+    return str;
+  });
+  return `${errorString}\n    at ${preparedTrace.join('')}`;
+};
+
+module.exports = {
+  prepareStackTrace,
+};

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -17,7 +17,6 @@ const cjsSourceMapCache = new WeakMap();
 // on filenames.
 const esmSourceMapCache = new Map();
 const { fileURLToPath, URL } = require('url');
-const { overrideStackTrace } = require('internal/errors');
 
 let experimentalSourceMaps;
 function maybeCacheSourceMap(filename, content, cjsModuleInstance) {
@@ -38,18 +37,22 @@ function maybeCacheSourceMap(filename, content, cjsModuleInstance) {
 
   const match = content.match(/\/[*/]#\s+sourceMappingURL=(?<sourceMappingURL>[^\s]+)/);
   if (match) {
+    const data = dataFromUrl(basePath, match.groups.sourceMappingURL);
+    const url = data ? null : match.groups.sourceMappingURL;
     if (cjsModuleInstance) {
       cjsSourceMapCache.set(cjsModuleInstance, {
         filename,
-        url: match.groups.sourceMappingURL,
-        data: dataFromUrl(basePath, match.groups.sourceMappingURL)
+        lineLengths: lineLengths(content),
+        data,
+        url
       });
     } else {
       // If there is no cjsModuleInstance assume we are in a
       // "modules/esm" context.
       esmSourceMapCache.set(filename, {
-        url: match.groups.sourceMappingURL,
-        data: dataFromUrl(basePath, match.groups.sourceMappingURL)
+        lineLengths: lineLengths(content),
+        data,
+        url
       });
     }
   }
@@ -71,6 +74,15 @@ function dataFromUrl(basePath, sourceMappingURL) {
     const sourceMapFile = resolve(basePath, sourceMappingURL);
     return sourceMapFromFile(sourceMapFile);
   }
+}
+
+// Cache the length of each line in the file that a source map was extracted
+// from. This allows translation from byte offset V8 coverage reports,
+// to line/column offset Source Map V3.
+function lineLengths(content) {
+  return content.split('\n').map((line) => {
+    return line.length;
+  });
 }
 
 function sourceMapFromFile(sourceMapFile) {
@@ -161,55 +173,13 @@ function appendCJSCache(obj) {
     const value = cjsSourceMapCache.get(Module._cache[key]);
     if (value) {
       obj[`file://${key}`] = {
-        url: value.url,
-        data: value.data
+        lineLengths: value.lineLengths,
+        data: value.data,
+        url: value.url
       };
     }
   });
 }
-
-// Create a prettified stacktrace, inserting context from source maps
-// if possible.
-const ErrorToString = Error.prototype.toString; // Capture original toString.
-const prepareStackTrace = (globalThis, error, trace) => {
-  // API for node internals to override error stack formatting
-  // without interfering with userland code.
-  // TODO(bcoe): add support for source-maps to repl.
-  if (overrideStackTrace.has(error)) {
-    const f = overrideStackTrace.get(error);
-    overrideStackTrace.delete(error);
-    return f(error, trace);
-  }
-
-  const { SourceMap } = require('internal/source_map/source_map');
-  const errorString = ErrorToString.call(error);
-
-  if (trace.length === 0) {
-    return errorString;
-  }
-  const preparedTrace = trace.map((t, i) => {
-    let str = i !== 0 ? '\n    at ' : '';
-    str = `${str}${t}`;
-    try {
-      const sourceMap = findSourceMap(t.getFileName(), error);
-      if (sourceMap && sourceMap.data) {
-        const sm = new SourceMap(sourceMap.data);
-        // Source Map V3 lines/columns use zero-based offsets whereas, in
-        // stack traces, they start at 1/1.
-        const [, , url, line, col] =
-                   sm.findEntry(t.getLineNumber() - 1, t.getColumnNumber() - 1);
-        if (url && line !== undefined && col !== undefined) {
-          str +=
-            `\n        -> ${url.replace('file://', '')}:${line + 1}:${col + 1}`;
-        }
-      }
-    } catch (err) {
-      debug(err.stack);
-    }
-    return str;
-  });
-  return `${errorString}\n    at ${preparedTrace.join('')}`;
-};
 
 // Attempt to lookup a source map, which is either attached to a file URI, or
 // keyed on an error instance.
@@ -230,8 +200,8 @@ function findSourceMap(uri, error) {
 }
 
 module.exports = {
+  findSourceMap,
   maybeCacheSourceMap,
-  prepareStackTrace,
   rekeySourceMap,
   sourceMapCacheToObject,
 };

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -80,7 +80,10 @@ function dataFromUrl(basePath, sourceMappingURL) {
 // from. This allows translation from byte offset V8 coverage reports,
 // to line/column offset Source Map V3.
 function lineLengths(content) {
-  return content.split('\n').map((line) => {
+  // We purposefully keep \r as part of the line-length calculation, in
+  // cases where there is a \r\n separator, so that this can be taken into
+  // account in coverage calculations.
+  return content.split(/\n|\u2028|\u2029/).map((line) => {
     return line.length;
   });
 }

--- a/node.gyp
+++ b/node.gyp
@@ -176,6 +176,7 @@
       'lib/internal/repl/history.js',
       'lib/internal/repl/utils.js',
       'lib/internal/socket_list.js',
+      'lib/internal/source_map/prepare_stack_trace.js',
       'lib/internal/source_map/source_map.js',
       'lib/internal/source_map/source_map_cache.js',
       'lib/internal/test/binding.js',

--- a/test/parallel/test-source-map.js
+++ b/test/parallel/test-source-map.js
@@ -216,7 +216,11 @@ function nextdir() {
     'istanbul-throw.js',
     coverageDirectory
   );
-  assert.deepStrictEqual(sourceMap.lineLengths, [1085, 30, 184, 648, 0]);
+  if (common.isWindows) {
+    assert.deepStrictEqual(sourceMap.lineLengths, [1087, 301, 185, 649, 0]);
+  } else {
+    assert.deepStrictEqual(sourceMap.lineLengths, [1085, 30, 184, 648, 0]);
+  }
 }
 
 function getSourceMapFromCache(fixtureFile, coverageDirectory) {

--- a/test/parallel/test-source-map.js
+++ b/test/parallel/test-source-map.js
@@ -217,7 +217,7 @@ function nextdir() {
     coverageDirectory
   );
   if (common.isWindows) {
-    assert.deepStrictEqual(sourceMap.lineLengths, [1087, 301, 185, 649, 0]);
+    assert.deepStrictEqual(sourceMap.lineLengths, [1086, 31, 185, 649, 0]);
   } else {
     assert.deepStrictEqual(sourceMap.lineLengths, [1085, 30, 184, 648, 0]);
   }

--- a/test/parallel/test-source-map.js
+++ b/test/parallel/test-source-map.js
@@ -193,6 +193,32 @@ function nextdir() {
   );
 }
 
+// Does not persist url parameter if source-map has been parsed.
+{
+  const coverageDirectory = nextdir();
+  spawnSync(process.execPath, [
+    require.resolve('../fixtures/source-map/inline-base64.js')
+  ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
+  const sourceMap = getSourceMapFromCache(
+    'inline-base64.js',
+    coverageDirectory
+  );
+  assert.strictEqual(sourceMap.url, null);
+}
+
+// Persists line lengths for in-memory representation of source file.
+{
+  const coverageDirectory = nextdir();
+  spawnSync(process.execPath, [
+    require.resolve('../fixtures/source-map/istanbul-throw.js')
+  ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
+  const sourceMap = getSourceMapFromCache(
+    'istanbul-throw.js',
+    coverageDirectory
+  );
+  assert.deepStrictEqual(sourceMap.lineLengths, [1085, 30, 184, 648, 0]);
+}
+
 function getSourceMapFromCache(fixtureFile, coverageDirectory) {
   const jsonFiles = fs.readdirSync(coverageDirectory);
   for (const jsonFile of jsonFiles) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

## Problem

I realized when integrating source-map functionality with coverage that we're missing a piece of information necessary to support tools like [ts-node](https://github.com/TypeStrong/ts-node):

* V8's coverage implementation is based on absolute byte offset, whereas Source Map V3 is based on line/column offset.
* when code is transpiled in memory (using hooks like `require.extensions`) we lack enough information to translate from bytes to lines/columns.

_we end up with a bad reports that look like this, due to missing information:_

<img width="628" alt="Screen Shot 2019-10-06 at 11 25 03 AM" src="https://user-images.githubusercontent.com/194609/66274044-42015000-e82f-11e9-858d-6415b7c01719.png">

👆 note that exactly the wrong code is highlighted 😆 

## Solution

If we track the line lengths of the source file that source maps were extracted from, this provides enough information to remap from byte offset to line/column offset.

I've introduced an additional value into the cache, `lineLengths`, to facilitate this.

_we can now generate the following report:_

<img width="473" alt="Screen Shot 2019-10-06 at 11 28 07 AM" src="https://user-images.githubusercontent.com/194609/66274106-ec797300-e82f-11e9-98a8-e229d901b1c4.png">
