### PR TITLE
doc: adds NO_COLOR to assert doc page

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -114,7 +114,7 @@ assert.deepEqual([[[1, 2, 3]], 4, 5], [[[1, 2, '3']], 4, 5]);
 //   ]
 ```
 
-To deactivate the colors, use the `NODE_DISABLE_COLORS` environment variable.
+To deactivate the colors, use `NO_COLOR` or `NODE_DISABLE_COLORS` environment variables.
 This will also deactivate the colors in the REPL.
 
 ## Legacy mode

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -119,7 +119,7 @@ To deactivate the colors, use the `NO_COLOR` or
 This will also deactivate the colors in the REPL.
 
 For more on the color support in terminal environments, read
-the tty [getColorDepth](tty.html#tty_writestream_getcolordepth_env) doc.
+the tty [getColorDepth()](tty.html#tty_writestream_getcolordepth_env) doc.
 
 ## Legacy mode
 

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -114,7 +114,8 @@ assert.deepEqual([[[1, 2, 3]], 4, 5], [[[1, 2, '3']], 4, 5]);
 //   ]
 ```
 
-To deactivate the colors, use `NO_COLOR` or `NODE_DISABLE_COLORS` environment variables.
+To deactivate the colors, use the `NO_COLOR` or
+`NODE_DISABLE_COLORS` environment variable.
 This will also deactivate the colors in the REPL.
 
 ## Legacy mode

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -118,6 +118,9 @@ To deactivate the colors, use the `NO_COLOR` or
 `NODE_DISABLE_COLORS` environment variable.
 This will also deactivate the colors in the REPL.
 
+For more on the color support in terminal environments, read
+the tty [getColorDepth](tty.html#tty_writestream_getcolordepth_env) doc.
+
 ## Legacy mode
 
 Legacy mode uses the [Abstract Equality Comparison][] in:


### PR DESCRIPTION
Adding `NO_COLOR` environment variable to disable colors to the assert docs.

Refs: #30484 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
