### PR TITLE
readline: eagerly load string_decoder

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -64,8 +64,7 @@ const {
   kClearScreenDown
 } = CSI;
 
-// Lazy load StringDecoder for startup performance.
-let StringDecoder;
+const { StringDecoder } = require('string_decoder');
 
 // Lazy load Readable for startup performance.
 let Readable;
@@ -92,9 +91,6 @@ function Interface(input, output, completer, terminal) {
   if (!(this instanceof Interface)) {
     return new Interface(input, output, completer, terminal);
   }
-
-  if (StringDecoder === undefined)
-    StringDecoder = require('string_decoder').StringDecoder;
 
   this._sawReturnAt = 0;
   this.isCompletionEnabled = true;
@@ -1131,8 +1127,6 @@ Interface.prototype[Symbol.asyncIterator] = function() {
 function emitKeypressEvents(stream, iface) {
   if (stream[KEYPRESS_DECODER]) return;
 
-  if (StringDecoder === undefined)
-    StringDecoder = require('string_decoder').StringDecoder;
   stream[KEYPRESS_DECODER] = new StringDecoder('utf8');
 
   stream[ESCAPE_DECODER] = emitKeys(stream);
@@ -1147,8 +1141,11 @@ function emitKeypressEvents(stream, iface) {
       if (r) {
         clearTimeout(timeoutId);
 
+        let escapeTimeout = ESCAPE_CODE_TIMEOUT;
+
         if (iface) {
           iface._sawKeyPress = r.length === 1;
+          escapeTimeout = iface.escapeCodeTimeout;
         }
 
         for (let i = 0; i < r.length; i++) {
@@ -1160,10 +1157,7 @@ function emitKeypressEvents(stream, iface) {
             stream[ESCAPE_DECODER].next(r[i]);
             // Escape letter at the tail position
             if (r[i] === kEscape && i + 1 === r.length) {
-              timeoutId = setTimeout(
-                escapeCodeTimeout,
-                iface ? iface.escapeCodeTimeout : ESCAPE_CODE_TIMEOUT
-              );
+              timeoutId = setTimeout(escapeCodeTimeout, escapeTimeout);
             }
           } catch (err) {
             // If the generator throws (it could happen in the `keypress`


### PR DESCRIPTION
There was no point in lazy loading the string_decoder, since it
would be used in all cases anyway.

Also refactor `escapeTimeout` to be set once outside the loop.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
