### PR TITLE
build: make linter failures fail `test-doc` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -592,11 +592,10 @@ test-hash-seed: all
 	$(NODE) test/pummel/test-hash-seed.js
 
 .PHONY: test-doc
-test-doc: doc-only ## Builds, lints, and verifies the docs.
+test-doc: doc-only lint ## Builds, lints, and verifies the docs.
 	@if [ "$(shell $(node_use_openssl))" != "true" ]; then \
 		echo "Skipping test-doc (no crypto)"; \
 	else \
-		$(MAKE) lint; \
 		$(PYTHON) tools/test.py $(PARALLEL_ARGS) doctool; \
 	fi
 


### PR DESCRIPTION
Linter failures in the `test-doc` make target were not failing the
build if the subsequent `doctools` test passed as its exit code
wasn't being preserved.

Make the `lint` target a dependency of `test-doc` so that it is
outside of the `node_use_openssl` guard -- its own dependencies
have their own guards where necessary and the targets that don't
require an available node (e.g. the C++ linters) will be allowed
to run.

Refs: https://github.com/nodejs/node/pull/29999#discussion_r335756298

I'd overlooked this when reviewing https://github.com/nodejs/node/pull/28199 where the regression was introduced.

cc @nodejs/build-files @danbev @sam-github 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
