### PR TITLE
doc: set module version 72 to node 12

### DIFF
--- a/doc/abi_version_registry.json
+++ b/doc/abi_version_registry.json
@@ -1,13 +1,13 @@
 {
   "NODE_MODULE_VERSION": [
-    { "modules": 79, "runtime": "node", "variant": "v8_7.8", "versions": "13.0.0-pre" },
+    { "modules": 79, "runtime": "node",     "variant": "v8_7.8",               "versions": "13.0.0-pre" },
     { "modules": 78, "runtime": "node",     "variant": "v8_7.7",               "versions": "13.0.0-pre" },
     { "modules": 77, "runtime": "node",     "variant": "v8_7.6",               "versions": "13.0.0-pre" },
     { "modules": 76, "runtime": "electron", "variant": "electron",             "versions": "8" },
     { "modules": 75, "runtime": "electron", "variant": "electron",             "versions": "7" },
     { "modules": 74, "runtime": "node",     "variant": "v8_7.5",               "versions": "13.0.0-pre" },
     { "modules": 73, "runtime": "electron", "variant": "electron",             "versions": "6" },
-    { "modules": 72, "runtime": "node",     "variant": "v8_7.4",               "versions": "12.0.0-pre" },
+    { "modules": 72, "runtime": "node",     "variant": "node",                 "versions": "12" },
     { "modules": 71, "runtime": "node",     "variant": "v8_7.3",               "versions": "12.0.0-pre" },
     { "modules": 70, "runtime": "electron", "variant": "electron",             "versions": "5" },
     { "modules": 69, "runtime": "electron", "variant": "electron",             "versions": "^4.0.4" },


### PR DESCRIPTION
Clearly state the modules version 72 is official node 12, similar as it
is done for other major node versions.

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
