### PR TITLE
[v12.x backport] Windows CI job update changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,6 +489,7 @@ test-all-valgrind: test-build
 test-all-suites: | clear-stalled test-build bench-addons-build doc-only ## Run all test suites.
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) test/*
 
+# CI_* variables should be kept synchronized with the ones in vcbuild.bat
 CI_NATIVE_SUITES ?= addons js-native-api node-api
 CI_JS_SUITES ?= default
 ifeq ($(node_use_openssl), false)

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -68,6 +68,7 @@ set cctest=
 set openssl_no_asm=
 set doc=
 set extra_msbuild_args=
+set exit_code=0
 
 :next-arg
 if "%1"=="" goto args-done
@@ -629,9 +630,11 @@ if defined no_cctest echo Skipping cctest because no-cctest was specified && got
 if not exist "%config%\cctest.exe" echo cctest.exe not found. Run "vcbuild test" or "vcbuild cctest" to build it. && goto run-test-py
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
+if %errorlevel% neq 0 set exit_code=%errorlevel%
 :run-test-py
 echo running 'python tools\test.py %test_args%'
 python tools\test.py %test_args%
+if %errorlevel% neq 0 set exit_code=%errorlevel%
 goto test-v8
 
 :test-v8
@@ -714,7 +717,7 @@ echo   vcbuild.bat no-cctest                : skip building cctest.exe
 goto exit
 
 :exit
-goto :EOF
+exit /b %exit_code%
 
 
 rem ***************

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -15,6 +15,13 @@ if /i "%1"=="/?" goto help
 
 cd %~dp0
 
+@rem CI_* variables should be kept synchronized with the ones in Makefile
+set CI_NATIVE_SUITES=addons js-native-api node-api
+set CI_JS_SUITES=default
+set CI_DOC=doctool
+@rem Same as the test-ci target in Makefile
+set "common_test_suites=%CI_JS_SUITES% %CI_NATIVE_SUITES% %CI_DOC%&set build_addons=1&set build_js_native_api_tests=1&set build_node_api_tests=1"
+
 @rem Process arguments.
 set config=Release
 set target=Build
@@ -51,10 +58,8 @@ set build_js_native_api_tests=
 set build_node_api_tests=
 set test_node_inspect=
 set test_check_deopts=
-set js_test_suites=default
 set v8_test_options=
 set v8_build_options=
-set "common_test_suites=%js_test_suites% doctool addons js-native-api node-api&set build_addons=1&set build_js_native_api_tests=1&set build_node_api_tests=1"
 set http2_debug=
 set nghttp2_debug=
 set link_module=
@@ -86,8 +91,8 @@ if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="ltcg"          set ltcg=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
 if /i "%1"=="test"          set test_args=%test_args% -J %common_test_suites%&set lint_cpp=1&set lint_js=1&set lint_md=1&goto arg-ok
-:: test-ci is deprecated
-if /i "%1"=="test-ci"       goto arg-ok
+if /i "%1"=="test-ci-native" set test_args=%test_args% %test_ci_args% -J -p tap --logfile test.tap %CI_NATIVE_SUITES% %CI_DOC%&set build_addons=1&set build_js_native_api_tests=1&set build_node_api_tests=1&set cctest_args=%cctest_args% --gtest_output=xml:cctest.junit.xml&goto arg-ok
+if /i "%1"=="test-ci-js"    set test_args=%test_args% %test_ci_args% -J -p tap --logfile test.tap %CI_JS_SUITES%&set no_cctest=1&goto arg-ok
 if /i "%1"=="build-addons"   set build_addons=1&goto arg-ok
 if /i "%1"=="build-js-native-api-tests"   set build_js_native_api_tests=1&goto arg-ok
 if /i "%1"=="build-node-api-tests"   set build_node_api_tests=1&goto arg-ok


### PR DESCRIPTION
This is a backport of https://github.com/nodejs/node/pull/30724 to v12. This is a cherry-pick without conflicts (but the same is not true for v10 and v8).

@nodejs/backporters I will update this with any feedback from the original PR. This needs to land soon after to avoid issues running CI.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
