### PR TITLE
src: accept single argument in getProxyDetails

### DIFF
--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -93,7 +93,9 @@ static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
 
   Local<Proxy> proxy = args[0].As<Proxy>();
 
-  // The length check keeps this function backwards compatible.
+  // TODO(BridgeAR): Remove the length check as soon as we prohibit access to
+  // the util binding layer. It's accessed in the wild and some code would break
+  // in case the check is removed.
   if (args.Length() == 1 || args[1]->IsTrue()) {
     Local<Value> ret[] = {
       proxy->GetTarget(),

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -94,8 +94,8 @@ static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
   Local<Proxy> proxy = args[0].As<Proxy>();
 
   // TODO(BridgeAR): Remove the length check as soon as we prohibit access to
-  // the util binding layer. It's accessed in the wild and some code would break
-  // in case the check is removed.
+  // the util binding layer. It's accessed in the wild and `esm` would break in
+  // case the check is removed.
   if (args.Length() == 1 || args[1]->IsTrue()) {
     Local<Value> ret[] = {
       proxy->GetTarget(),

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -91,11 +91,10 @@ static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
   if (!args[0]->IsProxy())
     return;
 
-  CHECK(args[1]->IsBoolean());
-
   Local<Proxy> proxy = args[0].As<Proxy>();
 
-  if (args[1]->IsTrue()) {
+  // The length check keeps this function backwards compatible.
+  if (args.Length() == 1 || args[1]->IsTrue()) {
     Local<Value> ret[] = {
       proxy->GetTarget(),
       proxy->GetHandler()

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -50,6 +50,10 @@ let details = processUtil.getProxyDetails(proxyObj, true);
 assert.strictEqual(target, details[0]);
 assert.strictEqual(handler, details[1]);
 
+details = processUtil.getProxyDetails(proxyObj);
+assert.strictEqual(target, details[0]);
+assert.strictEqual(handler, details[1]);
+
 details = processUtil.getProxyDetails(proxyObj, false);
 assert.strictEqual(target, details);
 


### PR DESCRIPTION
This makes sure this function stays backwards compatible in case
it's accessed through the binding directly.

Refs: https://github.com/nodejs/node/pull/29947#issuecomment-562987888
Refs: https://github.com/nodejs/node/pull/30767

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
