### PR TITLE
lib/timers.js: replace var with let/const

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -118,7 +118,7 @@ function setTimeout(callback, after, arg1, arg2, arg3) {
     throw new ERR_INVALID_CALLBACK(callback);
   }
 
-  var i, args;
+  let i, args;
   switch (arguments.length) {
     // fast cases
     case 1:
@@ -164,7 +164,7 @@ function setInterval(callback, repeat, arg1, arg2, arg3) {
     throw new ERR_INVALID_CALLBACK(callback);
   }
 
-  var i, args;
+  let i, args;
   switch (arguments.length) {
     // fast cases
     case 1:
@@ -248,7 +248,7 @@ function setImmediate(callback, arg1, arg2, arg3) {
     throw new ERR_INVALID_CALLBACK(callback);
   }
 
-  var i, args;
+  let i, args;
   switch (arguments.length) {
     // fast cases
     case 1:


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows 
