### PR TITLE
http: llhttp opt-in insecure HTTP header parsing

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -419,6 +419,16 @@ added: v9.0.0
 Specify the `module` of a custom [experimental ECMAScript Module loader][].
 `module` may be either a path to a file, or an ECMAScript Module name.
 
+### `--insecure-http-parser`
+<!-- YAML
+added: REPLACEME
+-->
+
+Use an insecure HTTP parser that accepts invalid HTTP headers. This may allow
+interoperability with non-conformant HTTP implementations. It may also allow
+request smuggling and other HTTP attacks that rely on invalid headers being
+accepted. Avoid using this option.
+
 ### `--max-http-header-size=size`
 <!-- YAML
 added: v11.6.0
@@ -1064,6 +1074,7 @@ Node.js options that are allowed are:
 * `--http-parser`
 * `--icu-data-dir`
 * `--input-type`
+* `--insecure-http-parser`
 * `--inspect-brk`
 * `--inspect-port`, `--debug-port`
 * `--inspect-publish-uid`

--- a/doc/node.1
+++ b/doc/node.1
@@ -213,6 +213,12 @@ Specify the
 .Ar module
 to use as a custom module loader.
 .
+.It Fl -insecure-http-parser
+Use an insecure HTTP parser that accepts invalid HTTP headers. This may allow
+interoperability with non-conformant HTTP implementations. It may also allow
+request smuggling and other HTTP attacks that rely on invalid headers being
+accepted. Avoid using this option.
+.
 .It Fl -max-http-header-size Ns = Ns Ar size
 Specify the maximum size of HTTP headers in bytes. Defaults to 8KB.
 .

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -39,6 +39,7 @@ const {
   freeParser,
   parsers,
   HTTPParser,
+  isLenient,
   prepareError,
 } = require('_http_common');
 const { OutgoingMessage } = require('_http_outgoing');
@@ -676,7 +677,8 @@ function tickOnSocket(req, socket) {
   req.socket = socket;
   parser.initialize(HTTPParser.RESPONSE,
                     new HTTPClientAsyncResource('HTTPINCOMINGMESSAGE', req),
-                    req.maxHeaderSize || 0);
+                    req.maxHeaderSize || 0,
+                    isLenient());
   parser.socket = socket;
   parser.outgoing = req;
   req.parser = parser;

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -27,6 +27,8 @@ const {
 const { setImmediate } = require('timers');
 
 const { methods, HTTPParser } = internalBinding('http_parser');
+const { getOptionValue } = require('internal/options');
+const insecureHTTPParser = getOptionValue('--insecure-http-parser');
 
 const FreeList = require('internal/freelist');
 const incoming = require('_http_incoming');
@@ -236,6 +238,16 @@ function prepareError(err, parser, rawPacket) {
     err.message = `Parse Error: ${err.reason}`;
 }
 
+let warnedLenient = false;
+
+function isLenient() {
+  if (insecureHTTPParser && !warnedLenient) {
+    warnedLenient = true;
+    process.emitWarning('Using insecure HTTP parsing');
+  }
+  return insecureHTTPParser;
+}
+
 module.exports = {
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
   _checkIsHttpToken: checkIsHttpToken,
@@ -248,5 +260,6 @@ module.exports = {
   parsers,
   kIncomingMessage,
   HTTPParser,
+  isLenient,
   prepareError,
 };

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -38,6 +38,7 @@ const {
   chunkExpression,
   kIncomingMessage,
   HTTPParser,
+  isLenient,
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
   prepareError,
 } = require('_http_common');
@@ -409,7 +410,8 @@ function connectionListenerInternal(server, socket) {
   parser.initialize(
     HTTPParser.REQUEST,
     new HTTPServerAsyncResource('HTTPINCOMINGMESSAGE', socket),
-    server.maxHeaderSize || 0
+    server.maxHeaderSize || 0,
+    isLenient(),
   );
   parser.socket = socket;
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -486,17 +486,24 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void Initialize(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
+    bool lenient = false;
 
     uint64_t max_http_header_size = 0;
 
     CHECK(args[0]->IsInt32());
     CHECK(args[1]->IsObject());
+
     if (args.Length() > 2) {
       CHECK(args[2]->IsNumber());
       max_http_header_size = args[2].As<Number>()->Value();
     }
     if (max_http_header_size == 0) {
       max_http_header_size = env->options()->max_http_header_size;
+    }
+
+    if (args.Length() > 3) {
+      CHECK(args[3]->IsBoolean());
+      lenient = args[3]->IsTrue();
     }
 
     llhttp_type_t type =
@@ -515,7 +522,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
     parser->set_provider_type(provider);
     parser->AsyncReset(args[1].As<Object>());
-    parser->Init(type, max_http_header_size);
+    parser->Init(type, max_http_header_size, lenient);
   }
 
   template <bool should_pause>
@@ -762,8 +769,9 @@ class Parser : public AsyncWrap, public StreamListener {
   }
 
 
-  void Init(llhttp_type_t type, uint64_t max_http_header_size) {
+  void Init(llhttp_type_t type, uint64_t max_http_header_size, bool lenient) {
     llhttp_init(&parser_, type, &settings);
+    llhttp_set_lenient(&parser_, lenient);
     header_nread_ = 0;
     url_.Reset();
     status_message_.Reset();

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -486,7 +486,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void Initialize(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
-    bool lenient = false;
+    bool lenient = args[3]->IsTrue();
 
     uint64_t max_http_header_size = 0;
 
@@ -499,11 +499,6 @@ class Parser : public AsyncWrap, public StreamListener {
     }
     if (max_http_header_size == 0) {
       max_http_header_size = env->options()->max_http_header_size;
-    }
-
-    if (args.Length() > 3) {
-      CHECK(args[3]->IsBoolean());
-      lenient = args[3]->IsTrue();
     }
 
     llhttp_type_t type =

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -375,6 +375,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::heap_snapshot_signal,
             kAllowedInEnvironment);
   AddOption("--http-parser", "", NoOp{}, kAllowedInEnvironment);
+  AddOption("--insecure-http-parser",
+            "use an insecure HTTP parser that accepts invalid HTTP headers",
+            &EnvironmentOptions::insecure_http_parser,
+            kAllowedInEnvironment);
   AddOption("--input-type",
             "set module type for string input",
             &EnvironmentOptions::module_type,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -158,6 +158,8 @@ class EnvironmentOptions : public Options {
   bool print_eval = false;
   bool force_repl = false;
 
+  bool insecure_http_parser = false;
+
   bool tls_min_v1_0 = false;
   bool tls_min_v1_1 = false;
   bool tls_min_v1_2 = false;


### PR DESCRIPTION
WIP - depends on https://github.com/nodejs/node/pull/30553

Allow insecure HTTP header parsing. Make clear it is insecure.

See:
- https://github.com/nodejs/node/pull/30553
- https://github.com/nodejs/node/issues/27711#issuecomment-556265881
- https://github.com/nodejs/node/issues/30515


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
