### PR TITLE
module: fix require in node repl

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -816,11 +816,11 @@ Module._resolveLookupPaths = function(request, parent) {
     return paths.length > 0 ? paths : null;
   }
 
-  // With --eval, parent.id is not set and parent.filename is null.
+  // In REPL, parent.filename is null.
   if (!parent || !parent.id || !parent.filename) {
     // Make require('./path/to/foo') work - normally the path is taken
-    // from realpath(__filename) but with eval there is no filename
-    const mainPaths = ['.'].concat(Module._nodeModulePaths('.'), modulePaths);
+    // from realpath(__filename) but in REPL there is no filename
+    const mainPaths = ['.'];
 
     debug('looking for %j in %j', request, mainPaths);
     return mainPaths;

--- a/test/parallel/test-repl-require.js
+++ b/test/parallel/test-repl-require.js
@@ -11,28 +11,61 @@ if (!common.isMainThread)
 process.chdir(fixtures.fixturesDir);
 const repl = require('repl');
 
-const server = net.createServer((conn) => {
-  repl.start('', conn).on('exit', () => {
-    conn.destroy();
-    server.close();
+{
+  const server = net.createServer((conn) => {
+    repl.start('', conn).on('exit', () => {
+      conn.destroy();
+      server.close();
+    });
   });
-});
 
-const host = common.localhostIPv4;
-const port = 0;
-const options = { host, port };
+  const host = common.localhostIPv4;
+  const port = 0;
+  const options = { host, port };
 
-let answer = '';
-server.listen(options, function() {
-  options.port = this.address().port;
-  const conn = net.connect(options);
-  conn.setEncoding('utf8');
-  conn.on('data', (data) => answer += data);
-  conn.write('require("baz")\nrequire("./baz")\n.exit\n');
-});
+  let answer = '';
+  server.listen(options, function() {
+    options.port = this.address().port;
+    const conn = net.connect(options);
+    conn.setEncoding('utf8');
+    conn.on('data', (data) => answer += data);
+    conn.write('require("baz")\nrequire("./baz")\n.exit\n');
+  });
 
-process.on('exit', function() {
-  assert.strictEqual(/Cannot find module/.test(answer), false);
-  assert.strictEqual(/Error/.test(answer), false);
-  assert.strictEqual(answer, '\'eye catcher\'\n\'perhaps I work\'\n');
-});
+  process.on('exit', function() {
+    assert.strictEqual(/Cannot find module/.test(answer), false);
+    assert.strictEqual(/Error/.test(answer), false);
+    assert.strictEqual(answer, '\'eye catcher\'\n\'perhaps I work\'\n');
+  });
+}
+
+// Test for https://github.com/nodejs/node/issues/30808
+// In REPL, we shouldn't look up relative modules from 'node_modules'.
+{
+  const server = net.createServer((conn) => {
+    repl.start('', conn).on('exit', () => {
+      conn.destroy();
+      server.close();
+    });
+  });
+
+  const host = common.localhostIPv4;
+  const port = 0;
+  const options = { host, port };
+
+  let answer = '';
+  server.listen(options, function() {
+    options.port = this.address().port;
+    const conn = net.connect(options);
+    conn.setEncoding('utf8');
+    conn.on('data', (data) => answer += data);
+    conn.write('require("./bar")\n.exit\n');
+  });
+
+  process.on('exit', function() {
+    assert.strictEqual(/Uncaught Error: Cannot find module '\.\/bar'/.test(answer), true);
+
+    assert.strictEqual(/code: 'MODULE_NOT_FOUND'/.test(answer), true);
+    assert.strictEqual(/requireStack: \[ '<repl>' \]/.test(answer), true);
+  });
+}

--- a/test/parallel/test-require-resolve.js
+++ b/test/parallel/test-require-resolve.js
@@ -23,6 +23,8 @@
 const common = require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
+const { builtinModules } = require('module');
+const path = require('path');
 
 assert.strictEqual(
   require.resolve(fixtures.path('a')).toLowerCase(),
@@ -52,3 +54,28 @@ const re = /^The "request" argument must be of type string\. Received type \w+$/
       message: re
     });
 });
+
+// Test require.resolve.paths.
+{
+  // builtinModules.
+  builtinModules.forEach((mod) => {
+    assert.strictEqual(require.resolve.paths(mod), null);
+  });
+
+  // node_modules.
+  const resolvedPaths = require.resolve.paths('eslint');
+  assert.strictEqual(Array.isArray(resolvedPaths), true);
+  assert.strictEqual(resolvedPaths.includes('/node_modules'), true);
+
+  // relativeModules.
+  const relativeModules = ['.', '..', './foo', '../bar'];
+  relativeModules.forEach((mod) => {
+    const resolvedPaths = require.resolve.paths(mod);
+    assert.strictEqual(Array.isArray(resolvedPaths), true);
+    assert.strictEqual(resolvedPaths.length, 1);
+    assert.strictEqual(resolvedPaths[0], path.dirname(__filename));
+
+    // Shouldn't look up relative modules from 'node_modules'.
+    assert.strictEqual(resolvedPaths.includes('/node_modules'), false);
+  });
+}

--- a/test/parallel/test-require-resolve.js
+++ b/test/parallel/test-require-resolve.js
@@ -65,7 +65,7 @@ const re = /^The "request" argument must be of type string\. Received type \w+$/
   // node_modules.
   const resolvedPaths = require.resolve.paths('eslint');
   assert.strictEqual(Array.isArray(resolvedPaths), true);
-  assert.strictEqual(resolvedPaths.includes('/node_modules'), true);
+  assert.strictEqual(resolvedPaths[0].includes('node_modules'), true);
 
   // relativeModules.
   const relativeModules = ['.', '..', './foo', '../bar'];


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/30808

In REPL, `module.filename` is `null`, and for relative path modules, we shouldn't look up relative modules from `node_modules`.
```node
> module.filename
null
>
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
