### PR TITLE
napi: implement napi_is_detached_arraybuffer

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3258,6 +3258,29 @@ that is, created with [`napi_create_external_arraybuffer`][].
 This API represents the invocation of the `ArrayBuffer` detach operation as
 defined in [Section 24.1.1.3][] of the ECMAScript Language Specification.
 
+### napi_is_detached_arraybuffer
+<!-- YAML
+added: REPLACEME
+-->
+
+```C
+napi_status napi_is_detached_arraybuffer(napi_env env,
+                                         napi_value arraybuffer,
+                                         bool* result)
+```
+
+* `[in] env`: The environment that the API is invoked under.
+* `[in] arraybuffer`: The JavaScript `ArrayBuffer` to be checked.
+* `[out] result`: Whether the `arraybuffer` is detached.
+
+Returns `napi_ok` if the API succeeded.
+
+The `ArrayBuffer` is considered detached if its internal data is `null`.
+
+This API represents the invocation of the `ArrayBuffer` `IsDetachedBuffer`
+operation as defined in [Section 24.1.1.2][] of the ECMAScript Language
+Specification.
+
 ## Working with JavaScript Properties
 
 N-API exposes a set of APIs to get and set properties on JavaScript
@@ -5259,6 +5282,7 @@ This API may only be called from the main thread.
 [Section 7]: https://tc39.github.io/ecma262/#sec-abstract-operations
 [Section 8.7]: https://tc39.es/ecma262/#sec-agents
 [Section 9.1.6]: https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+[Section 24.1.1.2]: https://tc39.es/ecma262/#sec-isdetachedbuffer
 [Travis CI]: https://travis-ci.org
 [Visual Studio]: https://visualstudio.microsoft.com
 [Working with JavaScript Properties]: #n_api_working_with_javascript_properties

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3263,6 +3263,8 @@ defined in [Section 24.1.1.3][] of the ECMAScript Language Specification.
 added: REPLACEME
 -->
 
+> Stability: 1 - Experimental
+
 ```C
 napi_status napi_is_detached_arraybuffer(napi_env env,
                                          napi_value arraybuffer,

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -518,6 +518,10 @@ NAPI_EXTERN napi_status napi_get_instance_data(napi_env env,
 // ArrayBuffer detaching
 NAPI_EXTERN napi_status napi_detach_arraybuffer(napi_env env,
                                                 napi_value arraybuffer);
+
+NAPI_EXTERN napi_status napi_is_detached_arraybuffer(napi_env env,
+                                                     napi_value value,
+                                                     bool* result);
 #endif  // NAPI_EXPERIMENTAL
 
 EXTERN_C_END

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -3049,7 +3049,7 @@ napi_status napi_is_detached_arraybuffer(napi_env env,
   v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(arraybuffer);
 
   *result = value->IsArrayBuffer() &&
-      value.As<v8::ArrayBuffer>()->GetBackingStore()->Data() == nullptr;
+            value.As<v8::ArrayBuffer>()->GetBackingStore()->Data() == nullptr;
 
   return napi_clear_last_error(env);
 }

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -3045,6 +3045,7 @@ napi_status napi_is_detached_arraybuffer(napi_env env,
                                          bool* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, arraybuffer);
+  CHECK_ARG(env, result);
 
   v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(arraybuffer);
 

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -3039,3 +3039,17 @@ napi_status napi_detach_arraybuffer(napi_env env, napi_value arraybuffer) {
 
   return napi_clear_last_error(env);
 }
+
+napi_status napi_is_detached_arraybuffer(napi_env env,
+                                         napi_value arraybuffer,
+                                         bool* result) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, arraybuffer);
+
+  v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(arraybuffer);
+
+  *result = value->IsArrayBuffer() &&
+      value.As<v8::ArrayBuffer>()->GetBackingStore()->Data() == nullptr;
+
+  return napi_clear_last_error(env);
+}

--- a/test/js-native-api/test_typedarray/test.js
+++ b/test/js-native-api/test_typedarray/test.js
@@ -87,8 +87,21 @@ arrayTypes.forEach((currentType) => {
   assert.ok(externalResult instanceof Int8Array);
   assert.strictEqual(externalResult.length, 3);
   assert.strictEqual(externalResult.byteLength, 3);
+  assert.ok(!test_typedarray.IsDetached(buffer.buffer));
   test_typedarray.Detach(buffer);
+  assert.ok(test_typedarray.IsDetached(buffer.buffer));
   assert.ok(externalResult instanceof Int8Array);
   assert.strictEqual(buffer.length, 0);
   assert.strictEqual(buffer.byteLength, 0);
+}
+
+{
+  const buffer = new ArrayBuffer(128);
+  assert.ok(!test_typedarray.IsDetached(buffer));
+}
+
+{
+  const buffer = test_typedarray.EmptyArrayBuffer();
+  assert.ok(buffer instanceof ArrayBuffer);
+  assert.ok(test_typedarray.IsDetached(buffer));
 }

--- a/test/js-native-api/test_typedarray/test.js
+++ b/test/js-native-api/test_typedarray/test.js
@@ -101,7 +101,7 @@ arrayTypes.forEach((currentType) => {
 }
 
 {
-  const buffer = test_typedarray.EmptyArrayBuffer();
+  const buffer = test_typedarray.NullArrayBuffer();
   assert.ok(buffer instanceof ArrayBuffer);
   assert.ok(test_typedarray.IsDetached(buffer));
 }

--- a/test/js-native-api/test_typedarray/test_typedarray.c
+++ b/test/js-native-api/test_typedarray/test_typedarray.c
@@ -97,6 +97,14 @@ static napi_value External(napi_env env, napi_callback_info info) {
   return output_array;
 }
 
+
+static napi_value EmptyArrayBuffer(napi_env env, napi_callback_info info) {
+  void* null_data = NULL;
+  napi_value array_buffer;
+  NAPI_CALL(env, napi_create_arraybuffer(env, 0, &null_data, &array_buffer));
+  return array_buffer;
+}
+
 static napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
   size_t argc = 4;
   napi_value args[4];
@@ -183,13 +191,35 @@ static napi_value Detach(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+static napi_value IsDetached(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments.");
+
+  napi_value array_buffer = args[0];
+  bool is_arraybuffer;
+  NAPI_CALL(env, napi_is_arraybuffer(env, array_buffer, &is_arraybuffer));
+  NAPI_ASSERT(env, is_arraybuffer, "Wrong type of arguments. Expects an array buffer as first argument.");
+
+  bool is_detached;
+  NAPI_CALL(env, napi_is_detached_arraybuffer(env, array_buffer, &is_detached));
+
+  napi_value result;
+  NAPI_CALL(env, napi_get_boolean(env, is_detached, &result));
+
+  return result;
+}
+
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("Multiply", Multiply),
     DECLARE_NAPI_PROPERTY("External", External),
+    DECLARE_NAPI_PROPERTY("EmptyArrayBuffer", EmptyArrayBuffer),
     DECLARE_NAPI_PROPERTY("CreateTypedArray", CreateTypedArray),
     DECLARE_NAPI_PROPERTY("Detach", Detach),
+    DECLARE_NAPI_PROPERTY("IsDetached", IsDetached),
   };
 
   NAPI_CALL(env, napi_define_properties(

--- a/test/js-native-api/test_typedarray/test_typedarray.c
+++ b/test/js-native-api/test_typedarray/test_typedarray.c
@@ -98,11 +98,12 @@ static napi_value External(napi_env env, napi_callback_info info) {
 }
 
 
-static napi_value EmptyArrayBuffer(napi_env env, napi_callback_info info) {
-  void* null_data = NULL;
-  napi_value array_buffer;
-  NAPI_CALL(env, napi_create_arraybuffer(env, 0, &null_data, &array_buffer));
-  return array_buffer;
+static napi_value NullArrayBuffer(napi_env env, napi_callback_info info) {
+  static void* data = NULL;
+  napi_value arraybuffer;
+  NAPI_CALL(env,
+      napi_create_external_arraybuffer(env, data, 0, NULL, NULL, &arraybuffer));
+  return arraybuffer;
 }
 
 static napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
@@ -200,7 +201,8 @@ static napi_value IsDetached(napi_env env, napi_callback_info info) {
   napi_value array_buffer = args[0];
   bool is_arraybuffer;
   NAPI_CALL(env, napi_is_arraybuffer(env, array_buffer, &is_arraybuffer));
-  NAPI_ASSERT(env, is_arraybuffer, "Wrong type of arguments. Expects an array buffer as first argument.");
+  NAPI_ASSERT(env, is_arraybuffer,
+      "Wrong type of arguments. Expects an array buffer as first argument.");
 
   bool is_detached;
   NAPI_CALL(env, napi_is_detached_arraybuffer(env, array_buffer, &is_detached));
@@ -216,7 +218,7 @@ napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("Multiply", Multiply),
     DECLARE_NAPI_PROPERTY("External", External),
-    DECLARE_NAPI_PROPERTY("EmptyArrayBuffer", EmptyArrayBuffer),
+    DECLARE_NAPI_PROPERTY("NullArrayBuffer", NullArrayBuffer),
     DECLARE_NAPI_PROPERTY("CreateTypedArray", CreateTypedArray),
     DECLARE_NAPI_PROPERTY("Detach", Detach),
     DECLARE_NAPI_PROPERTY("IsDetached", IsDetached),


### PR DESCRIPTION
This implements ArrayBuffer#IsDetachedBuffer operation as per ECMAScript
specification Section 24.1.1.2 https://tc39.es/ecma262/#sec-isdetachedbuffer.

Closes: https://github.com/nodejs/node/issues/29955

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Also superseeds https://github.com/nodejs/node/pull/30317.
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
