### PR TITLE
doc: fix up N-API doc

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -4920,7 +4920,7 @@ napiVersion: 2
 
 ```C
 NAPI_EXTERN napi_status napi_get_uv_event_loop(napi_env env,
-                                               uv_loop_s** loop);
+                                               struct uv_loop_s** loop);
 ```
 
 * `[in] env`: The environment that the API is invoked under.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -4353,7 +4353,7 @@ allows them to avoid blocking overall execution of the Node.js application.
 N-API provides an ABI-stable interface for these
 supporting functions which covers the most common asynchronous use cases.
 
-N-API defines the `napi_work` structure which is used to manage
+N-API defines the `napi_async_work` structure which is used to manage
 asynchronous workers. Instances are created/deleted with
 [`napi_create_async_work`][] and [`napi_delete_async_work`][].
 
@@ -4920,7 +4920,7 @@ napiVersion: 2
 
 ```C
 NAPI_EXTERN napi_status napi_get_uv_event_loop(napi_env env,
-                                               uv_loop_t** loop);
+                                               uv_loop_s** loop);
 ```
 
 * `[in] env`: The environment that the API is invoked under.


### PR DESCRIPTION
- Fixed the signature for `napi_status napi_get_uv_event_loop` from:
```C
NAPI_EXTERN napi_status napi_get_uv_event_loop(napi_env env,
                                               uv_loop_t** loop);
```
to:

```C
NAPI_EXTERN napi_status napi_get_uv_event_loop(napi_env env,
                                               uv_loop_s** loop);
```

- In section **Simple Asynchronous Operations** changed type `napi_work` to `napi_async_work`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

