### PR TITLE
doc: add explanation why keep var with for loop in async_hooks

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -129,6 +129,7 @@ function emitInitNative(asyncId, type, triggerAsyncId, resource) {
   active_hooks.call_depth += 1;
   // Use a single try/catch for all hooks to avoid setting up one per iteration.
   try {
+    // Using var here instead of let because "for (var ...)" is faster than let
     for (var i = 0; i < active_hooks.array.length; i++) {
       if (typeof active_hooks.array[i][init_symbol] === 'function') {
         active_hooks.array[i][init_symbol](
@@ -159,6 +160,7 @@ function emitHook(symbol, asyncId) {
   // Use a single try/catch for all hook to avoid setting up one per
   // iteration.
   try {
+    // Using var here instead of let because "for (var ...)" is faster than let
     for (var i = 0; i < active_hooks.array.length; i++) {
       if (typeof active_hooks.array[i][symbol] === 'function') {
         active_hooks.array[i][symbol](asyncId);


### PR DESCRIPTION
Refs: nceu19-async_hooks

This comment will help contributors to understand why keeping var in some for loop instead changing at to let, as discussed with @mcollina 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
