### PR TITLE
test: use arrow functions in addons tests

### DIFF
--- a/test/addons/async-hello-world/test-makecallback.js
+++ b/test/addons/async-hello-world/test-makecallback.js
@@ -3,7 +3,7 @@ const common = require('../../common');
 const assert = require('assert');
 const { runMakeCallback } = require(`./build/${common.buildType}/binding`);
 
-runMakeCallback(5, common.mustCall(function(err, val) {
+runMakeCallback(5, common.mustCall((err, val) => {
   assert.strictEqual(err, null);
   assert.strictEqual(val, 10);
   process.nextTick(common.mustCall());

--- a/test/addons/async-hello-world/test.js
+++ b/test/addons/async-hello-world/test.js
@@ -3,7 +3,7 @@ const common = require('../../common');
 const assert = require('assert');
 const { runCall } = require(`./build/${common.buildType}/binding`);
 
-runCall(5, common.mustCall(function(err, val) {
+runCall(5, common.mustCall((err, val) => {
   assert.strictEqual(err, null);
   assert.strictEqual(val, 10);
   process.nextTick(common.mustCall());

--- a/test/addons/load-long-path/test.js
+++ b/test/addons/load-long-path/test.js
@@ -48,6 +48,6 @@ fs.writeFileSync(addonDestinationPath, contents);
 
 // Run test
 const child = fork(__filename, ['child'], { stdio: 'inherit' });
-child.on('exit', common.mustCall(function(code) {
+child.on('exit', common.mustCall((code) => {
   assert.strictEqual(code, 0);
 }));

--- a/test/addons/make-callback-domain-warning/test.js
+++ b/test/addons/make-callback-domain-warning/test.js
@@ -10,23 +10,23 @@ function makeCallback(object, cb) {
 }
 
 let latestWarning = null;
-process.on('warning', function(warning) {
+process.on('warning', (warning) => {
   latestWarning = warning;
 });
 
 const d = domain.create();
 
 // When domain is disabled, no warning will be emitted
-makeCallback({ domain: d }, common.mustCall(function() {
+makeCallback({ domain: d }, common.mustCall(() => {
   assert.strictEqual(latestWarning, null);
 
-  d.run(common.mustCall(function() {
+  d.run(common.mustCall(() => {
     // No warning will be emitted when no domain property is applied
-    makeCallback({}, common.mustCall(function() {
+    makeCallback({}, common.mustCall(() => {
       assert.strictEqual(latestWarning, null);
 
       // Warning is emitted when domain property is used and domain is enabled
-      makeCallback({ domain: d }, common.mustCall(function() {
+      makeCallback({ domain: d }, common.mustCall(() => {
         assert.strictEqual(latestWarning.name, 'DeprecationWarning');
         assert.strictEqual(latestWarning.code, 'DEP0097');
       }));

--- a/test/addons/make-callback-recurse/test.js
+++ b/test/addons/make-callback-recurse/test.js
@@ -71,7 +71,7 @@ assert.throws(() => {
     if (arg === 1) {
       // The tests are first run on bootstrap during LoadEnvironment() in
       // src/node.cc. Now run the tests through node::MakeCallback().
-      setImmediate(function() {
+      setImmediate(() => {
         makeCallback({}, common.mustCall(() => {
           verifyExecutionOrder(2);
         }));

--- a/test/addons/openssl-client-cert-engine/test.js
+++ b/test/addons/openssl-client-cert-engine/test.js
@@ -43,14 +43,14 @@ const server = https.createServer(serverOptions, common.mustCall((req, res) => {
     headers: {}
   };
 
-  const req = https.request(clientOptions, common.mustCall(function(response) {
+  const req = https.request(clientOptions, common.mustCall((response) => {
     let body = '';
     response.setEncoding('utf8');
-    response.on('data', function(chunk) {
+    response.on('data', (chunk) => {
       body += chunk;
     });
 
-    response.on('end', common.mustCall(function() {
+    response.on('end', common.mustCall(() => {
       assert.strictEqual(body, 'hello world');
       server.close();
     }));

--- a/test/addons/openssl-key-engine/test.js
+++ b/test/addons/openssl-key-engine/test.js
@@ -45,14 +45,14 @@ const server = https.createServer(serverOptions, common.mustCall((req, res) => {
     headers: {}
   };
 
-  const req = https.request(clientOptions, common.mustCall(function(response) {
+  const req = https.request(clientOptions, common.mustCall((response) => {
     let body = '';
     response.setEncoding('utf8');
-    response.on('data', function(chunk) {
+    response.on('data', (chunk) => {
       body += chunk;
     });
 
-    response.on('end', common.mustCall(function() {
+    response.on('end', common.mustCall(() => {
       assert.strictEqual(body, 'hello world');
       server.close();
     }));

--- a/test/addons/repl-domain-abort/test.js
+++ b/test/addons/repl-domain-abort/test.js
@@ -31,7 +31,7 @@ if (common.isWindows)
   buildPath = buildPath.replace(/\\/g, '/');
 let cb_ran = false;
 
-process.on('exit', function() {
+process.on('exit', () => {
   assert(cb_ran);
   console.log('ok');
 });

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii.js
@@ -25,7 +25,7 @@ if (!binding.ensureAllocation(2 * kStringMaxLength))
   common.skip(skipMessage);
 
 const stringLengthHex = kStringMaxLength.toString(16);
-common.expectsError(function() {
+common.expectsError(() => {
   buf.toString('ascii');
 }, {
   message: `Cannot create a string longer than 0x${stringLengthHex} ` +

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
@@ -25,7 +25,7 @@ if (!binding.ensureAllocation(2 * kStringMaxLength))
   common.skip(skipMessage);
 
 const stringLengthHex = kStringMaxLength.toString(16);
-common.expectsError(function() {
+common.expectsError(() => {
   buf.toString('base64');
 }, {
   message: `Cannot create a string longer than 0x${stringLengthHex} ` +

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
@@ -27,7 +27,7 @@ if (!binding.ensureAllocation(2 * kStringMaxLength))
   common.skip(skipMessage);
 
 const stringLengthHex = kStringMaxLength.toString(16);
-common.expectsError(function() {
+common.expectsError(() => {
   buf.toString('latin1');
 }, {
   message: `Cannot create a string longer than 0x${stringLengthHex} ` +

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
@@ -25,7 +25,7 @@ if (!binding.ensureAllocation(2 * kStringMaxLength))
   common.skip(skipMessage);
 
 const stringLengthHex = kStringMaxLength.toString(16);
-common.expectsError(function() {
+common.expectsError(() => {
   buf.toString('hex');
 }, {
   message: `Cannot create a string longer than 0x${stringLengthHex} ` +

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
@@ -27,9 +27,9 @@ if (!binding.ensureAllocation(2 * kStringMaxLength))
 
 const stringLengthHex = kStringMaxLength.toString(16);
 
-assert.throws(function() {
+assert.throws(() => {
   buf.toString();
-}, function(e) {
+}, (e) => {
   if (e.message !== 'Array buffer allocation failed') {
     common.expectsError({
       message: `Cannot create a string longer than 0x${stringLengthHex} ` +
@@ -43,7 +43,7 @@ assert.throws(function() {
   }
 });
 
-common.expectsError(function() {
+common.expectsError(() => {
   buf.toString('utf8');
 }, {
   message: `Cannot create a string longer than 0x${stringLengthHex} ` +

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
@@ -26,7 +26,7 @@ if (!binding.ensureAllocation(2 * kStringMaxLength))
 
 const stringLengthHex = kStringMaxLength.toString(16);
 
-common.expectsError(function() {
+common.expectsError(() => {
   buf.toString('utf16le');
 }, {
   message: `Cannot create a string longer than 0x${stringLengthHex} ` +


### PR DESCRIPTION
Convert all anonymous callback functions in `test/addons/**/*.js`
to use arrow functions, except for those in
`test/addons/make-callback/test.js` (which reference `this`)

`writing-tests.md` states to use arrow functions when appropriate.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
