### PR TITLE
esm: modify resolution order for specifier flag

### DIFF
--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -9,6 +9,8 @@ const { getOptionValue } = require('internal/options');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const experimentalJsonModules = getOptionValue('--experimental-json-modules');
+const esModuleSpecifierResolution =
+  getOptionValue('--es-module-specifier-resolution');
 const typeFlag = getOptionValue('--input-type');
 const experimentalWasmModules = getOptionValue('--experimental-wasm-modules');
 const { resolve: moduleWrapResolve,
@@ -110,6 +112,8 @@ function resolve(specifier, parentURL) {
   if (!format) {
     if (isMain)
       format = type === TYPE_MODULE ? 'module' : 'commonjs';
+    else if (esModuleSpecifierResolution === 'node')
+      format = 'commonjs';
     else
       throw new ERR_UNKNOWN_FILE_EXTENSION(fileURLToPath(url));
   }

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -51,8 +51,7 @@ static const char* const EXTENSIONS[] = {
   ".js",
   ".json",
   ".node",
-  ".mjs",
-  ".cjs"
+  ".mjs"
 };
 
 ModuleWrap::ModuleWrap(Environment* env,

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -48,11 +48,11 @@ using v8::Undefined;
 using v8::Value;
 
 static const char* const EXTENSIONS[] = {
-  ".mjs",
-  ".cjs",
   ".js",
   ".json",
-  ".node"
+  ".node",
+  ".mjs",
+  ".cjs"
 };
 
 ModuleWrap::ModuleWrap(Environment* env,

--- a/test/es-module/test-esm-specifiers.mjs
+++ b/test/es-module/test-esm-specifiers.mjs
@@ -1,5 +1,5 @@
 // Flags: --experimental-modules --es-module-specifier-resolution=node
-import { mustNotCall } from '../common';
+import { mustNotCall } from '../common/index.mjs';
 import assert from 'assert';
 
 // commonJS index.js
@@ -14,8 +14,8 @@ assert.strictEqual(commonjs, 'commonjs');
 assert.strictEqual(module, 'module');
 assert.strictEqual(success, 'success');
 assert.strictEqual(explicit, 'esm');
-assert.strictEqual(implicit, 'esm');
-assert.strictEqual(implicitModule, 'esm');
+assert.strictEqual(implicit, 'cjs');
+assert.strictEqual(implicitModule, 'cjs');
 
 async function main() {
   try {

--- a/test/fixtures/es-module-specifiers/node_modules/implicit-main-type-module/entry.js
+++ b/test/fixtures/es-module-specifiers/node_modules/implicit-main-type-module/entry.js
@@ -1,1 +1,1 @@
-export default 'nope';
+export default 'cjs';


### PR DESCRIPTION
Currently `--es-module-specifier-resolution=node` has an alternative
resolution order than the default in common.js, this causes inconsistencies.
As discussed in @nodejs/modules we want to preserve resolution order between
implementations.