### PR TITLE
Don't use -latomic on macOS

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -291,7 +291,7 @@
           '-Wl,-bnoerrmsg',
         ],
       }],
-      ['OS in ("linux", "mac") and llvm_version != "0.0"', {
+      ['OS == "linux" and llvm_version != "0.0"', {
         'libraries': ['-latomic'],
       }],
     ],


### PR DESCRIPTION
Fixes build when using open-source clang. (Builds using Apple clang from Xcode
7 and later were already working, due to the fact that node's build system
misidentifies their llvm_version as "0.0" and thus the flag wasn't being added.)

Closes #30093

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
