### PR TITLE
readline: promote _getCursorPos to public api

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -400,7 +400,7 @@ as well as the column where the terminal caret will be rendered.
 
 ### rl.getCursorPos()
 <!-- YAML
-  added: REPLACEME
+added: REPLACEME
 -->
 
 * Returns: {Object}

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -398,6 +398,19 @@ reading input from a TTY stream.  The position of cursor determines the
 portion of the input string that will be modified as input is processed,
 as well as the column where the terminal caret will be rendered.
 
+### rl.getCursorPos()
+<!-- YAML
+  added: REPLACEME
+-->
+
+* Returns: {Object}
+  * `rows` {number} the row of the prompt the cursor currently lands on
+  * `cols` {number} the screen column the cursor currently lands on
+
+Returns the real position of the cursor in relation to the input
+prompt + string.  Long input (wrapping) strings, as well as multiple
+line prompts are included in the calculations.
+
 ## readline.clearLine(stream, dir\[, callback\])
 <!-- YAML
 added: v0.7.7

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -777,6 +777,7 @@ Interface.prototype._getCursorPos = function() {
   }
   return { cols: cols, rows: rows };
 };
+Interface.prototype.getCursorPos = Interface.prototype._getCursorPos;
 
 
 // This function moves cursor dx places to the right

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -365,7 +365,7 @@ Interface.prototype._refreshLine = function() {
   const lineRows = dispPos.rows;
 
   // cursor position
-  const cursorPos = this._getCursorPos();
+  const cursorPos = this.getCursorPos();
 
   // First move to the bottom of the current line, based on cursor pos
   const prevRows = this.prevRows || 0;
@@ -481,7 +481,7 @@ Interface.prototype._insertString = function(c) {
     this.line += c;
     this.cursor += c.length;
 
-    if (this._getCursorPos().cols === 0) {
+    if (this.getCursorPos().cols === 0) {
       this._refreshLine();
     } else {
       this._writeToOutput(c);
@@ -760,7 +760,7 @@ Interface.prototype._getDisplayPos = function(str) {
 
 
 // Returns current cursor's position and line
-Interface.prototype._getCursorPos = function() {
+Interface.prototype.getCursorPos = function() {
   const columns = this.columns;
   const strBeforeCursor = this._prompt + this.line.substring(0, this.cursor);
   const dispPos = this._getDisplayPos(
@@ -777,21 +777,21 @@ Interface.prototype._getCursorPos = function() {
   }
   return { cols: cols, rows: rows };
 };
-Interface.prototype.getCursorPos = Interface.prototype._getCursorPos;
+Interface.prototype._getCursorPos = Interface.prototype.getCursorPos;
 
 
 // This function moves cursor dx places to the right
 // (-dx for left) and refreshes the line if it is needed
 Interface.prototype._moveCursor = function(dx) {
   const oldcursor = this.cursor;
-  const oldPos = this._getCursorPos();
+  const oldPos = this.getCursorPos();
   this.cursor += dx;
 
   // bounds check
   if (this.cursor < 0) this.cursor = 0;
   else if (this.cursor > this.line.length) this.cursor = this.line.length;
 
-  const newPos = this._getCursorPos();
+  const newPos = this.getCursorPos();
 
   // Check if cursors are in the same line
   if (oldPos.rows === newPos.rows) {

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -590,7 +590,7 @@ function isWarned(emitter) {
       rli.question(expectedLines[0], function() {
         rli.close();
       });
-      const cursorPos = rli._getCursorPos();
+      const cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, expectedLines[0].length);
       rli.close();
@@ -606,7 +606,7 @@ function isWarned(emitter) {
       rli.question(expectedLines.join('\n'), function() {
         rli.close();
       });
-      const cursorPos = rli._getCursorPos();
+      const cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, expectedLines.length - 1);
       assert.strictEqual(cursorPos.cols, expectedLines.slice(-1)[0].length);
       rli.close();
@@ -623,11 +623,11 @@ function isWarned(emitter) {
       });
       fi.emit('data', 'the quick brown fox');
       fi.emit('keypress', '.', { ctrl: true, name: 'a' });
-      let cursorPos = rli._getCursorPos();
+      let cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 0);
       fi.emit('keypress', '.', { ctrl: true, name: 'e' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 19);
       rli.close();
@@ -643,28 +643,28 @@ function isWarned(emitter) {
         terminal: terminal
       });
       fi.emit('data', 'the quick brown fox');
-      let cursorPos = rli._getCursorPos();
+      let cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 19);
 
       // Back one character
       fi.emit('keypress', '.', { ctrl: true, name: 'b' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 18);
       // Back one character
       fi.emit('keypress', '.', { ctrl: true, name: 'b' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 17);
       // Forward one character
       fi.emit('keypress', '.', { ctrl: true, name: 'f' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 18);
       // Forward one character
       fi.emit('keypress', '.', { ctrl: true, name: 'f' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 19);
       rli.close();
@@ -683,13 +683,13 @@ function isWarned(emitter) {
 
       // Move left one character/code point
       fi.emit('keypress', '.', { name: 'left' });
-      let cursorPos = rli._getCursorPos();
+      let cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 0);
 
       // Move right one character/code point
       fi.emit('keypress', '.', { name: 'right' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       if (common.hasIntl) {
         assert.strictEqual(cursorPos.cols, 2);
@@ -717,12 +717,12 @@ function isWarned(emitter) {
 
       // Move left one character/code point
       fi.emit('keypress', '.', { name: 'left' });
-      let cursorPos = rli._getCursorPos();
+      let cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 0);
 
       fi.emit('data', '🐕');
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
 
       if (common.hasIntl) {
@@ -753,7 +753,7 @@ function isWarned(emitter) {
 
       // Move left one character/code point
       fi.emit('keypress', '.', { name: 'right' });
-      let cursorPos = rli._getCursorPos();
+      let cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       if (common.hasIntl) {
         assert.strictEqual(cursorPos.cols, 2);
@@ -764,7 +764,7 @@ function isWarned(emitter) {
       }
 
       fi.emit('data', '🐕');
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       if (common.hasIntl) {
         assert.strictEqual(cursorPos.cols, 4);
@@ -790,19 +790,19 @@ function isWarned(emitter) {
       });
       fi.emit('data', 'the quick brown fox');
       fi.emit('keypress', '.', { ctrl: true, name: 'left' });
-      let cursorPos = rli._getCursorPos();
+      let cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 16);
       fi.emit('keypress', '.', { meta: true, name: 'b' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 10);
       fi.emit('keypress', '.', { ctrl: true, name: 'right' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 16);
       fi.emit('keypress', '.', { meta: true, name: 'f' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 19);
       rli.close();
@@ -904,13 +904,13 @@ function isWarned(emitter) {
         terminal: terminal
       });
       fi.emit('data', 'the quick brown fox');
-      let cursorPos = rli._getCursorPos();
+      let cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 19);
 
       // Delete left character
       fi.emit('keypress', '.', { ctrl: true, name: 'h' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 18);
       rli.on('line', common.mustCall((line) => {
@@ -930,7 +930,7 @@ function isWarned(emitter) {
         terminal: terminal
       });
       fi.emit('data', '💻');
-      let cursorPos = rli._getCursorPos();
+      let cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       if (common.hasIntl) {
         assert.strictEqual(cursorPos.cols, 2);
@@ -939,7 +939,7 @@ function isWarned(emitter) {
       }
       // Delete left character
       fi.emit('keypress', '.', { ctrl: true, name: 'h' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 0);
       rli.on('line', common.mustCall((line) => {
@@ -962,13 +962,13 @@ function isWarned(emitter) {
 
       // Go to the start of the line
       fi.emit('keypress', '.', { ctrl: true, name: 'a' });
-      let cursorPos = rli._getCursorPos();
+      let cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 0);
 
       // Delete right character
       fi.emit('keypress', '.', { ctrl: true, name: 'd' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 0);
       rli.on('line', common.mustCall((line) => {
@@ -991,13 +991,13 @@ function isWarned(emitter) {
 
       // Go to the start of the line
       fi.emit('keypress', '.', { ctrl: true, name: 'a' });
-      let cursorPos = rli._getCursorPos();
+      let cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 0);
 
       // Delete right character
       fi.emit('keypress', '.', { ctrl: true, name: 'd' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 0);
       rli.on('line', common.mustCall((line) => {
@@ -1017,13 +1017,13 @@ function isWarned(emitter) {
         terminal: terminal
       });
       fi.emit('data', 'the quick brown fox');
-      let cursorPos = rli._getCursorPos();
+      let cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 19);
 
       // Delete from current to start of line
       fi.emit('keypress', '.', { ctrl: true, shift: true, name: 'backspace' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 0);
       rli.on('line', common.mustCall((line) => {
@@ -1046,13 +1046,13 @@ function isWarned(emitter) {
 
       // Go to the start of the line
       fi.emit('keypress', '.', { ctrl: true, name: 'a' });
-      let cursorPos = rli._getCursorPos();
+      let cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 0);
 
       // Delete from current to end of line
       fi.emit('keypress', '.', { ctrl: true, shift: true, name: 'delete' });
-      cursorPos = rli._getCursorPos();
+      cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 0);
       rli.on('line', common.mustCall((line) => {
@@ -1073,7 +1073,7 @@ function isWarned(emitter) {
       });
       fi.columns = 10;
       fi.emit('data', 'multi-line text');
-      const cursorPos = rli._getCursorPos();
+      const cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 1);
       assert.strictEqual(cursorPos.cols, 5);
       rli.close();
@@ -1090,7 +1090,7 @@ function isWarned(emitter) {
       });
       fi.columns = 10;
       fi.emit('data', 't');
-      const cursorPos = rli._getCursorPos();
+      const cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 4);
       assert.strictEqual(cursorPos.cols, 3);
       rli.close();
@@ -1108,7 +1108,7 @@ function isWarned(emitter) {
       const lines = ['line 1', 'line 2', 'line 3'];
       fi.emit('data', lines.join('\n'));
       fi.emit('keypress', '.', { ctrl: true, name: 'l' });
-      const cursorPos = rli._getCursorPos();
+      const cursorPos = rli.getCursorPos();
       assert.strictEqual(cursorPos.rows, 0);
       assert.strictEqual(cursorPos.cols, 6);
       rli.on('line', common.mustCall((line) => {

--- a/test/parallel/test-readline-position.js
+++ b/test/parallel/test-readline-position.js
@@ -37,7 +37,7 @@ const ctrlU = { ctrl: true, name: 'u' };
 
   for (const [cursor, string] of tests) {
     rl.write(string);
-    assert.strictEqual(rl._getCursorPos().cols, cursor);
+    assert.strictEqual(rl.getCursorPos().cols, cursor);
     rl.write(null, ctrlU);
   }
 }


### PR DESCRIPTION
Aliases Interface._getCursorPos to Interface.getCursorPos, for consumption as a public API.

If so desired, I can replace `_getCursorPos` method calls with `getCursorPos`, and create an alias the other way around.  Doing it like this was just the simplest way to accomplish exposing `_getCursorPos`.

refs: https://github.com/nodejs/node/issues/30347

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
