### PR TITLE
build: disable libstdc++ debug containers globally

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -30,10 +30,6 @@
     'openssl_fips%': '',
     'openssl_no_asm%': 0,
 
-    # Some STL containers (e.g. std::vector) do not preserve ABI compatibility
-    # between debug and non-debug mode.
-    'disable_glibcxx_debug': 1,
-
     # Don't use ICU data file (icudtl.dat) from V8, we use our own.
     'icu_use_data_file_flag%': 0,
 

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -64,9 +64,6 @@
     # Print to stdout on Android.
     'v8_android_log_stdout%': 0,
 
-    # Force disable libstdc++ debug mode.
-    'disable_glibcxx_debug%': 0,
-
     'v8_enable_backtrace%': 0,
 
     # Enable profiling support. Only required on Windows.
@@ -1166,11 +1163,6 @@
           ['OS=="linux" and v8_enable_backtrace==1', {
             # Support for backtrace_symbols.
             'ldflags': [ '-rdynamic' ],
-          }],
-          ['OS=="linux" and disable_glibcxx_debug==0', {
-            # Enable libstdc++ debugging facilities to help catch problems
-            # early, see http://crbug.com/65151 .
-            'defines': ['_GLIBCXX_DEBUG=1',],
           }],
           ['OS=="aix"', {
             'ldflags': [ '-Wl,-bbigtoc' ],


### PR DESCRIPTION
Make sure `_GLIBCXX_DEBUG` is (un)defined consistently by turning the
`disable_glibcxx_debug` in common.gypi into a global variable that
overrides the definition in toolchain.gypi.

Different parts of the debug build were using differently sized
std::vectors and that ended about as well as you would expect.

Fixes: https://github.com/nodejs/node/issues/30056