### PR TITLE
test: remove extra process.exit()

### DIFF
--- a/test/parallel/test-http2-connect-options.js
+++ b/test/parallel/test-http2-connect-options.js
@@ -36,7 +36,6 @@ server.listen(0, '127.0.0.1', common.mustCall(() => {
     client.close();
     req.close();
     server.close();
-    process.exit();
   }));
   req.end();
 }));


### PR DESCRIPTION
I missed this during the review of https://github.com/nodejs/node/pull/29816.

`process.exit()` has a tendency to hide test failures because it forces the process to exit. This test doesn't need the `process.exit()`, so this commit removes it.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
