### PR TITLE
src: improve checked uv loop close output

### DIFF
--- a/test/abort/test-addon-uv-handle-leak.js
+++ b/test/abort/test-addon-uv-handle-leak.js
@@ -47,8 +47,8 @@ if (process.argv[2] === 'child') {
 
   // Parse output that is formatted like this:
 
-  // uv loop at [0x559b65ed5770] has active handles
-  // [0x7f2de0018430] timer
+  // uv loop at [0x559b65ed5770] has open handles:
+  // [0x7f2de0018430] timer (active)
   //         Close callback: 0x7f2df31de220 CloseCallback(uv_handle_s*) [...]
   //         Data: 0x7f2df33df140 example_instance [...]
   //         (First field): 0x7f2df33dedc0 vtable for ExampleOwnerClass [...]
@@ -89,15 +89,15 @@ if (process.argv[2] === 'child') {
 
     switch (state) {
       case 'initial':
-        assert(/^uv loop at \[.+\] has \d+ active handles$/.test(line), line);
+        assert(/^uv loop at \[.+\] has open handles:$/.test(line), line);
         state = 'handle-start';
         break;
       case 'handle-start':
-        if (/Assertion .+ failed/.test(line)) {
-          state = 'done';
+        if (/^uv loop at \[.+\] has \d+ open handles in total$/.test(line)) {
+          state = 'assertion-failure';
           break;
         }
-        assert(/^\[.+\] timer$/.test(line), line);
+        assert(/^\[.+\] timer( \(active\))?$/.test(line), line);
         state = 'close-callback';
         break;
       case 'close-callback':
@@ -109,15 +109,19 @@ if (process.argv[2] === 'child') {
         state = 'maybe-first-field';
         break;
       case 'maybe-first-field':
-        if (/^\(First field\)$/.test(line)) {
+        if (!/^\(First field\)/.test(line)) {
           lines.unshift(line);
-          state = 'handle-start';
-          break;
         }
-        state = 'maybe-first-field';
+        state = 'handle-start';
+        break;
+      case 'assertion-failure':
+        assert(/Assertion .+ failed/.test(line), line);
+        state = 'done';
         break;
       case 'done':
         break;
     }
   }
+
+  assert.strictEqual(state, 'done');
 }

--- a/test/abort/test-addon-uv-handle-leak.js
+++ b/test/abort/test-addon-uv-handle-leak.js
@@ -58,6 +58,7 @@ if (process.argv[2] === 'child') {
   // [0x7f2de000b910] timer
   //         Close callback: 0x7f2df31de220 CloseCallback(uv_handle_s*) [...]
   //         Data: 0x42
+  // uv loop at [0x559b65ed5770] has 3 open handles in total
 
   function isGlibc() {
     try {


### PR DESCRIPTION
Addon developers may run into this when not closing libuv handles
inside Workers.

Previously, output may have included unhelpful statements such as
`uv loop at ... has 0 active handles`, which may sound like
everything’s supposed to be fine actually.

So, instead of printing the active handle count, print the total
handle count and mark active handles individually.

Also, fix the test for this to work properly and make sure that
parsing finishes properly.

FYI @laverdet

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
