### PR TITLE
src: expose granular SetIsolateUpForNode

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -291,9 +291,40 @@ class NODE_EXTERN MultiIsolatePlatform : public v8::Platform {
 NODE_EXTERN void SetIsolateCreateParams(v8::Isolate::CreateParams* params,
                                         ArrayBufferAllocator* allocator
                                             = nullptr);
+
+enum IsolateSettingsFlags {
+  MESSAGE_LISTENER_WITH_ERROR_LEVEL = 1 << 0,
+  DETAILED_SOURCE_POSITIONS_FOR_PROFILING = 1 << 1
+};
+
+struct IsolateSettings {
+  uint64_t flags = MESSAGE_LISTENER_WITH_ERROR_LEVEL |
+      DETAILED_SOURCE_POSITIONS_FOR_PROFILING;
+  v8::MicrotasksPolicy policy = v8::MicrotasksPolicy::kExplicit;
+
+  // Error handling callbacks
+  v8::Isolate::AbortOnUncaughtExceptionCallback
+      should_abort_on_uncaught_exception_callback = nullptr;
+  v8::FatalErrorCallback fatal_error_callback = nullptr;
+  v8::PrepareStackTraceCallback prepare_stack_trace_callback = nullptr;
+
+  // Miscellaneous callbacks
+  v8::PromiseRejectCallback promise_reject_callback = nullptr;
+  v8::AllowWasmCodeGenerationCallback
+      allow_wasm_code_generation_callback = nullptr;
+  v8::HostCleanupFinalizationGroupCallback
+      host_cleanup_finalization_group_callback = nullptr;
+};
+
+// Overriding IsolateSettings may produce unexpected behavior
+// in Node.js core functionality, so proceed at your own risk.
+NODE_EXTERN void SetIsolateUpForNode(v8::Isolate* isolate,
+                                     const IsolateSettings& settings);
+
 // Set a number of callbacks for the `isolate`, in particular the Node.js
 // uncaught exception listener.
 NODE_EXTERN void SetIsolateUpForNode(v8::Isolate* isolate);
+
 // Creates a new isolate with Node.js-specific settings.
 // This is a convenience method equivalent to using SetIsolateCreateParams(),
 // Isolate::Allocate(), MultiIsolatePlatform::RegisterIsolate(),

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -296,8 +296,8 @@ struct InitializationResult {
 };
 InitializationResult InitializeOncePerProcess(int argc, char** argv);
 void TearDownOncePerProcess();
-enum class IsolateSettingCategories { kErrorHandlers, kMisc };
-void SetIsolateUpForNode(v8::Isolate* isolate, IsolateSettingCategories cat);
+void SetIsolateErrorHandlers(v8::Isolate* isolate, const IsolateSettings& s);
+void SetIsolateMiscHandlers(v8::Isolate* isolate, const IsolateSettings& s);
 void SetIsolateCreateParamsForNode(v8::Isolate::CreateParams* params);
 
 #if HAVE_INSPECTOR

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -30,7 +30,9 @@ NodeMainInstance::NodeMainInstance(Isolate* isolate,
       owns_isolate_(false),
       deserialize_mode_(false) {
   isolate_data_.reset(new IsolateData(isolate_, event_loop, platform, nullptr));
-  SetIsolateUpForNode(isolate_, IsolateSettingCategories::kMisc);
+
+  IsolateSettings misc;
+  SetIsolateMiscHandlers(isolate_, misc);
 }
 
 std::unique_ptr<NodeMainInstance> NodeMainInstance::Create(
@@ -74,11 +76,12 @@ NodeMainInstance::NodeMainInstance(
                                       platform,
                                       array_buffer_allocator_.get(),
                                       per_isolate_data_indexes));
-  SetIsolateUpForNode(isolate_, IsolateSettingCategories::kMisc);
+  IsolateSettings s;
+  SetIsolateMiscHandlers(isolate_, s);
   if (!deserialize_mode_) {
     // If in deserialize mode, delay until after the deserialization is
     // complete.
-    SetIsolateUpForNode(isolate_, IsolateSettingCategories::kErrorHandlers);
+    SetIsolateErrorHandlers(isolate_, s);
   }
 }
 
@@ -182,7 +185,8 @@ std::unique_ptr<Environment> NodeMainInstance::CreateMainEnvironment(
     context =
         Context::FromSnapshot(isolate_, kNodeContextIndex).ToLocalChecked();
     InitializeContextRuntime(context);
-    SetIsolateUpForNode(isolate_, IsolateSettingCategories::kErrorHandlers);
+    IsolateSettings s;
+    SetIsolateErrorHandlers(isolate_, s);
   } else {
     context = NewContext(isolate_);
   }


### PR DESCRIPTION
This PR exposes a new embedder-focused API: `SetIsolateUpForNode`.

It maintains previous behavior for the single-param version of `SetIsolateUpForNode` and changes no defaults, but was designed to be flexible by allowing for embedders to conditionally override all callbacks and flags set by the previous two-param version of `SetIsolateUpForNode`.

cc @addaleax 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
