### PR TITLE
lib: replace Symbol.hasInstance by SymbolHasInstance

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -30,6 +30,7 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   Symbol,
+  SymbolHasInstance,
 } = primordials;
 
 module.exports = Writable;
@@ -203,9 +204,9 @@ ObjectDefineProperty(WritableState.prototype, 'buffer', {
 // Test _writableState for inheritance to account for Duplex streams,
 // whose prototype chain only points to Readable.
 var realHasInstance;
-if (typeof Symbol === 'function' && Symbol.hasInstance) {
-  realHasInstance = Function.prototype[Symbol.hasInstance];
-  ObjectDefineProperty(Writable, Symbol.hasInstance, {
+if (typeof Symbol === 'function' && SymbolHasInstance) {
+  realHasInstance = Function.prototype[SymbolHasInstance];
+  ObjectDefineProperty(Writable, SymbolHasInstance, {
     value: function(object) {
       if (realHasInstance.call(this, object))
         return true;

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -16,6 +16,7 @@ const {
   ObjectValues,
   ReflectOwnKeys,
   Symbol,
+  SymbolHasInstance,
 } = primordials;
 
 const { trace } = internalBinding('trace_events');
@@ -134,7 +135,7 @@ const consolePropAttributes = {
 };
 
 // Fixup global.console instanceof global.console.Console
-ObjectDefineProperty(Console, Symbol.hasInstance, {
+ObjectDefineProperty(Console, SymbolHasInstance, {
   value(instance) {
     return instance[kIsConsole];
   }


### PR DESCRIPTION
Just replaced every Symbol.hasInstance by SymbolHasInstance in the lib/* folder
For this, i just have added SymbolHasInstance in the import

```js
const {
  SymbolHasInstance,
} = primordials;
```

Of course i have removed unused import of Symbol 😄
I hope this pull request will help you ! :P