### PR TITLE
build: python3 support for configure

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -12,6 +12,7 @@ import shlex
 import subprocess
 import shutil
 import bz2
+import io
 
 from distutils.spawn import find_executable as which
 from distutils.version import StrictVersion
@@ -1497,10 +1498,11 @@ def configure_intl(o):
   icu_ver_major = None
   matchVerExp = r'^\s*#define\s+U_ICU_VERSION_SHORT\s+"([^"]*)".*'
   match_version = re.compile(matchVerExp)
-  for line in open(uvernum_h).readlines():
-    m = match_version.match(line)
-    if m:
-      icu_ver_major = m.group(1)
+  with io.open(uvernum_h, encoding='utf8') as in_file:
+    for line in in_file:
+      m = match_version.match(line)
+      if m:
+        icu_ver_major = str(m.group(1))
   if not icu_ver_major:
     error('Could not read U_ICU_VERSION_SHORT version from %s' % uvernum_h)
   elif int(icu_ver_major) < icu_versions['minimum_icu']:


### PR DESCRIPTION
Discovered while messing with some infra switching things around to `python3`. On Linux, if you call `configure` directly with a `python3` (not letting it find `python` for you) and have `LC_ALL=C` set, as we do in some of our infra, apparently `open()` defaults to ascii. This is a problem for icu version detection because there's a `©` at the top of deps/icu-small/source/common/unicode/uvernum.h which it reads to find major version number.

```
$ LC_ALL=C python3 ./configure.py
Traceback (most recent call last):
  File "./configure.py", line 1660, in <module>
    configure_intl(output)
  File "./configure.py", line 1498, in configure_intl
    for line in open(uvernum_h).readlines():
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 3: ordinal not in range(128)
```

This change fixes it and makes it work for Python 2 & 3. Although I don't really know what I'm doing  with the conversion back to ascii for later compatibility so someone who knows better should check.