### PR TITLE
src: split up InitializeContext

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -361,6 +361,9 @@ MaybeLocal<Object> GetPerContextExports(Local<Context> context) {
   return handle_scope.Escape(exports);
 }
 
+// Any initialization logic should be performed in
+// InitializeContext, because embedders don't necessarily
+// call NewContext and so they will experience breakages.
 Local<Context> NewContext(Isolate* isolate,
                           Local<ObjectTemplate> object_template) {
   auto context = Context::New(isolate, nullptr, object_template);
@@ -369,8 +372,6 @@ Local<Context> NewContext(Isolate* isolate,
   if (!InitializeContext(context)) {
     return Local<Context>();
   }
-
-  InitializeContextRuntime(context);
 
   return context;
 }
@@ -405,7 +406,7 @@ void InitializeContextRuntime(Local<Context> context) {
   }
 }
 
-bool InitializeContext(Local<Context> context) {
+bool InitializeContextForSnapshot(Local<Context> context) {
   Isolate* isolate = context->GetIsolate();
   HandleScope handle_scope(isolate);
 
@@ -456,6 +457,15 @@ bool InitializeContext(Local<Context> context) {
     }
   }
 
+  return true;
+}
+
+bool InitializeContext(Local<Context> context) {
+  if (!InitializeContextForSnapshot(context)) {
+    return false;
+  }
+
+  InitializeContextRuntime(context);
   return true;
 }
 


### PR DESCRIPTION
Refs https://github.com/electron/electron/pull/20684.
Refs https://github.com/nodejs/node/commit/1ec4154e507ba71d7aefca0a6e5c155be34e989a.

This PR splits out code from `InitializeContext` into a new function `InitializeContextForSnapshot` and moves the callsite of `InitializeContextRuntime` from `NewContext` to `InitializeContext` - embedders don't necessarily call `NewContext` and so we experienced a primordial-related crash:

<details>

```cpp
/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Helper (Renderer).app/Contents/MacOS/Electron Helper (Renderer)[69516]: ../../third_party/electron_node/src/env.cc:256:void node::Environment::CreateProperties(): Assertion `primordials->IsObject()' failed.
1: 0x107e8e3c5 node::Abort() [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 2: 0x107e8e14f node::Assert(node::AssertionInfo const&) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 3: 0x107e3527c node::EmitAsyncDestroy(node::Environment*, node::async_context) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 4: 0x107e362dc node::EmitAsyncDestroy(node::Environment*, node::async_context) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 5: 0x107e0d16d node::CreateEnvironment(node::IsolateData*, v8::Local<v8::Context>, int, char const* const*, int, char const* const*, bool) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 6: 0x1024e2b8f AtomInitializeICUandStartNode [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 7: 0x1024f959c AtomInitializeICUandStartNode [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 8: 0x1024f8796 AtomInitializeICUandStartNode [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 9: 0x107cb3048 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
10: 0x1060dc1d5 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
11: 0x1060e2b3a v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
12: 0x1060e2d5a v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
13: 0x106b2d6af v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
14: 0x1024fe179 AtomInitializeICUandStartNode [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
15: 0x107caa7f2 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
16: 0x106a397b0 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
17: 0x106fadee3 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
18: 0x106faa0f0 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
19: 0x106fa9817 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
20: 0x106fac8aa v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
21: 0x106fba636 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
22: 0x106b32cd1 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
23: 0x107ca0ca4 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
24: 0x107d2b1d9 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
25: 0x107d2b06b v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
26: 0x107c9ff25 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
27: 0x107ca0161 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
28: 0x107c7173d v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
29: 0x102a0e9bb AtomInitializeICUandStartNode [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
30: 0x107c86b86 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
31: 0x104a4309b v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
32: 0x104da29b5 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
33: 0x104da2aa3 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
34: 0x10472a2c2 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
35: 0x10473a27a v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
36: 0x10473a707 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
37: 0x104797d23 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
38: 0x1046d2ada v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
39: 0x10479768f v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
40: 0x7fff320ef683 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ [/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation]
41: 0x7fff320ef629 __CFRunLoopDoSource0 [/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation]
42: 0x7fff320d2feb __CFRunLoopDoSources0 [/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation]
43: 0x7fff320d25b5 __CFRunLoopRun [/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation]
44: 0x7fff320d1ebe CFRunLoopRunSpecific [/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation]
45: 0x7fff3433632f -[NSRunLoop(NSRunLoop) runMode:beforeDate:] [/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation]
46: 0x104798231 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
47: 0x104797058 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
48: 0x10473abe2 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
49: 0x10470e9a7 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
50: 0x107cea732 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
51: 0x103dd105c v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
52: 0x10607f6a9 v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
53: 0x102f6e3c4 AtomInitializeICUandStartNode [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
54: 0x102393194 AtomMain [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
55: 0x101a2b465  [/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin/8.0.0-nightly.20191021/Electron.app/Contents/Frameworks/Electron Helper (Renderer).app/Contents/MacOS/Electron Helper (Renderer)]
56: 0x7fff5e02b3d5 start [/usr/lib/system/libdyld.dylib]
Received signal 6
```

</details>

`InitializeContextRuntime` wasn't a public method, so we couldn't call it otherwise. To resolve this, 
any initialization logic should be performed in `InitializeContext` to minimize surface area of potential breakage for embedders like Electron.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
