### PR TITLE
[v12.x] http: fix monkey-patching of http_parser

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -75,6 +75,7 @@ const internalBindingWhitelist = new SafeSet([
   'fs',
   'fs_event_wrap',
   'http_parser',
+  'http_parser_llhttp',
   'icu',
   'inspector',
   'js_stream',


### PR DESCRIPTION
Fixes inability to monkey-patch the HTTP Parser on Node v12.x.  This is not an issue on Node v13+ since the parser was renamed back to the old (already monkey-patchable) `http_parser` name, so I made this PR to the v12.x branch, but I'm unclear as to whether or not that's the right move. However the test in master could also use updating so this doesn't break again (I'll send a separate PR for that).

Fixes: creationix/http-parser-js#65

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)