### PR TITLE
deps: V8: cherry-pick ca5b0ec

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.20',
+    'v8_embedder_string': '-node.21',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/heap/factory.cc
+++ b/deps/v8/src/heap/factory.cc
@@ -3070,20 +3070,22 @@ Handle<SyntheticModule> Factory::NewSyntheticModule(
     Handle<String> module_name, Handle<FixedArray> export_names,
     v8::Module::SyntheticModuleEvaluationSteps evaluation_steps) {
   ReadOnlyRoots roots(isolate());
-  Handle<SyntheticModule> module(
-      SyntheticModule::cast(New(synthetic_module_map(), AllocationType::kOld)),
-      isolate());
+
   Handle<ObjectHashTable> exports =
       ObjectHashTable::New(isolate(), static_cast<int>(export_names->length()));
   Handle<Foreign> evaluation_steps_foreign =
       NewForeign(reinterpret_cast<i::Address>(evaluation_steps));
-  module->set_exports(*exports);
+
+  Handle<SyntheticModule> module(
+      SyntheticModule::cast(New(synthetic_module_map(), AllocationType::kOld)),
+      isolate());
   module->set_hash(isolate()->GenerateIdentityHash(Smi::kMaxValue));
   module->set_module_namespace(roots.undefined_value());
   module->set_status(Module::kUninstantiated);
   module->set_exception(roots.the_hole_value());
   module->set_name(*module_name);
   module->set_export_names(*export_names);
+  module->set_exports(*exports);
   module->set_evaluation_steps(*evaluation_steps_foreign);
   return module;
 }

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -23918,6 +23918,31 @@ TEST(CreateSyntheticModule) {
   CHECK_EQ(i_module->status(), i::Module::kInstantiated);
 }
 
+TEST(CreateSyntheticModuleGC) {
+  // Try to make sure that CreateSyntheticModule() deals well with a GC
+  // happening during its execution.
+  i::FLAG_gc_interval = 10;
+  i::FLAG_inline_new = false;
+
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  v8::Isolate::Scope iscope(isolate);
+  v8::HandleScope scope(isolate);
+  v8::Local<v8::Context> context = v8::Context::New(isolate);
+  v8::Context::Scope cscope(context);
+
+  std::vector<v8::Local<v8::String>> export_names{v8_str("default")};
+  v8::Local<v8::String> module_name =
+      v8_str("CreateSyntheticModule-TestSyntheticModuleGC");
+
+  for (int i = 0; i < 200; i++) {
+    Local<Module> module = v8::Module::CreateSyntheticModule(
+        isolate, module_name, export_names,
+        UnexpectedSyntheticModuleEvaluationStepsCallback);
+    USE(module);
+  }
+}
+
 TEST(SyntheticModuleSetExports) {
   LocalContext env;
   v8::Isolate* isolate = env->GetIsolate();

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -33,7 +33,3 @@ test-async-hooks-http-parser-destroy: PASS,FLAKY
 [$system==freebsd]
 
 [$system==aix]
-
-[$mode==debug]
-# https://github.com/nodejs/node/issues/30498
-test-domain-error-types: PASS,FLAKY


### PR DESCRIPTION
Original commit message:

    [heap] Ensure SyntheticModule is initialized before next allocation

    Ensure that all fields of `SyntheticModule` are set before creating
    the exports hash table for it, because the latter may trigger
    garbage collection, leading to crashes.

    This has been causing failures in the Node.js CI over the last weeks,
    after making the creating of synthetic modules part of Node’s
    startup sequence.

    (I am generally not very familiar with this part of the V8
    code and there might be a better way, or possibly a way to add a
    reliable regression test, that I am not aware of.)

    Refs: https://github.com/nodejs/node/issues/30498
    Refs: https://github.com/nodejs/node/issues/30648
    Change-Id: I32da4b7bd888c6ec1421f34f5bd52e7bad154c1e
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1939752
    Commit-Queue: Ulan Degenbaev <ulan@chromium.org>
    Reviewed-by: Ulan Degenbaev <ulan@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#65247}

Refs: https://github.com/v8/v8/commit/ca5b0ec2722d2af4551c01ca78921fa16a26ae72
Fixes: https://github.com/nodejs/node/issues/30498
Fixes: https://github.com/nodejs/node/issues/30648

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
