### PR TITLE
test: remove spawn option for tmpdir.refresh()

### DIFF
--- a/test/async-hooks/test-pipeconnectwrap.js
+++ b/test/async-hooks/test-pipeconnectwrap.js
@@ -8,8 +8,7 @@ const { checkInvocations } = require('./hook-checks');
 const tmpdir = require('../common/tmpdir');
 const net = require('net');
 
-// Spawning messes up `async_hooks` state.
-tmpdir.refresh({ spawn: false });
+tmpdir.refresh();
 
 const hooks = initHooks();
 hooks.enable();

--- a/test/async-hooks/test-statwatcher.js
+++ b/test/async-hooks/test-statwatcher.js
@@ -11,7 +11,7 @@ const path = require('path');
 if (!common.isMainThread)
   common.skip('Worker bootstrapping works differently -> different async IDs');
 
-tmpdir.refresh({ spawn: false });
+tmpdir.refresh();
 
 const file1 = path.join(tmpdir.path, 'file1');
 const file2 = path.join(tmpdir.path, 'file2');

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -898,11 +898,7 @@ The `tmpdir` module supports the use of a temporary directory for testing.
 
 The realpath of the testing temporary directory.
 
-### refresh(\[opts\])
-
-* `opts` [&lt;Object>][] (optional) Extra options.
-  * `spawn` [&lt;boolean>][] (default: `true`) Indicates that `refresh` is
-    allowed to optionally spawn a subprocess.
+### refresh()
 
 Deletes and recreates the testing temporary directory.
 

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -1,7 +1,6 @@
 /* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
-const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const { debuglog } = require('util');
@@ -9,7 +8,7 @@ const { isMainThread } = require('worker_threads');
 
 const debug = debuglog('test/tmpdir');
 
-function rimrafSync(pathname, { spawn = true } = {}) {
+function rimrafSync(pathname) {
   const st = (() => {
     try {
       return fs.lstatSync(pathname);
@@ -23,17 +22,6 @@ function rimrafSync(pathname, { spawn = true } = {}) {
   // If (!st) then nothing to do.
   if (!st) {
     return;
-  }
-
-  // On Windows first try to delegate rmdir to a shell.
-  if (spawn && process.platform === 'win32' && st.isDirectory()) {
-    try {
-      // Try `rmdir` first.
-      execSync(`rmdir /q /s ${pathname}`, { timeout: 1000 });
-    } catch (e) {
-      // Attempt failed. Log and carry on.
-      debug(e);
-    }
   }
 
   fs.rmdirSync(pathname, { recursive: true, maxRetries: 5 });
@@ -70,7 +58,7 @@ function onexit() {
     process.chdir(testRoot);
 
   try {
-    rimrafSync(tmpPath, { spawn: false });
+    rimrafSync(tmpPath);
   } catch (e) {
     console.error('Can\'t clean tmpdir:', tmpPath);
 


### PR DESCRIPTION
Recent fixes to fs.rmdir({recursive: true}) (hopefully) make the spawn
option in our internal test tool unnecessary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
