### PR TITLE
net: noop destroyed socket

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -91,7 +91,8 @@ const {
     ERR_SERVER_ALREADY_LISTEN,
     ERR_SERVER_NOT_RUNNING,
     ERR_SOCKET_BAD_PORT,
-    ERR_SOCKET_CLOSED
+    ERR_SOCKET_CLOSED,
+    ERR_STREAM_DESTROYED
   },
   errnoException,
   exceptionWithHostPort,
@@ -571,7 +572,11 @@ Socket.prototype._read = function(n) {
 
   if (this.connecting || !this._handle) {
     debug('_read wait for connection');
-    this.once('connect', () => this._read(n));
+    this.once('connect', () => {
+      if (!this.destroyed) {
+        this._read(n)
+      }
+    });
   } else if (!this._handle.reading) {
     tryReadStart(this);
   }
@@ -757,7 +762,11 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
     this._pendingData = data;
     this._pendingEncoding = encoding;
     this.once('connect', function connect() {
-      this._writeGeneric(writev, data, encoding, cb);
+      if (this.destroyed) {
+        cb(new ERR_STREAM_DESTROYED('write'));
+      } else {
+        this._writeGeneric(writev, data, encoding, cb);
+      }
     });
     return;
   }


### PR DESCRIPTION
_write and _read can be called from 'connect' after
Socket.destroy() has been called. This should be a noop.

Refs: https://github.com/nodejs/node/pull/30837

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
