### PR TITLE
[WIP] Support requiring .mjs files

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1256,7 +1256,7 @@ Module._extensions['.mjs'] = function(module, filename) {
   const instantiated = promiseWait(job.instantiate());
   module.exports = instantiated.getNamespace();
   instantiated.evaluate(-1, false);
-}
+};
 
 function createRequireFromPath(filename) {
   // Allow a directory to be passed as the filename

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1248,13 +1248,18 @@ Module._extensions['.node'] = function(module, filename) {
 Module._extensions['.mjs'] = function(module, filename) {
   const ESMLoader = asyncESM.ESMLoader;
   const url = `${pathToFileURL(filename)}`;
-  const job = ESMLoader.getModuleJobWorker(
-    url,
-    'module'
-  );
-  const instantiated = promiseWait(job.instantiate()); // so long as builtin esm resolve is sync, this will complete sync (if the loader is extensible, an async loader will be have an observable effect here)
+  const job = ESMLoader.getModuleJobWorker(url, 'module');
+  /* So long as builtin esm resolve is sync, this will complete sync
+   * (if the loader is extensible, an async loader will be have an observable
+   * effect here)
+   */
+  const instantiated = promiseWait(job.instantiate());
   module.exports = instantiated.getNamespace();
-  promiseWait(instantiated.evaluate(-1, false)); // so long as the module doesn't contain TLA, this will be sync, otherwise it appears async
+  /**
+   * So long as the module doesn't contain TLA, this will be sync, otherwise it
+   * appears async
+   */
+  promiseWait(instantiated.evaluate(-1, false));
 }
 
 function createRequireFromPath(filename) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -86,6 +86,7 @@ const {
   ERR_REQUIRE_ESM
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
+const { promiseWait } = internalBinding('task_queue');
 const pendingDeprecation = getOptionValue('--pending-deprecation');
 
 module.exports = {
@@ -1038,36 +1039,34 @@ Module.prototype.load = function(filename) {
   this.paths = Module._nodeModulePaths(path.dirname(filename));
 
   const extension = findLongestRegisteredExtension(filename);
-  // allow .mjs to be overridden
-  if (filename.endsWith('.mjs') && !Module._extensions['.mjs']) {
-    throw new ERR_REQUIRE_ESM(filename);
-  }
   Module._extensions[extension](this, filename);
   this.loaded = true;
 
-  const ESMLoader = asyncESM.ESMLoader;
-  const url = `${pathToFileURL(filename)}`;
-  const module = ESMLoader.moduleMap.get(url);
-  // Create module entry at load time to snapshot exports correctly
-  const exports = this.exports;
-  // Called from cjs translator
-  if (module !== undefined && module.module !== undefined) {
-    if (module.module.getStatus() >= kInstantiated)
-      module.module.setExport('default', exports);
-  } else {
-    // Preemptively cache
-    // We use a function to defer promise creation for async hooks.
-    ESMLoader.moduleMap.set(
-      url,
-      // Module job creation will start promises.
-      // We make it a function to lazily trigger those promises
-      // for async hooks compatibility.
-      () => new ModuleJob(ESMLoader, url, () =>
-        new ModuleWrap(url, undefined, ['default'], function() {
-          this.setExport('default', exports);
-        })
-      , false /* isMain */, false /* inspectBrk */)
-    );
+  if (extension !== '.mjs') {
+    const ESMLoader = asyncESM.ESMLoader;
+    const url = `${pathToFileURL(filename)}`;
+    const module = ESMLoader.moduleMap.get(url);
+    // Create module entry at load time to snapshot exports correctly
+    const exports = this.exports;
+    // Called from cjs translator
+    if (module !== undefined && module.module !== undefined) {
+      if (module.module.getStatus() >= kInstantiated)
+        module.module.setExport('default', exports);
+    } else {
+      // Preemptively cache
+      // We use a function to defer promise creation for async hooks.
+      ESMLoader.moduleMap.set(
+        url,
+        // Module job creation will start promises.
+        // We make it a function to lazily trigger those promises
+        // for async hooks compatibility.
+        () => new ModuleJob(ESMLoader, url, () =>
+          new ModuleWrap(url, undefined, ['default'], function() {
+            this.setExport('default', exports);
+          })
+        , false /* isMain */, false /* inspectBrk */)
+      );
+    }
   }
 };
 
@@ -1245,6 +1244,18 @@ Module._extensions['.node'] = function(module, filename) {
   // Be aware this doesn't use `content`
   return process.dlopen(module, path.toNamespacedPath(filename));
 };
+
+Module._extensions['.mjs'] = function(module, filename) {
+  const ESMLoader = asyncESM.ESMLoader;
+  const url = `${pathToFileURL(filename)}`;
+  const job = ESMLoader.getModuleJobWorker(
+    url,
+    'module'
+  );
+  const instantiated = promiseWait(job.instantiate()); // so long as builtin esm resolve is sync, this will complete sync (if the loader is extensible, an async loader will be have an observable effect here)
+  module.exports = instantiated.getNamespace();
+  promiseWait(instantiated.evaluate(-1, false)); // so long as the module doesn't contain TLA, this will be sync, otherwise it appears async
+}
 
 function createRequireFromPath(filename) {
   // Allow a directory to be passed as the filename

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1255,11 +1255,7 @@ Module._extensions['.mjs'] = function(module, filename) {
    */
   const instantiated = promiseWait(job.instantiate());
   module.exports = instantiated.getNamespace();
-  /**
-   * So long as the module doesn't contain TLA, this will be sync, otherwise it
-   * appears async
-   */
-  promiseWait(instantiated.evaluate(-1, false));
+  instantiated.evaluate(-1, false);
 }
 
 function createRequireFromPath(filename) {

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -152,8 +152,7 @@ class Loader {
     }
   }
 
-  async getModuleJob(specifier, parentURL) {
-    const { url, format } = await this.resolve(specifier, parentURL);
+  getModuleJobWorker(url, format, parentURL) {
     let job = this.moduleMap.get(url);
     // CommonJS will set functions for lazy job evaluation.
     if (typeof job === 'function')
@@ -187,6 +186,11 @@ class Loader {
                         inspectBrk);
     this.moduleMap.set(url, job);
     return job;
+  }
+
+  async getModuleJob(specifier, parentURL) {
+    const { url, format } = await this.resolve(specifier, parentURL);
+    return this.getModuleJobWorker(url, format, parentURL);
   }
 }
 

--- a/test/parallel/test-require-mjs.js
+++ b/test/parallel/test-require-mjs.js
@@ -2,4 +2,4 @@
 require('../common');
 const assert = require('assert');
 
-assert.equal(require('../fixtures/es-modules/test-esm-ok.mjs').default, true);
+assert.strictEqual(require('../fixtures/es-modules/test-esm-ok.mjs').default, true);

--- a/test/parallel/test-require-mjs.js
+++ b/test/parallel/test-require-mjs.js
@@ -2,10 +2,4 @@
 require('../common');
 const assert = require('assert');
 
-assert.throws(
-  () => require('../fixtures/es-modules/test-esm-ok.mjs'),
-  {
-    message: /Must use import to load ES Module/,
-    code: 'ERR_REQUIRE_ESM'
-  }
-);
+assert.equal(require('../fixtures/es-modules/test-esm-ok.mjs').default, true);


### PR DESCRIPTION
This implements the ability to use `require` on `.mjs` files, loaded via the `esm` loader, using the same tradeoffs that [top level await](https://github.com/tc39/proposal-top-level-await) makes in `esm` itself. 

What this means: If possible, all execution and evaluation is done _synchronously_, via immediately unwrapping the execution's component promises. This means that any and all existing code should have no observable change in behavior, as there exist no asynchronous modules as of yet. The catch is that once a module which requires asynchronous execution is used, it must yield to the event loop to perform that execution, which, in turn, can allow other code to execute before the continuation after the async action, which is observable to callers of the now asynchronous module. If this matters to your callers, this means making your module execution asynchronous could be considered a breaking change to your library, however in practice, it will not matter for most callers. Moreover, as the ecosystem exists today, there are _zero_ asynchronously executing modules, and so until there are, there are no downsides to this approach _at all_, as no execution is changed from what one would expect today (excepting, ofc, that it's no longer an error to `require("./foo.mjs")`.

As of right now, this is missing:
* Support for `"type": "module"` in the cjs loader. (where did that go? I thought we already had something that did that internally - `getPackageType` or something?)
* New tests (I have no idea how to write tests for `node`, help appreciated)
* Speculative integration tests for https://github.com/nodejs/node/pull/30370 - the code is already written assuming `ModuleWrap.evaluate` may eventually return a promise.