### PR TITLE
http2: allow passing FileHandle to respondWithFD

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1440,7 +1440,7 @@ server.on('stream', (stream) => {
 added: v8.4.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/????
+    pr-url: https://github.com/nodejs/node/pull/29876
     description: The `fd` option may now be a `FileHandle`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18936

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1543,7 +1543,7 @@ changes:
                  regular file, is supported now.
 -->
 
-* `path` {string|Buffer}
+* `path` {string|Buffer|URL}
 * `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `statCheck` {Function}

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1439,13 +1439,16 @@ server.on('stream', (stream) => {
 <!-- YAML
 added: v8.4.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/????
+    description: The `fd` option may now be a `FileHandle`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18936
     description: Any readable file descriptor, not necessarily for a
                  regular file, is supported now.
 -->
 
-* `fd` {number} A readable file descriptor.
+* `fd` {number|FileHandle} A readable file descriptor.
 * `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `statCheck` {Function}
@@ -1491,8 +1494,8 @@ The `offset` and `length` options may be used to limit the response to a
 specific range subset. This can be used, for instance, to support HTTP Range
 requests.
 
-The file descriptor is not closed when the stream is closed, so it will need
-to be closed manually once it is no longer needed.
+The file descriptor or `FileHandle` is not closed when the stream is closed,
+so it will need to be closed manually once it is no longer needed.
 Using the same file descriptor concurrently for multiple streams
 is not supported and may result in data loss. Re-using a file descriptor
 after a stream has finished is supported.
@@ -1540,7 +1543,7 @@ changes:
                  regular file, is supported now.
 -->
 
-* `path` {string|Buffer|URL}
+* `path` {string|Buffer}
 * `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `statCheck` {Function}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1964,7 +1964,7 @@ Object.defineProperties(fs, {
     enumerable: true,
     get() {
       if (promises === null)
-        promises = require('internal/fs/promises');
+        promises = require('internal/fs/promises').exports;
       return promises;
     }
   }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -46,7 +46,7 @@ const {
 const pathModule = require('path');
 const { promisify } = require('internal/util');
 
-const kHandle = Symbol('handle');
+const kHandle = Symbol('kHandle');
 const { kUsePromises } = binding;
 
 const getDirectoryEntriesPromise = promisify(getDirents);
@@ -507,29 +507,34 @@ async function readFile(path, options) {
 }
 
 module.exports = {
-  access,
-  copyFile,
-  open,
-  opendir: promisify(opendir),
-  rename,
-  truncate,
-  rmdir,
-  mkdir,
-  readdir,
-  readlink,
-  symlink,
-  lstat,
-  stat,
-  link,
-  unlink,
-  chmod,
-  lchmod,
-  lchown,
-  chown,
-  utimes,
-  realpath,
-  mkdtemp,
-  writeFile,
-  appendFile,
-  readFile
+  exports: {
+    access,
+    copyFile,
+    open,
+    opendir: promisify(opendir),
+    rename,
+    truncate,
+    rmdir,
+    mkdir,
+    readdir,
+    readlink,
+    symlink,
+    lstat,
+    stat,
+    link,
+    unlink,
+    chmod,
+    lchmod,
+    lchown,
+    chown,
+    utimes,
+    realpath,
+    mkdtemp,
+    writeFile,
+    appendFile,
+    readFile,
+  },
+
+  kHandle,
+  FileHandle
 };

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -535,6 +535,5 @@ module.exports = {
     readFile,
   },
 
-  kHandle,
   FileHandle
 };

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2524,13 +2524,10 @@ class ServerHttp2Stream extends Http2Stream {
       this[kState].flags |= STREAM_FLAGS_HAS_TRAILERS;
     }
 
-    if (typeof fd !== 'number' &&
-        !(fd instanceof fsPromisesInternal.FileHandle)) {
-      throw new ERR_INVALID_ARG_TYPE('fd', ['number', 'FileHandle'], fd);
-    }
-
-    if (typeof fd !== 'number')  // FileHandle
+    if (fd instanceof fsPromisesInternal.FileHandle)
       fd = fd.fd;
+    else if (typeof fd !== 'number')
+      throw new ERR_INVALID_ARG_TYPE('fd', ['number', 'FileHandle'], fd);
 
     debugStreamObj(this, 'initiating response from fd');
     this[kUpdateTimer]();

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -82,6 +82,7 @@ const {
   hideStackFrames
 } = require('internal/errors');
 const { validateNumber, validateString } = require('internal/validators');
+const fsPromisesInternal = require('internal/fs/promises');
 const { utcDate } = require('internal/http');
 const { onServerStream,
         Http2ServerRequest,
@@ -2523,7 +2524,13 @@ class ServerHttp2Stream extends Http2Stream {
       this[kState].flags |= STREAM_FLAGS_HAS_TRAILERS;
     }
 
-    validateNumber(fd, 'fd');
+    if (typeof fd !== 'number' &&
+        !(fd instanceof fsPromisesInternal.FileHandle)) {
+      throw new ERR_INVALID_ARG_TYPE('fd', ['number', 'FileHandle'], fd);
+    }
+
+    if (typeof fd !== 'number')  // FileHandle
+      fd = fd.fd;
 
     debugStreamObj(this, 'initiating response from fd');
     this[kUpdateTimer]();

--- a/test/parallel/test-http2-respond-file-fd-errors.js
+++ b/test/parallel/test-http2-respond-file-fd-errors.js
@@ -42,7 +42,8 @@ server.on('stream', common.mustCall((stream) => {
       {
         type: TypeError,
         code: 'ERR_INVALID_ARG_TYPE',
-        message: 'The "fd" argument must be of type number. Received type ' +
+        message: 'The "fd" argument must be one of type number or FileHandle.' +
+                 ' Received type ' +
                  typeof types[type]
       }
     );

--- a/test/parallel/test-http2-respond-file-filehandle.js
+++ b/test/parallel/test-http2-respond-file-filehandle.js
@@ -25,7 +25,7 @@ fs.promises.open(fname, 'r').then(common.mustCall((fileHandle) => {
     });
   });
   server.on('close', common.mustCall(() => fileHandle.close()));
-  server.listen(0, () => {
+  server.listen(0, common.mustCall(() => {
 
     const client = http2.connect(`http://localhost:${server.address().port}`);
     const req = client.request();
@@ -43,5 +43,5 @@ fs.promises.open(fname, 'r').then(common.mustCall((fileHandle) => {
       server.close();
     }));
     req.end();
-  });
+  }));
 }));

--- a/test/parallel/test-http2-respond-file-filehandle.js
+++ b/test/parallel/test-http2-respond-file-filehandle.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+const assert = require('assert');
+const fs = require('fs');
+
+const {
+  HTTP2_HEADER_CONTENT_TYPE,
+  HTTP2_HEADER_CONTENT_LENGTH
+} = http2.constants;
+
+const fname = fixtures.path('elipses.txt');
+const data = fs.readFileSync(fname);
+const stat = fs.statSync(fname);
+fs.promises.open(fname, 'r').then(common.mustCall((fileHandle) => {
+  const server = http2.createServer();
+  server.on('stream', (stream) => {
+    stream.respondWithFD(fileHandle, {
+      [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain',
+      [HTTP2_HEADER_CONTENT_LENGTH]: stat.size,
+    });
+  });
+  server.on('close', common.mustCall(() => fileHandle.close()));
+  server.listen(0, () => {
+
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers[HTTP2_HEADER_CONTENT_TYPE], 'text/plain');
+      assert.strictEqual(+headers[HTTP2_HEADER_CONTENT_LENGTH], data.length);
+    }));
+    req.setEncoding('utf8');
+    let check = '';
+    req.on('data', (chunk) => check += chunk);
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(check, data.toString('utf8'));
+      client.close();
+      server.close();
+    }));
+    req.end();
+  });
+}));


### PR DESCRIPTION
This seems to make sense if we want to promote the use
of `fs.promises`, although it’s not strictly necessary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
