### PR TITLE
build: find Python syntax errors in dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,3 +98,5 @@ jobs:
         - python3.8 -m pip install flake8
       script:
         - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+  allow_failures:  # TODO (cclauss): remove this when dependencies are clean
+    - name: "Find syntax errors in our Python dependencies"

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,3 +88,13 @@ jobs:
         - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
             bash -x tools/lint-pr-commit-message.sh ${TRAVIS_PULL_REQUEST};
           fi
+
+    - name: "Find syntax errors in our Python dependencies"
+      language: python
+      python: 3.8
+      install:
+        - mv .flake8 disabled.flake8  # take the blinders off of flake8
+        - python3.8 -m pip install --upgrade pip
+        - python3.8 -m pip install flake8
+      script:
+        - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
As discussed in https://github.com/nodejs/node/issues/30129#issuecomment-546662351, when we vendor in code, we own the Syntax Errors in that code.  This PR adds a Travis CI test run that looks for syntax errors and undefined names in the Python code of our vendored dependencies. The `.flake8` config file at the root of this repo puts blinders on the linting of our dependencies so this test disables that file before starting the linting.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
