### PR TITLE
fs: Add noop stub for FSWatcher.prototype.start

### DIFF
--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -174,7 +174,7 @@ FSWatcher.prototype[kFSWatchStart] = function(filename,
   }
 };
 
-// To maximize backword-compatiblity for the end user
+// To maximize backward-compatiblity for the end user,
 // a no-op stub method has been added instead of
 // totally removing FSWatcher.prototpye.start.
 // This should not be documented

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -174,6 +174,8 @@ FSWatcher.prototype[kFSWatchStart] = function(filename,
   }
 };
 
+FSWatcher.prototype.start = () => {};
+
 // This method is a noop if the watcher has not been started or
 // has already been closed.
 FSWatcher.prototype.close = function() {

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -177,7 +177,7 @@ FSWatcher.prototype[kFSWatchStart] = function(filename,
 // To maximize backward-compatiblity for the end user,
 // a no-op stub method has been added instead of
 // totally removing FSWatcher.prototpye.start.
-// This should not be documented
+// This should not be documented.
 FSWatcher.prototype.start = () => {};
 
 // This method is a noop if the watcher has not been started or

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -174,6 +174,10 @@ FSWatcher.prototype[kFSWatchStart] = function(filename,
   }
 };
 
+// To maximize backword-compatiblity for the end user
+// a no-op stub method has been added instead of
+// totally removing FSWatcher.prototpye.start.
+// This should not be documented
 FSWatcher.prototype.start = () => {};
 
 // This method is a noop if the watcher has not been started or


### PR DESCRIPTION
Motivation: In a previous PR, #29905, I made this method a private
method since it had no value to the user.

There was discussion, https://github.com/nodejs/node/pull/29989, that maybe it should have been a runtime deprecation
first, but was ultimatley decided that for this type of method, a
noop stub was a better option.

This Adds back in the method, but as a noop stub, while also keeping
the real implementation private

I wasn't sure if i should add the tests back in that were removed.  


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
