### PR TITLE
Added napi_is_detached_arraybuffer method

### DIFF
--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -383,6 +383,9 @@ NAPI_EXTERN napi_status napi_create_arraybuffer(napi_env env,
                                                 size_t byte_length,
                                                 void** data,
                                                 napi_value* result);
+NAPI_EXTERN napi_status napi_is_detached_arraybuffer(napi_env env,
+                                                     napi_value value,
+                                                     bool* result);
 NAPI_EXTERN napi_status
 napi_create_external_arraybuffer(napi_env env,
                                  void* external_data,

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -2569,6 +2569,38 @@ napi_status napi_create_arraybuffer(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
+napi_status napi_is_detached_arraybuffer(napi_env env,
+                                         napi_value value,
+                                         napi_value* result) {
+  NAPI_PREAMBLE(env);
+  CHECK_ARG(env, result);
+  v8::Isolate* isolate = env->isolate;
+
+  v8::Local<v8::Value> val = v8impl::V8LocalValueFromJsValue(value);
+
+  if (!val->IsObject()) {
+    napi_throw_type_error(env,
+                          "ERR_NAPI_CONS_FUNCTION",
+                          "Value must be an Object");
+    GET_RETURN_STATUS(env);
+  }
+
+  if (!val->IsArrayBuffer()) {
+    *result = v8impl::JsValueFromV8LocalValue(v8::False(isolate));
+    return GET_RETURN_STATUS(env);
+  }
+
+  v8::Local<v8::ArrayBuffer> buffer = v8::Local<v8::ArrayBuffer>::Cast(val);
+
+  if (buffer->GetContents().Data() != nullptr) {
+    *result = v8impl::JsValueFromV8LocalValue(v8::True(isolate));
+  } else {
+    *result = v8impl::JsValueFromV8LocalValue(v8::False(isolate));
+  }
+
+  return GET_RETURN_STATUS(env);
+}
+
 napi_status napi_create_external_arraybuffer(napi_env env,
                                              void* external_data,
                                              size_t byte_length,


### PR DESCRIPTION
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines]

Fixes: https://github.com/nodejs/node/issues/29955