### PR TITLE
crypto: reject public keys properly

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -270,7 +270,10 @@ function prepareAsymmetricKey(key, ctx) {
          ...(ctx !== kCreatePrivate ? ['KeyObject'] : [])],
         key);
     }
-    return { data, ...parseKeyEncoding(key, undefined) };
+
+    const isPublic =
+      (ctx === kConsumePrivate || ctx === kCreatePrivate) ? false : undefined;
+    return { data, ...parseKeyEncoding(key, undefined, isPublic) };
   } else {
     throw new ERR_INVALID_ARG_TYPE(
       'key',

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -200,6 +200,14 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
     library: 'BIO routines',
     function: 'BIO_new_mem_buf',
   });
+
+  // This should not abort either: https://github.com/nodejs/node/issues/29904
+  assert.throws(() => {
+    createPrivateKey({ key: Buffer.alloc(0), format: 'der', type: 'spki' });
+  }, {
+    code: 'ERR_INVALID_OPT_VALUE',
+    message: 'The value "spki" is invalid for option "type"'
+  });
 }
 
 [

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -208,6 +208,19 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
     code: 'ERR_INVALID_OPT_VALUE',
     message: 'The value "spki" is invalid for option "type"'
   });
+
+  // Unlike SPKI, PKCS#1 is a valid encoding for private keys (and public keys),
+  // so it should be accepted by createPrivateKey, but OpenSSL won't parse it.
+  assert.throws(() => {
+    const key = createPublicKey(publicPem).export({
+      format: 'der',
+      type: 'pkcs1'
+    });
+    createPrivateKey({ key, format: 'der', type: 'pkcs1' });
+  }, {
+    message: /asn1 encoding/,
+    library: 'asn1 encoding routines'
+  });
 }
 
 [


### PR DESCRIPTION
If the underlying operation requires a private key, `isPublic` must be set to `false` instead of `undefined`. (The latter means that both public and private keys are accepted.)

Fixes: https://github.com/nodejs/node/issues/29904

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
