### PR TITLE
test: use useful message argument in test function

### DIFF
--- a/test/sequential/test-inspector-async-call-stack.js
+++ b/test/sequential/test-inspector-async-call-stack.js
@@ -6,18 +6,20 @@ common.skipIf32Bits();
 
 const assert = require('assert');
 const { internalBinding } = require('internal/test/binding');
-const async_wrap = internalBinding('async_wrap');
-const { kTotals } = async_wrap.constants;
+const { async_hook_fields, constants } = internalBinding('async_wrap');
+const { kTotals } = constants;
 const inspector = require('inspector');
 
 const setDepth = 'Debugger.setAsyncCallStackDepth';
 
 function verifyAsyncHookDisabled(message) {
-  assert.strictEqual(async_wrap.async_hook_fields[kTotals], 0);
+  assert.strictEqual(async_hook_fields[kTotals], 0,
+                     `${async_hook_fields[kTotals]} !== 0: ${message}`);
 }
 
 function verifyAsyncHookEnabled(message) {
-  assert.strictEqual(async_wrap.async_hook_fields[kTotals], 4);
+  assert.strictEqual(async_hook_fields[kTotals], 4,
+                     `${async_hook_fields[kTotals]} !== 4: ${message}`);
 }
 
 // By default inspector async hooks should not have been installed.


### PR DESCRIPTION
The message argument of two test functions in
test-inspector-async-call-stack is useful but unused. Use it!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
