### PR TITLE
src: use uv_async_t for WeakRefs

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -1118,6 +1118,7 @@ void Environment::RemoveCleanupHook(void (*fn)(void*), void* arg) {
 inline void Environment::RegisterFinalizationGroupForCleanup(
     v8::Local<v8::FinalizationGroup> group) {
   cleanup_finalization_groups_.emplace_back(isolate(), group);
+  uv_async_send(&cleanup_finalization_groups_async_);
 }
 
 size_t CleanupHookCallback::Hash::operator()(

--- a/src/env.cc
+++ b/src/env.cc
@@ -467,8 +467,7 @@ void Environment::InitializeLibuv(bool start_profiler_idle_notifier) {
         Environment* env = ContainerOf(
             &Environment::cleanup_finalization_groups_async_, async);
         env->CleanupFinalizationGroups();
-      }
-     );
+      });
   uv_unref(reinterpret_cast<uv_handle_t*>(&idle_prepare_handle_));
   uv_unref(reinterpret_cast<uv_handle_t*>(&idle_check_handle_));
   uv_unref(reinterpret_cast<uv_handle_t*>(&cleanup_finalization_groups_async_));

--- a/src/env.cc
+++ b/src/env.cc
@@ -460,8 +460,18 @@ void Environment::InitializeLibuv(bool start_profiler_idle_notifier) {
   // will be recorded with state=IDLE.
   uv_prepare_init(event_loop(), &idle_prepare_handle_);
   uv_check_init(event_loop(), &idle_check_handle_);
+  uv_async_init(
+      event_loop(),
+      &cleanup_finalization_groups_async_,
+      [](uv_async_t* async) {
+        Environment* env = ContainerOf(
+            &Environment::cleanup_finalization_groups_async_, async);
+        env->CleanupFinalizationGroups();
+      }
+     );
   uv_unref(reinterpret_cast<uv_handle_t*>(&idle_prepare_handle_));
   uv_unref(reinterpret_cast<uv_handle_t*>(&idle_check_handle_));
+  uv_unref(reinterpret_cast<uv_handle_t*>(&cleanup_finalization_groups_async_));
 
   thread_stopper()->Install(
     this, static_cast<void*>(this), [](uv_async_t* handle) {
@@ -522,6 +532,10 @@ void Environment::RegisterHandleCleanups() {
       nullptr);
   RegisterHandleCleanup(
       reinterpret_cast<uv_handle_t*>(&idle_check_handle_),
+      close_and_finish,
+      nullptr);
+  RegisterHandleCleanup(
+      reinterpret_cast<uv_handle_t*>(&cleanup_finalization_groups_async_),
       close_and_finish,
       nullptr);
 }
@@ -1040,19 +1054,27 @@ char* Environment::Reallocate(char* data, size_t old_size, size_t size) {
   return new_data;
 }
 
-bool Environment::RunWeakRefCleanup() {
+void Environment::RunWeakRefCleanup() {
   isolate()->ClearKeptObjects();
+}
 
-  while (!cleanup_finalization_groups_.empty()) {
+void Environment::CleanupFinalizationGroups() {
+  HandleScope handle_scope(isolate());
+  Context::Scope context_scope(context());
+  TryCatchScope try_catch(this);
+
+  while (!cleanup_finalization_groups_.empty() && can_call_into_js()) {
     Local<FinalizationGroup> fg =
         cleanup_finalization_groups_.front().Get(isolate());
     cleanup_finalization_groups_.pop_front();
     if (!FinalizationGroup::Cleanup(fg).FromMaybe(false)) {
-      return false;
+      if (try_catch.HasCaught() && !try_catch.HasTerminated())
+        errors::TriggerUncaughtException(isolate(), try_catch);
+      // Re-schedule the execution of the remainder of the queue.
+      uv_async_send(&cleanup_finalization_groups_async_);
+      return;
     }
   }
-
-  return true;
 }
 
 void AsyncRequest::Install(Environment* env, void* data, uv_async_cb target) {

--- a/src/env.h
+++ b/src/env.h
@@ -1128,7 +1128,8 @@ class Environment : public MemoryRetainer {
   void RunAtExitCallbacks();
 
   void RegisterFinalizationGroupForCleanup(v8::Local<v8::FinalizationGroup> fg);
-  bool RunWeakRefCleanup();
+  void RunWeakRefCleanup();
+  void CleanupFinalizationGroups();
 
   // Strings and private symbols are shared across shared contexts
   // The getters simply proxy to the per-isolate primitive.
@@ -1270,6 +1271,7 @@ class Environment : public MemoryRetainer {
   uv_idle_t immediate_idle_handle_;
   uv_prepare_t idle_prepare_handle_;
   uv_check_t idle_check_handle_;
+  uv_async_t cleanup_finalization_groups_async_;
   bool profiler_idle_notifier_started_ = false;
 
   AsyncHooks async_hooks_;

--- a/test/parallel/test-finalization-group-error.js
+++ b/test/parallel/test-finalization-group-error.js
@@ -18,6 +18,10 @@ setTimeout(() => {
     name: 'Error',
     message: 'test',
   });
+
+  // Give the callbacks scheduled by global.gc() time to run, as the underlying
+  // uv_async_t is unref’ed.
+  setTimeout(() => {}, 200);
 }, 200);
 
 process.on('uncaughtException', common.mustCall());

--- a/test/parallel/test-finalization-group-regular-gc.js
+++ b/test/parallel/test-finalization-group-regular-gc.js
@@ -1,0 +1,25 @@
+// Flags: --harmony-weak-refs
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+// Test that finalization callbacks do not crash when caused through a regular
+// GC (not global.gc()).
+
+const start = Date.now();
+const g = new globalThis.FinalizationGroup(() => {
+  const diff = Date.now() - start;
+  assert(diff < 10000, `${diff} >= 10000`);
+});
+g.register({}, 42);
+
+setImmediate(() => {
+  const arr = [];
+  // Build up enough memory usage to hopefully trigger a platform task but not
+  // enough to trigger GC as an interrupt.
+  while (arr.length < 1000000) arr.push([]);
+
+  setTimeout(() => {
+    g;  // Keep reference alive.
+  }, 200000).unref();
+});

--- a/test/parallel/test-finalization-group-regular-gc.js
+++ b/test/parallel/test-finalization-group-regular-gc.js
@@ -1,6 +1,6 @@
 // Flags: --harmony-weak-refs
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 // Test that finalization callbacks do not crash when caused through a regular


### PR DESCRIPTION
Schedule a task on the main event loop, similar to what the HTML
spec recommends for browsers.

Alternative to https://github.com/nodejs/node/pull/30198

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
