### PR TITLE
test: skip the unsupported test cases for IBM i

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.23',
+    'v8_embedder_string': '-node.24',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/base/platform/time.cc
+++ b/deps/v8/src/base/platform/time.cc
@@ -70,6 +70,9 @@ V8_INLINE int64_t ClockNow(clockid_t clk_id) {
 #if defined(V8_OS_AIX)
   thread_cputime_t tc;
   if (clk_id == CLOCK_THREAD_CPUTIME_ID) {
+#if defined(__PASE__)  // CLOCK_THREAD_CPUTIME_ID clock not supported on IBMi
+    return 0;
+#endif
     if (thread_cputime(-1, &tc) != 0) {
       UNREACHABLE();
     }

--- a/test/async-hooks/test-fseventwrap.js
+++ b/test/async-hooks/test-fseventwrap.js
@@ -10,6 +10,9 @@ const fs = require('fs');
 if (!common.isMainThread)
   common.skip('Worker bootstrapping works differently -> different async IDs');
 
+if (common.isIBMi)
+  common.skip('IBMi does not suppport fs.watch()');
+
 const hooks = initHooks();
 
 hooks.enable();

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -33,3 +33,12 @@ test-async-hooks-http-parser-destroy: PASS,FLAKY
 [$system==freebsd]
 
 [$system==aix]
+
+[$system==ibmi]
+# https://github.com/nodejs/node/pull/30819
+test-child-process-fork-net-server: SKIP
+test-cli-node-options: SKIP
+test-cluster-shared-leak: SKIP
+test-http-writable-true-after-close: SKIP
+test-http2-connect-method: SKIP
+test-net-error-twice: SKIP

--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -85,7 +85,8 @@ dns.lookup('::1', common.mustCall((error, result, addressType) => {
 // Windows doesn't usually have an entry for localhost 127.0.0.1 in
 // C:\Windows\System32\drivers\etc\hosts
 // so we disable this test on Windows.
-if (!common.isWindows) {
+// IBMi reports `ENOTFOUND` when get hostname by address 127.0.0.1
+if (!common.isWindows && !common.isIBMi) {
   dns.reverse('127.0.0.1', common.mustCall(function(error, domains) {
     assert.ifError(error);
     assert.ok(Array.isArray(domains));

--- a/test/parallel/test-child-process-spawnsync-validation-errors.js
+++ b/test/parallel/test-child-process-spawnsync-validation-errors.js
@@ -3,7 +3,8 @@ const common = require('../common');
 const assert = require('assert');
 const spawnSync = require('child_process').spawnSync;
 const signals = require('os').constants.signals;
-const rootUser = common.isWindows ? false : process.getuid() === 0;
+const rootUser = common.isWindows ? false :
+  common.isIBMi ? true : process.getuid() === 0;
 
 const invalidArgTypeError = common.expectsError(
   { code: 'ERR_INVALID_ARG_TYPE', type: TypeError },

--- a/test/parallel/test-child-process-uid-gid.js
+++ b/test/parallel/test-child-process-uid-gid.js
@@ -4,6 +4,9 @@ const assert = require('assert');
 const spawn = require('child_process').spawn;
 const expectedError = common.isWindows ? /\bENOTSUP\b/ : /\bEPERM\b/;
 
+if (common.isIBMi)
+  common.skip('IBMi has a different behavior');
+
 if (common.isWindows || process.getuid() !== 0) {
   assert.throws(() => {
     spawn('echo', ['fhqwhgads'], { uid: 0 });

--- a/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
+++ b/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
@@ -26,6 +26,9 @@ const common = require('../common');
 if (common.isOSX)
   common.skip('macOS may allow ordinary processes to use any port');
 
+if (common.isIBMi)
+  common.skip('IBMi may allow ordinary processes to use any port');
+
 if (common.isWindows)
   common.skip('not reliable on Windows');
 

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -8,6 +8,9 @@ const common = require('../common');
 if (!common.isWindows && process.getuid() === 0)
   common.skip('as this test should not be run as `root`');
 
+if (common.isIBMi)
+  common.skip('IBMi has a different access permission mechanism');
+
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');

--- a/test/parallel/test-fs-copyfile-respect-permissions.js
+++ b/test/parallel/test-fs-copyfile-respect-permissions.js
@@ -8,6 +8,9 @@ const common = require('../common');
 if (!common.isWindows && process.getuid() === 0)
   common.skip('as this test should not be run as `root`');
 
+if (common.isIBMi)
+  common.skip('IBMi has a different access permission mechanism');
+
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 

--- a/test/parallel/test-fs-options-immutable.js
+++ b/test/parallel/test-fs-options-immutable.js
@@ -46,7 +46,7 @@ if (common.canCreateSymLink()) {
   fs.appendFile(fileName, 'ABCD', options, common.mustCall(errHandler));
 }
 
-{
+if (!common.isIBMi) { // IBMi does not suppport fs.watch()
   const watch = fs.watch(__filename, options, common.mustNotCall());
   watch.close();
 }

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -144,8 +144,9 @@ function runTests(iter) {
 const path = `${tmpdir.path}/test-utimes-precision`;
 fs.writeFileSync(path, '');
 
-// Test Y2K38 for all platforms [except 'arm', 'OpenBSD' and 'SunOS']
-if (!process.arch.includes('arm') && !common.isOpenBSD && !common.isSunOS) {
+// Test Y2K38 for all platforms [except 'arm', 'OpenBSD', 'SunOS' and 'IBMi']
+if (!process.arch.includes('arm') &&
+  !common.isOpenBSD && !common.isSunOS && !common.isIBMi) {
   const Y2K38_mtime = 2 ** 31;
   fs.utimesSync(path, Y2K38_mtime, Y2K38_mtime);
   const Y2K38_stats = fs.statSync(path);

--- a/test/parallel/test-fs-watch-close-when-destroyed.js
+++ b/test/parallel/test-fs-watch-close-when-destroyed.js
@@ -4,6 +4,10 @@
 // already destroyed will result in a noop instead of a crash.
 
 const common = require('../common');
+
+if (common.isIBMi)
+  common.skip('IBMi does not support `fs.watch()`');
+
 const tmpdir = require('../common/tmpdir');
 const fs = require('fs');
 const path = require('path');

--- a/test/parallel/test-fs-watch-enoent.js
+++ b/test/parallel/test-fs-watch-enoent.js
@@ -4,6 +4,10 @@
 // This verifies the error thrown by fs.watch.
 
 const common = require('../common');
+
+if (common.isIBMi)
+  common.skip('IBMi does not support `fs.watch()`');
+
 const assert = require('assert');
 const fs = require('fs');
 const tmpdir = require('../common/tmpdir');

--- a/test/parallel/test-fs-watch.js
+++ b/test/parallel/test-fs-watch.js
@@ -1,6 +1,9 @@
 'use strict';
 const common = require('../common');
 
+if (common.isIBMi)
+  common.skip('IBMi does not support `fs.watch()`');
+
 // Tests if `filename` is provided to watcher on supported platforms
 
 const fs = require('fs');

--- a/test/parallel/test-memory-usage-emfile.js
+++ b/test/parallel/test-memory-usage-emfile.js
@@ -1,5 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
+
+// On IBMi, the rss memory always returns zero
+if (common.isIBMi)
+  common.skip('On IBMi, the rss memory always returns zero');
+
 const assert = require('assert');
 
 const fs = require('fs');

--- a/test/parallel/test-memory-usage.js
+++ b/test/parallel/test-memory-usage.js
@@ -20,11 +20,13 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const r = process.memoryUsage();
-assert.ok(r.rss > 0);
+// On IBMi, the rss memory always returns zero
+if (!common.isIBMi)
+  assert.ok(r.rss > 0);
 assert.ok(r.heapTotal > 0);
 assert.ok(r.heapUsed > 0);
 assert.ok(r.external > 0);

--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -31,10 +31,14 @@ const errorMessagesByPlatform = {
   darwin: ['file too short'],
   aix: ['Cannot load module',
         'Cannot run a file that does not have a valid format.',
-        'Exec format error']
+        'Exec format error'],
+  ibmi: ['Cannot load module',
+         'The module has too many section headers',
+         'or the file has been truncated.'],
 };
 // If we don't know a priori what the error would be, we accept anything.
-const errorMessages = errorMessagesByPlatform[process.platform] || [''];
+const platform = common.isIBMi ? 'ibmi' : process.platform;
+const errorMessages = errorMessagesByPlatform[platform] || [''];
 
 // On Windows, error messages are MUI dependent
 // Ref: https://github.com/nodejs/node/issues/13376

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -76,8 +76,9 @@ noEntSocketClient.on('error', common.mustCall(function(err) {
 }));
 
 
-// On Windows or when running as root, a chmod has no effect on named pipes
-if (!common.isWindows && process.getuid() !== 0) {
+// On Windows or IBMi or when running as root,
+// a chmod has no effect on named pipes
+if (!common.isWindows && !common.isIBMi && process.getuid() !== 0) {
   // Trying to connect to a socket one has no access to should result in EACCES
   const accessServer = net.createServer(
     common.mustNotCall('server callback should not run'));

--- a/test/parallel/test-os-process-priority.js
+++ b/test/parallel/test-os-process-priority.js
@@ -1,5 +1,9 @@
 'use strict';
 const common = require('../common');
+// IBMi process priority is different.
+if (common.isIBMi)
+  common.skip('IBMi has a different process priority');
+
 const assert = require('assert');
 const os = require('os');
 const {

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -85,9 +85,12 @@ const hostname = os.hostname();
 is.string(hostname);
 assert.ok(hostname.length > 0);
 
-const uptime = os.uptime();
-is.number(uptime);
-assert.ok(uptime > 0);
+// On IBMi, os.uptime() returns 'undefined'
+if (!common.isIBMi) {
+  const uptime = os.uptime();
+  is.number(uptime);
+  assert.ok(uptime > 0);
+}
 
 const cpus = os.cpus();
 is.array(cpus);
@@ -244,8 +247,11 @@ assert.strictEqual(`${os.platform}`, os.platform());
 assert.strictEqual(+os.totalmem, os.totalmem());
 
 // Assert that the following values are coercible to numbers.
-is.number(+os.uptime, 'uptime');
-is.number(os.uptime(), 'uptime');
+// On IBMi, os.uptime() returns 'undefined'
+if (!common.isIBMi) {
+  is.number(+os.uptime, 'uptime');
+  is.number(os.uptime(), 'uptime');
+}
 
 is.number(+os.freemem, 'freemem');
 is.number(os.freemem(), 'freemem');

--- a/test/parallel/test-process-euid-egid.js
+++ b/test/parallel/test-process-euid-egid.js
@@ -29,6 +29,10 @@ assert.throws(() => {
   message: 'User identifier does not exist: fhqwhgadshgnsdhjsdbkhsdabkfabkveyb'
 });
 
+// IBMi does not support below operations.
+if (common.isIBMi)
+  return;
+
 // If we're not running as super user...
 if (process.getuid() !== 0) {
   // Should not throw.

--- a/test/parallel/test-process-title-cli.js
+++ b/test/parallel/test-process-title-cli.js
@@ -6,6 +6,9 @@ const common = require('../common');
 if (common.isSunOS)
   common.skip(`Unsupported platform [${process.platform}]`);
 
+if (common.isIBMi)
+  common.skip('Unsupported platform IBMi');
+
 const assert = require('assert');
 
 // Verifies that the --title=foo command line flag set the process

--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -5,6 +5,9 @@ const common = require('../common');
 // FIXME add sunos support
 if (common.isSunOS)
   common.skip(`Unsupported platform [${process.platform}]`);
+// FIXME add IBMi support
+if (common.isIBMi)
+  common.skip('Unsupported platform IBMi');
 if (!common.isMainThread)
   common.skip('Setting the process title from Workers is not supported');
 

--- a/test/parallel/test-trace-events-metadata.js
+++ b/test/parallel/test-trace-events-metadata.js
@@ -64,8 +64,9 @@ proc.once('exit', common.mustCall(() => {
         (!process.release.lts ||
           trace.args.process.release.lts === process.release.lts)));
 
-    if (!common.isSunOS) {
+    if (!common.isSunOS && !common.isIBMi) {
       // Changing process.title is currently unsupported on SunOS/SmartOS
+      // and IBMi
       assert(traces.some((trace) =>
         trace.name === 'process_name' && trace.args.name === 'foo'));
       assert(traces.some((trace) =>

--- a/test/parallel/test-worker-memory.js
+++ b/test/parallel/test-worker-memory.js
@@ -1,5 +1,8 @@
 'use strict';
 const common = require('../common');
+if (common.isIBMi)
+  common.skip('On IBMi, the rss memory always returns zero');
+
 const assert = require('assert');
 const util = require('util');
 const { Worker } = require('worker_threads');

--- a/test/report/test-report-uv-handles.js
+++ b/test/report/test-report-uv-handles.js
@@ -2,6 +2,9 @@
 
 // Testcase to check reporting of uv handles.
 const common = require('../common');
+if (common.isIBMi)
+  common.skip('IBMi does not support fs.watch()');
+
 common.skipIfReportDisabled();
 if (process.argv[2] === 'child') {
   // Exit on loss of parent process

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -22,4 +22,10 @@ test-http2-large-file: PASS, FLAKY
 # https://github.com/nodejs/node/pull/29054
 test-buffer-creation-regression: SKIP
 
+[$system==ibmi]
+# https://github.com/nodejs/node/pull/29054
+test-buffer-creation-regression: SKIP
+# https://github.com/nodejs/node/pull/30819
+test-perf-hooks: SKIP
+
 [$arch==arm]

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -21,6 +21,8 @@
 
 'use strict';
 const common = require('../common');
+if (common.isIBMi)
+  common.skip('IBMi does not support fs.watch()');
 
 const assert = require('assert');
 const fs = require('fs');

--- a/test/sequential/test-inspector-contexts.js
+++ b/test/sequential/test-inspector-contexts.js
@@ -25,9 +25,9 @@ async function testContextCreatedAndDestroyed() {
     session.post('Runtime.enable', assert.ifError);
     const contextCreated = await mainContextPromise;
     const { name, origin, auxData } = contextCreated.params.context;
-    if (common.isSunOS || common.isWindows) {
-      // uv_get_process_title() is unimplemented on Solaris-likes, it returns
-      // an empty string.  On the Windows CI buildbots it returns
+    if (common.isSunOS || common.isWindows || common.isIBMi) {
+      // uv_get_process_title() is unimplemented on Solaris-likes and IBMi,
+      // it returns an empty string.  On the Windows CI buildbots it returns
       // "Administrator: Windows PowerShell[42]" because of a GetConsoleTitle()
       // quirk. Not much we can do about either, just verify that it contains
       // the PID.

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -65,6 +65,8 @@ def GuessOS():
     return 'netbsd'
   elif id == 'AIX':
     return 'aix'
+  elif id == 'OS400':
+    return 'ibmi'
   else:
     return None
 


### PR DESCRIPTION
This is a following PR of #30714.

The cases marked with `// TODO` need more investigations to identify if it is a system limit or can be resolved by code change. And I am working on it.

The other cases are identified that IBM i does not support them.

What we need to do is to indentify (and/or resolve) all the `// TODO` items.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
