### PR TITLE
tls: expose IETF name for current cipher suite

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -827,16 +827,27 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/26625
     description: Return the minimum cipher version, instead of a fixed string
       (`'TLSv1/SSLv3'`).
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30637
+    description: Return the IETF cipher name as `standardName`.
 -->
 
 * Returns: {Object}
-  * `name` {string} The name of the cipher suite.
+  * `name` {string} OpenSSL name for the cipher suite.
+  * `standardName` {string} IETF name for the cipher suite.
   * `version` {string} The minimum TLS protocol version supported by this cipher
     suite.
 
 Returns an object containing information on the negotiated cipher suite.
 
-For example: `{ name: 'AES256-SHA', version: 'TLSv1.2' }`.
+For example:
+```json
+{
+    "name": "AES128-SHA256",
+    "standardName": "TLS_RSA_WITH_AES_128_CBC_SHA256",
+    "version": "TLSv1.2"
+}
+```
 
 See
 [SSL_CIPHER_get_name](https://www.openssl.org/docs/man1.1.1/man3/SSL_CIPHER_get_name.html)

--- a/src/env.h
+++ b/src/env.h
@@ -351,6 +351,7 @@ constexpr size_t kFsStatsBufferLength =
   V(sni_context_string, "sni_context")                                         \
   V(source_string, "source")                                                   \
   V(stack_string, "stack")                                                     \
+  V(standard_name_string, "standardName")                                      \
   V(start_time_string, "startTime")                                            \
   V(status_string, "status")                                                   \
   V(stdio_string, "stdio")                                                     \

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2685,6 +2685,9 @@ void SSLWrap<Base>::GetCipher(const FunctionCallbackInfo<Value>& args) {
   const char* cipher_name = SSL_CIPHER_get_name(c);
   info->Set(context, env->name_string(),
             OneByteString(args.GetIsolate(), cipher_name)).Check();
+  const char* cipher_standard_name = SSL_CIPHER_standard_name(c);
+  info->Set(context, env->standard_name_string(),
+            OneByteString(args.GetIsolate(), cipher_standard_name)).Check();
   const char* cipher_version = SSL_CIPHER_get_version(c);
   info->Set(context, env->version_string(),
             OneByteString(args.GetIsolate(), cipher_version)).Check();

--- a/test/parallel/test-tls-getcipher.js
+++ b/test/parallel/test-tls-getcipher.js
@@ -52,6 +52,7 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
   }, common.mustCall(function() {
     const cipher = this.getCipher();
     assert.strictEqual(cipher.name, 'AES128-SHA256');
+    assert.strictEqual(cipher.standardName, 'TLS_RSA_WITH_AES_128_CBC_SHA256');
     assert.strictEqual(cipher.version, 'TLSv1.2');
     this.end();
   }));
@@ -65,6 +66,8 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
   }, common.mustCall(function() {
     const cipher = this.getCipher();
     assert.strictEqual(cipher.name, 'ECDHE-RSA-AES128-GCM-SHA256');
+    assert.strictEqual(cipher.standardName,
+                       'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256');
     assert.strictEqual(cipher.version, 'TLSv1.2');
     this.end();
   }));
@@ -86,6 +89,7 @@ tls.createServer({
   }, common.mustCall(() => {
     const cipher = client.getCipher();
     assert.strictEqual(cipher.name, 'TLS_AES_128_CCM_8_SHA256');
+    assert.strictEqual(cipher.standardName, cipher.name);
     assert.strictEqual(cipher.version, 'TLSv1.3');
     client.end();
   }));

--- a/test/parallel/test-tls-multi-key.js
+++ b/test/parallel/test-tls-multi-key.js
@@ -157,6 +157,7 @@ function test(options) {
     }, common.mustCall(function() {
       assert.deepStrictEqual(ecdsa.getCipher(), {
         name: 'ECDHE-ECDSA-AES256-GCM-SHA384',
+        standardName: 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384',
         version: 'TLSv1.2'
       });
       assert.strictEqual(ecdsa.getPeerCertificate().subject.CN, eccCN);
@@ -175,6 +176,7 @@ function test(options) {
     }, common.mustCall(function() {
       assert.deepStrictEqual(rsa.getCipher(), {
         name: 'ECDHE-RSA-AES256-GCM-SHA384',
+        standardName: 'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384',
         version: 'TLSv1.2'
       });
       assert.strictEqual(rsa.getPeerCertificate().subject.CN, rsaCN);

--- a/test/parallel/test-tls-multi-pfx.js
+++ b/test/parallel/test-tls-multi-pfx.js
@@ -42,9 +42,11 @@ const server = tls.createServer(options, function(conn) {
 process.on('exit', function() {
   assert.deepStrictEqual(ciphers, [{
     name: 'ECDHE-ECDSA-AES256-GCM-SHA384',
+    standardName: 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384',
     version: 'TLSv1.2'
   }, {
     name: 'ECDHE-RSA-AES256-GCM-SHA384',
+    standardName: 'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384',
     version: 'TLSv1.2'
   }]);
 });


### PR DESCRIPTION
OpenSSL has its own legacy names, but knowing the IETF name is useful
when trouble-shooting, or looking for more information on the cipher.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
