### PR TITLE
test: source_map_cache serialization shutdown coverage

### DIFF
--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -13,14 +13,15 @@ const _MAINSCRIPT = fixtures.path('loop.js');
 const DEBUG = false;
 const TIMEOUT = common.platformTimeout(15 * 1000);
 
-function spawnChildProcess(inspectorFlags, scriptContents, scriptFile) {
+function spawnChildProcess(inspectorFlags, scriptContents, scriptFile,
+                           childOptions) {
   const args = [].concat(inspectorFlags);
   if (scriptContents) {
     args.push('-e', scriptContents);
   } else {
     args.push(scriptFile);
   }
-  const child = spawn(process.execPath, args);
+  const child = spawn(process.execPath, args, childOptions);
 
   const handler = tearDown.bind(null, child);
   process.on('exit', handler);
@@ -320,7 +321,7 @@ class InspectorSession {
 class NodeInstance extends EventEmitter {
   constructor(inspectorFlags = ['--inspect-brk=0', '--expose-internals'],
               scriptContents = '',
-              scriptFile = _MAINSCRIPT) {
+              scriptFile = _MAINSCRIPT, childOptions = {}) {
     super();
 
     this._scriptPath = scriptFile;
@@ -328,7 +329,7 @@ class NodeInstance extends EventEmitter {
     this._portCallback = null;
     this.portPromise = new Promise((resolve) => this._portCallback = resolve);
     this._process = spawnChildProcess(inspectorFlags, scriptContents,
-                                      scriptFile);
+                                      scriptFile, childOptions);
     this._running = true;
     this._stderrLineCallback = null;
     this._unprocessedStderrLines = [];

--- a/test/fixtures/source-map/dummy.js
+++ b/test/fixtures/source-map/dummy.js
@@ -1,0 +1,1 @@
+//dummy file for calls that require modules as arguments

--- a/test/parallel/test-source-map-serialize-on-shutdown.js
+++ b/test/parallel/test-source-map-serialize-on-shutdown.js
@@ -1,0 +1,24 @@
+'use strict';
+require('../common');
+
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+const { NodeInstance } = require('../common/inspector-helper.js');
+
+// `sourceMapCacheToObject` and `appendCJSCache` methods of
+// /lib/internal/source_map/source_map_cache.js
+// should be called after process shutdown with flags
+// '--inspect' '--enable-source-maps' end env NODE_V8_COVERAGE
+new NodeInstance(
+  ['--inspect', '--enable-source-maps'],
+  '',
+  require.resolve('../fixtures/source-map/dummy.js'),
+  {
+    env: {
+      ...process.env,
+      NODE_V8_COVERAGE: path.join(tmpdir.path, `source_map_${__filename}`)
+    }
+  }
+);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
`sourceMapCacheToObject` and `appendCJSCache` methods of `/lib/internal/source_map/source_map_cache.js` should be called after process shutdown with flags '--inspect' '--enable-source-maps' and env NODE_V8_COVERAGE
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
