### PR TITLE
doc: fix description of N-API exception handlers

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1057,8 +1057,6 @@ napi_status napi_get_and_clear_last_exception(napi_env env,
 
 Returns `napi_ok` if the API succeeded.
 
-This API returns true if an exception is pending.
-
 This API can be called even if there is a pending JavaScript exception.
 
 #### napi_is_exception_pending
@@ -1075,8 +1073,6 @@ napi_status napi_is_exception_pending(napi_env env, bool* result);
 * `[out] result`: Boolean value that is set to true if an exception is pending.
 
 Returns `napi_ok` if the API succeeded.
-
-This API returns true if an exception is pending.
 
 This API can be called even if there is a pending JavaScript exception.
 


### PR DESCRIPTION
The return value is not a boolean and even if interpreted as one, it does not indicate whether an exception is pending.

For `napi_is_exception_pending`, the description of the `result` parameter already explains how to check whether an exception is pending.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
