### PR TITLE
crypto: cast oaepLabel to unsigned char*

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5513,8 +5513,9 @@ bool PublicKeyCipher::Cipher(Environment* env,
     // OpenSSL takes ownership of the label, so we need to create a copy.
     void* label = OPENSSL_memdup(oaep_label, oaep_label_len);
     CHECK_NOT_NULL(label);
-    if (0 >= EVP_PKEY_CTX_set0_rsa_oaep_label(ctx.get(), label,
-                                              oaep_label_len)) {
+    if (0 >= EVP_PKEY_CTX_set0_rsa_oaep_label(ctx.get(),
+                reinterpret_cast<unsigned char*>(label),
+                                      oaep_label_len)) {
       OPENSSL_free(label);
       return false;
     }


### PR DESCRIPTION
This PR fixes an incompatibility between BoringSSL and OpenSSL in compilation through Electron. 

OpenSSL has the signature
```
int EVP_PKEY_CTX_set0_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *label, int len);
```
whereas BoringSSL has:
```
int EVP_PKEY_CTX_set0_rsa_oaep_label(EVP_PKEY_CTX *ctx, uint8_t *label, size_t label_len);
```

Changing this in BoringSSL would not have the correct effect, since label (as returned by `OpenSSL_memdup`) is a `void*` & C++ doesn't cast from `void*` to `T*` without an explicit cast. OpenSSL has a lot of functions/macros that aren't typesafe which means we don't get the usual C++ type-checking and so this fails to compile without this patch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
