### PR TITLE
src: migrate to newer V8 ArrayBuffer APIs

### DIFF
--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -42,7 +42,7 @@ class AliasedBufferBase {
     // allocate v8 ArrayBuffer
     v8::Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(
         isolate_, size_in_bytes);
-    buffer_ = static_cast<NativeT*>(ab->GetContents().Data());
+    buffer_ = static_cast<NativeT*>(ab->GetBackingStore()->Data());
 
     // allocate v8 TypedArray
     v8::Local<V8T> js_array = V8T::New(ab, byte_offset_, count);
@@ -228,7 +228,7 @@ class AliasedBufferBase {
         isolate_, new_size_in_bytes);
 
     // allocate new native buffer
-    NativeT* new_buffer = static_cast<NativeT*>(ab->GetContents().Data());
+    NativeT* new_buffer = static_cast<NativeT*>(ab->GetBackingStore()->Data());
     // copy old content
     memcpy(new_buffer, buffer_, old_size_in_bytes);
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -192,16 +192,13 @@ bool HasInstance(Local<Object> obj) {
 char* Data(Local<Value> val) {
   CHECK(val->IsArrayBufferView());
   Local<ArrayBufferView> ui = val.As<ArrayBufferView>();
-  ArrayBuffer::Contents ab_c = ui->Buffer()->GetContents();
-  return static_cast<char*>(ab_c.Data()) + ui->ByteOffset();
+  return static_cast<char*>(ui->Buffer()->GetBackingStore()->Data()) +
+      ui->ByteOffset();
 }
 
 
 char* Data(Local<Object> obj) {
-  CHECK(obj->IsArrayBufferView());
-  Local<ArrayBufferView> ui = obj.As<ArrayBufferView>();
-  ArrayBuffer::Contents ab_c = ui->Buffer()->GetContents();
-  return static_cast<char*>(ab_c.Data()) + ui->ByteOffset();
+  return Data(obj.As<Value>());
 }
 
 
@@ -1060,13 +1057,13 @@ static void EncodeInto(const FunctionCallbackInfo<Value>& args) {
   Local<Uint8Array> dest = args[1].As<Uint8Array>();
   Local<ArrayBuffer> buf = dest->Buffer();
   char* write_result =
-      static_cast<char*>(buf->GetContents().Data()) + dest->ByteOffset();
+      static_cast<char*>(buf->GetBackingStore()->Data()) + dest->ByteOffset();
   size_t dest_length = dest->ByteLength();
 
   // results = [ read, written ]
   Local<Uint32Array> result_arr = args[2].As<Uint32Array>();
   uint32_t* results = reinterpret_cast<uint32_t*>(
-      static_cast<char*>(result_arr->Buffer()->GetContents().Data()) +
+      static_cast<char*>(result_arr->Buffer()->GetBackingStore()->Data()) +
       result_arr->ByteOffset());
 
   int nchars;

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -697,8 +697,8 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
 
   ScriptCompiler::CachedData* cached_data = nullptr;
   if (!cached_data_buf.IsEmpty()) {
-    ArrayBuffer::Contents contents = cached_data_buf->Buffer()->GetContents();
-    uint8_t* data = static_cast<uint8_t*>(contents.Data());
+    uint8_t* data = static_cast<uint8_t*>(
+        cached_data_buf->Buffer()->GetBackingStore()->Data());
     cached_data = new ScriptCompiler::CachedData(
         data + cached_data_buf->ByteOffset(), cached_data_buf->ByteLength());
   }
@@ -1044,8 +1044,8 @@ void ContextifyContext::CompileFunction(
   // Read cache from cached data buffer
   ScriptCompiler::CachedData* cached_data = nullptr;
   if (!cached_data_buf.IsEmpty()) {
-    ArrayBuffer::Contents contents = cached_data_buf->Buffer()->GetContents();
-    uint8_t* data = static_cast<uint8_t*>(contents.Data());
+    uint8_t* data = static_cast<uint8_t*>(
+        cached_data_buf->Buffer()->GetBackingStore()->Data());
     cached_data = new ScriptCompiler::CachedData(
       data + cached_data_buf->ByteOffset(), cached_data_buf->ByteLength());
   }

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -297,12 +297,16 @@ Maybe<bool> Message::Serialize(Environment* env,
     // Currently, we support ArrayBuffers and MessagePorts.
     if (entry->IsArrayBuffer()) {
       Local<ArrayBuffer> ab = entry.As<ArrayBuffer>();
-      // If we cannot render the ArrayBuffer unusable in this Isolate and
-      // take ownership of its memory, copying the buffer will have to do.
-      if (!ab->IsDetachable() || ab->IsExternal() ||
-          !env->isolate_data()->uses_node_allocator()) {
+      // If we cannot render the ArrayBuffer unusable in this Isolate,
+      // copying the buffer will have to do.
+      // Note that we can currently transfer ArrayBuffers even if they were
+      // not allocated by Node’s ArrayBufferAllocator in the first place,
+      // because we pass the underlying v8::BackingStore around rather than
+      // raw data *and* an Isolate with a non-default ArrayBuffer allocator
+      // is always going to outlive any Workers it creates, and so will its
+      // allocator along with it.
+      if (!ab->IsDetachable())
         continue;
-      }
       if (std::find(array_buffers.begin(), array_buffers.end(), ab) !=
           array_buffers.end()) {
         ThrowDataCloneException(
@@ -362,7 +366,9 @@ Maybe<bool> Message::Serialize(Environment* env,
   for (Local<ArrayBuffer> ab : array_buffers) {
     // If serialization succeeded, we render it inaccessible in this Isolate.
     std::shared_ptr<BackingStore> backing_store = ab->GetBackingStore();
-    ab->Externalize(backing_store);
+    // TODO(addaleax): This can/should be dropped once we have V8 8.0.
+    if (!ab->IsExternal())
+      ab->Externalize(backing_store);
     ab->Detach();
 
     array_buffers_.emplace_back(std::move(backing_store));

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -305,7 +305,10 @@ Maybe<bool> Message::Serialize(Environment* env,
       // raw data *and* an Isolate with a non-default ArrayBuffer allocator
       // is always going to outlive any Workers it creates, and so will its
       // allocator along with it.
-      if (!ab->IsDetachable())
+      // TODO(addaleax): Eventually remove the IsExternal() condition,
+      // see https://github.com/nodejs/node/pull/30339#issuecomment-552225353
+      // for details.
+      if (!ab->IsDetachable() || ab->IsExternal())
         continue;
       if (std::find(array_buffers.begin(), array_buffers.end(), ab) !=
           array_buffers.end()) {

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -171,7 +171,7 @@ static void GetLoadAvg(const FunctionCallbackInfo<Value>& args) {
   Local<Float64Array> array = args[0].As<Float64Array>();
   CHECK_EQ(array->Length(), 3);
   Local<ArrayBuffer> ab = array->Buffer();
-  double* loadavg = static_cast<double*>(ab->GetContents().Data());
+  double* loadavg = static_cast<double*>(ab->GetBackingStore()->Data());
   uv_loadavg(loadavg);
 }
 

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -109,7 +109,7 @@ static void CPUUsage(const FunctionCallbackInfo<Value>& args) {
   Local<Float64Array> array = args[0].As<Float64Array>();
   CHECK_EQ(array->Length(), 2);
   Local<ArrayBuffer> ab = array->Buffer();
-  double* fields = static_cast<double*>(ab->GetContents().Data());
+  double* fields = static_cast<double*>(ab->GetBackingStore()->Data());
 
   // Set the Float64Array elements to be user / system values in microseconds.
   fields[0] = MICROS_PER_SEC * rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec;
@@ -148,7 +148,7 @@ static void Hrtime(const FunctionCallbackInfo<Value>& args) {
   uint64_t t = uv_hrtime();
 
   Local<ArrayBuffer> ab = args[0].As<Uint32Array>()->Buffer();
-  uint32_t* fields = static_cast<uint32_t*>(ab->GetContents().Data());
+  uint32_t* fields = static_cast<uint32_t*>(ab->GetBackingStore()->Data());
 
   fields[0] = (t / NANOS_PER_SEC) >> 32;
   fields[1] = (t / NANOS_PER_SEC) & 0xffffffff;
@@ -157,7 +157,7 @@ static void Hrtime(const FunctionCallbackInfo<Value>& args) {
 
 static void HrtimeBigInt(const FunctionCallbackInfo<Value>& args) {
   Local<ArrayBuffer> ab = args[0].As<BigUint64Array>()->Buffer();
-  uint64_t* fields = static_cast<uint64_t*>(ab->GetContents().Data());
+  uint64_t* fields = static_cast<uint64_t*>(ab->GetBackingStore()->Data());
   fields[0] = uv_hrtime();
 }
 
@@ -204,7 +204,7 @@ static void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
   Local<Float64Array> array = args[0].As<Float64Array>();
   CHECK_EQ(array->Length(), 4);
   Local<ArrayBuffer> ab = array->Buffer();
-  double* fields = static_cast<double*>(ab->GetContents().Data());
+  double* fields = static_cast<double*>(ab->GetBackingStore()->Data());
 
   fields[0] = rss;
   fields[1] = v8_heap_stats.total_heap_size();
@@ -301,7 +301,7 @@ static void ResourceUsage(const FunctionCallbackInfo<Value>& args) {
   Local<Float64Array> array = args[0].As<Float64Array>();
   CHECK_EQ(array->Length(), 16);
   Local<ArrayBuffer> ab = array->Buffer();
-  double* fields = static_cast<double*>(ab->GetContents().Data());
+  double* fields = static_cast<double*>(ab->GetBackingStore()->Data());
 
   fields[0] = MICROS_PER_SEC * rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec;
   fields[1] = MICROS_PER_SEC * rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec;

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -622,7 +622,9 @@ void Worker::GetResourceLimits(const FunctionCallbackInfo<Value>& args) {
 
 Local<Float64Array> Worker::GetResourceLimits(Isolate* isolate) const {
   Local<ArrayBuffer> ab = ArrayBuffer::New(isolate, sizeof(resource_limits_));
-  memcpy(ab->GetContents().Data(), resource_limits_, sizeof(resource_limits_));
+  memcpy(ab->GetBackingStore()->Data(),
+         resource_limits_,
+         sizeof(resource_limits_));
   return Float64Array::New(ab, 0, kTotalResourceLimitCount);
 }
 

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -590,7 +590,8 @@ class ZlibStream : public CompressionStream<ZlibContext> {
     CHECK(args[4]->IsUint32Array());
     Local<Uint32Array> array = args[4].As<Uint32Array>();
     Local<ArrayBuffer> ab = array->Buffer();
-    uint32_t* write_result = static_cast<uint32_t*>(ab->GetContents().Data());
+    uint32_t* write_result = static_cast<uint32_t*>(
+        ab->GetBackingStore()->Data());
 
     CHECK(args[5]->IsFunction());
     Local<Function> write_js_callback = args[5].As<Function>();

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -514,7 +514,7 @@ void ArrayBufferViewContents<T, S>::Read(v8::Local<v8::ArrayBufferView> abv) {
   static_assert(sizeof(T) == 1, "Only supports one-byte data at the moment");
   length_ = abv->ByteLength();
   if (length_ > sizeof(stack_storage_) || abv->HasBuffer()) {
-    data_ = static_cast<T*>(abv->Buffer()->GetContents().Data()) +
+    data_ = static_cast<T*>(abv->Buffer()->GetBackingStore()->Data()) +
         abv->ByteOffset();
   } else {
     abv->CopyContents(stack_storage_, sizeof(stack_storage_));

--- a/src/util.h
+++ b/src/util.h
@@ -488,11 +488,12 @@ class BufferValue : public MaybeStackBuffer<char> {
 #define SPREAD_BUFFER_ARG(val, name)                                          \
   CHECK((val)->IsArrayBufferView());                                          \
   v8::Local<v8::ArrayBufferView> name = (val).As<v8::ArrayBufferView>();      \
-  v8::ArrayBuffer::Contents name##_c = name->Buffer()->GetContents();         \
+  std::shared_ptr<v8::BackingStore> name##_bs =                               \
+      name->Buffer()->GetBackingStore();                                      \
   const size_t name##_offset = name->ByteOffset();                            \
   const size_t name##_length = name->ByteLength();                            \
   char* const name##_data =                                                   \
-      static_cast<char*>(name##_c.Data()) + name##_offset;                    \
+      static_cast<char*>(name##_bs->Data()) + name##_offset;                  \
   if (name##_length > 0)                                                      \
     CHECK_NE(name##_data, nullptr);
 

--- a/test/addons/openssl-binding/binding.cc
+++ b/test/addons/openssl-binding/binding.cc
@@ -12,8 +12,8 @@ inline void RandomBytes(const v8::FunctionCallbackInfo<v8::Value>& info) {
   auto byte_length = view->ByteLength();
   assert(view->HasBuffer());
   auto buffer = view->Buffer();
-  auto contents = buffer->GetContents();
-  auto data = static_cast<unsigned char*>(contents.Data()) + byte_offset;
+  auto contents = buffer->GetBackingStore();
+  auto data = static_cast<unsigned char*>(contents->Data()) + byte_offset;
   assert(RAND_poll());
   auto rval = RAND_bytes(data, static_cast<int>(byte_length));
   info.GetReturnValue().Set(rval > 0);

--- a/test/addons/zlib-binding/binding.cc
+++ b/test/addons/zlib-binding/binding.cc
@@ -12,8 +12,8 @@ inline void CompressBytes(const v8::FunctionCallbackInfo<v8::Value>& info) {
   auto byte_length = view->ByteLength();
   assert(view->HasBuffer());
   auto buffer = view->Buffer();
-  auto contents = buffer->GetContents();
-  auto data = static_cast<unsigned char*>(contents.Data()) + byte_offset;
+  auto contents = buffer->GetBackingStore();
+  auto data = static_cast<unsigned char*>(contents->Data()) + byte_offset;
 
   Bytef buf[1024];
 


### PR DESCRIPTION
##### src: migrate off ArrayBuffer::GetContents

V8 deprecates `GetContents()` in favour of `GetBackingStore()`.
Update our code to reflect that.
V8 also deprecates `Externalize()` and `IsExternal()`; we should
be able to remove all usage of this once V8 8.0 is there.

Refs: https://github.com/v8/v8/commit/bfe3d6bce734e596e312465e207bcfd55a59fe34

##### ~~src: drop CallbackInfo for Buffer lifetime tracking~~

~~This has been rendered unnecessary by upstream V8 changes,
which now allow user-provided deleter functions out of the box.~~

~~(Sadly, that function signature mismatches our deleter function
signature, so we still need a heap allocation to track our deleter
data.)~~

~~Refs: https://github.com/v8/v8/commit/bba5f1f43d59cf06e6043eb94d689021cc94a4e2~~

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
