### PR TITLE
build: fix version checks in gyp files

### DIFF
--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -21,7 +21,8 @@
         }, 'target_arch=="arm64" and OS=="win"', {
           # VC-WIN64-ARM inherits from VC-noCE-common that has no asms.
           'includes': ['./openssl_no_asm.gypi'],
-        }, 'gas_version >= "2.26" or nasm_version >= "2.11.8"', {
+        }, 'gas_version and v(gas_version) >= v("2.26") or '
+           'nasm_version and v(nasm_version) >= v("2.11.8")', {
            # Require AVX512IFMA supported. See
            # https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_ia32cap.html
            # Currently crypto/poly1305/asm/poly1305-x86_64.pl requires AVX512IFMA.

--- a/deps/openssl/openssl.gypi
+++ b/deps/openssl/openssl.gypi
@@ -1036,7 +1036,9 @@
     #
     'conditions': [
       ['(OS=="win" and MSVS_VERSION>="2012") or '
-       'llvm_version>="3.3" or xcode_version>="5.0" or gas_version>="2.23"', {
+       'llvm_version and v(llvm_version) >= v("3.3") or '
+        'gas_version and v(gas_version) >= v("2.23") or '
+        'xcode_version and v(xcode_version) >= v("5.0")', {
         'openssl_sources_x64_win_masm': [
           '<@(openssl_sources_asm_latest_x64_win_masm)',
           '<@(openssl_sources_common_x64_win_masm)',

--- a/tools/gyp/pylib/gyp/input.py
+++ b/tools/gyp/pylib/gyp/input.py
@@ -19,6 +19,7 @@ import sys
 import threading
 import time
 import traceback
+from distutils.version import StrictVersion
 from gyp.common import GypError
 from gyp.common import OrderedSet
 
@@ -1084,7 +1085,8 @@ def EvalSingleCondition(
     else:
       ast_code = compile(cond_expr_expanded, '<string>', 'eval')
       cached_conditions_asts[cond_expr_expanded] = ast_code
-    if eval(ast_code, {'__builtins__': None}, variables):
+    env = {'__builtins__': None, 'v': StrictVersion}
+    if eval(ast_code, env, variables):
       return true_dict
     return false_dict
   except SyntaxError as e:


### PR DESCRIPTION
Make `distutils.version.StrictVersion` available as a helper to
gyp expressions so they can do proper version checks and update
the gyp files accordingly.

Caveat emptor: `StrictVersion` does *not* like empty strings so
this commit adds truthiness guards. The helper could deal with
those but I felt it better to make it explicit.

Fixes: https://github.com/nodejs/node/issues/29927

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
