### PR TITLE
doc: remove incorrect and outdated example

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -613,24 +613,6 @@ Emitted when the cluster master receives a message from any worker.
 
 See [`child_process` event: `'message'`][].
 
-Before Node.js v6.0, this event emitted only the message and the handle,
-but not the worker object, contrary to what the documentation stated.
-
-If support for older versions is required but a worker object is not
-required, it is possible to work around the discrepancy by checking the
-number of arguments:
-
-```js
-cluster.on('message', (worker, message, handle) => {
-  if (arguments.length === 2) {
-    handle = message;
-    message = worker;
-    worker = undefined;
-  }
-  // ...
-});
-```
-
 ## Event: 'online'
 <!-- YAML
 added: v0.7.0


### PR DESCRIPTION
This description and example are only relevant for versions older than 6.0, all of which have been EOL for a while now. Also, https://github.com/nodejs/node/commit/e03ee719e6e760777b237861bf0b7835432af8bb changed the example code to use an arrow function, effectively breaking it since `arguments.length` is not available in arrow functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
