### PR TITLE
[v10.x] deps: dlloads node static linked executable

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -521,7 +521,19 @@
         'ldflags': [
           '-Wl,--export-dynamic',
         ],
-      }]
+      }],
+      # if node is built as an executable, 
+      #      the openssl mechanism for keeping itself "dload"-ed to ensure proper 
+      #      atexit cleanup does not apply
+      ['node_shared_openssl!="true" and node_shared!="true"', {
+        'defines': [
+          # `OPENSSL_NO_PINSHARED` prevents openssl from dload 
+          #      current node executable, 
+          #      see https://github.com/nodejs/node/pull/21848 
+          #      or https://github.com/nodejs/node/issues/27925
+          'OPENSSL_NO_PINSHARED' 
+        ],
+      }],
     ],
   }
 }


### PR DESCRIPTION
OpenSSL dlloads itself to prevent unloading, in case it might be
dynamically loaded. However when linked statically this will lead to
dloading the main executable.

Refs: https://github.com/nodejs/node/pull/21848#issuecomment-498396551
Fixes: https://github.com/nodejs/node/issues/29992
PR-URL: https://github.com/nodejs/node/pull/28045
Fixes: https://github.com/nodejs/node/issues/27925
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Rich Trott <rtrott@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
