### PR TITLE
Fix #30068: refactored to use arrow functions

### DIFF
--- a/test/addons/make-callback-recurse/test.js
+++ b/test/addons/make-callback-recurse/test.js
@@ -10,8 +10,8 @@ const makeCallback = binding.makeCallback;
 const mustCallCheckDomains = common.mustCall(checkDomains);
 
 // Make sure that using MakeCallback allows the error to propagate.
-assert.throws(function() {
-  makeCallback({}, function() {
+assert.throws(() => {
+  makeCallback({}, () => {
     throw new Error('hi from domain error');
   });
 }, /^Error: hi from domain error$/);
@@ -27,22 +27,22 @@ assert.throws(function() {
 
   // Processing of the MicrotaskQueue is manually handled by node. They are not
   // processed until after the nextTickQueue has been processed.
-  Promise.resolve(1).then(common.mustCall(function() {
+  Promise.resolve(1).then(common.mustCall(() => {
     results.push(7);
   }));
 
   // The nextTick should run after all immediately invoked calls.
-  process.nextTick(common.mustCall(function() {
+  process.nextTick(common.mustCall(() => {
     results.push(3);
 
     // Run same test again but while processing the nextTickQueue to make sure
     // the following MakeCallback call breaks in the middle of processing the
     // queue and allows the script to run normally.
-    process.nextTick(common.mustCall(function() {
+    process.nextTick(common.mustCall(() => {
       results.push(6);
     }));
 
-    makeCallback({}, common.mustCall(function() {
+    makeCallback({}, common.mustCall(() => {
       results.push(4);
     }));
 
@@ -54,7 +54,7 @@ assert.throws(function() {
   // MakeCallback is calling the function immediately, but should then detect
   // that a script is already in the middle of execution and return before
   // either the nextTickQueue or MicrotaskQueue are processed.
-  makeCallback({}, common.mustCall(function() {
+  makeCallback({}, common.mustCall(() => {
     results.push(1);
   }));
 
@@ -63,7 +63,7 @@ assert.throws(function() {
   // and process them immediately.
   results.push(2);
 
-  setImmediate(common.mustCall(function() {
+  setImmediate(common.mustCall(() => {
     for (let i = 0; i < results.length; i++) {
       assert.strictEqual(results[i], i,
                          `verifyExecutionOrder(${arg}) results: ${results}`);
@@ -72,14 +72,14 @@ assert.throws(function() {
       // The tests are first run on bootstrap during LoadEnvironment() in
       // src/node.cc. Now run the tests through node::MakeCallback().
       setImmediate(function() {
-        makeCallback({}, common.mustCall(function() {
+        makeCallback({}, common.mustCall(() => {
           verifyExecutionOrder(2);
         }));
       });
     } else if (arg === 2) {
       // Make sure there are no conflicts using node::MakeCallback()
       // within timers.
-      setTimeout(common.mustCall(function() {
+      setTimeout(common.mustCall(() => {
         verifyExecutionOrder(3);
       }), 10);
     } else if (arg === 3) {
@@ -94,16 +94,16 @@ assert.throws(function() {
 function checkDomains() {
   // Check that domains are properly entered/exited when called in multiple
   // levels from both node::MakeCallback() and AsyncWrap::MakeCallback
-  setImmediate(common.mustCall(function() {
+  setImmediate(common.mustCall(() => {
     const d1 = domain.create();
     const d2 = domain.create();
     const d3 = domain.create();
 
-    makeCallback({ domain: d1 }, common.mustCall(function() {
+    makeCallback({ domain: d1 }, common.mustCall(() => {
       assert.strictEqual(d1, process.domain);
-      makeCallback({ domain: d2 }, common.mustCall(function() {
+      makeCallback({ domain: d2 }, common.mustCall(() => {
         assert.strictEqual(d2, process.domain);
-        makeCallback({ domain: d3 }, common.mustCall(function() {
+        makeCallback({ domain: d3 }, common.mustCall(() => {
           assert.strictEqual(d3, process.domain);
         }));
         assert.strictEqual(d2, process.domain);
@@ -112,16 +112,16 @@ function checkDomains() {
     }));
   }));
 
-  setTimeout(common.mustCall(function() {
+  setTimeout(common.mustCall(() => {
     const d1 = domain.create();
     const d2 = domain.create();
     const d3 = domain.create();
 
-    makeCallback({ domain: d1 }, common.mustCall(function() {
+    makeCallback({ domain: d1 }, common.mustCall(() => {
       assert.strictEqual(d1, process.domain);
-      makeCallback({ domain: d2 }, common.mustCall(function() {
+      makeCallback({ domain: d2 }, common.mustCall(() => {
         assert.strictEqual(d2, process.domain);
-        makeCallback({ domain: d3 }, common.mustCall(function() {
+        makeCallback({ domain: d3 }, common.mustCall(() => {
           assert.strictEqual(d3, process.domain);
         }));
         assert.strictEqual(d2, process.domain);
@@ -134,10 +134,10 @@ function checkDomains() {
     // Make sure nextTick, setImmediate and setTimeout can all recover properly
     // after a thrown makeCallback call.
     const d = domain.create();
-    d.on('error', common.mustCall(function(e) {
+    d.on('error', common.mustCall((e) => {
       assert.strictEqual(e.message, `throw from domain ${id}`);
     }));
-    makeCallback({ domain: d }, function() {
+    makeCallback({ domain: d }, () => {
       throw new Error(`throw from domain ${id}`);
     });
     throw new Error('UNREACHABLE');


### PR DESCRIPTION
Modified `common.mustCall()` to use arrow functions.