### PR TITLE
benchmark: use let instead of var in assert

### DIFF
--- a/benchmark/assert/deepequal-buffer.js
+++ b/benchmark/assert/deepequal-buffer.js
@@ -27,7 +27,7 @@ function main({ len, n, method, strict }) {
   const value2 = method.includes('not') ? expectedWrong : expected;
 
   bench.start();
-  for (var i = 0; i < n; ++i) {
+  for (let i = 0; i < n; ++i) {
     fn(actual, value2);
   }
   bench.end(n);

--- a/benchmark/assert/deepequal-map.js
+++ b/benchmark/assert/deepequal-map.js
@@ -24,7 +24,7 @@ function benchmark(method, n, values, values2) {
   const deepCopy = JSON.parse(JSON.stringify(values2 ? values2 : values));
   const expected = new Map(deepCopy);
   bench.start();
-  for (var i = 0; i < n; ++i) {
+  for (let i = 0; i < n; ++i) {
     method(actual, expected);
   }
   bench.end(n);
@@ -32,41 +32,50 @@ function benchmark(method, n, values, values2) {
 
 function main({ n, len, method, strict }) {
   const array = Array(len).fill(1);
-  var values, values2;
 
   switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
-    case 'deepEqual_primitiveOnly':
-      values = array.map((_, i) => [`str_${i}`, 123]);
+    case 'deepEqual_primitiveOnly': {
+      const values = array.map((_, i) => [`str_${i}`, 123]);
       benchmark(strict ? deepStrictEqual : deepEqual, n, values);
       break;
-    case 'deepEqual_objectOnly':
-      values = array.map((_, i) => [[`str_${i}`, 1], 123]);
+    }
+    case 'deepEqual_objectOnly': {
+      const values = array.map((_, i) => [[`str_${i}`, 1], 123]);
       benchmark(strict ? deepStrictEqual : deepEqual, n, values);
       break;
-    case 'deepEqual_mixed':
-      values = array.map((_, i) => [i % 2 ? [`str_${i}`, 1] : `str_${i}`, 123]);
+    }
+    case 'deepEqual_mixed': {
+      const values = array.map(
+        (_, i) => [i % 2 ? [`str_${i}`, 1] : `str_${i}`, 123]
+      );
       benchmark(strict ? deepStrictEqual : deepEqual, n, values);
       break;
-    case 'notDeepEqual_primitiveOnly':
-      values = array.map((_, i) => [`str_${i}`, 123]);
-      values2 = values.slice(0);
+    }
+    case 'notDeepEqual_primitiveOnly': {
+      const values = array.map((_, i) => [`str_${i}`, 123]);
+      const values2 = values.slice(0);
       values2[Math.floor(len / 2)] = ['w00t', 123];
       benchmark(strict ? notDeepStrictEqual : notDeepEqual, n, values, values2);
       break;
-    case 'notDeepEqual_objectOnly':
-      values = array.map((_, i) => [[`str_${i}`, 1], 123]);
-      values2 = values.slice(0);
+    }
+    case 'notDeepEqual_objectOnly': {
+      const values = array.map((_, i) => [[`str_${i}`, 1], 123]);
+      const values2 = values.slice(0);
       values2[Math.floor(len / 2)] = [['w00t'], 123];
       benchmark(strict ? notDeepStrictEqual : notDeepEqual, n, values, values2);
       break;
-    case 'notDeepEqual_mixed':
-      values = array.map((_, i) => [i % 2 ? [`str_${i}`, 1] : `str_${i}`, 123]);
-      values2 = values.slice(0);
+    }
+    case 'notDeepEqual_mixed': {
+      const values = array.map(
+        (_, i) => [i % 2 ? [`str_${i}`, 1] : `str_${i}`, 123]
+      );
+      const values2 = values.slice(0);
       values2[0] = ['w00t', 123];
       benchmark(strict ? notDeepStrictEqual : notDeepEqual, n, values, values2);
       break;
+    }
     default:
       throw new Error(`Unsupported method ${method}`);
   }

--- a/benchmark/assert/deepequal-object.js
+++ b/benchmark/assert/deepequal-object.js
@@ -42,7 +42,7 @@ function main({ size, n, method, strict }) {
   const value2 = method.includes('not') ? expectedWrong : expected;
 
   bench.start();
-  for (var i = 0; i < n; ++i) {
+  for (let i = 0; i < n; ++i) {
     fn(actual, value2);
   }
   bench.end(n);

--- a/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
@@ -26,7 +26,7 @@ const bench = common.createBenchmark(main, {
 
 function run(fn, n, actual, expected) {
   bench.start();
-  for (var i = 0; i < n; ++i) {
+  for (let i = 0; i < n; ++i) {
     fn(actual, expected);
   }
   bench.end(n);
@@ -38,7 +38,7 @@ function main({ n, len, primitive, method, strict }) {
   const expected = [];
   const expectedWrong = [];
 
-  for (var x = 0; x < len; x++) {
+  for (let x = 0; x < len; x++) {
     actual.push(prim);
     expected.push(prim);
     expectedWrong.push(prim);

--- a/benchmark/assert/deepequal-prims-and-objs-big-loop.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-loop.js
@@ -31,7 +31,7 @@ function main({ n, primitive, method, strict }) {
   const value2 = method.includes('not') ? expectedWrong : expected;
 
   bench.start();
-  for (var i = 0; i < n; ++i) {
+  for (let i = 0; i < n; ++i) {
     fn([actual], [value2]);
   }
   bench.end(n);

--- a/benchmark/assert/deepequal-set.js
+++ b/benchmark/assert/deepequal-set.js
@@ -24,7 +24,7 @@ function benchmark(method, n, values, values2) {
   const deepCopy = JSON.parse(JSON.stringify(values2 ? values2 : values));
   const expected = new Set(deepCopy);
   bench.start();
-  for (var i = 0; i < n; ++i) {
+  for (let i = 0; i < n; ++i) {
     method(actual, expected);
   }
   bench.end(n);
@@ -33,45 +33,49 @@ function benchmark(method, n, values, values2) {
 function main({ n, len, method, strict }) {
   const array = Array(len).fill(1);
 
-  var values, values2;
-
   switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
-    case 'deepEqual_primitiveOnly':
-      values = array.map((_, i) => `str_${i}`);
+    case 'deepEqual_primitiveOnly': {
+      const values = array.map((_, i) => `str_${i}`);
       benchmark(strict ? deepStrictEqual : deepEqual, n, values);
       break;
-    case 'deepEqual_objectOnly':
-      values = array.map((_, i) => [`str_${i}`, null]);
+    }
+    case 'deepEqual_objectOnly': {
+      const values = array.map((_, i) => [`str_${i}`, null]);
       benchmark(strict ? deepStrictEqual : deepEqual, n, values);
       break;
-    case 'deepEqual_mixed':
-      values = array.map((_, i) => {
+    }
+    case 'deepEqual_mixed': {
+      const values = array.map((_, i) => {
         return i % 2 ? [`str_${i}`, null] : `str_${i}`;
       });
       benchmark(strict ? deepStrictEqual : deepEqual, n, values);
       break;
-    case 'notDeepEqual_primitiveOnly':
-      values = array.map((_, i) => `str_${i}`);
-      values2 = values.slice(0);
+    }
+    case 'notDeepEqual_primitiveOnly': {
+      const values = array.map((_, i) => `str_${i}`);
+      const values2 = values.slice(0);
       values2[Math.floor(len / 2)] = 'w00t';
       benchmark(strict ? notDeepStrictEqual : notDeepEqual, n, values, values2);
       break;
-    case 'notDeepEqual_objectOnly':
-      values = array.map((_, i) => [`str_${i}`, null]);
-      values2 = values.slice(0);
+    }
+    case 'notDeepEqual_objectOnly': {
+      const values = array.map((_, i) => [`str_${i}`, null]);
+      const values2 = values.slice(0);
       values2[Math.floor(len / 2)] = ['w00t'];
       benchmark(strict ? notDeepStrictEqual : notDeepEqual, n, values, values2);
       break;
-    case 'notDeepEqual_mixed':
-      values = array.map((_, i) => {
+    }
+    case 'notDeepEqual_mixed': {
+      const values = array.map((_, i) => {
         return i % 2 ? [`str_${i}`, null] : `str_${i}`;
       });
-      values2 = values.slice();
+      const values2 = values.slice();
       values2[0] = 'w00t';
       benchmark(strict ? notDeepStrictEqual : notDeepEqual, n, values, values2);
       break;
+    }
     default:
       throw new Error(`Unsupported method "${method}"`);
   }

--- a/benchmark/assert/deepequal-typedarrays.js
+++ b/benchmark/assert/deepequal-typedarrays.js
@@ -36,7 +36,7 @@ function main({ type, n, len, method, strict }) {
   const value2 = method.includes('not') ? expectedWrong : expected;
 
   bench.start();
-  for (var i = 0; i < n; ++i) {
+  for (let i = 0; i < n; ++i) {
     actual[0] = i;
     value2[0] = i;
     fn(actual, value2);

--- a/benchmark/assert/ok.js
+++ b/benchmark/assert/ok.js
@@ -6,9 +6,8 @@ const assert = require('assert');
 const bench = common.createBenchmark(main, { n: [1e5] });
 
 function main({ n }) {
-  var i;
   bench.start();
-  for (i = 0; i < n; ++i) {
+  for (let i = 0; i < n; ++i) {
     if (i % 2 === 0)
       assert(true);
     else

--- a/benchmark/assert/throws.js
+++ b/benchmark/assert/throws.js
@@ -13,28 +13,27 @@ function main({ n, method }) {
   const doNotThrowError = () => { return 'foobar'; };
   const regExp = /foobar/;
   const message = 'failure';
-  var i;
 
   switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'doesNotThrow':
       bench.start();
-      for (i = 0; i < n; ++i) {
+      for (let i = 0; i < n; ++i) {
         doesNotThrow(doNotThrowError);
       }
       bench.end(n);
       break;
     case 'throws_TypeError':
       bench.start();
-      for (i = 0; i < n; ++i) {
+      for (let i = 0; i < n; ++i) {
         throws(throwError, TypeError, message);
       }
       bench.end(n);
       break;
     case 'throws_RegExp':
       bench.start();
-      for (i = 0; i < n; ++i) {
+      for (let i = 0; i < n; ++i) {
         throws(throwError, regExp, message);
       }
       bench.end(n);


### PR DESCRIPTION
Use let instead of var in benchmark/assert/deepequal-buffer.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
