### PR TITLE
doc: clarify IncomingMessage.destroy() description

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1740,8 +1740,8 @@ added: v0.3.0
 * `error` {Error}
 
 Calls `destroy()` on the socket that received the `IncomingMessage`. If `error`
-is provided, an `'error'` event is emitted and `error` is passed as an argument
-to any listeners on the event.
+is provided, an `'error'` event is emitted on the socket and `error` is passed
+as an argument to any listeners on the event.
 
 ### message.headers
 <!-- YAML


### PR DESCRIPTION
State that the 'error' event is emitted on the underlying socket, not
the IncomingMessage object.

Here are the relevant parts in the code:
- [IncomingMessage.destroy](https://github.com/nodejs/node/blob/master/lib/_http_incoming.js#L120)
- which calls [Steam.destroy](https://github.com/nodejs/node/blob/master/lib/internal/streams/destroy.js#L27)

Here's a program that demonstrates this
```js
http.createServer(req=>{
  req.on('error',console.error);
  req.destroy(new Error('hi'));
}).listen(8080)
```
Then, ```curl localhost:8080```
The Node.js process doesn't print the error

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
