### PR TITLE
fs: fix existsSync for invalid symlink at win32

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -228,7 +228,16 @@ function existsSync(path) {
     return false;
   }
   const ctx = { path };
-  binding.access(pathModule.toNamespacedPath(path), F_OK, undefined, ctx);
+  const nPath = pathModule.toNamespacedPath(path);
+  binding.access(nPath, F_OK, undefined, ctx);
+
+  // If it is an invalid symlink, existsSync should return false
+  // binding.access checking is not enough for win32 (return true in this case)
+  // So we need to call binding.stat for double checking
+  if (isWindows && ctx.errno === undefined) {
+    binding.stat(nPath, false, undefined, ctx);
+  }
+
   return ctx.errno === undefined;
 }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -231,9 +231,9 @@ function existsSync(path) {
   const nPath = pathModule.toNamespacedPath(path);
   binding.access(nPath, F_OK, undefined, ctx);
 
-  // If it is an invalid symlink, existsSync should return false
-  // binding.access checking is not enough for win32 (return true in this case)
-  // So we need to call binding.stat for double checking
+  // In case of an invalid symlink, `binding.access()` on win32
+  // will **not** return an error and is therefore not enough.
+  // Double check with `binding.stat()`.
   if (isWindows && ctx.errno === undefined) {
     binding.stat(nPath, false, undefined, ctx);
   }

--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -53,3 +53,20 @@ fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
     }));
   }));
 }));
+
+// Test invalid symlink
+{
+  const linkData = fixtures.path('/not/exists/dir');
+  const linkPath = path.join(tmpdir.path, 'invalid_junction_link');
+
+  fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
+    assert.ifError(err);
+
+    assert(!fs.existsSync(linkPath));
+
+    fs.unlink(linkPath, common.mustCall(function(err) {
+      assert.ifError(err);
+      assert(!fs.existsSync(linkPath));
+    }));
+  }));
+}

--- a/test/parallel/test-fs-symlink-dir.js
+++ b/test/parallel/test-fs-symlink-dir.js
@@ -44,3 +44,25 @@ for (const linkTarget of linkTargets) {
     testAsync(linkTarget, `${linkPath}-${path.basename(linkTarget)}-async`);
   }
 }
+
+// Test invalid symlink
+{
+  function testSync(target, path) {
+    fs.symlinkSync(target, path);
+    assert(!fs.existsSync(path));
+  }
+
+  function testAsync(target, path) {
+    fs.symlink(target, path, common.mustCall((err) => {
+      assert.ifError(err);
+      assert(!fs.existsSync(path));
+    }));
+  }
+
+  for (const linkTarget of linkTargets.map((p) => p + '-broken')) {
+    for (const linkPath of linkPaths) {
+      testSync(linkTarget, `${linkPath}-${path.basename(linkTarget)}-sync`);
+      testAsync(linkTarget, `${linkPath}-${path.basename(linkTarget)}-async`);
+    }
+  }
+}

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -58,6 +58,18 @@ fs.symlink(linkData, linkPath, common.mustCall(function(err) {
   }));
 }));
 
+// Test invalid symlink
+{
+  const linkData = fixtures.path('/not/exists/file');
+  const linkPath = path.join(tmpdir.path, 'symlink2.js');
+
+  fs.symlink(linkData, linkPath, common.mustCall(function(err) {
+    assert.ifError(err);
+
+    assert(!fs.existsSync(linkPath));
+  }));
+}
+
 [false, 1, {}, [], null, undefined].forEach((input) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/30538

### Background

https://github.com/nodejs/node/pull/18618 uses `access` instead of `stat` to implement `fs.existsSync`. Unfortunately, seems the two approaches both have some limitations at Windows:

|                         | Expected behavior of `existsSync` | `stat` | `access` |
| ----------------------- | ------------------------------------ | ------ | -------- |
| Invalid symlink         | `false`                              | ✅     |       |
| File without privileges | `true`                               |    | ✅       |

This PR adds a double check only at win32 platform to fix this issue.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
