### PR TITLE
build: fix detection of Visual Studio 2017

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -240,6 +240,10 @@ if %target_arch%==x86 if %msvs_host_arch%==x86 set vcvarsall_arg=x86
 :vs-set-2019
 if defined target_env if "%target_env%" NEQ "vs2019" goto vs-set-2017
 echo Looking for Visual Studio 2019
+@rem VCINSTALLDIR may be set if run from a VS Command Prompt and needs to be
+@rem cleared first as vswhere_usability_wrapper.cmd doesn't when it fails to
+@rem detect the version searched for
+set "VCINSTALLDIR="
 call tools\msvs\vswhere_usability_wrapper.cmd "[16.0,17.0)"
 if "_%VCINSTALLDIR%_" == "__" goto vs-set-2017
 if defined msi (


### PR DESCRIPTION
When run in a Visual Studio 2017 command prompt the `VCINSTALLDIR`
environment variable will be already set and is not cleared by the
`tools/msvs/vswhere_usability_wrapper.cmd` utility when it fails to
find Visual Studio 2019. This causes `vcbuild.bat` to incorrectly
assume Visual Studio 2019 and generate an incompatible configuration.

Clearing the value of `VCINSTALLDIR` before calling the utility fixes
the detection logic.

Fixes: https://github.com/nodejs/node/issues/30118
Refs: https://github.com/nodejs/node/pull/30022

cc @nodejs/platform-windows @nodejs/build-files @targos 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
