### PR TITLE
esm: decouple json modules from cjs cache

### DIFF
--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -136,39 +136,13 @@ translators.set('builtin', async function builtinStrategy(url) {
 translators.set('json', async function jsonStrategy(url) {
   debug(`Translating JSONModule ${url}`);
   debug(`Loading JSONModule ${url}`);
-  const pathname = url.startsWith('file:') ? fileURLToPath(url) : null;
-  let modulePath;
-  let module;
-  if (pathname) {
-    modulePath = isWindows ?
-      StringPrototype.replace(pathname, winSepRegEx, '\\') : pathname;
-    module = CJSModule._cache[modulePath];
-    if (module && module.loaded) {
-      const exports = module.exports;
-      return new ModuleWrap(url, undefined, ['default'], function() {
-        this.setExport('default', exports);
-      });
-    }
-  }
   const content = `${await getSource(url)}`;
-  if (pathname) {
-    // A require call could have been called on the same file during loading and
-    // that resolves synchronously. To make sure we always return the identical
-    // export, we have to check again if the module already exists or not.
-    module = CJSModule._cache[modulePath];
-    if (module && module.loaded) {
-      const exports = module.exports;
-      return new ModuleWrap(url, undefined, ['default'], function() {
-        this.setExport('default', exports);
-      });
-    }
-  }
   try {
     const exports = JsonParse(stripBOM(content));
-    module = {
-      exports,
-      loaded: true
-    };
+    return new ModuleWrap(url, undefined, ['default'], function() {
+      debug(`Parsing JSONModule ${url}`);
+      this.setExport('default', exports);
+    });
   } catch (err) {
     // TODO (BridgeAR): We could add a NodeCore error that wraps the JSON
     // parse error instead of just manipulating the original error message.
@@ -177,13 +151,6 @@ translators.set('json', async function jsonStrategy(url) {
     err.message = errPath(url) + ': ' + err.message;
     throw err;
   }
-  if (pathname) {
-    CJSModule._cache[modulePath] = module;
-  }
-  return new ModuleWrap(url, undefined, ['default'], function() {
-    debug(`Parsing JSONModule ${url}`);
-    this.setExport('default', module.exports);
-  });
 });
 
 // Strategy for loading a wasm module

--- a/test/es-module/test-esm-json-cache.mjs
+++ b/test/es-module/test-esm-json-cache.mjs
@@ -1,16 +1,15 @@
 // Flags: --experimental-json-modules
 import '../common/index.mjs';
 
-import { strictEqual, deepStrictEqual } from 'assert';
-
-import { createRequireFromPath as createRequire } from 'module';
+import { strictEqual, notStrictEqual, deepStrictEqual } from 'assert';
+import { createRequire } from 'module';
 import { fileURLToPath as fromURL } from 'url';
 
 import mod from '../fixtures/es-modules/json-cache/mod.cjs';
 import another from '../fixtures/es-modules/json-cache/another.cjs';
 import test from '../fixtures/es-modules/json-cache/test.json';
 
-const require = createRequire(fromURL(import.meta.url));
+const require = createRequire(import.meta.url);
 
 const modCjs = require('../fixtures/es-modules/json-cache/mod.cjs');
 const anotherCjs = require('../fixtures/es-modules/json-cache/another.cjs');
@@ -18,8 +17,8 @@ const testCjs = require('../fixtures/es-modules/json-cache/test.json');
 
 strictEqual(mod.one, 1);
 strictEqual(another.one, 'zalgo');
-strictEqual(test.one, 'it comes');
+strictEqual(test.one, 1);
 
 deepStrictEqual(mod, modCjs);
 deepStrictEqual(another, anotherCjs);
-deepStrictEqual(test, testCjs);
+notStrictEqual(test, testCjs);


### PR DESCRIPTION
I've opened this to discuss implementation issues with JSON modules on web and/or module attributes that could arise from the coupling as briefly mentioned in [the Modules WG meeting](https://github.com/nodejs/modules/blob/3b83652388cfd6322ebfe15a85c29e1af83fe83b/doc/meetings/2019-11-20.md). This is not meant to land while discussion (in particular about [module attributes](https://github.com/nodejs/modules/issues/427)) continues.

CC: @nodejs/modules 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
