### PR TITLE
src: prevent hard coding stack trace limit

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -592,9 +592,9 @@ void Environment::PrintSyncTrace() const {
 
   fprintf(
       stderr, "(node:%d) WARNING: Detected use of sync API\n", uv_os_getpid());
-  PrintStackTrace(
-      isolate(),
-      StackTrace::CurrentStackTrace(isolate(), 10, StackTrace::kDetailed));
+  PrintStackTrace(isolate(),
+                  StackTrace::CurrentStackTrace(
+                      isolate(), stack_trace_limit(), StackTrace::kDetailed));
 }
 
 void Environment::RunCleanup() {
@@ -949,9 +949,9 @@ void Environment::Exit(int exit_code) {
 
     fprintf(
         stderr, "WARNING: Exited the environment with code %d\n", exit_code);
-    PrintStackTrace(
-        isolate(),
-        StackTrace::CurrentStackTrace(isolate(), 10, StackTrace::kDetailed));
+    PrintStackTrace(isolate(),
+                    StackTrace::CurrentStackTrace(
+                        isolate(), stack_trace_limit(), StackTrace::kDetailed));
   }
   if (is_main_thread()) {
     stop_sub_worker_contexts();

--- a/src/env.h
+++ b/src/env.h
@@ -1231,6 +1231,8 @@ class Environment : public MemoryRetainer {
   inline void modify_base_object_count(int64_t delta);
   inline int64_t base_object_count() const;
 
+  inline int32_t stack_trace_limit() const { return 10; }
+
 #if HAVE_INSPECTOR
   void set_coverage_connection(
       std::unique_ptr<profiler::V8CoverageConnection> connection);

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -145,7 +145,7 @@ static std::string GetErrorSource(Isolate* isolate,
 }
 
 void PrintStackTrace(Isolate* isolate, Local<StackTrace> stack) {
-  for (int i = 0; i < stack->GetFrameCount() - 1; i++) {
+  for (int i = 0; i < stack->GetFrameCount(); i++) {
     Local<StackFrame> stack_frame = stack->GetFrame(isolate, i);
     node::Utf8Value fn_name_s(isolate, stack_frame->GetFunctionName());
     node::Utf8Value script_name(isolate, stack_frame->GetScriptName());

--- a/test/message/throw_error_with_getter_throw_traced.out
+++ b/test/message/throw_error_with_getter_throw_traced.out
@@ -10,3 +10,4 @@ Thrown at:
     at Module.load (internal/modules/cjs/loader.js:*:*)
     at Module._load (internal/modules/cjs/loader.js:*:*)
     at executeUserEntryPoint (internal/modules/run_main.js:*:*)
+    at internal/main/run_main_module.js:*:*

--- a/test/message/throw_null_traced.out
+++ b/test/message/throw_null_traced.out
@@ -10,3 +10,4 @@ Thrown at:
     at Module.load (internal/modules/cjs/loader.js:*:*)
     at Module._load (internal/modules/cjs/loader.js:*:*)
     at executeUserEntryPoint (internal/modules/run_main.js:*:*)
+    at internal/main/run_main_module.js:*:*

--- a/test/message/throw_undefined_traced.out
+++ b/test/message/throw_undefined_traced.out
@@ -10,3 +10,4 @@ Thrown at:
     at Module.load (internal/modules/cjs/loader.js:*:*)
     at Module._load (internal/modules/cjs/loader.js:*:*)
     at executeUserEntryPoint (internal/modules/run_main.js:*:*)
+    at internal/main/run_main_module.js:*:*


### PR DESCRIPTION
Refer to Environment::stack_trace_limit() while printing fresh
stacktraces in c++ land.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
