### PR TITLE
deps: V8: backport 93f189f19a03

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.20',
+    'v8_embedder_string': '-node.21',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/ic/accessor-assembler.cc
+++ b/deps/v8/src/ic/accessor-assembler.cc
@@ -1053,8 +1053,7 @@ void AccessorAssembler::HandleStoreICHandlerCase(
     {
       Comment("store_interceptor");
       TailCallRuntime(Runtime::kStorePropertyWithInterceptor, p->context(),
-                      p->value(), p->slot(), p->vector(), p->receiver(),
-                      p->name());
+                      p->value(), p->receiver(), p->name());
     }
 
     BIND(&if_slow);
@@ -1516,8 +1515,7 @@ void AccessorAssembler::HandleStoreICProtoHandler(
 
   {
     Label if_add_normal(this), if_store_global_proxy(this), if_api_setter(this),
-        if_accessor(this), if_native_data_property(this), if_slow(this),
-        if_interceptor(this);
+        if_accessor(this), if_native_data_property(this), if_slow(this);
 
     CSA_ASSERT(this, TaggedIsSmi(smi_handler));
     TNode<Int32T> handler_word = SmiToInt32(CAST(smi_handler));
@@ -1547,9 +1545,6 @@ void AccessorAssembler::HandleStoreICProtoHandler(
     GotoIf(Word32Equal(handler_kind, Int32Constant(StoreHandler::kSlow)),
            &if_slow);
 
-    GotoIf(Word32Equal(handler_kind, Int32Constant(StoreHandler::kInterceptor)),
-           &if_interceptor);
-
     GotoIf(
         Word32Equal(handler_kind,
                     Int32Constant(StoreHandler::kApiSetterHolderIsPrototype)),
@@ -1572,14 +1567,6 @@ void AccessorAssembler::HandleStoreICProtoHandler(
         TailCallRuntime(Runtime::kKeyedStoreIC_Slow, p->context(), p->value(),
                         p->receiver(), p->name());
       }
-    }
-
-    BIND(&if_interceptor);
-    {
-      Comment("store_interceptor");
-      TailCallRuntime(Runtime::kStorePropertyWithInterceptor, p->context(),
-                      p->value(), p->slot(), p->vector(), p->receiver(),
-                      p->name());
     }
 
     BIND(&if_add_normal);


### PR DESCRIPTION
Original commit message:

    [ic] Fix non-GlobalIC store to interceptor on the global object

    We possibly need to load the global object from the global proxy as the holder
    of the named interceptor.

    Change-Id: I0f9f2e448630608ae853588f6751b55574a9efd9
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1930903
    Commit-Queue: Igor Sheludko <ishell@chromium.org>
    Reviewed-by: Igor Sheludko <ishell@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#65119}

Refs: https://github.com/v8/v8/commit/93f189f19a030d5de6c5173711dca120ad76e5cd
