### PR TITLE
fs: remove options.encoding from Dir.read*()

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -351,13 +351,11 @@ added: REPLACEME
 Synchronously close the directory's underlying resource handle.
 Subsequent reads will result in errors.
 
-### dir.read([options])
+### dir.read()
 <!-- YAML
 added: REPLACEME
 -->
 
-* `options` {Object}
-  * `encoding` {string|null} **Default:** `'utf8'`
 * Returns: {Promise} containing {fs.Dirent}
 
 Asynchronously read the next directory entry via readdir(3) as an
@@ -369,13 +367,11 @@ is completed.
 _Directory entries returned by this function are in no particular order as
 provided by the operating system's underlying directory mechanisms._
 
-### dir.read([options, ]callback)
+### dir.read(callback)
 <!-- YAML
 added: REPLACEME
 -->
 
-* `options` {Object}
-  * `encoding` {string|null} **Default:** `'utf8'`
 * `callback` {Function}
   * `err` {Error}
   * `dirent` {fs.Dirent}
@@ -385,24 +381,18 @@ Asynchronously read the next directory entry via readdir(3) as an
 
 The `callback` will be called with a [Dirent][] after the read is completed.
 
-The `encoding` option sets the encoding of the `name` in the `dirent`.
-
 _Directory entries returned by this function are in no particular order as
 provided by the operating system's underlying directory mechanisms._
 
-### dir.readSync([options])
+### dir.readSync()
 <!-- YAML
 added: REPLACEME
 -->
 
-* `options` {Object}
-  * `encoding` {string|null} **Default:** `'utf8'`
 * Returns: {fs.Dirent}
 
 Synchronously read the next directory entry via readdir(3) as an
 [`fs.Dirent`][].
-
-The `encoding` option sets the encoding of the `name` in the `dirent`.
 
 _Directory entries returned by this function are in no particular order as
 provided by the operating system's underlying directory mechanisms._
@@ -2658,8 +2648,7 @@ Creates an [`fs.Dir`][], which contains all further functions for reading from
 and cleaning up the directory.
 
 The `encoding` option sets the encoding for the `path` while opening the
-directory and subsequent read operations (unless otherwise overriden during
-reads from the directory).
+directory and subsequent read operations.
 
 ## fs.opendirSync(path[, options])
 <!-- YAML
@@ -2677,8 +2666,7 @@ Creates an [`fs.Dir`][], which contains all further functions for reading from
 and cleaning up the directory.
 
 The `encoding` option sets the encoding for the `path` while opening the
-directory and subsequent read operations (unless otherwise overriden during
-reads from the directory).
+directory and subsequent read operations.
 
 ## fs.read(fd, buffer, offset, length, position, callback)
 <!-- YAML
@@ -4835,8 +4823,7 @@ Creates an [`fs.Dir`][], which contains all further functions for reading from
 and cleaning up the directory.
 
 The `encoding` option sets the encoding for the `path` while opening the
-directory and subsequent read operations (unless otherwise overriden during
-reads from the directory).
+directory and subsequent read operations.
 
 Example using async interation:
 

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -48,18 +48,16 @@ class Dir {
     return this[kDirPath];
   }
 
-  read(options, callback) {
+  read(callback) {
     if (this[kDirClosed] === true) {
       throw new ERR_DIR_CLOSED();
     }
 
-    callback = typeof options === 'function' ? options : callback;
     if (callback === undefined) {
-      return this[kDirReadPromisified](options);
+      return this[kDirReadPromisified]();
     } else if (typeof callback !== 'function') {
       throw new ERR_INVALID_CALLBACK(callback);
     }
-    options = getOptions(options, this[kDirOptions]);
 
     const req = new FSReqCallback();
     req.oncomplete = (err, result) => {
@@ -70,7 +68,7 @@ class Dir {
     };
 
     this[kDirHandle].read(
-      options.encoding,
+      this[kDirOptions].encoding,
       req
     );
   }
@@ -80,11 +78,9 @@ class Dir {
       throw new ERR_DIR_CLOSED();
     }
 
-    options = getOptions(options, this[kDirOptions]);
-
     const ctx = { path: this[kDirPath] };
     const result = this[kDirHandle].read(
-      options.encoding,
+      this[kDirOptions].encoding,
       undefined,
       ctx
     );


### PR DESCRIPTION
I had implemented it 'just in case' but in https://github.com/nodejs/node/pull/29893 it occurs to me that this is likely not a good idea and this functionality should not be released if possible.

This is unlikely to be necessary in any case, and causes much unwarranted complexity when implementing further optimizations.

i.e. if you really need multiple encodings, you're probably better off reading the whole thing more than once. Or, if someone really does come along with an actual compelling use case then we can reconsider.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
