### PR TITLE
doc: clarify writable.cork method

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -361,10 +361,9 @@ The buffered data will be flushed when either the [`stream.uncork()`][] or
 The primary intent of `writable.cork()` is to accommodate a situation in which
 it is more performant to write several small chunks to the internal buffer
 rather than drain them immediately to the underlying destination. Such
-buffering is usually inadvisable as it typically degrades performance, but
-where memory needs have been carefully considered, implementations
-that implement the `writable._writev()` method can perform buffered writes in
-a more optimized manner.
+buffering typically degrades performance, but where memory needs have been
+carefully considered, implementations that implement the `writable._writev()`
+method can perform buffered writes in a more optimized manner.
 
 See also: [`writable.uncork()`][].
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -362,7 +362,7 @@ The primary intent of `writable.cork()` is to accommodate a situation in which
 several small chunks are written to the stream in rapid succession. Instead of
 immediately forwarding them to the underlying destination, `writable.cork()`
 buffers all the chunks until `writable.uncork()` is called, which will pass
-them all to `writable._writev()`, if present. This prevents an head-of-line
+them all to `writable._writev()`, if present. This prevents a head-of-line
 blocking situation where data is being buffered while waiting for the first
 small chunk to be processed. However, use of `writable.cork()` without 
 implementing `writable._writev()` may have an adverse effect on throughput.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -359,10 +359,12 @@ The buffered data will be flushed when either the [`stream.uncork()`][] or
 [`stream.end()`][stream-end] methods are called.
 
 The primary intent of `writable.cork()` is to accommodate a situation in which
-it is more performant to write several small chunks to the internal buffer rather
-than drain them immediately to the underlying destination. In such situations,
-implementations that implement the `writable._writev()` method can perform
-buffered writes in a more optimized manner.
+it is more performant to write several small chunks to the internal buffer
+rather than drain them immediately to the underlying destination. Such
+buffering is usually inadvisable as the buffer can rapidly consume available
+memory, but where memory needs have been carefully considered, implementations
+that implement the `writable._writev()` method can perform buffered writes in
+a more optimized manner.
 
 See also: [`writable.uncork()`][].
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -364,12 +364,11 @@ immediately forwarding them to the underlining destination, `writable.cork()`
 buffers all the chunks until `writable.uncork()` is called, which will pass
 them all to `writable._writev()`, if present. This prevents an head-of-line
 blocking situation where data is being buffered while waiting for the first
-small chunk to be processed.
+small chunk to be processed. However, use of `writable.cork()` without 
+implementing `writable._writev()` may have an adverse effect on throughput.
 
-Note that using `writable.cork()` without implementing `writable._writev()` is
-likely to have an adverse effect on throughput.
 
-See also: [`writable.uncork()`][], [`writable._writev(chunks, callback)`][].
+See also: [`writable.uncork()`][], [`writable._writev()`][stream-_writev].
 
 ##### writable.destroy(\[error\])
 <!-- YAML

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -358,9 +358,9 @@ The `writable.cork()` method forces all written data to be buffered in memory.
 The buffered data will be flushed when either the [`stream.uncork()`][] or
 [`stream.end()`][stream-end] methods are called.
 
-The primary intent of `writable.cork()` is to avoid a situation where writing
-many small chunks of data to a stream do not cause a backup in the internal
-buffer that would have an adverse impact on performance. In such situations,
+The primary intent of `writable.cork()` is to accommodate a situation in which
+it is more performant to write several small chunks to the internal buffer rather
+than drain them immediately to the underlying destination. In such situations,
 implementations that implement the `writable._writev()` method can perform
 buffered writes in a more optimized manner.
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -361,8 +361,8 @@ The buffered data will be flushed when either the [`stream.uncork()`][] or
 The primary intent of `writable.cork()` is to accommodate a situation in which
 it is more performant to write several small chunks to the internal buffer
 rather than drain them immediately to the underlying destination. Such
-buffering is usually inadvisable as the buffer can rapidly consume available
-memory, but where memory needs have been carefully considered, implementations
+buffering is usually inadvisable as it typically degrades performance, but
+where memory needs have been carefully considered, implementations
 that implement the `writable._writev()` method can perform buffered writes in
 a more optimized manner.
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -359,13 +359,17 @@ The buffered data will be flushed when either the [`stream.uncork()`][] or
 [`stream.end()`][stream-end] methods are called.
 
 The primary intent of `writable.cork()` is to accommodate a situation in which
-it is more performant to write several small chunks to the internal buffer
-rather than drain them immediately to the underlying destination. Such
-buffering typically degrades performance, but where memory needs have been
-carefully considered, implementations that implement the `writable._writev()`
-method can perform buffered writes in a more optimized manner.
+several small chunks are written to the stream in rapid succession. Instead of
+immediately forwarding them to the underlining destination, `writable.cork()`
+buffers all the chunks until `writable.uncork()` is called, which will pass
+them all to `writable._writev()`, if present. This prevents an head-of-line
+blocking situation where data is being buffered while waiting for the first
+small chunk to be processed.
 
-See also: [`writable.uncork()`][].
+Note that using `writable.cork()` without implementing `writable._writev()` is
+likely to have an adverse effect on throughput.
+
+See also: [`writable.uncork()`][], [`writable._writev(chunks, callback)`][].
 
 ##### writable.destroy(\[error\])
 <!-- YAML

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -360,7 +360,7 @@ The buffered data will be flushed when either the [`stream.uncork()`][] or
 
 The primary intent of `writable.cork()` is to accommodate a situation in which
 several small chunks are written to the stream in rapid succession. Instead of
-immediately forwarding them to the underlining destination, `writable.cork()`
+immediately forwarding them to the underlying destination, `writable.cork()`
 buffers all the chunks until `writable.uncork()` is called, which will pass
 them all to `writable._writev()`, if present. This prevents an head-of-line
 blocking situation where data is being buffered while waiting for the first


### PR DESCRIPTION
The syntax of the sentence describing the role of writable.cork() was
unclear. This rephrase aims to make the distinction between writing
to the buffer and draining immediately to the underlying destination
clearer.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
