### PR TITLE
test: mark tests as flaky

### DIFF
--- a/test/async-hooks/async-hooks.status
+++ b/test/async-hooks/async-hooks.status
@@ -5,6 +5,8 @@ prefix async-hooks
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
+# https://github.com/nodejs/node/issues/21425
+test-statwatcher: PASS,FLAKY
 
 [$system==win32]
 

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -11,14 +11,24 @@ test-fs-stat-bigint: PASS,FLAKY
 test-net-connect-options-port: PASS,FLAKY
 
 [$system==win32]
-# https://github.com/nodejs/node/issues/20750
-test-http2-pipe: PASS,FLAKY
-# https://github.com/nodejs/node/issues/23277
-test-worker-memory: PASS,FLAKY
+# https://github.com/nodejs/node/issues/30620
+test-child-process-fork-exec-path: PASS,FLAKY
 # https://github.com/nodejs/node/issues/20750
 test-http2-client-upload: PASS,FLAKY
 # https://github.com/nodejs/node/issues/20750
 test-http2-client-upload-reject: PASS,FLAKY
+# https://github.com/nodejs/node/issues/30847
+test-http2-compat-client-upload-reject: PASS,FLAKY
+# https://github.com/nodejs/node/issues/30845
+test-http2-multistream-destroy-on-read-tls: PASS,FLAKY
+# https://github.com/nodejs/node/issues/20750
+test-http2-pipe: PASS,FLAKY
+# https://github.com/nodejs/node/issues/30844
+test-module-loading-globalpaths: PASS,FLAKY
+# https://github.com/nodejs/node/issues/23277
+test-worker-memory: PASS,FLAKY
+# https://github.com/nodejs/node/issues/30846
+test-worker-message-port-transfer-terminate: PASS,FLAKY
 
 [$system==linux]
 

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -9,6 +9,8 @@ prefix sequential
 [$system==win32]
 # https://github.com/nodejs/node/issues/22327
 test-http2-large-file: PASS, FLAKY
+# https://github.com/nodejs/node/issues/26401
+test-worker-prof: PASS, FLAKY
 
 [$system==linux]
 


### PR DESCRIPTION
Mark a few tests that failed recently in master as flaky. Most of the tests are only marked flaky on Windows, except `test-statwatcher` that has failures documented for other platforms in its issue.

cc @nodejs/testing @nodejs/platform-windows 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
