### PR TITLE
async_hooks: remove internal only error checking

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -8,6 +8,7 @@ const {
 
 const {
   ERR_ASYNC_CALLBACK,
+  ERR_ASYNC_TYPE,
   ERR_INVALID_ASYNC_ID
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
@@ -32,6 +33,7 @@ const {
   emitBefore,
   emitAfter,
   emitDestroy,
+  enabledHooksExist,
   initHooksExist,
 } = internal_async_hooks;
 
@@ -158,6 +160,10 @@ class AsyncResource {
     this[trigger_async_id_symbol] = triggerAsyncId;
 
     if (initHooksExist()) {
+      if (enabledHooksExist() && type.length === 0) {
+        throw new ERR_ASYNC_TYPE(type);
+      }
+
       emitInit(asyncId, type, triggerAsyncId, this);
     }
 

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -2,15 +2,9 @@
 
 const {
   FunctionPrototypeBind,
-  NumberIsSafeInteger,
   ObjectDefineProperty,
   Symbol,
 } = primordials;
-
-const {
-  ERR_ASYNC_TYPE,
-  ERR_INVALID_ASYNC_ID
-} = require('internal/errors').codes;
 
 const async_wrap = internalBinding('async_wrap');
 /* async_hook_fields is a Uint32Array wrapping the uint32_t array of
@@ -115,15 +109,6 @@ function fatalError(e) {
   process.exit(1);
 }
 
-
-function validateAsyncId(asyncId, type) {
-  // Skip validation when async_hooks is disabled
-  if (async_hook_fields[kCheck] <= 0) return;
-
-  if (!NumberIsSafeInteger(asyncId) || asyncId < -1) {
-    fatalError(new ERR_INVALID_ASYNC_ID(type, asyncId));
-  }
-}
 
 // Emit From Native //
 
@@ -313,6 +298,9 @@ function defaultTriggerAsyncIdScope(triggerAsyncId, block, ...args) {
   }
 }
 
+function enabledHooksExist() {
+  return async_hook_fields[kCheck] > 0;
+}
 
 function initHooksExist() {
   return async_hook_fields[kInit] > 0;
@@ -328,21 +316,11 @@ function destroyHooksExist() {
 
 
 function emitInitScript(asyncId, type, triggerAsyncId, resource) {
-  validateAsyncId(asyncId, 'asyncId');
-  if (triggerAsyncId !== null)
-    validateAsyncId(triggerAsyncId, 'triggerAsyncId');
-  if (async_hook_fields[kCheck] > 0 &&
-      (typeof type !== 'string' || type.length <= 0)) {
-    throw new ERR_ASYNC_TYPE(type);
-  }
-
   // Short circuit all checks for the common case. Which is that no hooks have
   // been set. Do this to remove performance impact for embedders (and core).
   if (async_hook_fields[kInit] === 0)
     return;
 
-  // This can run after the early return check b/c running this function
-  // manually means that the embedder must have used getDefaultTriggerAsyncId().
   if (triggerAsyncId === null) {
     triggerAsyncId = getDefaultTriggerAsyncId();
   }
@@ -352,12 +330,6 @@ function emitInitScript(asyncId, type, triggerAsyncId, resource) {
 
 
 function emitBeforeScript(asyncId, triggerAsyncId) {
-  // Validate the ids. An id of -1 means it was never set and is visible on the
-  // call graph. An id < -1 should never happen in any circumstance. Throw
-  // on user calls because async state should still be recoverable.
-  validateAsyncId(asyncId, 'asyncId');
-  validateAsyncId(triggerAsyncId, 'triggerAsyncId');
-
   pushAsyncIds(asyncId, triggerAsyncId);
 
   if (async_hook_fields[kBefore] > 0)
@@ -366,8 +338,6 @@ function emitBeforeScript(asyncId, triggerAsyncId) {
 
 
 function emitAfterScript(asyncId) {
-  validateAsyncId(asyncId, 'asyncId');
-
   if (async_hook_fields[kAfter] > 0)
     emitAfterNative(asyncId);
 
@@ -376,8 +346,6 @@ function emitAfterScript(asyncId) {
 
 
 function emitDestroyScript(asyncId) {
-  validateAsyncId(asyncId, 'asyncId');
-
   // Return early if there are no destroy callbacks, or invalid asyncId.
   if (async_hook_fields[kDestroy] === 0 || asyncId <= 0)
     return;
@@ -417,8 +385,7 @@ function popAsyncIds(asyncId) {
   const stackLength = async_hook_fields[kStackLength];
   if (stackLength === 0) return false;
 
-  if (async_hook_fields[kCheck] > 0 &&
-      async_id_fields[kExecutionAsyncId] !== asyncId) {
+  if (enabledHooksExist() && async_id_fields[kExecutionAsyncId] !== asyncId) {
     // Do the same thing as the native code (i.e. crash hard).
     return popAsyncIds_(asyncId);
   }
@@ -463,6 +430,7 @@ module.exports = {
   getOrSetAsyncId,
   getDefaultTriggerAsyncId,
   defaultTriggerAsyncIdScope,
+  enabledHooksExist,
   initHooksExist,
   afterHooksExist,
   destroyHooksExist,

--- a/test/async-hooks/test-emit-before-after.js
+++ b/test/async-hooks/test-emit-before-after.js
@@ -3,39 +3,8 @@
 
 const common = require('../common');
 const assert = require('assert');
-const spawnSync = require('child_process').spawnSync;
 const async_hooks = require('internal/async_hooks');
 const initHooks = require('./init-hooks');
-
-if (!common.isMainThread)
-  common.skip('Worker bootstrapping works differently -> different async IDs');
-
-switch (process.argv[2]) {
-  case 'test_invalid_async_id':
-    async_hooks.emitBefore(-2, 1);
-    return;
-  case 'test_invalid_trigger_id':
-    async_hooks.emitBefore(1, -2);
-    return;
-}
-assert.ok(!process.argv[2]);
-
-
-const c1 = spawnSync(process.execPath, [
-  '--expose-internals', __filename, 'test_invalid_async_id'
-]);
-assert.strictEqual(
-  c1.stderr.toString().split(/[\r\n]+/g)[0],
-  'RangeError [ERR_INVALID_ASYNC_ID]: Invalid asyncId value: -2');
-assert.strictEqual(c1.status, 1);
-
-const c2 = spawnSync(process.execPath, [
-  '--expose-internals', __filename, 'test_invalid_trigger_id'
-]);
-assert.strictEqual(
-  c2.stderr.toString().split(/[\r\n]+/g)[0],
-  'RangeError [ERR_INVALID_ASYNC_ID]: Invalid triggerAsyncId value: -2');
-assert.strictEqual(c2.status, 1);
 
 const expectedId = async_hooks.newAsyncId();
 const expectedTriggerId = async_hooks.newAsyncId();

--- a/test/async-hooks/test-emit-before-after.js
+++ b/test/async-hooks/test-emit-before-after.js
@@ -28,7 +28,6 @@ const checkOnce = (fn) => {
 };
 
 initHooks({
-  oninit: (id, type) => process.stdout.write(`${id} ${type}`),
   onbefore: checkOnce(chkBefore),
   onafter: checkOnce(chkAfter),
   allowNoInit: true

--- a/test/async-hooks/test-emit-before-after.js
+++ b/test/async-hooks/test-emit-before-after.js
@@ -14,9 +14,23 @@ const expectedType = 'test_emit_before_after_type';
 async_hooks.emitBefore(expectedId, expectedTriggerId);
 async_hooks.emitAfter(expectedId);
 
+const chkBefore = common.mustCall((id) => assert.strictEqual(id, expectedId));
+const chkAfter = common.mustCall((id) => assert.strictEqual(id, expectedId));
+
+const checkOnce = (fn) => {
+  let called = false;
+  return (...args) => {
+    if (called) return;
+
+    called = true;
+    fn(...args);
+  };
+};
+
 initHooks({
-  onbefore: common.mustCall((id) => assert.strictEqual(id, expectedId)),
-  onafter: common.mustCall((id) => assert.strictEqual(id, expectedId)),
+  oninit: (id, type) => process.stdout.write(`${id} ${type}`),
+  onbefore: checkOnce(chkBefore),
+  onafter: checkOnce(chkAfter),
   allowNoInit: true
 }).enable();
 

--- a/test/async-hooks/test-emit-init.js
+++ b/test/async-hooks/test-emit-init.js
@@ -3,7 +3,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-const spawnSync = require('child_process').spawnSync;
 const async_hooks = require('internal/async_hooks');
 const initHooks = require('./init-hooks');
 
@@ -22,45 +21,6 @@ const hooks1 = initHooks({
 });
 
 hooks1.enable();
-
-switch (process.argv[2]) {
-  case 'test_invalid_async_id':
-    async_hooks.emitInit();
-    return;
-  case 'test_invalid_trigger_id':
-    async_hooks.emitInit(expectedId);
-    return;
-  case 'test_invalid_trigger_id_negative':
-    async_hooks.emitInit(expectedId, expectedType, -2);
-    return;
-}
-assert.ok(!process.argv[2]);
-
-
-const c1 = spawnSync(process.execPath, [
-  '--expose-internals', __filename, 'test_invalid_async_id'
-]);
-assert.strictEqual(
-  c1.stderr.toString().split(/[\r\n]+/g)[0],
-  'RangeError [ERR_INVALID_ASYNC_ID]: Invalid asyncId value: undefined');
-assert.strictEqual(c1.status, 1);
-
-const c2 = spawnSync(process.execPath, [
-  '--expose-internals', __filename, 'test_invalid_trigger_id'
-]);
-assert.strictEqual(
-  c2.stderr.toString().split(/[\r\n]+/g)[0],
-  'RangeError [ERR_INVALID_ASYNC_ID]: Invalid triggerAsyncId value: undefined');
-assert.strictEqual(c2.status, 1);
-
-const c3 = spawnSync(process.execPath, [
-  '--expose-internals', __filename, 'test_invalid_trigger_id_negative'
-]);
-assert.strictEqual(
-  c3.stderr.toString().split(/[\r\n]+/g)[0],
-  'RangeError [ERR_INVALID_ASYNC_ID]: Invalid triggerAsyncId value: -2');
-assert.strictEqual(c3.status, 1);
-
 
 async_hooks.emitInit(expectedId, expectedType, expectedTriggerId,
                      expectedResource);


### PR DESCRIPTION
This error checking is mostly unnecessary and is just a Node core developer nicety, rather than something that is needed for the user-land. It can be safely removed without any practical impact while making nextTick, timers, immediates and AsyncResource substantially faster.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
