### PR TITLE
test: handle undefined default_configuration

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -118,8 +118,9 @@ const enoughTestCpu = Array.isArray(cpus) &&
 
 const rootDir = isWindows ? 'c:\\' : '/';
 
-const buildType = process.config.target_defaults.default_configuration;
-
+const buildType = process.config.target_defaults ?
+  process.config.target_defaults.default_configuration :
+  'Release';
 
 // If env var is set then enable async_hook hooks for all tests.
 if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {


### PR DESCRIPTION
This PR adds a check for `process.config.target_defaults` being undefined, as it is Electron's case, and ensures that the `buildType` is set to a default value of `Release` should it not be defined.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
