### PR TITLE
lib: delay access to CLI option to pre-execution

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -157,9 +157,6 @@ function NativeModule(id) {
   this.loaded = false;
   this.loading = false;
   this.canBeRequiredByUsers = !id.startsWith('internal/');
-
-  if (id === 'wasi')
-    this.canBeRequiredByUsers = !!internalBinding('config').experimentalWasi;
 }
 
 // To be called during pre-execution when --expose-internals is on.

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -61,6 +61,7 @@ function prepareMainThreadExecution(expandArgv1 = false) {
   initializeClusterIPC();
 
   initializeDeprecations();
+  initializeWASI();
   initializeCJSLoader();
   initializeESMLoader();
 
@@ -399,6 +400,14 @@ function initializePolicy() {
   }
 }
 
+function initializeWASI() {
+  if (getOptionValue('--experimental-wasi-unstable-preview0')) {
+    const { NativeModule } = require('internal/bootstrap/loaders');
+    const mod = NativeModule.map.get('wasi');
+    mod.canBeRequiredByUsers = true;
+  }
+}
+
 function initializeCJSLoader() {
   const CJSLoader = require('internal/modules/cjs/loader');
   CJSLoader.Module._initPaths();
@@ -456,5 +465,6 @@ module.exports = {
   setupTraceCategoryState,
   setupInspectorHooks,
   initializeReport,
-  initializeCJSLoader
+  initializeCJSLoader,
+  initializeWASI
 };

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -14,6 +14,7 @@ const {
   setupWarningHandler,
   setupDebugEnv,
   initializeDeprecations,
+  initializeWASI,
   initializeCJSLoader,
   initializeESMLoader,
   initializeFrozenIntrinsics,
@@ -108,6 +109,7 @@ port.on('message', (message) => {
       require('internal/process/policy').setup(manifestSrc, manifestURL);
     }
     initializeDeprecations();
+    initializeWASI();
     initializeCJSLoader();
     initializeESMLoader();
 

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -15,11 +15,14 @@ using v8::Number;
 using v8::Object;
 using v8::Value;
 
-// The config binding is used to provide an internal view of compile or runtime
+// The config binding is used to provide an internal view of compile time
 // config options that are required internally by lib/*.js code. This is an
 // alternative to dropping additional properties onto the process object as
 // has been the practice previously in node.cc.
 
+// Command line arguments are already accessible in the JS land via
+// require('internal/options').getOptionValue('--some-option'). Do not add them
+// here.
 static void Initialize(Local<Object> target,
                        Local<Value> unused,
                        Local<Context> context,
@@ -84,9 +87,6 @@ static void Initialize(Local<Object> target,
 
   READONLY_PROPERTY(target, "hasCachedBuiltins",
      v8::Boolean::New(isolate, native_module::has_code_cache));
-
-  if (env->options()->experimental_wasi)
-    READONLY_TRUE_PROPERTY(target, "experimentalWasi");
 }  // InitConfig
 
 }  // namespace node


### PR DESCRIPTION
CLI options should not be added through the config binding, instead
they are already available in the JS land via
`require('internal/options')`. Also CLI options in principle should
be processed in pre-execution instead of bootstrap scripts.

cc @ @cjihrig 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
