### PR TITLE
fix: correct typo in stream docs

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1112,7 +1112,7 @@ readable.on('readable', () => {
 
 The `while` loop is necessary when processing data with
 `readable.read()`. Only after `readable.read()` returns `null`,
-[`'readable'`][] will be emitted.
+[`'end'`][] will be emitted.
 
 A `Readable` stream in object mode will always return a single item from
 a call to [`readable.read(size)`][stream-read], regardless of the value of the


### PR DESCRIPTION
This corrects a little typo in the `stream` docs - it is the `end` event that will be emitted after a call to `readable.read()` returns null, not `readable`.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
