### PR TITLE
test: do not run release-npm test without crypto

### DIFF
--- a/test/parallel/test-release-npm.js
+++ b/test/parallel/test-release-npm.js
@@ -7,7 +7,7 @@ const path = require('path');
 
 const releaseReg = /^v\d+\.\d+\.\d+$/;
 
-// npm requires crypto support.
+// Npm requires crypto support.
 if (!releaseReg.test(process.version) || !common.hasCrypto) {
   common.skip('This test is only for release builds');
 }

--- a/test/parallel/test-release-npm.js
+++ b/test/parallel/test-release-npm.js
@@ -7,12 +7,13 @@ const path = require('path');
 
 const releaseReg = /^v\d+\.\d+\.\d+$/;
 
-if (!releaseReg.test(process.version)) {
+// npm requires crypto support.
+if (!releaseReg.test(process.version) || !common.hasCrypto) {
   common.skip('This test is only for release builds');
 }
 
 {
-  // Verify that npm does not print out a warning when executed
+  // Verify that npm does not print out a warning when executed.
 
   const npmCli = path.join(__dirname, '../../deps/npm/bin/npm-cli.js');
   const npmExec = child_process.spawnSync(process.execPath, [npmCli]);


### PR DESCRIPTION
npm requires crypto support and cannot be loaded without it.

This error is fixed: https://ci.nodejs.org/job/node-test-commit-linux-containered/15622/nodes=ubuntu1804_sharedlibs_withoutssl_x64/testReport/junit/(root)/test/parallel_test_release_npm/