### PR TITLE
test: test for minimum ICU version consistency

### DIFF
--- a/test/parallel/test-icu-minimum-version.js
+++ b/test/parallel/test-icu-minimum-version.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// Tests that the minimum ICU version for Node.js is at least the minimum ICU
+// version for V8.
+
+require('../common');
+const assert = require('assert');
+const path = require('path');
+const { readFileSync } = require('fs');
+
+const srcRoot = path.join(__dirname, '..', '..');
+const icuVersionsFile = path.join(srcRoot, 'tools', 'icu', 'icu_versions.json');
+const { minimum_icu: minimumICU } = require(icuVersionsFile);
+const v8SrcFile = path.join(srcRoot,
+                            'deps', 'v8', 'src', 'objects', 'intl-objects.h');
+const v8Src = readFileSync(v8SrcFile, { encoding: 'utf8' });
+const v8MinimumICU = v8Src.match(/#define\s+V8_MINIMUM_ICU_VERSION\s+(\d+)/)[1];
+assert.ok(minimumICU >= Number(v8MinimumICU),
+          `minimum ICU version in ${icuVersionsFile} (${minimumICU}) ` +
+          `must be at least that in ${v8SrcFile} (${Number(v8MinimumICU)})`);


### PR DESCRIPTION
The minimum ICU version for Node.js must be at least the minimum ICU
version for V8.

Refs: https://github.com/nodejs/node/pull/30607
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
