### PR TITLE
src: use BaseObjectPtr to store SNI context

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2991,9 +2991,15 @@ void SSLWrap<Base>::CertCbDone(const FunctionCallbackInfo<Value>& args) {
     goto fire_cb;
 
   if (cons->HasInstance(ctx)) {
-    SecureContext* sc;
-    ASSIGN_OR_RETURN_UNWRAP(&sc, ctx.As<Object>());
-    w->sni_context_.Reset(env->isolate(), ctx);
+    SecureContext* sc = Unwrap<SecureContext>(ctx.As<Object>());
+    CHECK_NOT_NULL(sc);
+    // XXX: There is a method w->SetSNIContext(sc), and you might think that
+    // it makes sense to call that here and make setting w->sni_context_ part
+    // of it. In fact, that passes the test suite, although SetSNIContext()
+    // performs a lot more operations.
+    // If anybody is familiar enough with the TLS code to know whether it makes
+    // sense, please do so or document why it doesn't.
+    w->sni_context_ = BaseObjectPtr<SecureContext>(sc);
 
     int rv;
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -144,6 +144,7 @@ template void SSLWrap<TLSWrap>::AddMethods(Environment* env,
 template void SSLWrap<TLSWrap>::ConfigureSecureContext(SecureContext* sc);
 template void SSLWrap<TLSWrap>::SetSNIContext(SecureContext* sc);
 template int SSLWrap<TLSWrap>::SetCACerts(SecureContext* sc);
+template void SSLWrap<TLSWrap>::MemoryInfo(MemoryTracker* tracker) const;
 template SSL_SESSION* SSLWrap<TLSWrap>::GetSessionCallback(
     SSL* s,
     const unsigned char* key,
@@ -3072,6 +3073,12 @@ int SSLWrap<Base>::SetCACerts(SecureContext* sc) {
   // NOTE: `SSL_set_client_CA_list` takes the ownership of `list`
   SSL_set_client_CA_list(ssl_.get(), list);
   return 1;
+}
+
+template <class Base>
+void SSLWrap<Base>::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackField("ocsp_response", ocsp_response_);
+  tracker->TrackField("sni_context", sni_context_);
 }
 
 int VerifyCallback(int preverify_ok, X509_STORE_CTX* ctx) {

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -288,7 +288,6 @@ class SSLWrap {
 
   void DestroySSL();
   void WaitForCertCb(CertCb cb, void* arg);
-  void SetSNIContext(SecureContext* sc);
   int SetCACerts(SecureContext* sc);
 
   inline Environment* ssl_env() const {

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -222,6 +222,8 @@ class SSLWrap {
   inline bool is_awaiting_new_session() const { return awaiting_new_session_; }
   inline bool is_waiting_cert_cb() const { return cert_cb_ != nullptr; }
 
+  void MemoryInfo(MemoryTracker* tracker) const;
+
  protected:
   typedef void (*CertCb)(void* arg);
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -310,7 +310,7 @@ class SSLWrap {
   ClientHelloParser hello_parser_;
 
   v8::Global<v8::ArrayBufferView> ocsp_response_;
-  v8::Global<v8::Value> sni_context_;
+  BaseObjectPtr<SecureContext> sni_context_;
 
   friend class SecureContext;
 };

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -1065,10 +1065,9 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
     return SSL_TLSEXT_ERR_NOACK;
   }
 
-  p->sni_context_.Reset(env->isolate(), ctx);
-
   SecureContext* sc = Unwrap<SecureContext>(ctx.As<Object>());
   CHECK_NOT_NULL(sc);
+  p->sni_context_ = BaseObjectPtr<SecureContext>(sc);
   p->SetSNIContext(sc);
   return SSL_TLSEXT_ERR_OK;
 }

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -1068,7 +1068,11 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
   SecureContext* sc = Unwrap<SecureContext>(ctx.As<Object>());
   CHECK_NOT_NULL(sc);
   p->sni_context_ = BaseObjectPtr<SecureContext>(sc);
-  p->SetSNIContext(sc);
+
+  p->ConfigureSecureContext(sc);
+  CHECK_EQ(SSL_set_SSL_CTX(p->ssl_.get(), sc->ctx_.get()), sc->ctx_.get());
+  p->SetCACerts(sc);
+
   return SSL_TLSEXT_ERR_OK;
 }
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -1089,6 +1089,7 @@ void TLSWrap::GetWriteQueueSize(const FunctionCallbackInfo<Value>& info) {
 
 
 void TLSWrap::MemoryInfo(MemoryTracker* tracker) const {
+  SSLWrap<TLSWrap>::MemoryInfo(tracker);
   tracker->TrackField("error", error_);
   tracker->TrackFieldWithSize("pending_cleartext_input",
                               pending_cleartext_input_.size(),


### PR DESCRIPTION
Rather than relying on a link to the JS object, store a pointer to
the C++ object directly.

(Also, add memory tracking that was previously missing.)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
