### PR TITLE
src: use forward declaration instead of include

### DIFF
--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -26,9 +26,10 @@
 
 #include "node.h"
 #include "handle_wrap.h"
-#include "env.h"
 #include "uv.h"
 #include "v8.h"
+
+class Environment;
 
 namespace node {
 


### PR DESCRIPTION
Reduce number of includes in header file to reduce build time.