### PR TITLE
esm: unflag --experimental-exports

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -158,13 +158,6 @@ the ability to import a directory that has an index file.
 
 Please see [customizing esm specifier resolution][] for example usage.
 
-### `--experimental-exports`
-<!-- YAML
-added: v12.7.0
--->
-
-Enable experimental resolution using the `exports` field in `package.json`.
-
 ### `--experimental-json-modules`
 <!-- YAML
 added: v12.9.0
@@ -998,7 +991,6 @@ Node.js options that are allowed are:
 * `--enable-fips`
 * `--enable-source-maps`
 * `--es-module-specifier-resolution`
-* `--experimental-exports`
 * `--experimental-json-modules`
 * `--experimental-loader`
 * `--experimental-modules`

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -202,7 +202,7 @@ NODE_MODULES_PATHS(START)
 5. return DIRS
 ```
 
-If `--experimental-exports` is enabled, Node.js allows packages loaded via
+Node.js allows packages loaded via
 `LOAD_NODE_MODULES` to explicitly declare which file paths to expose and how
 they should be interpreted. This expands on the control packages already had
 using the `main` field.

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -70,7 +70,6 @@ const {
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
 const pendingDeprecation = getOptionValue('--pending-deprecation');
-const experimentalExports = getOptionValue('--experimental-exports');
 
 module.exports = { wrapSafe, Module };
 
@@ -369,7 +368,7 @@ function findLongestRegisteredExtension(filename) {
 const EXPORTS_PATTERN = /^((?:@[^/\\%]+\/)?[^./\\%][^/\\%]*)(\/.*)?$/;
 function resolveExports(nmPath, request, absoluteRequest) {
   // The implementation's behavior is meant to mirror resolution in ESM.
-  if (experimentalExports && !absoluteRequest) {
+  if (!absoluteRequest) {
     const [, name, expansion = ''] =
       StringPrototype.match(request, EXPORTS_PATTERN) || [];
     if (!name) {

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -652,8 +652,7 @@ Maybe<const PackageConfig*> GetPackageConfig(Environment* env,
   }
 
   Local<Value> exports_v;
-  if (env->options()->experimental_exports &&
-      pkg_json->Get(env->context(),
+  if (pkg_json->Get(env->context(),
       env->exports_string()).ToLocal(&exports_v) &&
       !exports_v->IsNullOrUndefined()) {
     Global<Value> exports;
@@ -995,7 +994,6 @@ Maybe<URL> PackageExportsResolve(Environment* env,
                                  const std::string& pkg_subpath,
                                  const PackageConfig& pcfg,
                                  const URL& base) {
-  CHECK(env->options()->experimental_exports);
   Isolate* isolate = env->isolate();
   Local<Context> context = env->context();
   Local<Value> exports = pcfg.exports.Get(isolate);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -317,10 +317,6 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental Source Map V3 support",
             &EnvironmentOptions::enable_source_maps,
             kAllowedInEnvironment);
-  AddOption("--experimental-exports",
-            "experimental support for exports in package.json",
-            &EnvironmentOptions::experimental_exports,
-            kAllowedInEnvironment);
   AddOption("--experimental-json-modules",
             "experimental JSON interop support for the ES Module loader",
             &EnvironmentOptions::experimental_json_modules,
@@ -335,7 +331,6 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental ES Module support and caching modules",
             &EnvironmentOptions::experimental_modules,
             kAllowedInEnvironment);
-  Implies("--experimental-modules", "--experimental-exports");
   AddOption("--experimental-wasm-modules",
             "experimental ES Module support for webassembly modules",
             &EnvironmentOptions::experimental_wasm_modules,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -101,7 +101,6 @@ class EnvironmentOptions : public Options {
  public:
   bool abort_on_uncaught_exception = false;
   bool enable_source_maps = false;
-  bool experimental_exports = false;
   bool experimental_json_modules = false;
   bool experimental_modules = false;
   std::string es_module_specifier_resolution;


### PR DESCRIPTION
This removes the experimental `--experimental-exports` flag to make the support on by default.

This PR should not land until we have:

- [x] Resolution on package-relative loading PR (https://github.com/nodejs/node/pull/29327)
- [x] Consensus to land from the modules group

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
