### PR TITLE
http2: fix session memory tracking and small clean up

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1867,14 +1867,10 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
     // call in OnStreamAfterWrite() immediately provides data. If that does
     // happen, we concatenate the data we received with the already-stored
     // pending input data, slicing off the already processed part.
-    AllocatedBuffer new_buf = env()->AllocateManaged(
-        stream_buf_.len - stream_buf_offset_ + nread);
-    memcpy(new_buf.data(),
-           stream_buf_.base + stream_buf_offset_,
-           stream_buf_.len - stream_buf_offset_);
-    memcpy(new_buf.data() + stream_buf_.len - stream_buf_offset_,
-           buf.data(),
-           nread);
+    size_t pending_len = stream_buf_.len - stream_buf_offset_;
+    AllocatedBuffer new_buf = env()->AllocateManaged(pending_len + nread);
+    memcpy(new_buf.data(), stream_buf_.base + stream_buf_offset_, pending_len);
+    memcpy(new_buf.data() + pending_len, buf.data(), nread);
     buf = std::move(new_buf);
     nread = buf.size();
     stream_buf_offset_ = 0;

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1862,7 +1862,11 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
 
   statistics_.data_received += nread;
 
-  if (UNLIKELY(stream_buf_offset_ > 0)) {
+  if (LIKELY(stream_buf_offset_ == 0)) {
+    // Shrink to the actual amount of used data.
+    buf.Resize(nread);
+    IncrementCurrentSessionMemory(nread);
+  } else {
     // This is a very unlikely case, and should only happen if the ReadStart()
     // call in OnStreamAfterWrite() immediately provides data. If that does
     // happen, we concatenate the data we received with the already-stored
@@ -1871,19 +1875,17 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
     AllocatedBuffer new_buf = env()->AllocateManaged(pending_len + nread);
     memcpy(new_buf.data(), stream_buf_.base + stream_buf_offset_, pending_len);
     memcpy(new_buf.data() + pending_len, buf.data(), nread);
+
+    // The data in stream_buf_ is already accounted for, add nread received
+    // bytes to session memory but remove the already processed
+    // stream_buf_offset_ bytes.
+    IncrementCurrentSessionMemory(nread - stream_buf_offset_);
+
     buf = std::move(new_buf);
     nread = buf.size();
     stream_buf_offset_ = 0;
     stream_buf_ab_.Reset();
-
-    // We have now fully processed the stream_buf_ input chunk (by moving the
-    // remaining part into buf, which will be accounted for below).
-    DecrementCurrentSessionMemory(stream_buf_.len);
   }
-
-  // Shrink to the actual amount of used data.
-  buf.Resize(nread);
-  IncrementCurrentSessionMemory(nread);
 
   // Remember the current buffer, so that OnDataChunkReceived knows the
   // offset of a DATA frame's data into the socket read buffer.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
**http2: fix session memory tracking with pending input data**
Previously `DecrementCurrentSessionMemory` call was made after the relevant variable was reset to `0`.

**http2: small clean up in OnStreamRead**
Extract pending input memory size in a variable and change code appropriately.

Not sure how to reliably hit the changed case, could someone help so I can write a test for `DecrementCurrentSessionMemory`?
