### PR TITLE
src: make implementing CancelPendingDelayedTasks for platform optional

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -260,7 +260,11 @@ class NODE_EXTERN MultiIsolatePlatform : public v8::Platform {
   // flushing.
   virtual bool FlushForegroundTasks(v8::Isolate* isolate) = 0;
   virtual void DrainTasks(v8::Isolate* isolate) = 0;
-  virtual void CancelPendingDelayedTasks(v8::Isolate* isolate) = 0;
+
+  // TODO(addaleax): Remove this, it is unnecessary.
+  // This would currently be called before `UnregisterIsolate()` but will be
+  // folded into it in the future.
+  virtual void CancelPendingDelayedTasks(v8::Isolate* isolate);
 
   // This needs to be called between the calls to `Isolate::Allocate()` and
   // `Isolate::Initialize()`, so that initialization can already start
@@ -270,7 +274,8 @@ class NODE_EXTERN MultiIsolatePlatform : public v8::Platform {
   virtual void RegisterIsolate(v8::Isolate* isolate,
                                struct uv_loop_s* loop) = 0;
   // This needs to be called right before calling `Isolate::Dispose()`.
-  // This function may only be called once per `Isolate`.
+  // This function may only be called once per `Isolate`, and discard any
+  // pending delayed tasks scheduled for that isolate.
   virtual void UnregisterIsolate(v8::Isolate* isolate) = 0;
   // The platform should call the passed function once all state associated
   // with the given isolate has been cleaned up. This can, but does not have to,

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -155,7 +155,6 @@ int NodeMainInstance::Run() {
   RunAtExit(env.get());
 
   per_process::v8_platform.DrainVMTasks(isolate_);
-  per_process::v8_platform.CancelVMTasks(isolate_);
 
 #if defined(LEAK_SANITIZER)
   __lsan_do_leak_check();

--- a/src/node_v8_platform-inl.h
+++ b/src/node_v8_platform-inl.h
@@ -113,10 +113,6 @@ struct V8Platform {
     platform_->DrainTasks(isolate);
   }
 
-  inline void CancelVMTasks(v8::Isolate* isolate) {
-    platform_->CancelPendingDelayedTasks(isolate);
-  }
-
   inline void StartTracingAgent() {
     // Attach a new NodeTraceWriter only if this function hasn't been called
     // before.
@@ -150,7 +146,6 @@ struct V8Platform {
   inline void Initialize(int thread_pool_size) {}
   inline void Dispose() {}
   inline void DrainVMTasks(v8::Isolate* isolate) {}
-  inline void CancelVMTasks(v8::Isolate* isolate) {}
   inline void StartTracingAgent() {
     if (!per_process::cli_options->trace_event_categories.empty()) {
       fprintf(stderr,

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -148,8 +148,6 @@ class WorkerThreadData {
       w_->isolate_ = nullptr;
     }
 
-    w_->platform_->CancelPendingDelayedTasks(isolate);
-
     bool platform_finished = false;
 
     isolate_data_.reset();


### PR DESCRIPTION
Fold `CancelPendingDelayedTasks()` into `UnregisterIsolate()` and
make implementing it optional.

It makes sense for these two operations to happen at the same time,
so it is sufficient to provide a single operation instead of two
separate ones.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
