### PR TITLE
encoding: make TextDecoder handle BOM correctly

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -484,25 +484,22 @@ function makeTextDecoderJS() {
         this[kFlags] |= CONVERTER_FLAGS_FLUSH;
       }
 
-      if (!this[kBOMSeen] && !(this[kFlags] & CONVERTER_FLAGS_IGNORE_BOM)) {
-        if (this[kEncoding] === 'utf-8') {
-          if (input.length >= 3 &&
-              input[0] === 0xEF && input[1] === 0xBB && input[2] === 0xBF) {
-            input = input.slice(3);
-          }
-        } else if (this[kEncoding] === 'utf-16le') {
-          if (input.length >= 2 && input[0] === 0xFF && input[1] === 0xFE) {
-            input = input.slice(2);
-          }
+      let result = this[kFlags] & CONVERTER_FLAGS_FLUSH ?
+        this[kHandle].end(input) :
+        this[kHandle].write(input);
+
+      if (result.length > 0 &&
+          !this[kBOMSeen] &&
+          !(this[kFlags] & CONVERTER_FLAGS_IGNORE_BOM)) {
+        // If the very first result in the stream is a BOM, and we are not
+        // explicitly told to ignore it, then we discard it.
+        if (result[0] === '\ufeff') {
+          result = result.slice(1);
         }
         this[kBOMSeen] = true;
       }
 
-      if (this[kFlags] & CONVERTER_FLAGS_FLUSH) {
-        return this[kHandle].end(input);
-      }
-
-      return this[kHandle].write(input);
+      return result;
     }
   }
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -219,10 +219,10 @@ size_t Length(Local<Object> obj) {
 }
 
 
-inline MaybeLocal<Uint8Array> New(Environment* env,
-                                  Local<ArrayBuffer> ab,
-                                  size_t byte_offset,
-                                  size_t length) {
+MaybeLocal<Uint8Array> New(Environment* env,
+                           Local<ArrayBuffer> ab,
+                           size_t byte_offset,
+                           size_t length) {
   CHECK(!env->buffer_prototype_object().IsEmpty());
   Local<Uint8Array> ui = Uint8Array::New(ab, byte_offset, length);
   Maybe<bool> mb =

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -158,7 +158,11 @@ v8::MaybeLocal<v8::Object> New(Environment* env,
                                char* data,
                                size_t length,
                                bool uses_malloc);
-
+// Creates a Buffer instance over an existing Uint8Array.
+v8::MaybeLocal<v8::Uint8Array> New(Environment* env,
+                                   v8::Local<v8::ArrayBuffer> ab,
+                                   size_t byte_offset,
+                                   size_t length);
 // Construct a Buffer from a MaybeStackBuffer (and also its subclasses like
 // Utf8Value and TwoByteValue).
 // If |buf| is invalidated, an empty MaybeLocal is returned, and nothing is

--- a/test/wpt/status/encoding.json
+++ b/test/wpt/status/encoding.json
@@ -22,10 +22,7 @@
     "fail": "iso-2022-jp decoder state handling bug: https://encoding.spec.whatwg.org/#iso-2022-jp-decoder"
   },
   "textdecoder-byte-order-marks.any.js": {
-    "fail": "Mismatching BOM should not be ignored"
-  },
-  "textdecoder-copy.any.js": {
-    "fail": "Should not have output BOM: https://encoding.spec.whatwg.org/#concept-td-serialize"
+    "requires": ["small-icu"]
   },
   "textdecoder-fatal-single-byte.any.js": {
     "requires": ["full-icu"],


### PR DESCRIPTION
Do not accept the BOM if it comes from a different encoding, and
only discard the BOM after it has actually been read (including
when it is spread over multiple chunks in streaming mode).

Fixes: https://github.com/nodejs/node/issues/25315

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
