### PR TITLE
[x] stream: readable destroy stop stream

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -263,6 +263,9 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
   }
 
   if (chunk === null) {
+    if (state.destroyed) {
+      return false;
+    }
     state.reading = false;
     onEofChunk(stream, state);
   } else {
@@ -414,6 +417,10 @@ function howMuchToRead(n, state) {
 
 // You can override either this method, or the async _read(n) below.
 Readable.prototype.read = function(n) {
+  const state = this._readableState;
+  if (state.destroyed) {
+    return null;
+  }
   debug('read', n);
   // Same as parseInt(undefined, 10), however V8 7.3 performance regressed
   // in this scenario, so we are doing it manually.
@@ -422,7 +429,6 @@ Readable.prototype.read = function(n) {
   } else if (!Number.isInteger(n)) {
     n = parseInt(n, 10);
   }
-  const state = this._readableState;
   const nOrig = n;
 
   // If we're asking for more than the current hwm, then raise the hwm.
@@ -493,7 +499,7 @@ Readable.prototype.read = function(n) {
   // However, if we've ended, then there's no point, if we're already
   // reading, then it's unnecessary, and if we're destroyed, then it's
   // not allowed.
-  if (state.ended || state.reading || state.destroyed) {
+  if (state.ended || state.reading) {
     doRead = false;
     debug('reading or ended', doRead);
   } else if (doRead) {

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -121,10 +121,13 @@ const assert = require('assert');
   duplex.on('end', fail);
 
   duplex.destroy();
+  assert.strictEqual(duplex.push(null), false);
+  assert.strictEqual(duplex._readableState.ended, false);
 
   duplex.removeListener('end', fail);
   duplex.removeListener('finish', fail);
-  duplex.on('end', common.mustCall());
+  duplex.on('data', common.mustNotCall());
+  duplex.on('end', common.mustNotCall());
   duplex.on('finish', common.mustCall());
   assert.strictEqual(duplex.destroyed, true);
 }

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -24,6 +24,7 @@ const assert = require('assert');
 
   const expected = new Error('kaboom');
 
+  read.on('data', common.mustNotCall());
   read.on('end', common.mustNotCall('no end event'));
   read.on('close', common.mustCall());
   read.on('error', common.mustCall((err) => {
@@ -46,6 +47,7 @@ const assert = require('assert');
 
   const expected = new Error('kaboom');
 
+  read.on('data', common.mustNotCall());
   read.on('end', common.mustNotCall('no end event'));
   read.on('close', common.mustCall());
   read.on('error', common.mustCall((err) => {
@@ -71,6 +73,7 @@ const assert = require('assert');
 
   // Error is swallowed by the custom _destroy
   read.on('error', common.mustNotCall('no error event'));
+  read.on('data', common.mustNotCall());
   read.on('close', common.mustCall());
 
   read.destroy(expected);
@@ -108,12 +111,16 @@ const assert = require('assert');
   const fail = common.mustNotCall('no end event');
 
   read.on('end', fail);
+  read.on('data', common.mustNotCall());
   read.on('close', common.mustCall());
 
   read.destroy();
+  assert.strictEqual(read.push(null), false);
+  assert.strictEqual(read._readableState.ended, false);
 
   read.removeListener('end', fail);
-  read.on('end', common.mustCall());
+  read.on('end', common.mustNotCall());
+  read.on('data', common.mustNotCall());
   assert.strictEqual(read.destroyed, true);
 }
 
@@ -130,6 +137,7 @@ const assert = require('assert');
   });
 
   read.on('end', common.mustNotCall('no end event'));
+  read.on('data', common.mustNotCall());
   read.on('error', common.mustCall((err) => {
     assert.strictEqual(err, expected);
   }));
@@ -149,6 +157,7 @@ const assert = require('assert');
 
   // The internal destroy() mechanism should not be triggered
   read.on('end', common.mustNotCall());
+  read.on('data', common.mustNotCall());
   read.destroy();
 }
 

--- a/test/parallel/test-stream-transform-destroy.js
+++ b/test/parallel/test-stream-transform-destroy.js
@@ -116,7 +116,7 @@ const assert = require('assert');
 
   transform.removeListener('end', fail);
   transform.removeListener('finish', fail);
-  transform.on('end', common.mustCall());
+  transform.on('end', common.mustNotCall());
   transform.on('finish', common.mustCall());
 }
 


### PR DESCRIPTION
Readable stream should not continue to function after having been destroyed.

Currently there is no "proper" way to "kill" a Readable since it will still be partly functional after `destroy()` has been called.

The current workaround which I find unfortunate is to:

```js
r.destroy()
r.removeAllListeners('data')
r.removeAllListeners('end')
````

As a user I would expect that after destroy I would not receive any more data flow events.

This is breaking and semver-major.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
