### PR TITLE
crypto: add keyObject.params for asymmetric keys

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1311,10 +1311,10 @@ PKCS#1 and SEC1 encryption.
 
 ### keyObject.params
 <!-- YAML
-added: README
+added: REPLACEME
 -->
 
-* {object}
+* {Object}
 
 This property exists only on asymmetric keys. Depending on the type of the key,
 this object contains information about the key. None of the information obtained

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1309,6 +1309,26 @@ encryption mechanism, PEM-level encryption is not supported when encrypting
 a PKCS#8 key. See [RFC 5208][] for PKCS#8 encryption and [RFC 1421][] for
 PKCS#1 and SEC1 encryption.
 
+### keyObject.params
+<!-- YAML
+added: README
+-->
+
+* {object}
+
+This property exists only on asymmetric keys. Depending on the type of the key,
+this object contains information about the key. None of the information obtained
+through this property can be used to uniquely identify a key or to compromise
+the security of the key.
+
+For `'rsa'` and `'rsa-pss'` keys, this object has the property `modulusLength`.
+
+For `'dsa'` keys, this object has the properties `modulusLength` and
+`divisorLength`.
+
+For `'ec'` keys with a known curve, this object has the string property
+`namedCurve`.
+
 ### keyObject.symmetricKeySize
 <!-- YAML
 added: v11.6.0

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -76,11 +76,17 @@ class SecretKeyObject extends KeyObject {
 }
 
 const kAsymmetricKeyType = Symbol('kAsymmetricKeyType');
+const kParams = Symbol('kParams');
 
 class AsymmetricKeyObject extends KeyObject {
   get asymmetricKeyType() {
     return this[kAsymmetricKeyType] ||
            (this[kAsymmetricKeyType] = this[kHandle].getAsymmetricKeyType());
+  }
+
+  get params() {
+    return this[kParams] ||
+           (this[kParams] = this[kHandle].getAsymmetricParams());
   }
 }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3926,10 +3926,10 @@ static inline void SetParam(Environment* env, Local<Object> params,
 }
 
 Local<Value> KeyObject::GetAsymmetricParams() const {
-  CHECK_NE(this->key_type_, kKeyTypeSecret);
+  CHECK_NE(key_type_, kKeyTypeSecret);
 
   Local<Object> params = Object::New(env()->isolate());
-  EVP_PKEY* pkey = this->asymmetric_key_.get();
+  EVP_PKEY* pkey = asymmetric_key_.get();
   RSA* rsa;
   DSA* dsa;
   EC_KEY* ec;
@@ -3949,7 +3949,6 @@ Local<Value> KeyObject::GetAsymmetricParams() const {
              Integer::New(env()->isolate(), RSA_bits(rsa)));
     // TODO(tniessen): Add publicExponent.
     break;
-    return env()->crypto_rsa_pss_string();
   case EVP_PKEY_DSA:
     dsa = EVP_PKEY_get0_DSA(pkey);
     SetParam(env(), params, "modulusLength",
@@ -3961,7 +3960,7 @@ Local<Value> KeyObject::GetAsymmetricParams() const {
     ec = EVP_PKEY_get0_EC_KEY(pkey);
     ec_group = EC_KEY_get0_group(ec);
     ec_curve_id = EC_GROUP_get_curve_name(ec_group);
-    if (ec_curve_id != 0) {
+    if (ec_curve_id != NID_undef) {
       ec_curve_name = OBJ_nid2sn(ec_curve_id);
       if (ec_curve_name != nullptr) {
         SetParam(env(), params, "namedCurve",

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -440,6 +440,9 @@ class KeyObject : public BaseObject {
   static void GetAsymmetricKeyType(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   v8::Local<v8::Value> GetAsymmetricKeyType() const;
+  static void GetAsymmetricParams(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+  v8::Local<v8::Value> GetAsymmetricParams() const;
 
   static void GetSymmetricKeySize(
       const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -120,17 +120,20 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.strictEqual(publicKey.type, 'public');
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
   assert.strictEqual(publicKey.symmetricKeySize, undefined);
+  assert.strictEqual(publicKey.params.modulusLength, 2048);
 
   const privateKey = createPrivateKey(privatePem);
   assert.strictEqual(privateKey.type, 'private');
   assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
   assert.strictEqual(privateKey.symmetricKeySize, undefined);
+  assert.strictEqual(privateKey.params.modulusLength, 2048);
 
   // It should be possible to derive a public key from a private key.
   const derivedPublicKey = createPublicKey(privateKey);
   assert.strictEqual(derivedPublicKey.type, 'public');
   assert.strictEqual(derivedPublicKey.asymmetricKeyType, 'rsa');
   assert.strictEqual(derivedPublicKey.symmetricKeySize, undefined);
+  assert.strictEqual(derivedPublicKey.params.modulusLength, 2048);
 
   // Test exporting with an invalid options object, this should throw.
   for (const opt of [undefined, null, 'foo', 0, NaN]) {
@@ -293,6 +296,8 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.strictEqual(publicKey.type, 'public');
   assert.strictEqual(publicKey.asymmetricKeyType, 'dsa');
   assert.strictEqual(publicKey.symmetricKeySize, undefined);
+  assert.strictEqual(publicKey.params.modulusLength, 1088);
+  assert.strictEqual(publicKey.params.divisorLength, 160);
 
   const privateKey = createPrivateKey({
     key: privateDsa,
@@ -302,7 +307,8 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.strictEqual(privateKey.type, 'private');
   assert.strictEqual(privateKey.asymmetricKeyType, 'dsa');
   assert.strictEqual(privateKey.symmetricKeySize, undefined);
-
+  assert.strictEqual(privateKey.params.modulusLength, 1088);
+  assert.strictEqual(privateKey.params.divisorLength, 160);
 }
 
 {
@@ -318,9 +324,11 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
 
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa-pss');
+    assert.strictEqual(publicKey.params.modulusLength, 2048);
 
     assert.strictEqual(privateKey.type, 'private');
     assert.strictEqual(privateKey.asymmetricKeyType, 'rsa-pss');
+    assert.strictEqual(privateKey.params.modulusLength, 2048);
 
     for (const key of [privatePem, privateKey]) {
       // Any algorithm should work.

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -122,10 +122,12 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   assert.strictEqual(typeof publicKey, 'object');
   assert.strictEqual(publicKey.type, 'public');
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
+  assert.strictEqual(publicKey.params.modulusLength, 512);
 
   assert.strictEqual(typeof privateKey, 'object');
   assert.strictEqual(privateKey.type, 'private');
   assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
+  assert.strictEqual(privateKey.params.modulusLength, 512);
 }
 
 {
@@ -465,6 +467,22 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 
     testSignVerify(publicKey, { key: privateKey, passphrase: 'secret' });
   }));
+
+  generateKeyPair('ec', {
+    namedCurve: 'secp521r1'
+  }, common.mustCall((err, publicKey, privateKey) => {
+    assert.ifError(err);
+
+    assert.strictEqual(publicKey.type, 'public');
+    assert.strictEqual(publicKey.asymmetricKeyType, 'ec');
+    assert.strictEqual(publicKey.params.namedCurve, 'secp521r1');
+
+    assert.strictEqual(privateKey.type, 'private');
+    assert.strictEqual(privateKey.asymmetricKeyType, 'ec');
+    assert.strictEqual(privateKey.params.namedCurve, 'secp521r1');
+
+    testSignVerify(publicKey, privateKey);
+  }));
 }
 
 {
@@ -643,6 +661,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     assert.strictEqual(typeof publicKey, 'object');
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
+    assert.strictEqual(publicKey.params.modulusLength, 1024);
 
     // The private key should still be a string.
     assert.strictEqual(typeof privateKey, 'string');
@@ -667,6 +686,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     assert.strictEqual(typeof privateKey, 'object');
     assert.strictEqual(privateKey.type, 'private');
     assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
+    assert.strictEqual(privateKey.params.modulusLength, 1024);
 
     testEncryptDecrypt(publicKey, privateKey);
     testSignVerify(publicKey, privateKey);


### PR DESCRIPTION
This API exposes key parameters. It is conceptually different from the previously discussed `keyObject.fields` property since it does not give access to information that could compromise the security of the key, and the obtained information cannot be used to uniquely identify a key.

The intended purpose is to determine "security properties" of keys, e.g. to generate a new key pair with the same parameters, or to decide whether a key is secure enough.

I have not implemented the `publicExponent` property yet, mostly because I am not sure whether to use a `number` or a `BigInt`. In practice, most (all?) public exponents will fit into 32 bits and thus easily into `Number.MAX_SAFE_INTEGER`, and `generateKeyPair` currently only accepts safe integers, too. However, in theory, public exponents can be almost arbitrarily long, even though it can introduce efficiency and security concerns. I would like to hear opinions from @nodejs/crypto (or others).

Refs: https://github.com/nodejs/webcrypto/issues/16

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
