### PR TITLE
tools: fix build at non-English windows

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -108,6 +108,13 @@
     ],
   },
   'includes': ['toolchain.gypi', 'features.gypi'],
+  'target_defaults': {
+    'msvs_settings': {
+      'VCCLCompilerTool': {
+        'AdditionalOptions': ['/utf-8']
+      }
+    },
+  },
   'targets': [
     {
       'target_name': 'run_torque',


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/25885

There are some non-ASCII characters in v8's code, for example:
https://github.com/nodejs/node/blob/04e45db1726e1d2c11ecbf8cbacc82c88672fc83/deps/v8/src/objects/intl-objects.cc#L1630

This causes build failure at non-English windows. This PR adds `/utf-8` compiler option to fix it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
