### PR TITLE
build: add workaround for No module named 'distutils.spawn'

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -147,8 +147,9 @@ platforms. This is true regardless of entries in the table below.
   [WSL issue tracker](https://github.com/Microsoft/WSL/issues). Running the
   Windows binary (`node.exe`) in WSL is not recommended. It will not work
   without workarounds such as stdio redirection. 
-  If you running into `No module named 'distutils.spawn'` 
-  Error when executing `./configure`, please try `python3 -m pip install setuptools` or `sudo apt install python3-distutils -y`.
+  If you run into a `No module named 'distutils.spawn'` error when executing
+  `./configure`, please try `python3 -m pip install --upgrade setuptools` or
+  `sudo apt install python3-distutils -y`.
   For more information, see https://github.com/nodejs/node/issues/30189.
 
 <em id="fn6">6</em>: Running Node.js on x86 Windows should work and binaries

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -146,7 +146,10 @@ platforms. This is true regardless of entries in the table below.
   systems. Issues that only reproduce on WSL should be reported in the
   [WSL issue tracker](https://github.com/Microsoft/WSL/issues). Running the
   Windows binary (`node.exe`) in WSL is not recommended. It will not work
-  without workarounds such as stdio redirection.
+  without workarounds such as stdio redirection. 
+  If you running into `No module named 'distutils.spawn'` 
+  Error when executing `./configure`, please try `python3 -m pip install setuptools` or `sudo apt install python3-distutils -y`.
+  For more information, see https://github.com/nodejs/node/issues/30189.
 
 <em id="fn6">6</em>: Running Node.js on x86 Windows should work and binaries
 are provided. However, tests in our infrastructure only run on WoW64.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -146,11 +146,7 @@ platforms. This is true regardless of entries in the table below.
   systems. Issues that only reproduce on WSL should be reported in the
   [WSL issue tracker](https://github.com/Microsoft/WSL/issues). Running the
   Windows binary (`node.exe`) in WSL is not recommended. It will not work
-  without workarounds such as stdio redirection. 
-  If you run into a `No module named 'distutils.spawn'` error when executing
-  `./configure`, please try `python3 -m pip install --upgrade setuptools` or
-  `sudo apt install python3-distutils -y`.
-  For more information, see https://github.com/nodejs/node/issues/30189.
+  without workarounds such as stdio redirection.
 
 <em id="fn6">6</em>: Running Node.js on x86 Windows should work and binaries
 are provided. However, tests in our infrastructure only run on WoW64.
@@ -285,6 +281,11 @@ To build Node.js:
 $ ./configure
 $ make -j4
 ```
+
+If you run into a `No module named 'distutils.spawn'` error when executing
+`./configure`, please try `python3 -m pip install --upgrade setuptools` or
+`sudo apt install python3-distutils -y`.
+For more information, see https://github.com/nodejs/node/issues/30189.
 
 The `-j4` option will cause `make` to run 4 simultaneous compilation jobs which
 may reduce build time. For more information, see the


### PR DESCRIPTION
Fix: #30189 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
