### PR TITLE
test: use fs rimraf to refresh tmpdir

### DIFF
--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -184,7 +184,7 @@ function rimrafSync(path, options) {
     if (stats !== undefined && stats.isDirectory())
       _rmdirSync(path, options, null);
     else
-      unlinkSync(path);
+      _unlinkSync(path, options);
   } catch (err) {
     if (err.code === 'ENOENT')
       return;
@@ -194,6 +194,25 @@ function rimrafSync(path, options) {
       throw err;
 
     _rmdirSync(path, options, err);
+  }
+}
+
+
+function _unlinkSync(path, options) {
+  const tries = options.maxRetries + 1;
+
+  for (let i = 1; i <= tries; i++) {
+    try {
+      return unlinkSync(path);
+    } catch (err) {
+      // Only sleep if this is not the last try, and the delay is greater
+      // than zero, and an error was encountered that warrants a retry.
+      if (retryErrorCodes.has(err.code) &&
+          i < tries &&
+          options.retryDelay > 0) {
+        sleep(i * options.retryDelay);
+      }
+    }
   }
 }
 
@@ -264,7 +283,7 @@ function fixWinEPERMSync(path, options, originalErr) {
   if (stats.isDirectory())
     _rmdirSync(path, options, originalErr);
   else
-    unlinkSync(path);
+    _unlinkSync(path, options);
 }
 
 

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -5,6 +5,7 @@
 // - Bring your own custom fs module is not currently supported.
 // - Some basic code cleanup.
 'use strict';
+const { Buffer } = require('buffer');
 const {
   chmod,
   chmodSync,
@@ -19,7 +20,7 @@ const {
   unlink,
   unlinkSync
 } = require('fs');
-const { join } = require('path');
+const { sep } = require('path');
 const { setTimeout } = require('timers');
 const { sleep } = require('internal/util');
 const notEmptyErrorCodes = new Set(['ENOTEMPTY', 'EEXIST', 'EPERM']);
@@ -28,6 +29,8 @@ const retryErrorCodes = new Set(
 const isWindows = process.platform === 'win32';
 const epermHandler = isWindows ? fixWinEPERM : _rmdir;
 const epermHandlerSync = isWindows ? fixWinEPERMSync : _rmdirSync;
+const readdirEncoding = 'buffer';
+const separator = Buffer.from(sep);
 
 
 function rimraf(path, options, callback) {
@@ -116,7 +119,9 @@ function _rmdir(path, options, originalErr, callback) {
 
 
 function _rmchildren(path, options, callback) {
-  readdir(path, (err, files) => {
+  const pathBuf = Buffer.from(path);
+
+  readdir(pathBuf, readdirEncoding, (err, files) => {
     if (err)
       return callback(err);
 
@@ -128,7 +133,9 @@ function _rmchildren(path, options, callback) {
     let done = false;
 
     files.forEach((child) => {
-      rimraf(join(path, child), options, (err) => {
+      const childPath = Buffer.concat([pathBuf, separator, child]);
+
+      rimraf(childPath, options, (err) => {
         if (done)
           return;
 
@@ -205,8 +212,12 @@ function _rmdirSync(path, options, originalErr) {
       // original removal. Windows has a habit of not closing handles promptly
       // when files are deleted, resulting in spurious ENOTEMPTY failures. Work
       // around that issue by retrying on Windows.
-      readdirSync(path).forEach((child) => {
-        rimrafSync(join(path, child), options);
+      const pathBuf = Buffer.from(path);
+
+      readdirSync(pathBuf, readdirEncoding).forEach((child) => {
+        const childPath = Buffer.concat([pathBuf, separator, child]);
+
+        rimrafSync(childPath, options);
       });
 
       const tries = options.maxRetries + 1;

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -36,58 +36,10 @@ function rimrafSync(pathname, { spawn = true } = {}) {
     }
   }
 
-  try {
-    if (st.isDirectory())
-      rmdirSync(pathname, null);
-    else
-      fs.unlinkSync(pathname);
-  } catch (e) {
-    debug(e);
-    switch (e.code) {
-      case 'ENOENT':
-        // It's not there anymore. Work is done. Exiting.
-        return;
-
-      case 'EPERM':
-        // This can happen, try again with `rmdirSync`.
-        break;
-
-      case 'EISDIR':
-        // Got 'EISDIR' even after testing `st.isDirectory()`...
-        // Try again with `rmdirSync`.
-        break;
-
-      default:
-        throw e;
-    }
-    rmdirSync(pathname, e);
-  }
+  fs.rmdirSync(pathname, { recursive: true, maxRetries: 5 });
 
   if (fs.existsSync(pathname))
     throw new Error(`Unable to rimraf ${pathname}`);
-}
-
-function rmdirSync(p, originalEr) {
-  try {
-    fs.rmdirSync(p);
-  } catch (e) {
-    if (e.code === 'ENOTDIR')
-      throw originalEr;
-    if (e.code === 'ENOTEMPTY' || e.code === 'EEXIST' || e.code === 'EPERM') {
-      const enc = process.platform === 'linux' ? 'buffer' : 'utf8';
-      fs.readdirSync(p, enc).forEach((f) => {
-        if (f instanceof Buffer) {
-          const buf = Buffer.concat([Buffer.from(p), Buffer.from(path.sep), f]);
-          rimrafSync(buf);
-        } else {
-          rimrafSync(path.join(p, f));
-        }
-      });
-      fs.rmdirSync(p);
-      return;
-    }
-    throw e;
-  }
 }
 
 const testRoot = process.env.NODE_TEST_DIR ?


### PR DESCRIPTION
This PR is a revisit to https://github.com/nodejs/node/pull/29235 (which I couldn't reopen since I had force pushed the branch). The goal of that PR was to use core's new rimraf implementation when refreshing the tmpdir in tests. However, that PR hit a snag that I didn't have time to look into:

```
=== release test-fs-readdir-ucs2 ===
Path: parallel/test-fs-readdir-ucs2
--- stderr ---
Can't clean tmpdir: /home/travis/build/nodejs/node/test/.tmp.602
Files blocking: [ '=�\u0004�' ]
/home/travis/build/nodejs/node/test/common/tmpdir.js:88
    throw e;
    ^
Error: Unable to rimraf /home/travis/build/nodejs/node/test/.tmp.602
    at rimrafSync (/home/travis/build/nodejs/node/test/common/tmpdir.js:42:11)
    at process.onexit (/home/travis/build/nodejs/node/test/common/tmpdir.js:73:5)
    at process.emit (events.js:214:15)
Command: out/Release/node /home/travis/build/nodejs/node/test/parallel/test-fs-readdir-ucs2.js
```

I addressed that failure in the second commit here (I copied what the rimraf in our test suite does regarding encoding). It seems to be going well in the CI: https://ci.nodejs.org/job/node-test-commit/32928/.

Another alternative to 357e233 might be to introduce an encoding option to `rmdir()`.

cc'ing the people from #29235: @trott @targos @gengjiawen 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
