### PR TITLE
stream: increase MAX_HWM

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1084,7 +1084,7 @@ buffer will be returned.
 If the `size` argument is not specified, all of the data contained in the
 internal buffer will be returned.
 
-The `size` argument must be less than or equal to `Number.MAX_SAFE_INTEGER`.
+The `size` argument must be less than or equal to 2^31.
 
 The `readable.read()` method should only be called on `Readable` streams
 operating in paused mode. In flowing mode, `readable.read()` is called

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1084,7 +1084,7 @@ buffer will be returned.
 If the `size` argument is not specified, all of the data contained in the
 internal buffer will be returned.
 
-The `size` argument must be less than or equal to 2^31.
+The `size` argument must be less than or equal to 2^30.
 
 The `readable.read()` method should only be called on `Readable` streams
 operating in paused mode. In flowing mode, `readable.read()` is called

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1084,6 +1084,8 @@ buffer will be returned.
 If the `size` argument is not specified, all of the data contained in the
 internal buffer will be returned.
 
+The `size` argument must be less than or equal to `Number.MAX_SAFE_INTEGER`.
+
 The `readable.read()` method should only be called on `Readable` streams
 operating in paused mode. In flowing mode, `readable.read()` is called
 automatically until the internal buffer is fully drained.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1084,7 +1084,7 @@ buffer will be returned.
 If the `size` argument is not specified, all of the data contained in the
 internal buffer will be returned.
 
-The `size` argument must be less than or equal to 2^30.
+The `size` argument must be less than or equal to 1 GB.
 
 The `readable.read()` method should only be called on `Readable` streams
 operating in paused mode. In flowing mode, `readable.read()` is called

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -374,25 +374,6 @@ Readable.prototype.setEncoding = function(enc) {
   return this;
 };
 
-// Don't raise the hwm > 8MB
-const MAX_HWM = 0x800000;
-function computeNewHighWaterMark(n) {
-  if (n >= MAX_HWM) {
-    n = MAX_HWM;
-  } else {
-    // Get the next highest power of 2 to prevent increasing hwm excessively in
-    // tiny amounts
-    n--;
-    n |= n >>> 1;
-    n |= n >>> 2;
-    n |= n >>> 4;
-    n |= n >>> 8;
-    n |= n >>> 16;
-    n++;
-  }
-  return n;
-}
-
 // This function is designed to be inlinable, so please take care when making
 // changes to the function body.
 function howMuchToRead(n, state) {
@@ -425,9 +406,11 @@ Readable.prototype.read = function(n) {
   const state = this._readableState;
   const nOrig = n;
 
-  // If we're asking for more than the current hwm, then raise the hwm.
+  // If we're asking for more than the current hwm, then raise the hwm to
+  // the next highest power of 2 to prevent increasing hwm excessively in
+  // tiny amounts.
   if (n > state.highWaterMark)
-    state.highWaterMark = computeNewHighWaterMark(n);
+    state.highWaterMark = Math.pow(2, Math.ceil(Math.log(n) / Math.log(2)));
 
   if (n !== 0)
     state.emittedReadable = false;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -43,7 +43,6 @@ const {
   ERR_METHOD_NOT_IMPLEMENTED,
   ERR_STREAM_UNSHIFT_AFTER_END_EVENT
 } = require('internal/errors').codes;
-const { Math } = primordials;
 
 // Lazy loaded to improve the startup performance.
 let StringDecoder;
@@ -376,7 +375,7 @@ Readable.prototype.setEncoding = function(enc) {
 };
 
 // Don't raise the hwm > 1GB
-const MAX_HWM = Math.pow(2, 30);
+const MAX_HWM = 0x40000000;
 function computeNewHighWaterMark(n) {
   if (n >= MAX_HWM) {
     // TODO(ronag): Throw ERR_VALUE_OUT_OF_RANGE.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -45,6 +45,8 @@ const {
   ERR_VALUE_OUT_OF_RANGE
 } = require('internal/errors').codes;
 
+const MAX_HWM = Math.pow(2, 31);
+
 // Lazy loaded to improve the startup performance.
 let StringDecoder;
 let createReadableStreamAsyncIterator;
@@ -407,7 +409,7 @@ Readable.prototype.read = function(n) {
   const state = this._readableState;
   const nOrig = n;
 
-  if (n > Number.MAX_SAFE_INTEGER) {
+  if (n > MAX_HWM) {
     throw new ERR_VALUE_OUT_OF_RANGE('n');
   }
 
@@ -415,7 +417,10 @@ Readable.prototype.read = function(n) {
   // the next highest power of 2 to prevent increasing hwm excessively in
   // tiny amounts.
   if (n > state.highWaterMark)
-    state.highWaterMark = Math.pow(2, Math.ceil(Math.log(n) / Math.log(2)));
+    state.highWaterMark = Math.min(
+      MAX_HWM,
+      Math.pow(2, Math.ceil(Math.log(n) / Math.log(2)))
+    );
 
   if (n !== 0)
     state.emittedReadable = false;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -41,7 +41,8 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_STREAM_PUSH_AFTER_EOF,
   ERR_METHOD_NOT_IMPLEMENTED,
-  ERR_STREAM_UNSHIFT_AFTER_END_EVENT
+  ERR_STREAM_UNSHIFT_AFTER_END_EVENT,
+  ERR_VALUE_OUT_OF_RANGE
 } = require('internal/errors').codes;
 
 // Lazy loaded to improve the startup performance.
@@ -405,6 +406,10 @@ Readable.prototype.read = function(n) {
   }
   const state = this._readableState;
   const nOrig = n;
+
+  if (n > Number.MAX_SAFE_INTEGER) {
+    throw new ERR_VALUE_OUT_OF_RANGE('n');
+  }
 
   // If we're asking for more than the current hwm, then raise the hwm to
   // the next highest power of 2 to prevent increasing hwm excessively in

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -41,11 +41,8 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_STREAM_PUSH_AFTER_EOF,
   ERR_METHOD_NOT_IMPLEMENTED,
-  ERR_STREAM_UNSHIFT_AFTER_END_EVENT,
-  ERR_VALUE_OUT_OF_RANGE
+  ERR_STREAM_UNSHIFT_AFTER_END_EVENT
 } = require('internal/errors').codes;
-
-const MAX_HWM = Math.pow(2, 31);
 
 // Lazy loaded to improve the startup performance.
 let StringDecoder;
@@ -377,6 +374,26 @@ Readable.prototype.setEncoding = function(enc) {
   return this;
 };
 
+// Don't raise the hwm > 1GB
+const MAX_HWM = Math.pow(2, 30);
+function computeNewHighWaterMark(n) {
+  if (n >= MAX_HWM) {
+    // TODO(ronag): Throw ERR_VALUE_OUT_OF_RANGE.
+    n = MAX_HWM;
+  } else {
+    // Get the next highest power of 2 to prevent increasing hwm excessively in
+    // tiny amounts
+    n--;
+    n |= n >>> 1;
+    n |= n >>> 2;
+    n |= n >>> 4;
+    n |= n >>> 8;
+    n |= n >>> 16;
+    n++;
+  }
+  return n;
+}
+
 // This function is designed to be inlinable, so please take care when making
 // changes to the function body.
 function howMuchToRead(n, state) {
@@ -409,18 +426,9 @@ Readable.prototype.read = function(n) {
   const state = this._readableState;
   const nOrig = n;
 
-  if (n > MAX_HWM) {
-    throw new ERR_VALUE_OUT_OF_RANGE('n');
-  }
-
-  // If we're asking for more than the current hwm, then raise the hwm to
-  // the next highest power of 2 to prevent increasing hwm excessively in
-  // tiny amounts.
+  // If we're asking for more than the current hwm, then raise the hwm.
   if (n > state.highWaterMark)
-    state.highWaterMark = Math.min(
-      MAX_HWM,
-      Math.pow(2, Math.ceil(Math.log(n) / Math.log(2)))
-    );
+    state.highWaterMark = computeNewHighWaterMark(n);
 
   if (n !== 0)
     state.emittedReadable = false;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -43,6 +43,7 @@ const {
   ERR_METHOD_NOT_IMPLEMENTED,
   ERR_STREAM_UNSHIFT_AFTER_END_EVENT
 } = require('internal/errors').codes;
+const { Math } = primordials;
 
 // Lazy loaded to improve the startup performance.
 let StringDecoder;

--- a/test/parallel/test-readable-large-hwm.js
+++ b/test/parallel/test-readable-large-hwm.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const { Readable } = require('stream');
+
+// Make sure that readable completes
+// even when reading larger buffer.
+const bufferSize = 10 * 1024 * 1024;
+let n = 0;
+const r = new Readable({
+  read() {
+    // Try to fill readable buffer piece by piece.
+    r.push(Buffer.alloc(bufferSize / 10));
+
+    if (n++ > 10) {
+      r.push(null);
+    }
+  }
+});
+
+r.on('readable', () => {
+  while (true) {
+    const ret = r.read(bufferSize);
+    if (ret === null)
+      break;
+  }
+});
+r.on('end', common.mustCall());


### PR DESCRIPTION
MAX_HWM was added in 9208c89 where the highwatermark was changed to
always increase in steps of highest power of 2 to prevent increasing
hwm excessivly in tiny amounts.

Why a limit was added on the highwatermark is unclear but breaks
existing usage where a larger read size is used. The invariant for
read(n) is that a buffer of size n is always returned. Considering
a maximum ceiling on the buffer size breaks this invariant.

This PR significantly increases the limit to make it less likely to
break the previous invariant and also documents the limit.

Fixes: #29933

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
