### PR TITLE
stream: error on multiple callback _destroy

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  ERR_MULTIPLE_CALLBACK
+} = require('internal/errors').codes;
+
 function needError(stream, err) {
   if (!err) {
     return false;
@@ -52,7 +56,18 @@ function destroy(err, cb) {
     r.destroyed = true;
   }
 
+  let called = false;
   this._destroy(err || null, (err) => {
+    if (called) {
+      err = new ERR_MULTIPLE_CALLBACK();
+      if (needError(this, err)) {
+        process.nextTick(emitErrorNT, this, err);
+      }
+      return;
+    } else {
+      called = true;
+    }
+
     const emitClose = (w && w.emitClose) || (r && r.emitClose);
     if (cb) {
       // Invoke callback before scheduling emitClose so that callback

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -198,3 +198,24 @@ const assert = require('assert');
   assert.strictEqual(read.destroyed, true);
   read.read();
 }
+
+{
+  const read = new Readable({
+    destroy: common.mustCall(function (err, callback) {
+      callback();
+      callback();
+    })
+  });
+  let ticked = false;
+  read.on('error', common.mustCall((err) => {
+    assert.strictEqual(ticked, true);
+    assert.strictEqual(err.code, 'ERR_MULTIPLE_CALLBACK');
+  }));
+  read.destroy(null, common.mustCall((err) => {
+    assert.strictEqual(read.destroyed, true);
+    assert.strictEqual(ticked, false);
+    assert.strictEqual(err, undefined);
+  }));
+  ticked = true;
+  assert.strictEqual(read.destroyed, true);
+}


### PR DESCRIPTION
Adds a sanity check ensuring the callback for _destroy is only invoked once.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
