### PR TITLE
src: adds report_on_fatalerror option to per_process

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -456,7 +456,7 @@ void OnFatalError(const char* location, const char* message) {
 #ifdef NODE_REPORT
   Isolate* isolate = Isolate::GetCurrent();
   Environment* env = Environment::GetCurrent(isolate);
-  if (env == nullptr || env->isolate_data()->options()->report_on_fatalerror) {
+  if (per_process::cli_options->report_on_fatalerror) {
     report::TriggerNodeReport(
         isolate, env, message, "FatalError", "", Local<String>());
   }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -698,6 +698,15 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             "print V8 command line options",
             &PerProcessOptions::print_v8_help);
 
+#ifdef NODE_REPORT
+
+AddOption("--report-on-fatalerror",
+            "generate diagnostic report on fatal (internal) errors",
+            &PerProcessOptions::report_on_fatalerror,
+            kAllowedInEnvironment);
+            
+#endif  // NODE_REPORT
+
 #ifdef NODE_HAVE_I18N_SUPPORT
   AddOption("--icu-data-dir",
             "set ICU data load path to dir (overrides NODE_ICU_DATA)"

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -70,6 +70,15 @@ void PerProcessOptions::CheckOptions(std::vector<std::string>* errors) {
       use_largepages != "silent") {
     errors->push_back("invalid value for --use-largepages");
   }
+
+// #ifdef NODE_REPORT
+//   if (report_on_fatalerror) {
+//     errors->push_back(
+//         "--report-on-fatalerror option is valid only when "
+//         "--experimental-report is set");
+//   }
+// #endif  // NODE_REPORT
+
   per_isolate->CheckOptions(errors);
 }
 
@@ -98,12 +107,6 @@ void PerIsolateOptions::CheckOptions(std::vector<std::string>* errors) {
   if (!report_signal.empty()) {
     errors->push_back("--report-signal option is valid only when "
                       "--experimental-report is set");
-  }
-
-  if (report_on_fatalerror) {
-    errors->push_back(
-        "--report-on-fatalerror option is valid only when "
-        "--experimental-report is set");
   }
 
   if (report_on_signal) {
@@ -622,10 +625,6 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
             "generate diagnostic report upon receiving signals",
             &PerIsolateOptions::report_on_signal,
             kAllowedInEnvironment);
-  AddOption("--report-on-fatalerror",
-            "generate diagnostic report on fatal (internal) errors",
-            &PerIsolateOptions::report_on_fatalerror,
-            kAllowedInEnvironment);
   AddOption("--report-signal",
             "causes diagnostic report to be produced on provided signal,"
             " unsupported in Windows. (default: SIGUSR2)",
@@ -699,12 +698,10 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             &PerProcessOptions::print_v8_help);
 
 #ifdef NODE_REPORT
-
 AddOption("--report-on-fatalerror",
             "generate diagnostic report on fatal (internal) errors",
             &PerProcessOptions::report_on_fatalerror,
-            kAllowedInEnvironment);
-            
+            kAllowedInEnvironment);            
 #endif  // NODE_REPORT
 
 #ifdef NODE_HAVE_I18N_SUPPORT

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -190,7 +190,6 @@ class PerIsolateOptions : public Options {
 #ifdef NODE_REPORT
   bool report_uncaught_exception = false;
   bool report_on_signal = false;
-  bool report_on_fatalerror = false;
   std::string report_signal;
   std::string report_filename;
   std::string report_directory;

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -240,6 +240,7 @@ class PerProcessOptions : public Options {
 
 #ifdef NODE_REPORT
   std::vector<std::string> cmdline;
+  bool report_on_fatalerror = false;
 #endif  //  NODE_REPORT
 
   inline PerIsolateOptions* get_per_isolate_options();

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -119,13 +119,13 @@ static void SetSignal(const FunctionCallbackInfo<Value>& info) {
 static void ShouldReportOnFatalError(const FunctionCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
   info.GetReturnValue().Set(
-      env->isolate_data()->options()->report_on_fatalerror);
+    node::per_process::cli_options->report_on_fatalerror);
 }
 
 static void SetReportOnFatalError(const FunctionCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
   CHECK(info[0]->IsBoolean());
-  env->isolate_data()->options()->report_on_fatalerror = info[0]->IsTrue();
+  node::per_process::cli_options->report_on_fatalerror = info[0]->IsTrue();
 }
 
 static void ShouldReportOnSignal(const FunctionCallbackInfo<Value>& info) {

--- a/test/report/test-report-fatal-error.js
+++ b/test/report/test-report-fatal-error.js
@@ -21,18 +21,27 @@ if (process.argv[2] === 'child') {
   const helper = require('../common/report.js');
   const tmpdir = require('../common/tmpdir');
   tmpdir.refresh();
-  const spawn = require('child_process').spawn;
-  const args = ['--experimental-report',
-                '--report-on-fatalerror',
-                '--max-old-space-size=20',
-                __filename,
-                'child'];
-  const child = spawn(process.execPath, args, { cwd: tmpdir.path });
-  child.on('exit', common.mustCall((code) => {
-    assert.notStrictEqual(code, 0, 'Process exited unexpectedly');
-    const reports = helper.findReports(child.pid, tmpdir.path);
-    assert.strictEqual(reports.length, 1);
-    const report = reports[0];
-    helper.validate(report);
-  }));
+  const spawnSync = require('child_process').spawnSync;
+  let args = ['--experimental-report',
+              '--report-on-fatalerror',
+              '--max-old-space-size=20',
+              __filename,
+              'child'];
+
+  let child = spawnSync(process.execPath, args, { cwd: tmpdir.path });
+
+  assert.notStrictEqual(child.status, 0, 'Process exited unexpectedly');
+  let reports = helper.findReports(child.pid, tmpdir.path);
+  assert.strictEqual(reports.length, 1);
+  const report = reports[0];
+  helper.validate(report);
+
+  args = ['--max-old-space-size=20',
+          __filename,
+          'child'];
+
+  child = spawnSync(process.execPath, args, { cwd: tmpdir.path });
+  assert.notStrictEqual(child.status, 0, 'Process exited unexpectedly');
+  reports = helper.findReports(child.pid, tmpdir.path);
+  assert.strictEqual(reports.length, 0);
 }


### PR DESCRIPTION
#### Description
moving the `report_on_fatalerror` flag to `per_process` as it allows to read it's value on fatal error where `env` itself is null.

Fixes: https://github.com/nodejs/node/issues/29601

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
