### PR TITLE
stream: ensure finish is emitted in next tick

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -671,30 +671,40 @@ function prefinish(stream, state) {
   }
 }
 
-function finishMaybe(stream, state) {
+function finishMaybe(stream, state, sync) {
   const need = needFinish(state);
   if (need) {
     prefinish(stream, state);
     if (state.pendingcb === 0) {
-      state.finished = true;
-      stream.emit('finish');
-
-      if (state.autoDestroy) {
-        // In case of duplex streams we need a way to detect
-        // if the readable side is ready for autoDestroy as well
-        const rState = stream._readableState;
-        if (!rState || (rState.autoDestroy && rState.endEmitted)) {
-          stream.destroy();
-        }
+      state.pendingcb++;
+      if (sync) {
+        process.nextTick(finish, stream, state);
+      } else {
+        finish(stream, state);
       }
     }
   }
   return need;
 }
 
+function finish(stream, state) {
+  state.pendingcb--;
+  state.finished = true;
+  stream.emit('finish');
+
+  if (state.autoDestroy) {
+    // In case of duplex streams we need a way to detect
+    // if the readable side is ready for autoDestroy as well
+    const rState = stream._readableState;
+    if (!rState || (rState.autoDestroy && rState.endEmitted)) {
+      stream.destroy();
+    }
+  }
+}
+
 function endWritable(stream, state, cb) {
   state.ending = true;
-  finishMaybe(stream, state);
+  finishMaybe(stream, state, true);
   if (cb) {
     if (state.finished)
       process.nextTick(cb);

--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -70,5 +70,7 @@ const filename = path.join(tmpdir.path, 'sync-write-stream.txt');
   assert.strictEqual(stream.fd, fd);
 
   stream.end();
-  assert.strictEqual(stream.fd, null);
+  stream.on('close', common.mustCall(() => {
+    assert.strictEqual(stream.fd, null);
+  }));
 }

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -238,13 +238,15 @@ const assert = require('assert');
   // called again.
   const write = new Writable({
     write: common.mustNotCall(),
-    final: common.mustCall((cb) => cb(), 2)
+    final: common.mustCall((cb) => cb(), 2),
+    autoDestroy: true
   });
 
   write.end();
-  write.destroy();
-  write._undestroy();
-  write.end();
+  write.once('close', common.mustCall(() => {
+    write._undestroy();
+    write.end();
+  }));
 }
 
 {

--- a/test/parallel/test-stream-writable-finished.js
+++ b/test/parallel/test-stream-writable-finished.js
@@ -28,3 +28,16 @@ const assert = require('assert');
     assert.strictEqual(writable.writableFinished, true);
   }));
 }
+
+{
+  // Emit finish asynchronously
+
+  const w = new Writable({
+    write(chunk, encoding, cb) {
+      cb();
+    }
+  });
+
+  w.end();
+  w.on('finish', common.mustCall());
+}


### PR DESCRIPTION
When using `end()` it was possible for `'finish'` to be emitted synchronously causing incorrect behaviour and subtle bugs.

This is an edge case not usually encountered since a `write()` is usually pending and will be the one to initiate `finishMaybe()` through `afterWrite` which is always async.

This PR also cause `_destroy()` to be called in nextTick when `autoDestroy` is enabled during this edge case.

NOTE: `'prefinish'` must be synchronous in order to not break `Transform`. I've got another PR in the works to sort this out.

Should probably be semver major.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
