### PR TITLE
build: fix static dll compilation on Windows

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -23,6 +23,7 @@
     'node_shared_openssl%': 'false',
     'node_v8_options%': '',
     'node_core_target_name%': 'node',
+    'node_target_type%': 'executable',
     'node_lib_target_name%': 'libnode',
     'node_intermediate_lib_type%': 'static_library',
     'node_builtin_modules_path%': '',
@@ -315,7 +316,7 @@
   'targets': [
     {
       'target_name': '<(node_core_target_name)',
-      'type': 'executable',
+      'type': '<(node_target_type)',
 
       'defines': [
         'NODE_WANT_INTERNALS=1',

--- a/node.gyp
+++ b/node.gyp
@@ -251,14 +251,16 @@
       [ 'node_shared=="true"', {
         'node_target_type%': 'shared_library',
         'conditions': [
-          ['OS=="aix"', {
+          ['OS in ("aix", "win")', {
             # For AIX, always generate static library first,
             # It needs an extra step to generate exp and
             # then use both static lib and exp to create
             # shared lib.
-            'node_intermediate_lib_type': 'static_library',
+            # For Windows, always generate static library,
+            # which is necessary to compile node.dll
+            'node_intermediate_lib_type%': 'static_library',
           }, {
-            'node_intermediate_lib_type': 'shared_library',
+            'node_intermediate_lib_type%': 'shared_library',
           }],
         ],
       }, {

--- a/node.gyp
+++ b/node.gyp
@@ -746,6 +746,7 @@
           'libraries': [
             'Dbghelp',
             'Psapi',
+            'Winmm',
           ],
         }],
         [ 'node_use_etw=="true"', {


### PR DESCRIPTION
build: fix static dll compilation on Windows

This PR fixes the static dll compilation steps failing.
I'm uncertain about adding tests for this as I spotted in
the gyp files that shared mode isn't supported so to speak.

I tested this by running the following commands successfully:
- `.\vcbuild.bat dll`
- `.\vcbuild.bat dll x86`

Note: I encountered an issue when compiling a different
architecture after compiling the first for node 12 (though it
wasn't a problem against master). But if you delete the `out`
folder after the first build, the second build will pass.

Fixes: https://github.com/nodejs/node/issues/28845

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
