### PR TITLE
buffer: use for...of

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -524,7 +524,6 @@ Buffer.isEncoding = function isEncoding(encoding) {
 Buffer[kIsEncodingSymbol] = Buffer.isEncoding;
 
 Buffer.concat = function concat(list, length) {
-  let i;
   if (!ArrayIsArray(list)) {
     throw new ERR_INVALID_ARG_TYPE('list', 'Array', list);
   }
@@ -534,9 +533,9 @@ Buffer.concat = function concat(list, length) {
 
   if (length === undefined) {
     length = 0;
-    for (i = 0; i < list.length; i++) {
-      if (list[i].length) {
-        length += list[i].length;
+    for (const listEntry of list) {
+      if (listEntry.length) {
+        length += listEntry.length;
       }
     }
   } else {
@@ -545,7 +544,7 @@ Buffer.concat = function concat(list, length) {
 
   const buffer = Buffer.allocUnsafe(length);
   let pos = 0;
-  for (i = 0; i < list.length; i++) {
+  for (let i = 0; i < list.length; i++) {
     const buf = list[i];
     if (!isUint8Array(buf)) {
       // TODO(BridgeAR): This should not be of type ERR_INVALID_ARG_TYPE.


### PR DESCRIPTION
Searched for regular expression `for \([^\.]*.length` in `lib` and made changes in `buffer.js`

Refs: https://github.com/nodejs/node/pull/30910#discussion_r357042420
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
