### PR TITLE
module: fix dynamic import from eval

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -25,7 +25,6 @@ const defaultResolve = require('internal/modules/esm/default_resolve');
 const createDynamicModule = require(
   'internal/modules/esm/create_dynamic_module');
 const { translators } = require('internal/modules/esm/translators');
-const { ModuleWrap } = internalBinding('module_wrap');
 const { getOptionValue } = require('internal/options');
 
 const debug = require('internal/util/debuglog').debuglog('esm');
@@ -117,7 +116,17 @@ class Loader {
     source,
     url = pathToFileURL(`${process.cwd()}/[eval${++this.evalIndex}]`).href
   ) {
-    const evalInstance = (url) => new ModuleWrap(url, undefined, source, 0, 0);
+    const evalInstance = (url) => {
+      const { ModuleWrap, callbackMap } = internalBinding('module_wrap');
+      const module = new ModuleWrap(url, undefined, source, 0, 0);
+      callbackMap.set(module, {
+        importModuleDynamically: (specifier, { url }) => {
+          return this.import(specifier, url);
+        }
+      });
+
+      return module;
+    };
     const job = new ModuleJob(this, url, evalInstance, false, false);
     this.moduleMap.set(url, job);
     const { module, result } = await job.run();

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -64,6 +64,19 @@ function evalScript(name, body, breakFirstLine, print) {
   const module = new CJSModule(name);
   module.filename = path.join(cwd, name);
   module.paths = CJSModule._nodeModulePaths(cwd);
+
+  let fileURL;
+  module.importModuleDynamically = async (specifier) => {
+    if (!fileURL) {
+      const { pathToFileURL } = require('url');
+      fileURL = pathToFileURL(path.join(cwd, name)).href;
+    }
+
+    const asyncESM = require('internal/process/esm_loader');
+    const loader = await asyncESM.ESMLoader;
+    return loader.import(specifier, fileURL);
+  };
+
   global.kVmBreakFirstLineSymbol = kVmBreakFirstLineSymbol;
   const script = `
     global.__filename = ${JSONStringify(name)};
@@ -73,11 +86,14 @@ function evalScript(name, body, breakFirstLine, print) {
     global.require = require;
     const { kVmBreakFirstLineSymbol } = global;
     delete global.kVmBreakFirstLineSymbol;
+    const { importModuleDynamically } = module;
+    delete module.importModuleDynamically;
     return require("vm").runInThisContext(
       ${JSONStringify(body)}, {
         filename: ${JSONStringify(name)},
         displayErrors: true,
-        [kVmBreakFirstLineSymbol]: ${!!breakFirstLine}
+        [kVmBreakFirstLineSymbol]: ${!!breakFirstLine},
+        importModuleDynamically
       });\n`;
   const result = module._compile(script, `${name}-wrapper`);
   if (print) {

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -57,6 +57,7 @@ function evalModule(source, print) {
 function evalScript(name, body, breakFirstLine, print) {
   const CJSModule = require('internal/modules/cjs/loader').Module;
   const { kVmBreakFirstLineSymbol } = require('internal/util');
+  const { pathToFileURL } = require('url');
 
   const cwd = tryGetCwd();
   const origModule = global.module;  // Set e.g. when called from the REPL.
@@ -65,35 +66,29 @@ function evalScript(name, body, breakFirstLine, print) {
   module.filename = path.join(cwd, name);
   module.paths = CJSModule._nodeModulePaths(cwd);
 
-  let fileURL;
-  module.importModuleDynamically = async (specifier) => {
-    if (!fileURL) {
-      const { pathToFileURL } = require('url');
-      fileURL = pathToFileURL(path.join(cwd, name)).href;
-    }
-
-    const asyncESM = require('internal/process/esm_loader');
-    const loader = await asyncESM.ESMLoader;
-    return loader.import(specifier, fileURL);
-  };
-
   global.kVmBreakFirstLineSymbol = kVmBreakFirstLineSymbol;
+  global.asyncESM = require('internal/process/esm_loader');
+
+  const baseUrl = pathToFileURL(module.filename).href;
+
   const script = `
     global.__filename = ${JSONStringify(name)};
     global.exports = exports;
     global.module = module;
     global.__dirname = __dirname;
     global.require = require;
-    const { kVmBreakFirstLineSymbol } = global;
+    const { kVmBreakFirstLineSymbol, asyncESM } = global;
     delete global.kVmBreakFirstLineSymbol;
-    const { importModuleDynamically } = module;
-    delete module.importModuleDynamically;
+    delete global.asyncESM;
     return require("vm").runInThisContext(
       ${JSONStringify(body)}, {
         filename: ${JSONStringify(name)},
         displayErrors: true,
         [kVmBreakFirstLineSymbol]: ${!!breakFirstLine},
-        importModuleDynamically
+        async importModuleDynamically (specifier) {
+          const loader = await asyncESM.ESMLoader;
+          return loader.import(specifier, ${JSONStringify(baseUrl)});
+        }
       });\n`;
   const result = module._compile(script, `${name}-wrapper`);
   if (print) {

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -283,3 +283,23 @@ child.exec(
     assert.ifError(err);
     assert.strictEqual(stdout, '.mjs file\n');
   }));
+
+
+// Assert that packages can be dynamic imported initial cwd-relative with --eval
+child.exec(
+  `${nodejs} ${execOptions} ` +
+  '--eval "process.chdir(\'..\');' +
+          'import(\'./test/fixtures/es-modules/mjs-file.mjs\')"',
+  common.mustCall((err, stdout) => {
+    assert.ifError(err);
+    assert.strictEqual(stdout, '.mjs file\n');
+  }));
+
+child.exec(
+  `${nodejs} ` +
+  '--eval "process.chdir(\'..\');' +
+          'import(\'./test/fixtures/es-modules/mjs-file.mjs\')"',
+  common.mustCall((err, stdout) => {
+    assert.ifError(err);
+    assert.strictEqual(stdout, '.mjs file\n');
+  }));


### PR DESCRIPTION
This allows dynamic import to work from CLI `--eval` with or without
`--input-type=module`.

Fixes: https://github.com/nodejs/node/issues/30591


##### Checklist

- [x] `make -j4 test` (UNIX)
- [x] tests are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
