### PR TITLE
fs: refactor rimraf retry options

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3223,7 +3223,8 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30644
     description: The `maxBusyTries` option is renamed to `maxRetries`, and its
-                 default is 0.
+                 default is 0. The `emfileWait` option has been removed, and
+                 `EMFILE` errors use the same retry logic as other errors.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -3246,14 +3247,11 @@ changes:
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
-  * `emfileWait` {integer} If an `EMFILE` error is encountered, Node.js will
-  retry the operation with a linear backoff of 1ms longer on each try until the
-  timeout duration passes this limit. This option is ignored if the `recursive`
-  option is not `true`. **Default:** `1000`.
-  * `maxRetries` {integer} If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error is
-  encountered, Node.js will retry the operation with a linear backoff wait of
-  100ms longer on each try. This option represents the number of retries. This
-  option is ignored if the `recursive` option is not `true`. **Default:** `0`.
+  * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENOTEMPTY`, or `EPERM`
+  error is encountered, Node.js will retry the operation with a linear backoff
+  wait of 100ms longer on each try. This option represents the number of
+  retries. This option is ignored if the `recursive` option is not `true`.
+  **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
   recursive mode, errors are not reported if `path` does not exist, and
   operations are retried on failure. **Default:** `false`.
@@ -3273,7 +3271,8 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30644
     description: The `maxBusyTries` option is renamed to `maxRetries`, and its
-                 default is 0.
+                 default is 0. The `emfileWait` option has been removed, and
+                 `EMFILE` errors use the same retry logic as other errors.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -5005,7 +5004,8 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30644
     description: The `maxBusyTries` option is renamed to `maxRetries`, and its
-                 default is 0.
+                 default is 0. The `emfileWait` option has been removed, and
+                 `EMFILE` errors use the same retry logic as other errors.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -5016,14 +5016,11 @@ changes:
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
-  * `emfileWait` {integer} If an `EMFILE` error is encountered, Node.js will
-  retry the operation with a linear backoff of 1ms longer on each try until the
-  timeout duration passes this limit. This option is ignored if the `recursive`
-  option is not `true`. **Default:** `1000`.
-  * `maxRetries` {integer} If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error is
-  encountered, Node.js will retry the operation with a linear backoff wait of
-  100ms longer on each try. This option represents the number of retries. This
-  option is ignored if the `recursive` option is not `true`. **Default:** `0`.
+  * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENOTEMPTY`, or `EPERM`
+  error is encountered, Node.js will retry the operation with a linear backoff
+  wait of 100ms longer on each try. This option represents the number of
+  retries. This option is ignored if the `recursive` option is not `true`.
+  **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
   recursive mode, errors are not reported if `path` does not exist, and
   operations are retried on failure. **Default:** `false`.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3222,7 +3222,8 @@ added: v0.0.2
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30644
-    description: The `maxBusyTries` option is renamed to `maxRetries`.
+    description: The `maxBusyTries` option is renamed to `maxRetries`, and its
+                 default is 0.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -3252,7 +3253,7 @@ changes:
   * `maxRetries` {integer} If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error is
   encountered, Node.js will retry the operation with a linear backoff wait of
   100ms longer on each try. This option represents the number of retries. This
-  option is ignored if the `recursive` option is not `true`. **Default:** `3`.
+  option is ignored if the `recursive` option is not `true`. **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
   recursive mode, errors are not reported if `path` does not exist, and
   operations are retried on failure. **Default:** `false`.
@@ -3271,7 +3272,8 @@ added: v0.1.21
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30644
-    description: The `maxBusyTries` option is renamed to `maxRetries`.
+    description: The `maxBusyTries` option is renamed to `maxRetries`, and its
+                 default is 0.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -3286,6 +3288,10 @@ changes:
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
+  * `maxRetries` {integer} If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error is
+  encountered, Node.js will retry the operation. This option represents the
+  number of retries. This option is ignored if the `recursive` option is not
+  `true`. **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
   recursive mode, errors are not reported if `path` does not exist, and
   operations are retried on failure. **Default:** `false`.
@@ -4998,7 +5004,8 @@ added: v10.0.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30644
-    description: The `maxBusyTries` option is renamed to `maxRetries`.
+    description: The `maxBusyTries` option is renamed to `maxRetries`, and its
+                 default is 0.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -5016,7 +5023,7 @@ changes:
   * `maxRetries` {integer} If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error is
   encountered, Node.js will retry the operation with a linear backoff wait of
   100ms longer on each try. This option represents the number of retries. This
-  option is ignored if the `recursive` option is not `true`. **Default:** `3`.
+  option is ignored if the `recursive` option is not `true`. **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
   recursive mode, errors are not reported if `path` does not exist, and
   operations are retried on failure. **Default:** `false`.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3220,6 +3220,9 @@ Synchronous rename(2). Returns `undefined`.
 <!-- YAML
 added: v0.0.2
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30644
+    description: The `maxBusyTries` option is renamed to `maxRetries`.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -3246,7 +3249,7 @@ changes:
   retry the operation with a linear backoff of 1ms longer on each try until the
   timeout duration passes this limit. This option is ignored if the `recursive`
   option is not `true`. **Default:** `1000`.
-  * `maxBusyTries` {integer} If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error is
+  * `maxRetries` {integer} If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error is
   encountered, Node.js will retry the operation with a linear backoff wait of
   100ms longer on each try. This option represents the number of retries. This
   option is ignored if the `recursive` option is not `true`. **Default:** `3`.
@@ -3266,6 +3269,9 @@ Windows and an `ENOTDIR` error on POSIX.
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30644
+    description: The `maxBusyTries` option is renamed to `maxRetries`.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -4990,6 +4996,9 @@ upon success.
 <!-- YAML
 added: v10.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30644
+    description: The `maxBusyTries` option is renamed to `maxRetries`.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -5004,7 +5013,7 @@ changes:
   retry the operation with a linear backoff of 1ms longer on each try until the
   timeout duration passes this limit. This option is ignored if the `recursive`
   option is not `true`. **Default:** `1000`.
-  * `maxBusyTries` {integer} If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error is
+  * `maxRetries` {integer} If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error is
   encountered, Node.js will retry the operation with a linear backoff wait of
   100ms longer on each try. This option represents the number of retries. This
   option is ignored if the `recursive` option is not `true`. **Default:** `3`.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3224,7 +3224,8 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/30644
     description: The `maxBusyTries` option is renamed to `maxRetries`, and its
                  default is 0. The `emfileWait` option has been removed, and
-                 `EMFILE` errors use the same retry logic as other errors.
+                 `EMFILE` errors use the same retry logic as other errors. The
+                 `retryDelay` option is now supported.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -3249,12 +3250,15 @@ changes:
 * `options` {Object}
   * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENOTEMPTY`, or `EPERM`
   error is encountered, Node.js will retry the operation with a linear backoff
-  wait of 100ms longer on each try. This option represents the number of
-  retries. This option is ignored if the `recursive` option is not `true`.
+  wait of `retryDelay` ms longer on each try. This option represents the number
+  of retries. This option is ignored if the `recursive` option is not `true`.
   **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
   recursive mode, errors are not reported if `path` does not exist, and
   operations are retried on failure. **Default:** `false`.
+  * `retryDelay` {integer} The amount of time in milliseconds to wait between
+  retries. This option is ignored if the `recursive` option is not `true`.
+  **Default:** `100`.
 * `callback` {Function}
   * `err` {Error}
 
@@ -3272,7 +3276,8 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/30644
     description: The `maxBusyTries` option is renamed to `maxRetries`, and its
                  default is 0. The `emfileWait` option has been removed, and
-                 `EMFILE` errors use the same retry logic as other errors.
+                 `EMFILE` errors use the same retry logic as other errors. The
+                 `retryDelay` option is now supported.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -3294,6 +3299,9 @@ changes:
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
   recursive mode, errors are not reported if `path` does not exist, and
   operations are retried on failure. **Default:** `false`.
+  * `retryDelay` {integer} The amount of time in milliseconds to wait between
+  retries. This option is ignored if the `recursive` option is not `true`.
+  **Default:** `100`.
 
 Synchronous rmdir(2). Returns `undefined`.
 
@@ -5005,7 +5013,8 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/30644
     description: The `maxBusyTries` option is renamed to `maxRetries`, and its
                  default is 0. The `emfileWait` option has been removed, and
-                 `EMFILE` errors use the same retry logic as other errors.
+                 `EMFILE` errors use the same retry logic as other errors. The
+                 `retryDelay` option is now supported.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -5018,12 +5027,15 @@ changes:
 * `options` {Object}
   * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENOTEMPTY`, or `EPERM`
   error is encountered, Node.js will retry the operation with a linear backoff
-  wait of 100ms longer on each try. This option represents the number of
-  retries. This option is ignored if the `recursive` option is not `true`.
+  wait of `retryDelay` ms longer on each try. This option represents the number
+  of retries. This option is ignored if the `recursive` option is not `true`.
   **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
   recursive mode, errors are not reported if `path` does not exist, and
   operations are retried on failure. **Default:** `false`.
+  * `retryDelay` {integer} The amount of time in milliseconds to wait between
+  retries. This option is ignored if the `recursive` option is not `true`.
+  **Default:** `100`.
 * Returns: {Promise}
 
 Removes the directory identified by `path` then resolves the `Promise` with

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3225,7 +3225,8 @@ changes:
     description: The `maxBusyTries` option is renamed to `maxRetries`, and its
                  default is 0. The `emfileWait` option has been removed, and
                  `EMFILE` errors use the same retry logic as other errors. The
-                 `retryDelay` option is now supported.
+                 `retryDelay` option is now supported. `ENFILE` errors are now
+                 retried.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -3248,11 +3249,11 @@ changes:
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
-  * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENOTEMPTY`, or `EPERM`
-  error is encountered, Node.js will retry the operation with a linear backoff
-  wait of `retryDelay` ms longer on each try. This option represents the number
-  of retries. This option is ignored if the `recursive` option is not `true`.
-  **Default:** `0`.
+  * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
+  `EPERM` error is encountered, Node.js will retry the operation with a linear
+  backoff wait of `retryDelay` ms longer on each try. This option represents the
+  number of retries. This option is ignored if the `recursive` option is not
+  `true`. **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
   recursive mode, errors are not reported if `path` does not exist, and
   operations are retried on failure. **Default:** `false`.
@@ -3277,7 +3278,8 @@ changes:
     description: The `maxBusyTries` option is renamed to `maxRetries`, and its
                  default is 0. The `emfileWait` option has been removed, and
                  `EMFILE` errors use the same retry logic as other errors. The
-                 `retryDelay` option is now supported.
+                 `retryDelay` option is now supported. `ENFILE` errors are now
+                 retried.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -3292,8 +3294,9 @@ changes:
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
-  * `maxRetries` {integer} If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error is
-  encountered, Node.js will retry the operation. This option represents the
+  * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
+  `EPERM` error is encountered, Node.js will retry the operation with a linear
+  backoff wait of `retryDelay` ms longer on each try. This option represents the
   number of retries. This option is ignored if the `recursive` option is not
   `true`. **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
@@ -5014,7 +5017,8 @@ changes:
     description: The `maxBusyTries` option is renamed to `maxRetries`, and its
                  default is 0. The `emfileWait` option has been removed, and
                  `EMFILE` errors use the same retry logic as other errors. The
-                 `retryDelay` option is now supported.
+                 `retryDelay` option is now supported. `ENFILE` errors are now
+                 retried.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/29168
     description: The `recursive`, `maxBusyTries`, and `emfileWait` options are
@@ -5025,11 +5029,11 @@ changes:
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
-  * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENOTEMPTY`, or `EPERM`
-  error is encountered, Node.js will retry the operation with a linear backoff
-  wait of `retryDelay` ms longer on each try. This option represents the number
-  of retries. This option is ignored if the `recursive` option is not `true`.
-  **Default:** `0`.
+  * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
+  `EPERM` error is encountered, Node.js will retry the operation with a linear
+  backoff wait of `retryDelay` ms longer on each try. This option represents the
+  number of retries. This option is ignored if the `recursive` option is not
+  `true`. **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
   recursive mode, errors are not reported if `path` does not exist, and
   operations are retried on failure. **Default:** `false`.

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -22,25 +22,21 @@ const {
 const { join } = require('path');
 const { setTimeout } = require('timers');
 const notEmptyErrorCodes = new Set(['ENOTEMPTY', 'EEXIST', 'EPERM']);
+const retryErrorCodes = new Set(['EBUSY', 'EMFILE', 'ENOTEMPTY', 'EPERM']);
 const isWindows = process.platform === 'win32';
 const epermHandler = isWindows ? fixWinEPERM : _rmdir;
 const epermHandlerSync = isWindows ? fixWinEPERMSync : _rmdirSync;
 
 
 function rimraf(path, options, callback) {
-  let timeout = 0;  // For EMFILE handling.
   let retries = 0;
 
   _rimraf(path, options, function CB(err) {
     if (err) {
-      if ((err.code === 'EBUSY' || err.code === 'ENOTEMPTY' ||
-           err.code === 'EPERM') && retries < options.maxRetries) {
+      if (retryErrorCodes.has(err.code) && retries < options.maxRetries) {
         retries++;
         return setTimeout(_rimraf, retries * 100, path, options, CB);
       }
-
-      if (err.code === 'EMFILE' && timeout < options.emfileWait)
-        return setTimeout(_rimraf, timeout++, path, options, CB);
 
       // The file is already gone.
       if (err.code === 'ENOENT')

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -35,7 +35,7 @@ function rimraf(path, options, callback) {
   _rimraf(path, options, function CB(err) {
     if (err) {
       if ((err.code === 'EBUSY' || err.code === 'ENOTEMPTY' ||
-           err.code === 'EPERM') && busyTries < options.maxBusyTries) {
+           err.code === 'EPERM') && busyTries < options.maxRetries) {
         busyTries++;
         return setTimeout(_rimraf, busyTries * 100, path, options, CB);
       }

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -25,19 +25,18 @@ const notEmptyErrorCodes = new Set(['ENOTEMPTY', 'EEXIST', 'EPERM']);
 const isWindows = process.platform === 'win32';
 const epermHandler = isWindows ? fixWinEPERM : _rmdir;
 const epermHandlerSync = isWindows ? fixWinEPERMSync : _rmdirSync;
-const numRetries = isWindows ? 100 : 1;
 
 
 function rimraf(path, options, callback) {
   let timeout = 0;  // For EMFILE handling.
-  let busyTries = 0;
+  let retries = 0;
 
   _rimraf(path, options, function CB(err) {
     if (err) {
       if ((err.code === 'EBUSY' || err.code === 'ENOTEMPTY' ||
-           err.code === 'EPERM') && busyTries < options.maxRetries) {
-        busyTries++;
-        return setTimeout(_rimraf, busyTries * 100, path, options, CB);
+           err.code === 'EPERM') && retries < options.maxRetries) {
+        retries++;
+        return setTimeout(_rimraf, retries * 100, path, options, CB);
       }
 
       if (err.code === 'EMFILE' && timeout < options.emfileWait)
@@ -211,7 +210,7 @@ function _rmdirSync(path, options, originalErr) {
         rimrafSync(join(path, child), options);
       });
 
-      for (let i = 0; i < numRetries; i++) {
+      for (let i = 0; i < options.maxRetries + 1; i++) {
         try {
           return rmdirSync(path, options);
         } catch {} // Ignore errors.

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -35,7 +35,8 @@ function rimraf(path, options, callback) {
     if (err) {
       if (retryErrorCodes.has(err.code) && retries < options.maxRetries) {
         retries++;
-        return setTimeout(_rimraf, retries * 100, path, options, CB);
+        const delay = retries * options.retryDelay;
+        return setTimeout(_rimraf, delay, path, options, CB);
       }
 
       // The file is already gone.

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -22,7 +22,8 @@ const {
 const { join } = require('path');
 const { setTimeout } = require('timers');
 const notEmptyErrorCodes = new Set(['ENOTEMPTY', 'EEXIST', 'EPERM']);
-const retryErrorCodes = new Set(['EBUSY', 'EMFILE', 'ENOTEMPTY', 'EPERM']);
+const retryErrorCodes = new Set(
+  ['EBUSY', 'EMFILE', 'ENFILE', 'ENOTEMPTY', 'EPERM']);
 const isWindows = process.platform === 'win32';
 const epermHandler = isWindows ? fixWinEPERM : _rmdir;
 const epermHandlerSync = isWindows ? fixWinEPERMSync : _rmdirSync;

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -28,7 +28,6 @@ const {
 const { once } = require('internal/util');
 const { toPathIfFileURL } = require('internal/url');
 const {
-  validateInt32,
   validateUint32
 } = require('internal/validators');
 const pathModule = require('path');
@@ -566,7 +565,6 @@ function warnOnNonPortableTemplate(template) {
 }
 
 const defaultRmdirOptions = {
-  emfileWait: 1000,
   maxRetries: 0,
   recursive: false,
 };
@@ -582,7 +580,6 @@ const validateRmdirOptions = hideStackFrames((options) => {
   if (typeof options.recursive !== 'boolean')
     throw new ERR_INVALID_ARG_TYPE('recursive', 'boolean', options.recursive);
 
-  validateInt32(options.emfileWait, 'emfileWait', 0);
   validateUint32(options.maxRetries, 'maxRetries');
 
   return options;

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -567,7 +567,7 @@ function warnOnNonPortableTemplate(template) {
 
 const defaultRmdirOptions = {
   emfileWait: 1000,
-  maxBusyTries: 3,
+  maxRetries: 3,
   recursive: false,
 };
 
@@ -583,7 +583,7 @@ const validateRmdirOptions = hideStackFrames((options) => {
     throw new ERR_INVALID_ARG_TYPE('recursive', 'boolean', options.recursive);
 
   validateInt32(options.emfileWait, 'emfileWait', 0);
-  validateUint32(options.maxBusyTries, 'maxBusyTries');
+  validateUint32(options.maxRetries, 'maxRetries');
 
   return options;
 });

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -28,6 +28,7 @@ const {
 const { once } = require('internal/util');
 const { toPathIfFileURL } = require('internal/url');
 const {
+  validateInt32,
   validateUint32
 } = require('internal/validators');
 const pathModule = require('path');
@@ -565,6 +566,7 @@ function warnOnNonPortableTemplate(template) {
 }
 
 const defaultRmdirOptions = {
+  retryDelay: 100,
   maxRetries: 0,
   recursive: false,
 };
@@ -580,6 +582,7 @@ const validateRmdirOptions = hideStackFrames((options) => {
   if (typeof options.recursive !== 'boolean')
     throw new ERR_INVALID_ARG_TYPE('recursive', 'boolean', options.recursive);
 
+  validateInt32(options.retryDelay, 'retryDelay', 0);
   validateUint32(options.maxRetries, 'maxRetries');
 
   return options;

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -567,7 +567,7 @@ function warnOnNonPortableTemplate(template) {
 
 const defaultRmdirOptions = {
   emfileWait: 1000,
-  maxRetries: 3,
+  maxRetries: 0,
   recursive: false,
 };
 

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -156,7 +156,7 @@ function removeAsync(dir) {
 {
   const defaults = {
     emfileWait: 1000,
-    maxRetries: 3,
+    maxRetries: 0,
     recursive: false
   };
   const modified = {

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -155,12 +155,10 @@ function removeAsync(dir) {
 // Test input validation.
 {
   const defaults = {
-    emfileWait: 1000,
     maxRetries: 0,
     recursive: false
   };
   const modified = {
-    emfileWait: 953,
     maxRetries: 5,
     recursive: true
   };
@@ -171,7 +169,6 @@ function removeAsync(dir) {
   assert.deepStrictEqual(validateRmdirOptions({
     maxRetries: 99
   }), {
-    emfileWait: 1000,
     maxRetries: 99,
     recursive: false
   });
@@ -194,14 +191,6 @@ function removeAsync(dir) {
       type: TypeError,
       message: /^The "recursive" argument must be of type boolean\./
     });
-  });
-
-  common.expectsError(() => {
-    validateRmdirOptions({ emfileWait: -1 });
-  }, {
-    code: 'ERR_OUT_OF_RANGE',
-    type: RangeError,
-    message: /^The value of "emfileWait" is out of range\./
   });
 
   common.expectsError(() => {

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -155,10 +155,12 @@ function removeAsync(dir) {
 // Test input validation.
 {
   const defaults = {
+    retryDelay: 100,
     maxRetries: 0,
     recursive: false
   };
   const modified = {
+    retryDelay: 953,
     maxRetries: 5,
     recursive: true
   };
@@ -169,6 +171,7 @@ function removeAsync(dir) {
   assert.deepStrictEqual(validateRmdirOptions({
     maxRetries: 99
   }), {
+    retryDelay: 100,
     maxRetries: 99,
     recursive: false
   });
@@ -191,6 +194,14 @@ function removeAsync(dir) {
       type: TypeError,
       message: /^The "recursive" argument must be of type boolean\./
     });
+  });
+
+  common.expectsError(() => {
+    validateRmdirOptions({ retryDelay: -1 });
+  }, {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: /^The value of "retryDelay" is out of range\./
   });
 
   common.expectsError(() => {

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -156,12 +156,12 @@ function removeAsync(dir) {
 {
   const defaults = {
     emfileWait: 1000,
-    maxBusyTries: 3,
+    maxRetries: 3,
     recursive: false
   };
   const modified = {
     emfileWait: 953,
-    maxBusyTries: 5,
+    maxRetries: 5,
     recursive: true
   };
 
@@ -169,10 +169,10 @@ function removeAsync(dir) {
   assert.deepStrictEqual(validateRmdirOptions({}), defaults);
   assert.deepStrictEqual(validateRmdirOptions(modified), modified);
   assert.deepStrictEqual(validateRmdirOptions({
-    maxBusyTries: 99
+    maxRetries: 99
   }), {
     emfileWait: 1000,
-    maxBusyTries: 99,
+    maxRetries: 99,
     recursive: false
   });
 
@@ -205,10 +205,10 @@ function removeAsync(dir) {
   });
 
   common.expectsError(() => {
-    validateRmdirOptions({ maxBusyTries: -1 });
+    validateRmdirOptions({ maxRetries: -1 });
   }, {
     code: 'ERR_OUT_OF_RANGE',
     type: RangeError,
-    message: /^The value of "maxBusyTries" is out of range\./
+    message: /^The value of "maxRetries" is out of range\./
   });
 }


### PR DESCRIPTION
This PR implements the changes proposed in https://github.com/nodejs/node/issues/30580.

This PR doesn't quite close out #30580 though because synchronous retries are not able to be fully implemented just yet (https://github.com/libuv/libuv/pull/2548 should enable that soon though).

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
