### PR TITLE
src: add file name to 'Module did not self-register' error

### DIFF
--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -484,7 +484,9 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
         mp = dlib->GetSavedModuleFromGlobalHandleMap();
         if (mp == nullptr || mp->nm_context_register_func == nullptr) {
           dlib->Close();
-          env->ThrowError("Module did not self-register.");
+          char errmsg[1024];
+          snprintf(errmsg, 1024, "Module did not self-register: '%s'.", *filename);
+          env->ThrowError(errmsg);
           return false;
         }
       }

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -485,7 +485,10 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
         if (mp == nullptr || mp->nm_context_register_func == nullptr) {
           dlib->Close();
           char errmsg[1024];
-          snprintf(errmsg, sizeof(errmsg), "Module did not self-register: '%s'.", *filename);
+          snprintf(errmsg,
+                   sizeof(errmsg),
+                   "Module did not self-register: '%s'.",
+                   *filename);
           env->ThrowError(errmsg);
           return false;
         }

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -485,7 +485,7 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
         if (mp == nullptr || mp->nm_context_register_func == nullptr) {
           dlib->Close();
           char errmsg[1024];
-          snprintf(errmsg, 1024, "Module did not self-register: '%s'.", *filename);
+          snprintf(errmsg, sizeof(errmsg), "Module did not self-register: '%s'.", *filename);
           env->ThrowError(errmsg);
           return false;
         }

--- a/test/addons/dlopen-ping-pong/test-worker.js
+++ b/test/addons/dlopen-ping-pong/test-worker.js
@@ -16,5 +16,6 @@ require(bindingPath);
 new Worker(`require(${JSON.stringify(bindingPath)})`, { eval: true })
   .on('error', common.mustCall((err) => {
     assert.strictEqual(err.constructor, Error);
-    assert.strictEqual(err.message, `Module did not self-register: '${bindingPath}'.`);
+    assert.strictEqual(err.message,
+                       `Module did not self-register: '${bindingPath}'.`);
   }));

--- a/test/addons/dlopen-ping-pong/test-worker.js
+++ b/test/addons/dlopen-ping-pong/test-worker.js
@@ -16,5 +16,5 @@ require(bindingPath);
 new Worker(`require(${JSON.stringify(bindingPath)})`, { eval: true })
   .on('error', common.mustCall((err) => {
     assert.strictEqual(err.constructor, Error);
-    assert.strictEqual(err.message, 'Module did not self-register.');
+    assert.strictEqual(err.message, `Module did not self-register: '${bindingPath}.node'.`);
   }));

--- a/test/addons/dlopen-ping-pong/test-worker.js
+++ b/test/addons/dlopen-ping-pong/test-worker.js
@@ -16,5 +16,5 @@ require(bindingPath);
 new Worker(`require(${JSON.stringify(bindingPath)})`, { eval: true })
   .on('error', common.mustCall((err) => {
     assert.strictEqual(err.constructor, Error);
-    assert.strictEqual(err.message, `Module did not self-register: '${bindingPath}.node'.`);
+    assert.strictEqual(err.message, `Module did not self-register: '${bindingPath}'.`);
   }));

--- a/test/addons/dlopen-ping-pong/test.js
+++ b/test/addons/dlopen-ping-pong/test.js
@@ -19,5 +19,5 @@ assert.strictEqual(module.exports.ping(), 'pong');
 // Check that after the addon is loaded with
 // process.dlopen() a require() call fails.
 console.log('require:', `./build/${common.buildType}/binding`);
-const re = /^Error: Module did not self-register: '.*\/binding\.node'\.$/;
+const re = /^Error: Module did not self-register: '.*[\\\/]binding\.node'\.$/;
 assert.throws(() => require(`./build/${common.buildType}/binding`), re);

--- a/test/addons/dlopen-ping-pong/test.js
+++ b/test/addons/dlopen-ping-pong/test.js
@@ -19,5 +19,5 @@ assert.strictEqual(module.exports.ping(), 'pong');
 // Check that after the addon is loaded with
 // process.dlopen() a require() call fails.
 console.log('require:', `./build/${common.buildType}/binding`);
-const re = /^Error: Module did not self-register: '.*[\\\/]binding\.node'\.$/;
+const re = /^Error: Module did not self-register: '.*[\\/]binding\.node'\.$/;
 assert.throws(() => require(`./build/${common.buildType}/binding`), re);

--- a/test/addons/dlopen-ping-pong/test.js
+++ b/test/addons/dlopen-ping-pong/test.js
@@ -19,5 +19,5 @@ assert.strictEqual(module.exports.ping(), 'pong');
 // Check that after the addon is loaded with
 // process.dlopen() a require() call fails.
 console.log('require:', `./build/${common.buildType}/binding`);
-const re = /^Error: Module did not self-register: '.*\/binding.node'\.$/;
+const re = /^Error: Module did not self-register: '.*\/binding\.node'\.$/;
 assert.throws(() => require(`./build/${common.buildType}/binding`), re);

--- a/test/addons/dlopen-ping-pong/test.js
+++ b/test/addons/dlopen-ping-pong/test.js
@@ -19,5 +19,5 @@ assert.strictEqual(module.exports.ping(), 'pong');
 // Check that after the addon is loaded with
 // process.dlopen() a require() call fails.
 console.log('require:', `./build/${common.buildType}/binding`);
-const re = /^Error: Module did not self-register\.$/;
+const re = /^Error: Module did not self-register: '.*\/binding.node'\.$/;
 assert.throws(() => require(`./build/${common.buildType}/binding`), re);

--- a/test/addons/not-a-binding/test.js
+++ b/test/addons/not-a-binding/test.js
@@ -2,5 +2,5 @@
 const common = require('../../common');
 const assert = require('assert');
 
-const re = /^Error: Module did not self-register: '.*\/binding.node'\.$/;
+const re = /^Error: Module did not self-register: '.*\/binding\.node'\.$/;
 assert.throws(() => require(`./build/${common.buildType}/binding`), re);

--- a/test/addons/not-a-binding/test.js
+++ b/test/addons/not-a-binding/test.js
@@ -2,5 +2,5 @@
 const common = require('../../common');
 const assert = require('assert');
 
-const re = /^Error: Module did not self-register\.$/;
+const re = /^Error: Module did not self-register: '.*\/binding.node'\.$/;
 assert.throws(() => require(`./build/${common.buildType}/binding`), re);

--- a/test/addons/not-a-binding/test.js
+++ b/test/addons/not-a-binding/test.js
@@ -2,5 +2,5 @@
 const common = require('../../common');
 const assert = require('assert');
 
-const re = /^Error: Module did not self-register: '.*[\\\/]binding\.node'\.$/;
+const re = /^Error: Module did not self-register: '.*[\\/]binding\.node'\.$/;
 assert.throws(() => require(`./build/${common.buildType}/binding`), re);

--- a/test/addons/not-a-binding/test.js
+++ b/test/addons/not-a-binding/test.js
@@ -2,5 +2,5 @@
 const common = require('../../common');
 const assert = require('assert');
 
-const re = /^Error: Module did not self-register: '.*\/binding\.node'\.$/;
+const re = /^Error: Module did not self-register: '.*[\\\/]binding\.node'\.$/;
 assert.throws(() => require(`./build/${common.buildType}/binding`), re);


### PR DESCRIPTION
The 'Module did not self-register' error can be difficult to track down because it's not always obvious _which_ module is failing to self-register.

<img width="383" alt="" src="https://user-images.githubusercontent.com/172800/67606767-366ebe00-f737-11e9-934a-398db3378885.png">


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
