### PR TITLE
util: fix .format() not always calling toString when it should be

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1571,6 +1571,31 @@ function reduceToSingleString(
   return `${braces[0]}${ln}${join(output, `,\n${indentation}  `)} ${braces[1]}`;
 }
 
+function hasBuiltInToString(value) {
+  // Count objects that have no `toString` function as built-in.
+  if (typeof value.toString !== 'function') {
+    return true;
+  }
+
+  // The object has a own `toString` property. Thus it's not not a built-in one.
+  if (hasOwnProperty(value, 'toString')) {
+    return false;
+  }
+
+  // Find the object that has the `toString` property as own property in the
+  // prototype chain.
+  let pointer = value;
+  do {
+    pointer = ObjectGetPrototypeOf(pointer);
+  } while (!hasOwnProperty(pointer, 'toString'));
+
+  // Check closer if the object is a built-in.
+  const descriptor = ObjectGetOwnPropertyDescriptor(pointer, 'constructor');
+  return descriptor !== undefined &&
+    typeof descriptor.value === 'function' &&
+    builtInObjects.has(descriptor.value.name);
+}
+
 const firstErrorLine = (error) => error.message.split('\n')[0];
 let CIRCULAR_ERROR_MESSAGE;
 function tryStringify(arg) {
@@ -1629,29 +1654,17 @@ function formatWithOptionsInternal(inspectOptions, ...args) {
                 tempStr = formatNumber(stylizeNoColor, tempArg);
               } else if (typeof tempArg === 'bigint') {
                 tempStr = `${tempArg}n`;
+              } else if (typeof tempArg !== 'object' ||
+                         tempArg === null ||
+                         !hasBuiltInToString(tempArg)) {
+                tempStr = String(tempArg);
               } else {
-                let constr;
-                if (typeof tempArg !== 'object' ||
-                    tempArg === null ||
-                    (typeof tempArg.toString === 'function' &&
-                     // A direct own property.
-                     (ObjectPrototypeHasOwnProperty(tempArg, 'toString') ||
-                      // A direct own property on the constructor prototype in
-                      // case the constructor is not an built-in object.
-                      ((constr = tempArg.constructor) &&
-                      !builtInObjects.has(constr.name) &&
-                      constr.prototype &&
-                      ObjectPrototypeHasOwnProperty(constr.prototype,
-                                                    'toString'))))) {
-                  tempStr = String(tempArg);
-                } else {
-                  tempStr = inspect(tempArg, {
-                    ...inspectOptions,
-                    compact: 3,
-                    colors: false,
-                    depth: 0
-                  });
-                }
+                tempStr = inspect(tempArg, {
+                  ...inspectOptions,
+                  compact: 3,
+                  colors: false,
+                  depth: 0
+                });
               }
               break;
             case 106: // 'j'

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1578,7 +1578,7 @@ function hasBuiltInToString(value) {
   }
 
   // The object has a own `toString` property. Thus it's not not a built-in one.
-  if (hasOwnProperty(value, 'toString')) {
+  if (ObjectPrototypeHasOwnProperty(value, 'toString')) {
     return false;
   }
 
@@ -1587,7 +1587,7 @@ function hasBuiltInToString(value) {
   let pointer = value;
   do {
     pointer = ObjectGetPrototypeOf(pointer);
-  } while (!hasOwnProperty(pointer, 'toString'));
+  } while (!ObjectPrototypeHasOwnProperty(pointer, 'toString'));
 
   // Check closer if the object is a built-in.
   const descriptor = ObjectGetOwnPropertyDescriptor(pointer, 'constructor');

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -160,6 +160,66 @@ assert.strictEqual(util.format('%s', () => 5), '() => 5');
     util.format('%s', new Foobar(5)),
     'Foobar [ <5 empty items>, aaa: true ]'
   );
+
+  // Subclassing:
+  class B extends Foo {}
+
+  function C() {}
+  C.prototype.toString = function() {
+    return 'Custom';
+  };
+
+  function D() {
+    C.call(this);
+  }
+  D.prototype = Object.create(C.prototype);
+
+  assert.strictEqual(
+    util.format('%s', new B()),
+    'Bar'
+  );
+  assert.strictEqual(
+    util.format('%s', new C()),
+    'Custom'
+  );
+  assert.strictEqual(
+    util.format('%s', new D()),
+    'Custom'
+  );
+
+  D.prototype.constructor = D;
+  assert.strictEqual(
+    util.format('%s', new D()),
+    'Custom'
+  );
+
+  D.prototype.constructor = null;
+  assert.strictEqual(
+    util.format('%s', new D()),
+    'Custom'
+  );
+
+  D.prototype.constructor = { name: 'Foobar' };
+  assert.strictEqual(
+    util.format('%s', new D()),
+    'Custom'
+  );
+
+  Object.defineProperty(D.prototype, 'constructor', {
+    get() {
+      throw new Error();
+    },
+    configurable: true
+  });
+  assert.strictEqual(
+    util.format('%s', new D()),
+    'Custom'
+  );
+
+  assert.strictEqual(
+    util.format('%s', Object.create(null)),
+    '[Object: null prototype] {}'
+  );
 }
 
 // JSON format specifier


### PR DESCRIPTION
This makes sure that `util.format('%s', object)` will always call
a user defined `toString` function. It was formerly not the case
when the object had the function declared on the super class.

At the same time this also makes sure that getters won't be
triggered accessing the `constructor` property.

Fixes: #30333

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
