### PR TITLE
doc: improve doc Http2Stream: FrameError, Timeout and Trailers

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -970,6 +970,11 @@ an `Http2Stream`.
 added: v8.4.0
 -->
 
+* `type` {integer} The frame type.
+* `code` {integer} The error code.
+* `id` {integer} The stream id (or `0` if the frame isn't associated with a
+  stream).
+
 The `'frameError'` event is emitted when an error occurs while attempting to
 send a frame. When invoked, the handler function will receive an integer
 argument identifying the frame type, and an integer argument identifying the
@@ -984,6 +989,7 @@ added: v8.4.0
 The `'timeout'` event is emitted after no activity is received for this
 `Http2Stream` within the number of milliseconds set using
 `http2stream.setTimeout()`.
+Its listener does not expect any arguments.
 
 #### Event: 'trailers'
 <!-- YAML
@@ -991,7 +997,8 @@ added: v8.4.0
 -->
 
 The `'trailers'` event is emitted when a block of headers associated with
-trailing header fields is received. The listener callback is passed the
+trailing header fields is received. Its listener does not expect any arguments.
+The listener callback is passed the
 [HTTP/2 Headers Object][] and flags associated with the headers.
 
 This event might not be emitted if `http2stream.end()` is called

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -996,9 +996,11 @@ Its listener does not expect any arguments.
 added: v8.4.0
 -->
 
+* `headers` {HTTP/2 Headers Object} An object describing the headers
+* `flags` {number} The associated numeric flags
+
 The `'trailers'` event is emitted when a block of headers associated with
-trailing header fields is received. Its listener does not expect any arguments.
-The listener callback is passed the
+trailing header fields is received. The listener callback is passed the
 [HTTP/2 Headers Object][] and flags associated with the headers.
 
 This event might not be emitted if `http2stream.end()` is called


### PR DESCRIPTION
Changes in doc/http2.md for 'frameError', 'timeout', 'trailers' events
which tell readers that these events except any arguments or doesn't.

Fixes: https://github.com/nodejs/help/issues/877

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
