### PR TITLE
util: add filter predicate for inspect

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -398,6 +398,9 @@ stream.write('With ES6');
 <!-- YAML
 added: v0.3.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30511
+    description: The `filter` option has been added.
   - version: v13.0.0
     pr-url: https://github.com/nodejs/node/pull/27685
     description: Circular references now include a marker to the reference.
@@ -498,6 +501,11 @@ changes:
     set to `'set'`, only getters with a corresponding setter are inspected.
     This might cause side effects depending on the getter function.
     **Default:** `false`.
+  * `filter` {Function} Will be invoked for each traversed value.
+    If the function returns `false` the value will be redacted.
+    The first value passed to the function is the current value being inspected,
+    the second will be the `key` for this value.
+    `key` will be `undefined` when traversing the root or [`Map`][] / [`WeakMap`][] keys.
 * Returns: {string} The representation of `object`.
 
 The `util.inspect()` method returns a string representation of `object` that is
@@ -647,6 +655,20 @@ assert.strict.equal(
   inspect(o1, { sorted: true }),
   inspect(o2, { sorted: true })
 );
+```
+
+The `filter` option allows redacting output based on key and value.
+```js
+const { inspect } = require('util');
+console.log(inspect({
+  _unwantedProp: 1,
+  unwantedValue: 42
+}, {
+  filter(key, value) {
+    return key !== '_unwantedProp' || value !== 42;
+  }
+}));
+// { _unwantedProp: [Filtered], unwantedValue: [Filtered] }
 ```
 
 `util.inspect()` is a synchronous method intended for debugging. Its maximum

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -107,7 +107,8 @@ const inspectDefaultOptions = Object.seal({
   breakLength: 80,
   compact: 3,
   sorted: false,
-  getters: false
+  getters: false,
+  filter: undefined,
 });
 
 const kObjectType = 0;
@@ -186,7 +187,8 @@ function inspect(value, opts) {
     breakLength: inspectDefaultOptions.breakLength,
     compact: inspectDefaultOptions.compact,
     sorted: inspectDefaultOptions.sorted,
-    getters: inspectDefaultOptions.getters
+    getters: inspectDefaultOptions.getters,
+    filter: inspectDefaultOptions.filter,
   };
   if (arguments.length > 1) {
     // Legacy...
@@ -264,7 +266,8 @@ inspect.styles = Object.assign(Object.create(null), {
   date: 'magenta',
   // "name": intentionally not styling
   regexp: 'red',
-  module: 'underline'
+  module: 'underline',
+  filtered: 'red',
 });
 
 function addQuotes(str, quotes) {
@@ -527,7 +530,10 @@ function noPrototypeIterator(ctx, value, recurseTimes) {
 // Note: using `formatValue` directly requires the indentation level to be
 // corrected by setting `ctx.indentationLvL += diff` and then to decrease the
 // value afterwards again.
-function formatValue(ctx, value, recurseTimes, typedArray) {
+function formatValue(ctx, value, recurseTimes, typedArray, key) {
+  if (ctx.filter && ctx.filter(value, key) === false) {
+    return ctx.stylize('[Filtered]', 'filtered');
+  }
   // Primitive types cannot have properties.
   if (typeof value !== 'object' && typeof value !== 'function') {
     return formatPrimitive(ctx.stylize, value, ctx);
@@ -535,6 +541,7 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
   if (value === null) {
     return ctx.stylize('null', 'null');
   }
+
 
   // Memorize the context for custom inspection on proxies.
   const context = value;
@@ -1286,7 +1293,7 @@ function formatMap(ctx, value, recurseTimes) {
   ctx.indentationLvl += 2;
   for (const [k, v] of value) {
     output.push(`${formatValue(ctx, k, recurseTimes)} => ` +
-                formatValue(ctx, v, recurseTimes));
+                formatValue(ctx, v, recurseTimes, undefined, k));
   }
   ctx.indentationLvl -= 2;
   // See comment in formatSet
@@ -1301,7 +1308,7 @@ function formatSetIterInner(ctx, recurseTimes, entries, state) {
   let output = new Array(maxLength);
   ctx.indentationLvl += 2;
   for (var i = 0; i < maxLength; i++) {
-    output[i] = formatValue(ctx, entries[i], recurseTimes);
+    output[i] = formatValue(ctx, entries[i], recurseTimes, undefined, i);
   }
   ctx.indentationLvl -= 2;
   if (state === kWeak && !ctx.sorted) {
@@ -1330,7 +1337,13 @@ function formatMapIterInner(ctx, recurseTimes, entries, state) {
     for (; i < maxLength; i++) {
       const pos = i * 2;
       output[i] = `${formatValue(ctx, entries[pos], recurseTimes)}` +
-        ` => ${formatValue(ctx, entries[pos + 1], recurseTimes)}`;
+        ` => ${formatValue(
+          ctx,
+          entries[pos + 1],
+          recurseTimes,
+          undefined,
+          entries[pos]
+        )}`;
     }
     // Sort all entries to have a halfway reliable output (if more entries than
     // retrieved ones exist, we can not reliably return the same output) if the
@@ -1342,7 +1355,13 @@ function formatMapIterInner(ctx, recurseTimes, entries, state) {
       const pos = i * 2;
       const res = [
         formatValue(ctx, entries[pos], recurseTimes),
-        formatValue(ctx, entries[pos + 1], recurseTimes)
+        formatValue(
+          ctx,
+          entries[pos + 1],
+          recurseTimes,
+          undefined,
+          entries[pos]
+        )
       ];
       output[i] = reduceToSingleString(
         ctx, res, '', ['[', ']'], kArrayExtrasType, recurseTimes);
@@ -1406,7 +1425,7 @@ function formatProperty(ctx, value, recurseTimes, key, type) {
   if (desc.value !== undefined) {
     const diff = (type !== kObjectType || ctx.compact !== true) ? 2 : 3;
     ctx.indentationLvl += diff;
-    str = formatValue(ctx, desc.value, recurseTimes);
+    str = formatValue(ctx, desc.value, recurseTimes, undefined, key);
     if (diff === 3) {
       const len = ctx.colors ? removeColors(str).length : str.length;
       if (ctx.breakLength < len) {
@@ -1427,7 +1446,9 @@ function formatProperty(ctx, value, recurseTimes, key, type) {
         if (tmp === null) {
           str = `${s(`[${label}:`, sp)} ${s('null', 'null')}${s(']', sp)}`;
         } else if (typeof tmp === 'object') {
-          str = `${s(`[${label}]`, sp)} ${formatValue(ctx, tmp, recurseTimes)}`;
+          str = `${s(`[${label}]`, sp)} ${
+            formatValue(ctx, tmp, recurseTimes, undefined, key)
+          }`;
         } else {
           const primitive = formatPrimitive(s, tmp, ctx);
           str = `${s(`[${label}:`, sp)} ${primitive}${s(']', sp)}`;

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2521,3 +2521,53 @@ assert.strictEqual(
       throw err;
   }
 }
+
+{
+  // Filtering
+
+  const filterByValue = { filter(val) { return val !== 'test'; } };
+  assert.strictEqual(util.inspect('test', filterByValue), '[Filtered]');
+  assert.strictEqual(
+    util.inspect({ a: 'test' }, filterByValue),
+    '{ a: [Filtered] }'
+  );
+
+  const filterByKey = { filter(_, key) { return key !== 'a'; } };
+  assert.strictEqual(
+    util.inspect({ a: 'test' }, filterByKey),
+    '{ a: [Filtered] }'
+  );
+
+  const filterPrivateProps = {
+    filter(_, key) {
+      return !(key && (typeof key === 'symbol' || key.startsWith('_')));
+    }
+  };
+
+  assert.strictEqual(util.inspect({
+    _myPrivateVar: 1,
+    myPublicVar: 3,
+    [Symbol('myPrivateVar2')]: 2,
+    myPublicMap: new Map([['_privateNestedVar', 32]]),
+  }, filterPrivateProps), '{\n' +
+  '  _myPrivateVar: [Filtered],\n' +
+  '  myPublicVar: 3,\n' +
+  "  myPublicMap: Map { '_privateNestedVar' => [Filtered] },\n" +
+  '  [Symbol(myPrivateVar2)]: [Filtered]\n' +
+  '}');
+
+  const filterArrayIndex = {
+    filter(_, key) { return key !== 0; },
+  };
+
+  assert.strictEqual(
+    util.inspect(['test1', 'test2'], filterArrayIndex),
+    "[ [Filtered], 'test2' ]"
+  );
+
+  // color support
+  assert.strictEqual(
+    util.inspect('test', { ...filterByValue, colors: true }),
+    '\u001b[31m[Filtered]\u001b[39m'
+  );
+}


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Rationale:
`util.inspect` is (in my opinion) by far the most sophisticated value stringification inspection function that currently exists in the ecosystem.
However there is no way to programmatically filter out `noise` other than deep cloning/redacting the value prior, which can have unintended/negative consequences.

Notes:
- Not sure if it would be desirable to entirely omit the key/value vs. displaying `[Filtered]`.
  - Maybe make this configurable?
  - Maybe allow returning `string` to override value?
- Unsure about the wording of the docs, this isn't my strong suit.
- Implementation:
  - Might want to swap `typedArray` and `key` to avoid explicitly passing `undefined`.
  - Ways to avoid passing `key` into `formatValue`.
  