### PR TITLE
crypto: remove redundant validateUint32 argument

### DIFF
--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -66,8 +66,8 @@ function check(password, salt, iterations, keylen, digest) {
 
   password = getArrayBufferView(password, 'password');
   salt = getArrayBufferView(salt, 'salt');
-  validateUint32(iterations, 'iterations', 0);
-  validateUint32(keylen, 'keylen', 0);
+  validateUint32(iterations, 'iterations');
+  validateUint32(keylen, 'keylen');
 
   return { password, salt, iterations, keylen, digest };
 }


### PR DESCRIPTION
The third parameter should be a boolean indicating whether the number must be positive. Passing zero works, but is unnecessary, misleading and inconsistent with other uses of the same function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
