### PR TITLE
doc: esm: improve dual package hazard docs

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -499,6 +499,11 @@ create an ES module wrapper file that defines the named exports. Using
 ES module wrapper is used for `import` and the CommonJS entry point for
 `require`.
 
+> Note: While `--experimental-conditional-exports` is flagged, a package
+> using this pattern will throw when loaded via `require()` in modern
+> Node.js, unless package consumers use the `--experimental-conditional-exports`
+> flag.
+
 <!-- eslint-skip -->
 ```js
 // ./node_modules/pkg/package.json
@@ -553,13 +558,13 @@ This approach is appropriate for any of the following use cases:
 * The package stores internal state, and the package author would prefer not to
   refactor the package to isolate its state management. See the next section.
 
-A variant of this approach would add an export, e.g. `"./module"`, to point to
-an all-ES module-syntax version the package. This could be used via `import
+A variant of this approach not requiring `--experimental-conditional-exports`
+for consumers could be to add an export, e.g. `"./module"`, to point to an
+all-ES module-syntax version the package. This could be used via `import
 'pkg/module'` by users who are certain that the CommonJS version will not be
 loaded anywhere in the application, such as by dependencies; or if the CommonJS
 version can be loaded but doesn’t affect the ES module version (for example,
-because the package is stateless). This variant would not require
-`--experimental-conditional-exports`:
+because the package is stateless):
 
 <!-- eslint-skip -->
 ```js
@@ -573,6 +578,11 @@ because the package is stateless). This variant would not require
   }
 }
 ```
+
+If the `--experimental-conditional-exports` flag is dropped and therefore
+[Conditional Exports][] become available without a flag, this variant could be
+easily updated to use conditional exports by adding conditions to the `"."`
+path; while keeping `"./module"` for backward compatibility.
 
 ##### Approach #2: Isolate State
 
@@ -658,6 +668,28 @@ This approach is appropriate for any of the following use cases:
 
 Even with isolated state, there is still the cost of possible extra code
 execution between the CommonJS and ES module versions of a package.
+
+As with the previous approach, a variant of this approach not requiring
+`--experimental-conditional-exports` for consumers could be to add an export,
+e.g. `"./module"`, to point to an all-ES module-syntax version the package:
+
+<!-- eslint-skip -->
+```js
+// ./node_modules/pkg/package.json
+{
+  "type": "module",
+  "main": "./index.cjs",
+  "exports": {
+    ".": "./index.cjs",
+    "./module": "./index.mjs"
+  }
+}
+```
+
+If the `--experimental-conditional-exports` flag is dropped and therefore
+[Conditional Exports][] become available without a flag, this variant could be
+easily updated to use conditional exports by adding conditions to the `"."`
+path; while keeping `"./module"` for backward compatibility.
 
 ## <code>import</code> Specifiers
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -187,14 +187,13 @@ unspecified.
 There are two fields that can define entry points for a package: `"main"` and
 `"exports"`. The `"main"` field is supported in all versions of Node.js, but its
 capabilities are limited: it only defines the main entry point of the package.
-The `"exports"` field can also be used to define the main entry point of the
-package, as well as other defined entry points; and the package can be
-encapsulated, so that extra effort is required to reference files within the
-package that aren’t the defined public API. `"exports"` can also map an entry
-point to different files per environment, for example for all environments
-versus browser environments; and with `--experimental-conditional-exports`
-`"exports"` can define separate files for Node.js CommonJS and ES module
-environments.
+The `"exports"` field, part of [Package Exports][], provides an alternative to
+`"main"` where the package main entry point can be defined while also
+encapsulating the package, preventing any other entry points besides those
+defined in `"exports"`. If package entry points are defined in both `"main"` and
+`"exports"`, the latter takes precedence in versions of Node.js that support
+`"exports"`. [Conditional Exports][] can also be used within `"exports"` to
+define different package entry points per environment.
 
 #### <code>package.json</code> <code>"main"</code>
 
@@ -232,14 +231,6 @@ be interpreted as CommonJS.
 The `"main"` field can point to exactly one file, regardless of whether the
 package is referenced via `require` (in a CommonJS context) or `import` (in an
 ES module context).
-
-[Package Exports][] provide an alternative to `"main"` where the package main
-entry point can be defined while also encapsulating the package, preventing any
-other entry points besides those defined in `"exports"`. If package entry points
-are defined in both `"main"` and `"exports"`, the latter takes precedence in
-versions of Node.js that support `"exports"`. [Conditional Exports][] can also
-be used within `"exports"` to define different package entry points per
-environment.
 
 #### Package Exports
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -184,6 +184,18 @@ unspecified.
 
 ### Package Entry Points
 
+There are two fields that can define entry points for a package: `"main"` and
+`"exports"`. The `"main"` field is supported in all versions of Node.js, but its
+capabilities are limited: it only defines the main entry point of the package.
+The `"exports"` field can also be used to define the main entry point of the
+package, as well as other defined entry points; and the package can be
+encapsulated, so that extra effort is required to reference files within the
+package that aren’t the defined public API. `"exports"` can also map an entry
+point to different files per environment, for example for all environments
+versus browser environments; and with `--experimental-conditional-exports`
+`"exports"` can define separate files for Node.js CommonJS and ES module
+environments.
+
 #### <code>package.json</code> <code>"main"</code>
 
 The `package.json` `"main"` field defines the entry point for a package,
@@ -224,7 +236,10 @@ ES module context).
 [Package Exports][] provide an alternative to `"main"` where the package main
 entry point can be defined while also encapsulating the package, preventing any
 other entry points besides those defined in `"exports"`. If package entry points
-are defined in both `"main"` and `"exports"`, the latter takes precedence.
+are defined in both `"main"` and `"exports"`, the latter takes precedence in
+versions of Node.js that support `"exports"`. [Conditional Exports][] can also
+be used within `"exports"` to define different package entry points per
+environment.
 
 #### Package Exports
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -455,7 +455,7 @@ ignores) the top-level `"module"` field.
 
 Node.js can now run ES module entry points, and a package can contain both
 CommonJS and ES module entry points (either via separate specifiers such as
-`'pkg'` and `'pkg/module'`, or both at the same specifier via [Conditional
+`'pkg'` and `'pkg/es-module'`, or both at the same specifier via [Conditional
 Exports][] with the `--experimental-conditional-exports` flag). Unlike in the
 scenario where `"module"` is only used by bundlers, or ES module files are
 transpiled into CommonJS on the fly before evaluation by Node.js, the files
@@ -465,20 +465,21 @@ referenced by the ES module entry point are evaluated as ES modules.
 
 When an application is using a package that provides both CommonJS and ES module
 sources, there is a risk of certain bugs if both versions of the package get
-loaded. This potential comes from the fact that the `pkg` created by `const pkg
-= require('pkg')` is not the same as the `pkg` created by `import pkg from
-'pkg'` (or an alternative main path like `'pkg/module'`). This is the “dual
-package hazard,” where two versions of the same package can be loaded within the
-same runtime environment. While it is unlikely that an application or package
-would intentionally load both versions directly, it is common for an application
-to load one version while a dependency of the application loads the other
-version. This hazard can happen because Node.js supports intermixing CommonJS
-and ES modules, and can lead to unexpected behavior.
+loaded. This potential comes from the fact that the `pkgInstance` created by
+`const pkgInstance = require('pkg')` is not the same as the `pkgInstance`
+created by `import pkgInstance from 'pkg'` (or an alternative main path like
+`'pkg/module'`). This is the “dual package hazard,” where two versions of the
+same package can be loaded within the same runtime environment. While it is
+unlikely that an application or package would intentionally load both versions
+directly, it is common for an application to load one version while a dependency
+of the application loads the other version. This hazard can happen because
+Node.js supports intermixing CommonJS and ES modules, and can lead to unexpected
+behavior.
 
 If the package main export is a constructor, an `instanceof` comparison of
 instances created by the two versions returns `false`, and if the export is an
-object, properties added to one (like `pkg.foo = 3`) are not present on the
-other. This differs from how `import` and `require` statements work in
+object, properties added to one (like `pkgInstance.foo = 3`) are not present on
+the other. This differs from how `import` and `require` statements work in
 all-CommonJS or all-ES module environments, respectively, and therefore is
 surprising to users. It also differs from the behavior users are familiar with
 when using transpilation via tools like [Babel][] or [`esm`][].

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -443,41 +443,15 @@ referenced by the ES module entry point are evaluated as ES modules.
 
 When an application is using a package that provides both CommonJS and ES module
 sources, there is a risk of certain bugs if both versions of the package get
-loaded (for example, because one version is imported by the application and the
-other version is required by one of the application’s dependencies). Such a
-package might look like this:
-
-<!-- eslint-skip -->
-```js
-// ./node_modules/pkg/package.json
-{
-  "type": "module",
-  "main": "./pkg.cjs",
-  "exports": {
-    ".": "./pkg.cjs",
-    "./module": "./pkg.mjs"
-  }
-}
-```
-
-In this example, `require('pkg')` always resolves to `pkg.cjs`, including in
-versions of Node.js where ES modules are unsupported. In Node.js where ES
-modules are supported, `import 'pkg/module'` references `pkg.mjs`.
-
-The potential for bugs comes from the fact that the `pkg` created by `const pkg
+loaded. This potential comes from the fact that the `pkg` created by `const pkg
 = require('pkg')` is not the same as the `pkg` created by `import pkg from
-'pkg/module'`. This is the “dual package hazard,” where two versions of the same
-package can be loaded within the same runtime environment. While it is unlikely
-that an application or package would intentionally load both versions directly,
-it is common for an application to load one version while a dependency of the
-application loads the other version. This hazard can happen because Node.js
-supports intermixing CommonJS and ES modules, and can lead to unexpected
-behavior.
-
-The hazard is also present when [Conditional Exports][] with the
-`--experimental-conditional-exports` flag are used. In that case, instead of
-`'pkg'` and `'pkg/module'` as in the example above, both `require` and `import`
-would use `'pkg'`. The hazard is the same.
+'pkg'` (or an alternative main path like `'pkg/module'`). This is the “dual
+package hazard,” where two versions of the same package can be loaded within the
+same runtime environment. While it is unlikely that an application or package
+would intentionally load both versions directly, it is common for an application
+to load one version while a dependency of the application loads the other
+version. This hazard can happen because Node.js supports intermixing CommonJS
+and ES modules, and can lead to unexpected behavior.
 
 If the package main export is a constructor, an `instanceof` comparison of
 instances created by the two versions returns `false`, and if the export is an

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -184,6 +184,8 @@ unspecified.
 
 ### Package Entry Points
 
+#### <code>package.json</code> <code>"main"</code>
+
 The `package.json` `"main"` field defines the entry point for a package,
 whether the package is included into CommonJS via `require` or into an ES
 module via `import`.
@@ -219,7 +221,12 @@ The `"main"` field can point to exactly one file, regardless of whether the
 package is referenced via `require` (in a CommonJS context) or `import` (in an
 ES module context).
 
-### Package Exports
+[Package Exports][] provide an alternative to `"main"` where the package main
+entry point can be defined while also encapsulating the package, preventing any
+other entry points besides those defined in `"exports"`. If package entry points
+are defined in both `"main"` and `"exports"`, the latter takes precedence.
+
+#### Package Exports
 
 By default, all subpaths from a package can be imported (`import 'pkg/x.js'`).
 Custom subpath aliasing and encapsulation can be provided through the
@@ -1385,6 +1392,7 @@ success!
 [ECMAScript-modules implementation]: https://github.com/nodejs/modules/blob/master/doc/plan-for-new-modules-implementation.md
 [ES Module Integration Proposal for Web Assembly]: https://github.com/webassembly/esm-integration
 [Node.js EP for ES Modules]: https://github.com/nodejs/node-eps/blob/master/002-es-modules.md
+[Package Exports]: #esm_package_exports
 [Terminology]: #esm_terminology
 [WHATWG JSON modules specification]: https://html.spec.whatwg.org/#creating-a-json-module-script
 [`data:` URLs]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -574,7 +574,7 @@ This approach is appropriate for any of the following use cases:
 
 A variant of this approach not requiring `--experimental-conditional-exports`
 for consumers could be to add an export, e.g. `"./module"`, to point to an
-all-ES module-syntax version the package. This could be used via `import
+all-ES module-syntax version of the package. This could be used via `import
 'pkg/module'` by users who are certain that the CommonJS version will not be
 loaded anywhere in the application, such as by dependencies; or if the CommonJS
 version can be loaded but doesn’t affect the ES module version (for example,

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -685,7 +685,7 @@ execution between the CommonJS and ES module versions of a package.
 
 As with the previous approach, a variant of this approach not requiring
 `--experimental-conditional-exports` for consumers could be to add an export,
-e.g. `"./module"`, to point to an all-ES module-syntax version the package:
+e.g. `"./module"`, to point to an all-ES module-syntax version of the package:
 
 <!-- eslint-skip -->
 ```js


### PR DESCRIPTION
This updates the ES modules docs regarding hazards related to dual packages per the findings in https://github.com/nodejs/modules/issues/409. Basically, the hazard that we  previously thought was isolated to divergent specifiers (e.g. `'pkg'` resolving to `index.cjs` for CommonJS and `index.mjs` for ESM) happens for all dual packages even if the two entry points are at different specifiers (e.g. `'pkg'` and `'pkg/module'`). Therefore the section on writing dual packages applies not just to conditional exports but to the ES modules implementation generally.

Follow up to https://github.com/nodejs/node/pull/30051.

cc @guybedford @MylesBorins @nodejs/modules-active-members 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)