### PR TITLE
process: add CLI opt to hide experimental warnings

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -455,6 +455,14 @@ added: v0.8.0
 
 Silence deprecation warnings.
 
+### `--no-experimental-warnings`
+<!-- YAML
+added: REPLACEME
+-->
+
+Silence all experimental process warnings. These are emitted when using
+features which are considered experimental.
+
 ### `--no-force-async-hooks-checks`
 <!-- YAML
 added: v9.0.0
@@ -1111,6 +1119,7 @@ Node.js options that are allowed are:
 * `--max-http-header-size`
 * `--napi-modules`
 * `--no-deprecation`
+* `--no-experimental-warnings`
 * `--no-force-async-hooks-checks`
 * `--no-warnings`
 * `--openssl-config`

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -173,6 +173,8 @@ function slowCases(enc) {
 }
 
 function emitExperimentalWarning(feature) {
+  const { getOptionValue } = require('internal/options');
+  if (getOptionValue('--no-experimental-warnings')) return;
   if (experimentalWarnings.has(feature)) return;
   const msg = `${feature} is an experimental feature. This feature could ` +
        'change at any time';

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -409,6 +409,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "silence all process warnings",
             &EnvironmentOptions::no_warnings,
             kAllowedInEnvironment);
+AddOption("--no-experimental-warnings",
+            "silence all experimental process warnings",
+            &EnvironmentOptions::no_experimental_warnings,
+            kAllowedInEnvironment);
   AddOption("--force-context-aware",
             "disable loading non-context-aware addons",
             &EnvironmentOptions::force_context_aware,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -120,6 +120,7 @@ class EnvironmentOptions : public Options {
   bool no_deprecation = false;
   bool no_force_async_hooks_checks = false;
   bool no_warnings = false;
+  bool no_experimental_warnings = false;
   bool force_context_aware = false;
   bool pending_deprecation = false;
   bool preserve_symlinks = false;

--- a/test/parallel/test-process-no-emit-experimental-warnings.js
+++ b/test/parallel/test-process-no-emit-experimental-warnings.js
@@ -1,0 +1,16 @@
+// Flags: --no-experimental-warnings --expose-internals
+'use strict';
+// Test supressing experimental warnings.
+const common = require('../common');
+const { hijackStderr,
+        restoreStderr
+} = require('../common/hijackstdio');
+const { emitExperimentalWarning } = require('internal/util');
+
+function test() {
+  hijackStderr(common.mustNotCall('stderr.write must not be called'));
+  emitExperimentalWarning('testExperimentalWarning');
+  restoreStderr();
+}
+
+test();


### PR DESCRIPTION
Adds a command line option to supress experimental warnings. Currently
this cannot be accomplished without supressing all warnings (by using
the --no-warnings option). However, once this option is enabled, a user
can miss out on essential warnings as this supresses all warnings.
This commit adds the --no-experimental-warnings command line option to
allow users to ignore warnings they will expect while still being able
to monitor unexpected warnings.

Fixes: https://github.com/nodejs/node/issues/30810

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
