### PR TITLE
fs: synchronize close with other I/O for streams

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -7,6 +7,7 @@ const {
   NumberIsSafeInteger,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  Symbol,
 } = primordials;
 
 const {

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -10,7 +10,8 @@ const {
 } = primordials;
 
 const {
-  ERR_OUT_OF_RANGE
+  ERR_OUT_OF_RANGE,
+  ERR_STREAM_DESTROYED
 } = require('internal/errors').codes;
 const internalUtil = require('internal/util');
 const { validateNumber } = require('internal/validators');
@@ -22,6 +23,8 @@ const {
 } = require('internal/fs/utils');
 const { Readable, Writable } = require('stream');
 const { toPathIfFileURL } = require('internal/url');
+const kIoDone = Symbol('kIoDone');
+const kIsPerformingIO = Symbol('kIsPerformingIO');
 
 const kMinPoolSpace = 128;
 
@@ -86,6 +89,7 @@ function ReadStream(path, options) {
   this.pos = undefined;
   this.bytesRead = 0;
   this.closed = false;
+  this[kIsPerformingIO] = false;
 
   if (this.start !== undefined) {
     checkPosition(this.start, 'start');
@@ -155,6 +159,8 @@ ReadStream.prototype._read = function(n) {
     });
   }
 
+  if (this.destroyed) return;
+
   if (!pool || pool.length - pool.used < kMinPoolSpace) {
     // Discard the old pool.
     allocNewPool(this.readableHighWaterMark);
@@ -178,7 +184,12 @@ ReadStream.prototype._read = function(n) {
     return this.push(null);
 
   // the actual read.
+  this[kIsPerformingIO] = true;
   fs.read(this.fd, pool, pool.used, toRead, this.pos, (er, bytesRead) => {
+    this[kIsPerformingIO] = false;
+    // Tell ._destroy() that it's safe to close the fd now.
+    if (this.destroyed) return this.emit(kIoDone, er);
+
     if (er) {
       if (this.autoClose) {
         this.destroy();
@@ -224,8 +235,12 @@ ReadStream.prototype._destroy = function(err, cb) {
     return;
   }
 
+  if (this[kIsPerformingIO]) {
+    this.once(kIoDone, (er) => closeFsStream(this, cb, err || er));
+    return;
+  }
+
   closeFsStream(this, cb, err);
-  this.fd = null;
 };
 
 function closeFsStream(stream, cb, err) {
@@ -236,6 +251,8 @@ function closeFsStream(stream, cb, err) {
     if (!er)
       stream.emit('close');
   });
+
+  stream.fd = null;
 }
 
 ReadStream.prototype.close = function(cb) {
@@ -274,6 +291,7 @@ function WriteStream(path, options) {
   this.pos = undefined;
   this.bytesWritten = 0;
   this.closed = false;
+  this[kIsPerformingIO] = false;
 
   if (this.start !== undefined) {
     checkPosition(this.start, 'start');
@@ -339,7 +357,17 @@ WriteStream.prototype._write = function(data, encoding, cb) {
     });
   }
 
+  if (this.destroyed) return cb(new ERR_STREAM_DESTROYED('write'));
+
+  this[kIsPerformingIO] = true;
   fs.write(this.fd, data, 0, data.length, this.pos, (er, bytes) => {
+    this[kIsPerformingIO] = false;
+    // Tell ._destroy() that it's safe to close the fd now.
+    if (this.destroyed) {
+      cb(er);
+      return this.emit(kIoDone, er);
+    }
+
     if (er) {
       if (this.autoClose) {
         this.destroy();
@@ -362,7 +390,8 @@ WriteStream.prototype._writev = function(data, cb) {
     });
   }
 
-  const self = this;
+  if (this.destroyed) return cb(new ERR_STREAM_DESTROYED('write'));
+
   const len = data.length;
   const chunks = new Array(len);
   let size = 0;
@@ -374,12 +403,22 @@ WriteStream.prototype._writev = function(data, cb) {
     size += chunk.length;
   }
 
-  fs.writev(this.fd, chunks, this.pos, function(er, bytes) {
+  this[kIsPerformingIO] = true;
+  fs.writev(this.fd, chunks, this.pos, (er, bytes) => {
+    this[kIsPerformingIO] = false;
+    // Tell ._destroy() that it's safe to close the fd now.
+    if (this.destroyed) {
+      cb(er);
+      return this.emit(kIoDone, er);
+    }
+
     if (er) {
-      self.destroy();
+      if (this.autoClose) {
+        this.destroy();
+      }
       return cb(er);
     }
-    self.bytesWritten += bytes;
+    this.bytesWritten += bytes;
     cb();
   });
 


### PR DESCRIPTION
Part of the flakiness in the
parallel/test-readline-async-iterators-destroy test comes from
fs streams starting `_read()` and `_destroy()` without waiting
for the other to finish, which can lead to the `fs.read()` call
resulting in `EBADF` if timing is bad.

Fix this by synchronizing write and read operations with `close()`.

Refs: https://github.com/nodejs/node/issues/30660

/cc @ronag

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
