### PR TITLE
assert: handle (deep) equal(NaN, NaN) as being identical

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -558,6 +558,7 @@ assert.doesNotThrow(
 ## assert.equal(actual, expected\[, message\])
 <!-- YAML
 added: v0.1.21
+changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30766
     description: NaN is now treated as being identical in case both sides are
@@ -865,6 +866,7 @@ instead of the [`AssertionError`][].
 ## assert.notEqual(actual, expected\[, message\])
 <!-- YAML
 added: v0.1.21
+changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30766
     description: NaN is now treated as being identical in case both sides are

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -160,6 +160,10 @@ An alias of [`assert.ok()`][].
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/?????????????????????????
+    description: NaN is now treated as being identical in case both sides are
+                 NaN.
   - version: v12.0.0
     pr-url: https://github.com/nodejs/node/pull/25008
     description: The type tags are now properly compared and there are a couple
@@ -554,6 +558,10 @@ assert.doesNotThrow(
 ## assert.equal(actual, expected\[, message\])
 <!-- YAML
 added: v0.1.21
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/?????????????????????????
+    description: NaN is now treated as being identical in case both sides are
+                 NaN.
 -->
 
 * `actual` {any}
@@ -732,6 +740,10 @@ let err;
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/?????????????????????????
+    description: NaN is now treated as being identical in case both sides are
+                 NaN.
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15001
     description: The `Error` names and messages are now properly compared
@@ -853,6 +865,10 @@ instead of the [`AssertionError`][].
 ## assert.notEqual(actual, expected\[, message\])
 <!-- YAML
 added: v0.1.21
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/?????????????????????????
+    description: NaN is now treated as being identical in case both sides are
+                 NaN.
 -->
 
 * `actual` {any}

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -207,8 +207,8 @@ are also recursively evaluated by the following rules.
 ### Comparison details
 
 * Primitive values are compared with the [Abstract Equality Comparison][]
-  ( `==` ) with the exception of NaN. It is treated as being identical in case
-  both sides are NaN.
+  ( `==` ) with the exception of `NaN`. It is treated as being identical in case
+  both sides are `NaN`.
 * [Type tags][Object.prototype.toString()] of objects should be the same.
 * Only [enumerable "own" properties][] are considered.
 * [`Error`][] names and messages are always compared, even if these are not
@@ -579,8 +579,8 @@ An alias of [`assert.strictEqual()`][].
 > Stability: 0 - Deprecated: Use [`assert.strictEqual()`][] instead.
 
 Tests shallow, coercive equality between the `actual` and `expected` parameters
-using the [Abstract Equality Comparison][] ( `==` ). NaN is special handled and
-treated as being identical in case both sides are NaN.
+using the [Abstract Equality Comparison][] ( `==` ). `NaN` is special handled
+and treated as being identical in case both sides are `NaN`.
 
 ```js
 const assert = require('assert');
@@ -889,9 +889,9 @@ An alias of [`assert.notStrictEqual()`][].
 
 > Stability: 0 - Deprecated: Use [`assert.notStrictEqual()`][] instead.
 
-Tests shallow, coercive inequality with the [Abstract Equality Comparison][] (
-`!=` ). NaN is special handled and treated as being identical in case both sides
-are NaN.
+Tests shallow, coercive inequality with the [Abstract Equality Comparison][]
+(`!=` ). `NaN` is special handled and treated as being identical in case both
+sides are `NaN`.
 
 ```js
 const assert = require('assert');

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -207,7 +207,8 @@ are also recursively evaluated by the following rules.
 ### Comparison details
 
 * Primitive values are compared with the [Abstract Equality Comparison][]
-  ( `==` ).
+  ( `==` ) with the exception of NaN. It is treated as being identical in case
+  both sides are NaN.
 * [Type tags][Object.prototype.toString()] of objects should be the same.
 * Only [enumerable "own" properties][] are considered.
 * [`Error`][] names and messages are always compared, even if these are not
@@ -578,7 +579,8 @@ An alias of [`assert.strictEqual()`][].
 > Stability: 0 - Deprecated: Use [`assert.strictEqual()`][] instead.
 
 Tests shallow, coercive equality between the `actual` and `expected` parameters
-using the [Abstract Equality Comparison][] ( `==` ).
+using the [Abstract Equality Comparison][] ( `==` ). NaN is special handled and
+treated as being identical in case both sides are NaN.
 
 ```js
 const assert = require('assert');
@@ -587,6 +589,8 @@ assert.equal(1, 1);
 // OK, 1 == 1
 assert.equal(1, '1');
 // OK, 1 == '1'
+assert.equal(NaN, NaN);
+// OK
 
 assert.equal(1, 2);
 // AssertionError: 1 == 2
@@ -885,8 +889,9 @@ An alias of [`assert.notStrictEqual()`][].
 
 > Stability: 0 - Deprecated: Use [`assert.notStrictEqual()`][] instead.
 
-Tests shallow, coercive inequality with the [Abstract Equality Comparison][]
-( `!=` ).
+Tests shallow, coercive inequality with the [Abstract Equality Comparison][] (
+`!=` ). NaN is special handled and treated as being identical in case both sides
+are NaN.
 
 ```js
 const assert = require('assert');

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -161,7 +161,7 @@ An alias of [`assert.ok()`][].
 added: v0.1.21
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/?????????????????????????
+    pr-url: https://github.com/nodejs/node/pull/30766
     description: NaN is now treated as being identical in case both sides are
                  NaN.
   - version: v12.0.0
@@ -559,7 +559,7 @@ assert.doesNotThrow(
 <!-- YAML
 added: v0.1.21
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/?????????????????????????
+    pr-url: https://github.com/nodejs/node/pull/30766
     description: NaN is now treated as being identical in case both sides are
                  NaN.
 -->
@@ -741,7 +741,7 @@ let err;
 added: v0.1.21
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/?????????????????????????
+    pr-url: https://github.com/nodejs/node/pull/30766
     description: NaN is now treated as being identical in case both sides are
                  NaN.
   - version: v9.0.0
@@ -866,7 +866,7 @@ instead of the [`AssertionError`][].
 <!-- YAML
 added: v0.1.21
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/?????????????????????????
+    pr-url: https://github.com/nodejs/node/pull/30766
     description: NaN is now treated as being identical in case both sides are
                  NaN.
 -->

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -25,6 +25,7 @@ const {
   ObjectIs,
   ObjectKeys,
   ObjectPrototypeIsPrototypeOf,
+  NumberIsNaN
 } = primordials;
 
 const { Buffer } = require('buffer');
@@ -398,7 +399,7 @@ assert.equal = function equal(actual, expected, message) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
   // eslint-disable-next-line eqeqeq
-  if (actual != expected) {
+  if (actual != expected && (!NumberIsNaN(actual) || !NumberIsNaN(expected))) {
     innerFail({
       actual,
       expected,
@@ -416,7 +417,7 @@ assert.notEqual = function notEqual(actual, expected, message) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
   // eslint-disable-next-line eqeqeq
-  if (actual == expected) {
+  if (actual == expected || (NumberIsNaN(actual) && NumberIsNaN(expected))) {
     innerFail({
       actual,
       expected,

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -150,7 +150,7 @@ function innerDeepEqual(val1, val2, strict, memos) {
     if (val1 === null || typeof val1 !== 'object') {
       if (val2 === null || typeof val2 !== 'object') {
         // eslint-disable-next-line eqeqeq
-        return val1 == val2;
+        return val1 == val2 || (NumberIsNaN(val1) && NumberIsNaN(val2));
       }
       return false;
     }

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -595,10 +595,9 @@ assertNotDeepOrStrict(
 }
 
 // Handle NaN
-assert.notDeepEqual(NaN, NaN);
-assert.deepStrictEqual(NaN, NaN);
-assert.deepStrictEqual({ a: NaN }, { a: NaN });
-assert.deepStrictEqual([ 1, 2, NaN, 4 ], [ 1, 2, NaN, 4 ]);
+assertDeepAndStrictEqual(NaN, NaN);
+assertDeepAndStrictEqual({ a: NaN }, { a: NaN });
+assertDeepAndStrictEqual([ 1, 2, NaN, 4 ], [ 1, 2, NaN, 4 ]);
 
 // Handle boxed primitives
 {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -501,6 +501,12 @@ assert.throws(
   }
 );
 
+a.equal(NaN, NaN);
+a.throws(
+  () => a.notEqual(NaN, NaN),
+  a.AssertionError
+);
+
 // Test strict assert.
 {
   const a = require('assert');


### PR DESCRIPTION
This aligns the `equal` and `deepEqual()` implementation with the
strict version by accepting `NaN` as being identical in
case both sides are NaN.

Refs: https://github.com/nodejs/node/issues/30350#issuecomment-552191641

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
