### PR TITLE
http2: make maximum invalid frames and maximum rejected streams configurable

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1941,6 +1941,9 @@ error will be thrown.
 <!-- YAML
 added: v8.4.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30534
+    description: Added maxSessionInvalidFrames option with a default of 1000.
   - version: v13.0.0
     pr-url: https://github.com/nodejs/node/pull/29144
     description: The `PADDING_STRATEGY_CALLBACK` has been made equivalent to
@@ -2001,6 +2004,9 @@ changes:
     streams for the remote peer as if a `SETTINGS` frame had been received. Will
     be overridden if the remote peer sets its own value for
     `maxConcurrentStreams`. **Default:** `100`.
+  * `maxSessionInvalidFrames` {integer} Sets the maximum number of invalid
+    frames that will be tolerated before the session is closed.
+    **Default:** `1000`.
   * `settings` {HTTP/2 Settings Object} The initial settings to send to the
     remote peer upon connection.
   * `Http1IncomingMessage` {http.IncomingMessage} Specifies the
@@ -2053,6 +2059,9 @@ server.listen(80);
 <!-- YAML
 added: v8.4.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30534
+    description: Added maxSessionInvalidFrames option with a default of 1000.
   - version: v13.0.0
     pr-url: https://github.com/nodejs/node/pull/29144
     description: The `PADDING_STRATEGY_CALLBACK` has been made equivalent to
@@ -2113,6 +2122,9 @@ changes:
     streams for the remote peer as if a `SETTINGS` frame had been received. Will
     be overridden if the remote peer sets its own value for
     `maxConcurrentStreams`. **Default:** `100`.
+  * `maxSessionInvalidFrames` {integer} Sets the maximum number of invalid
+    frames that will be tolerated before the session is closed.
+    **Default:** `1000`.
   * `settings` {HTTP/2 Settings Object} The initial settings to send to the
     remote peer upon connection.
   * ...: Any [`tls.createServer()`][] options can be provided. For

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1946,7 +1946,7 @@ changes:
     description: Added maxSessionRejectedStreams option with a default of 100.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30534
-    description: Added maxSessionInvalidFrames option with a default of 1000.
+    description: Added `maxSessionInvalidFrames` option with a default of 1000.
   - version: v13.0.0
     pr-url: https://github.com/nodejs/node/pull/29144
     description: The `PADDING_STRATEGY_CALLBACK` has been made equivalent to
@@ -2073,7 +2073,7 @@ changes:
     description: Added maxSessionRejectedStreams option with a default of 100.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30534
-    description: Added maxSessionInvalidFrames option with a default of 1000.
+    description: Added `maxSessionInvalidFrames` option with a default of 1000.
   - version: v13.0.0
     pr-url: https://github.com/nodejs/node/pull/29144
     description: The `PADDING_STRATEGY_CALLBACK` has been made equivalent to

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1943,7 +1943,7 @@ added: v8.4.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30534
-    description: Added maxSessionRejectedStreams option with a default of 100.
+    description: Added `maxSessionRejectedStreams` option with a default of 100.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30534
     description: Added `maxSessionInvalidFrames` option with a default of 1000.
@@ -2070,7 +2070,7 @@ added: v8.4.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30534
-    description: Added maxSessionRejectedStreams option with a default of 100.
+    description: Added `maxSessionRejectedStreams` option with a default of 100.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30534
     description: Added `maxSessionInvalidFrames` option with a default of 1000.

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1943,6 +1943,9 @@ added: v8.4.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30534
+    description: Added maxSessionRejectedStreams option with a default of 100.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30534
     description: Added maxSessionInvalidFrames option with a default of 1000.
   - version: v13.0.0
     pr-url: https://github.com/nodejs/node/pull/29144
@@ -2007,6 +2010,12 @@ changes:
   * `maxSessionInvalidFrames` {integer} Sets the maximum number of invalid
     frames that will be tolerated before the session is closed.
     **Default:** `1000`.
+  * `maxSessionRejectedStreams` {integer} Sets the maximum number of rejected
+    upon creation streams that will be tolerated before the session is closed.
+    Each rejection is associated with an `NGHTTP2_ENHANCE_YOUR_CALM`
+    error that should tell the peer to not open any more streams, continuing
+    to open streams is therefore regarded as a sign of a misbehaving peer.
+    **Default:** `100`.
   * `settings` {HTTP/2 Settings Object} The initial settings to send to the
     remote peer upon connection.
   * `Http1IncomingMessage` {http.IncomingMessage} Specifies the
@@ -2059,6 +2068,9 @@ server.listen(80);
 <!-- YAML
 added: v8.4.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30534
+    description: Added maxSessionRejectedStreams option with a default of 100.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30534
     description: Added maxSessionInvalidFrames option with a default of 1000.
@@ -2125,6 +2137,12 @@ changes:
   * `maxSessionInvalidFrames` {integer} Sets the maximum number of invalid
     frames that will be tolerated before the session is closed.
     **Default:** `1000`.
+  * `maxSessionRejectedStreams` {integer} Sets the maximum number of rejected
+    upon creation streams that will be tolerated before the session is closed.
+    Each rejection is associated with an `NGHTTP2_ENHANCE_YOUR_CALM`
+    error that should tell the peer to not open any more streams, continuing
+    to open streams is therefore regarded as a sign of a misbehaving peer.
+    **Default:** `100`.
   * `settings` {HTTP/2 Settings Object} The initial settings to send to the
     remote peer upon connection.
   * ...: Any [`tls.createServer()`][] options can be provided. For

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -81,7 +81,11 @@ const {
   },
   hideStackFrames
 } = require('internal/errors');
-const { validateNumber, validateString } = require('internal/validators');
+const { validateNumber,
+        validateString,
+        validateUint32,
+        isUint32,
+} = require('internal/validators');
 const fsPromisesInternal = require('internal/fs/promises');
 const { utcDate } = require('internal/http');
 const { onServerStream,
@@ -199,6 +203,7 @@ const {
   kBitfield,
   kSessionPriorityListenerCount,
   kSessionFrameErrorListenerCount,
+  kSessionMaxInvalidFrames,
   kSessionUint8FieldCount,
   kSessionHasRemoteSettingsListeners,
   kSessionRemoteSettingsIsUpToDate,
@@ -935,6 +940,12 @@ function setupHandle(socket, type, options) {
     // encrypted socket.
     this[kAlpnProtocol] = 'h2c';
     this[kEncrypted] = false;
+  }
+
+  if (isUint32(options.maxSessionInvalidFrames)) {
+    const uint32 = new Uint32Array(
+      this[kNativeFields].buffer, kSessionMaxInvalidFrames, 1);
+    uint32[0] = options.maxSessionInvalidFrames;
   }
 
   const settings = typeof options.settings === 'object' ?
@@ -2767,6 +2778,9 @@ function initializeOptions(options) {
   options = { ...options };
   assertIsObject(options.settings, 'options.settings');
   options.settings = { ...options.settings };
+
+  if (options.maxSessionInvalidFrames !== undefined)
+    validateUint32(options.maxSessionInvalidFrames, 'maxSessionInvalidFrames');
 
   // Used only with allowHTTP1
   options.Http1IncomingMessage = options.Http1IncomingMessage ||

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -204,6 +204,7 @@ const {
   kSessionPriorityListenerCount,
   kSessionFrameErrorListenerCount,
   kSessionMaxInvalidFrames,
+  kSessionMaxRejectedStreams,
   kSessionUint8FieldCount,
   kSessionHasRemoteSettingsListeners,
   kSessionRemoteSettingsIsUpToDate,
@@ -946,6 +947,12 @@ function setupHandle(socket, type, options) {
     const uint32 = new Uint32Array(
       this[kNativeFields].buffer, kSessionMaxInvalidFrames, 1);
     uint32[0] = options.maxSessionInvalidFrames;
+  }
+
+  if (isUint32(options.maxSessionRejectedStreams)) {
+    const uint32 = new Uint32Array(
+      this[kNativeFields].buffer, kSessionMaxRejectedStreams, 1);
+    uint32[0] = options.maxSessionRejectedStreams;
   }
 
   const settings = typeof options.settings === 'object' ?
@@ -2781,6 +2788,13 @@ function initializeOptions(options) {
 
   if (options.maxSessionInvalidFrames !== undefined)
     validateUint32(options.maxSessionInvalidFrames, 'maxSessionInvalidFrames');
+
+  if (options.maxSessionRejectedStreams !== undefined) {
+    validateUint32(
+      options.maxSessionRejectedStreams,
+      'maxSessionRejectedStreams'
+    );
+  }
 
   // Used only with allowHTTP1
   options.Http1IncomingMessage = options.Http1IncomingMessage ||

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -647,7 +647,9 @@ Http2Session::Http2Session(Environment* env,
   {
     // Make the js_fields_ property accessible to JS land.
     Local<ArrayBuffer> ab =
-        ArrayBuffer::New(env->isolate(), js_fields_, kSessionUint8FieldCount);
+        ArrayBuffer::New(env->isolate(),
+                         reinterpret_cast<uint8_t*>(&js_fields_),
+                         kSessionUint8FieldCount);
     Local<Uint8Array> uint8_arr =
         Uint8Array::New(ab, 0, kSessionUint8FieldCount);
     USE(wrap->Set(env->context(), env->fields_string(), uint8_arr));
@@ -1046,7 +1048,7 @@ int Http2Session::OnFrameNotSent(nghttp2_session* handle,
   if (error_code == NGHTTP2_ERR_SESSION_CLOSING ||
       error_code == NGHTTP2_ERR_STREAM_CLOSED ||
       error_code == NGHTTP2_ERR_STREAM_CLOSING ||
-      session->js_fields_[kSessionFrameErrorListenerCount] == 0) {
+      session->js_fields_.frame_error_listener_count == 0) {
     return 0;
   }
 
@@ -1349,7 +1351,7 @@ void Http2Session::HandleHeadersFrame(const nghttp2_frame* frame) {
 // are considered advisory only, so this has no real effect other than to
 // simply let user code know that the priority has changed.
 void Http2Session::HandlePriorityFrame(const nghttp2_frame* frame) {
-  if (js_fields_[kSessionPriorityListenerCount] == 0) return;
+  if (js_fields_.priority_listener_count == 0) return;
   Isolate* isolate = env()->isolate();
   HandleScope scope(isolate);
   Local<Context> context = env()->context();
@@ -1418,7 +1420,7 @@ void Http2Session::HandleGoawayFrame(const nghttp2_frame* frame) {
 
 // Called by OnFrameReceived when a complete ALTSVC frame has been received.
 void Http2Session::HandleAltSvcFrame(const nghttp2_frame* frame) {
-  if (!(js_fields_[kBitfield] & (1 << kSessionHasAltsvcListeners))) return;
+  if (!(js_fields_.bitfield & (1 << kSessionHasAltsvcListeners))) return;
   Isolate* isolate = env()->isolate();
   HandleScope scope(isolate);
   Local<Context> context = env()->context();
@@ -1497,7 +1499,7 @@ void Http2Session::HandlePingFrame(const nghttp2_frame* frame) {
     return;
   }
 
-  if (!(js_fields_[kBitfield] & (1 << kSessionHasPingListeners))) return;
+  if (!(js_fields_.bitfield & (1 << kSessionHasPingListeners))) return;
   // Notify the session that a ping occurred
   arg = Buffer::Copy(env(),
                       reinterpret_cast<const char*>(frame->ping.opaque_data),
@@ -1509,8 +1511,8 @@ void Http2Session::HandlePingFrame(const nghttp2_frame* frame) {
 void Http2Session::HandleSettingsFrame(const nghttp2_frame* frame) {
   bool ack = frame->hd.flags & NGHTTP2_FLAG_ACK;
   if (!ack) {
-    js_fields_[kBitfield] &= ~(1 << kSessionRemoteSettingsIsUpToDate);
-    if (!(js_fields_[kBitfield] & (1 << kSessionHasRemoteSettingsListeners)))
+    js_fields_.bitfield &= ~(1 << kSessionRemoteSettingsIsUpToDate);
+    if (!(js_fields_.bitfield & (1 << kSessionHasRemoteSettingsListeners)))
       return;
     // This is not a SETTINGS acknowledgement, notify and return
     MakeCallback(env()->http2session_on_settings_function(), 0, nullptr);

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -920,7 +920,8 @@ int Http2Session::OnBeginHeadersCallback(nghttp2_session* handle,
     if (UNLIKELY(!session->CanAddStream() ||
                  Http2Stream::New(session, id, frame->headers.cat) ==
                      nullptr)) {
-      if (session->rejected_stream_count_++ > 100)
+      if (session->rejected_stream_count_++ >
+          session->js_fields_.max_rejected_streams)
         return NGHTTP2_ERR_CALLBACK_FAILURE;
       // Too many concurrent streams being opened
       nghttp2_submit_rst_stream(**session, NGHTTP2_FLAG_NONE, id,
@@ -3062,6 +3063,7 @@ void Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(target, kSessionPriorityListenerCount);
   NODE_DEFINE_CONSTANT(target, kSessionFrameErrorListenerCount);
   NODE_DEFINE_CONSTANT(target, kSessionMaxInvalidFrames);
+  NODE_DEFINE_CONSTANT(target, kSessionMaxRejectedStreams);
   NODE_DEFINE_CONSTANT(target, kSessionUint8FieldCount);
 
   NODE_DEFINE_CONSTANT(target, kSessionHasRemoteSettingsListeners);

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1011,8 +1011,12 @@ int Http2Session::OnInvalidFrame(nghttp2_session* handle,
                                  void* user_data) {
   Http2Session* session = static_cast<Http2Session*>(user_data);
 
-  Debug(session, "invalid frame received, code: %d", lib_error_code);
-  if (session->invalid_frame_count_++ > 1000)
+  Debug(session,
+        "invalid frame received (%u/%u), code: %d",
+        session->invalid_frame_count_,
+        session->js_fields_.max_invalid_frames,
+        lib_error_code);
+  if (session->invalid_frame_count_++ > session->js_fields_.max_invalid_frames)
     return 1;
 
   // If the error is fatal or if error code is ERR_STREAM_CLOSED... emit error
@@ -3057,6 +3061,7 @@ void Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(target, kBitfield);
   NODE_DEFINE_CONSTANT(target, kSessionPriorityListenerCount);
   NODE_DEFINE_CONSTANT(target, kSessionFrameErrorListenerCount);
+  NODE_DEFINE_CONSTANT(target, kSessionMaxInvalidFrames);
   NODE_DEFINE_CONSTANT(target, kSessionUint8FieldCount);
 
   NODE_DEFINE_CONSTANT(target, kSessionHasRemoteSettingsListeners);

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -678,6 +678,7 @@ typedef struct {
   uint8_t priority_listener_count;
   uint8_t frame_error_listener_count;
   uint32_t max_invalid_frames = 1000;
+  uint32_t max_rejected_streams = 100;
 } SessionJSFields;
 
 // Indices for js_fields_, which serves as a way to communicate data with JS
@@ -691,6 +692,7 @@ enum SessionUint8Fields {
   kSessionFrameErrorListenerCount =
       offsetof(SessionJSFields, frame_error_listener_count),
   kSessionMaxInvalidFrames = offsetof(SessionJSFields, max_invalid_frames),
+  kSessionMaxRejectedStreams = offsetof(SessionJSFields, max_rejected_streams),
   kSessionUint8FieldCount = sizeof(SessionJSFields)
 };
 
@@ -1024,7 +1026,7 @@ class Http2Session : public AsyncWrap, public StreamListener {
   // limit will result in the session being destroyed, as an indication of a
   // misbehaving peer. This counter is reset once new streams are being
   // accepted again.
-  int32_t rejected_stream_count_ = 0;
+  uint32_t rejected_stream_count_ = 0;
   // Also use the invalid frame count as a measure for rejecting input frames.
   uint32_t invalid_frame_count_ = 0;
 

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -673,15 +673,23 @@ class Http2Stream::Provider::Stream : public Http2Stream::Provider {
                         void* user_data);
 };
 
+typedef struct {
+  uint8_t bitfield;
+  uint8_t priority_listener_count;
+  uint8_t frame_error_listener_count;
+} SessionJSFields;
+
 // Indices for js_fields_, which serves as a way to communicate data with JS
 // land fast. In particular, we store information about the number/presence
 // of certain event listeners in JS, and skip calls from C++ into JS if they
 // are missing.
 enum SessionUint8Fields {
-  kBitfield,  // See below
-  kSessionPriorityListenerCount,
-  kSessionFrameErrorListenerCount,
-  kSessionUint8FieldCount
+  kBitfield = offsetof(SessionJSFields, bitfield),  // See below
+  kSessionPriorityListenerCount =
+      offsetof(SessionJSFields, priority_listener_count),
+  kSessionFrameErrorListenerCount =
+      offsetof(SessionJSFields, frame_error_listener_count),
+  kSessionUint8FieldCount = sizeof(SessionJSFields)
 };
 
 enum SessionBitfieldFlags {
@@ -968,7 +976,7 @@ class Http2Session : public AsyncWrap, public StreamListener {
   nghttp2_session* session_;
 
   // JS-accessible numeric fields, as indexed by SessionUint8Fields.
-  uint8_t js_fields_[kSessionUint8FieldCount] = {};
+  SessionJSFields js_fields_ = {};
 
   // The session type: client or server
   nghttp2_session_type session_type_;

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -677,6 +677,7 @@ typedef struct {
   uint8_t bitfield;
   uint8_t priority_listener_count;
   uint8_t frame_error_listener_count;
+  uint32_t max_invalid_frames = 1000;
 } SessionJSFields;
 
 // Indices for js_fields_, which serves as a way to communicate data with JS
@@ -689,6 +690,7 @@ enum SessionUint8Fields {
       offsetof(SessionJSFields, priority_listener_count),
   kSessionFrameErrorListenerCount =
       offsetof(SessionJSFields, frame_error_listener_count),
+  kSessionMaxInvalidFrames = offsetof(SessionJSFields, max_invalid_frames),
   kSessionUint8FieldCount = sizeof(SessionJSFields)
 };
 
@@ -1024,7 +1026,7 @@ class Http2Session : public AsyncWrap, public StreamListener {
   // accepted again.
   int32_t rejected_stream_count_ = 0;
   // Also use the invalid frame count as a measure for rejecting input frames.
-  int32_t invalid_frame_count_ = 0;
+  uint32_t invalid_frame_count_ = 0;
 
   void PushOutgoingBuffer(nghttp2_stream_write&& write);
   void CopyDataIntoOutgoing(const uint8_t* src, size_t src_length);

--- a/test/parallel/test-http2-createsecureserver-options.js
+++ b/test/parallel/test-http2-createsecureserver-options.js
@@ -7,7 +7,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const http2 = require('http2');
 
-// Error if invalid options are passed to createSecureServer
+// Error if invalid options are passed to createSecureServer.
 const invalidOptions = [() => {}, 1, 'test', null, Symbol('test')];
 invalidOptions.forEach((invalidOption) => {
   assert.throws(
@@ -21,7 +21,7 @@ invalidOptions.forEach((invalidOption) => {
   );
 });
 
-// Error if invalid options.settings are passed to createSecureServer
+// Error if invalid options.settings are passed to createSecureServer.
 invalidOptions.forEach((invalidSettingsOption) => {
   assert.throws(
     () => http2.createSecureServer({ settings: invalidSettingsOption }),
@@ -32,4 +32,31 @@ invalidOptions.forEach((invalidSettingsOption) => {
                `Received type ${typeof invalidSettingsOption}`
     }
   );
+});
+
+// Test that http2.createSecureServer validates input options.
+Object.entries({
+  maxSessionInvalidFrames: [
+    {
+      val: -1,
+      err: {
+        name: 'RangeError',
+        code: 'ERR_OUT_OF_RANGE',
+      },
+    },
+    {
+      val: Number.NEGATIVE_INFINITY,
+      err: {
+        name: 'RangeError',
+        code: 'ERR_OUT_OF_RANGE',
+      },
+    },
+  ],
+}).forEach(([opt, tests]) => {
+  tests.forEach(({ val, err }) => {
+    assert.throws(
+      () => http2.createSecureServer({ [opt]: val }),
+      err
+    );
+  });
 });

--- a/test/parallel/test-http2-createsecureserver-options.js
+++ b/test/parallel/test-http2-createsecureserver-options.js
@@ -52,6 +52,22 @@ Object.entries({
       },
     },
   ],
+  maxSessionRejectedStreams: [
+    {
+      val: -1,
+      err: {
+        name: 'RangeError',
+        code: 'ERR_OUT_OF_RANGE',
+      },
+    },
+    {
+      val: Number.NEGATIVE_INFINITY,
+      err: {
+        name: 'RangeError',
+        code: 'ERR_OUT_OF_RANGE',
+      },
+    },
+  ],
 }).forEach(([opt, tests]) => {
   tests.forEach(({ val, err }) => {
     assert.throws(

--- a/test/parallel/test-http2-createserver-options.js
+++ b/test/parallel/test-http2-createserver-options.js
@@ -52,6 +52,22 @@ Object.entries({
       },
     },
   ],
+  maxSessionRejectedStreams: [
+    {
+      val: -1,
+      err: {
+        name: 'RangeError',
+        code: 'ERR_OUT_OF_RANGE',
+      },
+    },
+    {
+      val: Number.NEGATIVE_INFINITY,
+      err: {
+        name: 'RangeError',
+        code: 'ERR_OUT_OF_RANGE',
+      },
+    },
+  ]
 }).forEach(([opt, tests]) => {
   tests.forEach(({ val, err }) => {
     assert.throws(

--- a/test/parallel/test-http2-createserver-options.js
+++ b/test/parallel/test-http2-createserver-options.js
@@ -7,7 +7,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const http2 = require('http2');
 
-// Error if invalid options are passed to createServer
+// Error if invalid options are passed to createServer.
 const invalidOptions = [1, true, 'test', null, Symbol('test')];
 invalidOptions.forEach((invalidOption) => {
   assert.throws(
@@ -21,7 +21,7 @@ invalidOptions.forEach((invalidOption) => {
   );
 });
 
-// Error if invalid options.settings are passed to createServer
+// Error if invalid options.settings are passed to createServer.
 invalidOptions.forEach((invalidSettingsOption) => {
   assert.throws(
     () => http2.createServer({ settings: invalidSettingsOption }),
@@ -32,4 +32,31 @@ invalidOptions.forEach((invalidSettingsOption) => {
                `Received type ${typeof invalidSettingsOption}`
     }
   );
+});
+
+// Test that http2.createServer validates input options.
+Object.entries({
+  maxSessionInvalidFrames: [
+    {
+      val: -1,
+      err: {
+        name: 'RangeError',
+        code: 'ERR_OUT_OF_RANGE',
+      },
+    },
+    {
+      val: Number.NEGATIVE_INFINITY,
+      err: {
+        name: 'RangeError',
+        code: 'ERR_OUT_OF_RANGE',
+      },
+    },
+  ],
+}).forEach(([opt, tests]) => {
+  tests.forEach(({ val, err }) => {
+    assert.throws(
+      () => http2.createServer({ [opt]: val }),
+      err
+    );
+  });
 });

--- a/test/parallel/test-http2-max-invalid-frames.js
+++ b/test/parallel/test-http2-max-invalid-frames.js
@@ -1,0 +1,86 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const http2 = require('http2');
+const net = require('net');
+
+// Verify that creating a number of invalid HTTP/2 streams will
+// result in the peer closing the session within maxSessionInvalidFrames
+// frames.
+
+const maxSessionInvalidFrames = 100;
+const server = http2.createServer({ maxSessionInvalidFrames });
+server.on('stream', (stream) => {
+  stream.respond({
+    'content-type': 'text/plain',
+    ':status': 200
+  });
+  stream.end('Hello, world!\n');
+});
+
+server.listen(0, () => {
+  const h2header = Buffer.alloc(9);
+  const conn = net.connect(server.address().port);
+
+  conn.write('PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n');
+
+  h2header[3] = 4;  // Send a settings frame.
+  conn.write(Buffer.from(h2header));
+
+  let inbuf = Buffer.alloc(0);
+  let state = 'settingsHeader';
+  let settingsFrameLength;
+  conn.on('data', (chunk) => {
+    inbuf = Buffer.concat([inbuf, chunk]);
+    switch (state) {
+      case 'settingsHeader':
+        if (inbuf.length < 9) return;
+        settingsFrameLength = inbuf.readIntBE(0, 3);
+        inbuf = inbuf.slice(9);
+        state = 'readingSettings';
+        // Fallthrough
+      case 'readingSettings':
+        if (inbuf.length < settingsFrameLength) return;
+        inbuf = inbuf.slice(settingsFrameLength);
+        h2header[3] = 4;  // Send a settings ACK.
+        h2header[4] = 1;
+        conn.write(Buffer.from(h2header));
+        state = 'ignoreInput';
+        writeRequests();
+    }
+  });
+
+  let gotError = false;
+  let streamId = 1;
+  let reqCount = 0;
+
+  function writeRequests() {
+    for (let i = 1; i < 10 && !gotError; i++) {
+      h2header[3] = 1;  // HEADERS
+      h2header[4] = 0x5;  // END_HEADERS|END_STREAM
+      h2header.writeIntBE(1, 0, 3);  // Length: 1
+      h2header.writeIntBE(streamId, 5, 4);  // Stream ID
+      streamId += 2;
+      // 0x88 = :status: 200
+      if (!conn.write(Buffer.concat([h2header, Buffer.from([0x88])]))) {
+        break;
+      }
+      reqCount++;
+    }
+    // Timeout requests to slow down the rate so we get more accurate reqCount.
+    if (!gotError)
+      setTimeout(writeRequests, 10);
+  }
+
+  conn.once('error', common.mustCall(() => {
+    gotError = true;
+    assert.ok(Math.abs(reqCount - maxSessionInvalidFrames) < 100,
+              `Request count (${reqCount}) must be around (±100)` +
+      ` maxSessionInvalidFrames option (${maxSessionInvalidFrames})`);
+    conn.destroy();
+    server.close();
+  }));
+});

--- a/test/parallel/test-http2-reset-flood.js
+++ b/test/parallel/test-http2-reset-flood.js
@@ -13,7 +13,7 @@ const { Worker, parentPort } = require('worker_threads');
 // the two event loops intermixing, as we are writing in a busy loop here.
 
 if (process.env.HAS_STARTED_WORKER) {
-  const server = http2.createServer();
+  const server = http2.createServer({ maxSessionInvalidFrames: 100 });
   server.on('stream', (stream) => {
     stream.respond({
       'content-type': 'text/plain',
@@ -59,19 +59,22 @@ const worker = new Worker(__filename).on('message', common.mustCall((port) => {
   });
 
   let gotError = false;
+  let streamId = 1;
 
   function writeRequests() {
-    for (let i = 1; !gotError; i += 2) {
+    for (let i = 1; i < 10 && !gotError; i++) {
       h2header[3] = 1;  // HEADERS
       h2header[4] = 0x5;  // END_HEADERS|END_STREAM
       h2header.writeIntBE(1, 0, 3);  // Length: 1
-      h2header.writeIntBE(i, 5, 4);  // Stream ID
+      h2header.writeIntBE(streamId, 5, 4);  // Stream ID
+      streamId += 2;
       // 0x88 = :status: 200
       if (!conn.write(Buffer.concat([h2header, Buffer.from([0x88])]))) {
-        process.nextTick(writeRequests);
         break;
       }
     }
+    if (!gotError)
+      setImmediate(writeRequests);
   }
 
   conn.once('error', common.mustCall(() => {


### PR DESCRIPTION
**http2: replace direct array usage with struct for js_fields_**

**http2: allow to configure maximum tolerated invalid frames**

**test: update and harden http2-reset-flood**
* use new maxSessionInvalidFrames to lower the needed frames
* slow down requests to generate less redundant after-session-close
  requests

**http2: make maximum tolerated rejected streams configurable**
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Closes: https://github.com/nodejs/node/issues/30505
This should also decrease the flakiness of `test-http2-reset-flood`.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Also, do we have a dedicated test for argument validation of `createServer`? I'm not sure where to put them.

/cc @nodejs/http2 