### PR TITLE
src: explicitly allocate backing stores for v8 stat buffers

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -543,32 +543,35 @@ inline double Environment::get_default_trigger_async_id() {
 
 inline double* Environment::heap_statistics_buffer() const {
   CHECK_NOT_NULL(heap_statistics_buffer_);
-  return heap_statistics_buffer_;
+  return static_cast<double*>(heap_statistics_buffer_->Data());
 }
 
-inline void Environment::set_heap_statistics_buffer(double* pointer) {
-  CHECK_NULL(heap_statistics_buffer_);  // Should be set only once.
-  heap_statistics_buffer_ = pointer;
+inline void Environment::set_heap_statistics_buffer(
+    std::shared_ptr<v8::BackingStore> backing_store) {
+  CHECK(!heap_statistics_buffer_);  // Should be set only once.
+  heap_statistics_buffer_ = std::move(backing_store);
 }
 
 inline double* Environment::heap_space_statistics_buffer() const {
-  CHECK_NOT_NULL(heap_space_statistics_buffer_);
-  return heap_space_statistics_buffer_;
+  CHECK(heap_space_statistics_buffer_);
+  return static_cast<double*>(heap_space_statistics_buffer_->Data());
 }
 
-inline void Environment::set_heap_space_statistics_buffer(double* pointer) {
-  CHECK_NULL(heap_space_statistics_buffer_);  // Should be set only once.
-  heap_space_statistics_buffer_ = pointer;
+inline void Environment::set_heap_space_statistics_buffer(
+    std::shared_ptr<v8::BackingStore> backing_store) {
+  CHECK(!heap_space_statistics_buffer_);  // Should be set only once.
+  heap_space_statistics_buffer_ = std::move(backing_store);
 }
 
 inline double* Environment::heap_code_statistics_buffer() const {
-  CHECK_NOT_NULL(heap_code_statistics_buffer_);
-  return heap_code_statistics_buffer_;
+  CHECK(heap_code_statistics_buffer_);
+  return static_cast<double*>(heap_code_statistics_buffer_->Data());
 }
 
-inline void Environment::set_heap_code_statistics_buffer(double* pointer) {
-  CHECK_NULL(heap_code_statistics_buffer_);  // Should be set only once.
-  heap_code_statistics_buffer_ = pointer;
+inline void Environment::set_heap_code_statistics_buffer(
+    std::shared_ptr<v8::BackingStore> backing_store) {
+  CHECK(!heap_code_statistics_buffer_);  // Should be set only once.
+  heap_code_statistics_buffer_ = std::move(backing_store);
 }
 
 inline char* Environment::http_parser_buffer() const {

--- a/src/env.cc
+++ b/src/env.cc
@@ -413,10 +413,7 @@ Environment::~Environment() {
     tracing_controller->RemoveTraceStateObserver(trace_state_observer_.get());
   }
 
-  delete[] heap_statistics_buffer_;
-  delete[] heap_space_statistics_buffer_;
   delete[] http_parser_buffer_;
-  delete[] heap_code_statistics_buffer_;
 
   TRACE_EVENT_NESTABLE_ASYNC_END0(
     TRACING_CATEGORY_NODE1(environment), "Environment", this);

--- a/src/env.h
+++ b/src/env.h
@@ -1019,13 +1019,16 @@ class Environment : public MemoryRetainer {
       package_json_cache;
 
   inline double* heap_statistics_buffer() const;
-  inline void set_heap_statistics_buffer(double* pointer);
+  inline void set_heap_statistics_buffer(
+      std::shared_ptr<v8::BackingStore> backing_store);
 
   inline double* heap_space_statistics_buffer() const;
-  inline void set_heap_space_statistics_buffer(double* pointer);
+  inline void set_heap_space_statistics_buffer(
+      std::shared_ptr<v8::BackingStore> backing_store);
 
   inline double* heap_code_statistics_buffer() const;
-  inline void set_heap_code_statistics_buffer(double* pointer);
+  inline void set_heap_code_statistics_buffer(
+      std::shared_ptr<v8::BackingStore> backing_store);
 
   inline char* http_parser_buffer() const;
   inline void set_http_parser_buffer(char* buffer);
@@ -1364,9 +1367,9 @@ class Environment : public MemoryRetainer {
   int handle_cleanup_waiting_ = 0;
   int request_waiting_ = 0;
 
-  double* heap_statistics_buffer_ = nullptr;
-  double* heap_space_statistics_buffer_ = nullptr;
-  double* heap_code_statistics_buffer_ = nullptr;
+  std::shared_ptr<v8::BackingStore> heap_statistics_buffer_;
+  std::shared_ptr<v8::BackingStore> heap_space_statistics_buffer_;
+  std::shared_ptr<v8::BackingStore> heap_code_statistics_buffer_;
 
   char* http_parser_buffer_ = nullptr;
   bool http_parser_buffer_in_use_ = false;

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -158,23 +158,12 @@ void Initialize(Local<Object> target,
                  "updateHeapStatisticsArrayBuffer",
                  UpdateHeapStatisticsArrayBuffer);
 
-  env->set_heap_statistics_buffer(new double[kHeapStatisticsPropertiesCount]);
-
   const size_t heap_statistics_buffer_byte_length =
       sizeof(*env->heap_statistics_buffer()) * kHeapStatisticsPropertiesCount;
 
-  std::unique_ptr<BackingStore> heap_statistics_backing =
-      ArrayBuffer::NewBackingStore(env->heap_statistics_buffer(),
-                                   heap_statistics_buffer_byte_length,
-                                   [](void*, size_t, void*){},
-                                   nullptr);
   Local<ArrayBuffer> heap_statistics_ab =
-      ArrayBuffer::New(env->isolate(),
-                       std::move(heap_statistics_backing));
-  // TODO(thangktran): drop this check when V8 is pumped to 8.0 .
-  if (!heap_statistics_ab->IsExternal())
-    heap_statistics_ab->Externalize(
-        heap_statistics_ab->GetBackingStore());
+      ArrayBuffer::New(env->isolate(), heap_statistics_buffer_byte_length);
+  env->set_heap_statistics_buffer(heap_statistics_ab->GetBackingStore());
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(),
                                     "heapStatisticsArrayBuffer"),
@@ -193,25 +182,15 @@ void Initialize(Local<Object> target,
                  "updateHeapCodeStatisticsArrayBuffer",
                  UpdateHeapCodeStatisticsArrayBuffer);
 
-  env->set_heap_code_statistics_buffer(
-    new double[kHeapCodeStatisticsPropertiesCount]);
-
   const size_t heap_code_statistics_buffer_byte_length =
       sizeof(*env->heap_code_statistics_buffer())
       * kHeapCodeStatisticsPropertiesCount;
 
-  std::unique_ptr<BackingStore> heap_code_statistics_backing =
-      ArrayBuffer::NewBackingStore(env->heap_code_statistics_buffer(),
-                                   heap_code_statistics_buffer_byte_length,
-                                   [](void*, size_t, void*){},
-                                   nullptr);
   Local<ArrayBuffer> heap_code_statistics_ab =
       ArrayBuffer::New(env->isolate(),
-                       std::move(heap_code_statistics_backing));
-  // TODO(thangktran): drop this check when V8 is pumped to 8.0 .
-  if (!heap_code_statistics_ab->IsExternal())
-    heap_code_statistics_ab->Externalize(
-        heap_code_statistics_ab->GetBackingStore());
+                       heap_code_statistics_buffer_byte_length);
+  env->set_heap_code_statistics_buffer(
+      heap_code_statistics_ab->GetBackingStore());
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(),
                                     "heapCodeStatisticsArrayBuffer"),
@@ -257,26 +236,16 @@ void Initialize(Local<Object> target,
                  "updateHeapSpaceStatisticsArrayBuffer",
                  UpdateHeapSpaceStatisticsBuffer);
 
-  env->set_heap_space_statistics_buffer(
-    new double[kHeapSpaceStatisticsPropertiesCount * number_of_heap_spaces]);
-
   const size_t heap_space_statistics_buffer_byte_length =
       sizeof(*env->heap_space_statistics_buffer()) *
       kHeapSpaceStatisticsPropertiesCount *
       number_of_heap_spaces;
 
-  std::unique_ptr<BackingStore> heap_space_statistics_backing =
-      ArrayBuffer::NewBackingStore(env->heap_space_statistics_buffer(),
-                                   heap_space_statistics_buffer_byte_length,
-                                   [](void*, size_t, void*){},
-                                   nullptr);
   Local<ArrayBuffer> heap_space_statistics_ab =
       ArrayBuffer::New(env->isolate(),
-                               std::move(heap_space_statistics_backing));
-  // TODO(thangktran): drop this check when V8 is pumped to 8.0 .
-  if (!heap_space_statistics_ab->IsExternal())
-    heap_space_statistics_ab->Externalize(
-        heap_space_statistics_ab->GetBackingStore());
+                       heap_space_statistics_buffer_byte_length);
+  env->set_heap_space_statistics_buffer(
+      heap_space_statistics_ab->GetBackingStore());
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(),
                                     "heapSpaceStatisticsArrayBuffer"),


### PR DESCRIPTION
This fixes flaky tests that crashed because the allocations ended
up at positions of previously allocated `ArrayBuffer`s that were
still in the backing store table. In particular, there was a race
condition window between destroying a Worker thread’s `Environment`
and destroying its `Isolate` in which the underlying memory was
already released but the `ArrayBuffer` was still existent, meaning
that new memory could be allocated at the address of the previous
`ArrayBuffer`.

Refs: https://github.com/nodejs/node/pull/30782

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
