### PR TITLE
stream: invoke buffered write callbacks on error

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -467,6 +467,7 @@ function onwriteError(stream, state, er, cb) {
   --state.pendingcb;
 
   cb(er);
+  errorBuffer(state, new ERR_STREAM_DESTROYED('write'));
   // This can emit error, but error must always follow cb.
   errorOrDestroy(stream, er);
 }
@@ -539,6 +540,16 @@ function afterWrite(stream, state, count, cb) {
   }
 
   finishMaybe(stream, state);
+}
+
+// If there's something in the buffer waiting, then invoke callbacks.
+function errorBuffer (state, err) {
+  for (let entry = state.bufferedRequest; entry; entry = entry.next) {
+    process.nextTick(entry.callback, err);
+  }
+  state.bufferedRequest = null;
+  state.lastBufferedRequest = null;
+  state.bufferedRequestCount = 0;
 }
 
 // If there's something in the buffer waiting, then process it
@@ -817,12 +828,7 @@ const destroy = destroyImpl.destroy;
 Writable.prototype.destroy = function(err, cb) {
   const state = this._writableState;
   if (!state.destroyed) {
-    for (let entry = state.bufferedRequest; entry; entry = entry.next) {
-      process.nextTick(entry.callback, new ERR_STREAM_DESTROYED('write'));
-    }
-    state.bufferedRequest = null;
-    state.lastBufferedRequest = null;
-    state.bufferedRequestCount = 0;
+    errorBuffer(state, new ERR_STREAM_DESTROYED('write'));
   }
   destroy.call(this, err, cb);
   return this;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -471,7 +471,7 @@ function onwriteError(stream, state, er, cb) {
   // not enabled. Passing `er` here doesn't make sense since
   // it's related to one specific write, not to the buffered
   // writes.
-  errorBuffer(state, new ERR_STREAM_DESTROYED('write'), false);
+  errorBuffer(state, new ERR_STREAM_DESTROYED('write'));
   // This can emit error, but error must always follow cb.
   errorOrDestroy(stream, er);
 }
@@ -543,19 +543,23 @@ function afterWrite(stream, state, count, cb) {
     cb();
   }
 
+  if (state.destroyed) {
+    errorBuffer(state, new ERR_STREAM_DESTROYED('write'));
+  }
+
   finishMaybe(stream, state);
 }
 
 // If there's something in the buffer waiting, then invoke callbacks.
-function errorBuffer(state, err, sync) {
+function errorBuffer(state, err) {
+  if (state.writing || !state.bufferedRequest) {
+    return;
+  }
+
   for (let entry = state.bufferedRequest; entry; entry = entry.next) {
     const len = state.objectMode ? 1 : entry.chunk.length;
     state.length -= len;
-    if (sync) {
-      process.nextTick(entry.callback, err);
-    } else {
-      entry.callback(err);
-    }
+    entry.callback(err);
   }
   state.bufferedRequest = null;
   state.lastBufferedRequest = null;
@@ -838,7 +842,7 @@ const destroy = destroyImpl.destroy;
 Writable.prototype.destroy = function(err, cb) {
   const state = this._writableState;
   if (!state.destroyed) {
-    errorBuffer(state, new ERR_STREAM_DESTROYED('write'), true);
+    process.nextTick(errorBuffer, state, new ERR_STREAM_DESTROYED('write'));
   }
   destroy.call(this, err, cb);
   return this;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -549,13 +549,14 @@ function afterWrite(stream, state, count, cb) {
 // If there's something in the buffer waiting, then invoke callbacks.
 function errorBuffer(state, err, sync) {
   for (let entry = state.bufferedRequest; entry; entry = entry.next) {
+    const len = state.objectMode ? 1 : entry.chunk.length;
+    state.length -= len;
     if (sync) {
       process.nextTick(entry.callback, err);
     } else {
       entry.callback(err);
     }
   }
-  state.length = 0;
   state.bufferedRequest = null;
   state.lastBufferedRequest = null;
   state.bufferedRequestCount = 0;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -467,6 +467,10 @@ function onwriteError(stream, state, er, cb) {
   --state.pendingcb;
 
   cb(er);
+  // Ensure callbacks are invoked even when autoDestroy is
+  // not enabled. Passing `er` here doesn't make sense since
+  // it's related to one specific write, not to the buffered
+  // writes.
   errorBuffer(state, new ERR_STREAM_DESTROYED('write'));
   // This can emit error, but error must always follow cb.
   errorOrDestroy(stream, er);
@@ -543,7 +547,7 @@ function afterWrite(stream, state, count, cb) {
 }
 
 // If there's something in the buffer waiting, then invoke callbacks.
-function errorBuffer (state, err) {
+function errorBuffer(state, err) {
   for (let entry = state.bufferedRequest; entry; entry = entry.next) {
     process.nextTick(entry.callback, err);
   }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -471,7 +471,7 @@ function onwriteError(stream, state, er, cb) {
   // not enabled. Passing `er` here doesn't make sense since
   // it's related to one specific write, not to the buffered
   // writes.
-  errorBuffer(state, new ERR_STREAM_DESTROYED('write'));
+  errorBuffer(state, new ERR_STREAM_DESTROYED('write'), false);
   // This can emit error, but error must always follow cb.
   errorOrDestroy(stream, er);
 }
@@ -547,9 +547,13 @@ function afterWrite(stream, state, count, cb) {
 }
 
 // If there's something in the buffer waiting, then invoke callbacks.
-function errorBuffer(state, err) {
+function errorBuffer(state, err, sync) {
   for (let entry = state.bufferedRequest; entry; entry = entry.next) {
-    process.nextTick(entry.callback, err);
+    if (sync) {
+      process.nextTick(entry.callback, err);
+    } else {
+      entry.callback(err);
+    }
   }
   state.bufferedRequest = null;
   state.lastBufferedRequest = null;
@@ -832,7 +836,7 @@ const destroy = destroyImpl.destroy;
 Writable.prototype.destroy = function(err, cb) {
   const state = this._writableState;
   if (!state.destroyed) {
-    errorBuffer(state, new ERR_STREAM_DESTROYED('write'));
+    errorBuffer(state, new ERR_STREAM_DESTROYED('write'), true);
   }
   destroy.call(this, err, cb);
   return this;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -555,6 +555,7 @@ function errorBuffer(state, err, sync) {
       entry.callback(err);
     }
   }
+  state.length = 0;
   state.bufferedRequest = null;
   state.lastBufferedRequest = null;
   state.bufferedRequestCount = 0;

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -366,3 +366,24 @@ const assert = require('assert');
   }));
   write.uncork();
 }
+
+{
+  // Ensure callback order.
+
+  let state = 0;
+  const write = new Writable({
+    write(chunk, enc, cb) {
+      // `setImmediate()` is used on purpose to ensure the callback is called
+      // after `process.nextTick()` callbacks.
+      setImmediate(cb);
+    }
+  });
+  write.write('asd', common.mustCall(() => {
+    assert.strictEqual(state++, 0);
+  }));
+  write.write('asd', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+    assert.strictEqual(state++, 1);
+  }));
+  write.destroy();
+}

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -355,14 +355,14 @@ const assert = require('assert');
     autoDestroy: false
   });
   write.cork();
-  write.write('asd', common.mustCall(err => {
+  write.write('asd', common.mustCall((err) => {
     assert.strictEqual(err.message, 'asd');
   }));
-  write.write('asd', common.mustCall(err => {
+  write.write('asd', common.mustCall((err) => {
     assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
   }));
-  write.on('error', common.mustCall(err => {
+  write.on('error', common.mustCall((err) => {
     assert.strictEqual(err.message, 'asd');
-  }))
+  }));
   write.uncork();
 }

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -344,3 +344,25 @@ const assert = require('assert');
   }));
   write.destroy(new Error('asd'));
 }
+
+{
+  // Call buffered write callback with error
+
+  const write = new Writable({
+    write(chunk, enc, cb) {
+      process.nextTick(cb, new Error('asd'));
+    },
+    autoDestroy: false
+  });
+  write.cork();
+  write.write('asd', common.mustCall(err => {
+    assert.strictEqual(err.message, 'asd');
+  }));
+  write.write('asd', common.mustCall(err => {
+    assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+  }));
+  write.on('error', common.mustCall(err => {
+    assert.strictEqual(err.message, 'asd');
+  }))
+  write.uncork();
+}


### PR DESCRIPTION
Buffered write callbacks were only invoked upon error if `autoDestroy` is enabled.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
