### PR TITLE
repl: fix current path for dynamic module imports

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -325,7 +325,7 @@ function REPLServer(prompt,
     let pwd;
     try {
       const { pathToFileURL } = require('url');
-      pwd = pathToFileURL(process.cwd()).href;
+      pwd = pathToFileURL(`${process.cwd()}/`).href;
     } catch {
     }
     while (true) {

--- a/test/parallel/test-repl-dynamic-import.js
+++ b/test/parallel/test-repl-dynamic-import.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// Flags: --experimental-modules
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const net = require('net');
+
+if (!common.isMainThread)
+  common.skip('process.chdir is not available in Workers');
+
+process.chdir(fixtures.fixturesDir);
+const repl = require('repl');
+
+const server = net.createServer((conn) => {
+  repl.start('', conn).on('exit', () => {
+    conn.destroy();
+    server.close();
+  });
+});
+
+const host = common.localhostIPv4;
+const port = 0;
+const options = { host, port };
+
+let answer = '';
+let expectedDataEvents = 2;
+server.listen(options, function() {
+  options.port = this.address().port;
+  const conn = net.connect(options);
+  conn.setEncoding('utf8');
+  conn.on('data', (data) => {
+    answer += data;
+    if (--expectedDataEvents === 0) {
+      conn.write('.exit\n');
+    }
+  });
+  conn.write('import("./es-modules/message.mjs").then(console.log)\n');
+});
+
+process.on('exit', function() {
+  assert.strictEqual(/Cannot find module/.test(answer), false);
+  assert.strictEqual(/Error/.test(answer), false);
+  assert.strictEqual(/{ message: 'A message' }/.test(answer), true);
+});


### PR DESCRIPTION
There was a terminal `/` missing from the current path when calling `import()` from the REPL. This means that in a dir `/foo/bar` calling `import('./dog.js')` will look for `/foo/dog.js`, even though it should be looking for `/foo/bar/dog.js`.

Here's a minimal reproduction:

```text
docker run -it --rm node:12.13.0 bash

mkdir -p /tmp/foo/bar
cd /tmp/foo/bar
echo "console.log('Yes, this is dog')" > dog.js
echo "import('./dog.js')" > call.js

node --experimental-modules call.js
(node:8) ExperimentalWarning: The ESM module loader is experimental.
Yes, this is dog

node --experimental-modules
Welcome to Node.js v12.13.0.
Type ".help" for more information.
> (node:15) ExperimentalWarning: The ESM module loader is experimental.

> import('./dog.js').then(console.log, console.error)
Promise { <pending> }
> Error: Cannot find module /tmp/foo/dog.js imported from /tmp/foo/bar
    at Loader.resolve [as _resolve] (internal/modules/esm/default_resolve.js:82:13)
    at Loader.resolve (internal/modules/esm/loader.js:73:33)
    at Loader.getModuleJob (internal/modules/esm/loader.js:147:40)
    at Loader.import (internal/modules/esm/loader.js:131:28)
    at vm.createScript.importModuleDynamically (repl.js:343:59)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async importModuleDynamicallyWrapper (internal/vm/source_text_module.js:292:17) {
  code: 'ERR_MODULE_NOT_FOUND'
}

> import(path.resolve('./dog.js')).then(console.log, console.error)
Promise { <pending> }
> Yes, this is dog
[Module] { default: {} }
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
