### PR TITLE
dgram: remove listeners on bind error

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -240,8 +240,8 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
       }, (err) => {
         // Callback to handle error.
         const ex = errnoException(err, 'open');
-        this.emit('error', ex);
         state.bindState = BIND_STATE_UNBOUND;
+        this.emit('error', ex);
       });
       return this;
     }
@@ -309,8 +309,8 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
       }, (err) => {
         // Callback to handle error.
         const ex = exceptionWithHostPort(err, 'bind', ip, port);
-        this.emit('error', ex);
         state.bindState = BIND_STATE_UNBOUND;
+        this.emit('error', ex);
       });
     } else {
       if (!state.handle)
@@ -319,8 +319,8 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
       const err = state.handle.bind(ip, port || 0, flags);
       if (err) {
         const ex = exceptionWithHostPort(err, 'bind', ip, port);
-        this.emit('error', ex);
         state.bindState = BIND_STATE_UNBOUND;
+        this.emit('error', ex);
         // Todo: close?
         return;
       }

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -211,8 +211,21 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
 
   state.bindState = BIND_STATE_BINDING;
 
-  if (arguments.length && typeof arguments[arguments.length - 1] === 'function')
-    this.once('listening', arguments[arguments.length - 1]);
+  const cb = arguments.length && arguments[arguments.length - 1];
+  if (typeof cb === 'function') {
+    function removeListeners() {
+      this.removeListener('error', removeListeners);
+      this.removeListener('listening', onListening);
+    }
+
+    function onListening() {
+      removeListeners.call(this);
+      cb.call(this);
+    }
+
+    this.on('error', removeListeners);
+    this.on('listening', onListening);
+  }
 
   if (port instanceof UDP) {
     replaceHandle(this, port);

--- a/test/parallel/test-dgram-bind-error-repeat.js
+++ b/test/parallel/test-dgram-bind-error-repeat.js
@@ -17,8 +17,7 @@ reservePortSocket.bind(() => {
   let errors = 0;
   newSocket.on('error', common.mustCall(() => {
     if (++errors < 20) {
-      const cb = errors === 20 ? common.mustCall() : common.mustNotCall();
-      newSocket.bind(port, cb);
+      newSocket.bind(port, common.mustNotCall());
     } else {
       newSocket.close();
       reservePortSocket.close();

--- a/test/parallel/test-dgram-bind-error-repeat.js
+++ b/test/parallel/test-dgram-bind-error-repeat.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+const dgram = require('dgram');
+
+// Regression test for https://github.com/nodejs/node/issues/30209
+// No warning should be emitted when re-trying `.bind()` on UDP sockets
+// repeatedly.
+
+process.on('warning', common.mustNotCall());
+
+const reservePortSocket = dgram.createSocket('udp4');
+reservePortSocket.bind(() => {
+  const { port } = reservePortSocket.address();
+
+  const newSocket = dgram.createSocket('udp4');
+
+  let errors = 0;
+  newSocket.on('error', common.mustCall(() => {
+    if (++errors < 20) {
+      const cb = errors === 20 ? common.mustCall() : common.mustNotCall();
+      newSocket.bind(port, cb);
+    } else {
+      newSocket.close();
+      reservePortSocket.close();
+    }
+  }, 20));
+  newSocket.bind(port, common.mustNotCall());
+});


### PR DESCRIPTION
##### dgram: reset bind state before emitting error

This was previously done inconsistently, sometimes before, sometimes
after emitting the event.

##### dgram: remove listeners on bind error

This avoids piling up `'listening'` event listeners if
`.bind()` fails repeatedly.

Fixes: https://github.com/nodejs/node/issues/30209

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
