### PR TITLE
build: add flag to enable pointer compression

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -73,9 +73,6 @@
     # TODO(refack): make v8-perfetto happen
     'v8_use_perfetto': 0,
 
-    'v8_enable_pointer_compression': 0,
-    'v8_enable_31bit_smis_on_64bit_arch': 0,
-
     ##### end V8 defaults #####
 
     'conditions': [

--- a/configure.py
+++ b/configure.py
@@ -346,6 +346,11 @@ parser.add_option('--enable-trace-maps',
     dest='trace_maps',
     help='Enable the --trace-maps flag in V8 (use at your own risk)')
 
+parser.add_option('--experimental-enable-pointer-compression',
+    action='store_true',
+    dest='enable_pointer_compression',
+    help='[Experimental] Enable V8 pointer compression (limits max heap to 4GB and breaks ABI compatibility)')
+
 parser.add_option('--v8-options',
     action='store',
     dest='v8_options',
@@ -1192,6 +1197,8 @@ def configure_v8(o):
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
   o['variables']['v8_promise_internal_field_count'] = 1 # Add internal field to promises for async hooks.
   o['variables']['v8_use_siphash'] = 0 if options.without_siphash else 1
+  o['variables']['v8_enable_pointer_compression'] = 1 if options.enable_pointer_compression else 0
+  o['variables']['v8_enable_31bit_smis_on_64bit_arch'] = 1 if options.enable_pointer_compression else 0
   o['variables']['v8_trace_maps'] = 1 if options.trace_maps else 0
   o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)

--- a/node.gyp
+++ b/node.gyp
@@ -2,6 +2,8 @@
   'variables': {
     'v8_use_siphash%': 0,
     'v8_trace_maps%': 0,
+    'v8_enable_pointer_compression%': 0,
+    'v8_enable_31bit_smis_on_64bit_arch%': 0,
     'node_use_dtrace%': 'false',
     'node_use_etw%': 'false',
     'node_no_browser_globals%': 'false',


### PR DESCRIPTION
This PR adds support for building node with pointer compression enabled. From some preliminary tests, enabling pointer compression shrinks memory usage by 40%.

See: https://github.com/nodejs/node/issues/26756

Note that building with this flag makes some of our addon tests fail:

```
=== release test ===
Path: addons/async-hooks-promise/test
Command: out/Release/node /home/matteo/repositories/node/test/addons/async-hooks-promise/test.js
--- CRASHED (Signal: 11) ---
=== release test ===
Path: addons/08_passing_wrapped_objects_around/test
Command: out/Release/node /home/matteo/repositories/node/test/addons/08_passing_wrapped_objects_around/test.js
--- CRASHED (Signal: 11) ---
=== release test ===
Path: addons/new-target/test
Command: out/Release/node /home/matteo/repositories/node/test/addons/new-target/test.js
--- CRASHED (Signal: 11) ---
=== release test ===
Path: addons/make-callback/test
Command: out/Release/node /home/matteo/repositories/node/test/addons/make-callback/test.js
--- CRASHED (Signal: 11) ---
=== release test ===
Path: addons/06_wrapping_c_objects/test
Command: out/Release/node /home/matteo/repositories/node/test/addons/06_wrapping_c_objects/test.js
--- CRASHED (Signal: 11) ---
=== release test ===
Path: addons/07_factory_of_wrapped_objects/test
Command: out/Release/node /home/matteo/repositories/node/test/addons/07_factory_of_wrapped_objects/test.js
--- CRASHED (Signal: 11) ---
=== release test-perf-hooks-timerify ===
Path: addons/non-node-context/test-perf-hooks-timerify
Command: out/Release/node /home/matteo/repositories/node/test/addons/non-node-context/test-perf-hooks-timerify.js
--- CRASHED (Signal: 11) ---
[02:41|% 100|+ 2807|-   7]: Done
Makefile:296: recipe for target 'jstest' failed
make[1]: *** [jstest] Error 1
Makefile:316: recipe for target 'test' failed
make: *** [test] Error 2
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
