### PR TITLE
src: fewer uses of NODE_USE_V8_PLATFORM

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -868,7 +868,7 @@ class Environment : public MemoryRetainer {
   void CreateProperties();
   // Should be called before InitializeInspector()
   void InitializeDiagnostics();
-#if HAVE_INSPECTOR && NODE_USE_V8_PLATFORM
+#if HAVE_INSPECTOR
   // If the environment is created for a worker, pass parent_handle and
   // the ownership if transferred into the Environment.
   int InitializeInspector(inspector::ParentInspectorHandle* parent_handle);

--- a/src/node.cc
+++ b/src/node.cc
@@ -226,7 +226,7 @@ MaybeLocal<Value> ExecuteBootstrapper(Environment* env,
   return scope.EscapeMaybe(result);
 }
 
-#if HAVE_INSPECTOR && NODE_USE_V8_PLATFORM
+#if HAVE_INSPECTOR
 int Environment::InitializeInspector(
     inspector::ParentInspectorHandle* parent_handle) {
   std::string inspector_path;

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -204,7 +204,7 @@ std::unique_ptr<Environment> NodeMainInstance::CreateMainEnvironment(
 
   // TODO(joyeecheung): when we snapshot the bootstrapped context,
   // the inspector and diagnostics setup should after after deserialization.
-#if HAVE_INSPECTOR && NODE_USE_V8_PLATFORM
+#if HAVE_INSPECTOR
   *exit_code = env->InitializeInspector(nullptr);
 #endif
   if (*exit_code != 0) {

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -8,7 +8,7 @@
 #include "util-inl.h"
 #include "async_wrap-inl.h"
 
-#if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
+#if HAVE_INSPECTOR
 #include "inspector/worker_inspector.h"  // ParentInspectorHandle
 #endif
 
@@ -39,7 +39,7 @@ namespace worker {
 
 namespace {
 
-#if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
+#if HAVE_INSPECTOR
 void WaitForWorkerInspectorToStop(Environment* child) {
   child->inspector_agent()->WaitForDisconnect();
   child->inspector_agent()->Stop();
@@ -82,7 +82,7 @@ Worker::Worker(Environment* env,
                 Number::New(env->isolate(), static_cast<double>(thread_id_)))
       .Check();
 
-#if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
+#if HAVE_INSPECTOR
   inspector_parent_handle_ =
       env->inspector_agent()->GetParentHandle(thread_id_, url);
 #endif
@@ -193,7 +193,7 @@ void Worker::Run() {
     Locker locker(isolate_);
     Isolate::Scope isolate_scope(isolate_);
     SealHandleScope outer_seal(isolate_);
-#if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
+#if HAVE_INSPECTOR
     bool inspector_started = false;
 #endif
 
@@ -225,7 +225,7 @@ void Worker::Run() {
         env_->stop_sub_worker_contexts();
         env_->RunCleanup();
         RunAtExit(env_.get());
-#if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
+#if HAVE_INSPECTOR
         if (inspector_started)
           WaitForWorkerInspectorToStop(env_.get());
 #endif
@@ -270,7 +270,7 @@ void Worker::Run() {
       if (is_stopped()) return;
       {
         env_->InitializeDiagnostics();
-#if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
+#if HAVE_INSPECTOR
         env_->InitializeInspector(inspector_parent_handle_.release());
         inspector_started = true;
 #endif

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -65,7 +65,7 @@ class Worker : public AsyncWrap {
   bool start_profiler_idle_notifier_;
   uv_thread_t tid_;
 
-#if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
+#if HAVE_INSPECTOR
   std::unique_ptr<inspector::ParentInspectorHandle> inspector_parent_handle_;
 #endif
 


### PR DESCRIPTION
This PR removes some uses of `NODE_USE_V8_PLATFORM` in conjunction with `HAVE_INSPECTOR`.

Electron makes use of `HAVE_INSPECTOR` but does not run with `NODE_USE_V8_PLATFORM` so this prevented some Inspector code from running properly on our end; specifically, we were seeing a crash in `test/parallel/test-inspector-connect-main-thread.js`:

<details>

```sh
/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/MacOS/Electron[77672]: ../../third_party/electron_node/src/inspector_agent.cc:834:std::unique_ptr<InspectorSession> node::inspector::Agent::ConnectToMainThread(std::unique_ptr<InspectorSessionDelegate>, bool): Assertion `(parent_handle_) != nullptr' failed.
 1: 0x122cb7c35 node::Abort() [/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 2: 0x122cb79bf node::Assert(node::AssertionInfo const&) [/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 3: 0x122d72a3d node::inspector::Agent::ConnectToMainThread(std::__1::unique_ptr<node::inspector::InspectorSessionDelegate, std::__1::default_delete<node::inspector::InspectorSessionDelegate> >, bool) [/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 4: 0x122d7baeb node::inspector::(anonymous namespace)::JSBindingsConnection<node::inspector::(anonymous namespace)::MainThreadConnection>::New(v8::FunctionCallbackInfo<v8::Value> const&) [/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 5: 0x11a93c05f v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) [/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 6: 0x11a8d19ee v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<true>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) [/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 7: 0x11a8d0882 v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments, v8::internal::Isolate*) [/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 8: 0x11a8d037c v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 9: 0x11b838da0 Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_BuiltinExit [/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
10: 0x11b603557 Builtins_JSBuiltinsConstructStub [/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
/Users/codebytere/build-tools/nix/commands/node.sh: line 8: 77672 Abort trap: 6           ELECTRON_RUN_AS_NODE=1 "$ELECTRON_EXEC" "$@"
```

</details>

cc @joyeecheung (who touched some of this recently) and @addaleax 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
