### PR TITLE
build: log the found compiler version if too old

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -775,7 +775,8 @@ def check_compiler(o):
   if not ok:
     warn('failed to autodetect C++ compiler version (CXX=%s)' % CXX)
   elif clang_version < (8, 0, 0) if is_clang else gcc_version < (6, 3, 0):
-    warn('C++ compiler too old, need g++ 6.3.0 or clang++ 8.0.0 (CXX=%s)' % CXX)
+    warn('C++ compiler too old, need g++ 6.3.0 or clang++ 8.0.0 (CXX=%s, %s)' %
+      (CXX, ".".join(map(str, clang_version if is_clang else gcc_version))))
 
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CC, 'c')
   if not ok:
@@ -784,7 +785,8 @@ def check_compiler(o):
     # clang 3.2 is a little white lie because any clang version will probably
     # do for the C bits.  However, we might as well encourage people to upgrade
     # to a version that is not completely ancient.
-    warn('C compiler too old, need gcc 4.2 or clang 3.2 (CC=%s)' % CC)
+    warn('C compiler too old, need gcc 4.2 or clang 3.2 (CC=%s, %s)' %
+      (CC, ".".join(map(str, gcc_version))))
 
   o['variables']['llvm_version'] = get_llvm_version(CC) if is_clang else '0.0'
 

--- a/configure.py
+++ b/configure.py
@@ -775,7 +775,7 @@ def check_compiler(o):
   if not ok:
     warn('failed to autodetect C++ compiler version (CXX=%s)' % CXX)
   elif clang_version < (8, 0, 0) if is_clang else gcc_version < (6, 3, 0):
-    warn('C++ compiler too old, need g++ 6.3.0 or clang++ 8.0.0 (CXX=%s, %s)' %
+    warn('C++ compiler too old (CXX=%s, %s), need g++ 6.3.0 or clang++ 8.0.0' %
       (CXX, ".".join(map(str, clang_version if is_clang else gcc_version))))
 
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CC, 'c')
@@ -785,7 +785,7 @@ def check_compiler(o):
     # clang 3.2 is a little white lie because any clang version will probably
     # do for the C bits.  However, we might as well encourage people to upgrade
     # to a version that is not completely ancient.
-    warn('C compiler too old, need gcc 4.2 or clang 3.2 (CC=%s, %s)' %
+    warn('C compiler too old (CC=%s, %s), need gcc 4.2 or clang 3.2' %
       (CC, ".".join(map(str, gcc_version))))
 
   o['variables']['llvm_version'] = get_llvm_version(CC) if is_clang else '0.0'

--- a/configure.py
+++ b/configure.py
@@ -775,7 +775,7 @@ def check_compiler(o):
   if not ok:
     warn('failed to autodetect C++ compiler version (CXX=%s)' % CXX)
   elif clang_version < (8, 0, 0) if is_clang else gcc_version < (6, 3, 0):
-    warn('C++ compiler too old (CXX=%s, %s), need g++ 6.3.0 or clang++ 8.0.0' %
+    warn('C++ compiler (CXX=%s, %s) too old, need g++ 6.3.0 or clang++ 8.0.0' %
       (CXX, ".".join(map(str, clang_version if is_clang else gcc_version))))
 
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CC, 'c')
@@ -785,7 +785,7 @@ def check_compiler(o):
     # clang 3.2 is a little white lie because any clang version will probably
     # do for the C bits.  However, we might as well encourage people to upgrade
     # to a version that is not completely ancient.
-    warn('C compiler too old (CC=%s, %s), need gcc 4.2 or clang 3.2' %
+    warn('C compiler (CC=%s, %s) too old, need gcc 4.2 or clang 3.2' %
       (CC, ".".join(map(str, gcc_version))))
 
   o['variables']['llvm_version'] = get_llvm_version(CC) if is_clang else '0.0'


### PR DESCRIPTION
`configure` will log a warning if the detected compiler is not new
enough. Take some of the guesswork out of it by also logging the
version of the compiler that was detected.

Before:
```console
-bash-4.2$ ./configure
Node configure: Found Python 2.7.5...
WARNING: C++ compiler too old, need g++ 6.3.0 or clang++ 8.0.0 (CXX=g++)
INFO: Using floating patch "tools/icu/patches/64/source/common/putil.cpp" from "tools/icu"
INFO: Using floating patch "tools/icu/patches/64/source/i18n/dtptngen.cpp" from "tools/icu"
WARNING: warnings were emitted in the configure phase
INFO: configure completed successfully
-bash-4.2$
```

After:
```console
-bash-4.2$ ./configure
Node configure: Found Python 2.7.5...
WARNING: C++ compiler too old, need g++ 6.3.0 or clang++ 8.0.0 (CXX=g++, 4.8.5)
INFO: Using floating patch "tools/icu/patches/64/source/common/putil.cpp" from "tools/icu"
INFO: Using floating patch "tools/icu/patches/64/source/i18n/dtptngen.cpp" from "tools/icu"
WARNING: warnings were emitted in the configure phase
INFO: configure completed successfully
-bash-4.2$
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
