### PR TITLE
util: fix isInsideNodeModules() check

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -8,7 +8,6 @@ const {
     ERR_UNKNOWN_SIGNAL
   },
   uvErrmapGet,
-  overrideStackTrace,
 } = require('internal/errors');
 const { signals } = internalBinding('constants').os;
 const {
@@ -340,12 +339,12 @@ function isInsideNodeModules() {
     // the perf implications should be okay.
     getStructuredStack = runInNewContext(`(function() {
       Error.stackTraceLimit = Infinity;
+      Error.prepareStackTrace = (err, trace) => trace;
+
       return function structuredStack() {
-        const e = new Error();
-        overrideStackTrace.set(e, (err, trace) => trace);
-        return e.stack;
+        return new Error().stack;
       };
-    })()`, { overrideStackTrace }, { filename: 'structured-stack' });
+    })()`, {}, { filename: 'structured-stack' });
   }
 
   const stack = getStructuredStack();


### PR DESCRIPTION
This PR reverts away from use of `overrideStackTrace` in `isInsideNodeModules()` introduced in https://github.com/nodejs/node/pull/29777.

At the moment, Electron uses the v8 version of `Error.prepareStackTrace` as defined in `v7.9.74` (where https://crbug.com/v8/7848 has been fixed) and not the one polyfilled here: https://github.com/nodejs/node/pull/23926. As a result, we were experiencing failures in `parallel/test-buffer-constructor-outside-node-modules.js` because the polyfilled `prepareStackTrace` was not being run and thus the following code inside that function would never be executed:

```js
  if (overrideStackTrace.has(error)) {
    const f = overrideStackTrace.get(error);
    overrideStackTrace.delete(error);
    return f(error, trace);
  }
```
so `isInsideNodeModules()` would always return false.

This change still allows for` isInsideNodeModules()` to be tested correctly while retaining correct functionality for Electron. Since `isInsideNodeModules()` is only ever invoked when determining whether to print a deprecation warning for `new Buffer()`, this change should have no effects on end users.

cc @devsnek @loc 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Co-authored-by: Andy Locascio <andy@slack-corp.com>