### PR TITLE
doc: adds assert doc for strict mode with pointer to strict equality

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -82,7 +82,9 @@ changes:
 
 In `strict` mode, `assert` functions use the comparison in the corresponding
 strict functions. For example, [`assert.deepEqual()`][] will behave like
-[`assert.deepStrictEqual()`][].
+[`assert.deepStrictEqual()`][]. This uses the [Strict Equality Comparison][]
+from the ECMAScript spec and does not refer to JavaScript strict mode (`"use strict";`)
+in any way.
 
 In `strict` mode, error messages for objects display a diff. In legacy mode,
 error messages for objects display the objects, often truncated.
@@ -1319,6 +1321,7 @@ second argument. This might lead to difficult-to-spot errors.
 [`assert.throws()`]: #assert_assert_throws_fn_error_message
 [`strict` mode]: #assert_strict_mode
 [Abstract Equality Comparison]: https://tc39.github.io/ecma262/#sec-abstract-equality-comparison
+[Strict Equality Comparison]: https://tc39.es/ecma262/#sec-strict-equality-comparison
 [Object wrappers]: https://developer.mozilla.org/en-US/docs/Glossary/Primitive#Primitive_wrapper_objects_in_JavaScript
 [Object.prototype.toString()]: https://tc39.github.io/ecma262/#sec-object.prototype.tostring
 [SameValue Comparison]: https://tc39.github.io/ecma262/#sec-samevalue

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -83,8 +83,8 @@ changes:
 In `strict` mode, `assert` functions use the comparison in the corresponding
 strict functions. For example, [`assert.deepEqual()`][] will behave like
 [`assert.deepStrictEqual()`][]. This uses the [Strict Equality Comparison][]
-from the ECMAScript spec and does not refer to JavaScript strict mode (`"use strict";`)
-in any way.
+from the ECMAScript spec and does not refer to JavaScript strict
+mode (`"use strict";`) in any way.
 
 In `strict` mode, error messages for objects display a diff. In legacy mode,
 error messages for objects display the objects, often truncated.

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -80,11 +80,9 @@ changes:
     description: Added strict mode to the assert module.
 -->
 
-In `strict` mode, `assert` functions use the comparison in the corresponding
-strict functions. For example, [`assert.deepEqual()`][] will behave like
-[`assert.deepStrictEqual()`][]. This uses the [Strict Equality Comparison][]
-from the ECMAScript spec and does not refer to JavaScript strict
-mode (`"use strict";`) in any way.
+In `strict` mode (not to be confused with `"use strict"`), `assert` functions
+use the comparison in the corresponding strict functions. For example,
+[`assert.deepEqual()`][] will behave like [`assert.deepStrictEqual()`][].
 
 In `strict` mode, error messages for objects display a diff. In legacy mode,
 error messages for objects display the objects, often truncated.
@@ -1321,7 +1319,6 @@ second argument. This might lead to difficult-to-spot errors.
 [`assert.throws()`]: #assert_assert_throws_fn_error_message
 [`strict` mode]: #assert_strict_mode
 [Abstract Equality Comparison]: https://tc39.github.io/ecma262/#sec-abstract-equality-comparison
-[Strict Equality Comparison]: https://tc39.es/ecma262/#sec-strict-equality-comparison
 [Object wrappers]: https://developer.mozilla.org/en-US/docs/Glossary/Primitive#Primitive_wrapper_objects_in_JavaScript
 [Object.prototype.toString()]: https://tc39.github.io/ecma262/#sec-object.prototype.tostring
 [SameValue Comparison]: https://tc39.github.io/ecma262/#sec-samevalue


### PR DESCRIPTION
Adds a note to not confuse strict mode in `assert` module with JS `"use strict"` directive.

Refs: https://github.com/nodejs/node/issues/30485

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
