### PR TITLE
stream: extract Readable.from in its own file

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -47,6 +47,7 @@ const {
 // Lazy loaded to improve the startup performance.
 let StringDecoder;
 let createReadableStreamAsyncIterator;
+let from;
 
 Object.setPrototypeOf(Readable.prototype, Stream.prototype);
 Object.setPrototypeOf(Readable, Stream);
@@ -1209,40 +1210,8 @@ function endReadableNT(state, stream) {
 }
 
 Readable.from = function(iterable, opts) {
-  let iterator;
-  if (iterable && iterable[Symbol.asyncIterator])
-    iterator = iterable[Symbol.asyncIterator]();
-  else if (iterable && iterable[Symbol.iterator])
-    iterator = iterable[Symbol.iterator]();
-  else
-    throw new ERR_INVALID_ARG_TYPE('iterable', ['Iterable'], iterable);
-
-  const readable = new Readable({
-    objectMode: true,
-    ...opts
-  });
-  // Reading boolean to protect against _read
-  // being called before last iteration completion.
-  let reading = false;
-  readable._read = function() {
-    if (!reading) {
-      reading = true;
-      next();
-    }
-  };
-  async function next() {
-    try {
-      const { value, done } = await iterator.next();
-      if (done) {
-        readable.push(null);
-      } else if (readable.push(await value)) {
-        next();
-      } else {
-        reading = false;
-      }
-    } catch (err) {
-      readable.destroy(err);
-    }
+  if (from === undefined) {
+    from = require('internal/streams/from');
   }
-  return readable;
+  return from(Readable, iterable, opts);
 };

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const {
+  ERR_INVALID_ARG_TYPE
+} = require('internal/errors').codes;
+
+function from(Readable, iterable, opts) {
+  let iterator;
+  if (iterable && iterable[Symbol.asyncIterator])
+    iterator = iterable[Symbol.asyncIterator]();
+  else if (iterable && iterable[Symbol.iterator])
+    iterator = iterable[Symbol.iterator]();
+  else
+    throw new ERR_INVALID_ARG_TYPE('iterable', ['Iterable'], iterable);
+
+  const readable = new Readable({
+    objectMode: true,
+    ...opts
+  });
+  // Reading boolean to protect against _read
+  // being called before last iteration completion.
+  let reading = false;
+  readable._read = function() {
+    if (!reading) {
+      reading = true;
+      next();
+    }
+  };
+  async function next() {
+    try {
+      const { value, done } = await iterator.next();
+      if (done) {
+        readable.push(null);
+      } else if (readable.push(await value)) {
+        next();
+      } else {
+        reading = false;
+      }
+    } catch (err) {
+      readable.destroy(err);
+    }
+  }
+  return readable;
+}
+
+module.exports = from;

--- a/node.gyp
+++ b/node.gyp
@@ -205,6 +205,7 @@
       'lib/internal/streams/async_iterator.js',
       'lib/internal/streams/buffer_list.js',
       'lib/internal/streams/duplexpair.js',
+      'lib/internal/streams/from.js',
       'lib/internal/streams/legacy.js',
       'lib/internal/streams/destroy.js',
       'lib/internal/streams/state.js',


### PR DESCRIPTION
In `readable-stream`, we cannot release the new version built from Node 10.17.0 because IE11 does not support generators needed for async-await to be transpiled correctly. `readable-stream` is all about backward compatibility, so it makes sense to still support IE11, even if we’ll likely remove support in the next major (built from Node 12).

This PR moves `Readable.from` into its own file, so we can replace it via a browser tag in package.json, and not ship `from` in the browser bundle for now.

See: https://github.com/nodejs/readable-stream/pull/420

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
