### PR TITLE
src: only initialize openssl once

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -833,13 +833,6 @@ int InitializeNodeWithArgs(std::vector<std::string>* argv,
                             &default_env_options->redirect_warnings);
   }
 
-#if HAVE_OPENSSL
-  std::string* openssl_config = &per_process::cli_options->openssl_config;
-  if (openssl_config->empty()) {
-    credentials::SafeGetenv("OPENSSL_CONF", openssl_config);
-  }
-#endif
-
 #if !defined(NODE_WITHOUT_NODE_OPTIONS)
   std::string node_options;
 


### PR DESCRIPTION
For compatibility with OpenSSL 1.1.0 and 1.0.1 a series of
initialization wrappers were being called, many deprecated, and many
calling each other internally already. Compatibility is unnecessary in
12.x and later, which support only OpenSSL 1.1.1, and the multiple calls
cause the configuration file to be loaded multiple times.

Fixes: https://github.com/nodejs/node/issues/29702

See:
- https://mta.openssl.org/pipermail/openssl-users/2019-October/011303.html
- https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_init_ssl.html
- https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_init_crypto.html

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
