### PR TITLE
wasi: require CLI flag to require() wasi module

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -401,11 +401,10 @@ function initializePolicy() {
 }
 
 function initializeWASI() {
-  if (getOptionValue('--experimental-wasi-unstable-preview0')) {
-    const { NativeModule } = require('internal/bootstrap/loaders');
-    const mod = NativeModule.map.get('wasi');
-    mod.canBeRequiredByUsers = true;
-  }
+  const { NativeModule } = require('internal/bootstrap/loaders');
+  const mod = NativeModule.map.get('wasi');
+  mod.canBeRequiredByUsers =
+    getOptionValue('--experimental-wasi-unstable-preview0');
 }
 
 function initializeCJSLoader() {

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -98,6 +98,7 @@ void NativeModuleLoader::InitializeModuleCategories() {
 #endif  // !HAVE_OPENSSL
 
       "sys",  // Deprecated.
+      "wasi",  // Experimental.
       "internal/test/binding",
       "internal/v8_prof_polyfill",
       "internal/v8_prof_processor",

--- a/test/wasi/test-wasi-require-flag.js
+++ b/test/wasi/test-wasi-require-flag.js
@@ -1,0 +1,9 @@
+'use strict';
+// This test verifies that the WASI module cannot be require()'ed without a
+// CLI flag while it is still experimental.
+require('../common');
+const assert = require('assert');
+
+assert.throws(() => {
+  require('wasi');
+}, /^Error: Cannot find module 'wasi'/);


### PR DESCRIPTION
This commit ensures that the WASI module cannot be require()'ed without a CLI flag while the module is still experimental.

This fixes a regression from https://github.com/nodejs/node/pull/30778.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
