### PR TITLE
doc: fix some recent doc nits

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -168,9 +168,9 @@ The default is `explicit`, which requires providing the full path to a
 module. The `node` mode will enable support for optional file extensions and
 the ability to import a directory that has an index file.
 
-Please see [customizing esm specifier resolution][] for example usage.
+Please see [customizing ESM specifier resolution][] for example usage.
 
-### `--experimental-conditional-exports
+### `--experimental-conditional-exports`
 <!-- YAML
 added: REPLACEME
 -->
@@ -1321,17 +1321,17 @@ greater than `4` (its current default value). For more information, see the
 [`tls.DEFAULT_MIN_VERSION`]: tls.html#tls_tls_default_min_version
 [`unhandledRejection`]: process.html#process_event_unhandledrejection
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
+[Conditional Exports]: esm.html#esm_conditional_exports
 [REPL]: repl.html
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage
 [Source Map]: https://sourcemaps.info/spec.html
 [Subresource Integrity]: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
 [V8 JavaScript code coverage]: https://v8project.blogspot.com/2017/12/javascript-code-coverage.html
-[customizing esm specifier resolution]: esm.html#esm_customizing_esm_specifier_resolution_algorithm
+[context-aware]: addons.html#addons_context_aware_addons
+[customizing ESM specifier resolution]: esm.html#esm_customizing_esm_specifier_resolution_algorithm
 [debugger]: debugger.html
 [debugging security implications]: https://nodejs.org/en/docs/guides/debugging-getting-started/#security-implications
 [emit_warning]: process.html#process_process_emitwarning_warning_type_code_ctor
 [experimental ECMAScript Module]: esm.html#esm_resolve_hook
 [libuv threadpool documentation]: http://docs.libuv.org/en/latest/threadpool.html
 [remote code execution]: https://www.owasp.org/index.php/Code_Injection
-[context-aware]: addons.html#addons_context_aware_addons
-[Conditional Exports]: esm.html#esm_conditional_exports

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -628,9 +628,9 @@ CommonJS and ES module instances of the package:
    package, it would be used like this:
 
     ```js
-    import date from 'date';
-    const someDate = new date();
-    // someDate contains state; date does not
+    import Date from 'date';
+    const someDate = new Date();
+    // someDate contains state; Date does not
     ```
 
    The `new` keyword isn’t required; a package’s function can return a new
@@ -1223,7 +1223,7 @@ _defaultEnv_ is the conditional environment name priority array,
 >    1. Throw a _Module Not Found_ error.
 > 1. If _pjson.exports_ is not **null** or **undefined**, then
 >    1. If _exports_ is an Object with both a key starting with _"."_ and a key
->       not starting with _"."_, throw a "Invalid Package Configuration" error.
+>       not starting with _"."_, throw an "Invalid Package Configuration" error.
 >    1. If _pjson.exports_ is a String or Array, or an Object containing no
 >       keys starting with _"."_, then
 >       1. Return **PACKAGE_EXPORTS_TARGET_RESOLVE**(_packageURL_,

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -234,15 +234,15 @@ RESOLVE_BARE_SPECIFIER(DIR, X)
    b. If "exports" is null or undefined, GOTO 3.
    c. If "exports" is an object with some keys starting with "." and some keys
       not starting with ".", throw "invalid config".
-   c. If "exports" is a string, or object with no keys starting with ".", treat
+   d. If "exports" is a string, or object with no keys starting with ".", treat
       it as having that value as its "." object property.
-   d. If subpath is "." and "exports" does not have a "." entry, GOTO 3.
-   e. Find the longest key in "exports" that the subpath starts with.
-   f. If no such key can be found, throw "not found".
-   g. let RESOLVED_URL =
+   e. If subpath is "." and "exports" does not have a "." entry, GOTO 3.
+   f. Find the longest key in "exports" that the subpath starts with.
+   g. If no such key can be found, throw "not found".
+   h. let RESOLVED_URL =
         PACKAGE_EXPORTS_TARGET_RESOLVE(pathToFileURL(DIR/name), exports[key],
-        subpath.slice(key.length)), as defined in the esm resolver.
-   h. return fileURLToPath(RESOLVED_URL)
+        subpath.slice(key.length)), as defined in the ESM resolver.
+   i. return fileURLToPath(RESOLVED_URL)
 3. return DIR/X
 ```
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -122,9 +122,6 @@ Enable experimental JSON interop support for the ES Module loader.
 .It Fl -experimental-modules
 Enable experimental ES module support and caching modules.
 .
-.It Fl -experimental-resolve-self
-Enable experimental support for a package to load itself.
-.
 .It Fl -experimental-policy
 Use the specified file as a security policy.
 .
@@ -137,6 +134,9 @@ keyword support in REPL.
 Enable experimental
 .Sy diagnostic report
 feature.
+.
+.It Fl -experimental-resolve-self
+Enable experimental support for a package to load itself.
 .
 .It Fl -experimental-vm-modules
 Enable experimental ES module support in VM module.


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

* Fix formatting.
* Fix list numbering.
* Unify abbreviation casing.
* Use an uppercased constructor in a hypothetic code example.
* Fix typos.
* Fix sorting in sections and references.
