### PR TITLE
test: add missing test flags

### DIFF
--- a/test/wasi/test-wasi-start-validation.js
+++ b/test/wasi/test-wasi-start-validation.js
@@ -1,3 +1,4 @@
+// Flags: --experimental-wasi-unstable-preview0
 'use strict';
 
 require('../common');


### PR DESCRIPTION
`test-wasi-start-validation.js` should require the `--experimental-wasi-unstable-preview0` flag in order to run. However, due to a recent regression, that hasn't been enforced. https://github.com/nodejs/node/pull/30963 fixes the regression and will cause this test to start (correctly) failing. This commit adds the missing flag.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)