### PR TITLE
src: make --use-largepages a runtime option

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -404,17 +404,6 @@ parser.add_option('--with-etw',
     dest='with_etw',
     help='build with ETW (default is true on Windows)')
 
-parser.add_option('--use-largepages',
-    action='store_true',
-    dest='node_use_large_pages',
-    help='build with Large Pages support. This feature is supported only on Linux kernel' +
-         '>= 2.6.38 with Transparent Huge pages enabled and FreeBSD')
-
-parser.add_option('--use-largepages-script-lld',
-    action='store_true',
-    dest='node_use_large_pages_script_lld',
-    help='link against the LLVM ld linker script. Implies -fuse-ld=lld in the linker flags')
-
 intl_optgroup.add_option('--with-intl',
     action='store',
     dest='with_intl',
@@ -1067,28 +1056,6 @@ def configure_node(o):
        'DTrace is currently only supported on SunOS, MacOS or Linux systems.')
   else:
     o['variables']['node_use_dtrace'] = 'false'
-
-  if options.node_use_large_pages and not flavor in ('linux', 'freebsd', 'mac'):
-    raise Exception(
-      'Large pages are supported only on Linux, FreeBSD and MacOS Systems.')
-  if options.node_use_large_pages and flavor in ('linux', 'freebsd', 'mac'):
-    if options.shared or options.enable_static:
-      raise Exception(
-        'Large pages are supported only while creating node executable.')
-    if target_arch!="x64":
-      raise Exception(
-        'Large pages are supported only x64 platform.')
-    if flavor == 'mac':
-      info('macOS server with 32GB or more is recommended')
-    if flavor == 'linux':
-      # Example full version string: 2.6.32-696.28.1.el6.x86_64
-      FULL_KERNEL_VERSION=os.uname()[2]
-      KERNEL_VERSION=FULL_KERNEL_VERSION.split('-')[0]
-      if KERNEL_VERSION < "2.6.38" and flavor == 'linux':
-        raise Exception(
-          'Large pages need Linux kernel version >= 2.6.38')
-  o['variables']['node_use_large_pages'] = b(options.node_use_large_pages)
-  o['variables']['node_use_large_pages_script_lld'] = b(options.node_use_large_pages_script_lld)
 
   if options.no_ifaddrs:
     o['defines'] += ['SUNOS_NO_IFADDRS']

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -863,7 +863,7 @@ environment variables.
 
 See `SSL_CERT_DIR` and `SSL_CERT_FILE`.
 
-### `--use-largepages`
+### `--use-largepages=num`
 <!-- YAML
 added: REPLACEME
 -->
@@ -871,6 +871,13 @@ added: REPLACEME
 Re-map the Node.js static code to large memory pages at startup. If supported on
 the target system, this will cause the Node.js static code to be moved onto 2
 MiB pages instead of 4 KiB pages.
+
+The following values are valid for `num`:
+* 0: No mapping will be attempted. This is the default.
+* 1: If supported by the OS, mapping will be attempted. Failure to map will be
+  ignored and will not be reported.
+* 2: If supported by the OS, mapping will be attempted. Failure to map will be
+  ignored and a message will be printed to standard error.
 
 ### `--v8-options`
 <!-- YAML

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -863,6 +863,15 @@ environment variables.
 
 See `SSL_CERT_DIR` and `SSL_CERT_FILE`.
 
+### `--use-largepages`
+<!-- YAML
+added: REPLACEME
+-->
+
+Re-map the Node.js static code to large memory pages at startup. If supported on
+the target system, this will cause the Node.js static code to be moved onto 2
+MiB pages instead of 4 KiB pages.
+
 ### `--v8-options`
 <!-- YAML
 added: v0.1.3
@@ -1119,6 +1128,7 @@ Node.js options that are allowed are:
 * `--track-heap-objects`
 * `--unhandled-rejections`
 * `--use-bundled-ca`
+* `--use-largepages`
 * `--use-openssl-ca`
 * `--v8-pool-size`
 * `--zero-fill-buffers`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -863,7 +863,7 @@ environment variables.
 
 See `SSL_CERT_DIR` and `SSL_CERT_FILE`.
 
-### `--use-largepages=num`
+### `--use-largepages=mode`
 <!-- YAML
 added: REPLACEME
 -->
@@ -872,12 +872,12 @@ Re-map the Node.js static code to large memory pages at startup. If supported on
 the target system, this will cause the Node.js static code to be moved onto 2
 MiB pages instead of 4 KiB pages.
 
-The following values are valid for `num`:
-* 0: No mapping will be attempted. This is the default.
-* 1: If supported by the OS, mapping will be attempted. Failure to map will be
-  ignored and will not be reported.
-* 2: If supported by the OS, mapping will be attempted. Failure to map will be
-  ignored and a message will be printed to standard error.
+The following values are valid for `mode`:
+* `off`: No mapping will be attempted. This is the default.
+* `silent`: If supported by the OS, mapping will be attempted. Failure to map
+  will be ignored and will not be reported.
+* `verbose`: If supported by the OS, mapping will be attempted. Failure to map
+  will be ignored and a message will be printed to standard error.
 
 ### `--v8-options`
 <!-- YAML

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -874,8 +874,8 @@ MiB pages instead of 4 KiB pages.
 
 The following values are valid for `mode`:
 * `off`: No mapping will be attempted. This is the default.
-* `silent`: If supported by the OS, mapping will be attempted. Failure to map
-  will be ignored and will not be reported.
+* `on`: If supported by the OS, mapping will be attempted. Failure to map will
+  be ignored and will not be reported.
 * `verbose`: If supported by the OS, mapping will be attempted. Failure to map
   will be ignored and a message will be printed to standard error.
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -875,9 +875,9 @@ MiB pages instead of 4 KiB pages.
 The following values are valid for `mode`:
 * `off`: No mapping will be attempted. This is the default.
 * `on`: If supported by the OS, mapping will be attempted. Failure to map will
-  be ignored and will not be reported.
-* `verbose`: If supported by the OS, mapping will be attempted. Failure to map
-  will be ignored and a message will be printed to standard error.
+  be ignored and a message will be printed to standard error.
+* `silent`: If supported by the OS, mapping will be attempted. Failure to map
+  will be ignored and will not be reported.
 
 ### `--v8-options`
 <!-- YAML

--- a/doc/node.1
+++ b/doc/node.1
@@ -398,6 +398,11 @@ See
 and
 .Ev SSL_CERT_FILE .
 .
+.It Fl -use-largepages
+Re-map the Node.js static code to large memory pages at startup. If supported on
+the target system, this will cause the Node.js static code to be moved onto 2
+MiB pages instead of 4 KiB pages.
+.
 .It Fl -v8-options
 Print V8 command-line options.
 .

--- a/doc/node.1
+++ b/doc/node.1
@@ -398,10 +398,12 @@ See
 and
 .Ev SSL_CERT_FILE .
 .
-.It Fl -use-largepages
+.It Fl -use-largepages Ns = Ns Ar num
 Re-map the Node.js static code to large memory pages at startup. If supported on
 the target system, this will cause the Node.js static code to be moved onto 2
 MiB pages instead of 4 KiB pages.
+.Pp
+The following values are valid: 0 (do not map), 1 (map, ignore failure, and do not report it), and 2 (map, ignore failure, but report it to standard error).
 .
 .It Fl -v8-options
 Print V8 command-line options.

--- a/doc/node.1
+++ b/doc/node.1
@@ -405,9 +405,8 @@ MiB pages instead of 4 KiB pages.
 .Pp
 .Ar mode
 must have one of the following values:
-`off` (the default value, meaning do not map), `on` (map and ignore failure
-without reporting it), or `verbose` (map and ignore failure, but report it to
-standard error).
+`off` (the default value, meaning do not map), `on` (map and ignore failure,
+reporting it to stderr), or `silent` (map and silently ignore failure).
 .
 .It Fl -v8-options
 Print V8 command-line options.

--- a/doc/node.1
+++ b/doc/node.1
@@ -405,8 +405,9 @@ MiB pages instead of 4 KiB pages.
 .Pp
 .Ar mode
 must have one of the following values:
-`off` (do not map), `silent` (map and ignore failure without reporting it), or
-`verbose` (map and ignore failure, but report it to standard error).
+`off` (the default value, meaning do not map), `on` (map and ignore failure
+without reporting it), or `verbose` (map and ignore failure, but report it to
+standard error).
 .
 .It Fl -v8-options
 Print V8 command-line options.

--- a/doc/node.1
+++ b/doc/node.1
@@ -398,12 +398,15 @@ See
 and
 .Ev SSL_CERT_FILE .
 .
-.It Fl -use-largepages Ns = Ns Ar num
+.It Fl -use-largepages Ns = Ns Ar mode
 Re-map the Node.js static code to large memory pages at startup. If supported on
 the target system, this will cause the Node.js static code to be moved onto 2
 MiB pages instead of 4 KiB pages.
 .Pp
-The following values are valid: 0 (do not map), 1 (map, ignore failure, and do not report it), and 2 (map, ignore failure, but report it to standard error).
+.Ar mode
+must have one of the following values:
+`off` (do not map), `silent` (map and ignore failure without reporting it), or
+`verbose` (map and ignore failure, but report it to standard error).
 .
 .It Fl -v8-options
 Print V8 command-line options.

--- a/node.gyp
+++ b/node.gyp
@@ -833,10 +833,9 @@
             }],
           ],
         }],
-        [ 'OS in "linux freebsd mac"', {
+        [ 'OS in "linux freebsd mac" and '
+          'target_arch=="x64"', {
           'defines': [ 'NODE_ENABLE_LARGE_CODE_PAGES=1' ],
-          # The current implementation of Large Pages is under Linux.
-          # Other implementations are possible but not currently supported.
           'sources': [
             'src/large_pages/node_large_page.cc',
             'src/large_pages/node_large_page.h'

--- a/node.gyp
+++ b/node.gyp
@@ -833,7 +833,7 @@
             }],
           ],
         }],
-        [ 'node_use_large_pages=="true" and OS in "linux freebsd mac"', {
+        [ 'OS in "linux freebsd mac"', {
           'defines': [ 'NODE_ENABLE_LARGE_CODE_PAGES=1' ],
           # The current implementation of Large Pages is under Linux.
           # Other implementations are possible but not currently supported.

--- a/node.gypi
+++ b/node.gypi
@@ -308,8 +308,7 @@
     }],
     [ 'OS=="linux" and '
       'target_arch=="x64" and '
-      'node_use_large_pages=="true" and '
-      'node_use_large_pages_script_lld=="false"', {
+      'llvm_version=="0.0"', {
       'ldflags': [
         '-Wl,-T',
         '<!(realpath src/large_pages/ld.implicit.script)',
@@ -317,8 +316,7 @@
     }],
     [ 'OS=="linux" and '
       'target_arch=="x64" and '
-      'node_use_large_pages=="true" and '
-      'node_use_large_pages_script_lld=="true"', {
+      'llvm_version!="0.0"', {
       'ldflags': [
         '-Wl,-T',
         '<!(realpath src/large_pages/ld.implicit.script.lld)',

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -62,7 +62,7 @@
 // Map a new area and copy the original code there
 // Use mmap using the start address with MAP_FIXED so we get exactly the
 // same virtual address
-// Use madvise with MADV_HUGE_PAGE to use Anonymous 2M Pages
+// Use madvise with MADV_HUGEPAGE to use Anonymous 2M Pages
 // If successful copy the code there and unmap the original region.
 
 extern char __nodetext;
@@ -308,7 +308,7 @@ static bool IsSuperPagesEnabled() {
 // a. map a new area and copy the original code there
 // b. mmap using the start address with MAP_FIXED so we get exactly
 //    the same virtual address (except on macOS).
-// c. madvise with MADV_HUGE_PAGE
+// c. madvise with MADV_HUGEPAGE
 // d. If successful copy the code there and unmap the original region
 int
 #if !defined(__APPLE__)
@@ -352,7 +352,7 @@ MoveTextRegionToLargePages(const text_region& r) {
     return -1;
   }
 
-  ret = madvise(tmem, size, MADV_HUGEPAGE);
+  ret = madvise(tmem, size, 14 /* MADV_HUGEPAGE */);
   if (ret == -1) {
     PrintSystemError(errno);
     ret = munmap(tmem, size);

--- a/src/node.cc
+++ b/src/node.cc
@@ -64,9 +64,7 @@
 #include "inspector/worker_inspector.h"  // ParentInspectorHandle
 #endif
 
-#ifdef NODE_ENABLE_LARGE_CODE_PAGES
 #include "large_pages/node_large_page.h"
-#endif
 
 #ifdef NODE_REPORT
 #include "node_report.h"
@@ -967,14 +965,6 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
 
   CHECK_GT(argc, 0);
 
-#ifdef NODE_ENABLE_LARGE_CODE_PAGES
-  if (node::IsLargePagesEnabled()) {
-    if (node::MapStaticCodeToLargePages() != 0) {
-      fprintf(stderr, "Reverting to default page size\n");
-    }
-  }
-#endif
-
   // Hack around with the argv pointer. Used for process.title = "blah".
   argv = uv_setup_args(argc, argv);
 
@@ -991,6 +981,14 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
     if (result.exit_code != 0) {
       result.early_return = true;
       return result;
+    }
+  }
+
+  if (per_process::cli_options->use_largepages) {
+    if (node::IsLargePagesEnabled()) {
+      if (node::MapStaticCodeToLargePages() != 0) {
+        fprintf(stderr, "Reverting to default page size\n");
+      }
     }
   }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -984,15 +984,25 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
     }
   }
 
+#if defined(NODE_ENABLE_LARGE_CODE_PAGES) && NODE_ENABLE_LARGE_CODE_PAGES
   if (per_process::cli_options->use_largepages == 1 ||
       per_process::cli_options->use_largepages == 2) {
     if (node::IsLargePagesEnabled()) {
       if (node::MapStaticCodeToLargePages() != 0 &&
           per_process::cli_options->use_largepages == 2) {
-        fprintf(stderr, "Reverting to default page size\n");
+        fprintf(stderr,
+                "Mapping code to large pages failed. Reverting to default page "
+                "size.\n");
       }
+    } else if (per_process::cli_options->use_largepages == 2) {
+      fprintf(stderr, "Large pages are not enabled.\n");
     }
   }
+#else
+  if (per_process::cli_options->use_largepages == 2) {
+    fprintf(stderr, "Mapping to large pages is not supported.\n");
+  }
+#endif  // NODE_ENABLE_LARGE_CODE_PAGES
 
   if (per_process::cli_options->print_version) {
     printf("%s\n", NODE_VERSION);

--- a/src/node.cc
+++ b/src/node.cc
@@ -985,21 +985,21 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
   }
 
 #if defined(NODE_ENABLE_LARGE_CODE_PAGES) && NODE_ENABLE_LARGE_CODE_PAGES
-  if (per_process::cli_options->use_largepages == 1 ||
-      per_process::cli_options->use_largepages == 2) {
+  if (per_process::cli_options->use_largepages == "silent" ||
+      per_process::cli_options->use_largepages == "verbose") {
     if (node::IsLargePagesEnabled()) {
       if (node::MapStaticCodeToLargePages() != 0 &&
-          per_process::cli_options->use_largepages == 2) {
+          per_process::cli_options->use_largepages == "verbose") {
         fprintf(stderr,
                 "Mapping code to large pages failed. Reverting to default page "
                 "size.\n");
       }
-    } else if (per_process::cli_options->use_largepages == 2) {
+    } else if (per_process::cli_options->use_largepages == "verbose") {
       fprintf(stderr, "Large pages are not enabled.\n");
     }
   }
 #else
-  if (per_process::cli_options->use_largepages == 2) {
+  if (per_process::cli_options->use_largepages == "verbose") {
     fprintf(stderr, "Mapping to large pages is not supported.\n");
   }
 #endif  // NODE_ENABLE_LARGE_CODE_PAGES

--- a/src/node.cc
+++ b/src/node.cc
@@ -984,9 +984,11 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
     }
   }
 
-  if (per_process::cli_options->use_largepages) {
+  if (per_process::cli_options->use_largepages == 1 ||
+      per_process::cli_options->use_largepages == 2) {
     if (node::IsLargePagesEnabled()) {
-      if (node::MapStaticCodeToLargePages() != 0) {
+      if (node::MapStaticCodeToLargePages() != 0 &&
+          per_process::cli_options->use_largepages == 2) {
         fprintf(stderr, "Reverting to default page size\n");
       }
     }

--- a/src/node.cc
+++ b/src/node.cc
@@ -985,7 +985,7 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
   }
 
 #if defined(NODE_ENABLE_LARGE_CODE_PAGES) && NODE_ENABLE_LARGE_CODE_PAGES
-  if (per_process::cli_options->use_largepages == "silent" ||
+  if (per_process::cli_options->use_largepages == "on" ||
       per_process::cli_options->use_largepages == "verbose") {
     if (node::IsLargePagesEnabled()) {
       if (node::MapStaticCodeToLargePages() != 0 &&

--- a/src/node.cc
+++ b/src/node.cc
@@ -986,20 +986,20 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
 
 #if defined(NODE_ENABLE_LARGE_CODE_PAGES) && NODE_ENABLE_LARGE_CODE_PAGES
   if (per_process::cli_options->use_largepages == "on" ||
-      per_process::cli_options->use_largepages == "verbose") {
+      per_process::cli_options->use_largepages == "silent") {
     if (node::IsLargePagesEnabled()) {
       if (node::MapStaticCodeToLargePages() != 0 &&
-          per_process::cli_options->use_largepages == "verbose") {
+          per_process::cli_options->use_largepages != "silent") {
         fprintf(stderr,
                 "Mapping code to large pages failed. Reverting to default page "
                 "size.\n");
       }
-    } else if (per_process::cli_options->use_largepages == "verbose") {
+    } else if (per_process::cli_options->use_largepages != "silent") {
       fprintf(stderr, "Large pages are not enabled.\n");
     }
   }
 #else
-  if (per_process::cli_options->use_largepages == "verbose") {
+  if (per_process::cli_options->use_largepages == "on") {
     fprintf(stderr, "Mapping to large pages is not supported.\n");
   }
 #endif  // NODE_ENABLE_LARGE_CODE_PAGES

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -63,6 +63,9 @@ void PerProcessOptions::CheckOptions(std::vector<std::string>* errors) {
                       "used, not both");
   }
 #endif
+  if (!(use_largepages >= 0 && use_largepages <= 2)) {
+    errors->push_back("--use-largepages must be one of 0, 1, or 2");
+  }
   per_isolate->CheckOptions(errors);
 }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -65,7 +65,7 @@ void PerProcessOptions::CheckOptions(std::vector<std::string>* errors) {
 #endif
   if (use_largepages != "off" &&
       use_largepages != "on" &&
-      use_largepages != "verbose") {
+      use_largepages != "silent") {
     errors->push_back("invalid value for --use-largepages");
   }
   per_isolate->CheckOptions(errors);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -63,8 +63,10 @@ void PerProcessOptions::CheckOptions(std::vector<std::string>* errors) {
                       "used, not both");
   }
 #endif
-  if (!(use_largepages >= 0 && use_largepages <= 2)) {
-    errors->push_back("--use-largepages must be one of 0, 1, or 2");
+  if (use_largepages != "off" &&
+      use_largepages != "silent" &&
+      use_largepages != "verbose") {
+    errors->push_back("invalid value for --use-largepages");
   }
   per_isolate->CheckOptions(errors);
 }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -748,6 +748,10 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             kAllowedInEnvironment);
 #endif
 #endif
+  AddOption("--use-largepages",
+            "Map the Node.js static code to large pages",
+            &PerProcessOptions::use_largepages,
+            kAllowedInEnvironment);
 
   Insert(iop, &PerProcessOptions::get_per_isolate_options);
 }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -64,7 +64,7 @@ void PerProcessOptions::CheckOptions(std::vector<std::string>* errors) {
   }
 #endif
   if (use_largepages != "off" &&
-      use_largepages != "silent" &&
+      use_largepages != "on" &&
       use_largepages != "verbose") {
     errors->push_back("invalid value for --use-largepages");
   }

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -235,6 +235,7 @@ class PerProcessOptions : public Options {
   bool force_fips_crypto = false;
 #endif
 #endif
+  bool use_largepages = false;
 
 #ifdef NODE_REPORT
   std::vector<std::string> cmdline;

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -235,7 +235,7 @@ class PerProcessOptions : public Options {
   bool force_fips_crypto = false;
 #endif
 #endif
-  bool use_largepages = false;
+  uint64_t use_largepages = 0;
 
 #ifdef NODE_REPORT
   std::vector<std::string> cmdline;

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -235,7 +235,7 @@ class PerProcessOptions : public Options {
   bool force_fips_crypto = false;
 #endif
 #endif
-  uint64_t use_largepages = 0;
+  std::string use_largepages = "off";
 
 #ifdef NODE_REPORT
   std::vector<std::string> cmdline;

--- a/test/parallel/test-startup-large-pages.js
+++ b/test/parallel/test-startup-large-pages.js
@@ -1,7 +1,6 @@
 'use strict';
 
-// A sanity check: Make sure that Node.js runs correctly when running with the
-// --use-largepages option.
+// Make sure that Node.js runs correctly with the --use-largepages option.
 
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-startup-large-pages.js
+++ b/test/parallel/test-startup-large-pages.js
@@ -8,7 +8,7 @@ const { spawnSync } = require('child_process');
 
 {
   const child = spawnSync(process.execPath,
-                          [ '--use-largepages=1', '-p', '42' ]);
+                          [ '--use-largepages=silent', '-p', '42' ]);
   const stdout = child.stdout.toString().match(/\S+/g);
   assert.strictEqual(child.status, 0);
   assert.strictEqual(child.signal, null);
@@ -18,11 +18,11 @@ const { spawnSync } = require('child_process');
 
 {
   const child = spawnSync(process.execPath,
-                          [ '--use-largepages=3', '-p', '42' ]);
+                          [ '--use-largepages=xyzzy', '-p', '42' ]);
   assert.strictEqual(child.status, 9);
   assert.strictEqual(child.signal, null);
   assert.strictEqual(child.stderr.toString().match(/\S+/g).slice(1).join(' '),
-                     '--use-largepages must be one of 0, 1, or 2');
+                     'invalid value for --use-largepages');
 }
 
 // TODO(gabrielschulhof): Run with --use-largepages=2 and make assertions about

--- a/test/parallel/test-startup-large-pages.js
+++ b/test/parallel/test-startup-large-pages.js
@@ -8,7 +8,7 @@ const { spawnSync } = require('child_process');
 
 {
   const child = spawnSync(process.execPath,
-                          [ '--use-largepages=silent', '-p', '42' ]);
+                          [ '--use-largepages=on', '-p', '42' ]);
   const stdout = child.stdout.toString().match(/\S+/g);
   assert.strictEqual(child.status, 0);
   assert.strictEqual(child.signal, null);

--- a/test/parallel/test-startup-large-pages.js
+++ b/test/parallel/test-startup-large-pages.js
@@ -25,6 +25,6 @@ const { spawnSync } = require('child_process');
                      'invalid value for --use-largepages');
 }
 
-// TODO(gabrielschulhof): Run with --use-largepages=2 and make assertions about
-// the stderr, which may or may not contain a message indicating that mapping to
-// large pages has failed.
+// TODO(gabrielschulhof): Run with --use-largepages=verbose and make assertions
+// about the stderr, which may or may not contain a message indicating that
+// mapping to large pages has failed.

--- a/test/parallel/test-startup-large-pages.js
+++ b/test/parallel/test-startup-large-pages.js
@@ -7,13 +7,25 @@ require('../common');
 const assert = require('assert');
 const { spawnSync } = require('child_process');
 
-const child = spawnSync(process.execPath, [ '--use-largepages', '-p', '42' ]);
-const stdout = child.stdout.toString().match(/\S+/g);
+{
+  const child = spawnSync(process.execPath,
+                          [ '--use-largepages=1', '-p', '42' ]);
+  const stdout = child.stdout.toString().match(/\S+/g);
+  assert.strictEqual(child.status, 0);
+  assert.strictEqual(child.signal, null);
+  assert.strictEqual(stdout.length, 1);
+  assert.strictEqual(stdout[0], '42');
+}
 
-assert.strictEqual(child.status, 0);
-assert.strictEqual(child.signal, null);
-assert.strictEqual(stdout.length, 1);
-assert.strictEqual(stdout[0], '42');
+{
+  const child = spawnSync(process.execPath,
+                          [ '--use-largepages=3', '-p', '42' ]);
+  assert.strictEqual(child.status, 9);
+  assert.strictEqual(child.signal, null);
+  assert.strictEqual(child.stderr.toString().match(/\S+/g).slice(1).join(' '),
+                     '--use-largepages must be one of 0, 1, or 2');
+}
 
-// TODO(gabrielschulhof): Make assertions about the stderr, which may or may not
-// contain a message indicating that mapping to large pages has failed.
+// TODO(gabrielschulhof): Run with --use-largepages=2 and make assertions about
+// the stderr, which may or may not contain a message indicating that mapping to
+// large pages has failed.

--- a/test/parallel/test-startup-large-pages.js
+++ b/test/parallel/test-startup-large-pages.js
@@ -25,6 +25,5 @@ const { spawnSync } = require('child_process');
                      'invalid value for --use-largepages');
 }
 
-// TODO(gabrielschulhof): Run with --use-largepages=verbose and make assertions
-// about the stderr, which may or may not contain a message indicating that
-// mapping to large pages has failed.
+// TODO(gabrielschulhof): Make assertions about the stderr, which may or may not
+// contain a message indicating that mapping to large pages has failed.

--- a/test/parallel/test-startup-large-pages.js
+++ b/test/parallel/test-startup-large-pages.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// A sanity check: Make sure that Node.js runs correctly when running with the
+// --use-largepages option.
+
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const child = spawnSync(process.execPath, [ '--use-largepages', '-p', '42' ]);
+const stdout = child.stdout.toString().match(/\S+/g);
+
+assert.strictEqual(child.status, 0);
+assert.strictEqual(child.signal, null);
+assert.strictEqual(stdout.length, 1);
+assert.strictEqual(stdout[0], '42');
+
+// TODO(gabrielschulhof): Make assertions about the stderr, which may or may not
+// contain a message indicating that mapping to large pages has failed.


### PR DESCRIPTION
Moves the option that instructs Node.js to-remap its static code to
large pages from a configure-time option to a runtime option. This
should make it easy to assess the performance impact of such a change
without having to custom-build.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
