### PR TITLE
crypto: guard with OPENSSL_NO_GOST

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2735,7 +2735,7 @@ void SSLWrap<Base>::GetSharedSigalgs(const FunctionCallbackInfo<Value>& args) {
       case NID_ED448:
         sig_with_md = "Ed448+";
         break;
-
+#ifndef OPENSSL_NO_GOST
       case NID_id_GostR3410_2001:
         sig_with_md = "gost2001+";
         break;
@@ -2747,7 +2747,7 @@ void SSLWrap<Base>::GetSharedSigalgs(const FunctionCallbackInfo<Value>& args) {
       case NID_id_GostR3410_2012_512:
         sig_with_md = "gost2012_512+";
         break;
-
+#endif  // !OPENSSL_NO_GOST
       default:
         const char* sn = OBJ_nid2sn(sign_nid);
 


### PR DESCRIPTION
This PR wraps references to Gost-based NIDs inside `GetSharedSigalgs` with `OPENSSL_NO_GOST`. This helps prevent compilation failures in Electron owing to BoringSSL incompatibilities as well as reduces the size of Node's shipped binary by removing some potentially unnecessary code.

cc @tniessen

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
