### PR TITLE
v8: inspect unserializable objects

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -24,6 +24,7 @@ const {
 } = internalBinding('serdes');
 const assert = require('internal/assert');
 const { copy } = internalBinding('buffer');
+const { inspect } = require('internal/util/inspect');
 const { FastBuffer } = require('internal/buffer');
 const { getValidatedPath } = require('internal/fs/utils');
 const { toNamespacedPath } = require('path');
@@ -242,7 +243,8 @@ class DefaultSerializer extends Serializer {
       i = arrayBufferViewTypeToIndex.get(tag);
 
       if (i === undefined) {
-        throw new this._getDataCloneError(`Unknown host object type: ${tag}`);
+        throw new this._getDataCloneError(
+          `Unserializable host object: ${inspect(abView)}`);
       }
     }
     this.writeUint32(i);

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -157,9 +157,9 @@ const deserializerTypeError =
 
 {
   assert.throws(() => v8.serialize(hostObject), {
-                  constructor: Error,
-                  message: 'Unserializable host object: JSStream {}'
-                });
+    constructor: Error,
+    message: 'Unserializable host object: JSStream {}'
+  });
 }
 
 {

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -156,8 +156,10 @@ const deserializerTypeError =
 }
 
 {
-  assert.throws(() => v8.serialize(hostObject),
-                /^Error: Unknown host object type: \[object .*\]$/);
+  assert.throws(() => v8.serialize(hostObject), {
+                  constructor: Error,
+                  message: 'Unserializable host object: JSStream {}'
+                });
 }
 
 {


### PR DESCRIPTION
This would otherwise sometimes just print relatively useless
information about the value in question, such as `[object Object]`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
