### PR TITLE
[readline doc] include line/cursor in readline documentation

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -354,7 +354,7 @@ async function processLineByLine() {
 added: REPLACEME
 -->
 
-* {string}
+* {string|undefined}
 
 The current input data being processed by node.
 

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -350,6 +350,9 @@ async function processLineByLine() {
 ```
 
 ### rl.line
+<!-- YAML
+added: REPLACEME
+-->
 
 * {string}
 
@@ -381,6 +384,9 @@ process.stdin.on('keypress', (c, k) => {
 ```
 
 ### rl.cursor
+<!-- YAML
+added: REPLACEME
+-->
 
 * {number}
 

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -349,6 +349,48 @@ async function processLineByLine() {
 }
 ```
 
+### rl.line
+
+* {string}
+
+The current input data being processed by node.
+
+This can be used when collecting input from a TTY stream to retrieve the
+current value that has been processed thus far, prior to the `line` event
+being emitted.  Once the `line` event has been emitted, this property will
+be an empty string.
+
+Be aware that modifying the value during the instance runtime may have
+unintended consequences if `rl.cursor` is not also controlled.
+
+**If not using a TTY stream for input, use the [`'line'`][] event.**
+
+One possible use case would be as follows:
+
+```js
+const values = ['lorem ipsum', 'dolor sit amet'];
+const rl = readline.createInterface(process.stdin);
+process.stdin.on('keypress', (c, k) => {
+  debounce(() => {
+    console.log(
+      '\n',
+      values.filter((val) => val.startsWith(rl.line)).join(' ')
+    );
+  }, 300);
+});
+```
+
+### rl.cursor
+
+* {number}
+
+The cursor position relative to `rl.line`.
+
+This will track where the current cursor lands in the input string, when
+reading input from a TTY stream.  The position of cursor determines the
+portion of the input string that will be modified as input is processed,
+as well as the column where the terminal caret will be rendered.
+
 ## readline.clearLine(stream, dir\[, callback\])
 <!-- YAML
 added: v0.7.7

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -389,7 +389,7 @@ process.stdin.on('keypress', (c, k) => {
 added: REPLACEME
 -->
 
-* {number}
+* {number|undefined}
 
 The cursor position relative to `rl.line`.
 

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -373,13 +373,14 @@ One possible use case would be as follows:
 ```js
 const values = ['lorem ipsum', 'dolor sit amet'];
 const rl = readline.createInterface(process.stdin);
+const showResults = debounce(() => {
+  console.log(
+    '\n',
+    values.filter((val) => val.startsWith(rl.line)).join(' ')
+  );
+}, 300);
 process.stdin.on('keypress', (c, k) => {
-  debounce(() => {
-    console.log(
-      '\n',
-      values.filter((val) => val.startsWith(rl.line)).join(' ')
-    );
-  }, 300);
+  showResults();
 });
 ```
 

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -351,7 +351,7 @@ async function processLineByLine() {
 
 ### rl.line
 <!-- YAML
-added: REPLACEME
+added: 0.1.98
 -->
 
 * {string|undefined}
@@ -386,7 +386,7 @@ process.stdin.on('keypress', (c, k) => {
 
 ### rl.cursor
 <!-- YAML
-added: REPLACEME
+added: 0.1.98
 -->
 
 * {number|undefined}


### PR DESCRIPTION
Documents the existence and purpose of the `line` and `cursor` properties, in an effort to make their usage public.

`line` can be used for reading the current input value during runtime, if reading from a TTY stream.  Both properties are necessary when developing a custom CLI input process using `readline` as an input processor.  This allows you to utilize the work that's been done in `readline`, instead of trying to recreate it.

Refs: https://github.com/nodejs/node/issues/30347
Refs: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40513

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
