### PR TITLE
lib: insert blank line after directives

### DIFF
--- a/lib/internal/cluster/shared_handle.js
+++ b/lib/internal/cluster/shared_handle.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('internal/assert');
 const dgram = require('internal/dgram');
 const net = require('net');

--- a/lib/internal/dgram.js
+++ b/lib/internal/dgram.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const { codes } = require('internal/errors');
 const { UDP } = internalBinding('udp_wrap');
 const { guessHandleType } = internalBinding('util');

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -5,6 +5,7 @@
 // - Bring your own custom fs module is not currently supported.
 // - Some basic code cleanup.
 'use strict';
+
 const {
   chmod,
   chmodSync,

--- a/lib/internal/main/print_bash_completion.js
+++ b/lib/internal/main/print_bash_completion.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const { options, aliases } = require('internal/options');
 
 const {

--- a/lib/internal/process/report.js
+++ b/lib/internal/process/report.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_SYNTHETIC

--- a/lib/internal/streams/duplexpair.js
+++ b/lib/internal/streams/duplexpair.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const { Duplex } = require('stream');
 
 const kCallback = Symbol('Callback');


### PR DESCRIPTION
Most of the files in `lib` use a blank line after 'use strict'. Insert
one in the small number of files that don't.

Eventually, this can be enforced by a lint rule.

Refs: https://github.com/nodejs/node/pull/21128#discussion_r351606626

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
