### PR TITLE
module: ignore resolution failures for inspect-brk

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1094,7 +1094,11 @@ Module.prototype._compile = function(content, filename) {
         // The resolution may fail if it requires a preload script
         try {
           resolvedArgv = Module._resolveFilename(process.argv[1], null, false);
-        } catch {}
+        } catch {
+          // We only expect this codepath to be reached in the case of a
+          // preloaded module (it will fail earlier with the main entry)
+          assert(Array.isArray(getOptionValue('--require')));
+        }
       } else {
         resolvedArgv = 'repl';
       }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1091,14 +1091,17 @@ Module.prototype._compile = function(content, filename) {
     if (!resolvedArgv) {
       // We enter the repl if we're not given a filename argument.
       if (process.argv[1]) {
-        resolvedArgv = Module._resolveFilename(process.argv[1], null, false);
+        // The resolution may fail if it requires a preload script
+        try {
+          resolvedArgv = Module._resolveFilename(process.argv[1], null, false);
+        } catch {}
       } else {
         resolvedArgv = 'repl';
       }
     }
 
     // Set breakpoint on module start
-    if (!hasPausedEntry && filename === resolvedArgv) {
+    if (resolvedArgv && !hasPausedEntry && filename === resolvedArgv) {
       hasPausedEntry = true;
       inspectorWrapper = internalBinding('inspector').callAndPauseOnStart;
     }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1091,7 +1091,6 @@ Module.prototype._compile = function(content, filename) {
     if (!resolvedArgv) {
       // We enter the repl if we're not given a filename argument.
       if (process.argv[1]) {
-        // The resolution may fail if it requires a preload script
         try {
           resolvedArgv = Module._resolveFilename(process.argv[1], null, false);
         } catch {

--- a/test/fixtures/test-resolution-inspect-brk-resolver.js
+++ b/test/fixtures/test-resolution-inspect-brk-resolver.js
@@ -1,0 +1,5 @@
+'use strict';
+// eslint-disable-next-line no-unused-vars
+const common = require('../common');
+
+require.extensions['.ext'] = require.extensions['.js'];

--- a/test/sequential/test-resolution-inspect-brk.js
+++ b/test/sequential/test-resolution-inspect-brk.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+// A test to ensure that preload modules are given a chance to execute before
+// resolving the main entry point with --inspect-brk active.
+
+const assert = require('assert');
+const cp = require('child_process');
+const path = require('path');
+
+function test(execArgv) {
+  const child = cp.spawn(process.execPath, execArgv);
+
+  child.stderr.once('data', common.mustCall(function() {
+    child.kill('SIGTERM');
+  }));
+
+  child.on('exit', common.mustCall(function(code, signal) {
+    assert.strictEqual(signal, 'SIGTERM');
+  }));
+}
+
+test([
+  '--require',
+  path.join(__dirname, '../fixtures/test-resolution-inspect-brk-resolver.js'),
+  '--inspect-brk',
+  '../fixtures/test-resolution-inspect-resolver-main.ext',
+]);


### PR DESCRIPTION
The resolution for the main entry point may fail when the resolution requires
a preloaded module to be executed first (for example when adding new extensions
to the resolution process). Silently skipping such failures allow us to defer
the resolution as long as needed without having any adverse change (since the
main entry point won't resolve anyway if it really can't be resolved at all).

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
