### PR TITLE
net: support passing a host with port to Server.prototype.listen

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -218,6 +218,49 @@ function normalizeArgs(args) {
   return arr;
 }
 
+// Normalize the options object passed to Server.prototype.listen
+function normalizeHostOption(options) {
+  let hostname, port;
+
+  try {
+    // eslint-disable-next-line
+    const parsedHost = new URL(`http://${options.host}`);
+    hostname = parsedHost.hostname;
+    port = parsedHost.port;
+  } catch {
+    // Some IPv6 addresses are not parsed correctly
+    if (isIPv6(options.host)) {
+      hostname = options.host;
+      port = '';
+    } else {
+      // eslint-disable-next-line
+      throw new TypeError('invalid `host` value');
+    }
+  }
+
+  if (options.hostname && hostname !== options.hostname) {
+    // eslint-disable-next-line
+    throw new TypeError('Mismatched hostname in "host" and "hostname" options');
+  } else {
+    options.hostname = hostname;
+  }
+
+  // Only attempt extracting a port if one was passed, e.g. `0.0.0.0:5000` vs
+  // `0.0.0.0`
+  if (port !== '') {
+    port = Number(port);
+
+    if (options.port && port !== options.port) {
+      // eslint-disable-next-line
+      throw new TypeError('Mismatched port in "host" and "port" options');
+    } else if (!isLegalPort(port)) {
+      throw new ERR_SOCKET_BAD_PORT(options.port);
+    } else {
+      options.port = port;
+    }
+  }
+}
+
 
 // Called when creating new Socket, or when re-using a closed Socket
 function initSocketHandle(self) {
@@ -1418,6 +1461,25 @@ Server.prototype.listen = function(...args) {
       options.port === null) {
     options.port = 0;
   }
+  // (options[, cb]) where a host is specified comprised of both a
+  // hostname and port
+  if (typeof options.host === 'string') {
+    normalizeHostOption(options);
+  }
+
+  // IPv6 hostnames are enclosed in square brackets, like [fe80::],
+  // which need be stripped away. Only do that if they contain a valid
+  // IPv6 address
+  if (typeof options.hostname === 'string') {
+    const inSquareBrackets = options.hostname[0] === '[' &&
+        options.hostname.slice(-1) === ']';
+    const enclosedHostname = options.hostname.slice(1, -1);
+
+    if (inSquareBrackets && isIPv6(enclosedHostname)) {
+      options.hostname = enclosedHostname;
+    }
+  }
+
   // ([port][, host][, backlog][, cb]) where port is specified
   // or (options[, cb]) where options.port is specified
   // or if options.port is normalized as 0 before
@@ -1428,8 +1490,8 @@ Server.prototype.listen = function(...args) {
     }
     backlog = options.backlog || backlogFromArgs;
     // start TCP server listening on host:port
-    if (options.host) {
-      lookupAndListen(this, options.port | 0, options.host, backlog,
+    if (options.hostname) {
+      lookupAndListen(this, options.port | 0, options.hostname, backlog,
                       options.exclusive, flags);
     } else { // Undefined host, listens on unspecified address
       // Default addressType 4 will be used to search for master server

--- a/test/parallel/test-net-server-listen-options.js
+++ b/test/parallel/test-net-server-listen-options.js
@@ -88,7 +88,6 @@ const listenOnPort = [
   // Neither port or path are specified in options
   shouldFailToListen({});
   shouldFailToListen({ host: 'localhost' });
-  shouldFailToListen({ host: 'localhost:3000' });
   shouldFailToListen({ host: { port: 3000 } });
   shouldFailToListen({ exclusive: true });
 }

--- a/test/sequential/test-net-server-bind.js
+++ b/test/sequential/test-net-server-bind.js
@@ -62,3 +62,185 @@ const net = require('net');
     server.close();
   }));
 }
+
+// Test host option
+{
+  let port = common.PORT + 3;
+
+  // Host is "textual" hostname + port
+  {
+    const testPort = ++port;
+    const host = `localhost:${port}`;
+
+    const server = net.createServer();
+    server.listen({ host }, common.mustCall(() => {
+      const { address, port: listenPort } = server.address();
+      assert.strictEqual(address, '127.0.0.1');
+      assert.strictEqual(listenPort, testPort);
+
+      server.close();
+    }));
+  }
+  // Host with IPv4 hostname + port
+  {
+    const testPort = ++port;
+    const host = `127.0.0.1:${port}`;
+
+    const server = net.createServer();
+    server.listen({ host }, common.mustCall(() => {
+      const { address, port: listenPort } = server.address();
+      assert.strictEqual(address, '127.0.0.1');
+      assert.strictEqual(listenPort, testPort);
+
+      server.close();
+    }));
+  }
+  // Host with IPv6 hostname + port
+  ipv6: {
+    if (!common.hasIPv6) {
+      break ipv6;
+    }
+
+    const testPort = ++port;
+    const host = `[::1]:${port}`;
+
+    const server = net.createServer();
+    server.listen({ host }, common.mustCall(() => {
+      const { address, port: listenPort } = server.address();
+      assert.strictEqual(address, '::1');
+      assert.strictEqual(listenPort, testPort);
+
+      server.close();
+    }));
+  }
+  // Host is a weird IPv6 address
+  ipv6: {
+    if (!common.hasIPv6) {
+      break ipv6;
+    }
+
+    const testPort = ++port;
+    const host = `[::1]:${port}`;
+
+    const server = net.createServer();
+    server.listen({ host }, common.mustCall(() => {
+      const { address, port: listenPort } = server.address();
+      assert.strictEqual(address, '::1');
+      assert.strictEqual(listenPort, testPort);
+
+      server.close();
+    }));
+  }
+
+  // TODO host with invalid port throws
+  // currently the URL constructor throws this error
+  // common.expectsError(() => {
+  //   net.createServer.listen({
+  //     host: '127.0.0.1:99999999999999',
+  //   }, common.mustNotCall());
+  // }, {
+  //   code: 'ERR_SOCKET_BAD_POT',
+  //   type: RangeError,
+  // });
+
+  // Host without port AND without port option throws
+  common.expectsError(() => {
+    net.createServer().listen({
+      host: '127.0.0.1',
+    }, common.mustNotCall());
+  }, {
+    code: 'ERR_INVALID_ARG_VALUE',
+    type: TypeError,
+    message: /^The argument 'options' must have the property "port" or "path"\. Received .+$/,
+  });
+
+  // Host with port and port option
+  {
+    const testPort = ++port;
+    const host = `127.0.0.1:${port}`;
+
+    const server = net.createServer();
+    server.listen({ host, port: testPort }, common.mustCall(() => {
+      const { address, port: listenPort } = server.address();
+      assert.strictEqual(address, '127.0.0.1');
+      assert.strictEqual(listenPort, testPort);
+
+      server.close();
+    }));
+  }
+
+  // TODO host with port AND port option *as a string*
+  // This errors out as converting the port to a number happens really
+  // late, only after we parse the host option
+  // {
+  //   const testPort = ++port;
+  //   const host = `127.0.0.1:${port}`;
+
+  //   const server = net.createServer();
+  //   server.listen({ host, port: String(testPort) }, common.mustCall(() => {
+  //     const { address, port: listenPort } = server.address();
+  //     assert.strictEqual(address, '127.0.0.1');
+  //     assert.strictEqual(listenPort, testPort);
+
+  //     server.close();
+  //   }));
+  // }
+
+  // Host with port and a conflicting port option throws
+  {
+    common.expectsError(() => {
+      net.createServer().listen({
+        host: '127.0.0.1:1234',
+        port: 4321,
+      }, common.mustNotCall());
+    }, {
+      type: TypeError,
+      message: /^Mismatched port in "host" and "port" options$/,
+    });
+  }
+
+  // Host with with hostname option
+  {
+    const server = net.createServer();
+    server.listen({
+      host: '127.0.0.1',
+      hostname: '127.0.0.1',
+      port: 0,
+    }, common.mustCall(() => {
+      const { address } = server.address();
+      assert.strictEqual(address, '127.0.0.1');
+
+      server.close();
+    }));
+  }
+
+  // Host with hostname and a conflicting hostname option throws
+  {
+    common.expectsError(() => {
+      net.createServer().listen({
+        host: '127.0.0.1',
+        hostname: '127.1.1.0',
+        port: 0,
+      }, common.mustNotCall());
+    }, {
+      type: TypeError,
+      message: /^Mismatched hostname in "host" and "hostname" options$/,
+    });
+  }
+
+  // A parsed URL
+  // TODO this currently errors out, see the port-as-string mentioned above
+  // {
+  //   const testPort = ++port;
+  //   const url = new URL(`http://127.0.0.1:${testPort}`);
+
+  //   const server = net.createServer();
+  //   server.listen(url, common.mustCall(() => {
+  //     const { address, port: listenPort } = server.address();
+  //     assert.strictEqual(address, '127.0.0.1');
+  //     assert.strictEqual(listenPort, testPort);
+
+  //     server.close();
+  //   }));
+  // }
+}


### PR DESCRIPTION
Distinguish between a `host` and `hostname` in the
`Server.prototype.listen` argument, to better align with how browsers
and other places in node distinguish between `host` and `hostname`.

For more context, see #16712.

This commit:
- Broadens the meaning of the `host` key to also potentially include a port (i.e. `hostname:port`)
  - Given such a `host` option, one can choose to not supply a `port` parameter
- Allows the user to pass in a `hostname` key, which behaves just like `host` in present-day node.

The following three are now equivalent:

```js
server.listen({
  host: 'localhost:5000',
})

server.listen({
  host: 'localhost',
  port: 5000,
})

server.listen({
  hostname: 'localhost',
  port: 5000
})

server.listen(new URL('http://localhost:5000'))
```

## Backwards-compatibility
An important aspect was keeping this change backwards-compatible. As such, the `host` option is parsed into its `hostname` and `port` components.

In case of a conflict between a `host` component and one of the other options, an exception is thrown:

```js
server.listen({
  host: 'localhost:5000',
  hostname: '127.0.0.1'
}) // => TypeError

server.listen({
  host: 'localhost:5000',
  port: 8080
}) // => TypeError
```

## Caveats
My goal here was to mock-up a PoC which implements the spirit of the
proposal in a backwards-compatible matter. Below are some caveats with
how I wrote the code and some tradeoffs I took to keep this a PoC. If
this proves to be interesting to the project, they'll be fixed, no
worries :)

- Right now, `host` is parsed using a hack around `new URL`. It's
  probably not the smartest way of going about this. Regard it as
  temporary until this gets more traction.

- Similarly, the new errors thrown here should be internal and worded
  better overall. So far they serve as an example.

- Since ipv6 addresses in urls must be enclosed in square brackets
  (i.e. `[80:fe::]`), and the rest of the code expects them to be free
  outside their cages, we need to trim those. To maintain current
  behaviour, we need to only trim those if the value inside is an ipv6
  address. Current node:

```js
net.createServer().listen({ host: '[foo].com', port: 0 });
```

After a tick throws `Error: getaddrinfo ENOTFOUND [foo].com`. Having
said that, `new URL('http://[foo].com')` throws an exception, and
Firefox doesn't believes it's a real URL.

- This pollutes the `options` variable with an extra `hostname` key
  the user might not have specified. The `options` variable gets
  printed in some cases, and this may not be ideal.
  - The bespoken error message need also be updated.

- Right now, a known bug is when you pass a host containing a port and
  you also pass the `port` key as a string (i.e. `listen({ host:
  'whatever:123', port: '123' })`), an error will be thrown about
  mismatching port values. One potential fix is moving the casting up,
  from the argument of `lookupAndListen` or `listenInCluster` to
  somewhere handling the arguments.

- The tests are fairly verbose and can be compacted. I opted to making
  them very explicit and long-form at this point for clarity.
  
- There are currently no tests for the lonely `hostname` option.

### node questions

- Is there a reason to try and identify invalid IPv6 addresses (like
  `1::2::3` or `:::`)? Currently, they fall back on trying to be
  resolved via dns and failing.
  
- Did I put the tests in the correct file? Is there a better place for
  it? e.g. test-net-server-address?


------

Sorry for the extra long PR comment, and thank you for your time.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
