### PR TITLE
test: harden tmpdir/rmdirSync error handling

### DIFF
--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -83,7 +83,7 @@ function rmdirSync(p, originalEr) {
           rimrafSync(path.join(p, f));
         }
       });
-      fs.rmdirSync(p);
+      rmdirSync(p, null);
       return;
     }
     throw e;


### PR DESCRIPTION
This makes rmdirSync call itself after handling ENOTEMPTY, EEXIST, EPERM
errors instead of directly using fs.rmdirSync to handle the possibility
of such errors repeating on the next try (i.e. FS finished writing new
file just as we are done with our loop to delete all files).

Refs: https://github.com/nodejs/node/issues/29852

This should handle `test/parallel/test-child-process-fork-exec-path`.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
/cc @nodejs/testing 