### PR TITLE
test: expand Worker test for non-shared ArrayBuffer

### DIFF
--- a/test/parallel/test-worker-sharedarraybuffer-from-worker-thread.js
+++ b/test/parallel/test-worker-sharedarraybuffer-from-worker-thread.js
@@ -5,19 +5,24 @@ const assert = require('assert');
 const { Worker } = require('worker_threads');
 
 // Regression test for https://github.com/nodejs/node/issues/28777
-// Make sure that SharedArrayBuffers created in Worker threads are accessible
-// after the creating thread ended.
+// Make sure that SharedArrayBuffers and transferred ArrayBuffers created in
+// Worker threads are accessible after the creating thread ended.
 
-const w = new Worker(`
-const { parentPort } = require('worker_threads');
-const sharedArrayBuffer = new SharedArrayBuffer(4);
-parentPort.postMessage(sharedArrayBuffer);
-`, { eval: true });
+for (const ctor of ['ArrayBuffer', 'SharedArrayBuffer']) {
+  const w = new Worker(`
+  const { parentPort } = require('worker_threads');
+  const arrayBuffer = new ${ctor}(4);
+  parentPort.postMessage(
+    arrayBuffer,
+    '${ctor}' === 'SharedArrayBuffer' ? [] : [arrayBuffer]);
+  `, { eval: true });
 
-let sharedArrayBuffer;
-w.once('message', common.mustCall((message) => sharedArrayBuffer = message));
-w.once('exit', common.mustCall(() => {
-  const uint8array = new Uint8Array(sharedArrayBuffer);
-  uint8array[0] = 42;
-  assert.deepStrictEqual(uint8array, new Uint8Array([42, 0, 0, 0]));
-}));
+  let arrayBuffer;
+  w.once('message', common.mustCall((message) => arrayBuffer = message));
+  w.once('exit', common.mustCall(() => {
+    assert.strictEqual(arrayBuffer.constructor.name, ctor);
+    const uint8array = new Uint8Array(arrayBuffer);
+    uint8array[0] = 42;
+    assert.deepStrictEqual(uint8array, new Uint8Array([42, 0, 0, 0]));
+  }));
+}


### PR DESCRIPTION
This test would be broken by V8 7.9 due to the changed `ArrayBuffer`
backing store management (the same way that V8 7.8 broke this for
`SharedArrayBuffer`s). While working on a solution, it would be
good to already have this test in Node.js to avoid unnecessary
accidental breakage.

Refs: https://github.com/nodejs/node-v8/issues/115

---

Fyi @targos @titzer 

There would be two ways to approach fixing this – either we make V8 more aware of the lifetime management of `ArrayBuffer::Allocator`s by holding a `shared_ptr` to them itself from the backing stores and get rid of the mechanism we use for tracking `SharedArrayBuffer` lifetime manually in Node.js, or we expand that mechanism to also account for non-shared `ArrayBuffer`s. Both solutions would require a non-trivial amount of work, although they should be somewhat straightforward.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
