### PR TITLE
src: expose ListNode<T>::prev_ on postmortem metadata

### DIFF
--- a/src/node_postmortem_metadata.cc
+++ b/src/node_postmortem_metadata.cc
@@ -27,9 +27,11 @@
     HandleWrap::handle_wrap_queue_)                                           \
   V(Environment_HandleWrapQueue, head_, ListNode_HandleWrap,                  \
     Environment::HandleWrapQueue::head_)                                      \
+  V(ListNode_HandleWrap, prev_, uintptr_t, ListNode<HandleWrap>::prev_)       \
   V(ListNode_HandleWrap, next_, uintptr_t, ListNode<HandleWrap>::next_)       \
   V(Environment_ReqWrapQueue, head_, ListNode_ReqWrapQueue,                   \
     Environment::ReqWrapQueue::head_)                                         \
+  V(ListNode_ReqWrap, prev_, uintptr_t, ListNode<ReqWrapBase>::prev_)         \
   V(ListNode_ReqWrap, next_, uintptr_t, ListNode<ReqWrapBase>::next_)
 
 extern "C" {

--- a/test/cctest/test_node_postmortem_metadata.cc
+++ b/test/cctest/test_node_postmortem_metadata.cc
@@ -19,8 +19,10 @@ extern uintptr_t
 extern uintptr_t
     nodedbg_offset_Environment__req_wrap_queue___Environment_ReqWrapQueue;
 extern uintptr_t nodedbg_offset_ExternalString__data__uintptr_t;
+extern uintptr_t nodedbg_offset_ListNode_ReqWrap__prev___uintptr_t;
 extern uintptr_t nodedbg_offset_ListNode_ReqWrap__next___uintptr_t;
 extern uintptr_t nodedbg_offset_ReqWrap__req_wrap_queue___ListNode_ReqWrapQueue;
+extern uintptr_t nodedbg_offset_ListNode_HandleWrap__prev___uintptr_t;
 extern uintptr_t nodedbg_offset_ListNode_HandleWrap__next___uintptr_t;
 extern uintptr_t
     nodedbg_offset_Environment_ReqWrapQueue__head___ListNode_ReqWrapQueue;
@@ -129,6 +131,12 @@ TEST_F(DebugSymbolsTest, HandleWrapList) {
   const Argv argv;
   Env env{handle_scope, argv};
 
+  auto queue = reinterpret_cast<uintptr_t>((*env)->handle_wrap_queue());
+  auto head = queue +
+      nodedbg_offset_Environment_HandleWrapQueue__head___ListNode_HandleWrap;
+  auto tail = head + nodedbg_offset_ListNode_HandleWrap__prev___uintptr_t;
+  tail = *reinterpret_cast<uintptr_t*>(tail);
+
   uv_tcp_t handle;
 
   auto obj_template = v8::FunctionTemplate::New(isolate_);
@@ -140,16 +148,12 @@ TEST_F(DebugSymbolsTest, HandleWrapList) {
                                      .ToLocalChecked();
   TestHandleWrap obj(*env, object, &handle);
 
-  auto queue = reinterpret_cast<uintptr_t>((*env)->handle_wrap_queue());
-  auto head = queue +
-      nodedbg_offset_Environment_HandleWrapQueue__head___ListNode_HandleWrap;
-  auto next =
-      head + nodedbg_offset_ListNode_HandleWrap__next___uintptr_t;
-  next = *reinterpret_cast<uintptr_t*>(next);
+  auto last = tail + nodedbg_offset_ListNode_HandleWrap__next___uintptr_t;
+  last = *reinterpret_cast<uintptr_t*>(last);
 
   auto expected = reinterpret_cast<uintptr_t>(&obj);
-  auto calculated = next -
-      nodedbg_offset_HandleWrap__handle_wrap_queue___ListNode_HandleWrap;
+  auto calculated =
+      last - nodedbg_offset_HandleWrap__handle_wrap_queue___ListNode_HandleWrap;
   EXPECT_EQ(expected, calculated);
 
   obj.persistent().Reset();  // ~HandleWrap() expects an empty handle.
@@ -159,6 +163,13 @@ TEST_F(DebugSymbolsTest, ReqWrapList) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
   Env env{handle_scope, argv};
+
+  auto queue = reinterpret_cast<uintptr_t>((*env)->req_wrap_queue());
+  auto head =
+      queue +
+      nodedbg_offset_Environment_ReqWrapQueue__head___ListNode_ReqWrapQueue;
+  auto tail = head + nodedbg_offset_ListNode_ReqWrap__prev___uintptr_t;
+  tail = *reinterpret_cast<uintptr_t*>(tail);
 
   auto obj_template = v8::FunctionTemplate::New(isolate_);
   obj_template->InstanceTemplate()->SetInternalFieldCount(1);
@@ -174,16 +185,12 @@ TEST_F(DebugSymbolsTest, ReqWrapList) {
   // ARM64 CI machinies.
   for (auto it : *(*env)->req_wrap_queue()) (void) &it;
 
-  auto queue = reinterpret_cast<uintptr_t>((*env)->req_wrap_queue());
-  auto head = queue +
-      nodedbg_offset_Environment_ReqWrapQueue__head___ListNode_ReqWrapQueue;
-  auto next =
-      head + nodedbg_offset_ListNode_ReqWrap__next___uintptr_t;
-  next = *reinterpret_cast<uintptr_t*>(next);
+  auto last = tail + nodedbg_offset_ListNode_ReqWrap__next___uintptr_t;
+  last = *reinterpret_cast<uintptr_t*>(last);
 
   auto expected = reinterpret_cast<uintptr_t>(&obj);
   auto calculated =
-      next - nodedbg_offset_ReqWrap__req_wrap_queue___ListNode_ReqWrapQueue;
+      last - nodedbg_offset_ReqWrap__req_wrap_queue___ListNode_ReqWrapQueue;
   EXPECT_EQ(expected, calculated);
 
   obj.Dispatched();


### PR DESCRIPTION
Make `ListNode<T>` postmortem easier to find last items in the queue.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
