### PR TITLE
[v10.x] deps: V8: backport fb63e5cf55e9

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -33,7 +33,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.54',
+    'v8_embedder_string': '-node.55',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/objects/intl-objects.cc
+++ b/deps/v8/src/objects/intl-objects.cc
@@ -138,7 +138,9 @@ icu::SimpleDateFormat* CreateICUDateFormat(Isolate* isolate,
                                                       status));
     icu::UnicodeString pattern;
     if (U_SUCCESS(status))
-      pattern = generator->getBestPattern(skeleton, status);
+      pattern = generator->getBestPattern(skeleton,
+                                          UDATPG_MATCH_HOUR_FIELD_LENGTH,
+                                          status);
 
     date_format = new icu::SimpleDateFormat(pattern, icu_locale, status);
     if (U_SUCCESS(status)) {

--- a/deps/v8/test/intl/regress-527926.js
+++ b/deps/v8/test/intl/regress-527926.js
@@ -1,0 +1,19 @@
+// Copyright 2019 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+let date = new Date(2015, 8, 1, 3, 0, 0);
+var fmt = new Intl.DateTimeFormat('ru', {hour:'2-digit', minute: '2-digit'})
+assertEquals("03:00", fmt.format(date));
+
+fmt = new Intl.DateTimeFormat(
+    'en', {hour:'2-digit', minute: '2-digit', hour12: false});
+assertEquals("03:00", fmt.format(date));
+
+fmt = new Intl.DateTimeFormat(
+    'ru', {hour:'2-digit', minute: '2-digit', hour12: false});
+assertEquals("03:00", fmt.format(date));
+
+fmt = new Intl.DateTimeFormat(
+    'ru', {hour:'2-digit', minute: '2-digit', hour12: true});
+assertEquals("03:00 AM", fmt.format(date));


### PR DESCRIPTION
Original commit message:

    [Intl] Fix output of hour:'2-digit', hour12: true

    Bug: chromium:527926
    Change-Id: I783ba59c6e4b117163e058032fb04283e1f43c46
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1529260
    Reviewed-by: Sathya Gunasekaran <gsathya@chromium.org>
    Commit-Queue: Frank Tang <ftang@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#60379}

Refs: https://github.com/v8/v8/commit/fb63e5cf55e93d7b4df51d3f382a6c84d25a5e86

Fixes: https://github.com/nodejs/node/issues/30369
