### PR TITLE
test: use arrow functions in async-hooks tests

### DIFF
--- a/test/async-hooks/test-disable-in-init.js
+++ b/test/async-hooks/test-disable-in-init.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 let nestedCall = false;
 
 async_hooks.createHook({
-  init: common.mustCall(function() {
+  init: common.mustCall(() => {
     nestedHook.disable();
     if (!nestedCall) {
       nestedCall = true;

--- a/test/async-hooks/test-graph.http.js
+++ b/test/async-hooks/test-graph.http.js
@@ -11,11 +11,11 @@ const http = require('http');
 const hooks = initHooks();
 hooks.enable();
 
-const server = http.createServer(common.mustCall(function(req, res) {
+const server = http.createServer(common.mustCall((req, res) => {
   res.end();
-  this.close(common.mustCall());
+  server.close(common.mustCall());
 }));
-server.listen(0, common.mustCall(function() {
+server.listen(0, common.mustCall(() => {
   http.get({
     host: '::1',
     family: 6,
@@ -23,7 +23,7 @@ server.listen(0, common.mustCall(function() {
   }, common.mustCall());
 }));
 
-process.on('exit', function() {
+process.on('exit', () => {
   hooks.disable();
 
   verifyGraph(

--- a/test/async-hooks/test-graph.pipeconnect.js
+++ b/test/async-hooks/test-graph.pipeconnect.js
@@ -12,9 +12,9 @@ tmpdir.refresh();
 const hooks = initHooks();
 hooks.enable();
 
-net.createServer(function(c) {
+const server = net.createServer((c) => {
   c.end();
-  this.close();
+  server.close();
 }).listen(common.PIPE, common.mustCall(onlisten));
 
 function onlisten() {

--- a/test/async-hooks/test-nexttick-default-trigger.js
+++ b/test/async-hooks/test-nexttick-default-trigger.js
@@ -14,11 +14,11 @@ hooks.enable();
 
 const rootAsyncId = async_hooks.executionAsyncId();
 
-process.nextTick(common.mustCall(function() {
+process.nextTick(common.mustCall(() => {
   assert.strictEqual(async_hooks.triggerAsyncId(), rootAsyncId);
 }));
 
-process.on('exit', function() {
+process.on('exit', () => {
   hooks.sanityCheck();
 
   const as = hooks.activitiesOfTypes('TickObject');

--- a/test/async-hooks/test-pipeconnectwrap.js
+++ b/test/async-hooks/test-pipeconnectwrap.js
@@ -17,9 +17,9 @@ let pipe1, pipe2;
 let pipeserver;
 let pipeconnect;
 
-net.createServer(common.mustCall(function(c) {
+const server = net.createServer(common.mustCall((c) => {
   c.end();
-  this.close();
+  server.close();
   process.nextTick(maybeOnconnect.bind(null, 'server'));
 })).listen(common.PIPE, common.mustCall(onlisten));
 

--- a/test/async-hooks/test-queue-microtask.js
+++ b/test/async-hooks/test-queue-microtask.js
@@ -11,11 +11,11 @@ hooks.enable();
 
 const rootAsyncId = async_hooks.executionAsyncId();
 
-queueMicrotask(common.mustCall(function() {
+queueMicrotask(common.mustCall(() => {
   assert.strictEqual(async_hooks.triggerAsyncId(), rootAsyncId);
 }));
 
-process.on('exit', function() {
+process.on('exit', () => {
   hooks.sanityCheck();
 
   const as = hooks.activitiesOfTypes('Microtask');


### PR DESCRIPTION
Convert all anonymous callback functions in `test/async-hooks/*.js`
to use arrow functions.

`writing-tests.md` states to use arrow functions when appropriate.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
