### PR TITLE
doc: --enable-source-maps and prepareStackTrace are incompatible

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -144,7 +144,6 @@ added: v12.12.0
 
 Enable experimental Source Map V3 support for stack traces.
 
-
 Currently, overriding `Error.prepareStackTrace` is ignored when the
 `--enable-source-maps` flag is set.
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -144,6 +144,9 @@ added: v12.12.0
 
 Enable experimental Source Map V3 support for stack traces.
 
+Note, that `--enable-source-maps` does not work in conjunction with the
+`Error.prepareStackTrace` hook.
+
 ### `--es-module-specifier-resolution=mode`
 <!-- YAML
 added: v12.0.0

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -144,8 +144,9 @@ added: v12.12.0
 
 Enable experimental Source Map V3 support for stack traces.
 
-Note, that `--enable-source-maps` does not work in conjunction with the
-`Error.prepareStackTrace` hook.
+
+Currently, overriding `Error.prepareStackTrace` is ignored when the
+`--enable-source-maps` flag is set.
 
 ### `--es-module-specifier-resolution=mode`
 <!-- YAML


### PR DESCRIPTION
document the fact that `--enable-source-maps` and `prepareStackTrace` are
incompatible, see #29994

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
