### PR TITLE
src: introduce custom smart pointers for `BaseObject`s

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -1099,6 +1099,7 @@
         'test/cctest/node_test_fixture.h',
         'test/cctest/test_aliased_buffer.cc',
         'test/cctest/test_base64.cc',
+        'test/cctest/test_base_object_ptr.cc',
         'test/cctest/test_node_postmortem_metadata.cc',
         'test/cctest/test_environment.cc',
         'test/cctest/test_linked_binding.cc',

--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -32,16 +32,25 @@
 namespace node {
 
 BaseObject::BaseObject(Environment* env, v8::Local<v8::Object> object)
-    : persistent_handle_(env->isolate(), object),
-      env_(env) {
+    : persistent_handle_(env->isolate(), object), env_(env) {
   CHECK_EQ(false, object.IsEmpty());
   CHECK_GT(object->InternalFieldCount(), 0);
   object->SetAlignedPointerInInternalField(0, static_cast<void*>(this));
-  env_->AddCleanupHook(DeleteMe, static_cast<void*>(this));
+  env->AddCleanupHook(DeleteMe, static_cast<void*>(this));
+  env->modify_base_object_count(1);
 }
 
 BaseObject::~BaseObject() {
-  RemoveCleanupHook();
+  env()->modify_base_object_count(-1);
+  env()->RemoveCleanupHook(DeleteMe, static_cast<void*>(this));
+
+  if (UNLIKELY(has_pointer_data())) {
+    PointerData* metadata = pointer_data();
+    CHECK_EQ(metadata->strong_ptr_count, 0);
+    metadata->self = nullptr;
+    if (metadata->weak_ptr_count == 0)
+      delete metadata;
+  }
 
   if (persistent_handle_.IsEmpty()) {
     // This most likely happened because the weak callback below cleared it.
@@ -49,7 +58,7 @@ BaseObject::~BaseObject() {
   }
 
   {
-    v8::HandleScope handle_scope(env_->isolate());
+    v8::HandleScope handle_scope(env()->isolate());
     object()->SetAlignedPointerInInternalField(0, nullptr);
   }
 }
@@ -58,20 +67,25 @@ void BaseObject::RemoveCleanupHook() {
   env_->RemoveCleanupHook(DeleteMe, static_cast<void*>(this));
 }
 
+void BaseObject::Detach() {
+  CHECK_GT(pointer_data()->strong_ptr_count, 0);
+  pointer_data()->is_detached = true;
+}
+
 v8::Global<v8::Object>& BaseObject::persistent() {
   return persistent_handle_;
 }
 
 
 v8::Local<v8::Object> BaseObject::object() const {
-  return PersistentToLocal::Default(env_->isolate(), persistent_handle_);
+  return PersistentToLocal::Default(env()->isolate(), persistent_handle_);
 }
 
 v8::Local<v8::Object> BaseObject::object(v8::Isolate* isolate) const {
   v8::Local<v8::Object> handle = object();
 
   DCHECK_EQ(handle->CreationContext()->GetIsolate(), isolate);
-  DCHECK_EQ(env_->isolate(), isolate);
+  DCHECK_EQ(env()->isolate(), isolate);
 
   return handle;
 }
@@ -79,7 +93,6 @@ v8::Local<v8::Object> BaseObject::object(v8::Isolate* isolate) const {
 Environment* BaseObject::env() const {
   return env_;
 }
-
 
 BaseObject* BaseObject::FromJSObject(v8::Local<v8::Object> obj) {
   CHECK_GT(obj->InternalFieldCount(), 0);
@@ -94,20 +107,34 @@ T* BaseObject::FromJSObject(v8::Local<v8::Object> object) {
 
 
 void BaseObject::MakeWeak() {
+  if (has_pointer_data()) {
+    pointer_data()->wants_weak_jsobj = true;
+    if (pointer_data()->strong_ptr_count > 0) return;
+  }
+
   persistent_handle_.SetWeak(
       this,
       [](const v8::WeakCallbackInfo<BaseObject>& data) {
-        std::unique_ptr<BaseObject> obj(data.GetParameter());
+        BaseObject* obj = data.GetParameter();
         // Clear the persistent handle so that ~BaseObject() doesn't attempt
         // to mess with internal fields, since the JS object may have
         // transitioned into an invalid state.
         // Refs: https://github.com/nodejs/node/issues/18897
         obj->persistent_handle_.Reset();
+        CHECK_IMPLIES(obj->has_pointer_data(),
+                      obj->pointer_data()->strong_ptr_count == 0);
+        obj->OnGCCollect();
       }, v8::WeakCallbackType::kParameter);
 }
 
+void BaseObject::OnGCCollect() {
+  delete this;
+}
 
 void BaseObject::ClearWeak() {
+  if (has_pointer_data())
+    pointer_data()->wants_weak_jsobj = false;
+
   persistent_handle_.ClearWeak();
 }
 
@@ -139,6 +166,176 @@ void BaseObject::InternalFieldSet(v8::Local<v8::String> property,
   // This could be e.g. value->IsFunction().
   CHECK(((*value)->*typecheck)());
   info.This()->SetInternalField(Field, value);
+}
+
+bool BaseObject::has_pointer_data() const {
+  return pointer_data_ != nullptr;
+}
+
+BaseObject::PointerData* BaseObject::pointer_data() {
+  if (!has_pointer_data()) {
+    PointerData* metadata = new PointerData();
+    metadata->wants_weak_jsobj = persistent_handle_.IsWeak();
+    metadata->self = this;
+    pointer_data_ = metadata;
+  }
+  CHECK(has_pointer_data());
+  return pointer_data_;
+}
+
+void BaseObject::decrease_refcount() {
+  CHECK(has_pointer_data());
+  PointerData* metadata = pointer_data();
+  CHECK_GT(metadata->strong_ptr_count, 0);
+  unsigned int new_refcount = --metadata->strong_ptr_count;
+  if (new_refcount == 0) {
+    if (metadata->is_detached) {
+      delete this;
+    } else if (metadata->wants_weak_jsobj && !persistent_handle_.IsEmpty()) {
+      MakeWeak();
+    }
+  }
+}
+
+void BaseObject::increase_refcount() {
+  unsigned int prev_refcount = pointer_data()->strong_ptr_count++;
+  if (prev_refcount == 0 && !persistent_handle_.IsEmpty())
+    persistent_handle_.ClearWeak();
+}
+
+template <typename T, bool kIsWeak>
+BaseObject::PointerData*
+BaseObjectPtrImpl<T, kIsWeak>::pointer_data() const {
+  if (kIsWeak) {
+    return data_.pointer_data;
+  } else {
+    if (get_base_object() == nullptr) return nullptr;
+    return get_base_object()->pointer_data();
+  }
+}
+
+template <typename T, bool kIsWeak>
+BaseObject* BaseObjectPtrImpl<T, kIsWeak>::get_base_object() const {
+  if (kIsWeak) {
+    if (pointer_data() == nullptr) return nullptr;
+    return pointer_data()->self;
+  } else {
+    return data_.target;
+  }
+}
+
+template <typename T, bool kIsWeak>
+BaseObjectPtrImpl<T, kIsWeak>::~BaseObjectPtrImpl() {
+  if (get() == nullptr) return;
+  if (kIsWeak) {
+    if (--pointer_data()->weak_ptr_count == 0 &&
+        pointer_data()->self == nullptr) {
+      delete pointer_data();
+    }
+  } else {
+    get()->decrease_refcount();
+  }
+}
+
+template <typename T, bool kIsWeak>
+BaseObjectPtrImpl<T, kIsWeak>::BaseObjectPtrImpl() {
+  data_.target = nullptr;
+}
+
+template <typename T, bool kIsWeak>
+BaseObjectPtrImpl<T, kIsWeak>::BaseObjectPtrImpl(T* target)
+  : BaseObjectPtrImpl() {
+  if (target == nullptr) return;
+  if (kIsWeak) {
+    data_.pointer_data = target->pointer_data();
+    CHECK_NOT_NULL(pointer_data());
+    pointer_data()->weak_ptr_count++;
+  } else {
+    data_.target = target;
+    CHECK_NOT_NULL(pointer_data());
+    get()->increase_refcount();
+  }
+}
+
+template <typename T, bool kIsWeak>
+template <typename U, bool kW>
+BaseObjectPtrImpl<T, kIsWeak>::BaseObjectPtrImpl(
+    const BaseObjectPtrImpl<U, kW>& other)
+  : BaseObjectPtrImpl(other.get()) {}
+
+template <typename T, bool kIsWeak>
+BaseObjectPtrImpl<T, kIsWeak>::BaseObjectPtrImpl(const BaseObjectPtrImpl& other)
+  : BaseObjectPtrImpl(other.get()) {}
+
+template <typename T, bool kIsWeak>
+template <typename U, bool kW>
+BaseObjectPtrImpl<T, kIsWeak>& BaseObjectPtrImpl<T, kIsWeak>::operator=(
+    const BaseObjectPtrImpl<U, kW>& other) {
+  if (other.get() == get()) return *this;
+  this->~BaseObjectPtrImpl();
+  return *new (this) BaseObjectPtrImpl(other);
+}
+
+template <typename T, bool kIsWeak>
+BaseObjectPtrImpl<T, kIsWeak>& BaseObjectPtrImpl<T, kIsWeak>::operator=(
+    const BaseObjectPtrImpl& other) {
+  if (other.get() == get()) return *this;
+  this->~BaseObjectPtrImpl();
+  return *new (this) BaseObjectPtrImpl(other);
+}
+
+template <typename T, bool kIsWeak>
+BaseObjectPtrImpl<T, kIsWeak>::BaseObjectPtrImpl(BaseObjectPtrImpl&& other)
+  : data_(other.data_) {
+  if (kIsWeak)
+    other.data_.target = nullptr;
+  else
+    other.data_.pointer_data = nullptr;
+}
+
+template <typename T, bool kIsWeak>
+BaseObjectPtrImpl<T, kIsWeak>& BaseObjectPtrImpl<T, kIsWeak>::operator=(
+    BaseObjectPtrImpl&& other) {
+  if (&other == this) return *this;
+  this->~BaseObjectPtrImpl();
+  return *new (this) BaseObjectPtrImpl(std::move(other));
+}
+
+template <typename T, bool kIsWeak>
+void BaseObjectPtrImpl<T, kIsWeak>::reset(T* ptr) {
+  *this = BaseObjectPtrImpl(ptr);
+}
+
+template <typename T, bool kIsWeak>
+T* BaseObjectPtrImpl<T, kIsWeak>::get() const {
+  return static_cast<T*>(get_base_object());
+}
+
+template <typename T, bool kIsWeak>
+T& BaseObjectPtrImpl<T, kIsWeak>::operator*() const {
+  return *get();
+}
+
+template <typename T, bool kIsWeak>
+T* BaseObjectPtrImpl<T, kIsWeak>::operator->() const {
+  return get();
+}
+
+template <typename T, bool kIsWeak>
+BaseObjectPtrImpl<T, kIsWeak>::operator bool() const {
+  return get() != nullptr;
+}
+
+template <typename T, typename... Args>
+BaseObjectPtr<T> MakeBaseObject(Args&&... args) {
+  return BaseObjectPtr<T>(new T(std::forward<Args>(args)...));
+}
+
+template <typename T, typename... Args>
+BaseObjectPtr<T> MakeDetachedBaseObject(Args&&... args) {
+  BaseObjectPtr<T> target = MakeBaseObject<T>(std::forward<Args>(args)...);
+  target->Detach();
+  return target;
 }
 
 }  // namespace node

--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -63,10 +63,6 @@ BaseObject::~BaseObject() {
   }
 }
 
-void BaseObject::RemoveCleanupHook() {
-  env_->RemoveCleanupHook(DeleteMe, static_cast<void*>(this));
-}
-
 void BaseObject::Detach() {
   CHECK_GT(pointer_data()->strong_ptr_count, 0);
   pointer_data()->is_detached = true;

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -97,7 +97,6 @@ class BaseObject : public MemoryRetainer {
   inline void Detach();
 
  protected:
-  inline void RemoveCleanupHook();  // TODO(addaleax): Remove.
   virtual inline void OnGCCollect();
 
  private:

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -575,10 +575,6 @@ class QueryWrap : public AsyncWrap {
       : AsyncWrap(channel->env(), req_wrap_obj, AsyncWrap::PROVIDER_QUERYWRAP),
         channel_(channel),
         trace_name_(name) {
-    // Make sure the channel object stays alive during the query lifetime.
-    req_wrap_obj->Set(env()->context(),
-                      env()->channel_string(),
-                      channel->object()).Check();
   }
 
   ~QueryWrap() override {
@@ -735,7 +731,7 @@ class QueryWrap : public AsyncWrap {
     UNREACHABLE();
   }
 
-  ChannelWrap* channel_;
+  BaseObjectPtr<ChannelWrap> channel_;
 
  private:
   std::unique_ptr<ResponseData> response_data_;

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -746,13 +746,9 @@ inline void IsolateData::set_options(
 }
 
 template <typename Fn>
-void Environment::CreateImmediate(Fn&& cb,
-                                  v8::Local<v8::Object> keep_alive,
-                                  bool ref) {
+void Environment::CreateImmediate(Fn&& cb, bool ref) {
   auto callback = std::make_unique<NativeImmediateCallbackImpl<Fn>>(
-      std::move(cb),
-      v8::Global<v8::Object>(isolate(), keep_alive),
-      ref);
+      std::move(cb), ref);
   NativeImmediateCallback* prev_tail = native_immediate_callbacks_tail_;
 
   native_immediate_callbacks_tail_ = callback.get();
@@ -765,8 +761,8 @@ void Environment::CreateImmediate(Fn&& cb,
 }
 
 template <typename Fn>
-void Environment::SetImmediate(Fn&& cb, v8::Local<v8::Object> keep_alive) {
-  CreateImmediate(std::move(cb), keep_alive, true);
+void Environment::SetImmediate(Fn&& cb) {
+  CreateImmediate(std::move(cb), true);
 
   if (immediate_info()->ref_count() == 0)
     ToggleImmediateRef(true);
@@ -774,8 +770,8 @@ void Environment::SetImmediate(Fn&& cb, v8::Local<v8::Object> keep_alive) {
 }
 
 template <typename Fn>
-void Environment::SetUnrefImmediate(Fn&& cb, v8::Local<v8::Object> keep_alive) {
-  CreateImmediate(std::move(cb), keep_alive, false);
+void Environment::SetUnrefImmediate(Fn&& cb) {
+  CreateImmediate(std::move(cb), false);
 }
 
 Environment::NativeImmediateCallback::NativeImmediateCallback(bool refed)
@@ -797,10 +793,9 @@ void Environment::NativeImmediateCallback::set_next(
 
 template <typename Fn>
 Environment::NativeImmediateCallbackImpl<Fn>::NativeImmediateCallbackImpl(
-    Fn&& callback, v8::Global<v8::Object>&& keep_alive, bool refed)
+    Fn&& callback, bool refed)
   : NativeImmediateCallback(refed),
-    callback_(std::move(callback)),
-    keep_alive_(std::move(keep_alive)) {}
+    callback_(std::move(callback)) {}
 
 template <typename Fn>
 void Environment::NativeImmediateCallbackImpl<Fn>::Call(Environment* env) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -1151,6 +1151,14 @@ void Environment::ForEachBaseObject(T&& iterator) {
   }
 }
 
+void Environment::modify_base_object_count(int64_t delta) {
+  base_object_count_ += delta;
+}
+
+int64_t Environment::base_object_count() const {
+  return base_object_count_;
+}
+
 bool AsyncRequest::is_stopped() const {
   return stopped_.load();
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -431,6 +431,8 @@ Environment::~Environment() {
       addon.Close();
     }
   }
+
+  CHECK_EQ(base_object_count(), 0);
 }
 
 void Environment::InitializeLibuv(bool start_profiler_idle_notifier) {
@@ -1088,6 +1090,10 @@ AsyncRequest::~AsyncRequest() {
 // Not really any better place than env.cc at this moment.
 void BaseObject::DeleteMe(void* data) {
   BaseObject* self = static_cast<BaseObject*>(data);
+  if (self->has_pointer_data() &&
+      self->pointer_data()->strong_ptr_count > 0) {
+    return self->Detach();
+  }
   delete self;
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -1183,13 +1183,9 @@ class Environment : public MemoryRetainer {
   // cb will be called as cb(env) on the next event loop iteration.
   // keep_alive will be kept alive between now and after the callback has run.
   template <typename Fn>
-  inline void SetImmediate(Fn&& cb,
-                           v8::Local<v8::Object> keep_alive =
-                               v8::Local<v8::Object>());
+  inline void SetImmediate(Fn&& cb);
   template <typename Fn>
-  inline void SetUnrefImmediate(Fn&& cb,
-                                v8::Local<v8::Object> keep_alive =
-                                    v8::Local<v8::Object>());
+  inline void SetUnrefImmediate(Fn&& cb);
   // This needs to be available for the JS-land setImmediate().
   void ToggleImmediateRef(bool ref);
 
@@ -1260,9 +1256,7 @@ class Environment : public MemoryRetainer {
 
  private:
   template <typename Fn>
-  inline void CreateImmediate(Fn&& cb,
-                              v8::Local<v8::Object> keep_alive,
-                              bool ref);
+  inline void CreateImmediate(Fn&& cb, bool ref);
 
   inline void ThrowError(v8::Local<v8::Value> (*fun)(v8::Local<v8::String>),
                          const char* errmsg);
@@ -1410,14 +1404,11 @@ class Environment : public MemoryRetainer {
   template <typename Fn>
   class NativeImmediateCallbackImpl final : public NativeImmediateCallback {
    public:
-    NativeImmediateCallbackImpl(Fn&& callback,
-                                v8::Global<v8::Object>&& keep_alive,
-                                bool refed);
+    NativeImmediateCallbackImpl(Fn&& callback, bool refed);
     void Call(Environment* env) override;
 
    private:
     Fn callback_;
-    v8::Global<v8::Object> keep_alive_;
   };
 
   std::unique_ptr<NativeImmediateCallback> native_immediate_callbacks_head_;

--- a/src/env.h
+++ b/src/env.h
@@ -1216,6 +1216,12 @@ class Environment : public MemoryRetainer {
 
   inline AsyncRequest* thread_stopper() { return &thread_stopper_; }
 
+  // The BaseObject count is a debugging helper that makes sure that there are
+  // no memory leaks caused by BaseObjects staying alive longer than expected
+  // (in particular, no circular BaseObjectPtr references).
+  inline void modify_base_object_count(int64_t delta);
+  inline int64_t base_object_count() const;
+
 #if HAVE_INSPECTOR
   void set_coverage_connection(
       std::unique_ptr<profiler::V8CoverageConnection> connection);
@@ -1426,6 +1432,8 @@ class Environment : public MemoryRetainer {
                      CleanupHookCallback::Equal> cleanup_hooks_;
   uint64_t cleanup_hook_counter_ = 0;
   bool started_cleanup_ = false;
+
+  int64_t base_object_count_ = 0;
 
   // A custom async abstraction (a pair of async handle and a state variable)
   // Used by embedders to shutdown running Node instance.

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -84,14 +84,8 @@ void HandleWrap::Close(Local<Value> close_callback) {
 }
 
 
-void HandleWrap::MakeWeak() {
-  persistent().SetWeak(
-      this,
-      [](const v8::WeakCallbackInfo<HandleWrap>& data) {
-        HandleWrap* handle_wrap = data.GetParameter();
-        handle_wrap->persistent().Reset();
-        handle_wrap->Close();
-      }, v8::WeakCallbackType::kParameter);
+void HandleWrap::OnGCCollect() {
+  Close();
 }
 
 
@@ -121,7 +115,9 @@ HandleWrap::HandleWrap(Environment* env,
 
 
 void HandleWrap::OnClose(uv_handle_t* handle) {
-  std::unique_ptr<HandleWrap> wrap { static_cast<HandleWrap*>(handle->data) };
+  BaseObjectPtr<HandleWrap> wrap { static_cast<HandleWrap*>(handle->data) };
+  wrap->Detach();
+
   Environment* env = wrap->env();
   HandleScope scope(env->isolate());
   Context::Scope context_scope(env->context());

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -127,6 +127,7 @@ void HandleWrap::OnClose(uv_handle_t* handle) {
   wrap->state_ = kClosed;
 
   wrap->OnClose();
+  wrap->handle_wrap_queue_.Remove();
 
   if (!wrap->persistent().IsEmpty() &&
       wrap->object()->Has(env->context(), env->handle_onclose_symbol())

--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -76,14 +76,13 @@ class HandleWrap : public AsyncWrap {
   static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
       Environment* env);
 
-  void MakeWeak();  // This hides BaseObject::MakeWeak()
-
  protected:
   HandleWrap(Environment* env,
              v8::Local<v8::Object> object,
              uv_handle_t* handle,
              AsyncWrap::ProviderType provider);
   virtual void OnClose() {}
+  void OnGCCollect() final;
 
   void MarkAsInitialized();
   void MarkAsUninitialized();

--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -119,6 +119,14 @@ void MemoryTracker::TrackField(const char* edge_name,
   TrackField(edge_name, value.get(), node_name);
 }
 
+template <typename T, bool kIsWeak>
+void MemoryTracker::TrackField(const char* edge_name,
+                               const BaseObjectPtrImpl<T, kIsWeak>& value,
+                               const char* node_name) {
+  if (value.get() == nullptr) return;
+  TrackField(edge_name, value.get(), node_name);
+}
+
 template <typename T, typename Iterator>
 void MemoryTracker::TrackField(const char* edge_name,
                                const T& value,

--- a/src/memory_tracker.h
+++ b/src/memory_tracker.h
@@ -30,6 +30,8 @@ namespace node {
 
 class MemoryTracker;
 class MemoryRetainerNode;
+template <typename T, bool kIsWeak>
+class BaseObjectPtrImpl;
 
 namespace crypto {
 class NodeBIO;
@@ -138,10 +140,16 @@ class MemoryTracker {
   inline void TrackField(const char* edge_name,
                          const std::unique_ptr<T>& value,
                          const char* node_name = nullptr);
+
   template <typename T>
   inline void TrackField(const char* edge_name,
                          const std::shared_ptr<T>& value,
                          const char* node_name = nullptr);
+
+  template <typename T, bool kIsWeak>
+  void TrackField(const char* edge_name,
+                  const BaseObjectPtrImpl<T, kIsWeak>& value,
+                  const char* node_name = nullptr);
 
   // For containers, the elements will be graphed as grandchildren nodes
   // if the container is not empty.

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -239,7 +239,6 @@ Http2Session::Http2Settings::Http2Settings(Environment* env,
     : AsyncWrap(env, obj, PROVIDER_HTTP2SETTINGS),
       session_(session),
       startTime_(start_time) {
-  RemoveCleanupHook();  // This object is owned by the Http2Session.
   Init();
 }
 
@@ -658,8 +657,6 @@ Http2Session::Http2Session(Environment* env,
 Http2Session::~Http2Session() {
   CHECK_EQ(flags_ & SESSION_STATE_HAS_SCOPE, 0);
   Debug(this, "freeing nghttp2 session");
-  for (const auto& iter : streams_)
-    iter.second->session_ = nullptr;
   nghttp2_session_del(session_);
   CHECK_EQ(current_nghttp2_memory_, 0);
 }
@@ -767,7 +764,7 @@ void Http2Session::Close(uint32_t code, bool socket_closed) {
   // If there are outstanding pings, those will need to be canceled, do
   // so on the next iteration of the event loop to avoid calling out into
   // javascript since this may be called during garbage collection.
-  while (std::unique_ptr<Http2Ping> ping = PopPing()) {
+  while (BaseObjectPtr<Http2Ping> ping = PopPing()) {
     ping->DetachFromSession();
     env()->SetImmediate(
         [ping = std::move(ping)](Environment* env) {
@@ -1483,7 +1480,7 @@ void Http2Session::HandlePingFrame(const nghttp2_frame* frame) {
   Local<Value> arg;
   bool ack = frame->hd.flags & NGHTTP2_FLAG_ACK;
   if (ack) {
-    std::unique_ptr<Http2Ping> ping = PopPing();
+    BaseObjectPtr<Http2Ping> ping = PopPing();
 
     if (!ping) {
       // PING Ack is unsolicited. Treat as a connection error. The HTTP/2
@@ -1522,7 +1519,7 @@ void Http2Session::HandleSettingsFrame(const nghttp2_frame* frame) {
 
   // If this is an acknowledgement, we should have an Http2Settings
   // object for it.
-  std::unique_ptr<Http2Settings> settings = PopSettings();
+  BaseObjectPtr<Http2Settings> settings = PopSettings();
   if (settings) {
     settings->Done(true);
     return;
@@ -1982,12 +1979,11 @@ Http2Stream::~Http2Stream() {
     nghttp2_rcbuf_decref(header.value);
   }
 
-  if (session_ == nullptr)
+  if (!session_)
     return;
   Debug(this, "tearing down stream");
   session_->DecrementCurrentSessionMemory(current_headers_length_);
   session_->RemoveStream(this);
-  session_ = nullptr;
 }
 
 std::string Http2Stream::diagnostic_name() const {
@@ -2189,8 +2185,10 @@ Http2Stream* Http2Stream::SubmitPushPromise(nghttp2_nv* nva,
                                      id_, nva, len, nullptr);
   CHECK_NE(*ret, NGHTTP2_ERR_NOMEM);
   Http2Stream* stream = nullptr;
-  if (*ret > 0)
-    stream = Http2Stream::New(session_, *ret, NGHTTP2_HCAT_HEADERS, options);
+  if (*ret > 0) {
+    stream = Http2Stream::New(
+        session_.get(), *ret, NGHTTP2_HCAT_HEADERS, options);
+  }
 
   return stream;
 }
@@ -2855,7 +2853,8 @@ void Http2Session::Ping(const FunctionCallbackInfo<Value>& args) {
   if (obj->Set(env->context(), env->ondone_string(), args[1]).IsNothing())
     return;
 
-  Http2Ping* ping = session->AddPing(std::make_unique<Http2Ping>(session, obj));
+  Http2Ping* ping = session->AddPing(
+      MakeDetachedBaseObject<Http2Ping>(session, obj));
   // To prevent abuse, we strictly limit the number of unacknowledged PING
   // frames that may be sent at any given time. This is configurable in the
   // Options when creating a Http2Session.
@@ -2884,16 +2883,16 @@ void Http2Session::Settings(const FunctionCallbackInfo<Value>& args) {
   if (obj->Set(env->context(), env->ondone_string(), args[0]).IsNothing())
     return;
 
-  Http2Session::Http2Settings* settings = session->AddSettings(
-      std::make_unique<Http2Settings>(session->env(), session, obj, 0));
+  Http2Settings* settings = session->AddSettings(
+      MakeDetachedBaseObject<Http2Settings>(session->env(), session, obj, 0));
   if (settings == nullptr) return args.GetReturnValue().Set(false);
 
   settings->Send();
   args.GetReturnValue().Set(true);
 }
 
-std::unique_ptr<Http2Session::Http2Ping> Http2Session::PopPing() {
-  std::unique_ptr<Http2Ping> ping;
+BaseObjectPtr<Http2Session::Http2Ping> Http2Session::PopPing() {
+  BaseObjectPtr<Http2Ping> ping;
   if (!outstanding_pings_.empty()) {
     ping = std::move(outstanding_pings_.front());
     outstanding_pings_.pop();
@@ -2903,7 +2902,7 @@ std::unique_ptr<Http2Session::Http2Ping> Http2Session::PopPing() {
 }
 
 Http2Session::Http2Ping* Http2Session::AddPing(
-    std::unique_ptr<Http2Session::Http2Ping> ping) {
+    BaseObjectPtr<Http2Session::Http2Ping> ping) {
   if (outstanding_pings_.size() == max_outstanding_pings_) {
     ping->Done(false);
     return nullptr;
@@ -2914,8 +2913,8 @@ Http2Session::Http2Ping* Http2Session::AddPing(
   return ptr;
 }
 
-std::unique_ptr<Http2Session::Http2Settings> Http2Session::PopSettings() {
-  std::unique_ptr<Http2Settings> settings;
+BaseObjectPtr<Http2Session::Http2Settings> Http2Session::PopSettings() {
+  BaseObjectPtr<Http2Settings> settings;
   if (!outstanding_settings_.empty()) {
     settings = std::move(outstanding_settings_.front());
     outstanding_settings_.pop();
@@ -2925,7 +2924,7 @@ std::unique_ptr<Http2Session::Http2Settings> Http2Session::PopSettings() {
 }
 
 Http2Session::Http2Settings* Http2Session::AddSettings(
-    std::unique_ptr<Http2Session::Http2Settings> settings) {
+    BaseObjectPtr<Http2Session::Http2Settings> settings) {
   if (outstanding_settings_.size() == max_outstanding_settings_) {
     settings->Done(false);
     return nullptr;
@@ -2940,7 +2939,6 @@ Http2Session::Http2Ping::Http2Ping(Http2Session* session, Local<Object> obj)
     : AsyncWrap(session->env(), obj, AsyncWrap::PROVIDER_HTTP2PING),
       session_(session),
       startTime_(uv_hrtime()) {
-  RemoveCleanupHook();  // This object is owned by the Http2Session.
 }
 
 void Http2Session::Http2Ping::Send(const uint8_t* payload) {

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -456,8 +456,8 @@ class Http2Stream : public AsyncWrap,
 
   nghttp2_stream* operator*();
 
-  Http2Session* session() { return session_; }
-  const Http2Session* session() const { return session_; }
+  Http2Session* session() { return session_.get(); }
+  const Http2Session* session() const { return session_.get(); }
 
   void EmitStatistics();
 
@@ -609,7 +609,7 @@ class Http2Stream : public AsyncWrap,
               nghttp2_headers_category category,
               int options);
 
-  Http2Session* session_ = nullptr;             // The Parent HTTP/2 Session
+  BaseObjectWeakPtr<Http2Session> session_;     // The Parent HTTP/2 Session
   int32_t id_ = 0;                              // The Stream Identifier
   int32_t code_ = NGHTTP2_NO_ERROR;             // The RST_STREAM code (if any)
   int flags_ = NGHTTP2_STREAM_FLAG_NONE;        // Internal state flags
@@ -822,11 +822,11 @@ class Http2Session : public AsyncWrap, public StreamListener {
     return env()->event_loop();
   }
 
-  std::unique_ptr<Http2Ping> PopPing();
-  Http2Ping* AddPing(std::unique_ptr<Http2Ping> ping);
+  BaseObjectPtr<Http2Ping> PopPing();
+  Http2Ping* AddPing(BaseObjectPtr<Http2Ping> ping);
 
-  std::unique_ptr<Http2Settings> PopSettings();
-  Http2Settings* AddSettings(std::unique_ptr<Http2Settings> settings);
+  BaseObjectPtr<Http2Settings> PopSettings();
+  Http2Settings* AddSettings(BaseObjectPtr<Http2Settings> settings);
 
   void IncrementCurrentSessionMemory(uint64_t amount) {
     current_session_memory_ += amount;
@@ -1001,10 +1001,10 @@ class Http2Session : public AsyncWrap, public StreamListener {
   size_t stream_buf_offset_ = 0;
 
   size_t max_outstanding_pings_ = DEFAULT_MAX_PINGS;
-  std::queue<std::unique_ptr<Http2Ping>> outstanding_pings_;
+  std::queue<BaseObjectPtr<Http2Ping>> outstanding_pings_;
 
   size_t max_outstanding_settings_ = DEFAULT_MAX_SETTINGS;
-  std::queue<std::unique_ptr<Http2Settings>> outstanding_settings_;
+  std::queue<BaseObjectPtr<Http2Settings>> outstanding_settings_;
 
   std::vector<nghttp2_stream_write> outgoing_buffers_;
   std::vector<uint8_t> outgoing_storage_;

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -71,6 +71,7 @@ void StreamPipe::Unpipe() {
   // Delay the JS-facing part with SetImmediate, because this might be from
   // inside the garbage collector, so we can’t run JS here.
   HandleScope handle_scope(env()->isolate());
+  BaseObjectPtr<StreamPipe> strong_ref{this};
   env()->SetImmediate([this](Environment* env) {
     HandleScope handle_scope(env->isolate());
     Context::Scope context_scope(env->context());
@@ -105,7 +106,7 @@ void StreamPipe::Unpipe() {
             .IsNothing()) {
       return;
     }
-  }, object());
+  });
 }
 
 uv_buf_t StreamPipe::ReadableListener::OnStreamAlloc(size_t suggested_size) {

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -316,9 +316,10 @@ void TLSWrap::EncOut() {
         // its not clear if it is always correct. Not calling Done() could block
         // data flow, so for now continue to call Done(), just do it in the next
         // tick.
-        env()->SetImmediate([this](Environment* env) {
+        BaseObjectPtr<TLSWrap> strong_ref{this};
+        env()->SetImmediate([this, strong_ref](Environment* env) {
           InvokeQueued(0);
-        }, object());
+        });
       }
     }
     return;
@@ -349,9 +350,10 @@ void TLSWrap::EncOut() {
     HandleScope handle_scope(env()->isolate());
 
     // Simulate asynchronous finishing, TLS cannot handle this at the moment.
-    env()->SetImmediate([this](Environment* env) {
+    BaseObjectPtr<TLSWrap> strong_ref{this};
+    env()->SetImmediate([this, strong_ref](Environment* env) {
       OnStreamAfterWrite(nullptr, 0);
-    }, object());
+    });
   }
 }
 
@@ -718,9 +720,10 @@ int TLSWrap::DoWrite(WriteWrap* w,
       StreamWriteResult res =
           underlying_stream()->Write(bufs, count, send_handle);
       if (!res.async) {
-        env()->SetImmediate([this](Environment* env) {
+        BaseObjectPtr<TLSWrap> strong_ref{this};
+        env()->SetImmediate([this, strong_ref](Environment* env) {
           OnStreamAfterWrite(current_empty_write_, 0);
-        }, object());
+        });
       }
       return 0;
     }

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -105,9 +105,9 @@ class NodeTestFixture : public ::testing::Test {
   }
 
   void TearDown() override {
+    platform->DrainTasks(isolate_);
     isolate_->Exit();
     isolate_->Dispose();
-    platform->DrainTasks(isolate_);
     platform->UnregisterIsolate(isolate_);
     isolate_ = nullptr;
   }

--- a/test/cctest/test_base_object_ptr.cc
+++ b/test/cctest/test_base_object_ptr.cc
@@ -1,0 +1,176 @@
+#include "gtest/gtest.h"
+#include "node.h"
+#include "base_object-inl.h"
+#include "node_test_fixture.h"
+
+using node::BaseObject;
+using node::BaseObjectPtr;
+using node::BaseObjectWeakPtr;
+using node::Environment;
+using node::MakeBaseObject;
+using node::MakeDetachedBaseObject;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Local;
+using v8::Object;
+
+class BaseObjectPtrTest : public EnvironmentTestFixture {};
+
+class DummyBaseObject : public BaseObject {
+ public:
+  DummyBaseObject(Environment* env, Local<Object> obj) : BaseObject(env, obj) {}
+
+  static Local<Object> MakeJSObject(Environment* env) {
+    return BaseObject::MakeLazilyInitializedJSTemplate(env)
+        ->GetFunction(env->context()).ToLocalChecked()
+        ->NewInstance(env->context()).ToLocalChecked();
+  }
+
+  static BaseObjectPtr<DummyBaseObject> NewDetached(Environment* env) {
+    Local<Object> obj = MakeJSObject(env);
+    return MakeDetachedBaseObject<DummyBaseObject>(env, obj);
+  }
+
+  static BaseObjectPtr<DummyBaseObject> New(Environment* env) {
+    Local<Object> obj = MakeJSObject(env);
+    return MakeBaseObject<DummyBaseObject>(env, obj);
+  }
+
+  SET_NO_MEMORY_INFO()
+  SET_MEMORY_INFO_NAME(DummyBaseObject)
+  SET_SELF_SIZE(DummyBaseObject)
+};
+
+TEST_F(BaseObjectPtrTest, ScopedDetached) {
+  const HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env env_{handle_scope, argv};
+  Environment* env = *env_;
+
+  EXPECT_EQ(env->base_object_count(), 0);
+  {
+    BaseObjectPtr<DummyBaseObject> ptr = DummyBaseObject::NewDetached(env);
+    EXPECT_EQ(env->base_object_count(), 1);
+  }
+  EXPECT_EQ(env->base_object_count(), 0);
+}
+
+TEST_F(BaseObjectPtrTest, ScopedDetachedWithWeak) {
+  const HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env env_{handle_scope, argv};
+  Environment* env = *env_;
+
+  BaseObjectWeakPtr<DummyBaseObject> weak_ptr;
+
+  EXPECT_EQ(env->base_object_count(), 0);
+  {
+    BaseObjectPtr<DummyBaseObject> ptr = DummyBaseObject::NewDetached(env);
+    weak_ptr = ptr;
+    EXPECT_EQ(env->base_object_count(), 1);
+  }
+  EXPECT_EQ(weak_ptr.get(), nullptr);
+  EXPECT_EQ(env->base_object_count(), 0);
+}
+
+TEST_F(BaseObjectPtrTest, Undetached) {
+  const HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env env_{handle_scope, argv};
+  Environment* env = *env_;
+
+  node::AddEnvironmentCleanupHook(isolate_, [](void* arg) {
+    EXPECT_EQ(static_cast<Environment*>(arg)->base_object_count(), 0);
+  }, env);
+
+  BaseObjectPtr<DummyBaseObject> ptr = DummyBaseObject::New(env);
+  EXPECT_EQ(env->base_object_count(), 1);
+}
+
+TEST_F(BaseObjectPtrTest, GCWeak) {
+  const HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env env_{handle_scope, argv};
+  Environment* env = *env_;
+
+  BaseObjectWeakPtr<DummyBaseObject> weak_ptr;
+
+  {
+    const HandleScope handle_scope(isolate_);
+    BaseObjectPtr<DummyBaseObject> ptr = DummyBaseObject::New(env);
+    weak_ptr = ptr;
+    ptr->MakeWeak();
+
+    EXPECT_EQ(env->base_object_count(), 1);
+    EXPECT_EQ(weak_ptr.get(), ptr.get());
+    EXPECT_EQ(weak_ptr->persistent().IsWeak(), false);
+
+    ptr.reset();
+  }
+
+  EXPECT_EQ(env->base_object_count(), 1);
+  EXPECT_NE(weak_ptr.get(), nullptr);
+  EXPECT_EQ(weak_ptr->persistent().IsWeak(), true);
+
+  v8::V8::SetFlagsFromString("--expose-gc");
+  isolate_->RequestGarbageCollectionForTesting(Isolate::kFullGarbageCollection);
+
+  EXPECT_EQ(env->base_object_count(), 0);
+  EXPECT_EQ(weak_ptr.get(), nullptr);
+}
+
+TEST_F(BaseObjectPtrTest, Moveable) {
+  const HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env env_{handle_scope, argv};
+  Environment* env = *env_;
+
+  BaseObjectPtr<DummyBaseObject> ptr = DummyBaseObject::NewDetached(env);
+  EXPECT_EQ(env->base_object_count(), 1);
+  BaseObjectWeakPtr<DummyBaseObject> weak_ptr { ptr };
+  EXPECT_EQ(weak_ptr.get(), ptr.get());
+
+  BaseObjectPtr<DummyBaseObject> ptr2 = std::move(ptr);
+  EXPECT_EQ(weak_ptr.get(), ptr2.get());
+  EXPECT_EQ(ptr.get(), nullptr);
+
+  BaseObjectWeakPtr<DummyBaseObject> weak_ptr2 = std::move(weak_ptr);
+  EXPECT_EQ(weak_ptr2.get(), ptr2.get());
+  EXPECT_EQ(weak_ptr.get(), nullptr);
+  EXPECT_EQ(env->base_object_count(), 1);
+
+  ptr2.reset();
+
+  EXPECT_EQ(weak_ptr2.get(), nullptr);
+  EXPECT_EQ(env->base_object_count(), 0);
+}
+
+TEST_F(BaseObjectPtrTest, NestedClasses) {
+  class ObjectWithPtr : public BaseObject {
+   public:
+    ObjectWithPtr(Environment* env, Local<Object> obj) : BaseObject(env, obj) {}
+
+    BaseObjectPtr<BaseObject> ptr1;
+    BaseObjectPtr<BaseObject> ptr2;
+
+    SET_NO_MEMORY_INFO()
+    SET_MEMORY_INFO_NAME(ObjectWithPtr)
+    SET_SELF_SIZE(ObjectWithPtr)
+  };
+
+  const HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env env_{handle_scope, argv};
+  Environment* env = *env_;
+
+  node::AddEnvironmentCleanupHook(isolate_, [](void* arg) {
+    EXPECT_EQ(static_cast<Environment*>(arg)->base_object_count(), 0);
+  }, env);
+
+  ObjectWithPtr* obj =
+      new ObjectWithPtr(env, DummyBaseObject::MakeJSObject(env));
+  obj->ptr1 = DummyBaseObject::NewDetached(env);
+  obj->ptr2 = DummyBaseObject::New(env);
+
+  EXPECT_EQ(env->base_object_count(), 3);
+}

--- a/test/cctest/test_node_postmortem_metadata.cc
+++ b/test/cctest/test_node_postmortem_metadata.cc
@@ -93,14 +93,13 @@ TEST_F(DebugSymbolsTest, BaseObjectPersistentHandle) {
 
   v8::Local<v8::Object> object =
       obj_templ->NewInstance(env.context()).ToLocalChecked();
-  DummyBaseObject obj(*env, object);
+  node::BaseObjectPtr<DummyBaseObject> obj =
+      node::MakeDetachedBaseObject<DummyBaseObject>(*env, object);
 
-  auto expected = reinterpret_cast<uintptr_t>(&obj.persistent());
-  auto calculated = reinterpret_cast<uintptr_t>(&obj) +
+  auto expected = reinterpret_cast<uintptr_t>(&obj->persistent());
+  auto calculated = reinterpret_cast<uintptr_t>(obj.get()) +
       nodedbg_offset_BaseObject__persistent_handle___v8_Persistent_v8_Object;
   EXPECT_EQ(expected, calculated);
-
-  obj.persistent().Reset();  // ~BaseObject() expects an empty handle.
 }
 
 


### PR DESCRIPTION
Note: Some of the commits here are from https://github.com/nodejs/quic/, where this concept has proven useful so far.

##### src: introduce custom smart pointers for `BaseObject`s

Referring to `BaseObject` instances using standard C++ smart pointers
can interfere with BaseObject’s own cleanup mechanisms
(explicit delete, delete-on-GC and delete-on-cleanup).

Introducing custom smart pointers allows referring to `BaseObject`s
safely while keeping those mechanisms intact.

Refs: https://github.com/nodejs/quic/pull/141
Refs: https://github.com/nodejs/quic/pull/149
Reviewed-By: James M Snell <jasnell@gmail.com>

##### http2: use custom BaseObject smart pointers

Refs: https://github.com/nodejs/quic/pull/141
Reviewed-By: James M Snell <jasnell@gmail.com>

##### src: use BaseObjectPtr for keeping channel alive in dns bindings

##### src: remove keep alive option from SetImmediate()

This is no longer necessary now that the copyable `BaseObjectPtr`
is available (as opposed to the only-movable `v8::Global`).

##### src: remove HandleWrap instances from list once closed

This allows keeping `BaseObjectPtr`s to `HandleWrap` instances.
Previously, the pointer kept the `HandleWrap` object alive, leaving
the Environment cleanup code that waits for the handle list to drain
in a busy loop, because only the `HandleWrap` destructor removed
the item from the list.

Refs: https://github.com/nodejs/quic/pull/165
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Daniel Bevenius <daniel.bevenius@gmail.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
