### PR TITLE
build: store cache on timed out builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
-x-ccache-setup-steps: &ccache-setup-steps
-  - export CCACHE_NOSTATS=1
-  - export CCACHE_SLOPPINESS="file_macro,include_file_mtime,include_file_ctime,time_macros,file_stat_matches"
-  - export CC='ccache gcc-6'
-  - export CXX='ccache g++-6'
-
 os: linux
 language: cpp
 env:
@@ -13,7 +7,7 @@ env:
 jobs:
   include:
     - stage: "Compile"
-      name: "Compile V8"
+      name: "Compile Node.js"
       cache: ccache
       addons:
         apt:
@@ -21,25 +15,16 @@ jobs:
             - ubuntu-toolchain-r-test
           packages:
             - g++-6
-      install: *ccache-setup-steps
+      install:
+        - export CCACHE_NOSTATS=1
+        - export CCACHE_SLOPPINESS="file_macro,include_file_mtime,include_file_ctime,time_macros,file_stat_matches"
+        - export CC='ccache gcc-6'
+        - export CXX='ccache g++-6'
       script:
         - pyenv global ${PYTHON_VERSION}
         - ./configure
-        - make -j2 -C out V=1 v8
-
-    - name: "Compile Node.js"
-      cache: ccache
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-      install: *ccache-setup-steps
-      script:
-        - pyenv global ${PYTHON_VERSION}
-        - ./configure
-        - make -j2 V=1
+        - timeout --preserve-status 45m make -j2 V=1
+      before_cache:
         - cp out/Release/node /home/travis/.ccache
         - cp out/Release/cctest /home/travis/.ccache
 

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -176,6 +176,13 @@ All pull requests must pass continuous integration tests. Code changes must pass
 on [project CI server](https://ci.nodejs.org/). Pull requests that only change
 documentation and comments can use Travis CI results.
 
+Travis CI jobs have a fixed running time limit that building Node.js sometimes
+exceeds. If the `Compile Node.js` Travis CI job has timed out it will fail after
+around 45 minutes. The exit code will be 143, indicating that a `SIGTERM` signal
+terminated the `make` command. When this happens, restart the timed out job. It
+will reuse built artifacts from the previous timed-out run, and thus take less
+time to complete.
+
 Do not land any pull requests without passing (green or yellow) CI runs. If
 there are CI failures unrelated to the change in the pull request, try "Resume
 Build". It is in the left navigation of the relevant `node-test-pull-request`


### PR DESCRIPTION
Building Node.js without a ccache cache takes longer than the [50 minute
Travis time limit](https://docs.travis-ci.com/user/customizing-the-build/#build-timeouts) for jobs for public repositories. To mitigate this we
added a job to compile V8 on the basis that in the worst case it would
complete within 50 minutes and provide a cache that could be used by a
restarted `Compile Node.js` job.

[Recent PRs](https://github.com/nodejs/node/pull/30232#issuecomment-553167777) have exceeded the 50 minute time limit for the `Compile V8`
job. When Travis times out a build the cache is not stored.

This commit drops the `Compile V8` job and adds a manual timeout to the
`Compile Node.js` job which will allow the cache to be stored and used
in restarts of the job.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
