### PR TITLE
build: add --without-node-code-cache configure option

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -981,13 +981,13 @@ def configure_node(o):
   o['variables']['want_separate_host_toolset'] = int(cross_compiling)
 
   if not options.without_node_snapshot:
-    o['variables']['node_use_node_snapshot'] = b(not cross_compiling)
+    o['variables']['node_use_node_snapshot'] = b(not cross_compiling and not options.shared)
   else:
     o['variables']['node_use_node_snapshot'] = 'false'
 
   if not options.without_node_code_cache:
     # TODO(refack): fix this when implementing embedded code-cache when cross-compiling.
-    o['variables']['node_use_node_code_cache'] = b(not cross_compiling)
+    o['variables']['node_use_node_code_cache'] = b(not cross_compiling and not options.shared)
   else:
     o['variables']['node_use_node_code_cache'] = 'false'
 

--- a/configure.py
+++ b/configure.py
@@ -981,13 +981,15 @@ def configure_node(o):
   o['variables']['want_separate_host_toolset'] = int(cross_compiling)
 
   if not options.without_node_snapshot:
-    o['variables']['node_use_node_snapshot'] = b(not cross_compiling and not options.shared)
+    o['variables']['node_use_node_snapshot'] = b(
+      not cross_compiling and not options.shared)
   else:
     o['variables']['node_use_node_snapshot'] = 'false'
 
   if not options.without_node_code_cache:
     # TODO(refack): fix this when implementing embedded code-cache when cross-compiling.
-    o['variables']['node_use_node_code_cache'] = b(not cross_compiling and not options.shared)
+    o['variables']['node_use_node_code_cache'] = b(
+      not cross_compiling and not options.shared)
   else:
     o['variables']['node_use_node_code_cache'] = 'false'
 

--- a/configure.py
+++ b/configure.py
@@ -455,6 +455,11 @@ parser.add_option('--without-node-snapshot',
     dest='without_node_snapshot',
     help='Turn off V8 snapshot integration. Currently experimental.')
 
+parser.add_option('--without-node-code-cache',
+    action='store_true',
+    dest='without_node_code_cache',
+    help='Turn off V8 Code cache integration.')
+
 intl_optgroup.add_option('--download',
     action='store',
     dest='download_list',
@@ -980,6 +985,12 @@ def configure_node(o):
   else:
     o['variables']['node_use_node_snapshot'] = 'false'
 
+  if not options.without_node_code_cache:
+    # TODO(refack): fix this when implementing embedded code-cache when cross-compiling.
+    o['variables']['node_use_node_code_cache'] = b(not cross_compiling)
+  else:
+    o['variables']['node_use_node_code_cache'] = 'false'
+
   if target_arch == 'arm':
     configure_arm(o)
   elif target_arch in ('mips', 'mipsel', 'mips64el'):
@@ -1100,9 +1111,7 @@ def configure_node(o):
     o['variables']['debug_nghttp2'] = 'false'
 
   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
-  # TODO(refack): fix this when implementing embedded code-cache when cross-compiling.
-  if o['variables']['want_separate_host_toolset'] == 0:
-    o['variables']['node_code_cache'] = 'yes' # For testing
+
   o['variables']['node_shared'] = b(options.shared)
   node_module_version = getmoduleversion.get_version()
 

--- a/node.gyp
+++ b/node.gyp
@@ -432,7 +432,7 @@
             },
           },
          }],
-        ['want_separate_host_toolset==0', {
+        ['node_use_node_code_cache=="true"', {
           'dependencies': [
             'mkcodecache',
           ],

--- a/test/parallel/test-code-cache.js
+++ b/test/parallel/test-code-cache.js
@@ -33,6 +33,8 @@ const loadedModules = process.moduleLoadList
 // are all compiled without cache and we are doing the bookkeeping right.
 if (!process.features.cached_builtins) {
   console.log('The binary is not configured with code cache');
+  assert(!process.config.variables.node_use_node_code_cache);
+
   if (isMainThread) {
     assert.deepStrictEqual(compiledWithCache, new Set());
     for (const key of loadedModules) {
@@ -46,10 +48,7 @@ if (!process.features.cached_builtins) {
     assert.notDeepStrictEqual(compiledWithCache, new Set());
   }
 } else {  // Native compiled
-  assert.strictEqual(
-    process.config.variables.node_code_cache,
-    'yes'
-  );
+  assert(process.config.variables.node_use_node_code_cache);
 
   if (!isMainThread) {
     for (const key of [ 'internal/bootstrap/pre_execution' ]) {


### PR DESCRIPTION
**build: add --without-node-code-cache configure option**

So that it's possible to build without code cache (in particular,
without building mkcodecache) for testing.

Refs: https://github.com/nodejs/node/issues/28845

**build: do not build mksnapshot and mkcodecache for --shared**

To build mkcodecache and mksnapshot (they are executables),
we currently build libnode with unresolved symbols, then build
the two exectuables with src/node_snapshot_stub.cc and
src/node_code_cache_stub.cc. Each of them write a C++ file to
disk when being run. We then use the generated C++ files & libnode
(with unresolved symbols) to build the final Node executable.

However, if libnode itself is the final product, then we should
not build it with unresolved symbols.
https://github.com/nodejs/node/pull/28897 added the two stubs
for the libnode target when the --shared configure option is used,
but it did not get rid of the actions to build and run mksnapshot
and mkcodecache for --shared, so to get it working we also
need a patch to make sure --shared imply --without-node-code-cache
and --without-node-snapshot, until we actually fix the TODO so that
mksnapshot and mkcodecache do not use the libnode that way.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
