### PR TITLE
stream: avoid unhandled exception when destroy w/ callback.

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const nop = () => {};
+
 function needError(stream, err) {
   if (!err) {
     return false;
@@ -50,6 +52,11 @@ function destroy(err, cb) {
   }
   if (r) {
     r.destroyed = true;
+  }
+
+  if (cb) {
+    // Error is handled through callback. Avoid unhandled exception.
+    this.on('error', nop);
   }
 
   this._destroy(err || null, (err) => {

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -344,3 +344,13 @@ const assert = require('assert');
   }));
   write.destroy(new Error('asd'));
 }
+
+{
+  const write = new Writable({
+    write(chunk, enc, cb) { cb(); }
+  });
+  // Make sure no unhandled exception.
+  write.destroy(new Error('asd'), common.mustCall((err) => {
+    assert.strictEqual(err.message, 'asd');
+  }));
+}


### PR DESCRIPTION
Providing a callback to destroy means that the error should be handled through that callback and thus an unhandled exception error should not be necessary.

Some minor preparation towards possibly making the `destroy(err, cb)` signature public.

With "better" ergonomics I'm hoping users that usually skip adding an `'error'` listeners before `destroy()` no longer end up with unhandled exceptions in edge cases.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
