### PR TITLE
doc: add missing 'added' versions to module.builtinModules

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -945,7 +945,10 @@ via `require('module')`.
 
 ### module.builtinModules
 <!-- YAML
-added: v9.3.0
+added:
+  - v9.3.0
+  - v8.10.0
+  - v6.13.0
 -->
 
 * {string[]}


### PR DESCRIPTION
This was backported later, but the documentation wasn't updated.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)