### PR TITLE
src: run native immediates during Environment cleanup

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -527,6 +527,9 @@ void Environment::RegisterHandleCleanups() {
 }
 
 void Environment::CleanupHandles() {
+  Isolate::DisallowJavascriptExecutionScope disallow_js(isolate(),
+      Isolate::DisallowJavascriptExecutionScope::THROW_ON_FAILURE);
+
   for (ReqWrapBase* request : req_wrap_queue_)
     request->Cancel();
 
@@ -661,7 +664,7 @@ void Environment::RunAndClearNativeImmediates() {
 
       head->Call(this);
       if (UNLIKELY(try_catch.HasCaught())) {
-        if (!try_catch.HasTerminated())
+        if (!try_catch.HasTerminated() && can_call_into_js())
           errors::TriggerUncaughtException(isolate(), try_catch);
 
         // We are done with the current callback. Move one iteration along,

--- a/src/env.cc
+++ b/src/env.cc
@@ -530,6 +530,8 @@ void Environment::CleanupHandles() {
   Isolate::DisallowJavascriptExecutionScope disallow_js(isolate(),
       Isolate::DisallowJavascriptExecutionScope::THROW_ON_FAILURE);
 
+  RunAndClearNativeImmediates(true /* skip SetUnrefImmediate()s */);
+
   for (ReqWrapBase* request : req_wrap_queue_)
     request->Cancel();
 
@@ -645,7 +647,7 @@ void Environment::AtExit(void (*cb)(void* arg), void* arg) {
   at_exit_functions_.push_front(ExitCallback{cb, arg});
 }
 
-void Environment::RunAndClearNativeImmediates() {
+void Environment::RunAndClearNativeImmediates(bool only_refed) {
   TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
                               "RunAndClearNativeImmediates", this);
   size_t ref_count = 0;
@@ -662,7 +664,9 @@ void Environment::RunAndClearNativeImmediates() {
       if (head->is_refed())
         ref_count++;
 
-      head->Call(this);
+      if (head->is_refed() || !only_refed)
+        head->Call(this);
+
       if (UNLIKELY(try_catch.HasCaught())) {
         if (!try_catch.HasTerminated() && can_call_into_js())
           errors::TriggerUncaughtException(isolate(), try_catch);

--- a/src/env.h
+++ b/src/env.h
@@ -1415,7 +1415,7 @@ class Environment : public MemoryRetainer {
   std::unique_ptr<NativeImmediateCallback> native_immediate_callbacks_head_;
   NativeImmediateCallback* native_immediate_callbacks_tail_ = nullptr;
 
-  void RunAndClearNativeImmediates();
+  void RunAndClearNativeImmediates(bool only_refed = false);
   static void CheckImmediate(uv_check_t* handle);
 
   // Use an unordered_set, so that we have efficient insertion and removal.

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -278,6 +278,9 @@ static void ReportFatalException(Environment* env,
                                  Local<Value> error,
                                  Local<Message> message,
                                  EnhanceFatalException enhance_stack) {
+  if (!env->can_call_into_js())
+    enhance_stack = EnhanceFatalException::kDontEnhance;
+
   Isolate* isolate = env->isolate();
   CHECK(!error.IsEmpty());
   CHECK(!message.IsEmpty());
@@ -956,7 +959,7 @@ void TriggerUncaughtException(Isolate* isolate,
   }
 
   MaybeLocal<Value> handled;
-  {
+  if (env->can_call_into_js()) {
     // We do not expect the global uncaught exception itself to throw any more
     // exceptions. If it does, exit the current Node.js instance.
     errors::TryCatchScope try_catch(env,

--- a/src/node_process_events.cc
+++ b/src/node_process_events.cc
@@ -34,6 +34,8 @@ Maybe<bool> ProcessEmitWarningGeneric(Environment* env,
                                       const char* warning,
                                       const char* type,
                                       const char* code) {
+  if (!env->can_call_into_js()) return Just(false);
+
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
 

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -42,7 +42,7 @@ StreamPipe::StreamPipe(StreamBase* source,
 }
 
 StreamPipe::~StreamPipe() {
-  Unpipe();
+  Unpipe(true);
 }
 
 StreamBase* StreamPipe::source() {
@@ -53,7 +53,7 @@ StreamBase* StreamPipe::sink() {
   return static_cast<StreamBase*>(writable_listener_.stream());
 }
 
-void StreamPipe::Unpipe() {
+void StreamPipe::Unpipe(bool is_in_deletion) {
   if (is_closed_)
     return;
 
@@ -67,6 +67,8 @@ void StreamPipe::Unpipe() {
   is_reading_ = false;
   source()->RemoveStreamListener(&readable_listener_);
   sink()->RemoveStreamListener(&writable_listener_);
+
+  if (is_in_deletion) return;
 
   // Delay the JS-facing part with SetImmediate, because this might be from
   // inside the garbage collector, so we can’t run JS here.

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -72,7 +72,7 @@ void StreamPipe::Unpipe() {
   // inside the garbage collector, so we can’t run JS here.
   HandleScope handle_scope(env()->isolate());
   BaseObjectPtr<StreamPipe> strong_ref{this};
-  env()->SetImmediate([this](Environment* env) {
+  env()->SetImmediate([this, strong_ref](Environment* env) {
     HandleScope handle_scope(env->isolate());
     Context::Scope context_scope(env->context());
     Local<Object> object = this->object();

--- a/src/stream_pipe.h
+++ b/src/stream_pipe.h
@@ -12,7 +12,7 @@ class StreamPipe : public AsyncWrap {
   StreamPipe(StreamBase* source, StreamBase* sink, v8::Local<v8::Object> obj);
   ~StreamPipe() override;
 
-  void Unpipe();
+  void Unpipe(bool is_in_deletion = false);
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -185,3 +185,26 @@ static void at_exit_js(void* arg) {
   assert(obj->IsObject());
   called_at_exit_js = true;
 }
+
+TEST_F(EnvironmentTest, SetImmediateCleanup) {
+  int called = 0;
+  int called_unref = 0;
+
+  {
+    const v8::HandleScope handle_scope(isolate_);
+    const Argv argv;
+    Env env {handle_scope, argv};
+
+    (*env)->SetImmediate([&](node::Environment* env_arg) {
+      EXPECT_EQ(env_arg, *env);
+      called++;
+    });
+    (*env)->SetUnrefImmediate([&](node::Environment* env_arg) {
+      EXPECT_EQ(env_arg, *env);
+      called_unref++;
+    });
+  }
+
+  EXPECT_EQ(called, 1);
+  EXPECT_EQ(called_unref, 0);
+}


### PR DESCRIPTION
This is a fix for #30643 that is, unfortunately, a bit more complex than I’d like. The last commit message provides an alternative, so if anyone prefers then I’d probably implement that first as quick fix for the flaky test and then rebase this PR against it.

---


##### src: keep object alive in stream_pipe code

This was overlooked in a489583eda4d7cebc06516834b31dc2a4cedb1b6.

Refs: https://github.com/nodejs/node/pull/30374

##### src: add more `can_call_into_js()` guards

This is in preparation for running native `SetImmediate()`
callbacks during shutdown.

##### src: no SetImmediate from destructor in stream_pipe code

Guard against running `SetImmediate()` from the destructor.
The object will not be alive or usable in the callback,
so it does not make sense to attempt to schedule the
`SetImmediate()`.

##### src: run native immediates during Environment cleanup

This can be necessary, because some parts of the Node.js code base
perform cleanup operations in the Immediate callbacks, e.g. HTTP/2.

This resolves flakiness in an HTTP/2 test that failed when a
`SetImmediate()` callback was not run or destroyed before the
`Environment` destructor started, because that callback held a
strong reference to the `Http2Session` object and the expectation
was that no such objects exist once the `Environment` constructor
starts.

Another, slightly more direct, alternative would have
been to clear the immediate queue rather than to run it. However,
this approach seems to make more sense as code generally assumes
that the `SetImmediate()` callback will always run; For example,
N-API uses an immediate callback to call buffer finalization
callbacks.

Unref’ed immediates are skipped, as the expectation is generally
that they may not run anyway.

Fixes: https://github.com/nodejs/node/issues/30643


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
