### PR TITLE
test: increase coverage for trace_events.js

### DIFF
--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2544,8 +2544,13 @@ assert.strictEqual(
   // Tracing class respects inspect depth.
   try {
     const trace = require('trace_events').createTracing({ categories: ['fo'] });
-    const actual = util.inspect({ trace }, { depth: 0 });
-    assert.strictEqual(actual, '{ trace: [Tracing] }');
+    const actualDepth0 = util.inspect({ trace }, { depth: 0 });
+    assert.strictEqual(actualDepth0, '{ trace: [Tracing] }');
+    const actualDepth1 = util.inspect({ trace }, { depth: 1 });
+    assert.strictEqual(
+      actualDepth1,
+      "{ trace: Tracing { enabled: false, categories: 'fo' } }"
+    );
   } catch (err) {
     if (err.code !== 'ERR_TRACE_EVENTS_UNAVAILABLE')
       throw err;


### PR DESCRIPTION
Add a test case to increase the test coverage for lib/trace_events.js.

Refs: https://codecov.io/gh/nodejs/node/src/ea7a6f9dbd05654fff3f8c474ac0f5126bc87376/lib/trace_events.js#L70...75
Refs: https://coverage.nodejs.org/coverage-ea7a6f9dbd05654f/lib/trace_events.js.html#L70

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
