### PR TITLE
src: expose ArrayBuffer version of Buffer::New()

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -229,6 +229,18 @@ MaybeLocal<Uint8Array> New(Environment* env,
   return ui;
 }
 
+MaybeLocal<Uint8Array> New(Isolate* isolate,
+                           Local<ArrayBuffer> ab,
+                           size_t byte_offset,
+                           size_t length) {
+  Environment* env = Environment::GetCurrent(isolate);
+  if (env == nullptr) {
+    THROW_ERR_BUFFER_CONTEXT_NOT_AVAILABLE(isolate);
+    return MaybeLocal<Uint8Array>();
+  }
+  return New(env, ab, byte_offset, length);
+}
+
 
 MaybeLocal<Object> New(Isolate* isolate,
                        Local<String> string,

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -65,6 +65,12 @@ NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                            char* data,
                                            size_t len);
 
+// Creates a Buffer instance over an existing ArrayBuffer.
+NODE_EXTERN v8::MaybeLocal<v8::Uint8Array> New(v8::Isolate* isolate,
+                                               v8::Local<v8::ArrayBuffer> ab,
+                                               size_t byte_offset,
+                                               size_t length);
+
 // This is verbose to be explicit with inline commenting
 static inline bool IsWithinBounds(size_t off, size_t len, size_t max) {
   // Asking to seek too far into the buffer

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -157,7 +157,7 @@ v8::MaybeLocal<v8::Object> New(Environment* env,
                                char* data,
                                size_t length,
                                bool uses_malloc);
-// Creates a Buffer instance over an existing Uint8Array.
+// Creates a Buffer instance over an existing ArrayBuffer.
 v8::MaybeLocal<v8::Uint8Array> New(Environment* env,
                                    v8::Local<v8::ArrayBuffer> ab,
                                    size_t byte_offset,


### PR DESCRIPTION
This can be useful to create `Buffer` instances for already-existing
`ArrayBuffer`s, e.g. ones created manually from a backing store
with a free callback (of which our variant in the public API has
some limitations).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
