### PR TITLE
process: remove TickInfo

### DIFF
--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -5,7 +5,6 @@ const {
 } = primordials;
 
 const {
-  tickInfo,
   promiseRejectEvents: {
     kPromiseRejectWithNoHandler,
     kPromiseHandlerAddedAfterReject,
@@ -19,9 +18,6 @@ const {
   noSideEffectsToString,
   triggerUncaughtException
 } = internalBinding('errors');
-
-// *Must* match Environment::TickInfo::Fields in src/env.h.
-const kHasRejectionToWarn = 1;
 
 const maybeUnhandledPromises = new WeakMap();
 const pendingUnhandledRejections = [];
@@ -46,14 +42,6 @@ const kThrowUnhandledRejections = 2;
 const kDefaultUnhandledRejections = 3;
 
 let unhandledRejectionsMode;
-
-function setHasRejectionToWarn(value) {
-  tickInfo[kHasRejectionToWarn] = value ? 1 : 0;
-}
-
-function hasRejectionToWarn() {
-  return tickInfo[kHasRejectionToWarn] === 1;
-}
 
 function getUnhandledRejectionsMode() {
   const { getOptionValue } = require('internal/options');
@@ -105,7 +93,6 @@ function unhandledRejection(promise, reason) {
   });
   // This causes the promise to be referenced at least for one tick.
   pendingUnhandledRejections.push(promise);
-  setHasRejectionToWarn(true);
 }
 
 function handledRejection(promise) {
@@ -121,11 +108,8 @@ function handledRejection(promise) {
       warning.name = 'PromiseRejectionHandledWarning';
       warning.id = uid;
       asyncHandledRejections.push({ promise, warning });
-      setHasRejectionToWarn(true);
-      return;
     }
   }
-  setHasRejectionToWarn(false);
 }
 
 const unhandledRejectionErrName = 'UnhandledPromiseRejectionWarning';
@@ -251,8 +235,6 @@ function listenForRejections() {
 }
 
 module.exports = {
-  hasRejectionToWarn,
-  setHasRejectionToWarn,
   listenForRejections,
   processPromiseRejections
 };

--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -6,9 +6,6 @@ const {
 } = primordials;
 
 const {
-  // For easy access to the nextTick state in the C++ land,
-  // and to avoid unnecessary calls into JS land.
-  tickInfo,
   // Used to run V8's micro task queue.
   runMicrotasks,
   setTickCallback,
@@ -20,8 +17,6 @@ const {
 } = internalBinding('errors');
 
 const {
-  setHasRejectionToWarn,
-  hasRejectionToWarn,
   listenForRejections,
   processPromiseRejections
 } = require('internal/process/promises');
@@ -43,30 +38,9 @@ const {
 } = require('internal/errors').codes;
 const FixedQueue = require('internal/fixed_queue');
 
-// *Must* match Environment::TickInfo::Fields in src/env.h.
-const kHasTickScheduled = 0;
-
-function hasTickScheduled() {
-  return tickInfo[kHasTickScheduled] === 1;
-}
-
-function setHasTickScheduled(value) {
-  tickInfo[kHasTickScheduled] = value ? 1 : 0;
-}
-
 const queue = new FixedQueue();
 
-// Should be in sync with RunNextTicksNative in node_task_queue.cc
 function runNextTicks() {
-  if (!hasTickScheduled() && !hasRejectionToWarn())
-    runMicrotasks();
-  if (!hasTickScheduled() && !hasRejectionToWarn())
-    return;
-
-  processTicksAndRejections();
-}
-
-function processTicksAndRejections() {
   let tock;
   do {
     while (tock = queue.shift()) {
@@ -96,8 +70,6 @@ function processTicksAndRejections() {
     }
     runMicrotasks();
   } while (!queue.isEmpty() || processPromiseRejections());
-  setHasTickScheduled(false);
-  setHasRejectionToWarn(false);
 }
 
 // `nextTick()` will not enqueue any callback when the process is about to
@@ -121,8 +93,6 @@ function nextTick(callback) {
         args[i - 1] = arguments[i];
   }
 
-  if (queue.isEmpty())
-    setHasTickScheduled(true);
   const asyncId = newAsyncId();
   const triggerAsyncId = getDefaultTriggerAsyncId();
   const tickObject = {
@@ -177,7 +147,7 @@ module.exports = {
     // Sets the per-isolate promise rejection callback
     listenForRejections();
     // Sets the callback to be run in every tick.
-    setTickCallback(processTicksAndRejections);
+    setTickCallback(runNextTicks);
     return {
       nextTick,
       runNextTicks

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -258,21 +258,6 @@ inline void ImmediateInfo::ref_count_dec(uint32_t decrement) {
   fields_[kRefCount] -= decrement;
 }
 
-inline TickInfo::TickInfo(v8::Isolate* isolate)
-    : fields_(isolate, kFieldsCount) {}
-
-inline AliasedUint8Array& TickInfo::fields() {
-  return fields_;
-}
-
-inline bool TickInfo::has_tick_scheduled() const {
-  return fields_[kHasTickScheduled] == 1;
-}
-
-inline bool TickInfo::has_rejection_to_warn() const {
-  return fields_[kHasRejectionToWarn] == 1;
-}
-
 inline void Environment::AssignToContext(v8::Local<v8::Context> context,
                                          const ContextInfo& info) {
   context->SetAlignedPointerInEmbedderData(
@@ -430,10 +415,6 @@ inline AsyncHooks* Environment::async_hooks() {
 
 inline ImmediateInfo* Environment::immediate_info() {
   return &immediate_info_;
-}
-
-inline TickInfo* Environment::tick_info() {
-  return &tick_info_;
 }
 
 inline uint64_t Environment::timer_base() const {

--- a/src/env.cc
+++ b/src/env.cc
@@ -298,7 +298,6 @@ Environment::Environment(IsolateData* isolate_data,
     : isolate_(context->GetIsolate()),
       isolate_data_(isolate_data),
       immediate_info_(context->GetIsolate()),
-      tick_info_(context->GetIsolate()),
       timer_base_(uv_now(isolate_data->event_loop())),
       exec_argv_(exec_args),
       argv_(args),
@@ -917,10 +916,6 @@ void ImmediateInfo::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("fields", fields_);
 }
 
-void TickInfo::MemoryInfo(MemoryTracker* tracker) const {
-  tracker->TrackField("fields", fields_);
-}
-
 void AsyncHooks::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("providers", providers_);
   tracker->TrackField("async_ids_stack", async_ids_stack_);
@@ -1000,7 +995,6 @@ inline size_t Environment::SelfSize() const {
   // if a certain scope is entered.
   size -= sizeof(thread_stopper_);
   size -= sizeof(async_hooks_);
-  size -= sizeof(tick_info_);
   size -= sizeof(immediate_info_);
   return size;
 }
@@ -1024,7 +1018,6 @@ void Environment::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("cleanup_hooks", cleanup_hooks_);
   tracker->TrackField("async_hooks", async_hooks_);
   tracker->TrackField("immediate_info", immediate_info_);
-  tracker->TrackField("tick_info", tick_info_);
 
 #define V(PropertyName, TypeName)                                              \
   tracker->TrackField(#PropertyName, PropertyName());

--- a/src/env.h
+++ b/src/env.h
@@ -758,31 +758,6 @@ class ImmediateInfo : public MemoryRetainer {
   AliasedUint32Array fields_;
 };
 
-class TickInfo : public MemoryRetainer {
- public:
-  inline AliasedUint8Array& fields();
-  inline bool has_tick_scheduled() const;
-  inline bool has_rejection_to_warn() const;
-
-  SET_MEMORY_INFO_NAME(TickInfo)
-  SET_SELF_SIZE(TickInfo)
-  void MemoryInfo(MemoryTracker* tracker) const override;
-
-  TickInfo(const TickInfo&) = delete;
-  TickInfo& operator=(const TickInfo&) = delete;
-  TickInfo(TickInfo&&) = delete;
-  TickInfo& operator=(TickInfo&&) = delete;
-  ~TickInfo() = default;
-
- private:
-  friend class Environment;  // So we can call the constructor.
-  inline explicit TickInfo(v8::Isolate* isolate);
-
-  enum Fields { kHasTickScheduled = 0, kHasRejectionToWarn, kFieldsCount };
-
-  AliasedUint8Array fields_;
-};
-
 class TrackingTraceStateObserver :
     public v8::TracingController::TraceStateObserver {
  public:
@@ -961,7 +936,6 @@ class Environment : public MemoryRetainer {
 
   inline AsyncHooks* async_hooks();
   inline ImmediateInfo* immediate_info();
-  inline TickInfo* tick_info();
   inline uint64_t timer_base() const;
   inline std::shared_ptr<KVStore> env_vars();
   inline void set_env_vars(std::shared_ptr<KVStore> env_vars);
@@ -1284,7 +1258,6 @@ class Environment : public MemoryRetainer {
 
   AsyncHooks async_hooks_;
   ImmediateInfo immediate_info_;
-  TickInfo tick_info_;
   const uint64_t timer_base_;
   std::shared_ptr<KVStore> env_vars_;
   bool printed_error_ = false;

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -11,7 +11,6 @@
 namespace node {
 
 using errors::TryCatchScope;
-using v8::Array;
 using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
@@ -129,9 +128,6 @@ static void Initialize(Local<Object> target,
   env->SetMethod(target, "enqueueMicrotask", EnqueueMicrotask);
   env->SetMethod(target, "setTickCallback", SetTickCallback);
   env->SetMethod(target, "runMicrotasks", RunMicrotasks);
-  target->Set(env->context(),
-              FIXED_ONE_BYTE_STRING(isolate, "tickInfo"),
-              env->tick_info()->fields().GetJSArray()).Check();
 
   Local<Object> events = Object::New(isolate);
   NODE_DEFINE_CONSTANT(events, kPromiseRejectWithNoHandler);


### PR DESCRIPTION
Judging by a variety of benchmarks (http, nextTick, etc.), there does not appear to be any particular performance benefit from maintaining this state to avoid this call into JavaScript.

In absence of that performance reason, it makes more sense to just simplify this (rather complex) code.

Perhaps a controversial change... and I'll also run most of the benchmarks in CI to try and get as much visibility into the impact.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
