### PR TITLE
docs: Buffer.toString(): add note about invalid data

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2159,6 +2159,8 @@ added: v0.1.90
 
 Decodes `buf` to a string according to the specified character encoding in
 `encoding`. `start` and `end` may be passed to decode only a subset of `buf`.
+If a byte sequence in the input is not valid in the given `encoding` then
+it is replaced with the replacement character `u+FFFD`.
 
 The maximum length of a string instance (in UTF-16 code units) is available
 as [`buffer.constants.MAX_STRING_LENGTH`][].

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2160,7 +2160,7 @@ added: v0.1.90
 Decodes `buf` to a string according to the specified character encoding in
 `encoding`. `start` and `end` may be passed to decode only a subset of `buf`.
 If a byte sequence in the input is not valid in the given `encoding` then
-it is replaced with the replacement character `u+FFFD`.
+it is replaced with the replacement character `U+FFFD`.
 
 The maximum length of a string instance (in UTF-16 code units) is available
 as [`buffer.constants.MAX_STRING_LENGTH`][].


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

New to the ecosystem. I looked up the docs to see how `Buffer.toString()` behaves upon invalid input data (for building solid code it's of course critically important to know whether it throws an error, or if it performs a surrogate escape instead). Is not documented as of today.

Once we modify the documentation we can close https://github.com/nodejs/node/issues/23280.

There is an existing patch: https://github.com/nodejs/node/pull/28249/ -- but it's probably too controversial as of the amount of information I think.

I tried to stay minimal here, so that we at least don't ignore the topic in the docs.

https://github.com/nodejs/node/issues/6075 is about the same topic, I think nobody questions that we need to have the behavior of `toString()` documented w.r.t. invalid byte sequences in the input.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
