### PR TITLE
test: improve dns lookup coverage

### DIFF
--- a/test/parallel/test-dns-lookup-promises.js
+++ b/test/parallel/test-dns-lookup-promises.js
@@ -1,0 +1,139 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { internalBinding } = require('internal/test/binding');
+const cares = internalBinding('cares_wrap');
+
+// Stub `getaddrinfo` to proxy its call dynamic stub. This has to be done before
+// we load the `dns` module to guarantee that the `dns` module uses the stub.
+let getaddrinfoStub = null;
+cares.getaddrinfo = (req) => getaddrinfoStub(req);
+
+const dnsPromises = require('dns').promises;
+
+function getaddrinfoNegative() {
+  return function getaddrinfoNegativeHandler(req) {
+    const originalReject = req.reject;
+    req.resolve = common.mustNotCall();
+    req.reject = common.mustCall(originalReject);
+    req.oncomplete(internalBinding('uv').UV_ENOMEM);
+  };
+}
+
+function getaddrinfoPositive(addresses) {
+  return function getaddrinfo_positive(req) {
+    const originalResolve = req.resolve;
+    req.reject = common.mustNotCall();
+    req.resolve = common.mustCall(originalResolve);
+    req.oncomplete(null, addresses);
+  };
+}
+
+async function lookupPositive() {
+  [
+    {
+      stub: getaddrinfoPositive(['::1']),
+      factory: () => dnsPromises.lookup('example.com'),
+      expectation: { address: '::1', family: 6 }
+    },
+    {
+      stub: getaddrinfoPositive(['127.0.0.1']),
+      factory: () => dnsPromises.lookup('example.com'),
+      expectation: { address: '127.0.0.1', family: 4 }
+    },
+    {
+      stub: getaddrinfoPositive(['127.0.0.1'], { family: 4 }),
+      factory: () => dnsPromises.lookup('example.com'),
+      expectation: { address: '127.0.0.1', family: 4 }
+    },
+    {
+      stub: getaddrinfoPositive(['some-address']),
+      factory: () => dnsPromises.lookup('example.com'),
+      expectation: { address: 'some-address', family: 0 }
+    },
+    {
+      stub: getaddrinfoPositive(['some-address2']),
+      factory: () => dnsPromises.lookup('example.com', { family: 6 }),
+      expectation: { address: 'some-address2', family: 6 }
+    }
+  ].forEach(async ({ stub, factory, expectation }) => {
+    getaddrinfoStub = stub;
+    assert.deepStrictEqual(await factory(), expectation);
+  });
+}
+
+async function lookupNegative() {
+  getaddrinfoStub = getaddrinfoNegative();
+  const expected = {
+    code: 'ENOMEM',
+    hostname: 'example.com',
+    syscall: 'getaddrinfo'
+  };
+  return assert.rejects(dnsPromises.lookup('example.com'), expected);
+}
+
+async function lookupallPositive() {
+  [
+    {
+      stub: getaddrinfoPositive(['::1', '::2']),
+      factory: () => dnsPromises.lookup('example', { all: true }),
+      expectation: [
+        { address: '::1', family: 6 },
+        { address: '::2', family: 6 }
+      ]
+    },
+    {
+      stub: getaddrinfoPositive(['::1', '::2']),
+      factory: () => dnsPromises.lookup('example', { all: true, family: 4 }),
+      expectation: [
+        { address: '::1', family: 4 },
+        { address: '::2', family: 4 }
+      ]
+    },
+    {
+      stub: getaddrinfoPositive(['127.0.0.1', 'some-address']),
+      factory: () => dnsPromises.lookup('example', { all: true }),
+      expectation: [
+        { address: '127.0.0.1', family: 4 },
+        { address: 'some-address', family: 0 }
+      ]
+    },
+    {
+      stub: getaddrinfoPositive(['127.0.0.1', 'some-address']),
+      factory: () => dnsPromises.lookup('example', { all: true, family: 6 }),
+      expectation: [
+        { address: '127.0.0.1', family: 6 },
+        { address: 'some-address', family: 6 }
+      ]
+    },
+    {
+      stub: getaddrinfoPositive([]),
+      factory: () => dnsPromises.lookup('example', { all: true }),
+      expectation: []
+    }
+  ].forEach(async ({ stub, factory, expectation }) => {
+    getaddrinfoStub = stub;
+    assert.deepStrictEqual(await factory(), expectation);
+  });
+}
+
+async function lookupallNegative() {
+  getaddrinfoStub = getaddrinfoNegative();
+  const expected = {
+    code: 'ENOMEM',
+    hostname: 'example.com',
+    syscall: 'getaddrinfo'
+  };
+  return assert.rejects(dnsPromises.lookup('example.com', { all: true }),
+                        expected);
+}
+
+(async () => {
+  await Promise.all([
+    lookupPositive(),
+    lookupNegative(),
+    lookupallPositive(),
+    lookupallNegative()
+  ]).then(common.mustCall());
+})();


### PR DESCRIPTION
Adding tests covering promises-related code paths.

[missing coverage](https://coverage.nodejs.org/coverage-cc3f2b386c6ee34f/lib/internal/dns/promises.js.html#L34)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
