### PR TITLE
async_hooks: only emit `after` for AsyncResource if stack not empty

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -17,6 +17,7 @@ const {
   executionAsyncId,
   triggerAsyncId,
   // Private API
+  hasAsyncIdStack,
   getHookArrays,
   enableHooks,
   disableHooks,
@@ -172,7 +173,8 @@ class AsyncResource {
         return fn(...args);
       return Reflect.apply(fn, thisArg, args);
     } finally {
-      emitAfter(asyncId);
+      if (hasAsyncIdStack())
+        emitAfter(asyncId);
     }
   }
 

--- a/test/parallel/test-queue-microtask-uncaught-asynchooks.js
+++ b/test/parallel/test-queue-microtask-uncaught-asynchooks.js
@@ -1,0 +1,36 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+// Regression test for https://github.com/nodejs/node/issues/30080:
+// An uncaught exception inside a queueMicrotask callback should not lead
+// to multiple after() calls for it.
+
+let µtaskId;
+const events = [];
+
+async_hooks.createHook({
+  init(id, type, triggerId, resoure) {
+    if (type === 'Microtask') {
+      µtaskId = id;
+      events.push('init');
+    }
+  },
+  before(id) {
+    if (id === µtaskId) events.push('before');
+  },
+  after(id) {
+    if (id === µtaskId) events.push('after');
+  },
+  destroy(id) {
+    if (id === µtaskId) events.push('destroy');
+  }
+}).enable();
+
+queueMicrotask(() => { throw new Error(); });
+
+process.on('uncaughtException', common.mustCall());
+process.on('exit', () => {
+  assert.deepStrictEqual(events, ['init', 'after', 'before', 'destroy']);
+});


### PR DESCRIPTION
We clear the async id stack inside the uncaught exception handler and
emit `after` events in the process, so we should not emit `after`
a second time from the `runInAsyncScope()` code.

This should match the behaviour we have in C++.

Fixes: https://github.com/nodejs/node/issues/30080

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
