### PR TITLE
util: add colors to debuglog()

### DIFF
--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { format } = require('internal/util/inspect');
+const { inspect, format, formatWithOptions } = require('internal/util/inspect');
 
 // `debugs` is deliberately initialized to undefined so any call to
 // debuglog() before initializeDebugEnv() is called will throw.
@@ -38,8 +38,10 @@ function debuglogImpl(set) {
       const pid = process.pid;
       emitWarningIfNeeded(set);
       debugs[set] = function debug(...args) {
-        const msg = format(...args);
-        process.stderr.write(format('%s %d: %s\n', set, pid, msg));
+        const colors = process.stderr.hasColors && process.stderr.hasColors();
+        const msg = formatWithOptions({ colors }, ...args);
+        const coloredPID = inspect(pid, { colors });
+        process.stderr.write(format('%s %s: %s\n', set, coloredPID, msg));
       };
     } else {
       debugs[set] = null;


### PR DESCRIPTION
This adds colors to the passed through arguments in case the stream
supports colors. The PID will also be highlighted.

This is especially helpful in case we print errors: core stack frames are going to be greyed out in that case. It should also improve highlighting objects.

![image](https://user-images.githubusercontent.com/8822573/71198438-14576f00-2294-11ea-80b3-32811dbd6d1a.png)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
