### PR TITLE
Replace Number to Primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -17,6 +17,8 @@ rules:
       message: "Use `const { JSON } = primordials;` instead of the global."
     - name: Math
       message: "Use `const { Math } = primordials;` instead of the global."
+    - name: Number
+      message: "Use `const { Number } = primordials;` instead of the global."
     - name: Object
       message: "Use `const { Object } = primordials;` instead of the global."
     - name: Reflect

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -2,6 +2,7 @@
 
 const {
   MathFloor,
+  Number,
 } = primordials;
 
 const {

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -8,6 +8,7 @@ const {
   ArrayIsArray,
   Boolean,
   MathFloor,
+  Number,
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectKeys,

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -3,6 +3,7 @@
 const {
   ArrayIsArray,
   DateNow,
+  Number,
   NumberIsFinite,
   ObjectSetPrototypeOf,
   ReflectOwnKeys,

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -3,6 +3,7 @@
 const {
   ArrayIsArray,
   MathMax,
+  Number,
   ObjectCreate,
   ObjectKeys,
 } = primordials;

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  Number,
   NumberIsNaN,
   ObjectCreate,
 } = primordials;

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -2,6 +2,7 @@
 
 const {
   Array,
+  Number,
   ObjectCreate,
   ObjectDefineProperties,
   ObjectDefineProperty,

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -16,6 +16,7 @@ const {
   MathMin,
   MathRound,
   MathSqrt,
+  Number,
   NumberIsNaN,
   NumberPrototypeValueOf,
   ObjectAssign,
@@ -39,7 +40,7 @@ const {
   SymbolPrototypeValueOf,
   SymbolIterator,
   SymbolToStringTag,
-  uncurryThis
+  uncurryThis,
 } = primordials;
 
 const {

--- a/lib/net.js
+++ b/lib/net.js
@@ -24,6 +24,7 @@
 const {
   ArrayIsArray,
   Boolean,
+  Number,
   NumberIsNaN,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,


### PR DESCRIPTION
Update some file to replace Number to the primordial Number.
And i just have created a line in "/lib/.eslintrc.yaml".
```yaml
rules:
  no-restricted-globals:
    - name: Number
      message: "Use `const { Number } = primordials;` instead of the global."
```

And replace every code :
```javascript
const {
  ArrayIsArray,
  MathMax,
  ObjectCreate,
  ObjectKeys,
} = primordials;
```

By 
```javascript
const {
  ArrayIsArray,
  MathMax,
  ObjectCreate,
  ObjectKeys,
  Number,
} = primordials;
```

in theses files :

- lib/internal/buffer.js
- lib/internal/console/constructor.js
- lib/internal/fs/utils.js
-  lib/internal/http2/util.js
- lib/internal/repl.js 
- lib/internal/url.js
- lib/internal/util/inspect.js
- lib/net.js

This task was given to me by @targos thanks ❤️ 

I hope this PR will help you :x 