### PR TITLE
build: fixes build for some os versions

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -356,6 +356,7 @@
       [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
         'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++1y' ],
+        'defines': ['__STDC_FORMAT_MACROS' ],
         'ldflags': [ '-rdynamic' ],
         'target_conditions': [
           # The 1990s toolchain on SmartOS can't handle thin archives.


### PR DESCRIPTION
For format macros, the __STDC_FORMAT_MACROS flag needs to be
passed, also passing the librt linker flag.

Fixes [#30077](https://github.com/nodejs/node/issues/30077)