### PR TITLE
doc: claim NODE_MODULE_VERSION=80 for Electron 9

### DIFF
--- a/doc/abi_version_registry.json
+++ b/doc/abi_version_registry.json
@@ -1,5 +1,6 @@
 {
   "NODE_MODULE_VERSION": [
+    { "modules": 80, "runtime": "electron", "variant": "electron",             "versions": "9" },
     { "modules": 79, "runtime": "node",     "variant": "v8_7.8",               "versions": "13" },
     { "modules": 78, "runtime": "node",     "variant": "v8_7.7",               "versions": "13.0.0-pre" },
     { "modules": 77, "runtime": "node",     "variant": "v8_7.6",               "versions": "13.0.0-pre" },


### PR DESCRIPTION
As in title, just claiming our next number