### PR TITLE
test: fix flaky test-http2-client-upload

### DIFF
--- a/test/parallel/test-http2-client-upload.js
+++ b/test/parallel/test-http2-client-upload.js
@@ -34,7 +34,7 @@ fs.readFile(loc, common.mustCall((err, data) => {
     stream.on('end', common.mustCall(() => {
       assert.deepStrictEqual(data, fileData);
     }));
-    // Waiting on close avoids sprious ECONNRESET seen in windows CI.
+    // Waiting on close avoids spurious ECONNRESET seen in windows CI.
     // Not sure if this is actually a bug; more details at
     // https://github.com/nodejs/node/issues/20750#issuecomment-511015247
     stream.on('close', () => countdown.dec());

--- a/test/parallel/test-http2-client-upload.js
+++ b/test/parallel/test-http2-client-upload.js
@@ -21,6 +21,12 @@ fs.readFile(loc, common.mustCall((err, data) => {
   fileData = data;
 
   const server = http2.createServer();
+  let client;
+
+  const countdown = new Countdown(3, () => {
+    server.close();
+    client.close();
+  });
 
   server.on('stream', common.mustCall((stream) => {
     let data = Buffer.alloc(0);
@@ -28,17 +34,16 @@ fs.readFile(loc, common.mustCall((err, data) => {
     stream.on('end', common.mustCall(() => {
       assert.deepStrictEqual(data, fileData);
     }));
+    // Waiting on close avoids sprious ECONNRESET seen in windows CI.
+    // Not sure if this is actually a bug; more details at
+    // https://github.com/nodejs/node/issues/20750#issuecomment-511015247
+    stream.on('close', () => countdown.dec());
     stream.respond();
     stream.end();
   }));
 
   server.listen(0, common.mustCall(() => {
-    const client = http2.connect(`http://localhost:${server.address().port}`);
-
-    const countdown = new Countdown(2, () => {
-      server.close();
-      client.close();
-    });
+    client = http2.connect(`http://localhost:${server.address().port}`);
 
     const req = client.request({ ':method': 'POST' });
     req.on('response', common.mustCall());


### PR DESCRIPTION
Wait for close event on server stream before shuting down server and
client to avoid races seen on windows CI.

Actually I'm not sure if this just hides a bug, see https://github.com/nodejs/node/issues/20750#issuecomment-511015247 for more details.
I still haven't transformed into a http2/nghttp/net expert and noone else took this since I last commented so I decided to start a PR to at least help CI.

Refs: https://github.com/nodejs/node/issues/20750#issuecomment-511015247
Refs: #29852

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

