### PR TITLE
async_hooks: proper handling for AH in runInAsyncScope

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -21,7 +21,6 @@ const {
   executionAsyncId,
   triggerAsyncId,
   // Private API
-  hasAsyncIdStack,
   getHookArrays,
   enableHooks,
   disableHooks,
@@ -172,14 +171,13 @@ class AsyncResource {
   runInAsyncScope(fn, thisArg, ...args) {
     const asyncId = this[async_id_symbol];
     emitBefore(asyncId, this[trigger_async_id_symbol]);
-    try {
-      if (thisArg === undefined)
-        return fn(...args);
-      return ReflectApply(fn, thisArg, args);
-    } finally {
-      if (hasAsyncIdStack())
-        emitAfter(asyncId);
-    }
+
+    const ret = thisArg === undefined ?
+      fn(...args) :
+      ReflectApply(fn, thisArg, args);
+
+    emitAfter(asyncId);
+    return ret;
   }
 
   emitDestroy() {


### PR DESCRIPTION
We should never try to manually run emitAfter in case of an error,
the exception handler will do it for us, if we're going to recover.

This PR expands on the fix in https://github.com/nodejs/node/pull/30087

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
