### PR TITLE
[v8.x backport] Windows CI job update changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,6 +395,7 @@ test-all: test-build test/gc/build/Release/binding.node ## Run everything in tes
 test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
+# CI_* variables should be kept synchronized with the ones in vcbuild.bat
 CI_NATIVE_SUITES ?= addons addons-napi
 CI_ASYNC_HOOKS := async-hooks
 CI_JS_SUITES ?= default

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -57,6 +57,7 @@ set v8_build_options=
 set http2_debug=
 set nghttp2_debug=
 set link_module=
+set exit_code=0
 
 :next-arg
 if "%1"=="" goto args-done
@@ -486,10 +487,12 @@ if defined skip_cctest goto run-test-py
 if not exist %config%\cctest.exe goto run-test-py
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
+if %errorlevel% neq 0 set exit_code=%errorlevel%
 :run-test-py
 REM when building a static library there's no binary to run tests
 if defined enable_static goto test-v8
 call :run-python tools\test.py %test_args%
+if %errorlevel% neq 0 set exit_code=%errorlevel%
 
 :test-v8
 if not defined custom_v8_test goto lint-cpp
@@ -587,7 +590,7 @@ echo %cmd1%
 exit /b %ERRORLEVEL%
 
 :exit
-goto :EOF
+exit /b %exit_code%
 
 
 rem ***************


### PR DESCRIPTION
This is a backport of https://github.com/nodejs/node/pull/30724 to v12. The changes are adapted for v8.

@nodejs/backporters I will update this with any feedback from the original PR. This needs to land soon after to avoid issues running CI.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
