### PR TITLE
stream: propagate errors from src streams in async iterator

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -109,6 +109,7 @@ function ReadableState(options, stream, isDuplex) {
   this.buffer = new BufferList();
   this.length = 0;
   this.pipes = [];
+  this.pipeSources = [];
   this.flowing = null;
   this.ended = false;
   this.endEmitted = false;
@@ -698,6 +699,9 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     }
   }
 
+  if (dest._readableState)
+    dest._readableState.pipeSources.push(this);
+
   state.pipes.push(dest);
   debug('pipe count=%d opts=%j', state.pipes.length, pipeOpts);
 
@@ -859,6 +863,16 @@ function pipeOnDrain(src, dest) {
   };
 }
 
+function unpipeSources(src, dest) {
+  const destState = dest._readableState;
+  if (!destState)
+    return;
+
+  const pipeSourcesIndex = destState.pipeSources.indexOf(src);
+  if (pipeSourcesIndex !== -1)
+    destState.pipeSources.splice(pipeSourcesIndex, 1);
+}
+
 
 Readable.prototype.unpipe = function(dest) {
   const state = this._readableState;
@@ -874,10 +888,13 @@ Readable.prototype.unpipe = function(dest) {
     state.pipes = [];
     state.flowing = false;
 
-    for (var i = 0; i < dests.length; i++)
+    for (let i = 0; i < dests.length; i++) {
+      unpipeSources(this, dests[i]);
       dests[i].emit('unpipe', this, { hasUnpiped: false });
+    }
     return this;
   }
+
 
   // Try to find the right one.
   const index = state.pipes.indexOf(dest);
@@ -887,6 +904,8 @@ Readable.prototype.unpipe = function(dest) {
   state.pipes.splice(index, 1);
   if (state.pipes.length === 0)
     state.flowing = false;
+
+  unpipeSources(this, dest);
 
   dest.emit('unpipe', this, unpipeInfo);
 

--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -54,6 +54,18 @@ function wrapForNext(lastPromise, iter) {
   };
 }
 
+function handlePipelineError(sources, current) {
+
+  if (!sources) return;
+
+  for (const stream of sources) {
+    const listener = (err) => current.emit('error', err);
+    stream.on('error', listener);
+    stream.on('unpipe', () => stream.off('error', listener));
+    handlePipelineError(stream._readableState.pipeSources, current);
+  }
+}
+
 const AsyncIteratorPrototype = ObjectGetPrototypeOf(
   ObjectGetPrototypeOf(async function* () {}).prototype);
 
@@ -168,6 +180,8 @@ const createReadableStreamAsyncIterator = (stream) => {
     },
   });
   iterator[kLastPromise] = null;
+
+  handlePipelineError(stream._readableState.pipeSources, stream);
 
   finished(stream, { writable: false }, (err) => {
     if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This should fix errors not being propagated when using async iterators on a piped stream if an error occured in one of the sources in the pipe chain/pipeline, which makes it very difficult & weird to handle errors.

Now piped streams keep track of the sources, so **only** when `Symbol.asyncIterator` is called on the destination stream, an `error` handle can be attached to each source & trigger an error on the  stream being iterated. 

The 3 added tests fail on master.

Fixes: #28194

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->