### PR TITLE
test: cover 'close' method (in Dir class) with tests

### DIFF
--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -33,6 +33,11 @@ const dirclosedError = {
   code: 'ERR_DIR_CLOSED'
 };
 
+const invalidCallbackObj = {
+  code: 'ERR_INVALID_CALLBACK',
+  name: 'TypeError'
+};
+
 // Check the opendir Sync version
 {
   const dir = fs.opendirSync(testDir);
@@ -205,3 +210,20 @@ for (const bufferSize of ['', '1', null]) {
   assertDirent(dir.readSync());
   dir.close();
 }
+
+// Check that when passing a string instead of function - throw an exception
+async function doAsyncIterInvalidCallbackTest() {
+  const dir = await fs.promises.opendir(testDir);
+``
+  assert.throws(() => dir.close('not function'), invalidCallbackObj);
+}
+doAsyncIterInvalidCallbackTest().then(common.mustCall());
+
+// Check if directory already closed - throw an exception
+async function doAsyncIterDirClosedTest() {
+  const dir = await fs.promises.opendir(testDir);
+  await dir.close();
+
+  assert.throws(() => dir.close(), dirclosedError);
+}
+doAsyncIterDirClosedTest().then(common.mustCall());

--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -214,7 +214,6 @@ for (const bufferSize of ['', '1', null]) {
 // Check that when passing a string instead of function - throw an exception
 async function doAsyncIterInvalidCallbackTest() {
   const dir = await fs.promises.opendir(testDir);
-``
   assert.throws(() => dir.close('not function'), invalidCallbackObj);
 }
 doAsyncIterInvalidCallbackTest().then(common.mustCall());


### PR DESCRIPTION
Add 2 tests for full covering of method 'close' in class Dir
1. If pass smth that not string as a callback - throw an exception
2. If do .close() on already closed directory - throw an exception

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
