### PR TITLE
test: improve WASI start() coverage

### DIFF
--- a/test/wasi/test-wasi-start-validation.js
+++ b/test/wasi/test-wasi-start-validation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const { WASI } = require('wasi');
 
@@ -29,3 +29,68 @@ const fixtures = require('../common/fixtures');
     );
   })();
 }
+
+(async () => {
+  const wasi = new WASI();
+  const bufferSource = fixtures.readSync('simple.wasm');
+  const wasm = await WebAssembly.compile(bufferSource);
+  const instance = await WebAssembly.instantiate(wasm);
+  const values = [undefined, null, 'foo', 42, true, false, () => {}];
+  let cnt = 0;
+
+  // Mock instance.exports to trigger start() validation.
+  Object.defineProperty(instance, 'exports', {
+    get() { return values[cnt++]; }
+  });
+
+  values.forEach((val) => {
+    assert.throws(
+      () => { wasi.start(instance); },
+      { code: 'ERR_INVALID_ARG_TYPE', message: /\binstance\.exports\b/ }
+    );
+  });
+})();
+
+(async () => {
+  const wasi = new WASI();
+  const bufferSource = fixtures.readSync('simple.wasm');
+  const wasm = await WebAssembly.compile(bufferSource);
+  const instance = await WebAssembly.instantiate(wasm);
+
+  // Mock instance.exports.memory to bypass start() validation.
+  Object.defineProperty(instance, 'exports', {
+    get() {
+      return {
+        memory: new WebAssembly.Memory({ initial: 1 })
+      };
+    }
+  });
+
+  wasi.start(instance);
+  assert.throws(
+    () => { wasi.start(instance); },
+    {
+      code: 'ERR_WASI_ALREADY_STARTED',
+      message: /^WASI instance has already started$/
+    }
+  );
+})();
+
+(async () => {
+  const wasi = new WASI();
+  const bufferSource = fixtures.readSync('simple.wasm');
+  const wasm = await WebAssembly.compile(bufferSource);
+  const instance = await WebAssembly.instantiate(wasm);
+
+  // Mock instance.exports to bypass start() validation.
+  Object.defineProperty(instance, 'exports', {
+    get() {
+      return {
+        memory: new WebAssembly.Memory({ initial: 1 }),
+        __wasi_unstable_reactor_start: common.mustCall()
+      };
+    }
+  });
+
+  wasi.start(instance);
+})();

--- a/test/wasi/test-wasi-start-validation.js
+++ b/test/wasi/test-wasi-start-validation.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 const { WASI } = require('wasi');
 
 const fixtures = require('../common/fixtures');
+const bufferSource = fixtures.readSync('simple.wasm');
 
 {
   const wasi = new WASI();
@@ -16,23 +17,19 @@ const fixtures = require('../common/fixtures');
   );
 }
 
-{
+(async () => {
   const wasi = new WASI({});
-  (async () => {
-    const bufferSource = fixtures.readSync('simple.wasm');
-    const wasm = await WebAssembly.compile(bufferSource);
-    const instance = await WebAssembly.instantiate(wasm);
+  const wasm = await WebAssembly.compile(bufferSource);
+  const instance = await WebAssembly.instantiate(wasm);
 
-    assert.throws(
-      () => { wasi.start(instance); },
-      { code: 'ERR_INVALID_ARG_TYPE', message: /\bWebAssembly\.Memory\b/ }
-    );
-  })();
-}
+  assert.throws(
+    () => { wasi.start(instance); },
+    { code: 'ERR_INVALID_ARG_TYPE', message: /\bWebAssembly\.Memory\b/ }
+  );
+})();
 
 (async () => {
   const wasi = new WASI();
-  const bufferSource = fixtures.readSync('simple.wasm');
   const wasm = await WebAssembly.compile(bufferSource);
   const instance = await WebAssembly.instantiate(wasm);
   const values = [undefined, null, 'foo', 42, true, false, () => {}];
@@ -53,7 +50,6 @@ const fixtures = require('../common/fixtures');
 
 (async () => {
   const wasi = new WASI();
-  const bufferSource = fixtures.readSync('simple.wasm');
   const wasm = await WebAssembly.compile(bufferSource);
   const instance = await WebAssembly.instantiate(wasm);
 
@@ -78,7 +74,6 @@ const fixtures = require('../common/fixtures');
 
 (async () => {
   const wasi = new WASI();
-  const bufferSource = fixtures.readSync('simple.wasm');
   const wasm = await WebAssembly.compile(bufferSource);
   const instance = await WebAssembly.instantiate(wasm);
 


### PR DESCRIPTION
This PR should get the WASI `start()` JS test coverage to 100%.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
