### PR TITLE
module: warn on require of .js inside type: module

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -959,13 +959,24 @@ Module.prototype._compile = function(content, filename) {
   return result;
 };
 
-
 // Native extension for .js
+let warnRequireESM = true;
 Module._extensions['.js'] = function(module, filename) {
-  if (experimentalModules && filename.endsWith('.js')) {
+  if (filename.endsWith('.js')) {
     const pkg = readPackageScope(filename);
     if (pkg && pkg.type === 'module') {
-      throw new ERR_REQUIRE_ESM(filename);
+      if (warnRequireESM) {
+        process.emitWarning(
+          'require() of .js file ' + filename + ' is not supported as it is ' +
+          'an ES module due to having "type": "module" in its package.json ' +
+          'file.\nRather use import to load this module, or if you are the ' +
+          'author you may want to use the .cjs extension for this file.'
+        );
+        warnRequireESM = false;
+      }
+      if (experimentalModules) {
+        throw new ERR_REQUIRE_ESM(filename);
+      }
     }
   }
   const content = fs.readFileSync(filename, 'utf8');

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -259,7 +259,10 @@ function readPackageScope(checkPath) {
     if (checkPath.endsWith(path.sep + 'node_modules'))
       return false;
     const pjson = readPackage(checkPath);
-    if (pjson) return pjson;
+    if (pjson) return {
+      path: checkPath,
+      data: pjson
+    };
   }
   return false;
 }
@@ -964,13 +967,18 @@ let warnRequireESM = true;
 Module._extensions['.js'] = function(module, filename) {
   if (filename.endsWith('.js')) {
     const pkg = readPackageScope(filename);
-    if (pkg && pkg.type === 'module') {
+    if (pkg && pkg.data && pkg.data.type === 'module') {
       if (warnRequireESM) {
         process.emitWarning(
-          'require() of .js file ' + filename + ' is not supported as it is ' +
-          'an ES module due to having "type": "module" in its package.json ' +
-          'file.\nRather use import to load this module, or if you are the ' +
-          'author you may want to use the .cjs extension for this file.'
+          ((module.parent && module.parent.filename) ?
+            `${module.parent.filename} contains a ` : '') +
+          `require() of ${filename}, which is a .js file whose nearest ` +
+          'parent package.json contains "type": "module" which therefore ' +
+          'defines all .js files in that package scope as ES modules. ' +
+          'require() of ES modules is not allowed. Instead, rename ' +
+          `${filename} to end in .cjs, or change the requiring code to use ` +
+          'import(), or remove "type": "module" from ' +
+          `${path.resolve(pkg.path, 'package.json')}.`
         );
         warnRequireESM = false;
       }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -969,14 +969,17 @@ Module._extensions['.js'] = function(module, filename) {
     const pkg = readPackageScope(filename);
     if (pkg && pkg.data && pkg.data.type === 'module') {
       if (warnRequireESM) {
+        const parentPath = module.parent && module.parent.filename;
+        const basename = parentPath &&
+            path.basename(filename) === path.basename(parentPath) ?
+          filename : path.basename(filename);
         process.emitWarning(
-          ((module.parent && module.parent.filename) ?
-            `${module.parent.filename} contains a ` : '') +
-          `require() of ${filename}, which is a .js file whose nearest ` +
-          'parent package.json contains "type": "module" which therefore ' +
-          'defines all .js files in that package scope as ES modules. ' +
-          'require() of ES modules is not allowed. Instead, rename ' +
-          `${filename} to end in .cjs, or change the requiring code to use ` +
+          'require() of ES modules is not supported.\nrequire() of ' +
+          `${filename} ${parentPath ? `from ${module.parent.filename} ` : ''}` +
+          'is an ES module file as it is a .js file whose nearest parent ' +
+          'package.json contains "type": "module" which defines all .js ' +
+          'files in that package scope as ES modules.\nInstead rename ' +
+          `${basename} to end in .cjs, change the requiring code to use ` +
           'import(), or remove "type": "module" from ' +
           `${path.resolve(pkg.path, 'package.json')}.`
         );

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const { spawn } = require('child_process');
+const assert = require('assert');
+const path = require('path');
+
+const entry = fixtures.path('/es-modules/cjs-esm.js');
+
+const child = spawn(process.execPath, [entry]);
+let stderr = '';
+child.stderr.setEncoding('utf8');
+child.stderr.on('data', (data) => {
+  stderr += data;
+});
+child.on('close', common.mustCall((code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+  assert.strictEqual(stderr, `(node:${child.pid}) Warning: require() of .js ` +
+      `file ${path.resolve(entry, '../package-type-module/cjs.js')} is not ` +
+      'supported as it is an ES module due to having "type": "module" in its ' +
+      'package.json file.\nRather use import to load this module, or if you ' +
+      'are the author you may want to use the .cjs extension for this file.\n');
+}));

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -14,6 +14,8 @@ const pjson = path.resolve(
   fixtures.path('/es-modules/package-type-module/package.json')
 );
 
+const basename = 'cjs.js';
+
 const child = spawn(process.execPath, [requiring]);
 let stderr = '';
 child.stderr.setEncoding('utf8');
@@ -23,11 +25,14 @@ child.stderr.on('data', (data) => {
 child.on('close', common.mustCall((code, signal) => {
   assert.strictEqual(code, 0);
   assert.strictEqual(signal, null);
-  assert.strictEqual(stderr, `(node:${child.pid}) Warning: ${requiring} ` +
-    `contains a require() of ${required}, which is a .js file whose nearest ` +
-    'parent package.json contains "type": "module" which therefore defines ' +
-    'all .js files in that package scope as ES modules. require() of ES ' +
-    `modules is not allowed. Instead, rename ${required} to end in .cjs, or ` +
-    'change the requiring code to use import(), or remove "type": "module" ' +
-    `from ${pjson}.\n`);
+
+  assert.strictEqual(stderr, `(node:${child.pid}) Warning: ` +
+    'require() of ES modules is not supported.\nrequire() of ' +
+    `${required} from ${requiring} ` +
+    'is an ES module file as it is a .js file whose nearest parent ' +
+    'package.json contains "type": "module" which defines all .js ' +
+    'files in that package scope as ES modules.\nInstead rename ' +
+    `${basename} to end in .cjs, change the requiring code to use ` +
+    'import(), or remove "type": "module" from ' +
+    `${pjson}.\n`);
 }));

--- a/test/fixtures/es-modules/cjs-esm.js
+++ b/test/fixtures/es-modules/cjs-esm.js
@@ -1,0 +1,1 @@
+require('./package-type-module/cjs.js');

--- a/test/fixtures/es-modules/package-type-module/cjs.js
+++ b/test/fixtures/es-modules/package-type-module/cjs.js
@@ -1,0 +1,1 @@
+module.exports = 'asdf';


### PR DESCRIPTION
This is a follow-up to the PR made in https://github.com/nodejs/node/pull/29732 ensuring a warning is emitted when violating the "type": "module" expected module format.

This was discussed at today's modules group meeting as a starting point for handling this case, and then whether or not an error will be thrown when modules are unflagged is still to be discussed further.

Example output:

```
(node:28347) Warning: require() of ES modules is not supported.
require() of /home/guybedford/Projects/node/test/fixtures/es-modules/package-type-module/cjs.js from /home/guybedford/Projects/node/test/fixtures/es-modules/cjs-esm.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename cjs.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /home/guybedford/Projects/node/test/fixtures/es-modules/package-type-module/package.json.
```

@nodejs/modules-active-members 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
