### PR TITLE
src: make AtExit() callbacks run in reverse order

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1354,10 +1354,10 @@ static void sanity_check(void*) {
 }
 
 void init(Local<Object> exports) {
+  AtExit(sanity_check);
   AtExit(at_exit_cb2, cookie);
   AtExit(at_exit_cb2, cookie);
   AtExit(at_exit_cb1, exports->GetIsolate());
-  AtExit(sanity_check);
 }
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/src/env.cc
+++ b/src/env.cc
@@ -637,7 +637,7 @@ void Environment::RunAtExitCallbacks() {
 }
 
 void Environment::AtExit(void (*cb)(void* arg), void* arg) {
-  at_exit_functions_.push_back(ExitCallback{cb, arg});
+  at_exit_functions_.push_front(ExitCallback{cb, arg});
 }
 
 void Environment::RunAndClearNativeImmediates() {

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -10,8 +10,12 @@ using node::RunAtExit;
 
 static bool called_cb_1 = false;
 static bool called_cb_2 = false;
+static bool called_cb_ordered_1 = false;
+static bool called_cb_ordered_2 = false;
 static void at_exit_callback1(void* arg);
 static void at_exit_callback2(void* arg);
+static void at_exit_callback_ordered1(void* arg);
+static void at_exit_callback_ordered2(void* arg);
 static std::string cb_1_arg;  // NOLINT(runtime/string)
 
 class EnvironmentTest : public EnvironmentTestFixture {
@@ -20,6 +24,8 @@ class EnvironmentTest : public EnvironmentTestFixture {
     NodeTestFixture::TearDown();
     called_cb_1 = false;
     called_cb_2 = false;
+    called_cb_ordered_1 = false;
+    called_cb_ordered_2 = false;
   }
 };
 
@@ -59,6 +65,19 @@ TEST_F(EnvironmentTest, AtExitWithoutEnvironment) {
   AtExit(at_exit_callback1);  // No Environment is passed to AtExit.
   RunAtExit(*env);
   EXPECT_TRUE(called_cb_1);
+}
+
+TEST_F(EnvironmentTest, AtExitOrder) {
+  const v8::HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env env {handle_scope, argv};
+
+  // Test that callbacks are run in reverse order.
+  AtExit(*env, at_exit_callback_ordered1);
+  AtExit(*env, at_exit_callback_ordered2);
+  RunAtExit(*env);
+  EXPECT_TRUE(called_cb_ordered_1);
+  EXPECT_TRUE(called_cb_ordered_2);
 }
 
 TEST_F(EnvironmentTest, AtExitWithArgument) {
@@ -133,4 +152,14 @@ static void at_exit_callback1(void* arg) {
 
 static void at_exit_callback2(void* arg) {
   called_cb_2 = true;
+}
+
+static void at_exit_callback_ordered1(void* arg) {
+  EXPECT_TRUE(called_cb_ordered_2);
+  called_cb_ordered_1 = true;
+}
+
+static void at_exit_callback_ordered2(void* arg) {
+  EXPECT_FALSE(called_cb_ordered_1);
+  called_cb_ordered_2 = true;
 }


### PR DESCRIPTION
This makes the actual behaviour match the documented (and arguably
the correct) behaviour.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
