### PR TITLE
src: fix -Wsign-compare warnings

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5050,8 +5050,8 @@ static AllocatedBuffer ConvertSignatureToP1363(Environment* env,
 
   const BIGNUM* r = ECDSA_SIG_get0_r(asn1_sig);
   const BIGNUM* s = ECDSA_SIG_get0_s(asn1_sig);
-  CHECK_EQ(n, BN_bn2binpad(r, data, n));
-  CHECK_EQ(n, BN_bn2binpad(s, data + n, n));
+  CHECK_EQ(n, static_cast<unsigned int>(BN_bn2binpad(r, data, n)));
+  CHECK_EQ(n, static_cast<unsigned int>(BN_bn2binpad(s, data + n, n)));
 
   ECDSA_SIG_free(asn1_sig);
 


### PR DESCRIPTION
This commit addresses the following compilation warnings:

../src/node_crypto.cc:5053:3: warning: comparison of integers
of different signs: 'unsigned int' and 'int' [-Wsign-compare]
  CHECK_EQ(n, BN_bn2binpad(r, data, n));

../src/node_crypto.cc:5054:3: warning: comparison of integers
of different signs: 'unsigned int' and 'int' [-Wsign-compare]
  CHECK_EQ(n, BN_bn2binpad(s, data + n, n));

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)