### PR TITLE
Replaced 'assert.throws' with 'common.expectsError'

### DIFF
--- a/test/js-native-api/test_bigint/test.js
+++ b/test/js-native-api/test_bigint/test.js
@@ -39,7 +39,9 @@ const {
   assert.strictEqual(num, TestWords(num));
 });
 
-assert.throws(CreateTooBigBigInt, {
+common.expectsError(CreateTooBigBigInt, {
+  code: 'ERR_INVALID_RANGE',
   name: 'RangeError',
   message: 'Maximum BigInt size exceeded',
+  type: RangeError
 });


### PR DESCRIPTION
Modified `test/js-native-api/test_bigint/test.js` to use `common.expectsError` instead of `assert.throws`.