### PR TITLE
util: add more predefined color codes to inspect.colors

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -678,12 +678,70 @@ The default styles and associated colors are:
 * `symbol`: `green`
 * `undefined`: `grey`
 
-The predefined color codes are: `white`, `grey`, `black`, `blue`, `cyan`,
-`green`, `magenta`, `red` and `yellow`. There are also `bold`, `italic`,
-`underline` and `inverse` codes.
-
 Color styling uses ANSI control codes that may not be supported on all
 terminals. To verify color support use [`tty.hasColors()`][].
+
+The predefined color codes are:
+
+#### Modifiers
+
+Modifier support varies throughout different terminals. They will mostly be
+ignored, if not supported.
+
+* `reset` - Resets all (color) modifiers to their defaults
+* **bold** - Make text bold
+* _italic_ - Make text italic
+* <span style="border-bottom: 1px;">underline</span> - Make text underlined
+* ~~strikethrough~~ - Puts a horizontal line through the center of the text
+  (Alias: `strikeThrough`, `crossedout`, `crossedOut`)
+* `hidden` - Prints the text, but makes it invisible (Alias: conceal)
+* <span style="opacity: 0.5;">dim</span> - Decreased color intensity (Alias:
+  `faint`)
+* <span style="border-top: 1px">overlined</span> - Make text overlined
+* blink - Hides and shows the text in an interval
+* <span style="filter: invert(100%)">inverse</span> - Swap foreground and
+  background colors (Alias: `swapcolors`, `swapColors`)
+* <span style="border-bottom: 1px double;">doubleunderline</span> - Make text
+  double underlined (Alias: `doubleUnderline`)
+* <span style="border: 1px">framed</span> - Draw a frame around the text
+
+#### Colors
+
+* `black`
+* `red`
+* `green`
+* `yellow`
+* `blue`
+* `magenta`
+* `cyan`
+* `white`
+* `gray` (alias: `grey`, `blackBright`)
+* `redBright`
+* `greenBright`
+* `yellowBright`
+* `blueBright`
+* `magentaBright`
+* `cyanBright`
+* `whiteBright`
+
+#### Background colors
+
+* `bgBlack`
+* `bgRed`
+* `bgGreen`
+* `bgYellow`
+* `bgBlue`
+* `bgMagenta`
+* `bgCyan`
+* `bgWhite`
+* `bgGray` (alias: `bgGrey`, `bgBlackBright`)
+* `bgRedBright`
+* `bgGreenBright`
+* `bgYellowBright`
+* `bgBlueBright`
+* `bgMagentaBright`
+* `bgCyanBright`
+* `bgWhiteBright`
 
 ### Custom inspection functions on Objects
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -681,7 +681,8 @@ The default styles and associated colors are:
 Color styling uses ANSI control codes that may not be supported on all
 terminals. To verify color support use [`tty.hasColors()`][].
 
-The predefined color codes are:
+Predefined control codes are listed below (grouped as "Modifiers", "Foreground
+colors", and "Background colors").
 
 #### Modifiers
 
@@ -705,7 +706,7 @@ ignored, if not supported.
   double underlined (Alias: `doubleUnderline`)
 * <span style="border: 1px">framed</span> - Draw a frame around the text
 
-#### Colors
+#### Foreground colors
 
 * `black`
 * `red`

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -116,6 +116,8 @@ const builtInObjects = new Set(
   ObjectGetOwnPropertyNames(global).filter((e) => /^([A-Z][a-z]+)+$/.test(e))
 );
 
+// These options must stay in sync with `getUserOptions`. So if any option will
+// be added or removed, `getUserOptions` must also be updated accordingly.
 const inspectDefaultOptions = ObjectSeal({
   showHidden: false,
   depth: 2,

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -276,7 +276,8 @@ inspect.colors = ObjectAssign(ObjectCreate(null), {
   italic: [3, 23],
   underline: [4, 24],
   blink: [5, 25],
-  inverse: [7, 27], // Alias: swapcolors, swapColors; Swap forground and background colors
+  // Swap forground and background colors
+  inverse: [7, 27], // Alias: swapcolors, swapColors
   hidden: [8, 28], // Alias: conceal
   strikethrough: [9, 29], // Alias: strikeThrough, crossedout, crossedOut
   doubleunderline: [21, 24], // Alias: doubleUnderline
@@ -317,7 +318,7 @@ inspect.colors = ObjectAssign(ObjectCreate(null), {
 });
 
 function defineColorAlias(target, alias) {
-  Object.defineProperty(inspect.colors, alias, {
+  ObjectDefineProperty(inspect.colors, alias, {
     get() {
       return this[target];
     },

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -264,23 +264,85 @@ ObjectDefineProperty(inspect, 'defaultOptions', {
   }
 });
 
-// http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
+// Set Graphics Rendition http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
+// Each color consists of an array with the color code as first entry and the
+// reset code as second entry.
+const defaultFG = 39;
+const defaultBG = 49;
 inspect.colors = ObjectAssign(ObjectCreate(null), {
+  reset: [0, 0],
   bold: [1, 22],
+  dim: [2, 22], // Alias: faint
   italic: [3, 23],
   underline: [4, 24],
-  inverse: [7, 27],
-  white: [37, 39],
-  grey: [90, 39],
-  black: [30, 39],
-  blue: [34, 39],
-  cyan: [36, 39],
-  green: [32, 39],
-  magenta: [35, 39],
-  red: [31, 39],
-  yellow: [33, 39]
+  blink: [5, 25],
+  inverse: [7, 27], // Alias: swapcolors, swapColors; Swap forground and background colors
+  hidden: [8, 28], // Alias: conceal
+  strikethrough: [9, 29], // Alias: strikeThrough, crossedout, crossedOut
+  doubleunderline: [21, 24], // Alias: doubleUnderline
+  black: [30, defaultFG],
+  red: [31, defaultFG],
+  green: [32, defaultFG],
+  yellow: [33, defaultFG],
+  blue: [34, defaultFG],
+  magenta: [35, defaultFG],
+  cyan: [36, defaultFG],
+  white: [37, defaultFG],
+  bgBlack: [40, defaultBG],
+  bgRed: [41, defaultBG],
+  bgGreen: [42, defaultBG],
+  bgYellow: [43, defaultBG],
+  bgBlue: [44, defaultBG],
+  bgMagenta: [45, defaultBG],
+  bgCyan: [46, defaultBG],
+  bgWhite: [47, defaultBG],
+  framed: [51, 54],
+  overlined: [53, 55],
+  gray: [90, defaultFG], // Alias: grey, blackBright
+  redBright: [91, defaultFG],
+  greenBright: [92, defaultFG],
+  yellowBright: [93, defaultFG],
+  blueBright: [94, defaultFG],
+  magentaBright: [95, defaultFG],
+  cyanBright: [96, defaultFG],
+  whiteBright: [97, defaultFG],
+  bgGray: [100, defaultBG], // Alias: bgGrey, bgBlackBright
+  bgRedBright: [101, defaultBG],
+  bgGreenBright: [102, defaultBG],
+  bgYellowBright: [103, defaultBG],
+  bgBlueBright: [104, defaultBG],
+  bgMagentaBright: [105, defaultBG],
+  bgCyanBright: [106, defaultBG],
+  bgWhiteBright: [107, defaultBG],
 });
 
+function defineColorAlias(target, alias) {
+  Object.defineProperty(inspect.colors, alias, {
+    get() {
+      return this[target];
+    },
+    set(value) {
+      this[target] = value;
+    },
+    configurable: true,
+    enumerable: false
+  });
+}
+
+defineColorAlias('gray', 'grey');
+defineColorAlias('gray', 'blackBright');
+defineColorAlias('bgGray', 'bgGrey');
+defineColorAlias('bgGray', 'bgBlackBright');
+defineColorAlias('dim', 'faint');
+defineColorAlias('strikethrough', 'crossedout');
+defineColorAlias('strikethrough', 'strikeThrough');
+defineColorAlias('strikethrough', 'crossedOut');
+defineColorAlias('hidden', 'conceal');
+defineColorAlias('inverse', 'swapColors');
+defineColorAlias('inverse', 'swapcolors');
+defineColorAlias('doubleunderline', 'doubleUnderline');
+
+// TODO(BridgeAR): Add function style support for more complex styles.
 // Don't use 'blue' not visible on cmd.exe
 inspect.styles = ObjectAssign(ObjectCreate(null), {
   special: 'cyan',
@@ -293,6 +355,7 @@ inspect.styles = ObjectAssign(ObjectCreate(null), {
   symbol: 'green',
   date: 'magenta',
   // "name": intentionally not styling
+  // TODO(BridgeAR): Highlight regular expressions properly.
   regexp: 'red',
   module: 'underline'
 });

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -173,13 +173,20 @@ const meta = [
 ];
 
 function getUserOptions(ctx) {
-  const obj = { stylize: ctx.stylize };
-  for (const key of ObjectKeys(inspectDefaultOptions)) {
-    obj[key] = ctx[key];
-  }
-  if (ctx.userOptions === undefined)
-    return obj;
-  return { ...obj, ...ctx.userOptions };
+  return {
+    stylize: ctx.stylize,
+    showHidden: ctx.showHidden,
+    depth: ctx.depth,
+    colors: ctx.colors,
+    customInspect: ctx.customInspect,
+    showProxy: ctx.showProxy,
+    maxArrayLength: ctx.maxArrayLength,
+    breakLength: ctx.breakLength,
+    compact: ctx.compact,
+    sorted: ctx.sorted,
+    getters: ctx.getters,
+    ...ctx.userOptions
+  };
 }
 
 /**

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2047,6 +2047,34 @@ assert.strictEqual(inspect(new BigUint64Array([0n])), 'BigUint64Array [ 0n ]');
     `\u001b[${string[0]}m'Oh no!'\u001b[${string[1]}m }`
   );
   rejection.catch(() => {});
+
+  // Verify that aliases do not show up as key while checking `inspect.colors`.
+  const colors = Object.keys(inspect.colors);
+  const aliases = Object.getOwnPropertyNames(inspect.colors)
+                  .filter((c) => !colors.includes(c));
+  assert(!colors.includes('grey'));
+  assert(colors.includes('gray'));
+  // Verify that all aliases are correctly mapped.
+  for (const alias of aliases) {
+    assert(Array.isArray(inspect.colors[alias]));
+  }
+  // Check consistent naming.
+  [
+    'black',
+    'red',
+    'green',
+    'yellow',
+    'blue',
+    'magenta',
+    'cyan',
+    'white'
+  ].forEach((color, i) => {
+    assert.deepStrictEqual(inspect.colors[color], [30 + i, 39]);
+    assert.deepStrictEqual(inspect.colors[`${color}Bright`], [90 + i, 39]);
+    const bgColor = `bg${color[0].toUpperCase()}${color.slice(1)}`;
+    assert.deepStrictEqual(inspect.colors[bgColor], [40 + i, 49]);
+    assert.deepStrictEqual(inspect.colors[`${bgColor}Bright`], [100 + i, 49]);
+  });
 }
 
 assert.strictEqual(

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -855,6 +855,10 @@ util.inspect({ hasOwnProperty: null });
     assert.strictEqual(opts.budget, undefined);
     assert.strictEqual(opts.indentationLvl, undefined);
     assert.strictEqual(opts.showHidden, false);
+    assert.deepStrictEqual(
+      new Set(Object.keys(util.inspect.defaultOptions).concat(['stylize'])),
+      new Set(Object.keys(opts))
+    );
     opts.showHidden = true;
     return { [util.inspect.custom]: common.mustCall((depth, opts2) => {
       assert.deepStrictEqual(clone, opts2);
@@ -881,10 +885,11 @@ util.inspect({ hasOwnProperty: null });
 }
 
 {
-  const subject = { [util.inspect.custom]: common.mustCall((depth) => {
+  const subject = { [util.inspect.custom]: common.mustCall((depth, opts) => {
     assert.strictEqual(depth, null);
+    assert.strictEqual(opts.compact, true);
   }) };
-  util.inspect(subject, { depth: null });
+  util.inspect(subject, { depth: null, compact: true });
 }
 
 {


### PR DESCRIPTION
1. commit: `util: improve inspect's customInspect performance`

```
This improves the performance to copy user options that are then
passed through to the custom inspect function.

The performance improvement depends on the complexity of the custom
inspect function. For very basic cases this is 100% faster than
before.
```

2. commit: `util: add more predefined color codes to inspect.colors`

```
This adds most commonly used ANSI color codes to
`util.inspect.colors`.
```

@nodejs/util PTAL

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
