### PR TITLE
test: avoid leftover report file

### DIFF
--- a/test/parallel/test-windows-failed-heap-allocation.js
+++ b/test/parallel/test-windows-failed-heap-allocation.js
@@ -14,9 +14,13 @@ if (process.argv[2] === 'heapBomb') {
   fn(2);
 }
 
+// Run child in tmpdir to avoid report files in repo
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
 // --max-old-space-size=3 is the min 'old space' in V8, explodes fast
 const cmd = `"${process.execPath}" --max-old-space-size=3 "${__filename}"`;
-exec(`${cmd} heapBomb`, common.mustCall((err) => {
+exec(`${cmd} heapBomb`, { cwd: tmpdir.path }, common.mustCall((err) => {
   const msg = `Wrong exit code of ${err.code}! Expected 134 for abort`;
   // Note: common.nodeProcessAborted() is not asserted here because it
   // returns true on 134 as well as 0xC0000005 (V8's base::OS::Abort)


### PR DESCRIPTION
test-windows-failed-heap-allocation forces a out of mem crash resulting
in a report file. To avoid a leftover in repo the child is started in a
tmp folder like in test-report-fatal-error.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
