### PR TITLE
lib: replace Symbol.asyncIterator by SymbolAsyncIterator

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -27,7 +27,7 @@ const {
   NumberIsNaN,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
-  Symbol,
+  SymbolAsyncIterator,
 } = primordials;
 
 module.exports = Readable;
@@ -1099,7 +1099,7 @@ Readable.prototype.wrap = function(stream) {
   return this;
 };
 
-Readable.prototype[Symbol.asyncIterator] = function() {
+Readable.prototype[SymbolAsyncIterator] = function() {
   if (createReadableStreamAsyncIterator === undefined) {
     createReadableStreamAsyncIterator =
       require('internal/streams/async_iterator');

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -3,6 +3,7 @@
 const {
   ObjectDefineProperty,
   Symbol,
+  SymbolAsyncIterator,
 } = primordials;
 
 const pathModule = require('path');
@@ -175,7 +176,7 @@ class Dir {
   }
 }
 
-ObjectDefineProperty(Dir.prototype, Symbol.asyncIterator, {
+ObjectDefineProperty(Dir.prototype, SymbolAsyncIterator, {
   value: Dir.prototype.entries,
   enumerable: false,
   writable: true,

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {
-  Symbol,
+  SymbolAsyncIterator,
   SymbolIterator
 } = primordials;
 const { Buffer } = require('buffer');
@@ -23,8 +23,8 @@ function from(Readable, iterable, opts) {
     });
   }
 
-  if (iterable && iterable[Symbol.asyncIterator])
-    iterator = iterable[Symbol.asyncIterator]();
+  if (iterable && iterable[SymbolAsyncIterator])
+    iterator = iterable[SymbolAsyncIterator]();
   else if (iterable && iterable[SymbolIterator])
     iterator = iterable[SymbolIterator]();
   else

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -37,6 +37,7 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   Symbol,
+  SymbolAsyncIterator,
 } = primordials;
 
 const {
@@ -1078,7 +1079,7 @@ Interface.prototype._ttyWrite = function(s, key) {
   }
 };
 
-Interface.prototype[Symbol.asyncIterator] = function() {
+Interface.prototype[SymbolAsyncIterator] = function() {
   if (this[kLineObjectStream] === undefined) {
     if (Readable === undefined) {
       Readable = require('stream').Readable;
@@ -1108,7 +1109,7 @@ Interface.prototype[Symbol.asyncIterator] = function() {
     this[kLineObjectStream] = readable;
   }
 
-  return this[kLineObjectStream][Symbol.asyncIterator]();
+  return this[kLineObjectStream][SymbolAsyncIterator]();
 };
 
 /**


### PR DESCRIPTION
Just replaced every Symbol.asyncIterator by SymbolAsyncIterator in the lib/* folder
For this, i just have added SymbolAsyncIterator in the import

```js
const {
  SymbolAsyncIterator,
} = primordials;
````

Of course i have removed unused import of Symbol 😄 
I hope this pull request will help you ! :P