### PR TITLE
events: allow monitoring error events

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -155,6 +155,18 @@ myEmitter.emit('error', new Error('whoops!'));
 // Prints: whoops! there was an error
 ```
 
+It is possible to monitor `'error'` events without consuming the emitted error
+by installing a listener using the symbol `errorMonitorSymbol`.
+
+```js
+const myEmitter = new MyEmitter();
+myEmitter.on(errorMonitorSymbol, (err) => {
+  MyMonitoringTool.log(err);
+});
+myEmitter.emit('error', new Error('whoops!'));
+// Still throws and crashes Node.js
+```
+
 ## Capture Rejections of Promises
 
 > Stability: 1 - captureRejections is experimental.
@@ -347,6 +359,19 @@ have the additional `emitter`, `type` and `count` properties, referring to
 the event emitter instance, the event’s name and the number of attached
 listeners, respectively.
 Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+### EventEmitter.errorMonitorSymbol
+<!-- YAML
+added: REPLACEME
+-->
+
+This symbol shall be used to install a listener only monitoring `'error'`
+events. Listeners installed using this symbol are called before the regular
+`'error'` listeners are called.
+
+Installing a listener using this symbol does not change the behavior once a
+`'error'` event is emitted, therefore the process will still crash if no
+regular `'error'` listener is installed.
 
 ### emitter.addListener(eventName, listener)
 <!-- YAML

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -160,7 +160,7 @@ by installing a listener using the symbol `errorMonitor`.
 
 ```js
 const myEmitter = new MyEmitter();
-myEmitter.on(errorMonitor, (err) => {
+myEmitter.on(EventEmitter.errorMonitor, (err) => {
   MyMonitoringTool.log(err);
 });
 myEmitter.emit('error', new Error('whoops!'));
@@ -365,11 +365,11 @@ Its `name` property is set to `'MaxListenersExceededWarning'`.
 added: REPLACEME
 -->
 
-This symbol shall be used to install a listener only monitoring `'error'`
+This symbol shall be used to install a listener for only monitoring `'error'`
 events. Listeners installed using this symbol are called before the regular
 `'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once a
+Installing a listener using this symbol does not change the behavior once an
 `'error'` event is emitted, therefore the process will still crash if no
 regular `'error'` listener is installed.
 

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -156,11 +156,11 @@ myEmitter.emit('error', new Error('whoops!'));
 ```
 
 It is possible to monitor `'error'` events without consuming the emitted error
-by installing a listener using the symbol `errorMonitorSymbol`.
+by installing a listener using the symbol `errorMonitor`.
 
 ```js
 const myEmitter = new MyEmitter();
-myEmitter.on(errorMonitorSymbol, (err) => {
+myEmitter.on(errorMonitor, (err) => {
   MyMonitoringTool.log(err);
 });
 myEmitter.emit('error', new Error('whoops!'));
@@ -360,7 +360,7 @@ the event emitter instance, the event’s name and the number of attached
 listeners, respectively.
 Its `name` property is set to `'MaxListenersExceededWarning'`.
 
-### EventEmitter.errorMonitorSymbol
+### EventEmitter.errorMonitor
 <!-- YAML
 added: REPLACEME
 -->

--- a/lib/events.js
+++ b/lib/events.js
@@ -54,6 +54,7 @@ const {
 } = require('internal/util/inspect');
 
 const kCapture = Symbol('kCapture');
+const kErrorMonitorSymbol = Symbol('events.error-monitor');
 
 function EventEmitter(opts) {
   EventEmitter.init.call(this, opts);
@@ -79,6 +80,13 @@ ObjectDefineProperty(EventEmitter, 'captureRejections', {
 
     EventEmitter.prototype[kCapture] = value;
   },
+  enumerable: true
+});
+
+ObjectDefineProperty(EventEmitter, 'errorMonitorSymbol', {
+  value: kErrorMonitorSymbol,
+  writable: false,
+  configurable: true,
   enumerable: true
 });
 
@@ -255,9 +263,11 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
   let doError = (type === 'error');
 
   const events = this._events;
-  if (events !== undefined)
+  if (events !== undefined) {
+    if (doError && events[kErrorMonitorSymbol] !== undefined)
+      this.emit(kErrorMonitorSymbol, ...args);
     doError = (doError && events.error === undefined);
-  else if (!doError)
+  } else if (!doError)
     return false;
 
   // If there is no 'error' event listener then throw.

--- a/lib/events.js
+++ b/lib/events.js
@@ -54,7 +54,7 @@ const {
 } = require('internal/util/inspect');
 
 const kCapture = Symbol('kCapture');
-const kErrorMonitorSymbol = Symbol('events.error-monitor');
+const kErrorMonitor = Symbol('events.errorMonitor');
 
 function EventEmitter(opts) {
   EventEmitter.init.call(this, opts);
@@ -83,8 +83,8 @@ ObjectDefineProperty(EventEmitter, 'captureRejections', {
   enumerable: true
 });
 
-ObjectDefineProperty(EventEmitter, 'errorMonitorSymbol', {
-  value: kErrorMonitorSymbol,
+ObjectDefineProperty(EventEmitter, 'errorMonitor', {
+  value: kErrorMonitor,
   writable: false,
   configurable: true,
   enumerable: true
@@ -264,8 +264,8 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
 
   const events = this._events;
   if (events !== undefined) {
-    if (doError && events[kErrorMonitorSymbol] !== undefined)
-      this.emit(kErrorMonitorSymbol, ...args);
+    if (doError && events[kErrorMonitor] !== undefined)
+      this.emit(kErrorMonitor, ...args);
     doError = (doError && events.error === undefined);
   } else if (!doError)
     return false;

--- a/test/parallel/test-event-emitter-error-monitor.js
+++ b/test/parallel/test-event-emitter-error-monitor.js
@@ -7,7 +7,7 @@ const EE = new EventEmitter();
 const theErr = new Error('MyError');
 
 EE.on(
-  EventEmitter.errorMonitorSymbol,
+  EventEmitter.errorMonitor,
   common.mustCall((e) => assert.strictEqual(e, theErr), 3)
 );
 

--- a/test/parallel/test-event-emitter-error-monitor.js
+++ b/test/parallel/test-event-emitter-error-monitor.js
@@ -8,7 +8,9 @@ const theErr = new Error('MyError');
 
 EE.on(
   EventEmitter.errorMonitor,
-  common.mustCall((e) => assert.strictEqual(e, theErr), 3)
+  common.mustCall(function onErrorMonitor(e) {
+    assert.strictEqual(e, theErr);
+  }, 3)
 );
 
 // Verify with no error listener
@@ -23,14 +25,7 @@ EE.emit('error', theErr);
 
 // Verify it works with once
 process.nextTick(() => EE.emit('error', theErr));
-async function testOnce() {
-  try {
-    await EventEmitter.once(EE, 'notTriggered');
-  } catch (e) {
-    assert.strictEqual(e, theErr);
-  }
-}
-testOnce();
+assert.rejects(EventEmitter.once(EE, 'notTriggered'), theErr);
 
 // Only error events trigger error monitor
 EE.on('aEvent', common.mustCall());

--- a/test/parallel/test-event-emitter-error-monitor.js
+++ b/test/parallel/test-event-emitter-error-monitor.js
@@ -1,0 +1,37 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const EventEmitter = require('events');
+
+const EE = new EventEmitter();
+const theErr = new Error('MyError');
+
+EE.on(
+  EventEmitter.errorMonitorSymbol,
+  common.mustCall((e) => assert.strictEqual(e, theErr), 3)
+);
+
+// Verify with no error listener
+common.expectsError(
+  () => EE.emit('error', theErr), theErr
+);
+
+// Verify with error listener
+EE.once('error', common.mustCall((e) => assert.strictEqual(e, theErr)));
+EE.emit('error', theErr);
+
+
+// Verify it works with once
+process.nextTick(() => EE.emit('error', theErr));
+async function testOnce() {
+  try {
+    await EventEmitter.once(EE, 'notTriggered');
+  } catch (e) {
+    assert.strictEqual(e, theErr);
+  }
+}
+testOnce();
+
+// Only error events trigger error monitor
+EE.on('aEvent', common.mustCall());
+EE.emit('aEvent');


### PR DESCRIPTION
Installing an error listener has a side effect that emitted errors are considered as handled. This is quite bad for monitoring/logging tools which tend to be interested in errors but don't want to cause side
effects like swallow an exception.

There are some workarounds in the wild like monkey patching emit or remit the error if monitoring tool detects that it is the only listener but this is error prone and risky.

This PR allows to install a listener to monitor errors with the side effect to consume the error. To avoid conflicts with other events it exports a symbol on EventEmitter which owns this special meaning.

Refs: https://github.com/open-telemetry/opentelemetry-js/issues/225

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
