### PR TITLE
http: fix incorrect headersTimeout measurement

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -47,6 +47,7 @@ const kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;
 const kOnBody = HTTPParser.kOnBody | 0;
 const kOnMessageComplete = HTTPParser.kOnMessageComplete | 0;
 const kOnExecute = HTTPParser.kOnExecute | 0;
+const kOnMessageBegin = HTTPParser.kOnMessageBegin | 0;
 
 const MAX_HEADER_PAIRS = 2000;
 
@@ -165,6 +166,7 @@ const parsers = new FreeList('parsers', 1000, function parsersCb() {
   parser[kOnHeadersComplete] = parserOnHeadersComplete;
   parser[kOnBody] = parserOnBody;
   parser[kOnMessageComplete] = parserOnMessageComplete;
+  parser[kOnMessageBegin] = null;
 
   return parser;
 });

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -142,6 +142,7 @@ const STATUS_CODES = {
 };
 
 const kOnExecute = HTTPParser.kOnExecute | 0;
+const kOnMessageBegin = HTTPParser.kOnMessageBegin | 0;
 
 class HTTPServerAsyncResource {
   constructor(type, socket) {
@@ -428,9 +429,6 @@ function connectionListenerInternal(server, socket) {
       isLenient() : server.insecureHTTPParser,
   );
   parser.socket = socket;
-
-  // We are starting to wait for our headers.
-  parser.parsingHeadersStart = nowDate();
   socket.parser = parser;
 
   // Propagate headers limit from server instance to parser
@@ -481,6 +479,7 @@ function connectionListenerInternal(server, socket) {
   }
   parser[kOnExecute] =
     onParserExecute.bind(undefined, server, socket, parser, state);
+  parser[kOnMessageBegin] = onParserMessageBegin.bind(undefined, parser);
 
   socket._paused = false;
 }
@@ -568,11 +567,17 @@ function socketOnData(server, socket, parser, state, d) {
   onParserExecuteCommon(server, socket, parser, state, ret, d);
 }
 
+function onParserMessageBegin(parser) {
+  // We are starting to wait for the headers.
+  parser.parsingHeadersStart = nowDate();
+}
+
 function onParserExecute(server, socket, parser, state, ret) {
   socket._unrefTimer();
-  const start = parser.parsingHeadersStart;
+
   debug('SERVER socketOnParserExecute %d', ret);
 
+  const start = parser.parsingHeadersStart;
   // If we have not parsed the headers, destroy the socket
   // after server.headersTimeout to protect from DoS attacks.
   // start === 0 means that we have parsed headers.
@@ -720,10 +725,6 @@ function emitCloseNT(self) {
 function parserOnIncoming(server, socket, state, req, keepAlive) {
   resetSocketTimeout(server, socket, state);
 
-  if (server.keepAliveTimeout > 0) {
-    req.on('end', resetHeadersTimeoutOnReqEnd);
-  }
-
   // Set to zero to communicate that we have finished parsing.
   socket.parser.parsingHeadersStart = 0;
 
@@ -849,17 +850,6 @@ function generateSocketListenerWrapper(originalFnName) {
 
     return res;
   };
-}
-
-function resetHeadersTimeoutOnReqEnd() {
-  debug('resetHeadersTimeoutOnReqEnd');
-
-  const parser = this.socket.parser;
-  // Parser can be null if the socket was destroyed
-  // in that case, there is nothing to do.
-  if (parser) {
-    parser.parsingHeadersStart = nowDate();
-  }
 }
 
 module.exports = {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -429,6 +429,7 @@ function connectionListenerInternal(server, socket) {
       isLenient() : server.insecureHTTPParser,
   );
   parser.socket = socket;
+  parser.parsingHeadersStart = nowDate();
   socket.parser = parser;
 
   // Propagate headers limit from server instance to parser

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -190,8 +190,7 @@ class Parser : public AsyncWrap, public StreamListener {
     if (!cb->IsFunction())
       return 0;
 
-    Local<Value> argv[0];
-    MaybeLocal<Value> r = MakeCallback(cb.As<Function>(), 0, argv);
+    MaybeLocal<Value> r = MakeCallback(cb.As<Function>(), 0, nullptr);
 
     if (r.IsEmpty()) {
       got_exception_ = true;

--- a/test/parallel/test-http-highwatermark.js
+++ b/test/parallel/test-http-highwatermark.js
@@ -14,7 +14,7 @@ let requestReceived = 0;
 const server = http.createServer(function(req, res) {
   const id = ++requestReceived;
   const enoughToDrain = req.connection.writableHighWaterMark;
-  const body = 'x'.repeat(enoughToDrain * 100);
+  const body = 'x'.repeat(enoughToDrain * 200);
 
   if (id === 1) {
     // Case of needParse = false

--- a/test/parallel/test-http-highwatermark.js
+++ b/test/parallel/test-http-highwatermark.js
@@ -14,7 +14,7 @@ let requestReceived = 0;
 const server = http.createServer(function(req, res) {
   const id = ++requestReceived;
   const enoughToDrain = req.connection.writableHighWaterMark;
-  const body = 'x'.repeat(enoughToDrain * 200);
+  const body = 'x'.repeat(enoughToDrain * 100);
 
   if (id === 1) {
     // Case of needParse = false

--- a/test/parallel/test-http-slow-headers-keepalive-multiple-requests.js
+++ b/test/parallel/test-http-slow-headers-keepalive-multiple-requests.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+const net = require('net');
+const { finished } = require('stream');
+
+const headers =
+  'GET / HTTP/1.1\r\n' +
+  'Host: localhost\r\n' +
+  'Connection: keep-alive\r\n' +
+  'Agent: node\r\n';
+
+const baseTimeout = 1000;
+
+const server = http.createServer(common.mustCall((req, res) => {
+  req.resume();
+  res.writeHead(200);
+  res.end();
+}, 2));
+
+server.keepAliveTimeout = 10 * baseTimeout;
+server.headersTimeout = baseTimeout;
+
+server.once('timeout', common.mustNotCall((socket) => {
+  socket.destroy();
+}));
+
+server.listen(0, () => {
+  const client = net.connect(server.address().port);
+
+  // first request
+  client.write(headers);
+  client.write('\r\n');
+
+  setTimeout(() => {
+    // second request
+    client.write(headers);
+    // `headersTimeout` doesn't seem to fire if request headers
+    // are sent in one packet.
+    setTimeout(() => {
+      client.write('\r\n');
+      client.end();
+    }, 10);
+  }, baseTimeout + 10);
+
+  finished(client, common.mustCall((err) => {
+    server.close();
+  }));
+});


### PR DESCRIPTION
For keep-alive connections, the headersTimeout may fire during subsequent requests
because the measurement was reset after a request and not before a request.

Fixes: https://github.com/nodejs/node/issues/27363

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
