### PR TITLE
process: refs --unhandled-rejections documentation in warning message

### DIFF
--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -133,6 +133,9 @@ function emitUnhandledRejectionWarning(uid, reason) {
     'Unhandled promise rejection. This error originated either by ' +
       'throwing inside of an async function without a catch block, ' +
       'or by rejecting a promise which was not handled with .catch(). ' +
+      'If you want node process to terminate on unhandled promise ' +
+      'rejection, use the CLI flag `--unhandled-rejections=strict` (see ' +
+      'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). ' +
       `(rejection id: ${uid})`
   );
   try {

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -133,7 +133,7 @@ function emitUnhandledRejectionWarning(uid, reason) {
     'Unhandled promise rejection. This error originated either by ' +
       'throwing inside of an async function without a catch block, ' +
       'or by rejecting a promise which was not handled with .catch(). ' +
-      'If you want node process to terminate on unhandled promise ' +
+      'To terminate the node process on unhandled promise ' +
       'rejection, use the CLI flag `--unhandled-rejections=strict` (see ' +
       'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). ' +
       `(rejection id: ${uid})`

--- a/test/parallel/test-promises-unhandled-proxy-rejections.js
+++ b/test/parallel/test-promises-unhandled-proxy-rejections.js
@@ -12,7 +12,10 @@ const expectedPromiseWarning = ['Unhandled promise rejection. ' +
   'This error originated either by throwing ' +
   'inside of an async function without a catch ' +
   'block, or by rejecting a promise which was ' +
-  'not handled with .catch(). (rejection id: 1)'];
+  'not handled with .catch(). If you want node ' +
+  'process to terminate on unhandled promise ' +
+  'rejection, use the CLI flag `--unhandled-rejections=strict` (see ' +
+  'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)'];
 
 function throwErr() {
   throw new Error('Error from proxy');

--- a/test/parallel/test-promises-unhandled-proxy-rejections.js
+++ b/test/parallel/test-promises-unhandled-proxy-rejections.js
@@ -12,9 +12,9 @@ const expectedPromiseWarning = ['Unhandled promise rejection. ' +
   'This error originated either by throwing ' +
   'inside of an async function without a catch ' +
   'block, or by rejecting a promise which was ' +
-  'not handled with .catch(). If you want node ' +
-  'process to terminate on unhandled promise ' +
-  'rejection, use the CLI flag `--unhandled-rejections=strict` (see ' +
+  'not handled with .catch(). To terminate the ' +
+  'node process on unhandled promise rejection, ' +
+  'use the CLI flag `--unhandled-rejections=strict` (see ' +
   'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)'];
 
 function throwErr() {

--- a/test/parallel/test-promises-unhandled-symbol-rejections.js
+++ b/test/parallel/test-promises-unhandled-symbol-rejections.js
@@ -13,9 +13,9 @@ const expectedPromiseWarning = ['Unhandled promise rejection. ' +
   'This error originated either by throwing ' +
   'inside of an async function without a catch ' +
   'block, or by rejecting a promise which was ' +
-  'not handled with .catch(). If you want node ' +
-  'process to terminate on unhandled promise ' +
-  'rejection, use the CLI flag `--unhandled-rejections=strict` (see ' +
+  'not handled with .catch(). To terminate the ' +
+  'node process on unhandled promise rejection, ' +
+  'use the CLI flag `--unhandled-rejections=strict` (see ' +
   'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)'];
 
 common.expectWarning({

--- a/test/parallel/test-promises-unhandled-symbol-rejections.js
+++ b/test/parallel/test-promises-unhandled-symbol-rejections.js
@@ -13,7 +13,10 @@ const expectedPromiseWarning = ['Unhandled promise rejection. ' +
   'This error originated either by throwing ' +
   'inside of an async function without a catch ' +
   'block, or by rejecting a promise which was ' +
-  'not handled with .catch(). (rejection id: 1)'];
+  'not handled with .catch(). If you want node ' +
+  'process to terminate on unhandled promise ' +
+  'rejection, use the CLI flag `--unhandled-rejections=strict` (see ' +
+  'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)'];
 
 common.expectWarning({
   DeprecationWarning: expectedDeprecationWarning,


### PR DESCRIPTION
This PR adds a note in the unhandled promise rejection that refers to the `--unhandled-rejection` flag documentation.

Refs: https://github.com/nodejs/node/issues/20392

CC: @benjamingr 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
