### PR TITLE
test: replace internal API test with public API test

### DIFF
--- a/test/parallel/test-freelist.js
+++ b/test/parallel/test-freelist.js
@@ -28,13 +28,3 @@ assert.strictEqual(flist1.free({ id: 'test5' }), false);
 assert.strictEqual(flist1.alloc().id, 'test3');
 assert.strictEqual(flist1.alloc().id, 'test2');
 assert.strictEqual(flist1.alloc().id, 'test1');
-
-// Check list has elements
-const flist2 = new FreeList('flist2', 2, Object);
-assert.strictEqual(flist2.hasItems(), false);
-
-flist2.free({ id: 'test1' });
-assert.strictEqual(flist2.hasItems(), true);
-
-flist2.alloc();
-assert.strictEqual(flist2.hasItems(), false);

--- a/test/parallel/test-http-common.js
+++ b/test/parallel/test-http-common.js
@@ -1,9 +1,11 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const httpCommon = require('_http_common');
-const checkIsHttpToken = httpCommon._checkIsHttpToken;
-const checkInvalidHeaderChar = httpCommon._checkInvalidHeaderChar;
+const {
+  _checkInvalidHeaderChar: checkInvalidHeaderChar,
+  _checkIsHttpToken: checkIsHttpToken,
+  parsers
+} = require('_http_common');
 
 // checkIsHttpToken
 assert(checkIsHttpToken('t'));
@@ -31,3 +33,13 @@ assert.strictEqual(checkInvalidHeaderChar('tt'), false);
 assert.strictEqual(checkInvalidHeaderChar('ttt'), false);
 assert.strictEqual(checkInvalidHeaderChar('tttt'), false);
 assert.strictEqual(checkInvalidHeaderChar('ttttt'), false);
+
+// parsers
+{
+  const dummyParser = { id: 'fhqwhgads' };
+  assert.strictEqual(parsers.hasItems(), false);
+  assert.strictEqual(parsers.free(dummyParser), true);
+  assert.strictEqual(parsers.hasItems(), true);
+  assert.strictEqual(parsers.alloc(), dummyParser);
+  assert.strictEqual(parsers.hasItems(), false);
+}


### PR DESCRIPTION
The internal freelist `hasItems()` test use the internal API directly.
This commit changes them to use the API as it is exposed publicly. It
tests the same code paths, but does it without needing
`--expose-internals`.

Refs: https://github.com/nodejs/node/pull/27588#pullrequestreview-234284081

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
