### PR TITLE
lib: update Symbol.toStringTag by SymbolToStringTag primordial

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -8,6 +8,7 @@ const {
   ObjectDefineProperties,
   ObjectGetOwnPropertyDescriptors,
   Symbol,
+  SymbolToStringTag,
 } = primordials;
 
 const {
@@ -358,7 +359,7 @@ ObjectDefineProperties(
     'encode': { enumerable: true },
     'encodeInto': { enumerable: true },
     'encoding': { enumerable: true },
-    [Symbol.toStringTag]: {
+    [SymbolToStringTag]: {
       configurable: true,
       value: 'TextEncoder'
     } });
@@ -554,7 +555,7 @@ function makeTextDecoderJS() {
   ObjectDefineProperties(TextDecoder.prototype, {
     decode: { enumerable: true },
     [inspect]: { enumerable: false },
-    [Symbol.toStringTag]: {
+    [SymbolToStringTag]: {
       configurable: true,
       value: 'TextDecoder'
     }

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -13,6 +13,7 @@ const {
   ReflectOwnKeys,
   Symbol,
   SymbolIterator,
+  SymbolToStringTag,
 } = primordials;
 
 const { inspect } = require('internal/util/inspect');
@@ -431,7 +432,7 @@ ObjectDefineProperties(URL.prototype, {
       return ret;
     }
   },
-  [Symbol.toStringTag]: {
+  [SymbolToStringTag]: {
     configurable: true,
     value: 'URL'
   },
@@ -859,7 +860,7 @@ function serializeParams(array) {
 // Mainly to mitigate func-name-matching ESLint rule
 function defineIDLClass(proto, classStr, obj) {
   // https://heycam.github.io/webidl/#dfn-class-string
-  ObjectDefineProperty(proto, Symbol.toStringTag, {
+  ObjectDefineProperty(proto, SymbolToStringTag, {
     writable: false,
     enumerable: false,
     configurable: true,
@@ -1244,7 +1245,7 @@ defineIDLClass(URLSearchParamsIteratorPrototype, 'URLSearchParams Iterator', {
     } else {
       outputStr = ` ${outputStrs.join(', ')}`;
     }
-    return `${this[Symbol.toStringTag]} {${outputStr} }`;
+    return `${this[SymbolToStringTag]} {${outputStr} }`;
   }
 });
 

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -15,8 +15,8 @@ const {
   ObjectPrototypePropertyIsEnumerable,
   ObjectPrototypeToString,
   StringPrototypeValueOf,
-  Symbol,
   SymbolPrototypeValueOf,
+  SymbolToStringTag,
 } = primordials;
 
 const { compare } = internalBinding('buffer');
@@ -120,7 +120,7 @@ function isEqualBoxedPrimitive(val1, val2) {
 
 function isIdenticalTypedArrayType(a, b) {
   // Fast path to reduce type checks in the common case.
-  const check = types[`is${a[Symbol.toStringTag]}`];
+  const check = types[`is${a[SymbolToStringTag]}`];
   if (check !== undefined && check(a)) {
     return check(b);
   }


### PR DESCRIPTION
This time i just replaced every Symboll.toStringTag by SymbolToStringTag in the lig/* folder.
I had to import SymbolToStringTag like that

```js
const {
  SymbolToStringTag,
} = primordials;
```

I hope this pull request will help you ! :P