### PR TITLE
domain: allow process.domain accessor to be replaced

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -46,7 +46,7 @@ const { WeakReference } = internalBinding('util');
 
 // Overwrite process.domain with a getter/setter that will allow for more
 // effective optimizations
-// Never directly access _domain, use the getter to ensure a consistent hook
+// Never directly access _domain. Use the getter to ensure a consistent hook
 // for user code
 const _domain = [null];
 ObjectDefineProperty(process, 'domain', {

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -46,8 +46,11 @@ const { WeakReference } = internalBinding('util');
 
 // Overwrite process.domain with a getter/setter that will allow for more
 // effective optimizations
+// Never directly access _domain, use the getter to ensure a consistent hook
+// for user code
 const _domain = [null];
 ObjectDefineProperty(process, 'domain', {
+  configurable: true,
   enumerable: true,
   get: function() {
     return _domain[0];

--- a/test/parallel/test-process-domain-configurable.js
+++ b/test/parallel/test-process-domain-configurable.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+{
+  const d = domain.create();
+  d.run(common.mustCall(() => {
+    const f = setTimeout(common.mustCall(() => {}), 1);
+    assert.strictEqual(f.domain, d);
+  }));
+
+  Object.defineProperty(process, 'domain', {
+    configurable: true,
+    enumerable: true,
+    get() { return null; },
+    set(v) {}
+  });
+
+  d.run(common.mustCall(() => {
+    const f = setTimeout(common.mustCall(() => {}), 1);
+    assert.strictEqual(f.domain, undefined);
+  }));
+}


### PR DESCRIPTION
This allows code wishing to censor domain usage to do so.

This affects https://github.com/Agoric/SES/issues/113 . Note, user code configuring this property is left to correctly handle error caused in doing so.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
