### PR TITLE
module: conditional exports condition renaming proposal for usability

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -349,6 +349,8 @@ The conditions supported in Node.js are matched in the following order:
   `--experimental-conditional-exports` flag._
 3. `"module"` - matched when the package is not loaded via `require()`.
    Can be any module format, this field does not set the type interpretation.
+   _This is currently only supported behind the
+  `--experimental-conditional-exports` flag._
 
 Using the `"commonjs"` condition it is possible to define a package that will
 have a different exported value for CommonJS and ES modules, which can be a

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -343,16 +343,14 @@ The conditions supported in Node.js are matched in the following order:
 
 1. `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
    module file. _This is currently only supported behind the
-  `--experimental-conditional-exports` flag._
-2. `"require"` - matched when the package is loaded with the CommonJS
-  module resolver such as via `require()`.
-  _This is currently only supported behind the
-  `--experimental-conditional-exports` flag._
-3. `"import"` - matched when the package is imported with the ES module
-   resolver such as when using a static or dynamic import expression.
-   Can be any module format, this field does not set the type interpretation.
+   `--experimental-conditional-exports` flag._
+2. `"require"` - matched when the package is loaded via `require()`.
    _This is currently only supported behind the
-  `--experimental-conditional-exports` flag._
+   `--experimental-conditional-exports` flag._
+3. `"import"` - matched when the package is loaded via `import` or
+   `import()`. Can be any module format, this field does not set the type
+   interpretation. _This is currently only supported behind the
+   `--experimental-conditional-exports` flag._
 
 Using the `"require"` condition it is possible to define a package that will
 have a different exported value for CommonJS and ES modules, which can be a

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -344,10 +344,12 @@ The conditions supported in Node.js are matched in the following order:
 1. `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
    module file. _This is currently only supported behind the
   `--experimental-conditional-exports` flag._
-2. `"require"` - matched when the package is loaded via `require()`.
+2. `"require"` - matched when the package is loaded with the CommonJS
+  module resolver such as via `require()`.
   _This is currently only supported behind the
   `--experimental-conditional-exports` flag._
-3. `"import"` - matched when the package is not loaded via `require()`.
+3. `"import"` - matched when the package is imported with the ES module
+   resolver such as when using a static or dynamic import expression.
    Can be any module format, this field does not set the type interpretation.
    _This is currently only supported behind the
   `--experimental-conditional-exports` flag._

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -354,10 +354,10 @@ The conditions supported in Node.js are matched in the following order:
 4. `"default"` - the generic fallback that will always match if no other
    more specific condition is matched first. Can be a CommonJS or ES module
    file.
-   
+
 > Setting any of the above flagged conditions for a published package is not
-recommended until they are unflagged to avoid breaking changes to packages in
-future.
+> recommended until they are unflagged to avoid breaking changes to packages in
+> future.
 
 Using the `"require"` condition it is possible to define a package that will
 have a different exported value for CommonJS and ES modules, which can be a
@@ -516,9 +516,8 @@ ES module wrapper is used for `import` and the CommonJS entry point for
 `require`.
 
 > Note: While `--experimental-conditional-exports` is flagged, a package
-> using this pattern will throw when loaded via `require()` in modern
-> Node.js, unless package consumers use the `--experimental-conditional-exports`
-> flag.
+> using this pattern will throw when loaded unless package consumers use the
+> `--experimental-conditional-exports` flag.
 
 <!-- eslint-skip -->
 ```js

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -351,6 +351,9 @@ The conditions supported in Node.js are matched in the following order:
    `import()`. Can be any module format, this field does not set the type
    interpretation. _This is currently only supported behind the
    `--experimental-conditional-exports` flag._
+4. `"default"` - the generic fallback that will always match if no other
+   more specific condition is matched first. Can be a CommonJS or ES module
+   file.
 
 Using the `"require"` condition it is possible to define a package that will
 have a different exported value for CommonJS and ES modules, which can be a

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -329,7 +329,7 @@ Node.js and the browser can be written:
   "main": "./index.js",
   "exports": {
     "./feature": {
-      "module": "./feature-default.js",
+      "import": "./feature-default.js",
       "browser": "./feature-browser.js"
     }
   }
@@ -344,15 +344,15 @@ The conditions supported in Node.js are matched in the following order:
 1. `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
    module file. _This is currently only supported behind the
   `--experimental-conditional-exports` flag._
-2. `"commonjs"` - matched when the package is loaded via `require()`.
+2. `"require"` - matched when the package is loaded via `require()`.
   _This is currently only supported behind the
   `--experimental-conditional-exports` flag._
-3. `"module"` - matched when the package is not loaded via `require()`.
+3. `"import"` - matched when the package is not loaded via `require()`.
    Can be any module format, this field does not set the type interpretation.
    _This is currently only supported behind the
   `--experimental-conditional-exports` flag._
 
-Using the `"commonjs"` condition it is possible to define a package that will
+Using the `"require"` condition it is possible to define a package that will
 have a different exported value for CommonJS and ES modules, which can be a
 hazard in that it can result in having two separate instances of the same
 package in use in an application, which can cause a number of bugs.
@@ -395,8 +395,8 @@ from exports subpaths.
 {
   "exports": {
     ".": {
-      "module": "./main.js",
-      "commonjs": "./main.cjs"
+      "import": "./main.js",
+      "require": "./main.cjs"
     }
   }
 }
@@ -408,8 +408,8 @@ can be written:
 ```js
 {
   "exports": {
-    "module": "./main.js",
-    "commonjs": "./main.cjs"
+    "import": "./main.js",
+    "require": "./main.cjs"
   }
 }
 ```
@@ -423,8 +423,8 @@ thrown:
   // Throws on resolution!
   "exports": {
     "./feature": "./lib/feature.js",
-    "module": "./main.js",
-    "commonjs": "./main.cjs"
+    "import": "./main.js",
+    "require": "./main.cjs"
   }
 }
 ```
@@ -520,8 +520,8 @@ ES module wrapper is used for `import` and the CommonJS entry point for
   "type": "module",
   "main": "./index.cjs",
   "exports": {
-    "commonjs": "./index.cjs",
-    "module": "./wrapper.mjs"
+    "require": "./index.cjs",
+    "import": "./wrapper.mjs"
   }
 }
 ```
@@ -606,8 +606,8 @@ CommonJS and ES module entry points directly (requires
   "type": "module",
   "main": "./index.cjs",
   "exports": {
-    "module": "./index.mjs",
-    "commonjs": "./index.cjs"
+    "import": "./index.mjs",
+    "require": "./index.cjs"
   }
 }
 ```
@@ -1150,7 +1150,7 @@ of these top-level routines unless stated otherwise.
 _isMain_ is **true** when resolving the Node.js application entry point.
 
 _defaultEnv_ is the conditional environment name priority array,
-`["node", "module"]`.
+`["node", "import"]`.
 
 <details>
 <summary>Resolver algorithm specification</summary>

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -329,8 +329,8 @@ Node.js and the browser can be written:
   "main": "./index.js",
   "exports": {
     "./feature": {
-      "browser": "./feature-browser.js",
-      "default": "./feature-default.js"
+      "module": "./feature-default.js",
+      "browser": "./feature-browser.js"
     }
   }
 }
@@ -341,17 +341,16 @@ will be used as the final fallback.
 
 The conditions supported in Node.js are matched in the following order:
 
-1. `"require"` - matched when the package is loaded via `require()`.
-  _This is currently only supported behind the
-  `--experimental-conditional-exports` flag._
-2. `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
+1. `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
    module file. _This is currently only supported behind the
   `--experimental-conditional-exports` flag._
-3. `"default"` - the generic fallback that will always match if no other
-   more specific condition is matched first. Can be a CommonJS or ES module
-   file.
+2. `"commonjs"` - matched when the package is loaded via `require()`.
+  _This is currently only supported behind the
+  `--experimental-conditional-exports` flag._
+3. `"module"` - matched when the package is not loaded via `require()`.
+   Can be any module format, this field does not set the type interpretation.
 
-Using the `"require"` condition it is possible to define a package that will
+Using the `"commonjs"` condition it is possible to define a package that will
 have a different exported value for CommonJS and ES modules, which can be a
 hazard in that it can result in having two separate instances of the same
 package in use in an application, which can cause a number of bugs.
@@ -394,8 +393,8 @@ from exports subpaths.
 {
   "exports": {
     ".": {
-      "require": "./main.cjs",
-      "default": "./main.js"
+      "module": "./main.js",
+      "commonjs": "./main.cjs"
     }
   }
 }
@@ -407,8 +406,8 @@ can be written:
 ```js
 {
   "exports": {
-    "require": "./main.cjs",
-    "default": "./main.js"
+    "module": "./main.js",
+    "commonjs": "./main.cjs"
   }
 }
 ```
@@ -422,8 +421,8 @@ thrown:
   // Throws on resolution!
   "exports": {
     "./feature": "./lib/feature.js",
-    "require": "./main.cjs",
-    "default": "./main.js"
+    "module": "./main.js",
+    "commonjs": "./main.cjs"
   }
 }
 ```
@@ -519,8 +518,8 @@ ES module wrapper is used for `import` and the CommonJS entry point for
   "type": "module",
   "main": "./index.cjs",
   "exports": {
-    "require": "./index.cjs",
-    "default": "./wrapper.mjs"
+    "commonjs": "./index.cjs",
+    "module": "./wrapper.mjs"
   }
 }
 ```
@@ -605,8 +604,8 @@ CommonJS and ES module entry points directly (requires
   "type": "module",
   "main": "./index.cjs",
   "exports": {
-    "require": "./index.cjs",
-    "default": "./index.mjs"
+    "module": "./index.mjs",
+    "commonjs": "./index.cjs"
   }
 }
 ```
@@ -1149,7 +1148,7 @@ of these top-level routines unless stated otherwise.
 _isMain_ is **true** when resolving the Node.js application entry point.
 
 _defaultEnv_ is the conditional environment name priority array,
-`["node", "default"]`.
+`["node", "module"]`.
 
 <details>
 <summary>Resolver algorithm specification</summary>

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -354,6 +354,10 @@ The conditions supported in Node.js are matched in the following order:
 4. `"default"` - the generic fallback that will always match if no other
    more specific condition is matched first. Can be a CommonJS or ES module
    file.
+   
+> Setting any of the above flagged conditions for a published package is not
+recommended until they are unflagged to avoid breaking changes to packages in
+future.
 
 Using the `"require"` condition it is possible to define a package that will
 have a different exported value for CommonJS and ES modules, which can be a

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -241,7 +241,8 @@ RESOLVE_BARE_SPECIFIER(DIR, X)
    g. If no such key can be found, throw "not found".
    h. let RESOLVED_URL =
         PACKAGE_EXPORTS_TARGET_RESOLVE(pathToFileURL(DIR/name), exports[key],
-        subpath.slice(key.length)), as defined in the ESM resolver.
+        subpath.slice(key.length), ["node", "commonjs"]), as defined in the ESM
+        resolver.
    i. return fileURLToPath(RESOLVED_URL)
 3. return DIR/X
 ```

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -241,7 +241,7 @@ RESOLVE_BARE_SPECIFIER(DIR, X)
    g. If no such key can be found, throw "not found".
    h. let RESOLVED_URL =
         PACKAGE_EXPORTS_TARGET_RESOLVE(pathToFileURL(DIR/name), exports[key],
-        subpath.slice(key.length), ["node", "commonjs"]), as defined in the ESM
+        subpath.slice(key.length), ["node", "require"]), as defined in the ESM
         resolver.
    i. return fileURLToPath(RESOLVED_URL)
 3. return DIR/X

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -596,10 +596,10 @@ function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
       }
     }
     if (experimentalConditionalExports &&
-        ObjectPrototypeHasOwnProperty(target, 'commonjs')) {
+        ObjectPrototypeHasOwnProperty(target, 'require')) {
       try {
-        const result = resolveExportsTarget(pkgPath, target.commonjs, subpath,
-                                             basePath, mappingKey);
+        const result = resolveExportsTarget(pkgPath, target.require, subpath,
+                                            basePath, mappingKey);
         emitExperimentalWarning('Conditional exports');
         return result;
       } catch (e) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -585,17 +585,6 @@ function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
     }
   } else if (typeof target === 'object' && target !== null) {
     if (experimentalConditionalExports &&
-        ObjectPrototypeHasOwnProperty(target, 'require')) {
-      try {
-        const result = resolveExportsTarget(pkgPath, target.require, subpath,
-                                            basePath, mappingKey);
-        emitExperimentalWarning('Conditional exports');
-        return result;
-      } catch (e) {
-        if (e.code !== 'MODULE_NOT_FOUND') throw e;
-      }
-    }
-    if (experimentalConditionalExports &&
         ObjectPrototypeHasOwnProperty(target, 'node')) {
       try {
         const result = resolveExportsTarget(pkgPath, target.node, subpath,
@@ -606,10 +595,13 @@ function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
         if (e.code !== 'MODULE_NOT_FOUND') throw e;
       }
     }
-    if (ObjectPrototypeHasOwnProperty(target, 'default')) {
+    if (experimentalConditionalExports &&
+        ObjectPrototypeHasOwnProperty(target, 'commonjs')) {
       try {
-        return resolveExportsTarget(pkgPath, target.default, subpath,
-                                    basePath, mappingKey);
+        const result = resolveExportsTarget(pkgPath, target.commonjs, subpath,
+                                             basePath, mappingKey);
+        emitExperimentalWarning('Conditional exports');
+        return result;
       } catch (e) {
         if (e.code !== 'MODULE_NOT_FOUND') throw e;
       }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -606,6 +606,14 @@ function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
         if (e.code !== 'MODULE_NOT_FOUND') throw e;
       }
     }
+    if (ObjectPrototypeHasOwnProperty(target, 'default')) {
+      try {
+        return resolveExportsTarget(pkgPath, target.default, subpath,
+                                    basePath, mappingKey);
+      } catch (e) {
+        if (e.code !== 'MODULE_NOT_FOUND') throw e;
+      }
+    }
   }
   let e;
   if (mappingKey !== '.') {

--- a/src/env.h
+++ b/src/env.h
@@ -201,6 +201,7 @@ constexpr size_t kFsStatsBufferLength =
   V(crypto_rsa_pss_string, "rsa-pss")                                          \
   V(cwd_string, "cwd")                                                         \
   V(data_string, "data")                                                       \
+  V(default_string, "default")                                                 \
   V(dest_string, "dest")                                                       \
   V(destroyed_string, "destroyed")                                             \
   V(detached_string, "detached")                                               \

--- a/src/env.h
+++ b/src/env.h
@@ -201,7 +201,6 @@ constexpr size_t kFsStatsBufferLength =
   V(crypto_rsa_pss_string, "rsa-pss")                                          \
   V(cwd_string, "cwd")                                                         \
   V(data_string, "data")                                                       \
-  V(default_string, "default")                                                 \
   V(dest_string, "dest")                                                       \
   V(destroyed_string, "destroyed")                                             \
   V(detached_string, "detached")                                               \

--- a/src/env.h
+++ b/src/env.h
@@ -255,6 +255,7 @@ constexpr size_t kFsStatsBufferLength =
   V(hostmaster_string, "hostmaster")                                           \
   V(http_1_1_string, "http/1.1")                                               \
   V(ignore_string, "ignore")                                                   \
+  V(import_string, "import")                                                   \
   V(infoaccess_string, "infoAccess")                                           \
   V(inherit_string, "inherit")                                                 \
   V(input_string, "input")                                                     \

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -968,10 +968,10 @@ Maybe<URL> ResolveExportsTarget(Environment* env,
       }
     }
     if (env->options()->experimental_conditional_exports &&
-        target_obj->HasOwnProperty(context, env->module_string()).FromJust()) {
+        target_obj->HasOwnProperty(context, env->import_string()).FromJust()) {
       matched = true;
       conditionalTarget =
-          target_obj->Get(context, env->module_string()).ToLocalChecked();
+          target_obj->Get(context, env->import_string()).ToLocalChecked();
       Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url,
             conditionalTarget, subpath, pkg_subpath, base, false);
       if (!resolved.IsNothing()) {

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -967,10 +967,10 @@ Maybe<URL> ResolveExportsTarget(Environment* env,
         return resolved;
       }
     }
-    if (target_obj->HasOwnProperty(context, env->default_string()).FromJust()) {
+    if (target_obj->HasOwnProperty(context, env->module_string()).FromJust()) {
       matched = true;
       conditionalTarget =
-          target_obj->Get(context, env->default_string()).ToLocalChecked();
+          target_obj->Get(context, env->module_string()).ToLocalChecked();
       Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url,
             conditionalTarget, subpath, pkg_subpath, base, false);
       if (!resolved.IsNothing()) {

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -967,10 +967,21 @@ Maybe<URL> ResolveExportsTarget(Environment* env,
         return resolved;
       }
     }
-    if (target_obj->HasOwnProperty(context, env->module_string()).FromJust()) {
+    if (env->options()->experimental_conditional_exports &&
+        target_obj->HasOwnProperty(context, env->module_string()).FromJust()) {
       matched = true;
       conditionalTarget =
           target_obj->Get(context, env->module_string()).ToLocalChecked();
+      Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url,
+            conditionalTarget, subpath, pkg_subpath, base, false);
+      if (!resolved.IsNothing()) {
+        return resolved;
+      }
+    }
+    if (target_obj->HasOwnProperty(context, env->default_string()).FromJust()) {
+      matched = true;
+      conditionalTarget =
+          target_obj->Get(context, env->default_string()).ToLocalChecked();
       Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url,
             conditionalTarget, subpath, pkg_subpath, base, false);
       if (!resolved.IsNothing()) {

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -31,7 +31,7 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     ['pkgexports-sugar', { default: 'main' }],
     // Conditional object exports sugar
     ['pkgexports-sugar2', isRequire ? { default: 'not-exported' } :
-      { default: 'main' }]
+      { default: 'main' }],
   ]);
 
   for (const [validSpecifier, expected] of validSpecifiers) {
@@ -51,7 +51,7 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     ['pkgexports-number/hidden.js', './hidden.js'],
     // Sugar cases still encapsulate
     ['pkgexports-sugar/not-exported.js', './not-exported.js'],
-    ['pkgexports-sugar2/not-exported.js', './not-exported.js']
+    ['pkgexports-sugar2/not-exported.js', './not-exported.js'],
   ]);
 
   const invalidExports = new Map([
@@ -94,6 +94,15 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
       assertIncludes(err.message, isRequire ?
         `do not define a valid '${subpath}' target` :
         `matched for '${subpath}'`);
+    }));
+  }
+
+  // Conditional export, even with no match, should still be used instead
+  // of falling back to main
+  if (isRequire) {
+    loadFixture('pkgexports-main').catch(mustCall((err) => {
+      strictEqual(err.code, 'MODULE_NOT_FOUND');
+      assertStartsWith(err.message, 'No valid export');
     }));
   }
 

--- a/test/fixtures/node_modules/pkgexports-main/main.cjs
+++ b/test/fixtures/node_modules/pkgexports-main/main.cjs
@@ -1,0 +1,1 @@
+module.exports = 'cjs';

--- a/test/fixtures/node_modules/pkgexports-main/module.mjs
+++ b/test/fixtures/node_modules/pkgexports-main/module.mjs
@@ -1,0 +1,1 @@
+export default 'module';

--- a/test/fixtures/node_modules/pkgexports-main/package.json
+++ b/test/fixtures/node_modules/pkgexports-main/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "./main.cjs",
+  "exports": {
+    "module": "./module.mjs"
+  }
+}

--- a/test/fixtures/node_modules/pkgexports-sugar-fail/package.json
+++ b/test/fixtures/node_modules/pkgexports-sugar-fail/package.json
@@ -1,6 +1,6 @@
 {
   "exports": {
-    "default": "./main.js",
+    "module": "./main.js",
     "./main": "./main.js"
   }
 }

--- a/test/fixtures/node_modules/pkgexports-sugar2/package.json
+++ b/test/fixtures/node_modules/pkgexports-sugar2/package.json
@@ -1,6 +1,6 @@
 {
   "exports": {
-    "require": "./not-exported.js",
-    "default": "./main.js"
+    "commonjs": "./not-exported.js",
+    "module": "./main.js"
   }
 }

--- a/test/fixtures/node_modules/pkgexports-sugar2/package.json
+++ b/test/fixtures/node_modules/pkgexports-sugar2/package.json
@@ -1,6 +1,6 @@
 {
   "exports": {
-    "commonjs": "./not-exported.js",
-    "module": "./main.js"
+    "require": "./not-exported.js",
+    "import": "./main.js"
   }
 }

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -19,6 +19,6 @@
     "./nofallback1": [],
     "./nofallback2": [null, {}, "builtin:x"],
     "./nodemodules": "./node_modules/internalpkg/x.js",
-    "./condition": [{ "commonjs": "./sp ce.js" }, "./asdf.js"]
+    "./condition": [{ "require": "./sp ce.js" }, "./asdf.js"]
   }
 }

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -19,6 +19,6 @@
     "./nofallback1": [],
     "./nofallback2": [null, {}, "builtin:x"],
     "./nodemodules": "./node_modules/internalpkg/x.js",
-    "./condition": [{ "require": "./sp ce.js" }, "./asdf.js"]
+    "./condition": [{ "commonjs": "./sp ce.js" }, "./asdf.js"]
   }
 }


### PR DESCRIPTION
A major priority for the modules implementation is resolver stability, and the dual mode story through conditional exports is a big remaining piece of this.

Common usability feedback out of various discussions on conditional exports so far has been that the `"default"` field may be seen to be a confusing name, and that it isn't clear when the `"require"` condition will match either.

To try and improve the overall usability this PR makes the following condition name changes:

* Add a new `"import"` condition as the converse of the `"require"` condition, only applying for the ESM loader.

All conditions (except for `"default"`) remain behind the `--experimental-conditional-exports` flag.

This makes the dual mode workflow look like:

```json
{
  "type": "module",
  "main": "./index.cjs",
  "exports": {
    "require": "./index.cjs",
    "import": "./index.js"
  }
}
```

instead of the previous:

```json
{
  "type": "module",
  "main": "./index.cjs",
  "exports": {
    "require": "./index.cjs",
    "default": "./index.js"
  }
}
```

the UX improvement being that the former seems like it will look more natural to most users unfamiliar with "exports".

Modules group discussion in https://github.com/nodejs/modules/issues/452, which this PR can be considered blocked on for now.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
