### PR TITLE
http,https: increase server headers timeout

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1064,7 +1064,7 @@ Stops the server from accepting new connections. See [`net.Server.close()`][].
 added: v11.3.0
 -->
 
-* {number} **Default:** `40000`
+* {number} **Default:** `60000`
 
 Limit the amount of time the parser will wait to receive the complete HTTP
 headers.

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -69,7 +69,7 @@ See [`server.close()`][`http.close()`] from the HTTP module for details.
 added: v11.3.0
 -->
 
-* {number} **Default:** `40000`
+* {number} **Default:** `60000`
 
 See [`http.Server#headersTimeout`][].
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -335,7 +335,7 @@ function Server(options, requestListener) {
   this.timeout = 0;
   this.keepAliveTimeout = 5000;
   this.maxHeadersCount = null;
-  this.headersTimeout = 40 * 1000; // 40 seconds
+  this.headersTimeout = 60 * 1000; // 60 seconds
 }
 Object.setPrototypeOf(Server.prototype, net.Server.prototype);
 Object.setPrototypeOf(Server, net.Server);

--- a/lib/https.js
+++ b/lib/https.js
@@ -74,7 +74,7 @@ function Server(opts, requestListener) {
   this.timeout = 0;
   this.keepAliveTimeout = 5000;
   this.maxHeadersCount = null;
-  this.headersTimeout = 40 * 1000; // 40 seconds
+  this.headersTimeout = 60 * 1000; // 60 seconds
 }
 Object.setPrototypeOf(Server.prototype, tls.Server.prototype);
 Object.setPrototypeOf(Server, tls.Server);

--- a/test/parallel/test-http-slow-headers.js
+++ b/test/parallel/test-http-slow-headers.js
@@ -17,8 +17,8 @@ const headers =
 const server = createServer(common.mustNotCall());
 let sendCharEvery = 1000;
 
-// 40 seconds is the default
-assert.strictEqual(server.headersTimeout, 40 * 1000);
+// 60 seconds is the default
+assert.strictEqual(server.headersTimeout, 60 * 1000);
 
 // Pass a REAL env variable to shortening up the default
 // value which is 40s otherwise this is useful for manual

--- a/test/parallel/test-https-slow-headers.js
+++ b/test/parallel/test-https-slow-headers.js
@@ -27,8 +27,8 @@ const server = createServer({
 
 let sendCharEvery = 1000;
 
-// 40 seconds is the default
-assert.strictEqual(server.headersTimeout, 40 * 1000);
+// 60 seconds is the default
+assert.strictEqual(server.headersTimeout, 60 * 1000);
 
 // Pass a REAL env variable to shortening up the default
 // value which is 40s otherwise


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/24980
Refs: https://github.com/nodejs/node/commit/eb43bc04b1

Increases the default server headers timeout from 40 seconds to 60 seconds in order to not break compatibility with AWS ELBs in the default configuration.

Over the last several months, I have helped no fewer than 20 different groups of people in Slack teams resolve this issue. I believe that this is worth of a change even though it was originally a security fix because this change keeps intact the intended fix, but restores compatibility in the default configuration with any load balancer that prewarms TCP connections and holds them for over 40 seconds, just like AWS ELBs do.

Node in its default configuration should not be broken with AWS ELBs.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
