### PR TITLE
inspector: do not access queueMicrotask from global

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -22,6 +22,7 @@ if (!hasInspector)
   throw new ERR_INSPECTOR_NOT_AVAILABLE();
 
 const EventEmitter = require('events');
+const { queueMicrotask } = require('internal/process/task_queues');
 const { validateString } = require('internal/validators');
 const { isMainThread } = require('worker_threads');
 


### PR DESCRIPTION
Grab it from the internal module where it's defined instead.
