### PR TITLE
doc: add notes about non-conforming streams

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1667,11 +1667,12 @@ of a stream that are intended for use by consumers (as described in the
 [API for Stream Consumers][] section). Doing so may lead to adverse side effects
 in application code consuming the stream.
 
-It is highly discouraged to override any public method. As well as emitting
-`'error'` events manually through `.emit(err)` instead of using API provided
-callbacks or `.destroy(err)`. Doing so can break current and future stream
-invariants leading to behaviour and/or compatibility issues with other streams,
-stream utilities and user expectations.
+It is highly discouraged to override any public method. As well as emitting any
+internal events such as `'error'`, `'data'`, `'end'`, `'finish'` and `'close'`
+manually through `.emit(err)` instead of using API provided callbacks or
+`.destroy(err)`. Doing so can break current and future stream invariants
+leading to behaviour and/or compatibility issues with other streams, stream
+utilities and user expectations.
 
 ### Simplified Construction
 <!-- YAML

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1667,12 +1667,12 @@ of a stream that are intended for use by consumers (as described in the
 [API for Stream Consumers][] section). Doing so may lead to adverse side effects
 in application code consuming the stream.
 
-It is highly discouraged to override any public method or to emit any internal
-events such as `'error'`, `'data'`, `'end'`, `'finish'` and `'close'` manually
-through `.emit(eventName)` instead of using API provided callbacks or
-`.destroy(err)`. Doing so can break current and future stream invariants
-leading to behavior and/or compatibility issues with other streams, stream
-utilities and user expectations.
+It is highly discouraged to override any public method such as `write()`,
+`end()`, `cork()`, `uncork()`, `read()` and `destroy()`, or to emit any
+internal event such as `'error'`, `'data'`, `'end'`, `'finish'` and `'close'`
+manually through `.emit()`. Doing so can break current and future stream
+invariants leading to behavior and/or compatibility issues with other streams,
+stream utilities and user expectations.
 
 ### Simplified Construction
 <!-- YAML

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1668,7 +1668,7 @@ of a stream that are intended for use by consumers (as described in the
 in application code consuming the stream.
 
 Avoid overriding public methods such as `write()`, `end()`, `cork()`,
-`uncork()`, `read()` and `destroy()`, or emitting an internal event such
+`uncork()`, `read()` and `destroy()`, or emitting internal events such
 as `'error'`, `'data'`, `'end'`, `'finish'` and `'close'` through `.emit()`.
 Doing so can break current and future stream invariants leading to behavior
 and/or compatibility issues with other streams, stream utilities, and user

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1667,12 +1667,12 @@ of a stream that are intended for use by consumers (as described in the
 [API for Stream Consumers][] section). Doing so may lead to adverse side effects
 in application code consuming the stream.
 
-It is highly discouraged to override any public method such as `write()`,
-`end()`, `cork()`, `uncork()`, `read()` and `destroy()`, or to emit any
+Avoid overriding public methods such as `write()`,
+`end()`, `cork()`, `uncork()`, `read()` and `destroy()`, or emitting an
 internal event such as `'error'`, `'data'`, `'end'`, `'finish'` and `'close'`
-manually through `.emit()`. Doing so can break current and future stream
+through `.emit()`. Doing so can break current and future stream
 invariants leading to behavior and/or compatibility issues with other streams,
-stream utilities and user expectations.
+stream utilities, and user expectations.
 
 ### Simplified Construction
 <!-- YAML

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1667,11 +1667,11 @@ of a stream that are intended for use by consumers (as described in the
 [API for Stream Consumers][] section). Doing so may lead to adverse side effects
 in application code consuming the stream.
 
-It is highly discouraged to override any public method. As well as emitting any
-internal events such as `'error'`, `'data'`, `'end'`, `'finish'` and `'close'`
-manually through `.emit(err)` instead of using API provided callbacks or
+It is highly discouraged to override any public method or to emit any internal
+events such as `'error'`, `'data'`, `'end'`, `'finish'` and `'close'` manually
+through `.emit(err)` instead of using API provided callbacks or
 `.destroy(err)`. Doing so can break current and future stream invariants
-leading to behaviour and/or compatibility issues with other streams, stream
+leading to behavior and/or compatibility issues with other streams, stream
 utilities and user expectations.
 
 ### Simplified Construction

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1669,7 +1669,7 @@ in application code consuming the stream.
 
 It is highly discouraged to override any public method or to emit any internal
 events such as `'error'`, `'data'`, `'end'`, `'finish'` and `'close'` manually
-through `.emit(err)` instead of using API provided callbacks or
+through `.emit(eventName)` instead of using API provided callbacks or
 `.destroy(err)`. Doing so can break current and future stream invariants
 leading to behavior and/or compatibility issues with other streams, stream
 utilities and user expectations.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1667,12 +1667,12 @@ of a stream that are intended for use by consumers (as described in the
 [API for Stream Consumers][] section). Doing so may lead to adverse side effects
 in application code consuming the stream.
 
-Avoid overriding public methods such as `write()`,
-`end()`, `cork()`, `uncork()`, `read()` and `destroy()`, or emitting an
-internal event such as `'error'`, `'data'`, `'end'`, `'finish'` and `'close'`
-through `.emit()`. Doing so can break current and future stream
-invariants leading to behavior and/or compatibility issues with other streams,
-stream utilities, and user expectations.
+Avoid overriding public methods such as `write()`, `end()`, `cork()`,
+`uncork()`, `read()` and `destroy()`, or emitting an internal event such
+as `'error'`, `'data'`, `'end'`, `'finish'` and `'close'` through `.emit()`.
+Doing so can break current and future stream invariants leading to behavior
+and/or compatibility issues with other streams, stream utilities, and user
+expectations.
 
 ### Simplified Construction
 <!-- YAML

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1667,6 +1667,12 @@ of a stream that are intended for use by consumers (as described in the
 [API for Stream Consumers][] section). Doing so may lead to adverse side effects
 in application code consuming the stream.
 
+It is highly discouraged to override any public method. As well as emitting
+`'error'` events manually through `.emit(err)` instead of using API provided
+callbacks or `.destroy(err)`. Doing so can break current and future stream
+invariants leading to behaviour and/or compatibility issues with other streams,
+stream utilities and user expectations.
+
 ### Simplified Construction
 <!-- YAML
 added: v1.2.0


### PR DESCRIPTION
A lot of streams in the ecosystem are overriding public stream methods that lead to very subtle and hard to find bugs. Discourage this usage and encourage using the existing framework.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
