### PR TITLE
doc: add note about fs.close undefined behavior

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1545,8 +1545,8 @@ added: v0.1.21
 
 Synchronous close(2). Returns `undefined`.
 
-Calling `fs.closeSync` on any file descriptor (`fd`) that is currently in use
-though any other `fs` operation may lead to undefined behavior.
+Calling `fs.closeSync()` on any file descriptor (`fd`) that is currently in use
+through any other `fs` operation may lead to undefined behavior.
 
 ## fs.constants
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1534,7 +1534,7 @@ Asynchronous close(2). No arguments other than a possible exception are given
 to the completion callback.
 
 Calling `fs.close()` on any file descriptor (`fd`) that is currently in use
-though any other `fs` operation may lead to undefined behavior.
+through any other `fs` operation may lead to undefined behavior.
 
 ## fs.closeSync(fd)
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1545,6 +1545,9 @@ added: v0.1.21
 
 Synchronous close(2). Returns `undefined`.
 
+Calling `fs.closeSync` on any file descriptor (`fd`) that is currently in use
+though any other `fs` operation may lead to undefined behavior.
+
 ## fs.constants
 
 * {Object}

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1533,7 +1533,7 @@ changes:
 Asynchronous close(2). No arguments other than a possible exception are given
 to the completion callback.
 
-Calling `fs.close` on any file descriptor (`fd`) that is currently in use
+Calling `fs.close()` on any file descriptor (`fd`) that is currently in use
 though any other `fs` operation may lead to undefined behavior.
 
 ## fs.closeSync(fd)

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1534,7 +1534,7 @@ Asynchronous close(2). No arguments other than a possible exception are given
 to the completion callback.
 
 Calling `fs.close` on any file descriptor (`fd`) that is currently in use
-through `fs.read`, `fs.write` or `fs.writev` may lead to undefined behavior.
+though any other `fs` operation may lead to undefined behavior.
 
 ## fs.closeSync(fd)
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1533,6 +1533,9 @@ changes:
 Asynchronous close(2). No arguments other than a possible exception are given
 to the completion callback.
 
+Calling `fs.close` on any file descriptor (`fd`) that is currently in use
+through `fs.read`, `fs.write` or `fs.writev` may lead to undefined behavior.
+
 ## fs.closeSync(fd)
 <!-- YAML
 added: v0.1.21


### PR DESCRIPTION
>Basically what the close(2) man page says – if it’s possible that the fd is being used for a syscall in one thread of the threadpool, we should not be calling close() concurrently.

Refs: https://github.com/nodejs/node/issues/30864

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
