### PR TITLE
deps: npm: patch support for 13.x

### DIFF
--- a/deps/npm/lib/utils/unsupported.js
+++ b/deps/npm/lib/utils/unsupported.js
@@ -6,7 +6,8 @@ var supportedNode = [
   {ver: '9', min: '9.0.0'},
   {ver: '10', min: '10.0.0'},
   {ver: '11', min: '11.0.0'},
-  {ver: '12', min: '12.0.0'}
+  {ver: '12', min: '12.0.0'},
+  {ver: '13', min: '13.0.0'}
 ]
 var knownBroken = '<6.0.0'
 


### PR DESCRIPTION
This should keep the npm warning at bay until it is patched
upstream.

/cc @ljharb 

Refs: https://github.com/npm/cli/pull/269
Refs: https://github.com/nodejs/node/issues/30066