### PR TITLE
Add FSWatcher.start function docs

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -434,6 +434,14 @@ added: v0.5.8
 Stop watching for changes on the given `fs.FSWatcher`. Once stopped, the
 `fs.FSWatcher` object is no longer usable.
 
+### watcher.start()
+<!-- YAML
+added: v0.5.8
+-->
+
+Start watching for changes on the given `fs.FSWatcher`.  If a watcher has
+already been started, this operation will be a noop.
+
 ## Class: fs.ReadStream
 <!-- YAML
 added: v0.1.93

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -135,8 +135,6 @@ function FSWatcher() {
 Object.setPrototypeOf(FSWatcher.prototype, EventEmitter.prototype);
 Object.setPrototypeOf(FSWatcher, EventEmitter);
 
-
-// FIXME(joyeecheung): this method is not documented.
 // At the moment if filename is undefined, we
 // 1. Throw an Error if it's the first time .start() is called
 // 2. Return silently if .start() has already been called


### PR DESCRIPTION
There was  `// FIXME` in the fs module for documenting the undocumented `FSWatcher.start` method.

This PR adds docs for that function.

Although, while looking into that function, it doesn't really make sense to have it exposed to an end user.  A user can't actually create an instance of a FSWatcher by themselves, they get it as a result of calling `fs.watch`, which will call start when a valid filename is given.  If the user calls start again on an already started watcher, then it is a noop.  Calling start on a closed watcher also does nothing.

I wonder if we should consider making this a "private" method.  It might be more effort than it is worth though and docs might just be enough

There are 2 more "FIXME"'s in this module related to docs that i'm planning on sending PR's for,  but wanted to get some input on the above paragraph, since they are very similar

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
