### PR TITLE
fix(worker): allow inspector.close() inside Worker

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -95,6 +95,8 @@ if (isMainThread) {
   process.chdir = workerThreadSetup.unavailable('process.chdir()');
   process.umask = wrapped.umask;
   process.cwd = rawMethods.cwd;
+
+  process._debugEnd = rawMethods._debugEnd;
 }
 
 // Set up methods on the process object for all threads

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -446,12 +446,12 @@ static void InitializeProcessMethods(Local<Object> target,
   // define various internal methods
   if (env->owns_process_state()) {
     env->SetMethod(target, "_debugProcess", DebugProcess);
-    env->SetMethod(target, "_debugEnd", DebugEnd);
     env->SetMethod(target, "abort", Abort);
     env->SetMethod(target, "causeSegfault", CauseSegfault);
     env->SetMethod(target, "chdir", Chdir);
   }
 
+  env->SetMethod(target, "_debugEnd", DebugEnd);
   env->SetMethod(
       target, "_startProfilerIdleNotifier", StartProfilerIdleNotifier);
   env->SetMethod(target, "_stopProfilerIdleNotifier", StopProfilerIdleNotifier);

--- a/test/parallel/test-worker-inspector-open.js
+++ b/test/parallel/test-worker-inspector-open.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+common.skipIfInspectorDisabled();
+
+const net = require('net');
+const { Worker, isMainThread, parentPort } = require('worker_threads');
+const inspector = require('inspector');
+const url = require('url');
+
+// This test ensures that inspector.open(), inspector.close(), inspector.url()
+// work inside Worker.
+function ping(port, callback) {
+  net.connect(port)
+    .on('connect', function() { close(this); })
+    .on('error', function(err) { close(this, err); });
+
+  function close(self, err) {
+    self.end();
+    self.on('close', () => callback(err));
+  }
+}
+
+function runMainThread() {
+  const worker = new Worker(__filename);
+
+  worker.on('message', common.mustCall(({ ws }) => {
+    ping(url.parse(ws).port, common.mustCall((err) => {
+      assert.ifError(err);
+      worker.postMessage({ done: true });
+    }));
+  }));
+}
+
+function runChildWorkerThread() {
+  inspector.open(0);
+  assert(inspector.url());
+  inspector.close();
+  assert(!inspector.url());
+
+  inspector.open(0);
+
+  parentPort.on('message', common.mustCall(({ done }) => {
+    if (done) {
+      parentPort.close();
+    }
+  }));
+
+  parentPort.postMessage({
+    ws: inspector.url()
+  });
+}
+
+if (isMainThread) {
+  runMainThread();
+} else {
+  runChildWorkerThread();
+}

--- a/test/parallel/test-worker-unsupported-things.js
+++ b/test/parallel/test-worker-unsupported-things.js
@@ -48,7 +48,6 @@ if (!process.env.HAS_STARTED_WORKER) {
   assert.strictEqual('_stopProfilerIdleNotifier' in process, false);
   assert.strictEqual('_debugProcess' in process, false);
   assert.strictEqual('_debugPause' in process, false);
-  assert.strictEqual('_debugEnd' in process, false);
 
   parentPort.postMessage(true);
 }


### PR DESCRIPTION
`inspector.close()` is an alias of `process._debugEnd()` which is missing inside Worker enviroments. This PR allows calling it inside Worker.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
