### PR TITLE
stream: pipe should not swallow error

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -799,7 +799,12 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     dest.removeListener('error', onerror);
     if (EE.listenerCount(dest, 'error') === 0) {
       if (!dest.destroyed) {
+        const errorEmitted = dest._writableState && dest._writableState.errorEmitted;
         errorOrDestroy(dest, er);
+        if (errorEmitted) {
+          // Force uncaughtException
+          dest.emit('error', er);
+        }
       } else {
         dest.emit('error', er);
       }

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -798,13 +798,10 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     unpipe();
     dest.removeListener('error', onerror);
     if (EE.listenerCount(dest, 'error') === 0) {
-      if (!dest.destroyed) {
-        const errorEmitted = dest._writableState && dest._writableState.errorEmitted;
+      const s = dest._writableState || dest._readableState;
+      if (s && !s.errorEmitted) {
+        // User incorrectly emitted 'error' directly on the stream.
         errorOrDestroy(dest, er);
-        if (errorEmitted) {
-          // Force uncaughtException
-          dest.emit('error', er);
-        }
       } else {
         dest.emit('error', er);
       }

--- a/test/parallel/test-stream2-finish-pipe-error.js
+++ b/test/parallel/test-stream2-finish-pipe-error.js
@@ -1,0 +1,21 @@
+'use strict';
+require('../common');
+const stream = require('stream');
+
+process.on('uncaughtException', common.mustCall());
+
+const r = new stream.Readable();
+r._read = function(size) {
+  r.push(Buffer.allocUnsafe(size));
+};
+
+const w = new stream.Writable();
+w._write = function(data, encoding, cb) {
+  cb(null);
+};
+
+r.pipe(w);
+
+// end() after pipe should cause unhandled exception
+w.end();
+

--- a/test/parallel/test-stream2-finish-pipe-error.js
+++ b/test/parallel/test-stream2-finish-pipe-error.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const stream = require('stream');
 
 process.on('uncaughtException', common.mustCall());
@@ -18,4 +18,3 @@ r.pipe(w);
 
 // end() after pipe should cause unhandled exception
 w.end();
-

--- a/test/parallel/test-stream2-finish-pipe.js
+++ b/test/parallel/test-stream2-finish-pipe.js
@@ -38,7 +38,7 @@ r.pipe(w);
 // end() must be called in nextTick or a WRITE_AFTER_END error occurs.
 process.nextTick(() => {
   // This might sound unrealistic, but it happens in net.js. When
-  // `socket.allowHalfOpen === false`, EOF will cause `.destroySoon()` call which
+  // socket.allowHalfOpen === false, EOF will cause .destroySoon() call which
   // ends the writable side of net.Socket.
   w.end();
 });

--- a/test/parallel/test-stream2-finish-pipe.js
+++ b/test/parallel/test-stream2-finish-pipe.js
@@ -42,4 +42,3 @@ process.nextTick(() => {
   // ends the writable side of net.Socket.
   w.end();
 });
-

--- a/test/parallel/test-stream2-finish-pipe.js
+++ b/test/parallel/test-stream2-finish-pipe.js
@@ -35,7 +35,11 @@ w._write = function(data, encoding, cb) {
 
 r.pipe(w);
 
-// This might sound unrealistic, but it happens in net.js. When
-// `socket.allowHalfOpen === false`, EOF will cause `.destroySoon()` call which
-// ends the writable side of net.Socket.
-w.end();
+// end() must be called in nextTick or a WRITE_AFTER_END error occurs.
+process.nextTick(() => {
+  // This might sound unrealistic, but it happens in net.js. When
+  // `socket.allowHalfOpen === false`, EOF will cause `.destroySoon()` call which
+  // ends the writable side of net.Socket.
+  w.end();
+});
+


### PR DESCRIPTION
`pipe` would not properly forward uncaught errors.

Could be considered bug fix but I still think its semver-major.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
