### PR TITLE
fs: make FSStatWatcher.start private

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1386,7 +1386,8 @@ function watchFile(filename, options, listener) {
     if (!watchers)
       watchers = require('internal/fs/watchers');
     stat = new watchers.StatWatcher(options.bigint);
-    stat.start(filename, options.persistent, options.interval);
+    stat[watchers.kFSStatWatcherStart](filename,
+                                       options.persistent, options.interval);
     statWatchers.set(filename, stat);
   }
 

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -91,10 +91,10 @@ StatWatcher.prototype[kFSStatWatcherStart] = function(filename,
   }
 };
 
-// To maximize backword-compatiblity for the end user
+// To maximize backward-compatiblity for the end user,
 // a no-op stub method has been added instead of
 // totally removing StatWatcher.prototpye.start.
-// This should not be documented
+// This should not be documented.
 StatWatcher.prototype.start = () => {};
 
 // FIXME(joyeecheung): this method is not documented while there is

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -26,6 +26,7 @@ const kOldStatus = Symbol('kOldStatus');
 const kUseBigint = Symbol('kUseBigint');
 
 const kFSWatchStart = Symbol('kFSWatchStart');
+const kFSStatWatcherStart = Symbol('kFSStatWatcherStart');
 
 function emitStop(self) {
   self.emit('stop');
@@ -54,13 +55,15 @@ function onchange(newStatus, stats) {
             getStatsFromBinding(stats, kFsStatsFieldsNumber));
 }
 
-// FIXME(joyeecheung): this method is not documented.
 // At the moment if filename is undefined, we
-// 1. Throw an Error if it's the first time .start() is called
-// 2. Return silently if .start() has already been called
+// 1. Throw an Error if it's the first
+//    time Symbol('kFSStatWatcherStart') is called
+// 2. Return silently if Symbol('kFSStatWatcherStart') has already been called
 //    on a valid filename and the wrap has been initialized
 // This method is a noop if the watcher has already been started.
-StatWatcher.prototype.start = function(filename, persistent, interval) {
+StatWatcher.prototype[kFSStatWatcherStart] = function(filename,
+                                                      persistent,
+                                                      interval) {
   if (this._handle !== null)
     return;
 
@@ -209,5 +212,6 @@ Object.defineProperty(FSEvent.prototype, 'owner', {
 module.exports = {
   FSWatcher,
   StatWatcher,
-  kFSWatchStart
+  kFSWatchStart,
+  kFSStatWatcherStart
 };

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -91,6 +91,8 @@ StatWatcher.prototype[kFSStatWatcherStart] = function(filename,
   }
 };
 
+StatWatcher.prototype.start = () => {};
+
 // FIXME(joyeecheung): this method is not documented while there is
 // another documented fs.unwatchFile(). The counterpart in
 // FSWatcher is .close()

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -91,6 +91,10 @@ StatWatcher.prototype[kFSStatWatcherStart] = function(filename,
   }
 };
 
+// To maximize backword-compatiblity for the end user
+// a no-op stub method has been added instead of
+// totally removing StatWatcher.prototpye.start.
+// This should not be documented
 StatWatcher.prototype.start = () => {};
 
 // FIXME(joyeecheung): this method is not documented while there is

--- a/test/parallel/test-fs-watchfile-bigint.js
+++ b/test/parallel/test-fs-watchfile-bigint.js
@@ -67,5 +67,3 @@ const watcher =
 // 'stop' should only be emitted once - stopping a stopped watcher should
 // not trigger a 'stop' event.
 watcher.on('stop', common.mustCall(function onStop() {}));
-
-watcher.start();  // Starting a started watcher should be a noop

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -82,8 +82,6 @@ const watcher =
 // not trigger a 'stop' event.
 watcher.on('stop', common.mustCall(function onStop() {}));
 
-watcher.start();  // Starting a started watcher should be a noop
-
 // Watch events should callback with a filename on supported systems.
 // Omitting AIX. It works but not reliably.
 if (common.isLinux || common.isOSX || common.isWindows) {


### PR DESCRIPTION
Similar to https://github.com/nodejs/node/pull/29905

An instance of FSStatWatcher is returned when a user calls fs.watchFile,
which will call the start method. A user can't create an instance
of a FSStatWatcher directly. If the start method is called by a user
it is a noop since the watcher has already started.

ATM, a user could call start on a closed watcher and i believe it would restart it, however, they would need to re-pass the filename and other function parameters.  I haven't actually tested that out, though.  This is what i see from the code.  It would be nice if it acted in a similar fashion to the FSWatch class, and a noop would happen if start was called on a closed watcher, but if this function becomes private, then that wouldn't matter

This method is also undocumented, in fact, the whole "Class" FSStatWatcher seems to be undocumented,  although that can be a different issue/PR

This PR makes this method private, and would be a semver-major change,  similar to the link issue above

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
