### PR TITLE
lib: Replace Symbol global by the primordials Symbol

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -23,6 +23,8 @@ rules:
       message: "Use `const { Object } = primordials;` instead of the global."
     - name: Reflect
       message: "Use `const { Reflect } = primordials;` instead of the global."
+    - name: Symbol
+      message: "Use `const { Symbol } = primordials;` instead of the global."
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -25,6 +25,7 @@ const {
   ObjectKeys,
   ObjectSetPrototypeOf,
   ObjectValues,
+  Symbol,
 } = primordials;
 
 const net = require('net');

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -23,6 +23,7 @@
 
 const {
   MathMin,
+  Symbol,
 } = primordials;
 const { setImmediate } = require('timers');
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -28,6 +28,7 @@ const {
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const { getDefaultHighWaterMark } = require('internal/streams/state');

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -24,6 +24,7 @@
 const {
   ObjectKeys,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const net = require('net');

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -27,6 +27,7 @@ const {
   NumberIsNaN,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 module.exports = Readable;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -29,6 +29,7 @@ const {
   Array,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 module.exports = Writable;

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -25,6 +25,7 @@ const {
   ObjectAssign,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -3,6 +3,7 @@
 const {
   NumberIsSafeInteger,
   ReflectApply,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -34,6 +34,7 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -30,6 +30,7 @@ const {
   Array,
   ObjectDefineProperty,
   ReflectApply,
+  Symbol,
 } = primordials;
 
 const EventEmitter = require('events');

--- a/lib/events.js
+++ b/lib/events.js
@@ -32,6 +32,7 @@ const {
   ObjectKeys,
   ReflectApply,
   ReflectOwnKeys,
+  Symbol,
 } = primordials;
 const kRejection = Symbol.for('nodejs.rejection');
 

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -3,6 +3,7 @@
 const {
   JSONParse,
   JSONStringify,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -4,6 +4,7 @@ const {
   FunctionPrototypeBind,
   NumberIsSafeInteger,
   ObjectDefineProperty,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -4,6 +4,7 @@ const {
   ArrayIsArray,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/internal/child_process/serialization.js
+++ b/lib/internal/child_process/serialization.js
@@ -3,6 +3,7 @@
 const {
   JSONParse,
   JSONStringify,
+  Symbol,
 } = primordials;
 const { Buffer } = require('buffer');
 const { StringDecoder } = require('string_decoder');

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -15,6 +15,7 @@ const {
   ObjectPrototypeHasOwnProperty,
   ObjectValues,
   ReflectOwnKeys,
+  Symbol,
 } = primordials;
 
 const { trace } = internalBinding('trace_events');

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -2,6 +2,7 @@
 
 const {
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -2,6 +2,7 @@
 
 const {
   ObjectDefineProperty,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const {
+  Symbol,
+} = primordials;
+
+const {
   getCiphers: _getCiphers,
   getCurves: _getCurves,
   getHashes: _getHashes,

--- a/lib/internal/dgram.js
+++ b/lib/internal/dgram.js
@@ -1,4 +1,9 @@
 'use strict';
+
+const {
+  Symbol,
+} = primordials;
+
 const { codes } = require('internal/errors');
 const { UDP } = internalBinding('udp_wrap');
 const { guessHandleType } = internalBinding('util');

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -7,6 +7,7 @@ const {
   ObjectCreate,
   ObjectDefineProperties,
   ObjectGetOwnPropertyDescriptors,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -16,6 +16,7 @@ const {
   NumberIsInteger,
   ObjectDefineProperty,
   ObjectKeys,
+  Symbol,
 } = primordials;
 
 const messages = new Map();

--- a/lib/internal/freeze_intrinsics.js
+++ b/lib/internal/freeze_intrinsics.js
@@ -31,7 +31,7 @@ module.exports = function() {
     getOwnPropertyDescriptors,
     getOwnPropertyNames,
     getOwnPropertySymbols,
-    getPrototypeOf
+    getPrototypeOf,
   } = Object;
   const objectHasOwnProperty = Object.prototype.hasOwnProperty;
   const { ownKeys } = Reflect;

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -2,6 +2,7 @@
 
 const {
   ObjectDefineProperty,
+  Symbol,
 } = primordials;
 
 const pathModule = require('path');

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -4,6 +4,7 @@ const {
   MathMax,
   MathMin,
   NumberIsSafeInteger,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -7,6 +7,7 @@ const {
   NumberIsFinite,
   ObjectSetPrototypeOf,
   ReflectOwnKeys,
+  Symbol,
 } = primordials;
 
 const { Buffer } = require('buffer');

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -3,6 +3,7 @@
 const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const errors = require('internal/errors');

--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  Symbol,
+} = primordials;
+
 const { setUnrefTimeout } = require('internal/timers');
 const { PerformanceEntry, notify } = internalBinding('performance');
 

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -8,6 +8,7 @@ const {
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
   ReflectGetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const assert = require('internal/assert');

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -11,6 +11,7 @@ const {
   ObjectDefineProperty,
   ObjectPrototypeHasOwnProperty,
   ReflectGetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -6,6 +6,7 @@ const {
   Number,
   ObjectCreate,
   ObjectKeys,
+  Symbol,
 } = primordials;
 
 const binding = internalBinding('http2');

--- a/lib/internal/js_stream_socket.js
+++ b/lib/internal/js_stream_socket.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  Symbol,
+} = primordials;
+
 const { setImmediate } = require('timers');
 const assert = require('internal/assert');
 const { Socket } = require('net');

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  Symbol,
+} = primordials;
+
 const Buffer = require('buffer').Buffer;
 const { writeBuffer } = internalBinding('fs');
 const errors = require('internal/errors');

--- a/lib/internal/priority_queue.js
+++ b/lib/internal/priority_queue.js
@@ -2,6 +2,7 @@
 
 const {
   Array,
+  Symbol,
 } = primordials;
 
 const kCompare = Symbol('compare');

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  Symbol,
+} = primordials;
+
 const acorn = require('internal/deps/acorn/acorn/dist/acorn');
 const privateMethods =
   require('internal/deps/acorn-plugins/acorn-private-methods/index');

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -2,6 +2,7 @@
 
 const {
   Array,
+  Symbol,
 } = primordials;
 
 const { Buffer } = require('buffer');

--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -4,6 +4,7 @@ const {
   ObjectCreate,
   ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const finished = require('internal/streams/end-of-stream');

--- a/lib/internal/streams/buffer_list.js
+++ b/lib/internal/streams/buffer_list.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  Symbol,
+} = primordials;
+
 const { Buffer } = require('buffer');
 const { inspect } = require('internal/util/inspect');
 

--- a/lib/internal/streams/duplexpair.js
+++ b/lib/internal/streams/duplexpair.js
@@ -1,4 +1,9 @@
 'use strict';
+
+const {
+  Symbol,
+} = primordials;
+
 const { Duplex } = require('stream');
 
 const kCallback = Symbol('Callback');

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const {
+  Symbol,
+} = primordials;
+
+const {
   ERR_INVALID_ARG_TYPE
 } = require('internal/errors').codes;
 

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -77,6 +77,7 @@ const {
   MathTrunc,
   NumberMIN_SAFE_INTEGER,
   ObjectCreate,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/internal/trace_events_async_hooks.js
+++ b/lib/internal/trace_events_async_hooks.js
@@ -4,6 +4,7 @@ const {
   ObjectKeys,
   SafeMap,
   SafeSet,
+  Symbol,
 } = primordials;
 
 const { trace } = internalBinding('trace_events');

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -11,6 +11,7 @@ const {
   ObjectKeys,
   ReflectGetOwnPropertyDescriptor,
   ReflectOwnKeys,
+  Symbol,
 } = primordials;
 
 const { inspect } = require('internal/util/inspect');

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -11,7 +11,9 @@ const {
   ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
   ReflectConstruct,
+  Symbol,
 } = primordials;
+
 const {
   codes: {
     ERR_INVALID_ARG_TYPE,

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -4,8 +4,8 @@ const {
   ArrayIsArray,
   ObjectCreate,
   ObjectDefineProperty,
-  Symbol,
   SafePromise,
+  Symbol,
 } = primordials;
 
 const { isContext } = internalBinding('contextify');

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -7,6 +7,7 @@ const {
   MathMax,
   ObjectCreate,
   ObjectEntries,
+  Symbol,
 } = primordials;
 
 const EventEmitter = require('events');

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -7,6 +7,7 @@ const {
   ObjectGetOwnPropertyDescriptors,
   ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/net.js
+++ b/lib/net.js
@@ -28,6 +28,7 @@ const {
   NumberIsNaN,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const EventEmitter = require('events');

--- a/lib/os.js
+++ b/lib/os.js
@@ -23,6 +23,7 @@
 
 const {
   ObjectDefineProperties,
+  Symbol,
 } = primordials;
 
 const { safeGetenv } = internalBinding('credentials');

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -7,6 +7,7 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectKeys,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -36,6 +36,7 @@ const {
   NumberIsNaN,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -55,6 +55,7 @@ const {
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -24,6 +24,7 @@
 const {
   ArrayBufferIsView,
   ObjectDefineProperties,
+  Symbol,
 } = primordials;
 
 const { Buffer } = require('buffer');

--- a/lib/trace_events.js
+++ b/lib/trace_events.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayIsArray,
+  Symbol,
 } = primordials;
 
 const { hasTracing } = internalBinding('config');

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -17,6 +17,7 @@
 const {
   Array,
   ObjectPrototypeToString,
+  Symbol,
 } = primordials;
 
 const { Buffer } = require('buffer');

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -24,6 +24,7 @@
 const {
   ArrayIsArray,
   ArrayPrototypeForEach,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -5,8 +5,10 @@ const {
   ArrayPrototypeForEach,
   ArrayPrototypeMap,
   FunctionPrototypeBind,
-  ObjectKeys
+  ObjectKeys,
+  Symbol,
 } = primordials;
+
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_WASI_ALREADY_STARTED

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -31,6 +31,7 @@ const {
   ObjectGetPrototypeOf,
   ObjectKeys,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const {


### PR DESCRIPTION
Update some file to replace Symbol global object to the Symbol primordials.

And i just have created a line in "/lib/.eslintrc.yaml".
```yaml
rules:
  no-restricted-globals:
    - name: Symbol
      message: "Use `const { Symbol } = primordials;` instead of the global."
```

Next, just adding : Symbol to every
```javascript
const {
  // [...]
  Symbol,
} = primordials;
```

This task was given to me by @targos thanks ❤️
I hope this new PR will help you :x