### PR TITLE
test: fix test runner for Python 3 on Windows

### DIFF
--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -29,6 +29,7 @@ import test
 import os
 import re
 from functools import reduce
+from io import open
 
 
 FLAGS_PATTERN = re.compile(r"//\s+Flags:(.*)")
@@ -56,7 +57,7 @@ class SimpleTestCase(test.TestCase):
 
   def GetCommand(self):
     result = [self.config.context.GetVm(self.arch, self.mode)]
-    source = open(self.file).read()
+    source = open(self.file, encoding='utf8').read()
     flags_match = FLAGS_PATTERN.search(source)
     if flags_match:
       flags = flags_match.group(1).strip().split()

--- a/tools/test.py
+++ b/tools/test.py
@@ -45,6 +45,7 @@ import multiprocessing
 import errno
 import copy
 
+from io import open
 from os.path import join, dirname, abspath, basename, isdir, exists
 from datetime import datetime
 try:
@@ -733,8 +734,8 @@ def Execute(args, context, timeout=None, env=None, disable_core_files=False, std
   )
   os.close(fd_out)
   os.close(fd_err)
-  output = open(outname).read()
-  errors = open(errname).read()
+  output = open(outname, encoding='utf8').read()
+  errors = open(errname, encoding='utf8').read()
   CheckedUnlink(outname)
   CheckedUnlink(errname)
 


### PR DESCRIPTION
Explicitly open files with utf8 encoding, otherwise the system could use
another encoding such as latin1 by default.

/cc @nodejs/python 