### PR TITLE
src: isolate->Dispose() order consistency

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -273,10 +273,11 @@ class NODE_EXTERN MultiIsolatePlatform : public v8::Platform {
   // This function may only be called once per `Isolate`.
   virtual void RegisterIsolate(v8::Isolate* isolate,
                                struct uv_loop_s* loop) = 0;
-  // This needs to be called right before calling `Isolate::Dispose()`.
+
   // This function may only be called once per `Isolate`, and discard any
   // pending delayed tasks scheduled for that isolate.
   virtual void UnregisterIsolate(v8::Isolate* isolate) = 0;
+
   // The platform should call the passed function once all state associated
   // with the given isolate has been cleaned up. This can, but does not have to,
   // happen asynchronously.

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -155,9 +155,9 @@ class WorkerThreadData {
     w_->platform_->AddIsolateFinishedCallback(isolate, [](void* data) {
       *static_cast<bool*>(data) = true;
     }, &platform_finished);
-    w_->platform_->UnregisterIsolate(isolate);
 
     isolate->Dispose();
+    w_->platform_->UnregisterIsolate(isolate);
 
     // Wait until the platform has cleaned up all relevant resources.
     while (!platform_finished)


### PR DESCRIPTION
Removes comment from `UnregisterIsolate()` specifying that `Isolate::Dispose()` should be called _after_ `UnregisterIsolate()` since that's no longer the case.

This was originally added to account for issues in V8 but now there should be no relevant tasks running during either call so their order is fungible. However, for consistency's sake, we were calling most of these in the same order (dispose and then unregister) so this also moves a straggling call from `node_worker` to bring it in line with all others.

cc @addaleax 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
