### PR TITLE
tty: truecolor check moved before 256 check

### DIFF
--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -173,9 +173,8 @@ function getColorDepth(env = process.env) {
       return COLORS_256;
   }
 
-  if (env.COLORTERM) {
-    if (env.COLORTERM === 'truecolor' || env.COLORTERM === '24bit')
-      return COLORS_16m;
+  if (env.COLORTERM === 'truecolor' || env.COLORTERM === '24bit') {
+    return COLORS_16m;
   }
 
   if (env.TERM) {

--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -173,6 +173,11 @@ function getColorDepth(env = process.env) {
       return COLORS_256;
   }
 
+  if (env.COLORTERM) {
+    if (env.COLORTERM === 'truecolor' || env.COLORTERM === '24bit')
+      return COLORS_16m;
+  }
+
   if (env.TERM) {
     if (/^xterm-256/.test(env.TERM))
       return COLORS_256;
@@ -187,12 +192,10 @@ function getColorDepth(env = process.env) {
         return COLORS_16;
       }
     }
-  }
-
-  if (env.COLORTERM) {
-    if (env.COLORTERM === 'truecolor' || env.COLORTERM === '24bit')
-      return COLORS_16m;
-    return COLORS_16;
+    // Move 16 color COLORTERM below 16m and 256
+    if (env.COLORTERM) {
+      return COLORS_16;
+    }
   }
 
   return COLORS_2;

--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -192,12 +192,11 @@ function getColorDepth(env = process.env) {
         return COLORS_16;
       }
     }
-    // Move 16 color COLORTERM below 16m and 256
-    if (env.COLORTERM) {
-      return COLORS_16;
-    }
   }
-
+  // Move 16 color COLORTERM below 16m and 256
+  if (env.COLORTERM) {
+    return COLORS_16;
+  }
   return COLORS_2;
 }
 

--- a/test/pseudo-tty/test-tty-color-support.js
+++ b/test/pseudo-tty/test-tty-color-support.js
@@ -71,6 +71,7 @@ const writeStream = new WriteStream(fd);
   [{ NO_COLOR: '', COLORTERM: '24bit' }, 1],
   [{ TMUX: '1', FORCE_COLOR: 0 }, 1],
   [{ NO_COLOR: 'true', FORCE_COLOR: 0, COLORTERM: 'truecolor' }, 1],
+  [{ TERM: 'xterm-256color', COLORTERM: 'truecolor' }, 24],
 ].forEach(([env, depth], i) => {
   const actual = writeStream.getColorDepth(env);
   assert.strictEqual(


### PR DESCRIPTION
256 color would be return instead of 16m if both env variables were set
Test added to pseudo-tty/test-tty-color-support
Related Issue: https://github.com/nodejs/node/issues/27609
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
