### PR TITLE
src: make debug_options getters public

### DIFF
--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -13,14 +13,6 @@ PerIsolateOptions* PerProcessOptions::get_per_isolate_options() {
   return per_isolate.get();
 }
 
-DebugOptions* EnvironmentOptions::get_debug_options() {
-  return &debug_options_;
-}
-
-const DebugOptions& EnvironmentOptions::debug_options() const {
-  return debug_options_;
-}
-
 EnvironmentOptions* PerIsolateOptions::get_per_env_options() {
   return per_env.get();
 }

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -172,8 +172,9 @@ class EnvironmentOptions : public Options {
 
   std::vector<std::string> user_argv;
 
-  inline DebugOptions* get_debug_options();
-  inline const DebugOptions& debug_options() const;
+  inline DebugOptions* get_debug_options() { return &debug_options_; }
+  inline const DebugOptions& debug_options() const { return debug_options_; }
+
   void CheckOptions(std::vector<std::string>* errors) override;
 
  private:


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/30466.

Now that Electron is parsing and passing CLI options, we can set DebugOptions ourselves through `ParseGlobalArgs`. However, we also need to create and start the inspector agent with the `DebugOptions` set by users, since the inspector agent `Start` function takes a parameter `const DebugOptions& options`.

The most straightforward way to do this is for us to pass `env->options()->debug_options()` to our inspector agent `Start` call, but since `debug_options` was defined in `src/node_options-inl.h` we'd need to require extra files to do what could trivially be consolidated into one. This PR therefore moves those definitions into a public-facing file, allowing us to pass correct options to the inspector without needing to parse all-new ones we'd previously parsed on startup.

cc @joyeecheung @addaleax 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
