### PR TITLE
src: remove unimplemented method from node.h

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -285,13 +285,6 @@ class NODE_EXTERN MultiIsolatePlatform : public v8::Platform {
                                           void* data) = 0;
 };
 
-// Set up some Node.js-specific defaults for `params`, in particular
-// the ArrayBuffer::Allocator if it is provided, memory limits, and
-// possibly a code event handler.
-NODE_EXTERN void SetIsolateCreateParams(v8::Isolate::CreateParams* params,
-                                        ArrayBufferAllocator* allocator
-                                            = nullptr);
-
 enum IsolateSettingsFlags {
   MESSAGE_LISTENER_WITH_ERROR_LEVEL = 1 << 0,
   DETAILED_SOURCE_POSITIONS_FOR_PROFILING = 1 << 1


### PR DESCRIPTION
This function was not actually available during any part
of the Node 12 release line because it had been removed
earlier (likely accidentally).

Refs: https://github.com/nodejs/node/pull/27220

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
