### PR TITLE
lib: replace var w/ let in lib/internal/error-serdes.js

### DIFF
--- a/lib/internal/error-serdes.js
+++ b/lib/internal/error-serdes.js
@@ -48,7 +48,7 @@ function TryGetAllProperties(object, target = object) {
 function GetConstructors(object) {
   const constructors = [];
 
-  for (var current = object;
+  for (let current = object;
     current !== null;
     current = Object.getPrototypeOf(current)) {
     const desc = Object.getOwnPropertyDescriptor(current, 'constructor');
@@ -82,7 +82,7 @@ function serializeError(error) {
     if (typeof error === 'object' &&
         ObjectPrototype.toString(error) === '[object Error]') {
       const constructors = GetConstructors(error);
-      for (var i = 0; i < constructors.length; i++) {
+      for (let i = 0; i < constructors.length; i++) {
         const name = GetName(constructors[i]);
         if (errorConstructorNames.has(name)) {
           const serialized = serialize({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


While running `make test` on a 2019  MacBook Pro with MacOS Catalina 10.15.1, there are test timeouts in `test/parallel/test-dgram-connect-send-empty-packet.js` and `test/parallel/test-dgram-send-empty-buffer.js`, even after following the instructions for modifying firewall settings. 
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
