### PR TITLE
lib: replace Date.now function by primordial DateNow

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayIsArray,
+  DateNow,
   ObjectSetPrototypeOf,
   ReflectOwnKeys,
 } = primordials;
@@ -487,7 +488,7 @@ function toUnixTimestamp(time, name = 'time') {
   }
   if (Number.isFinite(time)) {
     if (time < 0) {
-      return Date.now() / 1000;
+      return DateNow() / 1000;
     }
     return time;
   }

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -28,6 +28,7 @@
 'use strict';
 
 const {
+  DateNow,
   MathCeil,
   MathFloor,
   MathMax,
@@ -442,7 +443,7 @@ Interface.prototype._normalWrite = function(b) {
   }
   let string = this._decoder.write(b);
   if (this._sawReturnAt &&
-      Date.now() - this._sawReturnAt <= this.crlfDelay) {
+      DateNow() - this._sawReturnAt <= this.crlfDelay) {
     string = string.replace(/^\n/, '');
     this._sawReturnAt = 0;
   }
@@ -455,7 +456,7 @@ Interface.prototype._normalWrite = function(b) {
     this._line_buffer = null;
   }
   if (newPartContainsEnding) {
-    this._sawReturnAt = string.endsWith('\r') ? Date.now() : 0;
+    this._sawReturnAt = string.endsWith('\r') ? DateNow() : 0;
 
     // Got one or more newlines; process into "line" events
     const lines = string.split(lineEnding);
@@ -838,14 +839,14 @@ function _ttyWriteDumb(s, key) {
 
   switch (key.name) {
     case 'return':  // Carriage return, i.e. \r
-      this._sawReturnAt = Date.now();
+      this._sawReturnAt = DateNow();
       this._line();
       break;
 
     case 'enter':
       // When key interval > crlfDelay
       if (this._sawReturnAt === 0 ||
-          Date.now() - this._sawReturnAt > this.crlfDelay) {
+          DateNow() - this._sawReturnAt > this.crlfDelay) {
         this._line();
       }
       this._sawReturnAt = 0;
@@ -1019,14 +1020,14 @@ Interface.prototype._ttyWrite = function(s, key) {
 
     switch (key.name) {
       case 'return':  // Carriage return, i.e. \r
-        this._sawReturnAt = Date.now();
+        this._sawReturnAt = DateNow();
         this._line();
         break;
 
       case 'enter':
         // When key interval > crlfDelay
         if (this._sawReturnAt === 0 ||
-            Date.now() - this._sawReturnAt > this.crlfDelay) {
+            DateNow() - this._sawReturnAt > this.crlfDelay) {
           this._line();
         }
         this._sawReturnAt = 0;


### PR DESCRIPTION
Hello !

I replaced `Date.now()` in lib directory by the primordial `DateNow()`, guided by @targos :)

#### Checklist
- [x] `make -j4 test` (UNIX) passes