### PR TITLE
docs: remove http streams from the list of writeables

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -180,8 +180,6 @@ written.
 
 Examples of [`Writable`][] streams include:
 
-* [HTTP requests, on the client][]
-* [HTTP responses, on the server][]
 * [fs write streams][]
 * [zlib streams][zlib]
 * [crypto streams][crypto]
@@ -2814,8 +2812,6 @@ contain multi-byte characters.
 [API for Stream Consumers]: #stream_api_for_stream_consumers
 [API for Stream Implementers]: #stream_api_for_stream_implementers
 [Compatibility]: #stream_compatibility_with_older_node_js_versions
-[HTTP requests, on the client]: http.html#http_class_http_clientrequest
-[HTTP responses, on the server]: http.html#http_class_http_serverresponse
 [TCP sockets]: net.html#net_class_net_socket
 [child process stdin]: child_process.html#child_process_subprocess_stdin
 [child process stdout and stderr]: child_process.html#child_process_subprocess_stdout


### PR DESCRIPTION
The documentation lists HTTP server response and HTTP client request as writable streams. However, in fact, they are not, which confuses users. Example in this twitter thread: https://mobile.twitter.com/getify/status/1190456439996854273

I have checked other examples, they all extend `stream.Writable`, so they are fine to stay in the list.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)