### PR TITLE
esm: disable non-js exts outside package scopes

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1305,8 +1305,7 @@ _defaultEnv_ is the conditional environment name priority array,
 >       1. Return _"module"_.
 >    1. Throw an _Unsupported File Extension_ error.
 > 1. Otherwise,
->    1. If _isMain_ is **true** or _url_ ends in _".js"_, _".json"_ or
->       _".node"_, then
+>    1. If _isMain_ is **true**, then
 >       1. Return _"commonjs"_.
 >    1. Throw an _Unsupported File Extension_ error.
 

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -78,8 +78,18 @@ function resolve(specifier, parentURL) {
   }
 
   const isMain = parentURL === undefined;
-  if (isMain)
+  if (isMain) {
     parentURL = pathToFileURL(`${process.cwd()}/`).href;
+
+    // This is the initial entry point to the program, and --input-type has
+    // been passed as an option; but --input-type can only be used with
+    // --eval, --print or STDIN string input. It is not allowed with file
+    // input, to avoid user confusion over how expansive the effect of the
+    // flag should be (i.e. entry point only, package scope surrounding the
+    // entry point, etc.).
+    if (typeFlag)
+      throw new ERR_INPUT_TYPE_NOT_ALLOWED();
+  }
 
   let url = moduleWrapResolve(specifier, parentURL);
 
@@ -93,27 +103,13 @@ function resolve(specifier, parentURL) {
     url.hash = old.hash;
   }
 
-  const type = getPackageType(url.href);
-
   const ext = extname(url.pathname);
-  const extMap =
-      type !== TYPE_MODULE ? legacyExtensionFormatMap : extensionFormatMap;
-  let format = extMap[ext];
-
-  if (isMain && typeFlag) {
-    // This is the initial entry point to the program, and --input-type has
-    // been passed as an option; but --input-type can only be used with
-    // --eval, --print or STDIN string input. It is not allowed with file
-    // input, to avoid user confusion over how expansive the effect of the
-    // flag should be (i.e. entry point only, package scope surrounding the
-    // entry point, etc.).
-    throw new ERR_INPUT_TYPE_NOT_ALLOWED();
-  }
+  let format = extensionFormatMap[ext];
+  if (ext === '.js' || (!format && isMain))
+    format = getPackageType(url.href) === TYPE_MODULE ? 'module' : 'commonjs';
   if (!format) {
-    if (isMain)
-      format = type === TYPE_MODULE ? 'module' : 'commonjs';
-    else if (esModuleSpecifierResolution === 'node')
-      format = 'commonjs';
+    if (esModuleSpecifierResolution === 'node')
+      format = legacyExtensionFormatMap[ext];
     else
       throw new ERR_UNKNOWN_FILE_EXTENSION(fileURLToPath(url));
   }

--- a/test/es-module/test-esm-non-js.js
+++ b/test/es-module/test-esm-non-js.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const { spawn } = require('child_process');
+const assert = require('assert');
+
+const entry = require.resolve('./test-esm-json.mjs');
+
+// Verify non-js extensions fail for ESM
+const child = spawn(process.execPath, [entry]);
+
+let stderr = '';
+child.stderr.setEncoding('utf8');
+child.stderr.on('data', (data) => {
+  stderr += data;
+});
+child.on('close', common.mustCall((code, signal) => {
+  assert.strictEqual(code, 1);
+  assert.strictEqual(signal, null);
+  assert.ok(stderr.indexOf('ERR_UNKNOWN_FILE_EXTENSION') !== -1);
+}));


### PR DESCRIPTION
Up until now the ES module resolver still supports loading `.json` and `.node` files outside of ES module scopes (with `"type": "module"`), mainly for backwards compatibility with the CJS resolver.

This PR locks down that behaviour to ensure we are shipping the stricter semantics that don't permit users to just import JSON modules directly. The goal here is that if something like the module types proposal takes off, then we haven't already locked in ecosystem semantics that assume JSON imports.

The reason this is important is because right now the unflagged implementation will allow an `.mjs` file to import JSON, which once people start using will tend to make this a difficult thing to remove.

If we get compatibility bugs, we can certainly relax this stance though, but our general approach to the implementation up until now has been to try to be conservative with the semantics to avoid wrong paths, which has so far served us well.

For the main entry into Node.js we have an explicit `isMain` check which will always support non-extensions for bin use cases and these types of files.

The change is actually just the simple change at https://github.com/nodejs/node/pull/30501/files#diff-8e67f407bc32a0569e25d7ecaff6e494L1308, the rest is mostly just taking a chance to refactor the resolver logic a bit while retaining the same semantics.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
