### PR TITLE
test: add mustCall() to test-inspector-contexts

### DIFF
--- a/test/sequential/test-inspector-contexts.js
+++ b/test/sequential/test-inspector-contexts.js
@@ -155,4 +155,4 @@ async function testBreakpointHit() {
   await pausedPromise;
 }
 
-testContextCreatedAndDestroyed().then(testBreakpointHit);
+testContextCreatedAndDestroyed().then(common.mustCall(testBreakpointHit));

--- a/test/sequential/test-inspector-contexts.js
+++ b/test/sequential/test-inspector-contexts.js
@@ -5,7 +5,7 @@
 const common = require('../common');
 common.skipIfInspectorDisabled();
 
-const { strictEqual } = require('assert');
+const { ifError, strictEqual } = require('assert');
 const { createContext, runInNewContext } = require('vm');
 const { Session } = require('inspector');
 
@@ -22,7 +22,7 @@ async function testContextCreatedAndDestroyed() {
     const mainContextPromise =
         notificationPromise('Runtime.executionContextCreated');
 
-    session.post('Runtime.enable');
+    session.post('Runtime.enable', assert.ifError);
     const contextCreated = await mainContextPromise;
     const { name, origin, auxData } = contextCreated.params.context;
     if (common.isSunOS || common.isWindows) {
@@ -148,7 +148,7 @@ async function testContextCreatedAndDestroyed() {
 
 async function testBreakpointHit() {
   console.log('Testing breakpoint is hit in a new context');
-  session.post('Debugger.enable');
+  session.post('Debugger.enable', assert.ifError);
 
   const pausedPromise = notificationPromise('Debugger.paused');
   runInNewContext('debugger', {});

--- a/test/sequential/test-inspector-contexts.js
+++ b/test/sequential/test-inspector-contexts.js
@@ -65,8 +65,10 @@ async function testContextCreatedAndDestroyed() {
                        JSON.stringify(contextCreated));
 
     // GC is unpredictable...
+    console.log('Checking/waiting for GC.');
     while (!contextDestroyed)
       global.gc();
+    console.log('Context destroyed.');
 
     assert.strictEqual(contextDestroyed.params.executionContextId, id,
                        JSON.stringify(contextDestroyed));
@@ -95,8 +97,10 @@ async function testContextCreatedAndDestroyed() {
                        JSON.stringify(contextCreated));
 
     // GC is unpredictable...
+    console.log('Checking/waiting for GC again.');
     while (!contextDestroyed)
       global.gc();
+    console.log('Other context destroyed.');
   }
 
   {
@@ -119,8 +123,10 @@ async function testContextCreatedAndDestroyed() {
                        JSON.stringify(contextCreated));
 
     // GC is unpredictable...
+    console.log('Checking/waiting for GC a third time.');
     while (!contextDestroyed)
       global.gc();
+    console.log('Context destroyed once again.');
   }
 
   {
@@ -141,8 +147,10 @@ async function testContextCreatedAndDestroyed() {
                        JSON.stringify(contextCreated));
 
     // GC is unpredictable...
+    console.log('Checking/waiting for GC a fourth time.');
     while (!contextDestroyed)
       global.gc();
+    console.log('Context destroyed a fourth time.');
   }
 }
 


### PR DESCRIPTION
In test-inspector-contexts, if mainContextPromise is modified such that
the `method` argument is changed to something invalid, the test still
passes and the second part of the test never runs. Use
`common.mustCall()` to cause the test to fail if the second part of the
test does not run.

Refs: https://github.com/nodejs/node/issues/30519#issuecomment-558476839

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
