### PR TITLE
repl: fix referrer for dynamic import

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -332,10 +332,12 @@ function REPLServer(prompt,
     if (code === '\n')
       return cb(null);
 
-    let pwd;
+    let parentURL;
     try {
       const { pathToFileURL } = require('url');
-      pwd = pathToFileURL(process.cwd()).href;
+      // Adding `/repl` prevents dynamic imports from loading relative
+      // to the parent of `process.cwd()`.
+      parentURL = pathToFileURL(path.join(process.cwd(), 'repl')).href;
     } catch {
     }
     while (true) {
@@ -350,7 +352,7 @@ function REPLServer(prompt,
           filename: file,
           displayErrors: true,
           importModuleDynamically: async (specifier) => {
-            return asyncESM.ESMLoader.import(specifier, pwd);
+            return asyncESM.ESMLoader.import(specifier, parentURL);
           }
         });
       } catch (e) {

--- a/test/parallel/test-repl-import-referrer.js
+++ b/test/parallel/test-repl-import-referrer.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const fixtures = require('../common/fixtures');
+
+const args = ['--interactive', '--experimental-repl-await'];
+const opts = { cwd: fixtures.path('es-modules') };
+const child = cp.spawn(process.execPath, args, opts);
+
+let output = '';
+child.stdout.setEncoding('utf8');
+child.stdout.on('data', (data) => {
+  output += data;
+});
+
+child.on('exit', common.mustCall(() => {
+  const results = output.replace(/^> /mg, '').split('\n').slice(2);
+  assert.deepStrictEqual(results, ['[Module] { message: \'A message\' }', '']);
+}));
+
+child.stdin.write('await import(\'./message.mjs\');\n');
+child.stdin.write('.exit');
+child.stdin.end();


### PR DESCRIPTION
The ESM loader does not accept a directory as the referrer, it requires
a path within the directory.  Add `/repl` to ensure relative dynamic
imports can succeed.

Fixes: https://github.com/nodejs/node/issues/19570

##### Checklist

- [x] `make -j4 test` (UNIX)
- [x] tests are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
