### PR TITLE
stream: improve performance for sync write finishes

### DIFF
--- a/benchmark/streams/writable-manywrites.js
+++ b/benchmark/streams/writable-manywrites.js
@@ -4,14 +4,19 @@ const common = require('../common');
 const Writable = require('stream').Writable;
 
 const bench = common.createBenchmark(main, {
-  n: [2e6]
+  n: [2e6],
+  sync: ['yes', 'no']
 });
 
-function main({ n }) {
+function main({ n, sync }) {
   const b = Buffer.allocUnsafe(1024);
   const s = new Writable();
+  sync = sync === 'yes';
   s._write = function(chunk, encoding, cb) {
-    cb();
+    if (sync)
+      cb();
+    else
+      process.nextTick(cb);
   };
 
   bench.start();

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -142,6 +142,10 @@ function WritableState(options, stream, isDuplex) {
   // The amount that is being written when _write is called.
   this.writelen = 0;
 
+  // Storage for data passed to the afterWrite() callback in case of
+  // synchronous _write() completion.
+  this.afterWriteTickInfo = null;
+
   this.bufferedRequest = null;
   this.lastBufferedRequest = null;
 
@@ -498,22 +502,42 @@ function onwrite(stream, er) {
     }
 
     if (sync) {
-      process.nextTick(afterWrite, stream, state, cb);
+      // It is a common case that the callback passed to .write() is always
+      // the same. In that case, we do not schedule a new nextTick(), but rather
+      // just increase a counter, to improve performance and avoid memory
+      // allocations.
+      if (state.afterWriteTickInfo !== null &&
+          state.afterWriteTickInfo.cb === cb) {
+        state.afterWriteTickInfo.count++;
+      } else {
+        state.afterWriteTickInfo = { count: 1, cb, stream, state };
+        process.nextTick(afterWriteTick, state.afterWriteTickInfo);
+      }
     } else {
-      afterWrite(stream, state, cb);
+      afterWrite(stream, state, 1, cb);
     }
   }
 }
 
-function afterWrite(stream, state, cb) {
+function afterWriteTick({ stream, state, count, cb }) {
+  return afterWrite(stream, state, count, cb);
+}
+
+function afterWrite(stream, state, count, cb) {
+  state.afterWriteTickInfo = null;
+
   const needDrain = !state.ending && !stream.destroyed && state.length === 0 &&
     state.needDrain;
   if (needDrain) {
     state.needDrain = false;
     stream.emit('drain');
   }
-  state.pendingcb--;
-  cb();
+
+  while (count-- > 0) {
+    state.pendingcb--;
+    cb();
+  }
+
   finishMaybe(stream, state);
 }
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -520,12 +520,11 @@ function onwrite(stream, er) {
 }
 
 function afterWriteTick({ stream, state, count, cb }) {
+  state.afterWriteTickInfo = null;
   return afterWrite(stream, state, count, cb);
 }
 
 function afterWrite(stream, state, count, cb) {
-  state.afterWriteTickInfo = null;
-
   const needDrain = !state.ending && !stream.destroyed && state.length === 0 &&
     state.needDrain;
   if (needDrain) {

--- a/test/parallel/test-stream-writable-samecb-singletick.js
+++ b/test/parallel/test-stream-writable-samecb-singletick.js
@@ -1,0 +1,30 @@
+'use strict';
+const common = require('../common');
+const { Console } = require('console');
+const { Writable } = require('stream');
+const async_hooks = require('async_hooks');
+
+// Make sure that repeated calls to console.log(), and by extension
+// stream.write() for the underlying stream, allocate exactly 1 tick object.
+// At the time of writing, that is enough to ensure a flat memory profile
+// from repeated console.log() calls, rather than having callbacks pile up
+// over time, assuming that data can be written synchronously.
+// Refs: https://github.com/nodejs/node/issues/18013
+// Refs: https://github.com/nodejs/node/issues/18367
+
+const checkTickCreated = common.mustCall();
+
+async_hooks.createHook({
+  init(id, type, triggerId, resoure) {
+    if (type === 'TickObject') checkTickCreated();
+  }
+}).enable();
+
+const console = new Console(new Writable({
+  write: common.mustCall((chunk, encoding, cb) => {
+    cb();
+  }, 100)
+}));
+
+for (let i = 0; i < 100; i++)
+  console.log(i);


### PR DESCRIPTION
Improve performance and reduce memory usage when a writable stream
is written to with the same callback (which is the most common case)
and when the write operation finishes synchronously (which is also
often the case).

                                                         confidence improvement accuracy (*)    (**)   (***)
    streams/writable-manywrites.js sync='no' n=2000000                  0.99 %       ±3.20%  ±4.28%  ±5.61%
    streams/writable-manywrites.js sync='yes' n=2000000        ***    710.69 %      ±19.65% ±26.47% ±35.09%

Refs: https://github.com/nodejs/node/issues/18013
Refs: https://github.com/nodejs/node/issues/18367

@nodejs/streams @ronag

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
