### PR TITLE
util: fix inspection of errors with tampered name or stack property

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -936,12 +936,12 @@ function getFunctionBase(value, constructor, tag) {
 }
 
 function formatError(err, constructor, tag, ctx) {
-  let stack = err.stack || ErrorPrototypeToString(err);
+  const name = err.name != null ? String(err.name) : 'Error';
+  let len = name.length;
+  let stack = err.stack ? String(err.stack) : ErrorPrototypeToString(err);
 
   // A stack trace may contain arbitrary data. Only manipulate the output
   // for "regular errors" (errors that "look normal") for now.
-  const name = err.name || 'Error';
-  let len = name.length;
   if (constructor === null ||
       (name.endsWith('Error') &&
       stack.startsWith(name) &&

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -691,6 +691,35 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
   );
 }
 
+// Tampered error stack or name property (different type than string).
+// Note: Symbols are not supported by `Error#toString()` which is called by
+// accessing the `stack` property.
+[
+  [404, '404: foo', '[404]'],
+  [0, '0: foo', '[RangeError: foo]'],
+  [0n, '0: foo', '[RangeError: foo]'],
+  [null, 'null: foo', '[RangeError: foo]'],
+  [undefined, 'RangeError: foo', '[RangeError: foo]'],
+  [false, 'false: foo', '[RangeError: foo]'],
+  ['', 'foo', '[RangeError: foo]'],
+  [[1, 2, 3], '1,2,3: foo', '[1,2,3]'],
+].forEach(([value, outputStart, stack]) => {
+  let err = new RangeError('foo');
+  err.name = value;
+  assert(
+    util.inspect(err).startsWith(outputStart),
+    util.format(
+      'The name set to %o did not result in the expected output "%s"',
+      value,
+      outputStart
+    )
+  );
+
+  err = new RangeError('foo');
+  err.stack = value;
+  assert.strictEqual(util.inspect(err), stack);
+});
+
 // https://github.com/nodejs/node-v0.x-archive/issues/1941
 assert.strictEqual(util.inspect(Object.create(Date.prototype)), 'Date {}');
 


### PR DESCRIPTION
This makes sure that `util.inspect()` does not throw while inspecting
errors that have the name or stack property set to a different type
than string.

Fixes: https://github.com/nodejs/node/issues/30572

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
