### PR TITLE
process: set process.env prototype to null

### DIFF
--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -20,6 +20,7 @@ using v8::Name;
 using v8::NamedPropertyHandlerConfiguration;
 using v8::NewStringType;
 using v8::Nothing;
+using v8::Null;
 using v8::Object;
 using v8::ObjectTemplate;
 using v8::PropertyCallbackInfo;
@@ -353,6 +354,8 @@ MaybeLocal<Object> CreateEnvVarProxy(Local<Context> context,
   env_proxy_template->SetHandler(NamedPropertyHandlerConfiguration(
       EnvGetter, EnvSetter, EnvQuery, EnvDeleter, EnvEnumerator, data,
       PropertyHandlerFlags::kHasNoSideEffect));
-  return scope.EscapeMaybe(env_proxy_template->NewInstance(context));
+  MaybeLocal<Object> env_proxy = env_proxy_template->NewInstance(context);
+  CHECK(env_proxy.ToLocalChecked()->SetPrototype(context, Null(isolate)).FromJust());
+  return scope.EscapeMaybe(env_proxy);
 }
 }  // namespace node

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -354,8 +354,15 @@ MaybeLocal<Object> CreateEnvVarProxy(Local<Context> context,
   env_proxy_template->SetHandler(NamedPropertyHandlerConfiguration(
       EnvGetter, EnvSetter, EnvQuery, EnvDeleter, EnvEnumerator, data,
       PropertyHandlerFlags::kHasNoSideEffect));
-  MaybeLocal<Object> env_proxy = env_proxy_template->NewInstance(context);
-  CHECK(env_proxy.ToLocalChecked()->SetPrototype(context, Null(isolate)).FromJust());
-  return scope.EscapeMaybe(env_proxy);
+
+  MaybeLocal<Object> env_proxy_ml = env_proxy_template->NewInstance(context);
+  Local<Object> env_proxy;
+  if (!env_proxy_ml.ToLocal(&env_proxy)) {
+    return MaybeLocal<Object>();
+  }
+
+  CHECK(env_proxy->SetPrototype(context, Null(isolate)).FromJust());
+
+  return scope.Escape(env_proxy);
 }
 }  // namespace node

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -361,7 +361,9 @@ MaybeLocal<Object> CreateEnvVarProxy(Local<Context> context,
     return MaybeLocal<Object>();
   }
 
-  CHECK(env_proxy->SetPrototype(context, Null(isolate)).FromJust());
+  if (env_proxy->SetPrototype(context, Null(isolate)).IsNothing()) {
+    return MaybeLocal<Object>();
+  }
 
   return scope.Escape(env_proxy);
 }


### PR DESCRIPTION
This removes all  `Object.prototype` inherited features from `process.env` which make this a breaking change (e.g. `hasOwnProperty()`, `toString()` etc). Due to this, it might not be feasible to land this PR, but I wanted to create it, if nothing else, as a forum where we could have the discussion (I could have made an issue, but already had the code ready).

#### Why?

This is a naive attempt to protect Node.js apps a little better against [prototype pollution](https://www.youtube.com/watch?v=LUsiFV3dsK8) attacks. Environment variables are often used to configure an application. They are also used to configure Node.js itself (e.g. `NODE_OPTIONS`).

Since prototype pollution affects all normal objects in Node.js, you could argue that we shouldn't treat `process.env` in a special way. The reason I went down this rabbit hole anyway was that `process.env` is so powerful that it might deserve special treatment.

It came to my attention in #30008 that `spawn` and friends from the `child_process` module defaults to using `process.env` if no special `env` property is given in options. This means that all child processes spawned can be easily attacked using prototype pollution. This of course also applies to the main process if `process.env.*` is checked at runtime. So while the particular issue with child processes will be fixed by #30008, I felt it might be worth it fixing this for `process.env` in general.

#### Performance

@joyeecheung raised a valid point in #node-dev on IRC about whether or not property access performance of `process.env` would be impacted if we removed the prototype. It seems that since the object is created in C++ land, this doesn't affect it:

```
$ ./node --allow-natives-syntax
Welcome to Node.js v13.0.0-pre.
Type ".help" for more information.
> Object.getPrototypeOf(process.env)
null
> %HasFastProperties(process.env)
true
```

If we want to continue with this, we should consider running the benchmarks as well.

#### State of this PR

My C++ code might not be ideal. But at least it compiles and gets the point across. There is one failing test in [`test/parallel/test-process-env.js`](https://github.com/nodejs/node/blob/master/test/parallel/test-process-env.js), as that actually checks if `process.env` inherits from `Object.prototype`:

https://github.com/nodejs/node/blob/31217a8e88d7414579284267f8715112bf8a0fc6/test/parallel/test-process-env.js#L41-L42

I traced that test back to fee02db705152a42c8db442d3ab76b2296e59bbd, where it also seems like inheritance from `Object.prototype` was introduced (if I'm reading the C++ correctly).

#### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)