### PR TITLE
doc: remove imprecise and redundant testing text

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -69,13 +69,11 @@ There are three support tiers:
 
 * **Tier 1**: These platforms represent the majority of Node.js users. The
   Node.js Build Working Group maintains infrastructure for full test coverage.
-  All commits to the Node.js repository are tested on these platforms. Test
-  failures on tier 1 platforms will block releases.
+  Test failures on tier 1 platforms will block releases.
 * **Tier 2**: These platforms represent smaller segments of the Node.js user
   base. The Node.js Build Working Group maintains infrastructure for full test
-  coverage. All commits to the Node.js repository are tested on these platforms.
-  Test failures on tier 2 platforms will block releases. Delays in release of
-  binaries for these platforms are acceptable where necessary due to
+  coverage. Test failures on tier 2 platforms will block releases. Delays in
+  release of binaries for these platforms are acceptable where necessary due to
   infrastructure concerns.
 * **Experimental**: May not compile or test suite may not pass. The core team
   does not create releases for these platforms. Test failures on experimental


### PR DESCRIPTION
Remove "All commits...are tested on these platforms." for the following
reasons:

* It's somewhat redundant. The surrounding text makes it clear that we
  test on these platforms.
* It's imprecise. Commits, such as those that only affect documentation
  or linting do not get tested on all the platforms. (Well, perhaps they
  do in an after-the-fact kind of way when a subsequent commit gets
  tested, but I think that's a stretch.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
