### PR TITLE
deps: V8: cherry-pick d3a1a5b6c491

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.23',
+    'v8_embedder_string': '-node.24',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/objects/prototype-info.h
+++ b/deps/v8/src/objects/prototype-info.h
@@ -99,7 +99,7 @@ class V8_EXPORT_PRIVATE PrototypeUsers : public WeakArrayList {
   static inline Smi empty_slot_index(WeakArrayList array);
   static inline void set_empty_slot_index(WeakArrayList array, int index);
 
-  static void IsSlotEmpty(WeakArrayList array, int index);
+  static void ScanForEmptySlots(WeakArrayList array);
 
   DISALLOW_IMPLICIT_CONSTRUCTORS(PrototypeUsers);
 };


### PR DESCRIPTION
Original commit message:

    [objects] Fix memory leak in PrototypeUsers::Add

    PrototypeUsers::Add now iterates the WeakArrayList to find empty slots
    before growing the array. Not reusing empty slots caused a memory leak.

    It might also be desirable to shrink the WeakArrayList in the future.
    Right now it is only compacted when invoking CreateBlob.

    Also removed unused PrototypeUsers::IsEmptySlot declaration.

    Bug: v8:10031
    Change-Id: I570ec78fca37e8f0c794f1f40846a4daab47c225
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1967317
    Reviewed-by: Ulan Degenbaev <ulan@chromium.org>
    Reviewed-by: Igor Sheludko <ishell@chromium.org>
    Commit-Queue: Dominik Inführ <dinfuehr@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#65456}

Refs: https://github.com/v8/v8/commit/d3a1a5b6c4916f22e076e3349ed3619bfb014f29
Fixes: https://github.com/nodejs/node/issues/30753
