### PR TITLE
test: make test-os-checked-function work without test harness

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -23,17 +23,20 @@
 /* eslint-disable node-core/crypto-check */
 'use strict';
 const process = global.process;  // Some tests tamper with the process global.
-const path = require('path');
-const fs = require('fs');
+
 const assert = require('assert');
-const os = require('os');
 const { exec, execSync, spawnSync } = require('child_process');
+const fs = require('fs');
+// Do not require 'os' until needed so that test-os-checked-fucnction can
+// monkey patch it. If 'os' is required here, that test will fail.
+const path = require('path');
 const util = require('util');
+const { isMainThread } = require('worker_threads');
+
 const tmpdir = require('./tmpdir');
 const bits = ['arm64', 'mips', 'mipsel', 'ppc64', 's390x', 'x64']
   .includes(process.arch) ? 64 : 32;
 const hasIntl = !!process.config.variables.v8_enable_i18n_support;
-const { isMainThread } = require('worker_threads');
 
 // Some tests assume a umask of 0o022 so set that up front. Tests that need a
 // different umask will set it themselves.
@@ -102,22 +105,11 @@ if (process.argv.length === 2 &&
 
 const isWindows = process.platform === 'win32';
 const isAIX = process.platform === 'aix';
-// On IBMi, process.platform and os.platform() both return 'aix',
-// It is not enough to differentiate between IBMi and real AIX system.
-const isIBMi = os.type() === 'OS400';
-const isLinuxPPCBE = (process.platform === 'linux') &&
-                     (process.arch === 'ppc64') &&
-                     (os.endianness() === 'BE');
 const isSunOS = process.platform === 'sunos';
 const isFreeBSD = process.platform === 'freebsd';
 const isOpenBSD = process.platform === 'openbsd';
 const isLinux = process.platform === 'linux';
 const isOSX = process.platform === 'darwin';
-
-const enoughTestMem = os.totalmem() > 0x70000000; /* 1.75 Gb */
-const cpus = os.cpus();
-const enoughTestCpu = Array.isArray(cpus) &&
-                      (cpus.length > 1 || cpus[0].speed > 999);
 
 const rootDir = isWindows ? 'c:\\' : '/';
 
@@ -196,15 +188,6 @@ const PIPE = (() => {
   const pipePrefix = isWindows ? '\\\\.\\pipe\\' : localRelative;
   const pipeName = `node-test.${process.pid}.sock`;
   return path.join(pipePrefix, pipeName);
-})();
-
-const hasIPv6 = (() => {
-  const iFaces = os.networkInterfaces();
-  const re = isWindows ? /Loopback Pseudo-Interface/ : /lo/;
-  return Object.keys(iFaces).some((name) => {
-    return re.test(name) &&
-           iFaces[name].some(({ family }) => family === 'IPv6');
-  });
 })();
 
 /*
@@ -742,8 +725,6 @@ module.exports = {
   childShouldThrowAndAbort,
   createZeroFilledFile,
   disableCrashOnUnhandledRejection,
-  enoughTestCpu,
-  enoughTestMem,
   expectsError,
   expectsInternalAssertion,
   expectWarning,
@@ -753,14 +734,11 @@ module.exports = {
   getTTYfd,
   hasIntl,
   hasCrypto,
-  hasIPv6,
   hasMultiLocalhost,
   isAIX,
   isAlive,
   isFreeBSD,
-  isIBMi,
   isLinux,
-  isLinuxPPCBE,
   isMainThread,
   isOpenBSD,
   isOSX,
@@ -784,10 +762,26 @@ module.exports = {
   skipIfReportDisabled,
   skipIfWorker,
 
-  get localhostIPv6() { return '::1'; },
+  get enoughTestCPU() {
+    const cpus = require('os').cpus();
+    return Array.isArray(cpus) && (cpus.length > 1 || cpus[0].speed > 999);
+  },
+
+  get enoughTestMeme() {
+    return require('os').totalmem() > 0x70000000; /* 1.75 Gb */
+  },
 
   get hasFipsCrypto() {
     return hasCrypto && require('crypto').getFips();
+  },
+
+  get hasIPv6() {
+    const iFaces = require('os').networkInterfaces();
+    const re = isWindows ? /Loopback Pseudo-Interface/ : /lo/;
+    return Object.keys(iFaces).some((name) => {
+      return re.test(name) &&
+             iFaces[name].some(({ family }) => family === 'IPv6');
+    });
   },
 
   get inFreeBSDJail() {
@@ -800,6 +794,17 @@ module.exports = {
       inFreeBSDJail = false;
     }
     return inFreeBSDJail;
+  },
+
+  // On IBMi, process.platform and os.platform() both return 'aix',
+  // It is not enough to differentiate between IBMi and real AIX system.
+  get isIBMi() {
+    return require('os').type() === 'OS400';
+  },
+
+  get isLinuxPPCBE() {
+    return (process.platform === 'linux') && (process.arch === 'ppc64') &&
+           (require('os').endianness() === 'BE');
   },
 
   get localhostIPv4() {
@@ -822,6 +827,8 @@ module.exports = {
 
     return localhostIPv4;
   },
+
+  get localhostIPv6() { return '::1'; },
 
   // opensslCli defined lazily to reduce overhead of spawnSync
   get opensslCli() {

--- a/test/parallel/test-os-checked-function.js
+++ b/test/parallel/test-os-checked-function.js
@@ -1,7 +1,7 @@
-/* eslint-disable node-core/require-common-first */
 'use strict';
 // Flags: --expose_internals
 
+const common = require('../common');
 const { internalBinding } = require('internal/test/binding');
 
 // Monkey patch the os binding before requiring any other modules, including
@@ -12,7 +12,6 @@ internalBinding('os').getHomeDirectory = function(ctx) {
   ctx.message = 'baz';
 };
 
-const common = require('../common');
 const os = require('os');
 
 common.expectsError(os.homedir, {


### PR DESCRIPTION
First commit:

    test: delay loading 'os' in test/common module
    
    There is a test that doesn't load the common module initially because it
    needs to monkey-patch the 'os' module. I think it would be a good idea
    to minimize the side-effects of loading common anyway, so let's defer
    loading 'os' unless/until it's actually needed.


Second commit:


    test: make test-os-checked-function work without test harness
    
    Most tests in `test/parallel` work when invoked with `node` rather than
    `tools/test.py` but not test-os-checked-function because it doesn't load
    the `common` module initially, which means it won't get re-spawned with
    the necessary flags (in the Flags: comment, in this case
    --expose_internals). Now that common delays loading 'os' until it needs
    to load it, this test can load the common module and it will work from
    the command line without the test harness. Additionally, we now can
    remove a comment disabling a lint rule.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
