### PR TITLE
test: clean up http-set-trailers

### DIFF
--- a/test/parallel/test-http-set-trailers.js
+++ b/test/parallel/test-http-set-trailers.js
@@ -98,6 +98,5 @@ server.listen(0, () => {
   Promise.all([testHttp10, testHttp11, testClientTrailers]
     .map(util.promisify)
     .map((f) => f(server.address().port)))
-    .catch((e) => { throw e; })
-    .finally(() => server.close());
+    .then(() => server.close());
 });


### PR DESCRIPTION
* remove shared state of request counting from each listener by using
  callbacks to report test finish. This also fixes slight race condition
  where one of the request could finish before the other was taken into
  account resulting in ECONNREFUSED due to premature server.close()
* slightly move code for better cohesion
* fix error comment in testHttp10 'Trailer ...' -> 'No trailer ...'

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

/cc @nodejs/testing @nodejs/http 