### PR TITLE
lib: replace ArrayBuffer.isView by primordial ArrayBuffer

### DIFF
--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  ArrayBufferIsView,
   ObjectDefineProperties,
 } = primordials;
 
@@ -74,7 +75,7 @@ function StringDecoder(encoding) {
 StringDecoder.prototype.write = function write(buf) {
   if (typeof buf === 'string')
     return buf;
-  if (!ArrayBuffer.isView(buf))
+  if (!ArrayBufferIsView(buf))
     throw new ERR_INVALID_ARG_TYPE('buf',
                                    ['Buffer', 'TypedArray', 'DataView'],
                                    buf);


### PR DESCRIPTION
Hello !

I replaced ArrayBuffer.isView() in lib directory by the primordial ArrayBufferIsView()

Checklist
[x] vcbuild test (Windows) passes