### PR TITLE
deps: V8: cherry-pick ed40ab1

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.14',
+    'v8_embedder_string': '-node.15',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/regexp/regexp-ast.h
+++ b/deps/v8/src/regexp/regexp-ast.h
@@ -477,7 +477,7 @@ class RegExpCapture final : public RegExpTree {
   int max_match() override { return body_->max_match(); }
   RegExpTree* body() { return body_; }
   void set_body(RegExpTree* body) { body_ = body; }
-  int index() { return index_; }
+  int index() const { return index_; }
   const ZoneVector<uc16>* name() const { return name_; }
   void set_name(const ZoneVector<uc16>* name) { name_ = name; }
   static int StartRegister(int index) { return index * 2; }

--- a/deps/v8/test/mjsunit/harmony/regexp-named-captures.js
+++ b/deps/v8/test/mjsunit/harmony/regexp-named-captures.js
@@ -419,6 +419,15 @@ function toSlowMode(re) {
   assertEquals("cd", "abcd".replace(re, "$<$1>"));
 }
 
+// Named captures are ordered by capture index on the groups object.
+// https://crbug.com/v8/9822
+
+{
+  const r = /(?<BKey>.+)\s(?<AKey>.+)/;
+  const s = 'example string';
+  assertArrayEquals(["BKey", "AKey"], Object.keys(r.exec(s).groups));
+}
+
 // Tests for 'groups' semantics on the regexp result object.
 // https://crbug.com/v8/7192
 


### PR DESCRIPTION
Original commit message:

    [regexp] Fix the order of named captures on the groups object

    Named capture properties on the groups object should be ordered by the
    capture index (and not alpha-sorted). This was accidentally broken in
    https://crrev.com/c/1687413.

    Bug: v8:9822,v8:9423
    Change-Id: Iac6f866f077a1b7ce557ba47e8ba5d7e7014b3ce
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1864829
    Auto-Submit: Jakob Gruber <jgruber@chromium.org>
    Reviewed-by: Peter Marshall <petermarshall@chromium.org>
    Commit-Queue: Peter Marshall <petermarshall@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#64306}

Refs: https://github.com/v8/v8/commit/ed40ab15830d1a501effd00f4d3ffe66bd9ef97f
Fixes: https://github.com/nodejs/node/issues/29878
