### PR TITLE
http: set socket.server unconditionally

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -360,8 +360,7 @@ function connectionListenerInternal(server, socket) {
 
   // Ensure that the server property of the socket is correctly set.
   // See https://github.com/nodejs/node/issues/13435
-  if (socket.server === null)
-    socket.server = server;
+  socket.server = server;
 
   // If the user has added a listener to the server,
   // request, or response, then it's their responsibility.

--- a/test/parallel/test-http-generic-streams.js
+++ b/test/parallel/test-http-generic-streams.js
@@ -138,3 +138,17 @@ const MakeDuplexPair = require('../common/duplexpair');
   req.write(testData);
   req.end();
 }
+
+// Test 5: The client sends garbage.
+{
+  const server = http.createServer(common.mustNotCall());
+
+  const { clientSide, serverSide } = MakeDuplexPair();
+  server.emit('connection', serverSide);
+
+  server.on('clientError', common.mustCall());
+
+  // Send something that is not an HTTP request.
+  clientSide.end(
+    'I’m reading a book about anti-gravity. It’s impossible to put down!');
+}


### PR DESCRIPTION
This is useful for situations in which the socket was not
created for HTTP, e.g. when using arbitrary `Duplex` streams.

(The added test fails because previously, `socket.server.emit()`
would not work for emitting the `clientError` event, as
`socket.server` was `undefined`.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
