### PR TITLE
tools: fix Python 3 deprecation warning in test.py

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -29,7 +29,6 @@
 
 
 from __future__ import print_function
-import imp
 import logging
 import optparse
 import os
@@ -44,6 +43,30 @@ import utils
 import multiprocessing
 import errno
 import copy
+
+
+if sys.version_info >= (3, 5):
+    from importlib import machinery, util
+    def get_module(name, path):
+        loader_details = (
+            machinery.SourceFileLoader,
+            machinery.SOURCE_SUFFIXES
+        )
+        spec = machinery.FileFinder(path, loader_details).find_spec(name)
+        module = util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+else:
+    import imp
+    def get_module(name, path):
+        file = None
+        try:
+            (file, pathname, description) = imp.find_module(name, [path])
+            return imp.load_module(name, file, pathname, description)
+        finally:
+          if file:
+            file.close()
+
 
 from io import open
 from os.path import join, dirname, abspath, basename, isdir, exists
@@ -791,18 +814,13 @@ class TestRepository(TestSuite):
     if self.is_loaded:
       return self.config
     self.is_loaded = True
-    file = None
-    try:
-      (file, pathname, description) = imp.find_module('testcfg', [ self.path ])
-      module = imp.load_module('testcfg', file, pathname, description)
-      self.config = module.GetConfiguration(context, self.path)
-      if hasattr(self.config, 'additional_flags'):
-        self.config.additional_flags += context.node_args
-      else:
-        self.config.additional_flags = context.node_args
-    finally:
-      if file:
-        file.close()
+
+    module = get_module('testcfg', self.path)
+    self.config = module.GetConfiguration(context, self.path)
+    if hasattr(self.config, 'additional_flags'):
+      self.config.additional_flags += context.node_args
+    else:
+      self.config.additional_flags = context.node_args
     return self.config
 
   def GetBuildRequirements(self, path, context):

--- a/tools/test.py
+++ b/tools/test.py
@@ -46,26 +46,23 @@ import copy
 
 
 if sys.version_info >= (3, 5):
-    from importlib import machinery, util
-    def get_module(name, path):
-        loader_details = (
-            machinery.SourceFileLoader,
-            machinery.SOURCE_SUFFIXES
-        )
-        spec = machinery.FileFinder(path, loader_details).find_spec(name)
-        module = util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        return module
+  from importlib import machinery, util
+  def get_module(name, path):
+    loader_details = (machinery.SourceFileLoader, machinery.SOURCE_SUFFIXES)
+    spec = machinery.FileFinder(path, loader_details).find_spec(name)
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 else:
-    import imp
-    def get_module(name, path):
-        file = None
-        try:
-            (file, pathname, description) = imp.find_module(name, [path])
-            return imp.load_module(name, file, pathname, description)
-        finally:
-          if file:
-            file.close()
+  import imp
+  def get_module(name, path):
+    file = None
+    try:
+      (file, pathname, description) = imp.find_module(name, [path])
+      return imp.load_module(name, file, pathname, description)
+    finally:
+      if file:
+        file.close()
 
 
 from io import open


### PR DESCRIPTION
Since Python 3.4, the `imp` module is deprecated, causing a deprecation warning when running `tools/test.py`.

This fixes it by conditionally using `importlib` instead when running `tools/test.py` with Python 3.5+.

Notes:
- Python 3 < 3.5 is not supported, since `importlib.util.module_from_spec()` isn't available. Python 3 < 3.5 reached EOL so this should not be an issue.
- the use of a `importlib.machinery.FileFinder` should match the the behaviour of `imp.find_module()` and find any Python-recognised module file (like `testcfg.py`).
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
