### PR TITLE
doc: clarify unshift EOF

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1288,8 +1288,10 @@ changes:
 * `encoding` {string} Encoding of string chunks. Must be a valid
   `Buffer` encoding, such as `'utf8'` or `'ascii'`.
 
-Passing `chunk` as `null` signals the end of the stream (EOF), after which no
-more data can be written.
+Passing `chunk` as `null` signals the end of the stream (EOF) and behaves the
+same as `readable.push(null)`, after which no more data can be written. Note
+that the EOF signal is put at the end of the buffer and any buffered data will
+still be flushed.
 
 The `readable.unshift()` method pushes a chunk of data back into the internal
 buffer. This is useful in certain situations where a stream is being consumed by

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1289,9 +1289,9 @@ changes:
   `Buffer` encoding, such as `'utf8'` or `'ascii'`.
 
 Passing `chunk` as `null` signals the end of the stream (EOF) and behaves the
-same as `readable.push(null)`, after which no more data can be written. Note
-that the EOF signal is put at the end of the buffer and any buffered data will
-still be flushed.
+same as `readable.push(null)`, after which no more data can be written. The EOF
+signal is put at the end of the buffer and any buffered data will still be
+flushed.
 
 The `readable.unshift()` method pushes a chunk of data back into the internal
 buffer. This is useful in certain situations where a stream is being consumed by


### PR DESCRIPTION
We should not allow unshifting EOF.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
