### PR TITLE
fs: add `bufferSize` option to `fs.opendir()`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2625,11 +2625,18 @@ Functions based on `fs.open()` exhibit this behavior as well:
 ## fs.opendir(path\[, options\], callback)
 <!-- YAML
 added: v12.12.0
+changes:
+  - version: REPLACME
+    pr-url: ???
+    description: The `bufferSize` option was introduced.
 -->
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `encoding` {string|null} **Default:** `'utf8'`
+  * `bufferSize` {number} Size of the internal buffer when reading
+     directory entries. Higher values lead to better performance but higher
+     memory usage. **Default:** `32`
 * `callback` {Function}
   * `err` {Error}
   * `dir` {fs.Dir}
@@ -2645,11 +2652,18 @@ directory and subsequent read operations.
 ## fs.opendirSync(path\[, options\])
 <!-- YAML
 added: v12.12.0
+changes:
+  - version: REPLACME
+    pr-url: ???
+    description: The `bufferSize` option was introduced.
 -->
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `encoding` {string|null} **Default:** `'utf8'`
+  * `bufferSize` {number} Size of the internal buffer when reading
+     directory entries. Higher values lead to better performance but higher
+     memory usage. **Default:** `32`
 * Returns: {fs.Dir}
 
 Synchronously open a directory. See opendir(3).
@@ -4829,11 +4843,18 @@ a colon, Node.js will open a file system stream, as described by
 ### fsPromises.opendir(path\[, options\])
 <!-- YAML
 added: v12.12.0
+changes:
+  - version: REPLACME
+    pr-url: ???
+    description: The `bufferSize` option was introduced.
 -->
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `encoding` {string|null} **Default:** `'utf8'`
+  * `bufferSize` {number} Size of the internal buffer when reading
+     directory entries. Higher values lead to better performance but higher
+     memory usage. **Default:** `32`
 * Returns: {Promise} containing {fs.Dir}
 
 Asynchronously open a directory. See opendir(3).

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2634,9 +2634,9 @@ changes:
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `encoding` {string|null} **Default:** `'utf8'`
-  * `bufferSize` {number} Size of the internal buffer when reading
-     directory entries. Higher values lead to better performance but higher
-     memory usage. **Default:** `32`
+  * `bufferSize` {number} Number of directory entries that are buffered
+    internally when reading from the directory. Higher values lead to better
+    performance but higher memory usage. **Default:** `32`
 * `callback` {Function}
   * `err` {Error}
   * `dir` {fs.Dir}
@@ -2661,9 +2661,9 @@ changes:
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `encoding` {string|null} **Default:** `'utf8'`
-  * `bufferSize` {number} Size of the internal buffer when reading
-     directory entries. Higher values lead to better performance but higher
-     memory usage. **Default:** `32`
+  * `bufferSize` {number} Number of directory entries that are buffered
+    internally when reading from the directory. Higher values lead to better
+    performance but higher memory usage. **Default:** `32`
 * Returns: {fs.Dir}
 
 Synchronously open a directory. See opendir(3).
@@ -4852,9 +4852,9 @@ changes:
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `encoding` {string|null} **Default:** `'utf8'`
-  * `bufferSize` {number} Size of the internal buffer when reading
-     directory entries. Higher values lead to better performance but higher
-     memory usage. **Default:** `32`
+  * `bufferSize` {number} Number of directory entries that are buffered
+    internally when reading from the directory. Higher values lead to better
+    performance but higher memory usage. **Default:** `32`
 * Returns: {Promise} containing {fs.Dir}
 
 Asynchronously open a directory. See opendir(3).

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2626,8 +2626,8 @@ Functions based on `fs.open()` exhibit this behavior as well:
 <!-- YAML
 added: v12.12.0
 changes:
-  - version: REPLACME
-    pr-url: ???
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30114
     description: The `bufferSize` option was introduced.
 -->
 
@@ -2653,8 +2653,8 @@ directory and subsequent read operations.
 <!-- YAML
 added: v12.12.0
 changes:
-  - version: REPLACME
-    pr-url: ???
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30114
     description: The `bufferSize` option was introduced.
 -->
 
@@ -4844,8 +4844,8 @@ a colon, Node.js will open a file system stream, as described by
 <!-- YAML
 added: v12.12.0
 changes:
-  - version: REPLACME
-    pr-url: ???
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30114
     description: The `bufferSize` option was introduced.
 -->
 

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -9,6 +9,7 @@ const {
   codes: {
     ERR_DIR_CLOSED,
     ERR_INVALID_CALLBACK,
+    ERR_INVALID_OPT_VALUE,
     ERR_MISSING_ARGS
   }
 } = require('internal/errors');
@@ -39,9 +40,19 @@ class Dir {
     this[kDirPath] = path;
     this[kDirClosed] = false;
 
-    this[kDirOptions] = getOptions(options, {
-      encoding: 'utf8'
-    });
+    this[kDirOptions] = {
+      bufferSize: 32,
+      ...getOptions(options, {
+        encoding: 'utf8'
+      })
+    };
+
+    if (typeof this[kDirOptions].bufferSize !== 'number' ||
+        !Number.isInteger(this[kDirOptions].bufferSize) ||
+        this[kDirOptions].bufferSize <= 0) {
+      throw new ERR_INVALID_OPT_VALUE('bufferSize',
+                                      this[kDirOptions].bufferSize);
+    }
 
     this[kDirReadPromisified] =
         internalUtil.promisify(this[kDirReadImpl]).bind(this, false);
@@ -88,6 +99,7 @@ class Dir {
 
     this[kDirHandle].read(
       this[kDirOptions].encoding,
+      this[kDirOptions].bufferSize,
       req
     );
   }
@@ -105,6 +117,7 @@ class Dir {
     const ctx = { path: this[kDirPath] };
     const result = this[kDirHandle].read(
       this[kDirOptions].encoding,
+      this[kDirOptions].bufferSize,
       undefined,
       ctx
     );

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -22,6 +22,9 @@ const {
   getValidatedPath,
   handleErrorFromBinding
 } = require('internal/fs/utils');
+const {
+  validateUint32
+} = require('internal/validators');
 
 const kDirHandle = Symbol('kDirHandle');
 const kDirPath = Symbol('kDirPath');
@@ -47,12 +50,7 @@ class Dir {
       })
     };
 
-    if (typeof this[kDirOptions].bufferSize !== 'number' ||
-        !Number.isInteger(this[kDirOptions].bufferSize) ||
-        this[kDirOptions].bufferSize <= 0) {
-      throw new ERR_INVALID_OPT_VALUE('bufferSize',
-                                      this[kDirOptions].bufferSize);
-    }
+    validateUint32(this[kDirOptions].bufferSize, 'options.bufferSize', true);
 
     this[kDirReadPromisified] =
         internalUtil.promisify(this[kDirReadImpl]).bind(this, false);

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -9,7 +9,6 @@ const {
   codes: {
     ERR_DIR_CLOSED,
     ERR_INVALID_CALLBACK,
-    ERR_INVALID_OPT_VALUE,
     ERR_MISSING_ARGS
   }
 } = require('internal/errors');

--- a/src/node_dir.cc
+++ b/src/node_dir.cc
@@ -36,6 +36,7 @@ using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
 using v8::Null;
+using v8::Number;
 using v8::Object;
 using v8::ObjectTemplate;
 using v8::String;
@@ -59,8 +60,8 @@ DirHandle::DirHandle(Environment* env, Local<Object> obj, uv_dir_t* dir)
       dir_(dir) {
   MakeWeak();
 
-  dir_->nentries = arraysize(dirents_);
-  dir_->dirents = dirents_;
+  dir_->nentries = 0;
+  dir_->dirents = nullptr;
 }
 
 DirHandle* DirHandle::New(Environment* env, uv_dir_t* dir) {
@@ -230,22 +231,31 @@ void DirHandle::Read(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = env->isolate();
 
   const int argc = args.Length();
-  CHECK_GE(argc, 2);
+  CHECK_GE(argc, 3);
 
   const enum encoding encoding = ParseEncoding(isolate, args[0], UTF8);
 
   DirHandle* dir;
   ASSIGN_OR_RETURN_UNWRAP(&dir, args.Holder());
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
-  if (req_wrap_async != nullptr) {  // dir.read(encoding, req)
+  CHECK(args[1]->IsNumber());
+  uint64_t buffer_size = args[1].As<Number>()->Value();
+
+  if (buffer_size != dir->dirents_.size()) {
+    dir->dirents_.resize(buffer_size);
+    dir->dir_->nentries = buffer_size;
+    dir->dir_->dirents = dir->dirents_.data();
+  }
+
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  if (req_wrap_async != nullptr) {  // dir.read(encoding, bufferSize, req)
     AsyncCall(env, req_wrap_async, args, "readdir", encoding,
               AfterDirRead, uv_fs_readdir, dir->dir());
-  } else {  // dir.read(encoding, undefined, ctx)
-    CHECK_EQ(argc, 3);
+  } else {  // dir.read(encoding, bufferSize, undefined, ctx)
+    CHECK_EQ(argc, 4);
     FSReqWrapSync req_wrap_sync;
     FS_DIR_SYNC_TRACE_BEGIN(readdir);
-    int err = SyncCall(env, args[2], &req_wrap_sync, "readdir", uv_fs_readdir,
+    int err = SyncCall(env, args[3], &req_wrap_sync, "readdir", uv_fs_readdir,
                        dir->dir());
     FS_DIR_SYNC_TRACE_END(readdir);
     if (err < 0) {

--- a/src/node_dir.h
+++ b/src/node_dir.h
@@ -45,8 +45,8 @@ class DirHandle : public AsyncWrap {
   void GCClose();
 
   uv_dir_t* dir_;
-  // Up to 32 directory entries are read through a single libuv call.
-  uv_dirent_t dirents_[32];
+  // Multiple entries are read through a single libuv call.
+  std::vector<uv_dirent_t> dirents_;
   bool closing_ = false;
   bool closed_ = false;
 };

--- a/test/benchmark/test-benchmark-fs.js
+++ b/test/benchmark/test-benchmark-fs.js
@@ -7,6 +7,7 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 runBenchmark('fs', [
+  'bufferSize=32',
   'concurrent=1',
   'dir=.github',
   'dur=0.1',

--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -182,3 +182,19 @@ async function doAsyncIterThrowTest() {
   await assert.rejects(async () => dir.read(), dirclosedError);
 }
 doAsyncIterThrowTest().then(common.mustCall());
+
+// Check error thrown on invalid values of bufferSize
+for (const bufferSize of [-1, 0, 0.5, 1.5, Infinity, NaN, '', '1', null]) {
+  assert.throws(() => fs.opendirSync(testDir, { bufferSize }),
+                {
+                  message: /The value ".*" is invalid for option "bufferSize"/,
+                  code: 'ERR_INVALID_OPT_VALUE'
+                });
+}
+
+// Check that it passing a positive integer as bufferSize works
+{
+  const dir = fs.opendirSync(testDir, { bufferSize: 1024 });
+  assertDirent(dir.readSync());
+  dir.close();
+}

--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -192,7 +192,7 @@ for (const bufferSize of [-1, 0, 0.5, 1.5, Infinity, NaN, '', '1', null]) {
                 });
 }
 
-// Check that it passing a positive integer as bufferSize works
+// Check that passing a positive integer as bufferSize works
 {
   const dir = fs.opendirSync(testDir, { bufferSize: 1024 });
   assertDirent(dir.readSync());

--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -184,12 +184,19 @@ async function doAsyncIterThrowTest() {
 doAsyncIterThrowTest().then(common.mustCall());
 
 // Check error thrown on invalid values of bufferSize
-for (const bufferSize of [-1, 0, 0.5, 1.5, Infinity, NaN, '', '1', null]) {
-  assert.throws(() => fs.opendirSync(testDir, { bufferSize }),
-                {
-                  message: /The value ".*" is invalid for option "bufferSize"/,
-                  code: 'ERR_INVALID_OPT_VALUE'
-                });
+for (const bufferSize of [-1, 0, 0.5, 1.5, Infinity, NaN]) {
+  assert.throws(
+    () => fs.opendirSync(testDir, { bufferSize }),
+    {
+      code: 'ERR_OUT_OF_RANGE'
+    });
+}
+for (const bufferSize of ['', '1', null]) {
+  assert.throws(
+    () => fs.opendirSync(testDir, { bufferSize }),
+    {
+      code: 'ERR_INVALID_ARG_TYPE'
+    });
 }
 
 // Check that passing a positive integer as bufferSize works


### PR DESCRIPTION
Add an option that controls the size of the internal
buffer.

Fixes: https://github.com/nodejs/node/issues/29941

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
