### PR TITLE
build: make configure --without-snapshot a no-op

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -507,7 +507,7 @@ parser.add_option('--with-snapshot',
 
 parser.add_option('--without-snapshot',
     action='store_true',
-    dest='without_snapshot',
+    dest='unused_without_snapshot',
     help=optparse.SUPPRESS_HELP)
 
 parser.add_option('--without-siphash',
@@ -967,13 +967,13 @@ def configure_node(o):
   cross_compiling = (options.cross_compiling
                      if options.cross_compiling is not None
                      else target_arch != host_arch)
-  want_snapshots = not options.without_snapshot
-  o['variables']['want_separate_host_toolset'] = int(
-      cross_compiling and want_snapshots)
+  if options.unused_without_snapshot:
+    warn('building --without-snapshot is no longer possible')
+
+  o['variables']['want_separate_host_toolset'] = int(cross_compiling)
 
   if not options.without_node_snapshot:
-    o['variables']['node_use_node_snapshot'] = b(
-        not cross_compiling and want_snapshots)
+    o['variables']['node_use_node_snapshot'] = b(not cross_compiling)
   else:
     o['variables']['node_use_node_snapshot'] = 'false'
 
@@ -1177,7 +1177,6 @@ def configure_v8(o):
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
   o['variables']['v8_promise_internal_field_count'] = 1 # Add internal field to promises for async hooks.
   o['variables']['v8_use_siphash'] = 0 if options.without_siphash else 1
-  o['variables']['v8_use_snapshot'] = 0 if options.without_snapshot else 1
   o['variables']['v8_trace_maps'] = 1 if options.trace_maps else 0
   o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)

--- a/node.gyp
+++ b/node.gyp
@@ -1,7 +1,7 @@
 {
   'variables': {
     'v8_use_siphash%': 0,
-    'v8_use_snapshot%': 0,
+    'v8_use_snapshot%': 1,
     'v8_trace_maps%': 0,
     'node_use_dtrace%': 'false',
     'node_use_etw%': 'false',


### PR DESCRIPTION
From V8 7.9, the option will no longer exist upstream.

Refs: https://chromium-review.googlesource.com/c/chromium/src/+/1796325

I don't know if we need to make this semver-major, but I really want to land this in v13.x to allow updating V8 later on that branch.

/cc @nodejs/v8-update @joyeecheung 