### PR TITLE
src: change env.h includes for forward declarations when possible

### DIFF
--- a/src/connection_wrap.h
+++ b/src/connection_wrap.h
@@ -3,11 +3,12 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "env.h"
 #include "stream_wrap.h"
 #include "v8.h"
 
 namespace node {
+
+class Environment;
 
 template <typename WrapType, typename UVType>
 class ConnectionWrap : public LibuvStreamWrap {

--- a/src/diagnosticfilename-inl.h
+++ b/src/diagnosticfilename-inl.h
@@ -4,9 +4,9 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node_internals.h"
-#include "env-inl.h"
-
 namespace node {
+
+class Environment;
 
 inline DiagnosticFilename::DiagnosticFilename(
     Environment* env,

--- a/src/inspector/main_thread_interface.h
+++ b/src/inspector/main_thread_interface.h
@@ -5,7 +5,6 @@
 #error("This header can only be used when inspector is enabled")
 #endif
 
-#include "env.h"
 #include "inspector_agent.h"
 #include "node_mutex.h"
 

--- a/src/inspector_profiler.h
+++ b/src/inspector_profiler.h
@@ -7,7 +7,6 @@
 #error("This header can only be used when inspector is enabled")
 #endif
 
-#include "env.h"
 #include "inspector_agent.h"
 
 namespace node {

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -4,11 +4,12 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "async_wrap.h"
-#include "env.h"
 #include "stream_base.h"
 #include "v8.h"
 
 namespace node {
+
+class Environment;
 
 class JSStream : public AsyncWrap, public StreamBase {
  public:

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -26,11 +26,13 @@
 
 #include "node_crypto.h"
 #include "openssl/bio.h"
-#include "env.h"
 #include "util.h"
 #include "v8.h"
 
 namespace node {
+
+class Environment;
+
 namespace crypto {
 
 // This class represents buffers for OpenSSL I/O, implemented as a singly-linked

--- a/src/node_dtrace.h
+++ b/src/node_dtrace.h
@@ -24,7 +24,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "env.h"
 #include "v8.h"
 
 extern "C" {
@@ -75,6 +74,8 @@ typedef struct {
 }  // extern "C"
 
 namespace node {
+
+class Environment;
 
 void InitDTrace(Environment* env);
 

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -5,7 +5,6 @@
 
 #include "node.h"
 #include "node_perf_common.h"
-#include "env.h"
 #include "base_object-inl.h"
 #include "histogram-inl.h"
 
@@ -15,6 +14,9 @@
 #include <string>
 
 namespace node {
+
+class Environment;
+
 namespace performance {
 
 using v8::FunctionCallbackInfo;

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -26,11 +26,12 @@
 
 #include "node.h"
 #include "handle_wrap.h"
-#include "env.h"
 #include "uv.h"
 #include "v8.h"
 
 namespace node {
+
+class Environment;
 
 class StatWatcher : public HandleWrap {
  public:

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -4,7 +4,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
-#include "env.h"
 
 #include <string>
 

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -26,9 +26,10 @@
 
 #include "async_wrap.h"
 #include "connection_wrap.h"
-#include "env.h"
 
 namespace node {
+
+class Environment;
 
 class PipeWrap : public ConnectionWrap<PipeWrap, uv_pipe_t> {
  public:

--- a/src/req_wrap.h
+++ b/src/req_wrap.h
@@ -4,11 +4,12 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "async_wrap.h"
-#include "env.h"
 #include "util.h"
 #include "v8.h"
 
 namespace node {
+
+class Environment;
 
 class ReqWrapBase {
  public:

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -3,7 +3,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "env.h"
 #include "async_wrap-inl.h"
 #include "node.h"
 #include "util.h"
@@ -13,6 +12,7 @@
 namespace node {
 
 // Forward declarations
+class Environment;
 class ShutdownWrap;
 class WriteWrap;
 class StreamBase;

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -25,13 +25,13 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "stream_base.h"
-
-#include "env.h"
 #include "handle_wrap.h"
 #include "string_bytes.h"
 #include "v8.h"
 
 namespace node {
+
+class Environment;
 
 class LibuvStreamWrap : public HandleWrap, public StreamBase {
  public:

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -25,10 +25,11 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "async_wrap.h"
-#include "env.h"
 #include "connection_wrap.h"
 
 namespace node {
+
+class Environment;
 
 class TCPWrap : public ConnectionWrap<TCPWrap, uv_tcp_t> {
  public:

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -27,7 +27,6 @@
 #include "node_crypto.h"  // SSLWrap
 
 #include "async_wrap.h"
-#include "env.h"
 #include "stream_wrap.h"
 #include "v8.h"
 
@@ -38,6 +37,7 @@
 namespace node {
 
 // Forward-declarations
+class Environment;
 class WriteWrap;
 namespace crypto {
 class SecureContext;

--- a/src/tty_wrap.h
+++ b/src/tty_wrap.h
@@ -24,11 +24,12 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "env.h"
 #include "uv.h"
 #include "stream_wrap.h"
 
 namespace node {
+
+class Environment;
 
 class TTYWrap : public LibuvStreamWrap {
  public:

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -25,12 +25,13 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "async_wrap.h"
-#include "env.h"
 #include "handle_wrap.h"
 #include "uv.h"
 #include "v8.h"
 
 namespace node {
+
+class Environment;
 
 class UDPWrap: public HandleWrap {
  public:


### PR DESCRIPTION
Due to how the Environment class is used through the codebase,
there are a lot of includes referencing either env.h or env-inl.h.

This can cause that when any development touches those libraries,
a lot of files have to be recompiled.

This commit attempts to change those includes by forward declarations
when possible to mitigate the issue.

Partial fix for #27531

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

First PR in node, so if anything can be done better, please, tell me.