### PR TITLE
tools: check-imports using utf-8

### DIFF
--- a/tools/check-imports.py
+++ b/tools/check-imports.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 import glob
+import io
 import re
 import sys
 
@@ -15,7 +16,7 @@ def do_exist(file_name, lines, imported):
 
 
 def is_valid(file_name):
-  with open(file_name) as source_file:
+  with io.open(file_name, encoding='utf-8') as source_file:
     lines = [line.strip() for line in source_file]
 
   usings, importeds, line_numbers, valid = [], [], [], True


### PR DESCRIPTION
This PR uses `io.open(encoding="utf-8")` to resolve a UnicodeDecodeError on Python 3 after the fix in #30218 has been applied.

This can be replicated by running `docker build .` using the following:

<details><summary>Dockerfile</summary>

```
FROM ubuntu:bionic

# Install tools
RUN apt-get update
RUN apt-get install -y build-essential python3 python3-pip ninja-build make g++ vim git sudo

# Expose ports used by net tests
ENV NODE_COMMON_PORT=12346
EXPOSE 12346
# debug port used by v8 debugger
EXPOSE 5858
# debug port used by v8 insepctor
EXPOSE 9229

# Set up user node-dev: the tests fail when run by the root
RUN adduser --disabled-password --gecos '' node-dev
RUN adduser node-dev sudo
RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
USER node-dev
WORKDIR /home/node-dev
ENV HOME /home/node-dev

# Clone the code and build
RUN git clone --depth=1 https://github.com/nodejs/node.git
WORKDIR /home/node-dev/node
RUN python3 -m pip install setuptools
RUN python3 ./configure --ninja
ENV BUILD_WITH ninja
RUN make -j2 test
```

</details>

##### Checklist
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
