### PR TITLE
refactor test

### DIFF
--- a/test/parallel/test-async-hooks-promise-triggerid.js
+++ b/test/parallel/test-async-hooks-promise-triggerid.js
@@ -13,8 +13,7 @@ async_hooks.createHook({
     if (type === 'PROMISE') {
       // Check that the last known Promise is triggering the creation of
       // this one.
-      assert.strictEqual(promiseAsyncIds[promiseAsyncIds.length - 1] || 1,
-                         triggerId);
+      assert.strictEqual(triggerId, promiseAsyncIds[promiseAsyncIds.length - 1] || 1);
       promiseAsyncIds.push(id);
     }
   }, 3),

--- a/test/parallel/test-async-hooks-promise-triggerid.js
+++ b/test/parallel/test-async-hooks-promise-triggerid.js
@@ -13,7 +13,8 @@ async_hooks.createHook({
     if (type === 'PROMISE') {
       // Check that the last known Promise is triggering the creation of
       // this one.
-      assert.strictEqual(triggerId, promiseAsyncIds[promiseAsyncIds.length - 1] || 1);
+      assert.strictEqual(triggerId,
+                         promiseAsyncIds[promiseAsyncIds.length - 1] || 1);
       promiseAsyncIds.push(id);
     }
   }, 3),


### PR DESCRIPTION
Switch the argument order for the assertion to be in the correct order (`actual`, `expected`).

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
