### PR TITLE
doc: remove usage of "Node" in favor of "Node.js"

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,8 +23,8 @@ the HackerOne platform. See <https://hackerone.com/nodejs> for further details.
 ## Reporting a Bug in a third party module
 
 Security bugs in third party modules should be reported to their respective
-maintainers and should also be coordinated through the Node Ecosystem Security
-Team via [HackerOne](https://hackerone.com/nodejs-ecosystem).
+maintainers and should also be coordinated through the Node.js Ecosystem
+Security Team via [HackerOne](https://hackerone.com/nodejs-ecosystem).
 
 Details regarding this process can be found in the
 [Security Working Group repository](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md).

--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -55,9 +55,9 @@
   * OK: JavaScript, Google's V8
   <!--lint disable prohibited-strings remark-lint-->
   * NOT OK: Javascript, Google's v8
-  <!-- lint enable prohibited-strings remark-lint-->
 
 * Use _Node.js_ and not _Node_, _NodeJS_, or similar variants.
+  <!-- lint enable prohibited-strings remark-lint-->
   * When referring to the executable, _`node`_ is acceptable.
 
 See also API documentation structure overview in [doctools README][].

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3473,10 +3473,10 @@ completion callback.
 
 The `type` argument is only available on Windows and ignored on other platforms.
 It can be set to `'dir'`, `'file'`, or `'junction'`. If the `type` argument is
-not set, Node will autodetect `target` type and use `'file'` or `'dir'`. If the
-`target` does not exist, `'file'` will be used. Windows junction points require
-the destination path to be absolute.  When using `'junction'`, the `target`
-argument will automatically be normalized to absolute path.
+not set, Node.js will autodetect `target` type and use `'file'` or `'dir'`. If
+the `target` does not exist, `'file'` will be used. Windows junction points
+require the destination path to be absolute.  When using `'junction'`, the
+`target` argument will automatically be normalized to absolute path.
 
 Relative targets are relative to the link’s parent directory.
 

--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -49,7 +49,7 @@ In case of doubt, open an issue in the
 Node.js has two IRC channels:
 [#Node.js](https://webchat.freenode.net/?channels=node.js) for general help and
 questions, and
-[#Node-dev](https://webchat.freenode.net/?channels=node-dev) for development of
+[#node-dev](https://webchat.freenode.net/?channels=node-dev) for development of
 Node.js core specifically.
 
 ## Setting up your local environment


### PR DESCRIPTION
In accordance with the Style Guide, remove "Node" in favor of "Node.js".
A lint rule for this is forthcoming.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
