### PR TITLE
test: add tests for invalid symlink

### DIFF
--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -53,3 +53,21 @@ fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
     }));
   }));
 }));
+
+// Test invalid symlink
+// TODO: Fix Windows
+if (process.platform !== 'win32') {
+  const linkData = fixtures.path('/not/exists/dir');
+  const linkPath = path.join(tmpdir.path, 'invalid_junction_link');
+
+  fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
+    assert.ifError(err);
+
+    assert(!fs.existsSync(linkPath));
+
+    fs.unlink(linkPath, common.mustCall(function(err) {
+      assert.ifError(err);
+      assert(!fs.existsSync(linkPath));
+    }));
+  }));
+}

--- a/test/parallel/test-fs-symlink-dir.js
+++ b/test/parallel/test-fs-symlink-dir.js
@@ -44,3 +44,26 @@ for (const linkTarget of linkTargets) {
     testAsync(linkTarget, `${linkPath}-${path.basename(linkTarget)}-async`);
   }
 }
+
+// Test invalid symlink
+// TODO: Fix Windows
+if (process.platform !== 'win32') {
+  function testSync(target, path) {
+    fs.symlinkSync(target, path);
+    assert(!fs.existsSync(path));
+  }
+
+  function testAsync(target, path) {
+    fs.symlink(target, path, common.mustCall((err) => {
+      assert.ifError(err);
+      assert(!fs.existsSync(path));
+    }));
+  }
+
+  for (const linkTarget of linkTargets.map((p) => p + '-broken')) {
+    for (const linkPath of linkPaths) {
+      testSync(linkTarget, `${linkPath}-${path.basename(linkTarget)}-sync`);
+      testAsync(linkTarget, `${linkPath}-${path.basename(linkTarget)}-async`);
+    }
+  }
+}

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -58,6 +58,19 @@ fs.symlink(linkData, linkPath, common.mustCall(function(err) {
   }));
 }));
 
+// Test invalid symlink
+// TODO: Fix Windows
+if (process.platform !== 'win32') {
+  const invalidLinkData = fixtures.path('/not/exists/file');
+  const invalidLinkPath = path.join(tmpdir.path, 'symlink2.js');
+
+  fs.symlink(invalidLinkData, invalidLinkPath, common.mustCall(function(err) {
+    assert.ifError(err);
+
+    assert(!fs.existsSync(invalidLinkPath));
+  }));
+}
+
 [false, 1, {}, [], null, undefined].forEach((input) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

If the symlink is invalid (target file or dir not exists), calling `fs.existsSync()` should return `false`.

There are some issues at Windows currently(#30538), so `win32` platform is excluded temporarily. This condition could be removed after the issue fixed.

Seems this behavior is not mentioned explicitly in [the documentation](https://nodejs.org/api/fs.html#fs_fs_existssync_path). If it is not as expected please correct me