### PR TITLE
lib: replace Symbol.toPrimitive to SymbolToPrimitive primordials

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -35,6 +35,7 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   Symbol,
+  SymbolToPrimitive,
 } = primordials;
 
 const {
@@ -297,8 +298,8 @@ Buffer.from = function from(value, encodingOrOffset, length) {
     if (b)
       return b;
 
-    if (typeof value[Symbol.toPrimitive] === 'function') {
-      return Buffer.from(value[Symbol.toPrimitive]('string'),
+    if (typeof value[SymbolToPrimitive] === 'function') {
+      return Buffer.from(value[SymbolToPrimitive]('string'),
                          encodingOrOffset,
                          length);
     }

--- a/lib/os.js
+++ b/lib/os.js
@@ -23,7 +23,7 @@
 
 const {
   ObjectDefineProperties,
-  Symbol,
+  SymbolToPrimitive,
 } = primordials;
 
 const { safeGetenv } = internalBinding('credentials');
@@ -73,13 +73,13 @@ const getInterfaceAddresses = getCheckedFunction(_getInterfaceAddresses);
 const getOSRelease = getCheckedFunction(_getOSRelease);
 const getOSType = getCheckedFunction(_getOSType);
 
-getFreeMem[Symbol.toPrimitive] = () => getFreeMem();
-getHostname[Symbol.toPrimitive] = () => getHostname();
-getHomeDirectory[Symbol.toPrimitive] = () => getHomeDirectory();
-getOSRelease[Symbol.toPrimitive] = () => getOSRelease();
-getOSType[Symbol.toPrimitive] = () => getOSType();
-getTotalMem[Symbol.toPrimitive] = () => getTotalMem();
-getUptime[Symbol.toPrimitive] = () => getUptime();
+getFreeMem[SymbolToPrimitive] = () => getFreeMem();
+getHostname[SymbolToPrimitive] = () => getHostname();
+getHomeDirectory[SymbolToPrimitive] = () => getHomeDirectory();
+getOSRelease[SymbolToPrimitive] = () => getOSRelease();
+getOSType[SymbolToPrimitive] = () => getOSType();
+getTotalMem[SymbolToPrimitive] = () => getTotalMem();
+getUptime[SymbolToPrimitive] = () => getUptime();
 
 const kEndianness = isBigEndian ? 'BE' : 'LE';
 
@@ -117,12 +117,12 @@ function cpus() {
 function arch() {
   return process.arch;
 }
-arch[Symbol.toPrimitive] = () => process.arch;
+arch[SymbolToPrimitive] = () => process.arch;
 
 function platform() {
   return process.platform;
 }
-platform[Symbol.toPrimitive] = () => process.platform;
+platform[SymbolToPrimitive] = () => process.platform;
 
 function tmpdir() {
   var path;
@@ -143,12 +143,12 @@ function tmpdir() {
 
   return path;
 }
-tmpdir[Symbol.toPrimitive] = () => tmpdir();
+tmpdir[SymbolToPrimitive] = () => tmpdir();
 
 function endianness() {
   return kEndianness;
 }
-endianness[Symbol.toPrimitive] = () => kEndianness;
+endianness[SymbolToPrimitive] = () => kEndianness;
 
 // Returns the number of ones in the binary representation of the decimal
 // number.


### PR DESCRIPTION
Just replaced every Symbol.toPrimitive by SymbolToPrimitive in the lib/* folder
For this, i just have added SymbolToPrimitive in the import

```js
const {
  SymbolToPrimitive,
} = primordials;
```

I hope this pull request will help you ! :P