### PR TITLE
doc: createRequire can take import.meta.url directly

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -848,16 +848,15 @@ CommonJS, JSON, and Native modules can be used with
 [`module.createRequire()`][].
 
 ```js
-// cjs.js
+// cjs.cjs
 module.exports = 'cjs';
 
 // esm.mjs
 import { createRequire } from 'module';
-import { fileURLToPath as fromURL } from 'url';
 
-const require = createRequire(fromURL(import.meta.url));
+const require = createRequire(import.meta.url);
 
-const cjs = require('./cjs');
+const cjs = require('./cjs.cjs');
 cjs === 'cjs'; // true
 ```
 


### PR DESCRIPTION
This PR updates the `createRequire` example in https://nodejs.org/api/esm.html#esm_commonjs_json_and_native_modules to follow the new `createRequire` behavior, as opposed to the deprecated `createRequireFromPath` behavior. cc @MylesBorins 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)