### PR TITLE
fs: add missed FSWatcher.prototype.start deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2548,6 +2548,20 @@ APIs that do not make sense to use in userland. File streams should always be
 opened through their corresponding factory methods [`fs.createWriteStream()`][]
 and [`fs.createReadStream()`][]) or by passing a file descriptor in options.
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: `FSWatcher.start()`are internal
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Runtime deprecation
+-->
+
+Type: Runtime
+
+The `FSWatcher.prototype.start()` function is an undocumented internal API that
+does not make ense to use in userland.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -22,6 +22,8 @@ const { toNamespacedPath } = require('path');
 const { validateUint32 } = require('internal/validators');
 const assert = require('internal/assert');
 
+const { deprecate } = require('internal/util');
+
 const kOldStatus = Symbol('kOldStatus');
 const kUseBigint = Symbol('kUseBigint');
 
@@ -173,6 +175,11 @@ FSWatcher.prototype[kFSWatchStart] = function(filename,
     throw error;
   }
 };
+
+FSWatcher.prototype.start = deprecate(
+  FSWatcher.prototype[kFSWatchStart],
+  'FSWatcher.prototype.start() is deprecated',
+  'DEP0XXX');
 
 // This method is a noop if the watcher has not been started or
 // has already been closed.


### PR DESCRIPTION
https://github.com/nodejs/node/pull/29905 should have had a runtime deprecation.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

