### PR TITLE
cli: add --trace-exit cli option

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -774,6 +774,14 @@ added: v7.7.0
 
 Enables the collection of trace event tracing information.
 
+### `--trace-exit`
+<!-- YAML
+added: REPLACEME
+-->
+
+Prints a stack trace whenever an environment is been exited proactively, i.e.
+invoking `process.exit()`.
+
 ### `--trace-sync-io`
 <!-- YAML
 added: v2.1.0
@@ -1101,6 +1109,7 @@ Node.js options that are allowed are:
 * `--trace-event-categories`
 * `--trace-event-file-pattern`
 * `--trace-events-enabled`
+* `--trace-exit`
 * `--trace-sync-io`
 * `--trace-tls`
 * `--trace-uncaught`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -779,8 +779,8 @@ Enables the collection of trace event tracing information.
 added: REPLACEME
 -->
 
-Prints a stack trace whenever an environment is been exited proactively, i.e.
-invoking `process.exit()`.
+Prints a stack trace whenever an environment is exited proactively,
+i.e. invoking `process.exit()`.
 
 ### `--trace-sync-io`
 <!-- YAML

--- a/doc/node.1
+++ b/doc/node.1
@@ -349,6 +349,10 @@ and
 .It Fl -trace-events-enabled
 Enable the collection of trace event tracing information.
 .
+.It Fl -trace-exit
+Prints a stack trace whenever an environment is been exited proactively, i.e.
+invoking `process.exit()`.
+.
 .It Fl -trace-sync-io
 Print a stack trace whenever synchronous I/O is detected after the first turn of the event loop.
 .

--- a/doc/node.1
+++ b/doc/node.1
@@ -350,8 +350,8 @@ and
 Enable the collection of trace event tracing information.
 .
 .It Fl -trace-exit
-Prints a stack trace whenever an environment is been exited proactively, i.e.
-invoking `process.exit()`.
+Prints a stack trace whenever an environment is exited proactively,
+i.e. invoking `process.exit()`.
 .
 .It Fl -trace-sync-io
 Print a stack trace whenever synchronous I/O is detected after the first turn of the event loop.

--- a/src/env.cc
+++ b/src/env.cc
@@ -940,6 +940,21 @@ void AsyncHooks::grow_async_ids_stack() {
 uv_key_t Environment::thread_local_env = {};
 
 void Environment::Exit(int exit_code) {
+  if (options()->trace_exit) {
+    HandleScope handle_scope(isolate());
+
+    if (is_main_thread()) {
+      fprintf(stderr, "(node:%d) ", uv_os_getpid());
+    } else {
+      fprintf(stderr, "(node:%d, thread:%llu) ", uv_os_getpid(), thread_id());
+    }
+
+    fprintf(
+        stderr, "WARNING: Exited the environment with code %d\n", exit_code);
+    PrintStackTrace(
+        isolate(),
+        StackTrace::CurrentStackTrace(isolate(), 10, StackTrace::kDetailed));
+  }
   if (is_main_thread()) {
     stop_sub_worker_contexts();
     DisposePlatform();

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -476,6 +476,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "show stack traces on deprecations",
             &EnvironmentOptions::trace_deprecation,
             kAllowedInEnvironment);
+  AddOption("--trace-exit",
+            "show stack trace when an environment exits",
+            &EnvironmentOptions::trace_exit,
+            kAllowedInEnvironment);
   AddOption("--trace-sync-io",
             "show stack trace when use of sync IO is detected after the "
             "first tick",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -141,6 +141,7 @@ class EnvironmentOptions : public Options {
   bool test_udp_no_try_send = false;
   bool throw_deprecation = false;
   bool trace_deprecation = false;
+  bool trace_exit = false;
   bool trace_sync_io = false;
   bool trace_tls = false;
   bool trace_uncaught = false;

--- a/test/parallel/test-trace-exit.js
+++ b/test/parallel/test-trace-exit.js
@@ -1,0 +1,59 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { promisify } = require('util');
+const execFile = promisify(require('child_process').execFile);
+const { Worker, isMainThread, workerData } = require('worker_threads');
+
+const variant = process.argv[process.argv.length - 1];
+switch (true) {
+  case variant === 'main-thread': {
+    return;
+  }
+  case variant === 'main-thread-exit': {
+    return process.exit(0);
+  }
+  case variant.startsWith('worker-thread'): {
+    const worker = new Worker(__filename, { workerData: variant });
+    worker.on('error', common.mustNotCall());
+    worker.on('exit', common.mustCall((code) => {
+      assert.strictEqual(code, 0);
+    }));
+    return;
+  }
+  case !isMainThread: {
+    if (workerData === 'worker-thread-exit') {
+      process.exit(0);
+    }
+    return;
+  }
+}
+
+(async function() {
+  for (const { execArgv, variant, warnings } of [
+    { execArgv: ['--trace-exit'], variant: 'main-thread-exit', warnings: 1 },
+    { execArgv: [], variant: 'main-thread-exit', warnings: 0 },
+    { execArgv: ['--trace-exit'], variant: 'main-thread', warnings: 0 },
+    { execArgv: [], variant: 'main-thread', warnings: 0 },
+    { execArgv: ['--trace-exit'], variant: 'worker-thread-exit', warnings: 1 },
+    { execArgv: [], variant: 'worker-thread-exit', warnings: 0 },
+    { execArgv: ['--trace-exit'], variant: 'worker-thread', warnings: 0 },
+    { execArgv: [], variant: 'worker-thread', warnings: 0 },
+  ]) {
+    const { stdout, stderr } =
+      await execFile(process.execPath, [...execArgv, __filename, variant]);
+    assert.strictEqual(stdout, '');
+    const actualWarnings =
+      stderr.match(/WARNING: Exited the environment with code 0/g);
+    if (warnings === 0) {
+      assert.strictEqual(actualWarnings, null);
+      return;
+    }
+    assert.strictEqual(actualWarnings.length, warnings);
+
+    if (variant.startsWith('worker')) {
+      const workerIds = stderr.match(/\(node:\d+, thread:\d+)/g);
+      assert.strictEqual(workerIds.length, warnings);
+    }
+  }
+})().then(common.mustCall());


### PR DESCRIPTION
It could be convenient to trace abnormal exit of the Node.js processes
that printing stacktrace on each `process.exit` call with a cli option.
This also takes effects on worker threads.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
