### PR TITLE
lib: replace every Symbol.for by SymbolFor

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -25,6 +25,7 @@ const {
   ObjectKeys,
   ObjectSetPrototypeOf,
   Symbol,
+  SymbolFor,
 } = primordials;
 
 const net = require('net');
@@ -377,7 +378,7 @@ Server.prototype[EE.captureRejectionSymbol] = function(
       }
       break;
     default:
-      net.Server.prototype[Symbol.for('nodejs.rejection')]
+      net.Server.prototype[SymbolFor('nodejs.rejection')]
         .call(this, err, event, ...args);
   }
 };

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -26,6 +26,7 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   Symbol,
+  SymbolFor,
 } = primordials;
 
 const {
@@ -1294,7 +1295,7 @@ Server.prototype[EE.captureRejectionSymbol] = function(
       sock.destroy(err);
       break;
     default:
-      net.Server.prototype[Symbol.for('nodejs.rejection')]
+      net.Server.prototype[SymbolFor('nodejs.rejection')]
         .call(this, err, event, sock);
   }
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -33,8 +33,9 @@ const {
   ReflectApply,
   ReflectOwnKeys,
   Symbol,
+  SymbolFor,
 } = primordials;
-const kRejection = Symbol.for('nodejs.rejection');
+const kRejection = SymbolFor('nodejs.rejection');
 
 let spliceOne;
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -17,6 +17,7 @@ const {
   ObjectDefineProperty,
   ObjectKeys,
   Symbol,
+  SymbolFor,
 } = primordials;
 
 const messages = new Map();
@@ -199,7 +200,7 @@ class SystemError extends Error {
     return `${this.name} [${this.code}]: ${this.message}`;
   }
 
-  [Symbol.for('nodejs.util.inspect.custom')](recurseTimes, ctx) {
+  [SymbolFor('nodejs.util.inspect.custom')](recurseTimes, ctx) {
     return lazyInternalUtilInspect().inspect(this, {
       ...ctx,
       getters: true,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -12,6 +12,7 @@ const {
   ObjectSetPrototypeOf,
   ReflectConstruct,
   Symbol,
+  SymbolFor,
 } = primordials;
 
 const {
@@ -425,7 +426,7 @@ module.exports = {
 
   // Symbol used to provide a custom inspect function for an object as an
   // alternative to using 'inspect'
-  customInspectSymbol: Symbol.for('nodejs.util.inspect.custom'),
+  customInspectSymbol: SymbolFor('nodejs.util.inspect.custom'),
 
   // Used by the buffer module to capture an internal reference to the
   // default isEncoding implementation, just in case userland overrides it.

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -8,6 +8,7 @@ const {
   ObjectCreate,
   ObjectEntries,
   Symbol,
+  SymbolFor,
 } = primordials;
 
 const EventEmitter = require('events');
@@ -62,7 +63,7 @@ const kOnCouldNotSerializeErr = Symbol('kOnCouldNotSerializeErr');
 const kOnErrorMessage = Symbol('kOnErrorMessage');
 const kParentSideStdio = Symbol('kParentSideStdio');
 
-const SHARE_ENV = Symbol.for('nodejs.worker_threads.SHARE_ENV');
+const SHARE_ENV = SymbolFor('nodejs.worker_threads.SHARE_ENV');
 const debug = require('internal/util/debuglog').debuglog('worker');
 
 let cwdCounter;


### PR DESCRIPTION
Just replacing every Symbol.for by SymbolFor in the lib/* folder

And adding SymbolFor in the import
```js
const {
  // [...]
  SymbolFor,
} = primordials;
```

This task was given to me by @targos thanks again ❤️
I hope this new PR will help you :x