### PR TITLE
build,win: fix goto exit in vcbuild

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -718,6 +718,7 @@ echo   vcbuild.bat no-cctest                : skip building cctest.exe
 goto exit
 
 :exit
+if %errorlevel% neq 0 exit /b %errorlevel%
 exit /b %exit_code%
 
 


### PR DESCRIPTION
In https://github.com/nodejs/node/commit/3b484edce3736cbcba26be1eec512df5282ca5bf I changed `vcbuild.bat` to exit with an error if `cctest` fails.

While in many places `vcbuild.bat` exits immediately with `exit /b 1` if an error is found, I missed that in other places it jumps to `:exit` and expects it exit with error. My change broke this, and this PR should fix it.

This should land in all LTS branches.

cc @nodejs/platform-windows 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
