### PR TITLE
boostrap: polyfill globalThis internally and stop using global

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -56,7 +56,6 @@ globals:
   DCHECK_LT: false
   DCHECK_NE: false
   # Parameters passed to internal modules
-  global: false
   require: false
   process: false
   exports: false

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -287,7 +287,8 @@ NativeModule.prototype.compile = function() {
       requireWithFallbackInDeps : nativeModuleRequire;
 
     const fn = compileFunction(id);
-    fn(this.exports, requireFn, this, process, internalBinding, primordials);
+    fn(this.exports, requireFn, this, process,
+       internalBinding, primordials, globalThis);
 
     this.loaded = true;
   } finally {

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -167,34 +167,35 @@ if (!config.noBrowserGlobals) {
   // Override global console from the one provided by the VM
   // to the one implemented by Node.js
   // https://console.spec.whatwg.org/#console-namespace
-  exposeNamespace(global, 'console', createGlobalConsole(global.console));
+  exposeNamespace(globalThis, 'console',
+                  createGlobalConsole(globalThis.console));
 
   const { URL, URLSearchParams } = require('internal/url');
   // https://url.spec.whatwg.org/#url
-  exposeInterface(global, 'URL', URL);
+  exposeInterface(globalThis, 'URL', URL);
   // https://url.spec.whatwg.org/#urlsearchparams
-  exposeInterface(global, 'URLSearchParams', URLSearchParams);
+  exposeInterface(globalThis, 'URLSearchParams', URLSearchParams);
 
   const {
     TextEncoder, TextDecoder
   } = require('internal/encoding');
   // https://encoding.spec.whatwg.org/#textencoder
-  exposeInterface(global, 'TextEncoder', TextEncoder);
+  exposeInterface(globalThis, 'TextEncoder', TextEncoder);
   // https://encoding.spec.whatwg.org/#textdecoder
-  exposeInterface(global, 'TextDecoder', TextDecoder);
+  exposeInterface(globalThis, 'TextDecoder', TextDecoder);
 
   // https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope
   const timers = require('timers');
-  defineOperation(global, 'clearInterval', timers.clearInterval);
-  defineOperation(global, 'clearTimeout', timers.clearTimeout);
-  defineOperation(global, 'setInterval', timers.setInterval);
-  defineOperation(global, 'setTimeout', timers.setTimeout);
+  defineOperation(globalThis, 'clearInterval', timers.clearInterval);
+  defineOperation(globalThis, 'clearTimeout', timers.clearTimeout);
+  defineOperation(globalThis, 'setInterval', timers.setInterval);
+  defineOperation(globalThis, 'setTimeout', timers.setTimeout);
 
-  defineOperation(global, 'queueMicrotask', queueMicrotask);
+  defineOperation(globalThis, 'queueMicrotask', queueMicrotask);
 
   // Non-standard extensions:
-  defineOperation(global, 'clearImmediate', timers.clearImmediate);
-  defineOperation(global, 'setImmediate', timers.setImmediate);
+  defineOperation(globalThis, 'clearImmediate', timers.clearImmediate);
+  defineOperation(globalThis, 'setImmediate', timers.setImmediate);
 }
 
 // Set the per-Environment callback that will be called
@@ -328,7 +329,7 @@ function setupProcessObject() {
     value: 'process'
   });
   // Make process globally available to users by putting it on the global proxy
-  Object.defineProperty(global, 'process', {
+  Object.defineProperty(globalThis, 'process', {
     value: process,
     enumerable: false,
     writable: true,
@@ -362,7 +363,14 @@ function setupProcessStdio(getStdout, getStdin, getStderr) {
 }
 
 function setupGlobalProxy() {
-  Object.defineProperty(global, Symbol.toStringTag, {
+  Object.defineProperty(globalThis, 'global', {
+    value: globalThis,
+    writable: true,
+    enumerable: true,
+    configurable: true
+  });
+
+  Object.defineProperty(globalThis, Symbol.toStringTag, {
     value: 'global',
     writable: false,
     enumerable: false,
@@ -386,7 +394,7 @@ function setupGlobalProxy() {
     }, `'${name}' is deprecated, use 'global'`, 'DEP0016');
   }
 
-  Object.defineProperties(global, {
+  Object.defineProperties(globalThis, {
     GLOBAL: {
       configurable: true,
       get: makeGetter('GLOBAL'),
@@ -409,7 +417,7 @@ function setupBuffer() {
   delete bufferBinding.setBufferPrototype;
   delete bufferBinding.zeroFill;
 
-  Object.defineProperty(global, 'Buffer', {
+  Object.defineProperty(globalThis, 'Buffer', {
     value: Buffer,
     enumerable: false,
     writable: true,

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -288,11 +288,11 @@ function initializeDeprecations() {
                                       'DEP0134');
   }
 
-  // Create global.process and global.Buffer as getters so that we have a
-  // deprecation path for these in ES Modules.
+  // Create globalThis.process and globalThis.Buffer as getters so that
+  // we have a deprecation path for these in ES Modules.
   // See https://github.com/nodejs/node/pull/26334.
   let _process = process;
-  Object.defineProperty(global, 'process', {
+  Object.defineProperty(globalThis, 'process', {
     get() {
       return _process;
     },
@@ -304,7 +304,7 @@ function initializeDeprecations() {
   });
 
   let _Buffer = Buffer;
-  Object.defineProperty(global, 'Buffer', {
+  Object.defineProperty(globalThis, 'Buffer', {
     get() {
       return _Buffer;
     },

--- a/lib/internal/main/eval_string.js
+++ b/lib/internal/main/eval_string.js
@@ -12,7 +12,7 @@ const { addBuiltinLibsToObject } = require('internal/modules/cjs/helpers');
 const { getOptionValue } = require('internal/options');
 
 prepareMainThreadExecution();
-addBuiltinLibsToObject(global);
+addBuiltinLibsToObject(globalThis);
 markBootstrapComplete();
 
 const source = getOptionValue('--eval');

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -84,7 +84,7 @@ primordials.SafePromise = makeSafe(
   'Reflect'
 ].forEach((name) => {
   const target = primordials[name] = Object.create(null);
-  copyProps(global[name], target);
+  copyProps(globalThis[name], target);
 });
 
 // Create copies of intrinsic objects
@@ -103,7 +103,7 @@ primordials.SafePromise = makeSafe(
   'String',
   'Symbol',
 ].forEach((name) => {
-  const original = global[name];
+  const original = globalThis[name];
   const target = primordials[name] = Object.setPrototypeOf({
     [name]: function(...args) {
       return new.target ?

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -57,20 +57,20 @@ function evalScript(name, body, breakFirstLine, print) {
   const { kVmBreakFirstLineSymbol } = require('internal/util');
 
   const cwd = tryGetCwd();
-  const origModule = global.module;  // Set e.g. when called from the REPL.
+  const origModule = globalThis.module;  // Set e.g. when called from the REPL.
 
   const module = new CJSModule(name);
   module.filename = path.join(cwd, name);
   module.paths = CJSModule._nodeModulePaths(cwd);
-  global.kVmBreakFirstLineSymbol = kVmBreakFirstLineSymbol;
+  globalThis.kVmBreakFirstLineSymbol = kVmBreakFirstLineSymbol;
   const script = `
-    global.__filename = ${JSON.stringify(name)};
-    global.exports = exports;
-    global.module = module;
-    global.__dirname = __dirname;
-    global.require = require;
-    const { kVmBreakFirstLineSymbol } = global;
-    delete global.kVmBreakFirstLineSymbol;
+    globalThis.__filename = ${JSON.stringify(name)};
+    globalThis.exports = exports;
+    globalThis.module = module;
+    globalThis.__dirname = __dirname;
+    globalThis.require = require;
+    const { kVmBreakFirstLineSymbol } = globalThis;
+    delete globalThis.kVmBreakFirstLineSymbol;
     return require("vm").runInThisContext(
       ${JSON.stringify(body)}, {
         filename: ${JSON.stringify(name)},
@@ -84,7 +84,7 @@ function evalScript(name, body, breakFirstLine, print) {
   }
 
   if (origModule !== undefined)
-    global.module = origModule;
+    globalThis.module = origModule;
 }
 
 const exceptionHandlerState = { captureFn: null };

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -94,7 +94,7 @@ const { NativeModule } = require('internal/bootstrap/loaders');
 let hexSlice;
 
 const builtInObjects = new Set(
-  Object.getOwnPropertyNames(global).filter((e) => /^([A-Z][a-z]+)+$/.test(e))
+  Object.getOwnPropertyNames(globalThis).filter((e) => /^([A-Z][a-z]+)+$/.test(e))
 );
 
 const inspectDefaultOptions = Object.seal({

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -876,7 +876,7 @@ REPLServer.prototype.close = function close() {
 REPLServer.prototype.createContext = function() {
   let context;
   if (this.useGlobal) {
-    context = global;
+    context = globalThis;
   } else {
     sendInspectorCommand((session) => {
       session.post('Runtime.enable');
@@ -888,11 +888,11 @@ REPLServer.prototype.createContext = function() {
     }, () => {
       context = vm.createContext();
     });
-    for (const name of Object.getOwnPropertyNames(global)) {
+    for (const name of Object.getOwnPropertyNames(globalThis)) {
       // Only set properties on the context that do not exist as primordial.
       if (!(name in primordials)) {
-        Object.defineProperty(context, name,
-                              Object.getOwnPropertyDescriptor(global, name));
+        Object.defineProperty(
+          context, name, Object.getOwnPropertyDescriptor(globalThis, name));
       }
     }
     context.global = context;

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -419,7 +419,10 @@ bool InitializeContext(Local<Context> context) {
 
     Local<String> primordials_string =
         FIXED_ONE_BYTE_STRING(isolate, "primordials");
-    Local<String> global_string = FIXED_ONE_BYTE_STRING(isolate, "global");
+    // TODO(joyeecheung): remove this once we only need to support V8
+    // that ships globalThis.
+    Local<String> global_this_string =
+        FIXED_ONE_BYTE_STRING(isolate, "globalThis");
     Local<String> exports_string = FIXED_ONE_BYTE_STRING(isolate, "exports");
 
     // Create primordials first and make it available to per-context scripts.
@@ -436,7 +439,7 @@ bool InitializeContext(Local<Context> context) {
 
     for (const char** module = context_files; *module != nullptr; module++) {
       std::vector<Local<String>> parameters = {
-          global_string, exports_string, primordials_string};
+          global_this_string, exports_string, primordials_string};
       Local<Value> arguments[] = {context->Global(), exports, primordials};
       MaybeLocal<Function> maybe_fn =
           native_module::NativeModuleEnv::LookupAndCompile(

--- a/src/node.cc
+++ b/src/node.cc
@@ -279,7 +279,10 @@ MaybeLocal<Value> Environment::BootstrapInternalLoaders() {
       process_string(),
       FIXED_ONE_BYTE_STRING(isolate_, "getLinkedBinding"),
       FIXED_ONE_BYTE_STRING(isolate_, "getInternalBinding"),
-      primordials_string()};
+      primordials_string(),
+      // TODO(joyeecheung): remove this once we only need to support V8
+      // that ships globalThis.
+      FIXED_ONE_BYTE_STRING(isolate_, "globalThis")};
   std::vector<Local<Value>> loaders_args = {
       process_object(),
       NewFunctionTemplate(binding::GetLinkedBinding)
@@ -288,7 +291,8 @@ MaybeLocal<Value> Environment::BootstrapInternalLoaders() {
       NewFunctionTemplate(binding::GetInternalBinding)
           ->GetFunction(context())
           .ToLocalChecked(),
-      primordials()};
+      primordials(),
+      context()->Global()};
 
   // Bootstrap internal loaders
   Local<Value> loader_exports;
@@ -315,27 +319,26 @@ MaybeLocal<Value> Environment::BootstrapInternalLoaders() {
 MaybeLocal<Value> Environment::BootstrapNode() {
   EscapableHandleScope scope(isolate_);
 
-  Local<Object> global = context()->Global();
-  // TODO(joyeecheung): this can be done in JS land now.
-  global->Set(context(), FIXED_ONE_BYTE_STRING(isolate_, "global"), global)
-      .Check();
-
   // process, require, internalBinding, isMainThread,
-  // ownsProcessState, primordials
+  // ownsProcessState, primordials, globalThis
   std::vector<Local<String>> node_params = {
       process_string(),
       require_string(),
       internal_binding_string(),
       FIXED_ONE_BYTE_STRING(isolate_, "isMainThread"),
       FIXED_ONE_BYTE_STRING(isolate_, "ownsProcessState"),
-      primordials_string()};
+      primordials_string(),
+      // TODO(joyeecheung): remove this once we only need to support V8
+      // that ships globalThis.
+      FIXED_ONE_BYTE_STRING(isolate_, "globalThis")};
   std::vector<Local<Value>> node_args = {
       process_object(),
       native_module_require(),
       internal_binding_loader(),
       Boolean::New(isolate_, is_main_thread()),
       Boolean::New(isolate_, owns_process_state()),
-      primordials()};
+      primordials(),
+      context()->Global()};
 
   MaybeLocal<Value> result = ExecuteBootstrapper(
       this, "internal/bootstrap/node", &node_params, &node_args);

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -169,7 +169,10 @@ MaybeLocal<Function> NativeModuleLoader::CompileAsModule(
       FIXED_ONE_BYTE_STRING(isolate, "module"),
       FIXED_ONE_BYTE_STRING(isolate, "process"),
       FIXED_ONE_BYTE_STRING(isolate, "internalBinding"),
-      FIXED_ONE_BYTE_STRING(isolate, "primordials")};
+      FIXED_ONE_BYTE_STRING(isolate, "primordials"),
+      // TODO(joyeecheung): remove this once we only need to support V8
+      // that ships globalThis.
+      FIXED_ONE_BYTE_STRING(isolate, "globalThis")};
   return LookupAndCompile(context, id, &parameters, result);
 }
 


### PR DESCRIPTION
This patch adds a contextual polyfill of the stage-4 globalThis
object for internal JavaScript and migrate to that instead of using
`global` internally. With this we can just define the `global`
alias in `bootstrap/node.js` instead of in C++.
We use a polyfill here instead of using the object shipped by
V8 directly to reduce the churn of backports.

Refs: https://github.com/tc39/proposal-global

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
