### PR TITLE
fs: do not emit 'finish' before 'open' on writing empty file

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -272,6 +272,12 @@ Object.setPrototypeOf(WriteStream.prototype, Writable.prototype);
 Object.setPrototypeOf(WriteStream, Writable);
 
 WriteStream.prototype._final = function(callback) {
+  if (typeof this.fd !== 'number') {
+    return this.once('open', function() {
+      this._final(callback);
+    });
+  }
+
   if (this.autoClose) {
     this.destroy();
   }

--- a/test/parallel/test-fs-write-stream-end.js
+++ b/test/parallel/test-fs-write-stream-end.js
@@ -44,3 +44,17 @@ tmpdir.refresh();
     assert.strictEqual(content, 'a\n');
   }));
 }
+
+{
+  const file = path.join(tmpdir.path, 'write-end-test2.txt');
+  const stream = fs.createWriteStream(file);
+  stream.end();
+
+  let calledOpen = false;
+  stream.on('open', () => {
+    calledOpen = true;
+  });
+  stream.on('finish', common.mustCall(() => {
+    assert.strictEqual(calledOpen, true);
+  }));
+}


### PR DESCRIPTION
'finish' could previously be emitted before the file has been
created when ending a write stream without having written any
data.

Refs: https://github.com/expressjs/multer/issues/238

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
