### PR TITLE
src: add missing V8::ShutdownPlatform() call

### DIFF
--- a/src/node_v8_platform-inl.h
+++ b/src/node_v8_platform-inl.h
@@ -99,8 +99,8 @@ struct V8Platform {
   }
 
   inline void Dispose() {
-    v8::V8::ShutdownPlatform();
     StopTracingAgent();
+    v8::V8::ShutdownPlatform();
     platform_->Shutdown();
     delete platform_;
     platform_ = nullptr;

--- a/src/node_v8_platform-inl.h
+++ b/src/node_v8_platform-inl.h
@@ -99,6 +99,7 @@ struct V8Platform {
   }
 
   inline void Dispose() {
+    v8::V8::ShutdownPlatform();
     StopTracingAgent();
     platform_->Shutdown();
     delete platform_;


### PR DESCRIPTION
This isn’t really making any trouble at this point, but the V8 API
contract basically says that we should call this as a counterpart
to `V8::InitializePlatform()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
