### PR TITLE
stream: make all streams error in a pipeline

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -43,15 +43,21 @@ function destroyer(stream, reading, writing, callback) {
 
     // request.destroy just do .end - .abort is what we want
     if (isRequest(stream)) return stream.abort();
-    if (typeof stream.destroy === 'function') return stream.destroy();
+    if (typeof stream.destroy === 'function') {
+      if (stream.req && stream._writableState === undefined) {
+        // This is a ClientRequest
+        // TODO(mcollina): backward compatible fix to avoid crashing.
+        // Possibly remove in a later semver-major change.
+        stream.req.on('error', noop);
+      }
+      return stream.destroy(err);
+    }
 
     callback(err || new ERR_STREAM_DESTROYED('pipe'));
   };
 }
 
-function call(fn) {
-  fn();
-}
+function noop() {}
 
 function pipe(from, to) {
   return from.pipe(to);
@@ -81,9 +87,15 @@ function pipeline(...streams) {
     const writing = i > 0;
     return destroyer(stream, reading, writing, function(err) {
       if (!error) error = err;
-      if (err) destroys.forEach(call);
+      if (err) {
+        for (const destroy of destroys) {
+          destroy(err);
+        }
+      }
       if (reading) return;
-      destroys.forEach(call);
+      for (const destroy of destroys) {
+        destroy();
+      }
       callback(error);
     });
   });

--- a/test/parallel/test-stream-pipeline-async-iterator.js
+++ b/test/parallel/test-stream-pipeline-async-iterator.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+const { Readable, PassThrough, pipeline } = require('stream');
+const assert = require('assert');
+
+const _err = new Error('kaboom');
+
+async function run() {
+  const source = new Readable({
+    read() {
+    }
+  });
+  source.push('hello');
+  source.push('world');
+
+  setImmediate(() => { source.destroy(_err); });
+
+  const iterator = pipeline(
+    source,
+    new PassThrough(),
+    () => {});
+
+  iterator.setEncoding('utf8');
+
+  for await (const k of iterator) {
+    assert.strictEqual(k, 'helloworld');
+  }
+}
+
+run().catch(common.mustCall((err) => assert.strictEqual(err, _err)));

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -119,6 +119,12 @@ const { promisify } = require('util');
   transform.on('close', common.mustCall());
   write.on('close', common.mustCall());
 
+  [read, transform, write].forEach((stream) => {
+    stream.on('error', common.mustCall((err) => {
+      assert.deepStrictEqual(err, new Error('kaboom'));
+    }));
+  });
+
   const dst = pipeline(read, transform, write, common.mustCall((err) => {
     assert.deepStrictEqual(err, new Error('kaboom'));
   }));


### PR DESCRIPTION
This changes makes all stream in a pipeline emit 'error' in
case of an abnormal termination of the pipeline. If the last stream
is currently being async iterated, this change will make the iteration
reject accordingly.

See: https://github.com/nodejs/node/pull/30861
Fixes: https://github.com/nodejs/node/issues/28194

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
