### PR TITLE
[v10.x backport] lib: fix comment nits in bootstrap\loaders.js

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -19,7 +19,7 @@
 //   can be created using NODE_MODULE_CONTEXT_AWARE_CPP() with the flag
 //   NM_F_LINKED.
 // - internalBinding(): the private internal C++ binding loader, inaccessible
-//   from user land because they are only available from NativeModule.require()
+//   from user land because they are only available from NativeModule.require().
 //   These C++ bindings are created using NODE_MODULE_CONTEXT_AWARE_INTERNAL()
 //   and have their nm_flags set to NM_F_INTERNAL.
 //
@@ -61,7 +61,7 @@
     keys: ObjectKeys,
   } = Object;
 
-  // Set up process.moduleLoadList
+  // Set up process.moduleLoadList.
   const moduleLoadList = [];
   ObjectDefineProperty(process, 'moduleLoadList', {
     value: moduleLoadList,
@@ -70,7 +70,7 @@
     writable: false
   });
 
-  // Set up process.binding() and process._linkedBinding()
+  // Set up process.binding() and process._linkedBinding().
   {
     const bindingObj = ObjectCreate(null);
 
@@ -93,7 +93,7 @@
     };
   }
 
-  // Set up internalBinding() in the closure
+  // Set up internalBinding() in the closure.
   let internalBinding;
   {
     const bindingObj = ObjectCreate(null);
@@ -115,11 +115,11 @@
     };
   }
 
-  // Create this WeakMap in js-land because V8 has no C++ API for WeakMap
+  // Create this WeakMap in js-land because V8 has no C++ API for WeakMap.
   internalBinding('module_wrap').callbackMap = new WeakMap();
   const { ContextifyScript } = process.binding('contextify');
 
-  // Set up NativeModule
+  // Set up NativeModule.
   function NativeModule(id) {
     this.filename = `${id}.js`;
     this.id = id;
@@ -128,7 +128,7 @@
     this.exportKeys = undefined;
     this.loaded = false;
     this.loading = false;
-    this.script = null;  // The ContextifyScript of the module
+    this.script = null;  // The ContextifyScript of the module.
   }
 
   NativeModule._source = getBinding('natives');
@@ -160,7 +160,7 @@
     if (!NativeModule.exists(id)) {
       // Model the error off the internal/errors.js model, but
       // do not use that module given that it could actually be
-      // the one causing the error if there's a bug in Node.js
+      // the one causing the error if there's a bug in Node.js.
       // eslint-disable-next-line no-restricted-syntax
       const err = new Error(`No such built-in module: ${id}`);
       err.code = 'ERR_UNKNOWN_BUILTIN_MODULE';
@@ -201,7 +201,7 @@
 
   if (config.exposeInternals) {
     NativeModule.nonInternalExists = function(id) {
-      // Do not expose this to user land even with --expose-internals
+      // Do not expose this to user land even with --expose-internals.
       if (id === loaderId) {
         return false;
       }
@@ -209,7 +209,7 @@
     };
 
     NativeModule.isInternal = function(id) {
-      // Do not expose this to user land even with --expose-internals
+      // Do not expose this to user land even with --expose-internals.
       return id === loaderId;
     };
   } else {
@@ -243,7 +243,7 @@
   };
 
   // Provide named exports for all builtin libraries so that the libraries
-  // may be imported in a nicer way for esm users. The default export is left
+  // may be imported in a nicer way for ESM users. The default export is left
   // as the entire namespace (module.exports) and wrapped in a proxy such
   // that APMs and other behavior are still left intact.
   NativeModule.prototype.proxifyExports = function() {


### PR DESCRIPTION
PR-URL: https://github.com/nodejs/node/pull/24641
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Franziska Hinkelmann <franziska.hinkelmann@gmail.com>

(cherry picked from commit 1db808ca5f54ac30a47818112f78378c93ef2be6)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
