### PR TITLE
fs: buffer dir entries in opendir()

### DIFF
--- a/benchmark/fs/bench-opendir.js
+++ b/benchmark/fs/bench-opendir.js
@@ -26,18 +26,20 @@ async function main({ n, dir, mode }) {
       await new Promise((resolve, reject) => {
         function read() {
           dir.read((err, entry) => {
-            if (err)
+            if (err) {
               reject(err);
-            if (entry === null)
+            } else if (entry === null) {
               resolve(dir.close());
-            else
+            } else {
+              counter++;
               read();
+            }
           });
         }
 
         read();
       });
-    } {
+    } else {
       const dir = fs.opendirSync(fullPath);
       while (dir.readSync() !== null)
         counter++;

--- a/benchmark/fs/bench-opendir.js
+++ b/benchmark/fs/bench-opendir.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const path = require('path');
+
+const bench = common.createBenchmark(main, {
+  n: [100],
+  dir: [ 'lib', 'test/parallel'],
+  mode: [ 'async', 'sync' ]
+});
+
+function main({ n, dir, mode }) {
+  const fullPath = path.resolve(__dirname, '../../', dir);
+
+  (async () => {
+    bench.start();
+
+    let counter = 0;
+    for (let i = 0; i < n; i++) {
+      if (mode === 'async') {
+        // eslint-disable-next-line no-unused-vars
+        for await (const entry of await fs.promises.opendir(fullPath))
+          counter++;
+      } else {
+        const dir = fs.opendirSync(fullPath);
+        while (dir.readSync() !== null)
+          counter++;
+        dir.closeSync();
+      }
+    }
+
+    bench.end(counter);
+  })();
+}

--- a/benchmark/fs/bench-opendir.js
+++ b/benchmark/fs/bench-opendir.js
@@ -10,26 +10,24 @@ const bench = common.createBenchmark(main, {
   mode: [ 'async', 'sync' ]
 });
 
-function main({ n, dir, mode }) {
+async function main({ n, dir, mode }) {
   const fullPath = path.resolve(__dirname, '../../', dir);
 
-  (async () => {
-    bench.start();
+  bench.start();
 
-    let counter = 0;
-    for (let i = 0; i < n; i++) {
-      if (mode === 'async') {
-        // eslint-disable-next-line no-unused-vars
-        for await (const entry of await fs.promises.opendir(fullPath))
-          counter++;
-      } else {
-        const dir = fs.opendirSync(fullPath);
-        while (dir.readSync() !== null)
-          counter++;
-        dir.closeSync();
-      }
+  let counter = 0;
+  for (let i = 0; i < n; i++) {
+    if (mode === 'async') {
+      // eslint-disable-next-line no-unused-vars
+      for await (const entry of await fs.promises.opendir(fullPath))
+        counter++;
+    } else {
+      const dir = fs.opendirSync(fullPath);
+      while (dir.readSync() !== null)
+        counter++;
+      dir.closeSync();
     }
+  }
 
-    bench.end(counter);
-  })();
+  bench.end(counter);
 }

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -362,8 +362,10 @@ Asynchronously read the next directory entry via readdir(3) as an
 After the read is completed, a `Promise` is returned that will be resolved with
 an [`fs.Dirent`][], or `null` if there are no more directory entries to read.
 
-_Directory entries returned by this function are in no particular order as
-provided by the operating system's underlying directory mechanisms._
+Directory entries returned by this function are in no particular order as
+provided by the operating system's underlying directory mechanisms.
+Entries added or removed while iterating over the directory may or may not be
+included in the iteration results.
 
 ### dir.read(callback)
 <!-- YAML
@@ -380,8 +382,10 @@ Asynchronously read the next directory entry via readdir(3) as an
 After the read is completed, the `callback` will be called with an
 [`fs.Dirent`][], or `null` if there are no more directory entries to read.
 
-_Directory entries returned by this function are in no particular order as
-provided by the operating system's underlying directory mechanisms._
+Directory entries returned by this function are in no particular order as
+provided by the operating system's underlying directory mechanisms.
+Entries added or removed while iterating over the directory may or may not be
+included in the iteration results.
 
 ### dir.readSync()
 <!-- YAML
@@ -395,8 +399,10 @@ Synchronously read the next directory entry via readdir(3) as an
 
 If there are no more directory entries to read, `null` will be returned.
 
-_Directory entries returned by this function are in no particular order as
-provided by the operating system's underlying directory mechanisms._
+Directory entries returned by this function are in no particular order as
+provided by the operating system's underlying directory mechanisms.
+Entries added or removed while iterating over the directory may or may not be
+included in the iteration results.
 
 ### dir\[Symbol.asyncIterator\]()
 <!-- YAML
@@ -413,8 +419,10 @@ The `null` case from `dir.read()` is handled internally.
 
 See [`fs.Dir`][] for an example.
 
-_Directory entries returned by this iterator are in no particular order as
-provided by the operating system's underlying directory mechanisms._
+Directory entries returned by this iterator are in no particular order as
+provided by the operating system's underlying directory mechanisms.
+Entries added or removed while iterating over the directory may or may not be
+included in the iteration results.
 
 ## Class: fs.Dirent
 <!-- YAML

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -43,7 +43,8 @@ class Dir {
       encoding: 'utf8'
     });
 
-    this[kDirReadPromisified] = internalUtil.promisify(this[kDirReadImpl]).bind(this, false);
+    this[kDirReadPromisified] =
+        internalUtil.promisify(this[kDirReadImpl]).bind(this, false);
     this[kDirClosePromisified] = internalUtil.promisify(this.close).bind(this);
   }
 

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -27,6 +27,7 @@ const kDirPath = Symbol('kDirPath');
 const kDirBufferedEntries = Symbol('kDirBufferedEntries');
 const kDirClosed = Symbol('kDirClosed');
 const kDirOptions = Symbol('kDirOptions');
+const kDirReadImpl = Symbol('kDirReadImpl');
 const kDirReadPromisified = Symbol('kDirReadPromisified');
 const kDirClosePromisified = Symbol('kDirClosePromisified');
 
@@ -42,7 +43,7 @@ class Dir {
       encoding: 'utf8'
     });
 
-    this[kDirReadPromisified] = internalUtil.promisify(this.read).bind(this);
+    this[kDirReadPromisified] = internalUtil.promisify(this[kDirReadImpl]).bind(this, false);
     this[kDirClosePromisified] = internalUtil.promisify(this.close).bind(this);
   }
 
@@ -51,6 +52,10 @@ class Dir {
   }
 
   read(callback) {
+    return this[kDirReadImpl](true, callback);
+  }
+
+  [kDirReadImpl](maybeSync, callback) {
     if (this[kDirClosed] === true) {
       throw new ERR_DIR_CLOSED();
     }
@@ -63,7 +68,10 @@ class Dir {
 
     if (this[kDirBufferedEntries].length > 0) {
       const [ name, type ] = this[kDirBufferedEntries].splice(0, 2);
-      getDirent(this[kDirPath], name, type, callback);
+      if (maybeSync)
+        process.nextTick(getDirent, this[kDirPath], name, type, callback);
+      else
+        getDirent(this[kDirPath], name, type, callback);
       return;
     }
 

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -24,6 +24,7 @@ const {
 
 const kDirHandle = Symbol('kDirHandle');
 const kDirPath = Symbol('kDirPath');
+const kDirBufferedEntries = Symbol('kDirBufferedEntries');
 const kDirClosed = Symbol('kDirClosed');
 const kDirOptions = Symbol('kDirOptions');
 const kDirReadPromisified = Symbol('kDirReadPromisified');
@@ -33,6 +34,7 @@ class Dir {
   constructor(handle, path, options) {
     if (handle == null) throw new ERR_MISSING_ARGS('handle');
     this[kDirHandle] = handle;
+    this[kDirBufferedEntries] = [];
     this[kDirPath] = path;
     this[kDirClosed] = false;
 
@@ -59,11 +61,19 @@ class Dir {
       throw new ERR_INVALID_CALLBACK(callback);
     }
 
+    if (this[kDirBufferedEntries].length > 0) {
+      const [ name, type ] = this[kDirBufferedEntries].splice(0, 2);
+      getDirent(this[kDirPath], name, type, callback);
+      return;
+    }
+
     const req = new FSReqCallback();
     req.oncomplete = (err, result) => {
       if (err || result === null) {
         return callback(err, result);
       }
+
+      this[kDirBufferedEntries] = result.slice(2);
       getDirent(this[kDirPath], result[0], result[1], callback);
     };
 
@@ -78,6 +88,11 @@ class Dir {
       throw new ERR_DIR_CLOSED();
     }
 
+    if (this[kDirBufferedEntries].length > 0) {
+      const [ name, type ] = this[kDirBufferedEntries].splice(0, 2);
+      return getDirent(this[kDirPath], name, type);
+    }
+
     const ctx = { path: this[kDirPath] };
     const result = this[kDirHandle].read(
       this[kDirOptions].encoding,
@@ -90,6 +105,7 @@ class Dir {
       return result;
     }
 
+    this[kDirBufferedEntries] = result.slice(2);
     return getDirent(this[kDirPath], result[0], result[1]);
   }
 

--- a/src/node_dir.h
+++ b/src/node_dir.h
@@ -25,7 +25,6 @@ class DirHandle : public AsyncWrap {
   static void Close(const v8::FunctionCallbackInfo<Value>& args);
 
   inline uv_dir_t* dir() { return dir_; }
-  AsyncWrap* GetAsyncWrap() { return this; }
 
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackFieldWithSize("dir", sizeof(*dir_));
@@ -46,7 +45,8 @@ class DirHandle : public AsyncWrap {
   void GCClose();
 
   uv_dir_t* dir_;
-  uv_dirent_t dirent_;
+  // Up to 32 directory entries are read through a single libuv call.
+  uv_dirent_t dirents_[32];
   bool closing_ = false;
   bool closed_ = false;
 };

--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -58,17 +58,27 @@ const dirclosedError = {
 // Check the opendir async version
 fs.opendir(testDir, common.mustCall(function(err, dir) {
   assert.ifError(err);
-  dir.read(common.mustCall(function(err, dirent) {
+  let sync = true;
+  dir.read(common.mustCall((err, dirent) => {
+    assert(!sync);
     assert.ifError(err);
 
     // Order is operating / file system dependent
     assert(files.includes(dirent.name), `'files' should include ${dirent}`);
     assertDirent(dirent);
 
-    dir.close(common.mustCall(function(err) {
+    let syncInner = true;
+    dir.read(common.mustCall((err, dirent) => {
+      assert(!syncInner);
       assert.ifError(err);
+
+      dir.close(common.mustCall(function(err) {
+        assert.ifError(err);
+      }));
     }));
+    syncInner = false;
   }));
+  sync = false;
 }));
 
 // opendir() on file should throw ENOTDIR


### PR DESCRIPTION
Read up to 32 directory entries in one batch when `dir.readSync()`
or `dir.read()` are called.

This increases performance significantly, although it introduces
quite a bit of edge case complexity.

                                                                 confidence improvement accuracy (*)    (**)    (***)
     fs/bench-opendir.js mode='async' dir='lib' n=100                  ***    155.93 %      ±30.05% ±40.34%  ±53.21%
     fs/bench-opendir.js mode='async' dir='test/parallel' n=100        ***    479.65 %      ±56.81% ±76.47% ±101.32%
     fs/bench-opendir.js mode='sync' dir='lib' n=100                           10.38 %      ±14.39% ±19.16%  ±24.96%
     fs/bench-opendir.js mode='sync' dir='test/parallel' n=100         ***     63.13 %      ±12.84% ±17.18%  ±22.58%

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
