### PR TITLE
Consistency of method naming

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2534,7 +2534,7 @@ method to accept input and produce output. The `transform._transform()`
 implementation handles the bytes being written, computes an output, then passes
 that output off to the readable portion using the `readable.push()` method.
 
-The `transform.push()` method may be called zero or more times to generate
+The `readable.push()` method may be called zero or more times to generate
 output from a single input chunk, depending on how much is to be output
 as a result of the chunk.
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2503,7 +2503,7 @@ method. This will be called when there is no more written data to be consumed,
 but before the [`'end'`][] event is emitted signaling the end of the
 [`Readable`][] stream.
 
-Within the `transform._flush()` implementation, the `readable.push()` method
+Within the `transform._flush()` implementation, the `transform.push()` method
 may be called zero or more times, as appropriate. The `callback` function must
 be called when the flush operation is complete.
 
@@ -2532,9 +2532,9 @@ methods only.
 All `Transform` stream implementations must provide a `_transform()`
 method to accept input and produce output. The `transform._transform()`
 implementation handles the bytes being written, computes an output, then passes
-that output off to the readable portion using the `readable.push()` method.
+that output off to the readable portion using the `transform.push()` method.
 
-The `readable.push()` method may be called zero or more times to generate
+The `transform.push()` method may be called zero or more times to generate
 output from a single input chunk, depending on how much is to be output
 as a result of the chunk.
 
@@ -2544,7 +2544,7 @@ The `callback` function must be called only when the current chunk is completely
 consumed. The first argument passed to the `callback` must be an `Error` object
 if an error occurred while processing the input or `null` otherwise. If a second
 argument is passed to the `callback`, it will be forwarded on to the
-`readable.push()` method. In other words, the following are equivalent:
+`transform.push()` method. In other words, the following are equivalent:
 
 ```js
 transform.prototype._transform = function(data, encoding, callback) {


### PR DESCRIPTION
referred to as readable.push several other times in transform documentation and also documented under readable, so makes sense to just stick with readable.push

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
