### PR TITLE
stream: first error wins and cannot be overriden

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -140,8 +140,8 @@ function ReadableState(options, stream, isDuplex) {
   // Has it been destroyed
   this.destroyed = false;
 
-  // Indicates whether the stream has errored.
-  this.errored = false;
+  // Indicates whether the stream has errored. Contains the error.
+  this.errored = null;
 
   // Crypto is kind of old and crusty.  Historically, its default string
   // encoding is 'binary' so we have to make this configurable.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -171,7 +171,8 @@ function WritableState(options, stream, isDuplex) {
   // Indicates whether the stream has errored. When true all write() calls
   // should return false. This is needed since when autoDestroy
   // is disabled we need a way to tell whether the stream has failed.
-  this.errored = false;
+  // Contains the error.
+  this.errored = null;
 
   // Count buffered requests
   this.bufferedRequestCount = 0;
@@ -488,7 +489,12 @@ function onwrite(stream, er) {
   state.writelen = 0;
 
   if (er) {
-    state.errored = true;
+    if (!state.errored) {
+      state.errored = er;
+    }
+    if (stream._readableState && !stream._readableState.errored) {
+      stream._readableState.errored = er;
+    }
     if (sync) {
       process.nextTick(onwriteError, stream, state, er, cb);
     } else {

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -8,21 +8,19 @@ function destroy(err, cb) {
   const w = this._writableState;
 
   if (err) {
-    if (w) {
-      w.errored = true;
+    if (w && !w.errored) {
+      w.errored = err;
     }
-    if (r) {
-      r.errored = true;
+    if (r && !r.errored) {
+      r.errored = err;
     }
   }
 
   if ((w && w.destroyed) || (r && r.destroyed)) {
     if (cb) {
-      cb(err);
-    } else if (err) {
-      process.nextTick(emitErrorNT, this, err);
+      // TODO(ronag): Wait until 'close' is emitted (if not already emitted).
+      cb((w && w.errored) || (r && r.errored));
     }
-
     return this;
   }
 
@@ -38,32 +36,30 @@ function destroy(err, cb) {
 
   this._destroy(err || null, (err) => {
     if (err) {
-      if (w) {
-        w.errored = true;
+      if (w && !w.errored) {
+        w.errored = err;
       }
-      if (r) {
-        r.errored = true;
+      if (r && !r.errored) {
+        r.errored = err;
       }
     }
 
     if (cb) {
       // Invoke callback before scheduling emitClose so that callback
       // can schedule before.
-      cb(err);
+      cb((w && w.errored) || (r && r.errored));
       // Don't emit 'error' if passed a callback.
       process.nextTick(emitCloseNT, this);
-    } else if (err) {
-      process.nextTick(emitErrorCloseNT, this, err);
     } else {
-      process.nextTick(emitCloseNT, this);
+      process.nextTick(emitErrorCloseNT, this);
     }
   });
 
   return this;
 }
 
-function emitErrorCloseNT(self, err) {
-  emitErrorNT(self, err);
+function emitErrorCloseNT(self) {
+  emitErrorNT(self);
   emitCloseNT(self);
 }
 
@@ -76,9 +72,15 @@ function emitCloseNT(self) {
   }
 }
 
-function emitErrorNT(self, err) {
+function emitErrorNT(self) {
   const r = self._readableState;
   const w = self._writableState;
+
+  const err = (w && w.errored) || (r && r.errored);
+
+  if (!err) {
+    return;
+  }
 
   if ((w && w.errorEmitted) || (r && r.errorEmitted)) {
     return;
@@ -100,7 +102,7 @@ function undestroy() {
 
   if (r) {
     r.destroyed = false;
-    r.errored = false;
+    r.errored = null;
     r.reading = false;
     r.ended = false;
     r.endEmitted = false;
@@ -109,7 +111,7 @@ function undestroy() {
 
   if (w) {
     w.destroyed = false;
-    w.errored = false;
+    w.errored = null;
     w.ended = false;
     w.ending = false;
     w.finalCalled = false;
@@ -132,13 +134,13 @@ function errorOrDestroy(stream, err) {
   if ((r && r.autoDestroy) || (w && w.autoDestroy))
     stream.destroy(err);
   else if (err) {
-    if (w) {
-      w.errored = true;
+    if (w && !w.errored) {
+      w.errored = err;
     }
-    if (r) {
-      r.errored = true;
+    if (r && !r.errored) {
+      r.errored = err;
     }
-    emitErrorNT(stream, err);
+    emitErrorNT(stream);
   }
 }
 

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -19,6 +19,7 @@ function destroy(err, cb) {
   if ((w && w.destroyed) || (r && r.destroyed)) {
     if (cb) {
       // TODO(ronag): Wait until 'close' is emitted (if not already emitted).
+      // TODO(ronag): cb in nextTick.
       cb((w && w.errored) || (r && r.errored));
     }
     return this;
@@ -47,6 +48,7 @@ function destroy(err, cb) {
     if (cb) {
       // Invoke callback before scheduling emitClose so that callback
       // can schedule before.
+      // TODO(ronag): cb in nextTick.
       cb((w && w.errored) || (r && r.errored));
       // Don't emit 'error' if passed a callback.
       process.nextTick(emitCloseNT, this);

--- a/test/parallel/test-stream-auto-destroy.js
+++ b/test/parallel/test-stream-auto-destroy.js
@@ -86,13 +86,14 @@ const assert = require('assert');
 {
   const r = new stream.Readable({
     read() {
-      r2.emit('error', new Error('fail'));
+      r2.destroy(new Error('fail'));
     }
   });
   const r2 = new stream.Readable({
     autoDestroy: true,
     destroy: common.mustCall((err, cb) => cb())
   });
+  r2.on('error', common.mustCall());
 
   r.pipe(r2);
 }
@@ -100,13 +101,14 @@ const assert = require('assert');
 {
   const r = new stream.Readable({
     read() {
-      w.emit('error', new Error('fail'));
+      w.destroy(new Error('fail'));
     }
   });
   const w = new stream.Writable({
     autoDestroy: true,
     destroy: common.mustCall((err, cb) => cb())
   });
+  w.on('error', common.mustCall());
 
   r.pipe(w);
 }

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -76,8 +76,8 @@ const assert = require('assert');
   duplex.on('end', common.mustNotCall('no end event'));
   duplex.on('finish', common.mustNotCall('no finish event'));
 
-  // Error is swallowed by the custom _destroy
-  duplex.on('error', common.mustNotCall('no error event'));
+  // Error is NOT swallowed by the custom _destroy
+  duplex.on('error', common.mustCall());
   duplex.on('close', common.mustCall());
 
   duplex.destroy(expected);

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -69,8 +69,8 @@ const assert = require('assert');
 
   read.on('end', common.mustNotCall('no end event'));
 
-  // Error is swallowed by the custom _destroy
-  read.on('error', common.mustNotCall('no error event'));
+  // Error is NOT swallowed by the custom _destroy
+  read.on('error', common.mustCall());
   read.on('close', common.mustCall());
 
   read.destroy(expected);
@@ -134,13 +134,13 @@ const assert = require('assert');
   read.on('error', common.mustCall((err) => {
     assert.strictEqual(ticked, true);
     assert.strictEqual(read._readableState.errorEmitted, true);
-    assert.strictEqual(read._readableState.errored, true);
+    assert.strictEqual(read._readableState.errored, expected);
     assert.strictEqual(err, expected);
   }));
 
   read.destroy();
   assert.strictEqual(read._readableState.errorEmitted, false);
-  assert.strictEqual(read._readableState.errored, true);
+  assert.strictEqual(read._readableState.errored, expected);
   assert.strictEqual(read.destroyed, true);
   ticked = true;
 }
@@ -190,15 +190,15 @@ const assert = require('assert');
   // destroy(err, callback);
   read.on('error', common.mustNotCall());
 
-  assert.strictEqual(read._readableState.errored, false);
+  assert.strictEqual(read._readableState.errored, null);
   assert.strictEqual(read._readableState.errorEmitted, false);
 
   read.destroy(expected, common.mustCall(function(err) {
-    assert.strictEqual(read._readableState.errored, true);
+    assert.strictEqual(read._readableState.errored, expected);
     assert.strictEqual(err, expected);
   }));
   assert.strictEqual(read._readableState.errorEmitted, false);
-  assert.strictEqual(read._readableState.errored, true);
+  assert.strictEqual(read._readableState.errored, expected);
   ticked = true;
 }
 
@@ -223,14 +223,15 @@ const assert = require('assert');
 
   readable.destroy();
   assert.strictEqual(readable.destroyed, true);
-  assert.strictEqual(readable._readableState.errored, false);
+  assert.strictEqual(readable._readableState.errored, null);
   assert.strictEqual(readable._readableState.errorEmitted, false);
 
   // Test case where `readable.destroy()` is called again with an error before
   // the `_destroy()` callback is called.
-  readable.destroy(new Error('kaboom 2'));
+  const expected = new Error('kaboom 2');
+  readable.destroy(expected);
   assert.strictEqual(readable._readableState.errorEmitted, false);
-  assert.strictEqual(readable._readableState.errored, true);
+  assert.strictEqual(readable._readableState.errored, expected);
 
   ticked = true;
 }

--- a/test/parallel/test-stream-transform-destroy.js
+++ b/test/parallel/test-stream-transform-destroy.js
@@ -72,8 +72,8 @@ const assert = require('assert');
   transform.on('close', common.mustCall());
   transform.on('finish', common.mustNotCall('no finish event'));
 
-  // Error is swallowed by the custom _destroy
-  transform.on('error', common.mustNotCall('no error event'));
+  // Error is NOT swallowed by the custom _destroy
+  transform.on('error', common.mustCall());
 
   transform.destroy(expected);
 }

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -276,9 +276,6 @@ const assert = require('assert');
   write.destroy(expected, common.mustCall(function(err) {
     assert.strictEqual(err, expected);
   }));
-  write.on('error', common.mustCall((err) => {
-    assert.strictEqual(err, expected);
-  }));
 }
 
 {


### PR DESCRIPTION
The first stream error is the only one that gets emitted as `'error'` or forwarded through callbacks. Also it cannot be overriden or swallowed by `_destroy`. This is in order to easier reason what will happen in regards to streams and errors. Currently it's quite difficult to know what to expect in different cases.

See https://github.com/nodejs/node/issues/30979 for further discussion.

`destroy(err, cb)`, i.e. `destroy` with callback is now also able to actually override the error (see https://github.com/nodejs/node/pull/30982/files#r357996368). I don't believe this affects anything in practice.

semver-major

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
