### PR TITLE
test: deflake test-tls-close-notify.js

### DIFF
--- a/test/parallel/test-tls-close-notify.js
+++ b/test/parallel/test-tls-close-notify.js
@@ -35,19 +35,18 @@ const server = tls.createServer({
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem')
 }, function(c) {
-  // Send close-notify without shutting down TCP socket
-  const req = new ShutdownWrap();
-  req.oncomplete = common.mustCall(() => {});
-  req.handle = c._handle;
-  c._handle.shutdown(req);
+  // Ensure that we receive 'end' event anyway.
+  c.on('end', common.mustCall(function() {
+    server.close();
+  }));
 }).listen(0, common.mustCall(function() {
   const c = tls.connect(this.address().port, {
     rejectUnauthorized: false
   }, common.mustCall(function() {
-    // Ensure that we receive 'end' event anyway
-    c.on('end', common.mustCall(function() {
-      c.destroy();
-      server.close();
-    }));
+    // Send close-notify without shutting down TCP socket.
+    const req = new ShutdownWrap();
+    req.oncomplete = common.mustCall(() => {});
+    req.handle = c._handle;
+    c._handle.shutdown(req);
   }));
 }));


### PR DESCRIPTION
This test occasionally fails on macOS with the following error

```
events.js:187
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:201:27)
Emitted 'error' event on TLSSocket instance at:
    at emitErrorNT (internal/streams/destroy.js:84:8)
    at processTicksAndRejections (internal/process/task_queues.js:80:21) {
  errno: -54,
  code: 'ECONNRESET',
  syscall: 'read'
}
```

Fix it by making the client send the close_notify alert instead of the
server.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
