### PR TITLE
module: fixup lint regression

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1169,7 +1169,7 @@ Module.prototype._compile = function(content, filename) {
         } catch {
           // We only expect this codepath to be reached in the case of a
           // preloaded module (it will fail earlier with the main entry)
-          assert(Array.isArray(getOptionValue('--require')));
+          assert(ArrayIsArray(getOptionValue('--require')));
         }
       } else {
         resolvedArgv = 'repl';

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -38,6 +38,4 @@ child.on('close', common.mustCall((code, signal) => {
     `${pjson}.\n`));
   assert.ok(stderr.includes(
     'Error [ERR_REQUIRE_ESM]: Must use import to load ES Module'));
-
-  assert.ok(stderr.includes('Must use import to load ES Module'));
 }));

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -28,7 +28,7 @@ child.on('close', common.mustCall((code, signal) => {
 
   assert.ok(stderr.replace(/\r/, '').indexOf(
     `Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: ${required}` +
-    `\nrequire() of ES modules is not supported.\nrequire() of ` +
+    '\nrequire() of ES modules is not supported.\nrequire() of ' +
     `${required} from ${requiring} ` +
     'is an ES module file as it is a .js file whose nearest parent ' +
     'package.json contains "type": "module" which defines all .js ' +

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -26,9 +26,9 @@ child.on('close', common.mustCall((code, signal) => {
   assert.strictEqual(code, 1);
   assert.strictEqual(signal, null);
 
-  assert.ok(stderr.indexOf(
+  assert.ok(stderr.replace(/\r/, '').indexOf(
     `Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: ${required}` +
-    '\nrequire() of ES modules is not supported.\nrequire() of ' +
+    `\nrequire() of ES modules is not supported.\nrequire() of ` +
     `${required} from ${requiring} ` +
     'is an ES module file as it is a .js file whose nearest parent ' +
     'package.json contains "type": "module" which defines all .js ' +

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -26,7 +26,7 @@ child.on('close', common.mustCall((code, signal) => {
   assert.strictEqual(code, 1);
   assert.strictEqual(signal, null);
 
-  assert.ok(stderr.replace(/\r/, '').indexOf(
+  assert.ok(stderr.replace(/\r/g, '').indexOf(
     `Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: ${required}` +
     '\nrequire() of ES modules is not supported.\nrequire() of ' +
     `${required} from ${requiring} ` +

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -26,7 +26,7 @@ child.on('close', common.mustCall((code, signal) => {
   assert.strictEqual(code, 1);
   assert.strictEqual(signal, null);
 
-  assert.ok(stderr.replace(/\r/g, '').indexOf(
+  assert.ok(stderr.replace(/\r/g, '').includes(
     `Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: ${required}` +
     '\nrequire() of ES modules is not supported.\nrequire() of ' +
     `${required} from ${requiring} ` +
@@ -35,10 +35,9 @@ child.on('close', common.mustCall((code, signal) => {
     'files in that package scope as ES modules.\nInstead rename ' +
     `${basename} to end in .cjs, change the requiring code to use ` +
     'import(), or remove "type": "module" from ' +
-    `${pjson}.\n`) !== -1);
-  assert.ok(stderr.indexOf(
-    'Error [ERR_REQUIRE_ESM]: Must use import to load ES Module') !== -1);
+    `${pjson}.\n`));
+  assert.ok(stderr.includes(
+    'Error [ERR_REQUIRE_ESM]: Must use import to load ES Module'));
 
-  assert.strictEqual(
-    stderr.match(/Must use import to load ES Module/g).length, 1);
+  assert.ok(stderr.includes('Must use import to load ES Module'));
 }));

--- a/test/es-module/test-esm-specifiers-both-flags.mjs
+++ b/test/es-module/test-esm-specifiers-both-flags.mjs
@@ -10,7 +10,7 @@ const flags = '--es-module-specifier-resolution=node ' +
               '--experimental-specifier-resolution=node';
 
 exec(`${process.execPath} ${flags}`, {
-  timeout: 300
+  timeout: 500
 }, mustCall((error) => {
   assert(error.message.includes(expectedError));
 }));

--- a/test/es-module/test-esm-specifiers-both-flags.mjs
+++ b/test/es-module/test-esm-specifiers-both-flags.mjs
@@ -9,8 +9,6 @@ const expectedError =
 const flags = '--es-module-specifier-resolution=node ' +
               '--experimental-specifier-resolution=node';
 
-exec(`${process.execPath} ${flags}`, {
-  timeout: 500
-}, mustCall((error) => {
+exec(`${process.execPath} ${flags}`, mustCall((error) => {
   assert(error.message.includes(expectedError));
 }));


### PR DESCRIPTION
The CI for https://github.com/nodejs/node/pull/30336 was run before the linting change to ensure the use of primordials causing the commit at https://github.com/nodejs/node/commit/1549c8e077422b79573936960daaa4c695620310 to fail.

This should resolve that issue.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
