### PR TITLE
lib: replace Symbol.iterator by SymbolIterator

### DIFF
--- a/lib/internal/streams/buffer_list.js
+++ b/lib/internal/streams/buffer_list.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {
-  Symbol,
+  SymbolIterator,
 } = primordials;
 
 const { Buffer } = require('buffer');
@@ -94,7 +94,7 @@ module.exports = class BufferList {
     return this.head.data;
   }
 
-  *[Symbol.iterator]() {
+  *[SymbolIterator]() {
     for (let p = this.head; p; p = p.next) {
       yield p.data;
     }

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -2,6 +2,7 @@
 
 const {
   Symbol,
+  SymbolIterator
 } = primordials;
 
 const {
@@ -12,8 +13,8 @@ function from(Readable, iterable, opts) {
   let iterator;
   if (iterable && iterable[Symbol.asyncIterator])
     iterator = iterable[Symbol.asyncIterator]();
-  else if (iterable && iterable[Symbol.iterator])
-    iterator = iterable[Symbol.iterator]();
+  else if (iterable && iterable[SymbolIterator])
+    iterator = iterable[SymbolIterator]();
   else
     throw new ERR_INVALID_ARG_TYPE('iterable', ['Iterable'], iterable);
 

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -12,6 +12,7 @@ const {
   ReflectGetOwnPropertyDescriptor,
   ReflectOwnKeys,
   Symbol,
+  SymbolIterator,
 } = primordials;
 
 const { inspect } = require('internal/util/inspect');
@@ -87,7 +88,7 @@ const kFormat = Symbol('format');
 
 // https://tc39.github.io/ecma262/#sec-%iteratorprototype%-object
 const IteratorPrototype = ObjectGetPrototypeOf(
-  ObjectGetPrototypeOf([][Symbol.iterator]())
+  ObjectGetPrototypeOf([][SymbolIterator]())
 );
 
 const unpairedSurrogateRe =
@@ -139,8 +140,8 @@ class URLSearchParams {
     if (init === null || init === undefined) {
       this[searchParams] = [];
     } else if (typeof init === 'object' || typeof init === 'function') {
-      const method = init[Symbol.iterator];
-      if (method === this[Symbol.iterator]) {
+      const method = init[SymbolIterator];
+      if (method === this[SymbolIterator]) {
         // While the spec does not have this branch, we can use it as a
         // shortcut to avoid having to go through the costly generic iterator.
         const childParams = init[searchParams];
@@ -156,7 +157,7 @@ class URLSearchParams {
         for (const pair of init) {
           if ((typeof pair !== 'object' && typeof pair !== 'function') ||
               pair === null ||
-              typeof pair[Symbol.iterator] !== 'function') {
+              typeof pair[SymbolIterator] !== 'function') {
             throw new ERR_INVALID_TUPLE('Each query pair', '[name, value]');
           }
           const convertedPair = [];
@@ -1149,7 +1150,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
 });
 
 // https://heycam.github.io/webidl/#es-iterable-entries
-ObjectDefineProperty(URLSearchParams.prototype, Symbol.iterator, {
+ObjectDefineProperty(URLSearchParams.prototype, SymbolIterator, {
   writable: true,
   configurable: true,
   value: URLSearchParams.prototype.entries


### PR DESCRIPTION
Just replaced every Symbol.iterator by SymbolIterator in the lib/* folder

For this, i just have added SymbolIterator in the import
```js
const {
  // [...]
  SymbolIterator,
} = primordials;
```

I hope this pull request will help you ! 😄 