### PR TITLE
net: improve performance by destructuring primordials

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const { Object } = primordials;
+const { Object: { defineProperty, setPrototypeOf } } = primordials;
 
 const EventEmitter = require('events');
 const stream = require('stream');
@@ -336,7 +336,7 @@ function Socket(options) {
         // makeSyncWrite adjusts this value like the original handle would, so
         // we need to let it do that by turning it into a writable, own
         // property.
-        Object.defineProperty(this._handle, 'bytesWritten', {
+        defineProperty(this._handle, 'bytesWritten', {
           value: 0, writable: true
         });
       }
@@ -372,8 +372,8 @@ function Socket(options) {
   this[kBytesRead] = 0;
   this[kBytesWritten] = 0;
 }
-Object.setPrototypeOf(Socket.prototype, stream.Duplex.prototype);
-Object.setPrototypeOf(Socket, stream.Duplex);
+setPrototypeOf(Socket.prototype, stream.Duplex.prototype);
+setPrototypeOf(Socket, stream.Duplex);
 
 // Refresh existing timeouts.
 Socket.prototype._unrefTimer = function _unrefTimer() {
@@ -503,13 +503,13 @@ Socket.prototype.address = function() {
 };
 
 
-Object.defineProperty(Socket.prototype, '_connecting', {
+defineProperty(Socket.prototype, '_connecting', {
   get: function() {
     return this.connecting;
   }
 });
 
-Object.defineProperty(Socket.prototype, 'pending', {
+defineProperty(Socket.prototype, 'pending', {
   get() {
     return !this._handle || this.connecting;
   },
@@ -517,7 +517,7 @@ Object.defineProperty(Socket.prototype, 'pending', {
 });
 
 
-Object.defineProperty(Socket.prototype, 'readyState', {
+defineProperty(Socket.prototype, 'readyState', {
   get: function() {
     if (this.connecting) {
       return 'opening';
@@ -534,7 +534,7 @@ Object.defineProperty(Socket.prototype, 'readyState', {
 });
 
 
-Object.defineProperty(Socket.prototype, 'bufferSize', {
+defineProperty(Socket.prototype, 'bufferSize', {
   get: function() { // eslint-disable-line getter-return
     if (this._handle) {
       return this[kLastWriteQueueSize] + this.writableLength;
@@ -542,7 +542,7 @@ Object.defineProperty(Socket.prototype, 'bufferSize', {
   }
 });
 
-Object.defineProperty(Socket.prototype, kUpdateTimer, {
+defineProperty(Socket.prototype, kUpdateTimer, {
   get: function() {
     return this._unrefTimer;
   }
@@ -690,7 +690,7 @@ Socket.prototype._getpeername = function() {
 };
 
 function protoGetter(name, callback) {
-  Object.defineProperty(Socket.prototype, name, {
+  defineProperty(Socket.prototype, name, {
     configurable: false,
     enumerable: true,
     get: callback
@@ -1162,7 +1162,7 @@ function Server(options, connectionListener) {
 
   this._connections = 0;
 
-  Object.defineProperty(this, 'connections', {
+  defineProperty(this, 'connections', {
     get: deprecate(() => {
 
       if (this._usingWorkers) {
@@ -1186,8 +1186,8 @@ function Server(options, connectionListener) {
   this.allowHalfOpen = options.allowHalfOpen || false;
   this.pauseOnConnect = !!options.pauseOnConnect;
 }
-Object.setPrototypeOf(Server.prototype, EventEmitter.prototype);
-Object.setPrototypeOf(Server, EventEmitter);
+setPrototypeOf(Server.prototype, EventEmitter.prototype);
+setPrototypeOf(Server, EventEmitter);
 
 
 function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }
@@ -1491,7 +1491,7 @@ function lookupAndListen(self, port, address, backlog, exclusive, flags) {
   });
 }
 
-Object.defineProperty(Server.prototype, 'listening', {
+defineProperty(Server.prototype, 'listening', {
   get: function() {
     return !!this._handle;
   },
@@ -1648,12 +1648,12 @@ function emitCloseNT(self) {
 
 // Legacy alias on the C++ wrapper object. This is not public API, so we may
 // want to runtime-deprecate it at some point. There's no hurry, though.
-Object.defineProperty(TCP.prototype, 'owner', {
+defineProperty(TCP.prototype, 'owner', {
   get() { return this[owner_symbol]; },
   set(v) { return this[owner_symbol] = v; }
 });
 
-Object.defineProperty(Socket.prototype, '_handle', {
+defineProperty(Socket.prototype, '_handle', {
   get() { return this[kHandle]; },
   set(v) { return this[kHandle] = v; }
 });

--- a/lib/net.js
+++ b/lib/net.js
@@ -23,8 +23,8 @@
 
 const {
   Object: {
-    defineProperty: objectDefineProperty,
-    setPrototypeOf: objectSetPrototypeOf
+    defineProperty: ObjectDefineProperty,
+    setPrototypeOf: ObjectSetPrototypeOf
   }
 } = primordials;
 
@@ -341,7 +341,7 @@ function Socket(options) {
         // makeSyncWrite adjusts this value like the original handle would, so
         // we need to let it do that by turning it into a writable, own
         // property.
-        objectDefineProperty(this._handle, 'bytesWritten', {
+        ObjectDefineProperty(this._handle, 'bytesWritten', {
           value: 0, writable: true
         });
       }
@@ -377,8 +377,8 @@ function Socket(options) {
   this[kBytesRead] = 0;
   this[kBytesWritten] = 0;
 }
-objectSetPrototypeOf(Socket.prototype, stream.Duplex.prototype);
-objectSetPrototypeOf(Socket, stream.Duplex);
+ObjectSetPrototypeOf(Socket.prototype, stream.Duplex.prototype);
+ObjectSetPrototypeOf(Socket, stream.Duplex);
 
 // Refresh existing timeouts.
 Socket.prototype._unrefTimer = function _unrefTimer() {
@@ -508,13 +508,13 @@ Socket.prototype.address = function() {
 };
 
 
-objectDefineProperty(Socket.prototype, '_connecting', {
+ObjectDefineProperty(Socket.prototype, '_connecting', {
   get: function() {
     return this.connecting;
   }
 });
 
-objectDefineProperty(Socket.prototype, 'pending', {
+ObjectDefineProperty(Socket.prototype, 'pending', {
   get() {
     return !this._handle || this.connecting;
   },
@@ -522,7 +522,7 @@ objectDefineProperty(Socket.prototype, 'pending', {
 });
 
 
-objectDefineProperty(Socket.prototype, 'readyState', {
+ObjectDefineProperty(Socket.prototype, 'readyState', {
   get: function() {
     if (this.connecting) {
       return 'opening';
@@ -539,7 +539,7 @@ objectDefineProperty(Socket.prototype, 'readyState', {
 });
 
 
-objectDefineProperty(Socket.prototype, 'bufferSize', {
+ObjectDefineProperty(Socket.prototype, 'bufferSize', {
   get: function() {
     if (this._handle) {
       return this[kLastWriteQueueSize] + this.writableLength;
@@ -547,7 +547,7 @@ objectDefineProperty(Socket.prototype, 'bufferSize', {
   }
 });
 
-objectDefineProperty(Socket.prototype, kUpdateTimer, {
+ObjectDefineProperty(Socket.prototype, kUpdateTimer, {
   get: function() {
     return this._unrefTimer;
   }
@@ -695,7 +695,7 @@ Socket.prototype._getpeername = function() {
 };
 
 function protoGetter(name, callback) {
-  objectDefineProperty(Socket.prototype, name, {
+  ObjectDefineProperty(Socket.prototype, name, {
     configurable: false,
     enumerable: true,
     get: callback
@@ -1167,7 +1167,7 @@ function Server(options, connectionListener) {
 
   this._connections = 0;
 
-  objectDefineProperty(this, 'connections', {
+  ObjectDefineProperty(this, 'connections', {
     get: deprecate(() => {
 
       if (this._usingWorkers) {
@@ -1191,8 +1191,8 @@ function Server(options, connectionListener) {
   this.allowHalfOpen = options.allowHalfOpen || false;
   this.pauseOnConnect = !!options.pauseOnConnect;
 }
-objectSetPrototypeOf(Server.prototype, EventEmitter.prototype);
-objectSetPrototypeOf(Server, EventEmitter);
+ObjectSetPrototypeOf(Server.prototype, EventEmitter.prototype);
+ObjectSetPrototypeOf(Server, EventEmitter);
 
 
 function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }
@@ -1496,7 +1496,7 @@ function lookupAndListen(self, port, address, backlog, exclusive, flags) {
   });
 }
 
-objectDefineProperty(Server.prototype, 'listening', {
+ObjectDefineProperty(Server.prototype, 'listening', {
   get: function() {
     return !!this._handle;
   },
@@ -1653,12 +1653,12 @@ function emitCloseNT(self) {
 
 // Legacy alias on the C++ wrapper object. This is not public API, so we may
 // want to runtime-deprecate it at some point. There's no hurry, though.
-objectDefineProperty(TCP.prototype, 'owner', {
+ObjectDefineProperty(TCP.prototype, 'owner', {
   get() { return this[owner_symbol]; },
   set(v) { return this[owner_symbol] = v; }
 });
 
-objectDefineProperty(Socket.prototype, '_handle', {
+ObjectDefineProperty(Socket.prototype, '_handle', {
   get() { return this[kHandle]; },
   set(v) { return this[kHandle] = v; }
 });

--- a/lib/net.js
+++ b/lib/net.js
@@ -535,7 +535,7 @@ defineProperty(Socket.prototype, 'readyState', {
 
 
 defineProperty(Socket.prototype, 'bufferSize', {
-  get: function() { // eslint-disable-line getter-return
+  get: function() {
     if (this._handle) {
       return this[kLastWriteQueueSize] + this.writableLength;
     }

--- a/lib/net.js
+++ b/lib/net.js
@@ -21,7 +21,12 @@
 
 'use strict';
 
-const { Object: { defineProperty, setPrototypeOf } } = primordials;
+const {
+  Object: {
+    defineProperty: objectDefineProperty,
+    setPrototypeOf: objectSetPrototypeOf
+  }
+} = primordials;
 
 const EventEmitter = require('events');
 const stream = require('stream');
@@ -336,7 +341,7 @@ function Socket(options) {
         // makeSyncWrite adjusts this value like the original handle would, so
         // we need to let it do that by turning it into a writable, own
         // property.
-        defineProperty(this._handle, 'bytesWritten', {
+        objectDefineProperty(this._handle, 'bytesWritten', {
           value: 0, writable: true
         });
       }
@@ -372,8 +377,8 @@ function Socket(options) {
   this[kBytesRead] = 0;
   this[kBytesWritten] = 0;
 }
-setPrototypeOf(Socket.prototype, stream.Duplex.prototype);
-setPrototypeOf(Socket, stream.Duplex);
+objectSetPrototypeOf(Socket.prototype, stream.Duplex.prototype);
+objectSetPrototypeOf(Socket, stream.Duplex);
 
 // Refresh existing timeouts.
 Socket.prototype._unrefTimer = function _unrefTimer() {
@@ -503,13 +508,13 @@ Socket.prototype.address = function() {
 };
 
 
-defineProperty(Socket.prototype, '_connecting', {
+objectDefineProperty(Socket.prototype, '_connecting', {
   get: function() {
     return this.connecting;
   }
 });
 
-defineProperty(Socket.prototype, 'pending', {
+objectDefineProperty(Socket.prototype, 'pending', {
   get() {
     return !this._handle || this.connecting;
   },
@@ -517,7 +522,7 @@ defineProperty(Socket.prototype, 'pending', {
 });
 
 
-defineProperty(Socket.prototype, 'readyState', {
+objectDefineProperty(Socket.prototype, 'readyState', {
   get: function() {
     if (this.connecting) {
       return 'opening';
@@ -534,7 +539,7 @@ defineProperty(Socket.prototype, 'readyState', {
 });
 
 
-defineProperty(Socket.prototype, 'bufferSize', {
+objectDefineProperty(Socket.prototype, 'bufferSize', {
   get: function() {
     if (this._handle) {
       return this[kLastWriteQueueSize] + this.writableLength;
@@ -542,7 +547,7 @@ defineProperty(Socket.prototype, 'bufferSize', {
   }
 });
 
-defineProperty(Socket.prototype, kUpdateTimer, {
+objectDefineProperty(Socket.prototype, kUpdateTimer, {
   get: function() {
     return this._unrefTimer;
   }
@@ -690,7 +695,7 @@ Socket.prototype._getpeername = function() {
 };
 
 function protoGetter(name, callback) {
-  defineProperty(Socket.prototype, name, {
+  objectDefineProperty(Socket.prototype, name, {
     configurable: false,
     enumerable: true,
     get: callback
@@ -1162,7 +1167,7 @@ function Server(options, connectionListener) {
 
   this._connections = 0;
 
-  defineProperty(this, 'connections', {
+  objectDefineProperty(this, 'connections', {
     get: deprecate(() => {
 
       if (this._usingWorkers) {
@@ -1186,8 +1191,8 @@ function Server(options, connectionListener) {
   this.allowHalfOpen = options.allowHalfOpen || false;
   this.pauseOnConnect = !!options.pauseOnConnect;
 }
-setPrototypeOf(Server.prototype, EventEmitter.prototype);
-setPrototypeOf(Server, EventEmitter);
+objectSetPrototypeOf(Server.prototype, EventEmitter.prototype);
+objectSetPrototypeOf(Server, EventEmitter);
 
 
 function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }
@@ -1491,7 +1496,7 @@ function lookupAndListen(self, port, address, backlog, exclusive, flags) {
   });
 }
 
-defineProperty(Server.prototype, 'listening', {
+objectDefineProperty(Server.prototype, 'listening', {
   get: function() {
     return !!this._handle;
   },
@@ -1648,12 +1653,12 @@ function emitCloseNT(self) {
 
 // Legacy alias on the C++ wrapper object. This is not public API, so we may
 // want to runtime-deprecate it at some point. There's no hurry, though.
-defineProperty(TCP.prototype, 'owner', {
+objectDefineProperty(TCP.prototype, 'owner', {
   get() { return this[owner_symbol]; },
   set(v) { return this[owner_symbol] = v; }
 });
 
-defineProperty(Socket.prototype, '_handle', {
+objectDefineProperty(Socket.prototype, '_handle', {
   get() { return this[kHandle]; },
   set(v) { return this[kHandle] = v; }
 });


### PR DESCRIPTION
Refs: #29766 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
