### PR TITLE
doc: update message.url example in http.IncomingMessage

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1973,54 +1973,31 @@ Accept: text/plain\r\n
 \r\n
 ```
 
-Then `request.url` will be:
+To parse the url into its parts The WHATWG URL API can be used:
 
-<!-- eslint-disable semi -->
 ```js
-'/status?name=ryan'
+new URL(request.url, `http://${request.headers.host}`);
 ```
 
-To parse the url into its parts `require('url').parse(request.url)`
-can be used:
+When `request.url` is `'/status?name=ryan'` and `request.headers.host` is `'localhost:3000'`:
 
 ```console
 $ node
-> require('url').parse('/status?name=ryan')
-Url {
-  protocol: null,
-  slashes: null,
-  auth: null,
-  host: null,
-  port: null,
-  hostname: null,
-  hash: null,
-  search: '?name=ryan',
-  query: 'name=ryan',
+> new URL('/status?name=ryan', 'localhost:3000')
+URL {
+  href: 'http://localhost:3000/status?name=ryan',
+  origin: 'http://localhost:3000',
+  protocol: 'http:',
+  username: '',
+  password: '',
+  host: 'localhost:3000',
+  hostname: 'localhost',
+  port: '3000',
   pathname: '/status',
-  path: '/status?name=ryan',
-  href: '/status?name=ryan' }
-```
-
-To extract the parameters from the query string, the
-`require('querystring').parse` function can be used, or
-`true` can be passed as the second argument to `require('url').parse`:
-
-```console
-$ node
-> require('url').parse('/status?name=ryan', true)
-Url {
-  protocol: null,
-  slashes: null,
-  auth: null,
-  host: null,
-  port: null,
-  hostname: null,
-  hash: null,
   search: '?name=ryan',
-  query: { name: 'ryan' },
-  pathname: '/status',
-  path: '/status?name=ryan',
-  href: '/status?name=ryan' }
+  searchParams: URLSearchParams { 'name' => 'ryan' },
+  hash: ''
+}
 ```
 
 ## http.METHODS

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1984,7 +1984,7 @@ When `request.url` is `'/status?name=ryan'` and
 
 ```console
 $ node
-> new URL('/status?name=ryan', 'localhost:3000')
+> new URL(request.url, request.headers.host)
 URL {
   href: 'http://localhost:3000/status?name=ryan',
   origin: 'http://localhost:3000',

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1973,13 +1973,14 @@ Accept: text/plain\r\n
 \r\n
 ```
 
-To parse the url into its parts The WHATWG URL API can be used:
+To parse the URL into its parts:
 
 ```js
 new URL(request.url, `http://${request.headers.host}`);
 ```
 
-When `request.url` is `'/status?name=ryan'` and `request.headers.host` is `'localhost:3000'`:
+When `request.url` is `'/status?name=ryan'` and
+`request.headers.host` is `'localhost:3000'`:
 
 ```console
 $ node


### PR DESCRIPTION
Update message.url example to use The WHATWG URL API.
This is because the old example suggests using deprecated url API.

Fixes: https://github.com/nodejs/node/issues/30048
Refs: https://nodejs.org/dist/latest-v12.x/docs/api/http.html#http_message_url

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
