### PR TITLE
build: ignore report files generated during tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ _UpgradeReport_Files/
 /*.tap
 /*.xml
 /node_trace.*.log
+/report.*.json
 # coverage related
 /gcovr
 /build


### PR DESCRIPTION
At least on windows I get files like report.20191212.212411.11544.0.001.json
in the root of my repo but I expect they shouldn't be committed.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
