### PR TITLE
stream: do not chunk strings and Buffer in Readable.from.

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1642,6 +1642,10 @@ readable.on('data', (chunk) => {
 });
 ```
 
+Calling `Readable.from(string)` or `Readable.from(buffer)` will not have
+the strings or buffers be iterated to match the other streams semantics
+for performance reasons.
+
 ## API for Stream Implementers
 
 <!--type=misc-->

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -4,6 +4,7 @@ const {
   Symbol,
   SymbolIterator
 } = primordials;
+const { Buffer } = require('buffer');
 
 const {
   ERR_INVALID_ARG_TYPE
@@ -11,6 +12,17 @@ const {
 
 function from(Readable, iterable, opts) {
   let iterator;
+  if (typeof iterable === 'string' || iterable instanceof Buffer) {
+    return new Readable({
+      objectMode: true,
+      ...opts,
+      read() {
+        this.push(iterable);
+        this.push(null);
+      }
+    });
+  }
+
   if (iterable && iterable[Symbol.asyncIterator])
     iterator = iterable[Symbol.asyncIterator]();
   else if (iterable && iterable[SymbolIterator])

--- a/test/parallel/test-readable-from.js
+++ b/test/parallel/test-readable-from.js
@@ -56,10 +56,20 @@ async function toReadablePromises() {
 async function toReadableString() {
   const stream = Readable.from('abc');
 
-  const expected = ['a', 'b', 'c'];
+  const expected = ['abc'];
 
   for await (const chunk of stream) {
     strictEqual(chunk, expected.shift());
+  }
+}
+
+async function toReadableBuffer() {
+  const stream = Readable.from(Buffer.from('abc'));
+
+  const expected = ['abc'];
+
+  for await (const chunk of stream) {
+    strictEqual(chunk.toString(), expected.shift());
   }
 }
 
@@ -154,6 +164,7 @@ Promise.all([
   toReadableSyncIterator(),
   toReadablePromises(),
   toReadableString(),
+  toReadableBuffer(),
   toReadableOnData(),
   toReadableOnDataNonObject(),
   destroysTheStreamWhenThrowing(),


### PR DESCRIPTION
This PR makes `Readable.from()` to **not** iterate over strings and buffers to avoid unnecessary overhead.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
