### PR TITLE
crypto: forbid setting the PBKDF2 iter count to 0

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2294,6 +2294,10 @@ console.log(hashes); // ['DSA', 'DSA-SHA', 'DSA-SHA1', ...]
 <!-- YAML
 added: v0.5.5
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30578
+    description: The `iterations` parameter is now restricted to positive
+                 values. Earlier releases treated other values as one.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/11305
     description: The `digest` parameter is always required now.
@@ -2369,6 +2373,10 @@ negative performance implications for some applications; see the
 <!-- YAML
 added: v0.9.3
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30578
+    description: The `iterations` parameter is now restricted to positive
+                 values. Earlier releases treated other values as one.
   - version: v6.0.0
     pr-url: https://github.com/nodejs/node/pull/4047
     description: Calling this function without passing the `digest` parameter

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -66,7 +66,7 @@ function check(password, salt, iterations, keylen, digest) {
 
   password = getArrayBufferView(password, 'password');
   salt = getArrayBufferView(salt, 'salt');
-  validateUint32(iterations, 'iterations');
+  validateUint32(iterations, 'iterations', true);
   validateUint32(keylen, 'keylen');
 
   return { password, salt, iterations, keylen, digest };

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -68,15 +68,17 @@ assert.throws(
   }
 );
 
-assert.throws(
-  () => crypto.pbkdf2Sync('password', 'salt', -1, 20, 'sha1'),
-  {
-    code: 'ERR_OUT_OF_RANGE',
-    name: 'RangeError',
-    message: 'The value of "iterations" is out of range. ' +
-             'It must be >= 0 && < 4294967296. Received -1'
-  }
-);
+for (const iterations of [-1, 0]) {
+  assert.throws(
+    () => crypto.pbkdf2Sync('password', 'salt', iterations, 20, 'sha1'),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      name: 'RangeError',
+      message: 'The value of "iterations" is out of range. ' +
+               `It must be >= 1 && < 4294967296. Received ${iterations}`
+    }
+  );
+}
 
 ['str', null, undefined, [], {}].forEach((notNumber) => {
   assert.throws(


### PR DESCRIPTION
RFC 2898 does not permit an iteration count of zero, and OpenSSL 1.1.1 will treat it as one iteration internally.

Future OpenSSL versions will reject such inputs (already on master branch), but until that happens, Node.js should manually reject them.

Refs: https://github.com/nodejs/webcrypto/pull/29

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
