### PR TITLE
tools: use print() function in buildbot_run.py

### DIFF
--- a/tools/gyp/buildbot/buildbot_run.py
+++ b/tools/gyp/buildbot/buildbot_run.py
@@ -4,6 +4,7 @@
 # found in the LICENSE file.
 
 """Argument-less script to select what to run on the buildbots."""
+from __future__ import print_function
 
 import os
 import shutil
@@ -24,14 +25,14 @@ def CallSubProcess(*args, **kwargs):
   with open(os.devnull) as devnull_fd:
     retcode = subprocess.call(stdin=devnull_fd, *args, **kwargs)
   if retcode != 0:
-    print '@@@STEP_EXCEPTION@@@'
+    print('@@@STEP_EXCEPTION@@@')
     sys.exit(1)
 
 
 def PrepareCmake():
   """Build CMake 2.8.8 since the version in Precise is 2.8.7."""
   if os.environ['BUILDBOT_CLOBBER'] == '1':
-    print '@@@BUILD_STEP Clobber CMake checkout@@@'
+    print('@@@BUILD_STEP Clobber CMake checkout@@@')
     shutil.rmtree(CMAKE_DIR)
 
   # We always build CMake 2.8.8, so no need to do anything
@@ -39,10 +40,10 @@ def PrepareCmake():
   if os.path.isdir(CMAKE_DIR):
     return
 
-  print '@@@BUILD_STEP Initialize CMake checkout@@@'
+  print('@@@BUILD_STEP Initialize CMake checkout@@@')
   os.mkdir(CMAKE_DIR)
 
-  print '@@@BUILD_STEP Sync CMake@@@'
+  print('@@@BUILD_STEP Sync CMake@@@')
   CallSubProcess(
       ['git', 'clone',
        '--depth', '1',
@@ -53,7 +54,7 @@ def PrepareCmake():
        CMAKE_DIR],
       cwd=CMAKE_DIR)
 
-  print '@@@BUILD_STEP Build CMake@@@'
+  print('@@@BUILD_STEP Build CMake@@@')
   CallSubProcess(
       ['/bin/bash', 'bootstrap', '--prefix=%s' % CMAKE_DIR],
       cwd=CMAKE_DIR)
@@ -74,7 +75,7 @@ def GypTestFormat(title, format=None, msvs_version=None, tests=[]):
   if not format:
     format = title
 
-  print '@@@BUILD_STEP ' + title + '@@@'
+  print('@@@BUILD_STEP ' + title + '@@@')
   sys.stdout.flush()
   env = os.environ.copy()
   if msvs_version:
@@ -89,17 +90,17 @@ def GypTestFormat(title, format=None, msvs_version=None, tests=[]):
   retcode = subprocess.call(command, cwd=ROOT_DIR, env=env, shell=True)
   if retcode:
     # Emit failure tag, and keep going.
-    print '@@@STEP_FAILURE@@@'
+    print('@@@STEP_FAILURE@@@')
     return 1
   return 0
 
 
 def GypBuild():
   # Dump out/ directory.
-  print '@@@BUILD_STEP cleanup@@@'
-  print 'Removing %s...' % OUT_DIR
+  print('@@@BUILD_STEP cleanup@@@')
+  print('Removing %s...' % OUT_DIR)
   shutil.rmtree(OUT_DIR, ignore_errors=True)
-  print 'Done.'
+  print('Done.')
 
   retcode = 0
   if sys.platform.startswith('linux'):
@@ -128,7 +129,7 @@ def GypBuild():
     #     after the build proper that could be used for cumulative failures),
     #     use that instead of this. This isolates the final return value so
     #     that it isn't misattributed to the last stage.
-    print '@@@BUILD_STEP failures@@@'
+    print('@@@BUILD_STEP failures@@@')
     sys.exit(retcode)
 
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but
__print()__ function works as expected in both Python 2 and 3.

Discovered via #30143

`futurize -f libfuturize.fixes.fix_print_with_import -w tools/gyp/buildbot/buildbot_run.py`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
