### PR TITLE
http2: make http2/compat.write more http/1 compliant

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -651,30 +651,32 @@ class Http2ServerResponse extends Stream {
   }
 
   write(chunk, encoding, cb) {
+    const state = this[kState];
+
     if (typeof encoding === 'function') {
       cb = encoding;
       encoding = 'utf8';
     }
 
-    if (this[kState].ending) {
-      const err = new ERR_STREAM_WRITE_AFTER_END();
+    let err;
+    if (state.ending) {
+      err = new ERR_STREAM_WRITE_AFTER_END();
+    } else if (state.closed) {
+      err = new ERR_HTTP2_INVALID_STREAM();
+    } else if (state.destroyed) {
+      return false;
+    }
+
+    if (err) {
       if (typeof cb === 'function')
         process.nextTick(cb, err);
       this.destroy(err);
-      return false;
-    } else if (this[kState].closed) {
-      const err = new ERR_HTTP2_INVALID_STREAM();
-      if (typeof cb === 'function')
-        process.nextTick(cb, err);
-      this.destroy(err);
-      return false;
-    } else if (this[kState].destroyed) {
       return false;
     }
 
     const stream = this[kStream];
     if (!stream.headersSent)
-      this.writeHead(this[kState].statusCode);
+      this.writeHead(state.statusCode);
     return stream.write(chunk, encoding, cb);
   }
 

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -41,8 +41,7 @@ const {
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_CALLBACK,
     ERR_INVALID_HTTP_TOKEN,
-    ERR_STREAM_WRITE_AFTER_END,
-    ERR_STREAM_DESTROYED
+    ERR_STREAM_WRITE_AFTER_END
   },
   hideStackFrames
 } = require('internal/errors');
@@ -62,8 +61,6 @@ const kAborted = Symbol('aborted');
 
 let statusMessageWarned = false;
 let statusConnectionHeaderWarned = false;
-
-function nop() {}
 
 // Defines and implements an API compatibility layer on top of the core
 // HTTP/2 implementation, intended to provide an interface that is as
@@ -654,29 +651,25 @@ class Http2ServerResponse extends Stream {
   }
 
   write(chunk, encoding, cb) {
-    const state = this[kState];
-
     if (typeof encoding === 'function') {
       cb = encoding;
       encoding = 'utf8';
     }
 
-    if (typeof cb !== 'function')
-      cb = nop;
-
-    let err;
-    if (state.ending) {
-      err = new ERR_STREAM_WRITE_AFTER_END();
-    } else if (state.destroyed) {
-      err = new ERR_STREAM_DESTROYED('write');
-    } else if (state.closed) {
-      err = new ERR_HTTP2_INVALID_STREAM();
-    }
-
-    if (err) {
-      process.nextTick(cb, err);
+    if (this[kState].ending) {
+      const err = new ERR_STREAM_WRITE_AFTER_END();
+      if (typeof cb === 'function')
+        process.nextTick(cb, err);
       this.destroy(err);
-      return;
+      return false;
+    } else if (this[kState].closed) {
+      const err = new ERR_HTTP2_INVALID_STREAM();
+      if (typeof cb === 'function')
+        process.nextTick(cb, err);
+      this.destroy(err);
+      return false;
+    } else if (this[kState].destroyed) {
+      return false;
     }
 
     const stream = this[kStream];
@@ -728,14 +721,11 @@ class Http2ServerResponse extends Stream {
   }
 
   destroy(err) {
-    const stream = this[kStream];
-    const state = this[kState];
-
-    if (state.destroyed)
+    if (this[kState].destroyed)
       return;
 
-    state.destroyed = true;
-    stream.destroy(err);
+    this[kState].destroyed = true;
+    this[kStream].destroy(err);
   }
 
   setTimeout(msecs, callback) {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -40,7 +40,9 @@ const {
     ERR_HTTP2_STATUS_INVALID,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_CALLBACK,
-    ERR_INVALID_HTTP_TOKEN
+    ERR_INVALID_HTTP_TOKEN,
+    ERR_STREAM_WRITE_AFTER_END,
+    ERR_STREAM_DESTROYED
   },
   hideStackFrames
 } = require('internal/errors');
@@ -60,6 +62,8 @@ const kAborted = Symbol('aborted');
 
 let statusMessageWarned = false;
 let statusConnectionHeaderWarned = false;
+
+function nop() {}
 
 // Defines and implements an API compatibility layer on top of the core
 // HTTP/2 implementation, intended to provide an interface that is as
@@ -439,6 +443,7 @@ class Http2ServerResponse extends Stream {
     this[kState] = {
       closed: false,
       ending: false,
+      destroyed: false,
       headRequest: false,
       sendDate: true,
       statusCode: HTTP_STATUS_OK,
@@ -649,17 +654,28 @@ class Http2ServerResponse extends Stream {
   }
 
   write(chunk, encoding, cb) {
+    const state = this[kState];
+
     if (typeof encoding === 'function') {
       cb = encoding;
       encoding = 'utf8';
     }
 
-    if (this[kState].closed) {
-      const err = new ERR_HTTP2_INVALID_STREAM();
-      if (typeof cb === 'function')
-        process.nextTick(cb, err);
-      else
-        throw err;
+    if (typeof cb !== 'function')
+      cb = nop;
+
+    let err;
+    if (state.ending) {
+      err = new ERR_STREAM_WRITE_AFTER_END();
+    } else if (state.destroyed) {
+      err = new ERR_STREAM_DESTROYED('write');
+    } else if (state.closed) {
+      err = new ERR_HTTP2_INVALID_STREAM();
+    }
+
+    if (err) {
+      process.nextTick(cb, err);
+      this.destroy(err);
       return;
     }
 
@@ -712,9 +728,14 @@ class Http2ServerResponse extends Stream {
   }
 
   destroy(err) {
-    if (this[kState].closed)
+    const stream = this[kStream];
+    const state = this[kState];
+
+    if (state.destroyed)
       return;
-    this[kStream].destroy(err);
+
+    state.destroyed = true;
+    stream.destroy(err);
   }
 
   setTimeout(msecs, callback) {

--- a/test/parallel/test-http2-compat-serverresponse-write.js
+++ b/test/parallel/test-http2-compat-serverresponse-write.js
@@ -10,42 +10,90 @@ if (!hasCrypto)
   skip('missing crypto');
 const { createServer, connect } = require('http2');
 const assert = require('assert');
+{
+  const server = createServer();
+  server.listen(0, mustCall(() => {
+    const port = server.address().port;
+    const url = `http://localhost:${port}`;
+    const client = connect(url, mustCall(() => {
+      const request = client.request();
+      request.resume();
+      request.on('end', mustCall());
+      request.on('close', mustCall(() => {
+        client.close();
+      }));
+    }));
 
-const server = createServer();
-server.listen(0, mustCall(() => {
-  const port = server.address().port;
-  const url = `http://localhost:${port}`;
-  const client = connect(url, mustCall(() => {
-    const request = client.request();
-    request.resume();
-    request.on('end', mustCall());
-    request.on('close', mustCall(() => {
-      client.close();
+    server.once('request', mustCall((request, response) => {
+      // response.write() returns true
+      assert(response.write('muahaha', 'utf8', mustCall()));
+
+      response.stream.close(0, mustCall(() => {
+        response.on('error', mustNotCall());
+
+        // response.write() without cb returns error
+        response.write('muahaha', mustCall((err) => {
+          assert.strictEqual(err.code, 'ERR_HTTP2_INVALID_STREAM');
+
+          // response.write() with cb returns falsy value
+          assert(!response.write('muahaha', mustCall()));
+
+          client.destroy();
+          server.close();
+        }));
+      }));
     }));
   }));
+}
 
-  server.once('request', mustCall((request, response) => {
-    // response.write() returns true
-    assert(response.write('muahaha', 'utf8', mustCall()));
+{
+  // Http2ServerResponse.write ERR_STREAM_WRITE_AFTER_END
+  const server = createServer();
+  server.listen(0, mustCall(() => {
+    const port = server.address().port;
+    const url = `http://localhost:${port}`;
+    const client = connect(url, mustCall(() => {
+      const request = client.request();
+      request.resume();
+      request.on('end', mustCall());
+      request.on('close', mustCall(() => {
+        client.close();
+      }));
+    }));
 
-    response.stream.close(0, mustCall(() => {
-      response.on('error', mustNotCall());
-
-      // response.write() without cb returns error
-      assert.throws(
-        () => { response.write('muahaha'); },
-        {
-          name: 'Error',
-          code: 'ERR_HTTP2_INVALID_STREAM',
-          message: 'The stream has been destroyed'
-        }
-      );
-
-      // response.write() with cb returns falsy value
-      assert(!response.write('muahaha', mustCall()));
-
-      client.destroy();
-      server.close();
+    server.once('request', mustCall((request, response) => {
+      response.end();
+      response.write('asd', mustCall((err) => {
+        assert.strictEqual(err.code, 'ERR_STREAM_WRITE_AFTER_END');
+        client.destroy();
+        server.close();
+      }));
     }));
   }));
-}));
+}
+
+{
+  // Http2ServerResponse.destroy ERR_STREAM_DESTROYED
+  const server = createServer();
+  server.listen(0, mustCall(() => {
+    const port = server.address().port;
+    const url = `http://localhost:${port}`;
+    const client = connect(url, mustCall(() => {
+      const request = client.request();
+      request.resume();
+      request.on('end', mustCall());
+      request.on('close', mustCall(() => {
+        client.close();
+      }));
+    }));
+
+    server.once('request', mustCall((request, response) => {
+      response.destroy();
+      response.write('asd', mustCall((err) => {
+        assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+        client.destroy();
+        server.close();
+      }));
+    }));
+  }));
+}

--- a/test/parallel/test-http2-compat-serverresponse-write.js
+++ b/test/parallel/test-http2-compat-serverresponse-write.js
@@ -90,7 +90,7 @@ const assert = require('assert');
     server.once('request', mustCall((request, response) => {
       response.destroy();
       response.write('asd', mustCall((err) => {
-        assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+        assert.strictEqual(err.code, null);
         client.destroy();
         server.close();
       }));

--- a/test/parallel/test-http2-compat-serverresponse-write.js
+++ b/test/parallel/test-http2-compat-serverresponse-write.js
@@ -71,29 +71,3 @@ const assert = require('assert');
     }));
   }));
 }
-
-{
-  // Http2ServerResponse.destroy ERR_STREAM_DESTROYED
-  const server = createServer();
-  server.listen(0, mustCall(() => {
-    const port = server.address().port;
-    const url = `http://localhost:${port}`;
-    const client = connect(url, mustCall(() => {
-      const request = client.request();
-      request.resume();
-      request.on('end', mustCall());
-      request.on('close', mustCall(() => {
-        client.close();
-      }));
-    }));
-
-    server.once('request', mustCall((request, response) => {
-      response.destroy();
-      response.write('asd', mustCall((err) => {
-        assert.strictEqual(err.code, null);
-        client.destroy();
-        server.close();
-      }));
-    }));
-  }));
-}


### PR DESCRIPTION
`HTTP2ServerResponse.write` would behave differently than both http1 and streams. This PR makes it more compliant with `stream.Writable` behaviour.

In particular, prior to this PR, `write` would `throw err` instead of calling `destroy(err)`

Refs: https://github.com/nodejs/node/issues/29529

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
