### PR TITLE
stream: improve write performance

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -493,30 +493,30 @@ function onwrite(stream, er) {
       onwriteError(stream, state, er, cb);
     }
   } else {
-    // Check if we're actually ready to finish, but don't emit yet
-    var finished = needFinish(state) || stream.destroyed;
-
-    if (!finished &&
-        !state.corked &&
+    if (!state.corked &&
         !state.bufferProcessing &&
         state.bufferedRequest) {
       clearBuffer(stream, state);
     }
 
-    if (sync) {
-      // It is a common case that the callback passed to .write() is always
-      // the same. In that case, we do not schedule a new nextTick(), but rather
-      // just increase a counter, to improve performance and avoid memory
-      // allocations.
-      if (state.afterWriteTickInfo !== null &&
-          state.afterWriteTickInfo.cb === cb) {
-        state.afterWriteTickInfo.count++;
+    if (state.ending || state.needDrain || cb !== nop) {
+      if (sync) {
+        // It is a common case that the callback passed to .write() is always
+        // the same. In that case, we do not schedule a new nextTick(), but
+        //  rather just increase a counter, to improve performance and avoid
+        // memory allocations.
+        if (state.afterWriteTickInfo !== null &&
+            state.afterWriteTickInfo.cb === cb) {
+          state.afterWriteTickInfo.count++;
+        } else {
+          state.afterWriteTickInfo = { count: 1, cb, stream, state };
+          process.nextTick(afterWriteTick, state.afterWriteTickInfo);
+        }
       } else {
-        state.afterWriteTickInfo = { count: 1, cb, stream, state };
-        process.nextTick(afterWriteTick, state.afterWriteTickInfo);
+        afterWrite(stream, state, 1, cb);
       }
     } else {
-      afterWrite(stream, state, 1, cb);
+      state.pendingcb--;
     }
   }
 }


### PR DESCRIPTION
This is inspired by #30710.

Depends on #30733 (which is included).

Improves performance of `write` by avoiding `process.nextTick` and a number of conditions when possible in the hot path in sync mode.

<details>
```
                                           confidence improvement accuracy (*)    (**)   (***)
 streams/writable-manywrites.js n=2000000        ***   1085.31 %      ±19.19% ±25.86% ±34.31%
````
</details>

EDIT: A bit more modest improvement after #30710

```bash
                                                      confidence improvement accuracy (*)   (**)  (***)
 streams/writable-manywrites.js sync='no' n=2000000                  0.10 %       ±1.46% ±1.94% ±2.54%
 streams/writable-manywrites.js sync='yes' n=2000000        ***      8.43 %       ±1.73% ±2.30% ±3.00%
```

Note since #30733 is probably semver major, this should be the same.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
