### PR TITLE
tools: add unified plugin changing links for html docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -745,7 +745,7 @@ $(LINK_DATA): $(wildcard lib/*.js) tools/doc/apilinks.js
 	$(call available-node, $(gen-apilink))
 
 out/doc/api/%.json out/doc/api/%.html: doc/api/%.md tools/doc/generate.js \
-	tools/doc/html.js tools/doc/json.js tools/doc/apilinks.js | $(LINK_DATA)
+	tools/doc/markdown.js tools/doc/html.js tools/doc/json.js tools/doc/apilinks.js | $(LINK_DATA)
 	$(call available-node, $(gen-api))
 
 out/doc/api/all.html: $(apidocs_html) tools/doc/allhtml.js \

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -11,6 +11,7 @@ try {
 const assert = require('assert');
 const { readFile } = require('fs');
 const fixtures = require('../common/fixtures');
+const { replaceLinks } = require('../../tools/doc/markdown.js');
 const html = require('../../tools/doc/html.js');
 const path = require('path');
 
@@ -24,6 +25,7 @@ const htmlStringify = require('rehype-stringify');
 
 async function toHTML({ input, filename, nodeVersion }) {
   const content = unified()
+    .use(replaceLinks)
     .use(markdown)
     .use(html.firstHeader)
     .use(html.preprocessText)
@@ -95,6 +97,21 @@ const testData = [
   {
     file: fixtures.path('altdocs.md'),
     html: '<li><a href="https://nodejs.org/docs/latest-v8.x/api/foo.html">8.x',
+  },
+  {
+    file: fixtures.path('document_with_links.md'),
+    html: '<h1>Usage and Example<span><a class="mark"' +
+    'href="#foo_usage_and_example" id="foo_usage_and_example">#</a>' +
+    '</span></h1><h2>Usage<span><a class="mark" href="#foo_usage"' +
+    'id="foo_usage">#</a></span></h2><p><code>node [options] index.js' +
+    '</code></p><p>Please see the<a href="cli.html#cli-options">' +
+    'Command Line Options</a>document for more information.</p><h2>' +
+    'Example<span><a class="mark" href="#foo_example" id="foo_example">' +
+    '#</a></span></h2><p>An example of a<a href="example.html">' +
+    'webserver</a>written with Node.js which responds with<code>' +
+    '\'Hello, World!\'</code>:</p><h2>See also<span><a class="mark"' +
+    'href="#foo_see_also" id="foo_see_also">#</a></span></h2><p>Check' +
+    'out also<a href="https://nodejs.org/">this guide</a></p>'
   },
 ];
 

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -23,9 +23,22 @@ const remark2rehype = require('remark-rehype');
 const raw = require('rehype-raw');
 const htmlStringify = require('rehype-stringify');
 
+// Test links mapper is an object of the following structure:
+// {
+//   [filename]: {
+//     [link definition identifier]: [url to the linked resource]
+//   }
+// }
+const testLinksMapper = {
+  'foo': {
+    'command line options': 'cli.html#cli-options',
+    'web server': 'example.html'
+  }
+};
+
 async function toHTML({ input, filename, nodeVersion }) {
   const content = unified()
-    .use(replaceLinks)
+    .use(replaceLinks, { filename, linksMapper: testLinksMapper })
     .use(markdown)
     .use(html.firstHeader)
     .use(html.preprocessText)
@@ -103,7 +116,7 @@ const testData = [
     html: '<h1>Usage and Example<span><a class="mark"' +
     'href="#foo_usage_and_example" id="foo_usage_and_example">#</a>' +
     '</span></h1><h2>Usage<span><a class="mark" href="#foo_usage"' +
-    'id="foo_usage">#</a></span></h2><p><code>node [options] index.js' +
+    'id="foo_usage">#</a></span></h2><p><code>node \\[options\\] index.js' +
     '</code></p><p>Please see the<a href="cli.html#cli-options">' +
     'Command Line Options</a>document for more information.</p><h2>' +
     'Example<span><a class="mark" href="#foo_example" id="foo_example">' +

--- a/test/fixtures/document_with_links.md
+++ b/test/fixtures/document_with_links.md
@@ -1,0 +1,23 @@
+# Usage and Example
+
+## Usage
+
+`node [options] index.js`
+
+Please see the [Command Line Options][] document for more information.
+
+## Example
+
+An example of a [web server][] written with Node.js which responds with
+`'Hello, World!'`:
+
+## See also
+
+Check out also [this guide][]
+
+[Command Line Options]: cli.md#options
+[this guide]: https://nodejs.org/
+[web server]: example.md
+
+[Command Line Options `.html`]: cli.html#cli-options
+[web server `.html`]: example.html

--- a/test/fixtures/document_with_links.md
+++ b/test/fixtures/document_with_links.md
@@ -18,6 +18,3 @@ Check out also [this guide][]
 [Command Line Options]: cli.md#options
 [this guide]: https://nodejs.org/
 [web server]: example.md
-
-[Command Line Options `.html`]: cli.html#cli-options
-[web server `.html`]: example.html

--- a/test/fixtures/document_with_links.md
+++ b/test/fixtures/document_with_links.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-`node [options] index.js`
+`node \[options\] index.js`
 
 Please see the [Command Line Options][] document for more information.
 

--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -30,6 +30,7 @@ const raw = require('rehype-raw');
 const htmlStringify = require('rehype-stringify');
 
 const { replaceLinks } = require('./markdown');
+const linksMapper = require('./links-mapper');
 const html = require('./html');
 const json = require('./json');
 
@@ -71,7 +72,7 @@ async function main() {
   const input = await fs.readFile(filename, 'utf8');
 
   const content = await unified()
-    .use(replaceLinks)
+    .use(replaceLinks, { filename, linksMapper })
     .use(markdown)
     .use(html.preprocessText)
     .use(json.jsonAPI, { filename })

--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -29,6 +29,7 @@ const remark2rehype = require('remark-rehype');
 const raw = require('rehype-raw');
 const htmlStringify = require('rehype-stringify');
 
+const { replaceLinks } = require('./markdown');
 const html = require('./html');
 const json = require('./json');
 
@@ -70,6 +71,7 @@ async function main() {
   const input = await fs.readFile(filename, 'utf8');
 
   const content = await unified()
+    .use(replaceLinks)
     .use(markdown)
     .use(html.preprocessText)
     .use(json.jsonAPI, { filename })

--- a/tools/doc/links-mapper.json
+++ b/tools/doc/links-mapper.json
@@ -1,0 +1,6 @@
+{
+  "doc/api/synopsis.md": {
+    "command line options": "cli.html#cli_command_line_options",
+    "web server": "http.html"
+  }
+}

--- a/tools/doc/markdown.js
+++ b/tools/doc/markdown.js
@@ -1,24 +1,3 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 'use strict';
 
 const visit = require('unist-util-visit');

--- a/tools/doc/markdown.js
+++ b/tools/doc/markdown.js
@@ -1,0 +1,43 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+const visit = require('unist-util-visit');
+
+module.exports = {
+  replaceLinks
+};
+
+function replaceLinks() {
+  return (tree) => {
+    const linksIdenfitiers = tree.children
+      .filter((child) => child.type === 'definition')
+      .map((child) => child.identifier);
+
+    visit(tree, 'linkReference', (node) => {
+      const htmlLinkIdentifier = `${node.identifier} \`.html\``;
+      if (linksIdenfitiers.includes(htmlLinkIdentifier)) {
+        node.identifier = htmlLinkIdentifier;
+      }
+    });
+  };
+}

--- a/tools/doc/markdown.js
+++ b/tools/doc/markdown.js
@@ -6,16 +6,15 @@ module.exports = {
   replaceLinks
 };
 
-function replaceLinks() {
+function replaceLinks({ filename, linksMapper }) {
   return (tree) => {
-    const linksIdenfitiers = tree.children
-      .filter((child) => child.type === 'definition')
-      .map((child) => child.identifier);
+    const fileHtmlUrls = linksMapper[filename];
 
-    visit(tree, 'linkReference', (node) => {
-      const htmlLinkIdentifier = `${node.identifier} \`.html\``;
-      if (linksIdenfitiers.includes(htmlLinkIdentifier)) {
-        node.identifier = htmlLinkIdentifier;
+    visit(tree, 'definition', (node) => {
+      const htmlUrl = fileHtmlUrls && fileHtmlUrls[node.identifier];
+
+      if (htmlUrl && typeof htmlUrl === 'string') {
+        node.url = htmlUrl;
       }
     });
   };


### PR DESCRIPTION
This commit introduces additional stage in the process of generating
html docs from markdown files. Plugin transforms links to *.md files
in the respository to links to *.html files in the online documentation.

Fixes: https://github.com/nodejs/node/issues/28689

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
