### PR TITLE
test: deflake test-http-dump-req-when-res-ends.js

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -19,8 +19,6 @@ test-worker-memory: PASS,FLAKY
 test-http2-client-upload: PASS,FLAKY
 # https://github.com/nodejs/node/issues/20750
 test-http2-client-upload-reject: PASS,FLAKY
-# https://github.com/nodejs/node/issues/30011
-test-http-dump-req-when-res-ends: PASS,FLAKY
 
 [$system==linux]
 

--- a/test/parallel/test-http-dump-req-when-res-ends.js
+++ b/test/parallel/test-http-dump-req-when-res-ends.js
@@ -48,8 +48,12 @@ server.listen(0, mustCall(function() {
 
     res.resume();
 
-    // Wait for the response.
-    res.on('end', function() {
+    // On some platforms the `'end'` event might not be emitted because the
+    // socket could be destroyed by the other peer while data is still being
+    // sent. In this case the 'aborted'` event is emitted instead of `'end'`.
+    // `'close'` is used here because it is always emitted and does not
+    // invalidate the test.
+    res.on('close', function() {
       server.close();
     });
   }));


### PR DESCRIPTION
On some platforms the `'end'` event might not be emitted because the
socket could be destroyed by the other peer while the client is still
sending the data triggering an error. Use the `'close'` event instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
