### PR TITLE
fs: add synchronous retries to rimraf

### DIFF
--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -21,6 +21,7 @@ const {
 } = require('fs');
 const { join } = require('path');
 const { setTimeout } = require('timers');
+const { sleep } = require('internal/util');
 const notEmptyErrorCodes = new Set(['ENOTEMPTY', 'EEXIST', 'EPERM']);
 const retryErrorCodes = new Set(
   ['EBUSY', 'EMFILE', 'ENFILE', 'ENOTEMPTY', 'EPERM']);
@@ -208,10 +209,12 @@ function _rmdirSync(path, options, originalErr) {
         rimrafSync(join(path, child), options);
       });
 
-      for (let i = 0; i < options.maxRetries + 1; i++) {
+      for (let i = 1; i <= options.maxRetries + 1; i++) {
         try {
           return rmdirSync(path, options);
-        } catch {} // Ignore errors.
+        } catch {
+          sleep(i * options.retryDelay);
+        }
       }
     }
   }

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -209,12 +209,19 @@ function _rmdirSync(path, options, originalErr) {
         rimrafSync(join(path, child), options);
       });
 
-      for (let i = 1; i <= options.maxRetries + 1; i++) {
+      const tries = options.maxRetries + 1;
+
+      for (let i = 1; i <= tries; i++) {
         try {
           return rmdirSync(path, options);
-        } catch {
-          if (options.retryDelay > 0)
+        } catch (err) {
+          // Only sleep if this is not the last try, and the delay is greater
+          // than zero, and an error was encountered that warrants a retry.
+          if (retryErrorCodes.has(err.code) &&
+              i < tries &&
+              options.retryDelay > 0) {
             sleep(i * options.retryDelay);
+          }
         }
       }
     }

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -213,7 +213,8 @@ function _rmdirSync(path, options, originalErr) {
         try {
           return rmdirSync(path, options);
         } catch {
-          sleep(i * options.retryDelay);
+          if (options.retryDelay > 0)
+            sleep(i * options.retryDelay);
         }
       }
     }


### PR DESCRIPTION
This PR builds on https://github.com/nodejs/node/pull/30784 and https://github.com/nodejs/node/pull/30783.

The third commit in this PR gives the synchronous version of rimraf the same linear retry logic as the asynchronous version. Prior to this commit, sync rimraf kept retrying the operation as soon as possible until `maxRetries` was reached.

Fixes: https://github.com/nodejs/node/issues/30580
Refs: https://github.com/nodejs/node/pull/30569

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)