### PR TITLE
child_process: document kill() return value

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1061,10 +1061,12 @@ added: v0.1.90
 -->
 
 * `signal` {number|string}
+* Returns: {boolean}
 
 The `subprocess.kill()` method sends a signal to the child process. If no
 argument is given, the process will be sent the `'SIGTERM'` signal. See
-signal(7) for a list of available signals.
+signal(7) for a list of available signals. This function returns `true` if
+kill(2) succeeds, and `false` otherwise.
 
 ```js
 const { spawn } = require('child_process');


### PR DESCRIPTION
This commit documents the return value from `subprocess.kill()`.

Refs: https://github.com/nodejs/node/issues/30668

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)