### PR TITLE
cli: add --trace-uncaught flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -747,6 +747,18 @@ added: v12.2.0
 Prints TLS packet trace information to `stderr`. This can be used to debug TLS
 connection problems.
 
+### `--trace-uncaught`
+<!-- YAML
+added: REPLACEME
+-->
+
+Print stack traces for uncaught exceptions; usually, the stack trace associated
+with the creation of an `Error` is printed, whereas this makes Node.js also
+print the stack trace associated with throwing the value (which does not need
+to be an `Error` instance).
+
+Enabling this option may affect garbage collection behavior negatively.
+
 ### `--trace-warnings`
 <!-- YAML
 added: v6.0.0
@@ -1044,6 +1056,7 @@ Node.js options that are allowed are:
 * `--trace-events-enabled`
 * `--trace-sync-io`
 * `--trace-tls`
+* `--trace-uncaught`
 * `--trace-warnings`
 * `--track-heap-objects`
 * `--unhandled-rejections`

--- a/doc/node.1
+++ b/doc/node.1
@@ -337,6 +337,18 @@ Print a stack trace whenever synchronous I/O is detected after the first turn of
 .It Fl -trace-tls
 Prints TLS packet trace information to stderr.
 .
+.It Fl -trace-uncaught
+Print stack traces for uncaught exceptions; usually, the stack trace associated
+with the creation of an
+.Sy Error
+is printed, whereas this makes Node.js also
+print the stack trace associated with throwing the value (which does not need
+to be an
+.Sy Error
+instance).
+.Pp
+Enabling this option may affect garbage collection behavior negatively.
+.
 .It Fl -trace-warnings
 Print stack traces for process warnings (including deprecations).
 .

--- a/src/env.cc
+++ b/src/env.cc
@@ -381,9 +381,6 @@ Environment::Environment(IsolateData* isolate_data,
     async_hooks_.no_force_checks();
   }
 
-  if (options_->trace_uncaught)
-    isolate()->SetCaptureStackTraceForUncaughtExceptions(true);
-
   // TODO(joyeecheung): deserialize when the snapshot covers the environment
   // properties.
   CreateProperties();

--- a/src/env.cc
+++ b/src/env.cc
@@ -381,6 +381,9 @@ Environment::Environment(IsolateData* isolate_data,
     async_hooks_.no_force_checks();
   }
 
+  if (options_->trace_uncaught)
+    isolate()->SetCaptureStackTraceForUncaughtExceptions(true);
+
   // TODO(joyeecheung): deserialize when the snapshot covers the environment
   // properties.
   CreateProperties();

--- a/src/node.cc
+++ b/src/node.cc
@@ -265,6 +265,8 @@ int Environment::InitializeInspector(
 void Environment::InitializeDiagnostics() {
   isolate_->GetHeapProfiler()->AddBuildEmbedderGraphCallback(
       Environment::BuildEmbedderGraph, this);
+  if (options_->trace_uncaught)
+    isolate_->SetCaptureStackTraceForUncaughtExceptions(true);
 
 #if defined HAVE_DTRACE || defined HAVE_ETW
   InitDTrace(this);

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -380,6 +380,19 @@ static void ReportFatalException(Environment* env,
             "%s\n%s: %s\n", *arrow_string, *name_string, *message_string);
       }
     }
+
+    if (!env->options()->trace_uncaught) {
+      PrintErrorString("(Use `node --trace-uncaught ...` to show "
+                       "where the exception was thrown)\n");
+    }
+  }
+
+  if (env->options()->trace_uncaught) {
+    Local<StackTrace> trace = message->GetStackTrace();
+    if (!trace.IsEmpty()) {
+      PrintErrorString("Thrown at:\n");
+      PrintStackTrace(env->isolate(), trace);
+    }
   }
 
   fflush(stderr);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -476,6 +476,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "prints TLS packet trace information to stderr",
             &EnvironmentOptions::trace_tls,
             kAllowedInEnvironment);
+  AddOption("--trace-uncaught",
+            "show stack traces for the `throw` behind uncaught exceptions",
+            &EnvironmentOptions::trace_uncaught,
+            kAllowedInEnvironment);
   AddOption("--trace-warnings",
             "show stack traces on process warnings",
             &EnvironmentOptions::trace_warnings,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -140,6 +140,7 @@ class EnvironmentOptions : public Options {
   bool trace_deprecation = false;
   bool trace_sync_io = false;
   bool trace_tls = false;
+  bool trace_uncaught = false;
   bool trace_warnings = false;
   std::string unhandled_rejections;
   std::string userland_loader;

--- a/test/message/eval_messages.out
+++ b/test/message/eval_messages.out
@@ -55,9 +55,11 @@ ReferenceError: y is not defined
 var ______________________________________________; throw 10
                                                     ^
 10
+(Use `node --trace-uncaught ...` to show where the exception was thrown)
 
 [eval]:1
 var ______________________________________________; throw 10
                                                     ^
 10
+(Use `node --trace-uncaught ...` to show where the exception was thrown)
 done

--- a/test/message/stdin_messages.out
+++ b/test/message/stdin_messages.out
@@ -67,9 +67,11 @@ ReferenceError: y is not defined
 var ______________________________________________; throw 10
                                                     ^
 10
+(Use `node --trace-uncaught ...` to show where the exception was thrown)
 
 [stdin]:1
 var ______________________________________________; throw 10
                                                     ^
 10
+(Use `node --trace-uncaught ...` to show where the exception was thrown)
 done

--- a/test/message/throw_error_with_getter_throw.out
+++ b/test/message/throw_error_with_getter_throw.out
@@ -3,3 +3,4 @@
 throw {  // eslint-disable-line no-throw-literal
 ^
 [object Object]
+(Use `node --trace-uncaught ...` to show where the exception was thrown)

--- a/test/message/throw_error_with_getter_throw_traced.js
+++ b/test/message/throw_error_with_getter_throw_traced.js
@@ -1,0 +1,11 @@
+// Flags: --trace-uncaught
+'use strict';
+require('../common');
+throw {  // eslint-disable-line no-throw-literal
+  get stack() {
+    throw new Error('weird throw but ok');
+  },
+  get name() {
+    throw new Error('weird throw but ok');
+  },
+};

--- a/test/message/throw_error_with_getter_throw_traced.out
+++ b/test/message/throw_error_with_getter_throw_traced.out
@@ -1,0 +1,12 @@
+
+*:4
+throw {  // eslint-disable-line no-throw-literal
+^
+[object Object]
+Thrown at:
+    at *throw_error_with_getter_throw_traced.js:*:*
+    at Module._compile (internal/modules/cjs/loader.js:*:*)
+    at Module._extensions..js (internal/modules/cjs/loader.js:*:*)
+    at Module.load (internal/modules/cjs/loader.js:*:*)
+    at Module._load (internal/modules/cjs/loader.js:*:*)
+    at Module.runMain (internal/modules/cjs/loader.js:*:*)

--- a/test/message/throw_null.out
+++ b/test/message/throw_null.out
@@ -3,3 +3,4 @@
 throw null;
 ^
 null
+(Use `node --trace-uncaught ...` to show where the exception was thrown)

--- a/test/message/throw_null_traced.js
+++ b/test/message/throw_null_traced.js
@@ -1,0 +1,6 @@
+// Flags: --trace-uncaught
+'use strict';
+require('../common');
+
+// eslint-disable-next-line no-throw-literal
+throw null;

--- a/test/message/throw_null_traced.out
+++ b/test/message/throw_null_traced.out
@@ -1,0 +1,12 @@
+
+*test*message*throw_null_traced.js:*
+throw null;
+^
+null
+Thrown at:
+    at *throw_null_traced.js:*:*
+    at Module._compile (internal/modules/cjs/loader.js:*:*)
+    at Module._extensions..js (internal/modules/cjs/loader.js:*:*)
+    at Module.load (internal/modules/cjs/loader.js:*:*)
+    at Module._load (internal/modules/cjs/loader.js:*:*)
+    at Module.runMain (internal/modules/cjs/loader.js:*:*)

--- a/test/message/throw_undefined.out
+++ b/test/message/throw_undefined.out
@@ -3,3 +3,4 @@
 throw undefined;
 ^
 undefined
+(Use `node --trace-uncaught ...` to show where the exception was thrown)

--- a/test/message/throw_undefined_traced.js
+++ b/test/message/throw_undefined_traced.js
@@ -1,0 +1,6 @@
+// Flags: --trace-uncaught
+'use strict';
+require('../common');
+
+// eslint-disable-next-line no-throw-literal
+throw undefined;

--- a/test/message/throw_undefined_traced.out
+++ b/test/message/throw_undefined_traced.out
@@ -1,0 +1,12 @@
+
+*test*message*throw_undefined_traced.js:*
+throw undefined;
+^
+undefined
+Thrown at:
+    at *throw_undefined_traced.js:*:*
+    at Module._compile (internal/modules/cjs/loader.js:*:*)
+    at Module._extensions..js (internal/modules/cjs/loader.js:*:*)
+    at Module.load (internal/modules/cjs/loader.js:*:*)
+    at Module._load (internal/modules/cjs/loader.js:*:*)
+    at Module.runMain (internal/modules/cjs/loader.js:*:*)


### PR DESCRIPTION
Add a flag that makes Node.js print the stack trace at the
time of *throwing* uncaught exceptions, rather than at the
creation of the `Error` object, if there is any.

This is disabled by default because it affects GC behavior.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
