### PR TITLE
repl: support previews by eager evaluating input

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -512,8 +512,7 @@ added: v0.1.91
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/30811
-    description: The `preview` option is available from now on. The input
-                 generates output previews from now on.
+    description: The `preview` option is now available.
   - version: v12.0.0
     pr-url: https://github.com/nodejs/node/pull/26518
     description: The `terminal` option now follows the default description in

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -510,6 +510,10 @@ with REPL instances programmatically.
 <!-- YAML
 added: v0.1.91
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/30811
+    description: The `preview` option is available from now on. The input
+                 generates output previews from now on.
   - version: v12.0.0
     pr-url: https://github.com/nodejs/node/pull/26518
     description: The `terminal` option now follows the default description in
@@ -562,6 +566,8 @@ changes:
   * `breakEvalOnSigint` {boolean} Stop evaluating the current piece of code when
     `SIGINT` is received, such as when `Ctrl+C` is pressed. This cannot be used
     together with a custom `eval` function. **Default:** `false`.
+  * `preview` {boolean} Defines if the repl prints output previews or not.
+     **Default:** `true`. Always `false` in case `terminal` is falsy.
 * Returns: {repl.REPLServer}
 
 The `repl.start()` method creates and starts a [`repl.REPLServer`][] instance.

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -4,7 +4,10 @@ const {
   Symbol,
 } = primordials;
 
-const acorn = require('internal/deps/acorn/acorn/dist/acorn');
+const { MathMin } = primordials;
+
+const { tokTypes: tt, Parser: AcornParser } =
+  require('internal/deps/acorn/acorn/dist/acorn');
 const privateMethods =
   require('internal/deps/acorn-plugins/acorn-private-methods/index');
 const classFields =
@@ -13,7 +16,30 @@ const numericSeparator =
   require('internal/deps/acorn-plugins/acorn-numeric-separator/index');
 const staticClassFeatures =
   require('internal/deps/acorn-plugins/acorn-static-class-features/index');
-const { tokTypes: tt, Parser: AcornParser } = acorn;
+
+const { sendInspectorCommand } = require('internal/util/inspector');
+
+const {
+  ERR_INSPECTOR_NOT_AVAILABLE
+} = require('internal/errors').codes;
+
+const {
+  clearLine,
+  cursorTo,
+  moveCursor,
+} = require('readline');
+
+const { inspect } = require('util');
+
+const debug = require('internal/util/debuglog').debuglog('repl');
+
+const inspectOptions = {
+  depth: 1,
+  colors: false,
+  compact: true,
+  breakLength: Infinity
+};
+const inspectedOptions = inspect(inspectOptions, { colors: false });
 
 // If the error is that we've unexpectedly ended the input,
 // then let the user try to recover by adding more input.
@@ -91,7 +117,144 @@ function isRecoverableError(e, code) {
   }
 }
 
+function setupPreview(repl, contextSymbol, bufferSymbol, active) {
+  // Simple terminals can't handle previews.
+  if (process.env.TERM === 'dumb' || !active) {
+    return { showInputPreview() {}, clearPreview() {} };
+  }
+
+  let preview = null;
+  let lastPreview = '';
+
+  const clearPreview = () => {
+    if (preview !== null) {
+      moveCursor(repl.output, 0, 1);
+      clearLine(repl.output);
+      moveCursor(repl.output, 0, -1);
+      lastPreview = preview;
+      preview = null;
+    }
+  };
+
+  // This returns a code preview for arbitrary input code.
+  function getPreviewInput(input, callback) {
+    // For similar reasons as `defaultEval`, wrap expressions starting with a
+    // curly brace with parenthesis.
+    if (input.startsWith('{') && !input.endsWith(';')) {
+      input = `(${input})`;
+    }
+    sendInspectorCommand((session) => {
+      session.post('Runtime.evaluate', {
+        expression: input,
+        throwOnSideEffect: true,
+        timeout: 333,
+        contextId: repl[contextSymbol],
+      }, (error, preview) => {
+        if (error) {
+          callback(error);
+          return;
+        }
+        const { result } = preview;
+        if (result.value !== undefined) {
+          callback(null, inspect(result.value, inspectOptions));
+        // Ignore EvalErrors, SyntaxErrors and ReferenceErrors. It is not clear
+        // where they came from and if they are recoverable or not. Other errors
+        // may be inspected.
+        } else if (preview.exceptionDetails &&
+                   (result.className === 'EvalError' ||
+                     result.className === 'SyntaxError' ||
+                     result.className === 'ReferenceError')) {
+          callback(null, null);
+        } else if (result.objectId) {
+          session.post('Runtime.callFunctionOn', {
+            functionDeclaration: `(v) => util.inspect(v, ${inspectedOptions})`,
+            objectId: result.objectId,
+            arguments: [result]
+          }, (error, preview) => {
+            if (error) {
+              callback(error);
+            } else {
+              callback(null, preview.result.value);
+            }
+          });
+        } else {
+          // Either not serializable or undefined.
+          callback(null, result.unserializableValue || result.type);
+        }
+      });
+    }, () => callback(new ERR_INSPECTOR_NOT_AVAILABLE()));
+  }
+
+  const showInputPreview = () => {
+    // Prevent duplicated previews after a refresh.
+    if (preview !== null) {
+      return;
+    }
+
+    const line = repl.line.trim();
+
+    // Do not preview if the command is buffered or if the line is empty.
+    if (repl[bufferSymbol] || line === '') {
+      return;
+    }
+
+    getPreviewInput(line, (error, inspected) => {
+      // Ignore the output if the value is identical to the current line and the
+      // former preview is not identical to this preview.
+      if ((line === inspected && lastPreview !== inspected) ||
+          inspected === null) {
+        return;
+      }
+      if (error) {
+        debug('Error while generating preview', error);
+        return;
+      }
+      // Do not preview `undefined` if colors are deactivated or explicitly
+      // requested.
+      if (inspected === 'undefined' &&
+          (!repl.useColors || repl.ignoreUndefined)) {
+        return;
+      }
+
+      preview = inspected;
+
+      // Limit the output to maximum 250 characters. Otherwise it becomes a)
+      // difficult to read and b) non terminal REPLs would visualize the whole
+      // output.
+      const maxColumns = MathMin(repl.columns, 250);
+
+      if (inspected.length > maxColumns) {
+        inspected = `${inspected.slice(0, maxColumns - 6)}...`;
+      }
+      const lineBreakPos = inspected.indexOf('\n');
+      if (lineBreakPos !== -1) {
+        inspected = `${inspected.slice(0, lineBreakPos)}`;
+      }
+      const result = repl.useColors ?
+        `\u001b[90m${inspected}\u001b[39m` :
+        `// ${inspected}`;
+
+      repl.output.write(`\n${result}`);
+      moveCursor(repl.output, 0, -1);
+      cursorTo(repl.output, repl.cursor + repl._prompt.length);
+    });
+  };
+
+  // Refresh prints the whole screen again and the preview will be removed
+  // during that procedure. Print the preview again. This also makes sure
+  // the preview is always correct after resizing the terminal window.
+  const tmpRefresh = repl._refreshLine.bind(repl);
+  repl._refreshLine = () => {
+    preview = null;
+    tmpRefresh();
+    showInputPreview();
+  };
+
+  return { showInputPreview, clearPreview };
+}
+
 module.exports = {
   isRecoverableError,
-  kStandaloneREPL: Symbol('kStandaloneREPL')
+  kStandaloneREPL: Symbol('kStandaloneREPL'),
+  setupPreview
 };

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -1,10 +1,9 @@
 'use strict';
 
 const {
+  MathMin,
   Symbol,
 } = primordials;
-
-const { MathMin } = primordials;
 
 const { tokTypes: tt, Parser: AcornParser } =
   require('internal/deps/acorn/acorn/dist/acorn');

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -98,7 +98,8 @@ const experimentalREPLAwait = require('internal/options').getOptionValue(
 );
 const {
   isRecoverableError,
-  kStandaloneREPL
+  kStandaloneREPL,
+  setupPreview,
 } = require('internal/repl/utils');
 const {
   getOwnNonIndexProperties,
@@ -203,6 +204,9 @@ function REPLServer(prompt,
       options.useColors = true;
     }
   }
+
+  const preview = options.terminal &&
+    (options.preview !== undefined ? !!options.preview : true);
 
   this.inputStream = options.input;
   this.outputStream = options.output;
@@ -804,9 +808,20 @@ function REPLServer(prompt,
     }
   });
 
+  const {
+    clearPreview,
+    showInputPreview
+  } = setupPreview(
+    this,
+    kContextId,
+    kBufferedCommandSymbol,
+    preview
+  );
+
   // Wrap readline tty to enable editor mode and pausing.
   const ttyWrite = self._ttyWrite.bind(self);
   self._ttyWrite = (d, key) => {
+    clearPreview();
     key = key || {};
     if (paused && !(self.breakEvalOnSigint && key.ctrl && key.name === 'c')) {
       pausedBuffer.push(['key', [d, key]]);
@@ -819,6 +834,7 @@ function REPLServer(prompt,
         self.clearLine();
       }
       ttyWrite(d, key);
+      showInputPreview();
       return;
     }
 

--- a/test/parallel/test-repl-history-navigation.js
+++ b/test/parallel/test-repl-history-navigation.js
@@ -46,28 +46,50 @@ ActionStream.prototype.readable = true;
 const ENTER = { name: 'enter' };
 const UP = { name: 'up' };
 const DOWN = { name: 'down' };
+const LEFT = { name: 'left' };
+const DELETE = { name: 'delete' };
 
 const prompt = '> ';
+
+const prev = process.features.inspector;
 
 const tests = [
   { // Creates few history to navigate for
     env: { NODE_REPL_HISTORY: defaultHistoryPath },
     test: [ 'let ab = 45', ENTER,
             '555 + 909', ENTER,
-            '{key : {key2 :[] }}', ENTER],
+            '{key : {key2 :[] }}', ENTER,
+            'Array(100).fill(1).map((e, i) => i ** i)', LEFT, LEFT, DELETE,
+            '2', ENTER],
     expected: [],
     clean: false
   },
   {
     env: { NODE_REPL_HISTORY: defaultHistoryPath },
-    test: [UP, UP, UP, UP, DOWN, DOWN, DOWN],
+    test: [UP, UP, UP, UP, UP, DOWN, DOWN, DOWN, DOWN],
     expected: [prompt,
+               `${prompt}Array(100).fill(1).map((e, i) => i ** 2)`,
+               prev && '\n// [ 0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, ' +
+                 '144, 169, 196, 225, 256, 289, 324, 361, 400, 441, 484, 529,' +
+                 ' 576, 625, 676, 729, 784, 841, 900, 961, 1024, 1089, 1156, ' +
+                 '1225, 1296, 1369, 1444, 1521, 1600, 1681, 1764, 1849, 1936,' +
+                 ' 2025, 2116, 2209, ...',
                `${prompt}{key : {key2 :[] }}`,
+               prev && '\n// { key: { key2: [] } }',
                `${prompt}555 + 909`,
+               prev && '\n// 1464',
                `${prompt}let ab = 45`,
                `${prompt}555 + 909`,
+               prev && '\n// 1464',
                `${prompt}{key : {key2 :[] }}`,
-               prompt],
+               prev && '\n// { key: { key2: [] } }',
+               `${prompt}Array(100).fill(1).map((e, i) => i ** 2)`,
+               prev && '\n// [ 0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, ' +
+                 '144, 169, 196, 225, 256, 289, 324, 361, 400, 441, 484, 529,' +
+                 ' 576, 625, 676, 729, 784, 841, 900, 961, 1024, 1089, 1156, ' +
+                 '1225, 1296, 1369, 1444, 1521, 1600, 1681, 1764, 1849, 1936,' +
+                 ' 2025, 2116, 2209, ...',
+               prompt].filter((e) => typeof e === 'string'),
     clean: true
   }
 ];

--- a/test/parallel/test-repl-preview.js
+++ b/test/parallel/test-repl-preview.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const common = require('../common');
+const ArrayStream = require('../common/arraystream');
+const assert = require('assert');
+const Repl = require('repl');
+
+common.skipIfInspectorDisabled();
+
+const PROMPT = 'repl > ';
+
+class REPLStream extends ArrayStream {
+  constructor() {
+    super();
+    this.lines = [''];
+  }
+  write(chunk) {
+    const chunkLines = chunk.toString('utf8').split('\n');
+    this.lines[this.lines.length - 1] += chunkLines[0];
+    if (chunkLines.length > 1) {
+      this.lines.push(...chunkLines.slice(1));
+    }
+    this.emit('line');
+    return true;
+  }
+  wait() {
+    this.lines = [''];
+    return new Promise((resolve, reject) => {
+      const onError = (err) => {
+        this.removeListener('line', onLine);
+        reject(err);
+      };
+      const onLine = () => {
+        if (this.lines[this.lines.length - 1].includes(PROMPT)) {
+          this.removeListener('error', onError);
+          this.removeListener('line', onLine);
+          resolve(this.lines);
+        }
+      };
+      this.once('error', onError);
+      this.on('line', onLine);
+    });
+  }
+}
+
+function runAndWait(cmds, repl) {
+  const promise = repl.inputStream.wait();
+  for (const cmd of cmds) {
+    repl.inputStream.run([cmd]);
+  }
+  return promise;
+}
+
+async function tests(options) {
+  const repl = Repl.start({
+    prompt: PROMPT,
+    stream: new REPLStream(),
+    ignoreUndefined: true,
+    useColors: true,
+    ...options
+  });
+
+  repl.inputStream.run([
+    'function foo(x) { return x; }',
+    'function koo() { console.log("abc"); }',
+    'a = undefined;'
+  ]);
+  const testCases = [
+    ['foo', [2, 4], '[Function: foo]',
+     'foo',
+     '\x1B[90m[Function: foo]\x1B[39m\x1B[1A\x1B[11G\x1B[1B\x1B[2K\x1B[1A\r',
+     '\x1B[36m[Function: foo]\x1B[39m',
+     '\x1B[1G\x1B[0Jrepl > \x1B[8G'],
+    ['koo', [2, 4], '[Function: koo]',
+     'koo',
+     '\x1B[90m[Function: koo]\x1B[39m\x1B[1A\x1B[11G\x1B[1B\x1B[2K\x1B[1A\r',
+     '\x1B[36m[Function: koo]\x1B[39m',
+     '\x1B[1G\x1B[0Jrepl > \x1B[8G'],
+    ['a', [1, 2], undefined],
+    ['{ a: true }', [2, 3], '{ a: \x1B[33mtrue\x1B[39m }',
+     '{ a: true }\r',
+     '{ a: \x1B[33mtrue\x1B[39m }',
+     '\x1B[1G\x1B[0Jrepl > \x1B[8G'],
+    ['1n + 2n', [2, 5], '\x1B[33m3n\x1B[39m',
+     '1n + 2',
+     '\x1B[90mType[39m\x1B[1A\x1B[14G\x1B[1B\x1B[2K\x1B[1An',
+     '\x1B[90m3n\x1B[39m\x1B[1A\x1B[15G\x1B[1B\x1B[2K\x1B[1A\r',
+     '\x1B[33m3n\x1B[39m',
+     '\x1B[1G\x1B[0Jrepl > \x1B[8G'],
+    ['{ a: true };', [2, 4], '\x1B[33mtrue\x1B[39m',
+     '{ a: true };',
+     '\x1B[90mtrue\x1B[39m\x1B[1A\x1B[20G\x1B[1B\x1B[2K\x1B[1A\r',
+     '\x1B[33mtrue\x1B[39m',
+     '\x1B[1G\x1B[0Jrepl > \x1B[8G'],
+    [' \t { a: true};', [2, 5], '\x1B[33mtrue\x1B[39m',
+     ' \t { a: true}',
+     '\x1B[90m{ a: true }\x1B[39m\x1B[1A\x1B[21G\x1B[1B\x1B[2K\x1B[1A;',
+     '\x1B[90mtrue\x1B[39m\x1B[1A\x1B[22G\x1B[1B\x1B[2K\x1B[1A\r',
+     '\x1B[33mtrue\x1B[39m',
+     '\x1B[1G\x1B[0Jrepl > \x1B[8G']
+  ];
+
+  const hasPreview = repl.terminal &&
+    (options.preview !== undefined ? !!options.preview : true);
+
+  for (const [input, length, expected, ...preview] of testCases) {
+    console.log(`Testing ${input}`);
+
+    const toBeRun = input.split('\n');
+    let lines = await runAndWait(toBeRun, repl);
+
+    assert.strictEqual(lines.length, length[+hasPreview]);
+    if (expected === undefined) {
+      assert(!lines.some((e) => e.includes('undefined')));
+    } else if (hasPreview) {
+      // Remove error messages. That allows the code to run in different
+      // engines.
+      // eslint-disable-next-line no-control-regex
+      lines = lines.map((line) => line.replace(/Error: .+?\x1B/, ''));
+      assert.deepStrictEqual(lines, preview);
+    } else {
+      assert.ok(lines[0].includes(expected), lines);
+    }
+  }
+}
+
+tests({ terminal: false }); // No preview
+tests({ terminal: true }); // Preview
+tests({ terminal: false, preview: false }); // No preview
+tests({ terminal: false, preview: true }); // No preview
+tests({ terminal: true, preview: true }); // Preview


### PR DESCRIPTION
This adds input previews by using the inspectors eager evaluation
functionality.
It is implemented as additional line that is not counted towards
the actual input. In case no colors are supported, it will be visible
as comment. Otherwise it's grey.
It will be triggered on any line change. It is heavily tested against
edge cases and adheres to "dumb" terminals (previews are deactived
in that case).

Small videos that outline the behavior:

https://asciinema.org/a/YwJ92D8vrj7bD5XGNGZzFhxU8
https://asciinema.org/a/bgalyUuG49w96RSzwfhYzLpXL

This is an alternative to https://github.com/nodejs/node/pull/22875.

Fixes: https://github.com/nodejs/node/issues/20977

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
