### PR TITLE
errors: annotate frames for prepareStackTrace()

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -153,9 +153,6 @@ added: v12.12.0
 
 Enable experimental Source Map V3 support for stack traces.
 
-Currently, overriding `Error.prepareStackTrace` is ignored when the
-`--enable-source-maps` flag is set.
-
 ### `--experimental-conditional-exports`
 <!-- YAML
 added: v13.2.0

--- a/lib/internal/source_map/prepare_stack_trace.js
+++ b/lib/internal/source_map/prepare_stack_trace.js
@@ -17,15 +17,37 @@ const prepareStackTrace = (globalThis, error, trace) => {
     return f(error, trace);
   }
 
-  const { SourceMap } = require('internal/source_map/source_map');
+  const decoratedTrace = decorateCallSites(error, trace);
+
+  // `globalThis` is the global that contains the constructor which
+  // created `error`.
+  if (typeof globalThis.Error.prepareStackTrace === 'function') {
+    return globalThis.Error.prepareStackTrace(error, decoratedTrace);
+  }
+
   const errorString = ErrorToString.call(error);
 
-  if (trace.length === 0) {
+  if (decoratedTrace.length === 0) {
     return errorString;
   }
-  const preparedTrace = trace.map((t, i) => {
+  const preparedTrace = decoratedTrace.map((t, i) => {
     let str = i !== 0 ? '\n    at ' : '';
     str = `${str}${t}`;
+    if (t.getOriginalLineNumber) {
+      str += `\n        -> ${
+        t.getOriginalFileName()
+      }:${
+        t.getOriginalLineNumber()
+      }:${t.getOriginalColumnNumber()}`;
+    }
+    return str;
+  });
+  return `${errorString}\n    at ${preparedTrace.join('')}`;
+};
+
+function decorateCallSites(error, trace) {
+  const { SourceMap } = require('internal/source_map/source_map');
+  return trace.map((t) => {
     try {
       const sourceMap = findSourceMap(t.getFileName(), error);
       if (sourceMap && sourceMap.data) {
@@ -35,17 +57,30 @@ const prepareStackTrace = (globalThis, error, trace) => {
         const [, , url, line, col] =
                    sm.findEntry(t.getLineNumber() - 1, t.getColumnNumber() - 1);
         if (url && line !== undefined && col !== undefined) {
-          str +=
-            `\n        -> ${url.replace('file://', '')}:${line + 1}:${col + 1}`;
+          return decorateCallSite(t, url.replace('file://', ''), line + 1,
+                                  col + 1);
         }
       }
     } catch (err) {
       debug(err.stack);
     }
-    return str;
+    return decorateCallSite(t, t.getFileName(), t.getLineNumber(),
+                            t.getColumnNumber());
   });
-  return `${errorString}\n    at ${preparedTrace.join('')}`;
-};
+}
+
+function decorateCallSite(callSite, fileName, lineNumber, columnNumber) {
+  callSite.getOriginalFileName = () => {
+    return fileName;
+  };
+  callSite.getOriginalLineNumber = () => {
+    return lineNumber;
+  };
+  callSite.getOriginalColumnNumber = () => {
+    return columnNumber;
+  };
+  return callSite;
+}
 
 module.exports = {
   prepareStackTrace,

--- a/test/parallel/test-error-prepare-stack-trace.js
+++ b/test/parallel/test-error-prepare-stack-trace.js
@@ -1,0 +1,47 @@
+// Flags: --enable-source-maps
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// Error.prepareStackTrace() can be overridden with source maps enabled.
+{
+  let prepareCalled = false;
+  Error.prepareStackTrace = (_error, trace) => {
+    prepareCalled = true;
+  };
+  try {
+    throw new Error('foo');
+  } catch (err) {
+    err.stack;
+  }
+  assert(prepareCalled);
+}
+
+// Error.prepareStackTrace() should expose getOriginalLineNumber(),
+// getOriginalColumnNumber(), getOriginalFileName().
+{
+  let callSite;
+  Error.prepareStackTrace = (_error, trace) => {
+    const throwingRequireCallSite = trace[0];
+    if (throwingRequireCallSite.getFileName().endsWith('typescript-throw.js')) {
+      callSite = throwingRequireCallSite;
+    }
+  };
+  try {
+    // Require a file that throws an exception, and has a source map.
+    require('../fixtures/source-map/typescript-throw.js');
+  } catch (err) {
+    err.stack; // Force prepareStackTrace() to be called.
+  }
+  assert(callSite);
+
+  assert(callSite.getFileName().endsWith('typescript-throw.js'));
+  assert(callSite.getOriginalFileName().endsWith('typescript-throw.ts'));
+
+  assert.strictEqual(callSite.getLineNumber(), 20);
+  assert.strictEqual(callSite.getColumnNumber(), 15);
+
+  assert.strictEqual(callSite.getOriginalLineNumber(), 18);
+  assert.strictEqual(callSite.getOriginalColumnNumber(), 11);
+}


### PR DESCRIPTION
When source-maps are enabled, overriding `Error.prepareStackTrace()`
is again supported.  `Error.prepareStackTrace()` will now be passed
stack frames with the methods `getOriginalFileName()`,
`getOriginalLineNumber()`, and `getOriginalColumnNumber()` which provide
information parsed from source map.

---

I think this is a good solution to the exception @dougwilson raises in #29994, and provides tools like [depd](https://github.com/dougwilson/nodejs-depd) an option for taking advantage of source-map information.

fixes #29994

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
