### PR TITLE
doc: clarify expectations for PR commit messages

### DIFF
--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -192,9 +192,6 @@ One of the existing contributors will help get things situated and the
 contributor landing the Pull Request will ensure that everything follows
 the project guidelines.
 
-See [core-validate-commit](https://github.com/nodejs/core-validate-commit) -
-A utility that ensures commits follow the commit formatting guidelines.
-
 ### Step 5: Rebase
 
 As a best practice, once you have committed your changes, it is a good idea


### PR DESCRIPTION
Prior to this commit, new contributors were suggested
to use a utility to validate commit messages. Although
not inaccurate, this utility produces misleading results.

* Remove reference to `core-validate-commit`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

---

The last line in section [Step 4: Commit of the Contributing Pull Requests guide](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#step-4-commit) suggests using a utility to validate commit messages, namely [`core-validate-commit`](https://www.npmjs.com/package/core-validate-commit). The following is what results when running the tool against a commit that has followed the guide (and even went too far by adding its PR-URL).

![disambig](https://user-images.githubusercontent.com/17770407/70754145-72201000-1d04-11ea-8780-b8ea18f928bd.png)

As can be seen in the snip above, the utility produces misleading results that may inadvertently lead new contributors to think that they, themselves are required to include this metadata in their PR's commit message when in reality, omitting this metadata will not cause the CI checks to fail. See how this leads to the confusion experienced here: https://github.com/nodejs/node/pull/30216#issuecomment-565170460.

Although this PR is removing reference to this tool entirely from this document, I hope that it leads to a constructive discussion about a preferred way of making this clarification (if it is deemed that this is not ideal).

/cc @MylesBorins
