### PR TITLE
doc: remove "maintenance is supported by" text in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -69,17 +69,14 @@ There are three support tiers:
 
 * **Tier 1**: These platforms represent the majority of Node.js users. The
   Node.js Build Working Group maintains infrastructure for full test coverage.
-  Maintenance is supported by the Node.js core team. All commits to the
-  Node.js repository are tested on multiple variants of these platforms. Test
-  failures on tier 1 platforms will block releases.
+  All commits to the Node.js repository are tested on multiple variants of these
+  platforms. Test failures on tier 1 platforms will block releases.
 * **Tier 2**: These platforms represent smaller segments of the Node.js user
   base. The Node.js Build Working Group maintains infrastructure for full test
-  coverage. Maintenance is supported by smaller groups or individuals within
-  the Node.js core team, or the vendor of the platform itself. All commits to
-  the Node.js repository are tested on multiple variants of these platforms
-  where practical. Test failures on tier 2 platforms will block releases.
-  Delays in release of binaries for these platforms are acceptable
-  where necessary due to infrastructure concerns.
+  coverage. All commits to the Node.js repository are tested on multiple
+  variants of these platforms where practical. Test failures on tier 2 platforms
+  will block releases. Delays in release of binaries for these platforms are
+  acceptable where necessary due to infrastructure concerns.
 * **Experimental**: May not compile or test suite may not pass. The core team
   does not create releases for these platforms. Test failures on experimental
   platforms do not block releases. Contributions to improve support for these


### PR DESCRIPTION
The "maintenance is supported by" stuff in BUILDING.md is unclear. It
seems unnecessary so I propose removing it.

I don't understand what it means to, in this context, support
maintenance. Does it mean that you simply do the maintenance? Does that
mean it really just means "maintain"? Do we really mean that we mantain
support, rather than support maintenance?

That information does not seem necessary to include. I'm not sure it's
meaningful. With (for example) Windows, is it accurate to say that the
Node.js core team maintains support for it? Or is it accurate to say
that support is maintaned by smaller groups or individuals within the
Node.js core team?  Both could be considered accurate. So is the
difference meaningful?

I think the more important elements of determinig tier support are the
other listed elements.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
