### PR TITLE
module: unflag resolve self

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -178,7 +178,7 @@ added: v8.5.0
 -->
 
 Enable latest experimental modules features (currently
-`--experimental-conditional-exports` and `--experimental-resolve-self`).
+`--experimental-conditional-exports`).
 
 ### `--experimental-policy`
 <!-- YAML
@@ -200,14 +200,6 @@ added: v11.8.0
 -->
 
 Enable experimental diagnostic report feature.
-
-### `--experimental-resolve-self`
-<!-- YAML
-added: v13.1.0
--->
-
-Enable experimental support for a package using `require` or `import` to load
-itself.
 
 ### `--experimental-specifier-resolution=mode`
 <!-- YAML
@@ -1091,7 +1083,6 @@ Node.js options that are allowed are:
 * `--experimental-policy`
 * `--experimental-repl-await`
 * `--experimental-report`
-* `--experimental-resolve-self`
 * `--experimental-specifier-resolution`
 * `--experimental-vm-modules`
 * `--experimental-wasi-unstable-preview1`

--- a/doc/node.1
+++ b/doc/node.1
@@ -138,9 +138,6 @@ Enable experimental
 .Sy diagnostic report
 feature.
 .
-.It Fl -experimental-resolve-self
-Enable experimental support for a package to load itself.
-.
 .It Fl -experimental-vm-modules
 Enable experimental ES module support in VM module.
 .

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -67,7 +67,6 @@ const { getOptionValue } = require('internal/options');
 const enableSourceMaps = getOptionValue('--enable-source-maps');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
-const experimentalSelf = getOptionValue('--experimental-resolve-self');
 const experimentalConditionalExports =
     getOptionValue('--experimental-conditional-exports');
 const manifest = getOptionValue('--experimental-policy') ?
@@ -432,10 +431,6 @@ function resolveBasePath(basePath, exts, isMain, trailingSlash, request) {
 }
 
 function trySelf(parentPath, isMain, request) {
-  if (!experimentalSelf) {
-    return false;
-  }
-
   const { data: pkg, path: basePath } = readPackageScope(parentPath) || {};
   if (!pkg || 'exports' in pkg === false) return false;
   if (typeof pkg.name !== 'string') return false;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -431,6 +431,9 @@ function resolveBasePath(basePath, exts, isMain, trailingSlash, request) {
 }
 
 function trySelf(parentPath, isMain, request) {
+  if (!experimentalConditionalExports) {
+    return false;
+  }
   const { data: pkg, path: basePath } = readPackageScope(parentPath) || {};
   if (!pkg || 'exports' in pkg === false) return false;
   if (typeof pkg.name !== 'string') return false;

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -1153,9 +1153,6 @@ Maybe<URL> ResolveSelf(Environment* env,
                        const std::string& pkg_name,
                        const std::string& pkg_subpath,
                        const URL& base) {
-  if (!env->options()->experimental_resolve_self) {
-    return Nothing<URL>();
-  }
   const PackageConfig* pcfg;
   if (GetPackageScopeConfig(env, base, base).To(&pcfg) &&
       pcfg->exists == Exists::Yes) {

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -325,15 +325,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::userland_loader,
             kAllowedInEnvironment);
   AddAlias("--loader", "--experimental-loader");
-  AddAlias("--experimental-modules", { "--experimental-conditional-exports",
-                                       "--experimental-resolve-self" });
+  AddAlias("--experimental-modules", { "--experimental-conditional-exports" });
   AddOption("--experimental-conditional-exports",
             "experimental support for conditional exports targets",
             &EnvironmentOptions::experimental_conditional_exports,
-            kAllowedInEnvironment);
-  AddOption("--experimental-resolve-self",
-            "experimental support for require/import of the current package",
-            &EnvironmentOptions::experimental_resolve_self,
             kAllowedInEnvironment);
   AddOption("--experimental-wasm-modules",
             "experimental ES Module support for webassembly modules",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -103,7 +103,6 @@ class EnvironmentOptions : public Options {
   bool enable_source_maps = false;
   bool experimental_conditional_exports = false;
   bool experimental_json_modules = false;
-  bool experimental_resolve_self = false;
   std::string experimental_specifier_resolution;
   std::string es_module_specifier_resolution;
   bool experimental_wasm_modules = false;

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -170,12 +170,7 @@ function assertIncludes(actual, expected) {
     '--experimental-conditional-exports',
     '/es-modules/conditional-exports.js',
     'Conditional exports',
-  ],
-  [
-    '--experimental-resolve-self',
-    '/node_modules/pkgexports/resolve-self.js',
-    'Package name self resolution',
-  ],
+  ]
 ].forEach(([flag, file, message]) => {
   const child = spawn(process.execPath, [flag, path(file)]);
 


### PR DESCRIPTION
Unflags the `--experimental-resolve-self` option, which allows packages to load their own `"exports"` definitions through an import to their own package name.

~~For CommonJS this approach is backwards-compatible because the own name resolution is only attempted after all other resolutions fail.~~

Backwards compatibility is now ensured by only supporting own-name resolution when `"exports"` in the package.json is set. When it is, this resolution applies before any node_modules lookup checks.

Opening now to discuss along with overall resolver stability concerns.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
