### PR TITLE
inspector: turn platform tasks that outlive Agent into no-ops

### DIFF
--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -241,9 +241,9 @@ void MainThreadInterface::Post(std::unique_ptr<Request> request) {
       isolate_->RequestInterrupt([](v8::Isolate* isolate, void* opaque) {
         std::unique_ptr<std::weak_ptr<MainThreadInterface>> interface_ptr {
           static_cast<std::weak_ptr<MainThreadInterface>*>(opaque) };
-        std::shared_ptr<MainThreadInterface> interface = interface_ptr->lock();
-        if (interface)
-          interface->DispatchMessages();
+        std::shared_ptr<MainThreadInterface> iface = interface_ptr->lock();
+        if (iface)
+          iface->DispatchMessages();
       }, static_cast<void*>(interface_ptr));
     }
   }

--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -91,9 +91,7 @@ class DispatchMessagesTask : public v8::Task {
                                 : thread_(thread) {}
 
   void Run() override {
-    std::shared_ptr<MainThreadInterface> thread = thread_.lock();
-    if (thread)
-      thread->DispatchMessages();
+    if (auto thread = thread_.lock()) thread->DispatchMessages();
   }
 
  private:
@@ -241,9 +239,7 @@ void MainThreadInterface::Post(std::unique_ptr<Request> request) {
       isolate_->RequestInterrupt([](v8::Isolate* isolate, void* opaque) {
         std::unique_ptr<std::weak_ptr<MainThreadInterface>> interface_ptr {
           static_cast<std::weak_ptr<MainThreadInterface>*>(opaque) };
-        std::shared_ptr<MainThreadInterface> iface = interface_ptr->lock();
-        if (iface)
-          iface->DispatchMessages();
+        if (auto iface = interface_ptr->lock()) iface->DispatchMessages();
       }, static_cast<void*>(interface_ptr));
     }
   }

--- a/src/inspector/main_thread_interface.h
+++ b/src/inspector/main_thread_interface.h
@@ -70,7 +70,8 @@ class MainThreadHandle : public std::enable_shared_from_this<MainThreadHandle> {
   friend class MainThreadInterface;
 };
 
-class MainThreadInterface {
+class MainThreadInterface :
+    public std::enable_shared_from_this<MainThreadInterface> {
  public:
   MainThreadInterface(Agent* agent, uv_loop_t*, v8::Isolate* isolate,
                       v8::Platform* platform);

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -665,10 +665,10 @@ class NodeInspectorClient : public V8InspectorClient {
   }
 
   std::shared_ptr<MainThreadHandle> getThreadHandle() {
-    if (interface_ == nullptr) {
-      interface_.reset(new MainThreadInterface(
+    if (!interface_) {
+      interface_ = std::make_shared<MainThreadInterface>(
           env_->inspector_agent(), env_->event_loop(), env_->isolate(),
-          env_->isolate_data()->platform()));
+          env_->isolate_data()->platform());
     }
     return interface_->GetHandle();
   }
@@ -739,7 +739,7 @@ class NodeInspectorClient : public V8InspectorClient {
   bool waiting_for_frontend_ = false;
   bool waiting_for_sessions_disconnect_ = false;
   // Allows accessing Inspector from non-main threads
-  std::unique_ptr<MainThreadInterface> interface_;
+  std::shared_ptr<MainThreadInterface> interface_;
   std::shared_ptr<WorkerManager> worker_manager_;
 };
 


### PR DESCRIPTION
Turn tasks scheduled on the `v8::Isolate` or on the given platform
into no-ops if the underlying `MainThreadInterface` has gone away
before the task could be run (which would happen when the
`Environment` instance and with it the `inspector::Agent` instance
are destroyed).

This addresses an issue that Electron has been having with
inspector support, and generally just seems like the right thing
to do, as we may not fully be in control of the relative timing
of Environment teardown, platform tasks execution, and the
execution of `RequestInterrupt()` callbacks (although
the former two always happen in the same order in our own code).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
