### PR TITLE
v8: remove "this API is unstable" note

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -270,9 +270,6 @@ The serialization API provides means of serializing JavaScript values in a way
 that is compatible with the [HTML structured clone algorithm][].
 The format is backward-compatible (i.e. safe to store to disk).
 
-This API is under development, and changes (including incompatible
-changes to the API or wire format) may occur until this warning is removed.
-
 ### v8.serialize(value)
 <!-- YAML
 added: v8.0.0


### PR DESCRIPTION
As #30234 marked this as stable I think this line should be removed as well?