### PR TITLE
buffer,n-api: properly handle Environment cleanup

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -53,6 +53,7 @@ using v8::Context;
 using v8::EscapableHandleScope;
 using v8::FunctionCallbackInfo;
 using v8::Global;
+using v8::HandleScope;
 using v8::Int32;
 using v8::Integer;
 using v8::Isolate;
@@ -73,8 +74,10 @@ namespace {
 
 class CallbackInfo {
  public:
+  ~CallbackInfo();
+
   static inline void Free(char* data, void* hint);
-  static inline CallbackInfo* New(Isolate* isolate,
+  static inline CallbackInfo* New(Environment* env,
                                   Local<ArrayBuffer> object,
                                   FreeCallback callback,
                                   char* data,
@@ -84,9 +87,10 @@ class CallbackInfo {
   CallbackInfo& operator=(const CallbackInfo&) = delete;
 
  private:
+  static void CleanupHook(void* data);
   static void WeakCallback(const WeakCallbackInfo<CallbackInfo>&);
   inline void WeakCallback(Isolate* isolate);
-  inline CallbackInfo(Isolate* isolate,
+  inline CallbackInfo(Environment* env,
                       Local<ArrayBuffer> object,
                       FreeCallback callback,
                       char* data,
@@ -95,6 +99,7 @@ class CallbackInfo {
   FreeCallback const callback_;
   char* const data_;
   void* const hint_;
+  Environment* const env_;
 };
 
 
@@ -103,31 +108,53 @@ void CallbackInfo::Free(char* data, void*) {
 }
 
 
-CallbackInfo* CallbackInfo::New(Isolate* isolate,
+CallbackInfo* CallbackInfo::New(Environment* env,
                                 Local<ArrayBuffer> object,
                                 FreeCallback callback,
                                 char* data,
                                 void* hint) {
-  return new CallbackInfo(isolate, object, callback, data, hint);
+  return new CallbackInfo(env, object, callback, data, hint);
 }
 
 
-CallbackInfo::CallbackInfo(Isolate* isolate,
+CallbackInfo::CallbackInfo(Environment* env,
                            Local<ArrayBuffer> object,
                            FreeCallback callback,
                            char* data,
                            void* hint)
-    : persistent_(isolate, object),
+    : persistent_(env->isolate(), object),
       callback_(callback),
       data_(data),
-      hint_(hint) {
+      hint_(hint),
+      env_(env) {
   ArrayBuffer::Contents obj_c = object->GetContents();
   CHECK_EQ(data_, static_cast<char*>(obj_c.Data()));
   if (object->ByteLength() != 0)
     CHECK_NOT_NULL(data_);
 
   persistent_.SetWeak(this, WeakCallback, v8::WeakCallbackType::kParameter);
-  isolate->AdjustAmountOfExternalAllocatedMemory(sizeof(*this));
+  env->AddCleanupHook(CleanupHook, this);
+  env->isolate()->AdjustAmountOfExternalAllocatedMemory(sizeof(*this));
+}
+
+
+CallbackInfo::~CallbackInfo() {
+  persistent_.Reset();
+  env_->RemoveCleanupHook(CleanupHook, this);
+}
+
+
+void CallbackInfo::CleanupHook(void* data) {
+  CallbackInfo* self = static_cast<CallbackInfo*>(data);
+
+  {
+    HandleScope handle_scope(self->env_->isolate());
+    Local<ArrayBuffer> ab = self->persistent_.Get(self->env_->isolate());
+    CHECK(!ab.IsEmpty());
+    ab->Detach();
+  }
+
+  self->WeakCallback(self->env_->isolate());
 }
 
 
@@ -388,7 +415,7 @@ MaybeLocal<Object> New(Environment* env,
   }
   MaybeLocal<Uint8Array> ui = Buffer::New(env, ab, 0, length);
 
-  CallbackInfo::New(env->isolate(), ab, callback, data, hint);
+  CallbackInfo::New(env, ab, callback, data, hint);
 
   if (ui.IsEmpty())
     return MaybeLocal<Object>();

--- a/test/addons/worker-buffer-callback/binding.cc
+++ b/test/addons/worker-buffer-callback/binding.cc
@@ -3,17 +3,24 @@
 #include <v8.h>
 
 using v8::Context;
+using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
 using v8::Value;
 
+uint32_t free_call_count = 0;
 char data[] = "hello";
+
+void GetFreeCallCount(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(free_call_count);
+}
 
 void Initialize(Local<Object> exports,
                 Local<Value> module,
                 Local<Context> context) {
   Isolate* isolate = context->GetIsolate();
+  NODE_SET_METHOD(exports, "getFreeCallCount", GetFreeCallCount);
   exports->Set(context,
                v8::String::NewFromUtf8(
                    isolate, "buffer", v8::NewStringType::kNormal)
@@ -22,7 +29,9 @@ void Initialize(Local<Object> exports,
                    isolate,
                    data,
                    sizeof(data),
-                   [](char* data, void* hint) {},
+                   [](char* data, void* hint) {
+                     free_call_count++;
+                   },
                    nullptr).ToLocalChecked()).Check();
 }
 

--- a/test/addons/worker-buffer-callback/test-free-called.js
+++ b/test/addons/worker-buffer-callback/test-free-called.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../../common');
+const path = require('path');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
+const { getFreeCallCount } = require(binding);
+
+// Test that buffers allocated with a free callback through our APIs are
+// released when a Worker owning it exits.
+
+const w = new Worker(`require(${JSON.stringify(binding)})`, { eval: true });
+
+assert.strictEqual(getFreeCallCount(), 0);
+w.on('exit', common.mustCall(() => {
+  assert.strictEqual(getFreeCallCount(), 1);
+}));

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -1,3 +1,4 @@
+#include "node_buffer.h"
 #include "node_internals.h"
 #include "libplatform/libplatform.h"
 
@@ -207,4 +208,35 @@ TEST_F(EnvironmentTest, SetImmediateCleanup) {
 
   EXPECT_EQ(called, 1);
   EXPECT_EQ(called_unref, 0);
+}
+
+static char hello[] = "hello";
+
+TEST_F(EnvironmentTest, BufferWithFreeCallbackIsDetached) {
+  // Test that a Buffer allocated with a free callback is detached after
+  // its callback has been called.
+  const v8::HandleScope handle_scope(isolate_);
+  const Argv argv;
+
+  int callback_calls = 0;
+
+  v8::Local<v8::ArrayBuffer> ab;
+  {
+    Env env {handle_scope, argv};
+    v8::Local<v8::Object> buf_obj = node::Buffer::New(
+        isolate_,
+        hello,
+        sizeof(hello),
+        [](char* data, void* hint) {
+          CHECK_EQ(data, hello);
+          ++*static_cast<int*>(hint);
+        },
+        &callback_calls).ToLocalChecked();
+    CHECK(buf_obj->IsUint8Array());
+    ab = buf_obj.As<v8::Uint8Array>()->Buffer();
+    CHECK_EQ(ab->ByteLength(), sizeof(hello));
+  }
+
+  CHECK_EQ(callback_calls, 1);
+  CHECK_EQ(ab->ByteLength(), 0);
 }

--- a/test/node-api/test_worker_buffer_callback/binding.gyp
+++ b/test/node-api/test_worker_buffer_callback/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'test_worker_buffer_callback.c' ]
+    }
+  ]
+}

--- a/test/node-api/test_worker_buffer_callback/test-free-called.js
+++ b/test/node-api/test_worker_buffer_callback/test-free-called.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../../common');
+const path = require('path');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
+const { getFreeCallCount } = require(binding);
+
+// Test that buffers allocated with a free callback through our APIs are
+// released when a Worker owning it exits.
+
+const w = new Worker(`require(${JSON.stringify(binding)})`, { eval: true });
+
+assert.strictEqual(getFreeCallCount(), 0);
+w.on('exit', common.mustCall(() => {
+  assert.strictEqual(getFreeCallCount(), 1);
+}));

--- a/test/node-api/test_worker_buffer_callback/test.js
+++ b/test/node-api/test_worker_buffer_callback/test.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const { MessageChannel } = require('worker_threads');
+const { buffer } = require(`./build/${common.buildType}/binding`);
+
+// Test that buffers allocated with a free callback through our APIs are not
+// transferred.
+
+const { port1 } = new MessageChannel();
+const origByteLength = buffer.byteLength;
+port1.postMessage(buffer, [buffer]);
+
+assert.strictEqual(buffer.byteLength, origByteLength);
+assert.notStrictEqual(buffer.byteLength, 0);

--- a/test/node-api/test_worker_buffer_callback/test_worker_buffer_callback.c
+++ b/test/node-api/test_worker_buffer_callback/test_worker_buffer_callback.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <node_api.h>
+#include <assert.h>
+#include "../../js-native-api/common.h"
+
+uint32_t free_call_count = 0;
+char data[] = "hello";
+
+napi_value GetFreeCallCount(napi_env env, napi_callback_info info) {
+  napi_value value;
+  NAPI_CALL(env, napi_create_uint32(env, free_call_count, &value));
+  return value;
+}
+
+static void finalize_cb(napi_env env, void* finalize_data, void* hint) {
+  assert(finalize_data == data);
+  free_call_count++;
+}
+
+NAPI_MODULE_INIT() {
+  napi_property_descriptor properties[] = {
+    DECLARE_NAPI_PROPERTY("getFreeCallCount", GetFreeCallCount)
+  };
+
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  // This is a slight variation on the non-N-API test: We create an ArrayBuffer
+  // rather than a Node.js Buffer, since testing the latter would only test
+  // the same code paths and not the ones specific to N-API.
+  napi_value buffer;
+  NAPI_CALL(env, napi_create_external_arraybuffer(
+      env,
+      data,
+      sizeof(data),
+      finalize_cb,
+      NULL,
+      &buffer));
+
+  NAPI_CALL(env, napi_set_named_property(env, exports, "buffer", buffer));
+
+  return exports;
+}


### PR DESCRIPTION
##### buffer: release buffers with free callbacks on env exit

Invoke the free callback for a given `Buffer` if it was created
with one, and mark the underlying `ArrayBuffer` as detached.

This makes sure that the memory is released e.g. when addons inside
Workers create such `Buffer`s.

##### n-api: detach external ArrayBuffers on env exit

Make sure that `ArrayBuffer`s created using
`napi_create_external_arraybuffer` are rendered unusable
after its memory has been released.

##### test: port worker + buffer test to N-API

This ports `test/addons/worker-buffer-callback` to N-API,
with the small exception of using external `ArrayBuffer`s rather
than external Node.js `Buffer`s.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
