### PR TITLE
esm: exit the process with an error if loader has an issue

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -480,16 +480,16 @@ function runMainESM(mainPath) {
   return esmLoader.initializeLoader().then(() => {
     const main = path.isAbsolute(mainPath) ?
       pathToFileURL(mainPath).href : mainPath;
-    return esmLoader.ESMLoader.import(main).catch((e) => {
-      if (hasUncaughtExceptionCaptureCallback()) {
-        process._fatalException(e);
-        return;
-      }
-      internalBinding('errors').triggerUncaughtException(
-        e,
-        true /* fromPromise */
-      );
-    });
+    return esmLoader.ESMLoader.import(main);
+  }).catch((e) => {
+    if (hasUncaughtExceptionCaptureCallback()) {
+      process._fatalException(e);
+      return;
+    }
+    internalBinding('errors').triggerUncaughtException(
+      e,
+      true /* fromPromise */
+    );
   });
 }
 

--- a/test/message/esm_loader_not_found.mjs
+++ b/test/message/esm_loader_not_found.mjs
@@ -1,0 +1,3 @@
+// Flags:  --experimental-modules --experimental-loader i-dont-exist
+import '../common/index.mjs';
+console.log('This should not be printed');

--- a/test/message/esm_loader_not_found.out
+++ b/test/message/esm_loader_not_found.out
@@ -1,0 +1,18 @@
+(node:*) ExperimentalWarning: The ESM module loader is experimental.
+(node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
+internal/modules/esm/default_resolve.js:*
+  let url = moduleWrapResolve(specifier, parentURL);
+            ^
+
+Error: Cannot find package 'i-dont-exist' imported from *
+    at Loader.resolve [as _resolve] (internal/modules/esm/default_resolve.js:*:*)
+    at Loader.resolve (internal/modules/esm/loader.js:*:*)
+    at Loader.getModuleJob (internal/modules/esm/loader.js:*:*)
+    at Loader.import (internal/modules/esm/loader.js:*:*)
+    at internal/process/esm_loader.js:*:*
+    at Object.initializeLoader (internal/process/esm_loader.js:*:*)
+    at runMainESM (internal/bootstrap/pre_execution.js:*:*)
+    at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
+    at internal/main/run_main_module.js:*:* {
+  code: 'ERR_MODULE_NOT_FOUND'
+}

--- a/test/message/esm_loader_syntax_error.mjs
+++ b/test/message/esm_loader_syntax_error.mjs
@@ -1,0 +1,3 @@
+// Flags:  --experimental-modules --experimental-loader ./test/fixtures/es-module-loaders/syntax-error.mjs
+import '../common/index.mjs';
+console.log('This should not be printed');

--- a/test/message/esm_loader_syntax_error.out
+++ b/test/message/esm_loader_syntax_error.out
@@ -1,0 +1,9 @@
+(node:*) ExperimentalWarning: The ESM module loader is experimental.
+(node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
+file://*/test/fixtures/es-module-loaders/syntax-error.mjs:2
+await async () => 0;
+^^^^^
+
+SyntaxError: Unexpected reserved word
+    at Loader.moduleStrategy (internal/modules/esm/translators.js:*:*)
+    at async link (internal/modules/esm/module_job.js:*:*)


### PR DESCRIPTION
Previously, this would trigger an unhandled rejection that the user
cannot handle.

Fixes: https://github.com/nodejs/node/issues/30205

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
