### PR TITLE
src: cleanup unused headers

### DIFF
--- a/src/api/encoding.cc
+++ b/src/api/encoding.cc
@@ -1,5 +1,4 @@
 #include "node.h"
-#include "env-inl.h"
 #include "string_bytes.h"
 #include "util-inl.h"
 #include "v8.h"

--- a/src/api/utils.cc
+++ b/src/api/utils.cc
@@ -1,6 +1,4 @@
 #include "node.h"
-#include "node_internals.h"
-#include "util-inl.h"
 
 #include <csignal>
 

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -27,7 +27,6 @@
 #include "util-inl.h"
 
 #include "v8.h"
-#include "v8-profiler.h"
 
 using v8::Context;
 using v8::DontDelete;

--- a/src/connect_wrap.cc
+++ b/src/connect_wrap.cc
@@ -1,14 +1,18 @@
 #include "connect_wrap.h"
-
-#include "env-inl.h"
 #include "req_wrap-inl.h"
-#include "util-inl.h"
+
+namespace v8 {
+class Object;
+template <class T> class Local;
+}  // namespace v8
+
 
 namespace node {
 
 using v8::Local;
 using v8::Object;
 
+class Environment;
 
 ConnectWrap::ConnectWrap(Environment* env,
     Local<Object> req_wrap_obj,

--- a/src/connect_wrap.cc
+++ b/src/connect_wrap.cc
@@ -1,12 +1,6 @@
 #include "connect_wrap.h"
 #include "req_wrap-inl.h"
 
-namespace v8 {
-class Object;
-template <class T> class Local;
-}  // namespace v8
-
-
 namespace node {
 
 using v8::Local;

--- a/src/connect_wrap.h
+++ b/src/connect_wrap.h
@@ -3,12 +3,17 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "env.h"
 #include "req_wrap-inl.h"
 #include "async_wrap.h"
-#include "v8.h"
+
+namespace v8 {
+class Object;
+template <class T> class Local;
+}  // namespace v8
 
 namespace node {
+
+class Environment;
 
 class ConnectWrap : public ReqWrap<uv_connect_t> {
  public:

--- a/src/connect_wrap.h
+++ b/src/connect_wrap.h
@@ -8,8 +8,6 @@
 
 namespace node {
 
-class Environment;
-
 class ConnectWrap : public ReqWrap<uv_connect_t> {
  public:
   ConnectWrap(Environment* env,

--- a/src/connect_wrap.h
+++ b/src/connect_wrap.h
@@ -6,11 +6,6 @@
 #include "req_wrap-inl.h"
 #include "async_wrap.h"
 
-namespace v8 {
-class Object;
-template <class T> class Local;
-}  // namespace v8
-
 namespace node {
 
 class Environment;

--- a/src/connection_wrap.h
+++ b/src/connection_wrap.h
@@ -4,7 +4,11 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "stream_wrap.h"
-#include "v8.h"
+
+namespace v8 {
+class Object;
+template <class T> class Local;
+}  // namespace v8
 
 namespace node {
 

--- a/src/connection_wrap.h
+++ b/src/connection_wrap.h
@@ -5,11 +5,6 @@
 
 #include "stream_wrap.h"
 
-namespace v8 {
-class Object;
-template <class T> class Local;
-}  // namespace v8
-
 namespace node {
 
 class Environment;

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -1,4 +1,6 @@
 #include "debug_utils.h"
+#include "env-inl.h"
+#include "util-inl.h"
 
 #ifdef __POSIX__
 #if defined(__linux__)

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -1,6 +1,4 @@
 #include "debug_utils.h"
-#include "env-inl.h"
-#include "util-inl.h"
 
 #ifdef __POSIX__
 #if defined(__linux__)

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -1,6 +1,5 @@
 #include "debug_utils.h"
 #include "env-inl.h"
-#include "util-inl.h"
 
 #ifdef __POSIX__
 #if defined(__linux__)

--- a/src/env.cc
+++ b/src/env.cc
@@ -7,7 +7,6 @@
 #include "node_errors.h"
 #include "node_file.h"
 #include "node_internals.h"
-#include "node_native_module.h"
 #include "node_options-inl.h"
 #include "node_process.h"
 #include "node_v8_platform-inl.h"

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -21,7 +21,6 @@
 
 #include "async_wrap-inl.h"
 #include "env-inl.h"
-#include "util-inl.h"
 #include "node.h"
 #include "handle_wrap.h"
 #include "string_bytes.h"

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -23,7 +23,6 @@
 #include "async_wrap-inl.h"
 #include "env-inl.h"
 #include "util-inl.h"
-#include "node.h"
 
 namespace node {
 

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -2,7 +2,6 @@
 
 #include "async_wrap.h"
 #include "env-inl.h"
-#include "node_buffer.h"
 #include "node_errors.h"
 #include "stream_base-inl.h"
 #include "util-inl.h"

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -6,14 +6,6 @@
 #include "async_wrap.h"
 #include "stream_base.h"
 
-namespace v8 {
-class Context;
-class Object;
-class Value;
-template <class T> class Local;
-template <typename T> class FunctionCallbackInfo;
-}  // namespace v8
-
 namespace node {
 
 class Environment;

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -5,7 +5,14 @@
 
 #include "async_wrap.h"
 #include "stream_base.h"
-#include "v8.h"
+
+namespace v8 {
+class Context;
+class Object;
+class Value;
+template <class T> class Local;
+template <typename T> class FunctionCallbackInfo;
+}  // namespace v8
 
 namespace node {
 

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -6,10 +6,12 @@
 #include <unordered_map>
 #include <string>
 #include <vector>
-#include "node_url.h"
 #include "base_object-inl.h"
 
 namespace node {
+
+class Environment;
+
 namespace loader {
 
 enum ScriptType : int {

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -6,7 +6,7 @@
 #include <unordered_map>
 #include <string>
 #include <vector>
-#include "base_object-inl.h"
+#include "base_object.h"
 
 namespace node {
 

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -11,14 +11,6 @@
 #define NAPI_EXPERIMENTAL
 #include "node_api.h"
 
-namespace v8 {
-class Context;
-class Object;
-class Value;
-template <class T> class Local;
-template <typename T> class FunctionCallbackInfo;
-}  // namespace v8
-
 enum {
   NM_F_BUILTIN = 1 << 0,  // Unused.
   NM_F_LINKED = 1 << 1,

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -10,9 +10,14 @@
 #include "node.h"
 #define NAPI_EXPERIMENTAL
 #include "node_api.h"
-#include "util.h"
-#include "uv.h"
-#include "v8.h"
+
+namespace v8 {
+class Context;
+class Object;
+class Value;
+template <class T> class Local;
+template <typename T> class FunctionCallbackInfo;
+}  // namespace v8
 
 enum {
   NM_F_BUILTIN = 1 << 0,  // Unused.

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -28,7 +28,6 @@
 #include "string_bytes.h"
 #include "string_search.h"
 #include "util-inl.h"
-#include "v8-profiler.h"
 #include "v8.h"
 
 #include <cstring>

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -3,8 +3,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "node.h"
-#include "util.h"
 #include "env.h"
 #include "v8.h"
 

--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -32,10 +32,6 @@
 #include <pthread.h>
 #endif
 
-namespace v8 {
-class Isolate;
-}
-
 namespace node {
 
 class Watchdog {

--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -24,7 +24,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "v8.h"
 #include "uv.h"
 #include "node_mutex.h"
 #include <vector>
@@ -32,6 +31,10 @@
 #ifdef __POSIX__
 #include <pthread.h>
 #endif
+
+namespace v8 {
+class Isolate;
+}
 
 namespace node {
 

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -26,7 +26,6 @@
 
 #include "stream_base.h"
 #include "handle_wrap.h"
-#include "string_bytes.h"
 #include "v8.h"
 
 namespace node {

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -27,7 +27,7 @@
 // Decodes a v8::Local<v8::String> or Buffer to a raw char*
 
 #include "v8.h"
-#include "env.h"
+#include "env-inl.h"
 
 namespace node {
 

--- a/src/string_decoder-inl.h
+++ b/src/string_decoder-inl.h
@@ -4,7 +4,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "string_decoder.h"
-#include "util.h"
 
 namespace node {
 

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -3,7 +3,6 @@
 
 #include "libplatform/v8-tracing.h"
 #include "uv.h"
-#include "v8.h"
 #include "util.h"
 #include "node_mutex.h"
 
@@ -11,6 +10,11 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+
+namespace v8 {
+class ConvertableToTraceFormat;
+class TracingController;
+}
 
 namespace node {
 namespace tracing {

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -14,7 +14,7 @@
 namespace v8 {
 class ConvertableToTraceFormat;
 class TracingController;
-}
+}  // namespace v8
 
 namespace node {
 namespace tracing {

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -24,13 +24,13 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "async_wrap.h"
 #include "handle_wrap.h"
 #include "uv.h"
 #include "v8.h"
 
 namespace node {
 
+class AsyncWrap;
 class Environment;
 
 class UDPWrap: public HandleWrap {

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -30,7 +30,6 @@
 
 namespace node {
 
-class AsyncWrap;
 class Environment;
 
 class UDPWrap: public HandleWrap {


### PR DESCRIPTION
Node codebase has evolved a lot in the more than 10 years of its
existence. As more features (and code) have been added, changed,
removed, it's sometimes hard to keep track of what gets used and what
not.

This commits attempts to clean some of those potentially left-over
headers using suggestions from  include-what-you-use

Refs: #27531

- [x] `make -j4 test` (UNIX)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

In addition, also tested with `make -j8` `make -j8 test-all`
