### PR TITLE
lib: add parent to ERR_UNKNOWN_FILE_EXTENSION message

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1210,7 +1210,7 @@ E('ERR_UNKNOWN_BUILTIN_MODULE', 'No such built-in module: %s', Error);
 E('ERR_UNKNOWN_CREDENTIAL', '%s identifier does not exist: %s', Error);
 E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s', TypeError);
 E('ERR_UNKNOWN_FILE_EXTENSION',
-  'Unknown file extension \'%s\' for %s imported from %s',
+  'Unknown file extension "%s" for %s imported from %s',
   TypeError);
 E('ERR_UNKNOWN_MODULE_FORMAT', 'Unknown module format: %s', RangeError);
 E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s', TypeError);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1210,7 +1210,7 @@ E('ERR_UNKNOWN_BUILTIN_MODULE', 'No such built-in module: %s', Error);
 E('ERR_UNKNOWN_CREDENTIAL', '%s identifier does not exist: %s', Error);
 E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s', TypeError);
 E('ERR_UNKNOWN_FILE_EXTENSION',
-  'Unknown file extension %s for %s imported from %s',
+  'Unknown file extension \'%s\' for %s imported from %s',
   TypeError);
 E('ERR_UNKNOWN_MODULE_FORMAT', 'Unknown module format: %s', RangeError);
 E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s', TypeError);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1209,7 +1209,8 @@ E('ERR_UNHANDLED_ERROR',
 E('ERR_UNKNOWN_BUILTIN_MODULE', 'No such built-in module: %s', Error);
 E('ERR_UNKNOWN_CREDENTIAL', '%s identifier does not exist: %s', Error);
 E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s', TypeError);
-E('ERR_UNKNOWN_FILE_EXTENSION', 'Unknown file extension %s imported from %s',
+E('ERR_UNKNOWN_FILE_EXTENSION',
+  'Unknown file extension %s for %s imported from %s',
   TypeError);
 E('ERR_UNKNOWN_MODULE_FORMAT', 'Unknown module format: %s', RangeError);
 E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s', TypeError);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1209,7 +1209,8 @@ E('ERR_UNHANDLED_ERROR',
 E('ERR_UNKNOWN_BUILTIN_MODULE', 'No such built-in module: %s', Error);
 E('ERR_UNKNOWN_CREDENTIAL', '%s identifier does not exist: %s', Error);
 E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s', TypeError);
-E('ERR_UNKNOWN_FILE_EXTENSION', 'Unknown file extension: %s', TypeError);
+E('ERR_UNKNOWN_FILE_EXTENSION', 'Unknown file extension %s imported from %s',
+  TypeError);
 E('ERR_UNKNOWN_MODULE_FORMAT', 'Unknown module format: %s', RangeError);
 E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s', TypeError);
 

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -116,7 +116,9 @@ function resolve(specifier, parentURL) {
         'ExperimentalWarning');
       format = legacyExtensionFormatMap[ext];
     } else {
-      throw new ERR_UNKNOWN_FILE_EXTENSION(fileURLToPath(url));
+      throw new ERR_UNKNOWN_FILE_EXTENSION(
+        fileURLToPath(url),
+        fileURLToPath(parentURL));
     }
   }
   return { url: `${url}`, format };

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -117,6 +117,7 @@ function resolve(specifier, parentURL) {
       format = legacyExtensionFormatMap[ext];
     } else {
       throw new ERR_UNKNOWN_FILE_EXTENSION(
+        ext,
         fileURLToPath(url),
         fileURLToPath(parentURL));
     }

--- a/test/es-module/test-esm-invalid-extension.js
+++ b/test/es-module/test-esm-invalid-extension.js
@@ -6,8 +6,10 @@ const { spawnSync } = require('child_process');
 const fixture = fixtures.path('/es-modules/import-invalid-ext.mjs');
 const child = spawnSync(process.execPath, [fixture]);
 const errMsg = 'TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension';
+const importMsg = `imported from ${fixture}`;
 
 assert.strictEqual(child.status, 1);
 assert.strictEqual(child.signal, null);
 assert.strictEqual(child.stdout.toString().trim(), '');
 assert(child.stderr.toString().includes(errMsg));
+assert(child.stderr.toString().includes(importMsg));


### PR DESCRIPTION
- `default_resolve.js` updated to pass `parentURL` into error
- `ERR_UNKNOWN_FILE_EXTENSION` updated to include `parentURL`
- test added to check for import message in error

Fixes: https://github.com/nodejs/node/issues/30721

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
