### PR TITLE
test: change var to const in test/parallel/test-repl-multiline.js

### DIFF
--- a/test/parallel/test-repl-multiline.js
+++ b/test/parallel/test-repl-multiline.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const repl = require('repl');
 const inputStream = new ArrayStream();
 const outputStream = new ArrayStream();
-const input = ['var foo = {', '};', 'foo;'];
+const input = ['const foo = {', '};', 'foo;'];
 let output = '';
 
 outputStream.write = (data) => { output += data.replace('\r', ''); };


### PR DESCRIPTION
Changed var to const

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
