### PR TITLE
doc: fixed a typo in process.md

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1957,7 +1957,7 @@ If Node.js is spawned with an IPC channel, the `process.send()` method can be
 used to send messages to the parent process. Messages will be received as a
 [`'message'`][] event on the parent's [`ChildProcess`][] object.
 
-If Node.js was not spawned with an IPC channel, `process.send()` will be
+If Node.js was not spawned with an IPC channel, `process.send` will be
 `undefined`.
 
 The message goes through serialization and parsing. The resulting message might


### PR DESCRIPTION
If the process was not spawned with an IPC channel, `process.send`
will be undefined and calling it as `process.send()` would throw error

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
