### PR TITLE
fs: make FSWatcher.start private

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1342,10 +1342,10 @@ function watch(filename, options, listener) {
   if (!watchers)
     watchers = require('internal/fs/watchers');
   const watcher = new watchers.FSWatcher();
-  watcher._start(filename,
-                 options.persistent,
-                 options.recursive,
-                 options.encoding);
+  watcher[watchers.kFSWatchStart](filename,
+                                  options.persistent,
+                                  options.recursive,
+                                  options.encoding);
 
   if (listener) {
     watcher.addListener('change', listener);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1342,10 +1342,10 @@ function watch(filename, options, listener) {
   if (!watchers)
     watchers = require('internal/fs/watchers');
   const watcher = new watchers.FSWatcher();
-  watcher.start(filename,
-                options.persistent,
-                options.recursive,
-                options.encoding);
+  watcher._start(filename,
+                 options.persistent,
+                 options.recursive,
+                 options.encoding);
 
   if (listener) {
     watcher.addListener('change', listener);

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -25,6 +25,8 @@ const assert = require('internal/assert');
 const kOldStatus = Symbol('kOldStatus');
 const kUseBigint = Symbol('kUseBigint');
 
+const kFSWatchStart = Symbol('kFSWatchStart');
+
 function emitStop(self) {
   self.emit('stop');
 }
@@ -136,15 +138,15 @@ Object.setPrototypeOf(FSWatcher.prototype, EventEmitter.prototype);
 Object.setPrototypeOf(FSWatcher, EventEmitter);
 
 // At the moment if filename is undefined, we
-// 1. Throw an Error if it's the first time ._start() is called
-// 2. Return silently if ._start() has already been called
+// 1. Throw an Error if it's the first time Symbol('kFSWatchStart') is called
+// 2. Return silently if Symbol('kFSWatchStart') has already been called
 //    on a valid filename and the wrap has been initialized
 // 3. Return silently if the watcher has already been closed
 // This method is a noop if the watcher has already been started.
-FSWatcher.prototype._start = function(filename,
-                                      persistent,
-                                      recursive,
-                                      encoding) {
+FSWatcher.prototype[kFSWatchStart] = function(filename,
+                                              persistent,
+                                              recursive,
+                                              encoding) {
   if (this._handle === null) {  // closed
     return;
   }
@@ -200,5 +202,6 @@ Object.defineProperty(FSEvent.prototype, 'owner', {
 
 module.exports = {
   FSWatcher,
-  StatWatcher
+  StatWatcher,
+  kFSWatchStart
 };

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -135,18 +135,16 @@ function FSWatcher() {
 Object.setPrototypeOf(FSWatcher.prototype, EventEmitter.prototype);
 Object.setPrototypeOf(FSWatcher, EventEmitter);
 
-
-// FIXME(joyeecheung): this method is not documented.
 // At the moment if filename is undefined, we
-// 1. Throw an Error if it's the first time .start() is called
-// 2. Return silently if .start() has already been called
+// 1. Throw an Error if it's the first time ._start() is called
+// 2. Return silently if ._start() has already been called
 //    on a valid filename and the wrap has been initialized
 // 3. Return silently if the watcher has already been closed
 // This method is a noop if the watcher has already been started.
-FSWatcher.prototype.start = function(filename,
-                                     persistent,
-                                     recursive,
-                                     encoding) {
+FSWatcher.prototype._start = function(filename,
+                                      persistent,
+                                      recursive,
+                                      encoding) {
   if (this._handle === null) {  // closed
     return;
   }

--- a/test/parallel/test-fs-watch.js
+++ b/test/parallel/test-fs-watch.js
@@ -57,8 +57,6 @@ for (const testCase of cases) {
   });
   watcher.on('close', common.mustCall(() => {
     watcher.close(); // Closing a closed watcher should be a noop
-    // Starting a closed watcher should be a noop
-    watcher._start();
   }));
   watcher.on('change', common.mustCall(function(eventType, argFilename) {
     if (interval) {
@@ -71,16 +69,11 @@ for (const testCase of cases) {
       assert.strictEqual(eventType, 'change');
     assert.strictEqual(argFilename, testCase.fileName);
 
-    // Starting a started watcher should be a noop
-    watcher._start();
-    watcher._start(pathToWatch);
-
     watcher.close();
 
     // We document that watchers cannot be used anymore when it's closed,
     // here we turn the methods into noops instead of throwing
     watcher.close(); // Closing a closed watcher should be a noop
-    watcher._start();  // Starting a closed watcher should be a noop
   }));
 
   // Long content so it's actually flushed. toUpperCase so there's real change.

--- a/test/parallel/test-fs-watch.js
+++ b/test/parallel/test-fs-watch.js
@@ -58,7 +58,7 @@ for (const testCase of cases) {
   watcher.on('close', common.mustCall(() => {
     watcher.close(); // Closing a closed watcher should be a noop
     // Starting a closed watcher should be a noop
-    watcher.start();
+    watcher._start();
   }));
   watcher.on('change', common.mustCall(function(eventType, argFilename) {
     if (interval) {
@@ -72,15 +72,15 @@ for (const testCase of cases) {
     assert.strictEqual(argFilename, testCase.fileName);
 
     // Starting a started watcher should be a noop
-    watcher.start();
-    watcher.start(pathToWatch);
+    watcher._start();
+    watcher._start(pathToWatch);
 
     watcher.close();
 
     // We document that watchers cannot be used anymore when it's closed,
     // here we turn the methods into noops instead of throwing
     watcher.close(); // Closing a closed watcher should be a noop
-    watcher.start();  // Starting a closed watcher should be a noop
+    watcher._start();  // Starting a closed watcher should be a noop
   }));
 
   // Long content so it's actually flushed. toUpperCase so there's real change.


### PR DESCRIPTION
* This is a semver-major change to rename the FSWatcher.start
function to FSWatcher._start to make it private

Also see #29872 

The motivation here is that it serves no purpose to the end user.
An instance of FSWatcher is returned when a user calls fs.watch,
which will call the start method.  A user can't create an instance
of a FSWatcher directly.  If the start method is called by a user
it is a noop since the watcher has already started.  Calling start
after a watcher has closed is also a noop

@addaleax @cjihrig I went straight for changing the function to private, do we need an entry or anything in the deprecations.md?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
