### PR TITLE
buffer: use dynamic buffer pool

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -612,11 +612,11 @@ console.log(buf);
 
 A `TypeError` will be thrown if `size` is not a number.
 
-The `Buffer` module pre-allocates an internal `Buffer` instance of
-size [`Buffer.poolSize`][] that is used as a pool for the fast allocation of new
-`Buffer` instances created using [`Buffer.allocUnsafe()`][] and the deprecated
-`new Buffer(size)` constructor only when `size` is less than or equal to
-`Buffer.poolSize >> 1` (floor of [`Buffer.poolSize`][] divided by two).
+The `Buffer` module uses an internal `Buffer` instance as pool for the fast
+allocation of new `Buffer` instances created using [`Buffer.allocUnsafe()`][]
+and the deprecated `new Buffer(size)` constructor. The `size` of that pool is
+dynamically changed depending on the allocation frequency and allocation size.
+The maximum pool size is equal to `Buffer.poolSize`.
 
 Use of this pre-allocated internal memory pool is a key difference between
 calling `Buffer.alloc(size, fill)` vs. `Buffer.allocUnsafe(size).fill(fill)`.
@@ -983,11 +983,17 @@ console.log(Buffer.isEncoding(''));
 ### Class Property: Buffer.poolSize
 <!-- YAML
 added: v0.11.3
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30661
+    description: The default changed to 2MB and the pool is not pre-allocated
+                 anymore. Instead, it's increased or decreased in size depending
+                 on the allocation frequency up to the size of this value.
 -->
 
-* {integer} **Default:** `8192`
+* {integer} **Default:** `2 * 1024 * 1024` (2 MB)
 
-This is the size (in bytes) of pre-allocated internal `Buffer` instances used
+This is the maximum size (in bytes) of an internal `Buffer` instance used
 for pooling. This value may be modified.
 
 ### buf\[index\]

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -182,11 +182,6 @@ function toInteger(n, defaultVal) {
 }
 
 function _copy(source, target, targetStart, sourceStart, sourceEnd) {
-  if (!isUint8Array(source))
-    throw new ERR_INVALID_ARG_TYPE('source', ['Buffer', 'Uint8Array'], source);
-  if (!isUint8Array(target))
-    throw new ERR_INVALID_ARG_TYPE('target', ['Buffer', 'Uint8Array'], target);
-
   if (targetStart === undefined) {
     targetStart = 0;
   } else {
@@ -739,6 +734,10 @@ ObjectDefineProperty(Buffer.prototype, 'offset', {
 
 Buffer.prototype.copy =
   function copy(target, targetStart, sourceStart, sourceEnd) {
+    if (!isUint8Array(target))
+      throw new ERR_INVALID_ARG_TYPE(
+        'target', ['Buffer', 'Uint8Array'], target);
+
     return _copy(this, target, targetStart, sourceStart, sourceEnd);
   };
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -23,6 +23,7 @@
 
 const {
   MathFloor,
+  MathMax,
   MathMin,
   MathTrunc,
   ObjectCreate,
@@ -110,8 +111,14 @@ const constants = ObjectDefineProperties({}, {
   }
 });
 
-Buffer.poolSize = 8 * 1024;
-let poolSize, poolOffset, allocPool;
+// `Buffer.poolSize` is a theoretical maximum. The actual pool size is
+// dynamically increased and decreased depending on the allocation frequency.
+// Frequent larger allocations also increase the size faster.
+Buffer.poolSize = 2 * 1024 * 1024; // 2 MB
+let poolSize = 0;
+let lastPoolCreatedAt = 0;
+let poolOffset = 0;
+let allocPool = allocate(0);
 
 // A toggle used to access the zero fill setting of the array buffer allocator
 // in C++.
@@ -132,16 +139,29 @@ function createUnsafeBuffer(size) {
   }
 }
 
-function createPool() {
-  poolSize = Buffer.poolSize;
+// This is faster than using the bigint version.
+function getNow() {
+  const hr = process.hrtime();
+  return hr[0] * 1000 + hr[1] / 1e6;
+}
+
+function createPool(length) {
+  const now = getNow();
+  // Check if at least one second passed since the last pool creation.
+  if (now - lastPoolCreatedAt > 1000) {
+    poolSize = MathMax(MathFloor(poolSize / 2), length * 2);
+  } else {
+    poolSize = length * 2 + poolSize;
+  }
+  poolSize = MathMin(Buffer.poolSize, poolSize);
   allocPool = createUnsafeBuffer(poolSize).buffer;
+  lastPoolCreatedAt = now;
   poolOffset = 0;
 }
-createPool();
 
 function alignPool() {
   // Ensure aligned slices
-  if (poolOffset & 0x7) {
+  if ((poolOffset & 0x7) !== 0) {
     poolOffset |= 0x7;
     poolOffset++;
   }
@@ -374,9 +394,10 @@ function allocate(size) {
   if (size <= 0) {
     return new FastBuffer();
   }
+
   if (size < (Buffer.poolSize >>> 1)) {
     if (size > (poolSize - poolOffset))
-      createPool();
+      createPool(size);
     const b = new FastBuffer(allocPool, poolOffset, size);
     poolOffset += size;
     alignPool();
@@ -392,7 +413,7 @@ function fromStringFast(string, ops) {
     return createFromString(string, ops.encodingVal);
 
   if (length > (poolSize - poolOffset))
-    createPool();
+    createPool(length);
   let b = new FastBuffer(allocPool, poolOffset, length);
   const actual = ops.write(b, string, 0, length);
   if (actual !== length) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -536,7 +536,7 @@ Buffer.concat = function concat(list, length) {
     validateInt32(length, 'length', 0);
   }
 
-  const buffer = Buffer.allocUnsafe(length);
+  const buffer = allocate(length);
   let pos = 0;
   for (i = 0; i < list.length; i++) {
     const buf = list[i];


### PR DESCRIPTION
1. commit: `buffer: use internal allocate function instead of public one`

```
This makes sure that `Buffer.concat` does not use exposed functions
that might have been tampered with. Instead, it uses the direct
call to the internal `allocate` function and skipps the size check.
```

2. commit: `buffer: only validate if necessary`

```
This moves a validation check and removes another one that is done
twice. The validation is obsolete in case of `Buffer.concat`. For
`Buffer.copy` only one check is required (one side is already
guaranteed to be an instance of buffer).
```

3. commit: `test: harden test/parallel/test-zlib-unused-weak.js`

```
This makes sure the buffer pool size is taken into account while
checking for the GC overhead. It would otherwise indicate a faulty
result.
```

4. commit: `buffer: use a dynamic pool size instead of a fixed one`

```
This significantly improves the performance in case lots of smallish
buffers are used. In case they are frequently allocated, the pool
will increase to a size of up to 2 MB. It starts with no pool and is
therefore smaller by default than the current default. That way it's
better for devices that have hard memory constraints.
```

Fixes: #30611 (at least partially)
Refs: #27121

Benchmark:
https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/471/
https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/472

Benchmark results (at least one star for accuracy):

```
                                                                     confidence improvement accuracy (*)    (**)    (***)
buffers/buffer-creation.js n=600000 len=1024 type='fast-allocUnsafe'        ***    293.90 %      ±24.37% ±32.82%  ±43.53%
buffers/buffer-creation.js n=600000 len=1024 type='slow-allocUnsafe'          *      9.16 %       ±9.04% ±12.04%  ±15.68%
buffers/buffer-creation.js n=600000 len=4096 type='fast-allocUnsafe'        ***   1288.00 %      ±66.61% ±89.72% ±118.99%
buffers/buffer-creation.js n=600000 len=8192 type='fast-allocUnsafe'        ***    846.83 %      ±38.02% ±51.23%  ±67.99%

buffers/buffer-from.js n=800000 len=100 source='buffer'                     ***      7.86 %       ±3.00%  ±3.99%  ±5.19%
buffers/buffer-from.js n=800000 len=100 source='string-base64'               **     10.76 %       ±7.04%  ±9.41% ±12.32%
buffers/buffer-from.js n=800000 len=100 source='string-utf8'                  *      9.05 %       ±8.76% ±11.70% ±15.32%
buffers/buffer-from.js n=800000 len=2048 source='array'                     ***     20.93 %       ±7.66% ±10.27% ±13.52%
buffers/buffer-from.js n=800000 len=2048 source='buffer'                    ***     11.19 %       ±5.99%  ±7.98% ±10.43%
buffers/buffer-from.js n=800000 len=2048 source='string'                    ***     22.33 %       ±7.46%  ±9.92% ±12.91%
buffers/buffer-from.js n=800000 len=2048 source='string-base64'              **     14.42 %       ±9.02% ±12.05% ±15.76%
buffers/buffer-from.js n=800000 len=2048 source='string-utf8'               ***     25.95 %       ±8.25% ±10.97% ±14.28%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
