### PR TITLE
crypto: expose certificate decoding function

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -44,6 +44,10 @@ const pendingDeprecation = getOptionValue('--pending-deprecation');
 const { fipsMode } = internalBinding('config');
 const fipsForced = getOptionValue('--force-fips');
 const { getFipsCrypto, setFipsCrypto } = internalBinding('crypto');
+const { parseX509 } = internalBinding('crypto');
+const {
+  isArrayBufferView,
+} = require('internal/util/types');
 const {
   randomBytes,
   randomFill,
@@ -150,6 +154,13 @@ function createVerify(algorithm, options) {
   return new Verify(algorithm, options);
 }
 
+function parseCert(cert) {
+  if (!isArrayBufferView(cert)) {
+    throw new ERR_INVALID_ARG_TYPE('cert', 'ArrayBufferView', buf);
+  }
+  return parseX509(cert);
+}
+
 module.exports = {
   // Methods
   createCipheriv,
@@ -190,6 +201,7 @@ module.exports = {
   setFips: !fipsMode ? setFipsDisabled :
     fipsForced ? setFipsForced : setFipsCrypto,
   verify: verifyOneShot,
+  parseCert,
 
   // Classes
   Certificate,


### PR DESCRIPTION
Format is the same as:
- https://nodejs.org/api/tls.html#tls_tlssocket_getcertificate

No docs or tests yet, @nodejs/crypto, I'll finish this if we want it.

Its easy, it just exposes current data format of the tls APIs, and makes testing whether certificates can be decoded quite easy, rather than having to round-trip them through TLS just to get a parsed cert :-(.

Maybe some other format would be better, and then it could be added to tls and crypto, but starting with a "better" format in crypto that is different from what tls does seems like it would increase inconsistency.

Fixes: https://github.com/nodejs/node/issues/29181

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
