### PR TITLE
module: implement logical conditional exports ordering

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1517,6 +1517,8 @@ _defaultEnv_ is the conditional environment name priority array,
 > 1. If _exports_ is an Object with both a key starting with _"."_ and a key not
 >    starting with _"."_, throw an "Invalid Package Configuration" error.
 > 1. If _exports_ is an Object and all keys of _exports_ start with _"."_, then
+>    1. If _exports_ contains any index property keys, as defined in ECMA-262
+>       6.1.7 Array Index, throw an _Invalid Package Configuration_ error.
 >    1. Set _packagePath_ to _"./"_ concatenated with _packagePath_.
 >    1. If _packagePath_ is a key of _exports_, then
 >       1. Let _target_ be the value of _exports\[packagePath\]_.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1517,8 +1517,6 @@ _defaultEnv_ is the conditional environment name priority array,
 > 1. If _exports_ is an Object with both a key starting with _"."_ and a key not
 >    starting with _"."_, throw an "Invalid Package Configuration" error.
 > 1. If _exports_ is an Object and all keys of _exports_ start with _"."_, then
->    1. If _exports_ contains any index property keys, as defined in ECMA-262
->       6.1.7 Array Index, throw an _Invalid Package Configuration_ error.
 >    1. Set _packagePath_ to _"./"_ concatenated with _packagePath_.
 >    1. If _packagePath_ is a key of _exports_, then
 >       1. Let _target_ be the value of _exports\[packagePath\]_.
@@ -1552,7 +1550,9 @@ _defaultEnv_ is the conditional environment name priority array,
 >       1. If _resolved_ is contained in _resolvedTarget_, then
 >          1. Return _resolved_.
 > 1. Otherwise, if _target_ is a non-null Object, then
->    1. For each property _p_ of _target_, in object insertion order,
+>    1. If _exports_ contains any index property keys, as defined in ECMA-262
+>       [6.1.7 Array Index][], throw an _Invalid Package Configuration_ error.
+>    1. For each property _p_ of _target_, in object insertion order as,
 >       1. If _env_ contains an entry for _p_, then
 >          1. Let _targetValue_ be the value of the _p_ property in _target_.
 >          1. Let _resolved_ be the result of **PACKAGE_EXPORTS_TARGET_RESOLVE**
@@ -1654,3 +1654,4 @@ success!
 [special scheme]: https://url.spec.whatwg.org/#special-scheme
 [the official standard format]: https://tc39.github.io/ecma262/#sec-modules
 [transpiler loader example]: #esm_transpiler_loader
+[6.1.7 Array Index]: https://tc39.es/ecma262/#integer-index

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -343,25 +343,26 @@ Node.js and the browser can be written:
 When resolving the `"."` export, if no matching target is found, the `"main"`
 will be used as the final fallback.
 
-The conditions supported in Node.js are matched in the following order:
+The conditions supported in Node.js condition matching:
 
-1. `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
-   module file. _This is currently only supported behind the
-   `--experimental-conditional-exports` flag._
-2. `"require"` - matched when the package is loaded via `require()`.
-   _This is currently only supported behind the
-   `--experimental-conditional-exports` flag._
-3. `"import"` - matched when the package is loaded via `import` or
+* `"default"` - the generic fallback that will always match. Can be a CommonJS
+   or ES module file.
+* `"import"` - matched when the package is loaded via `import` or
    `import()`. Can be any module format, this field does not set the type
    interpretation. _This is currently only supported behind the
    `--experimental-conditional-exports` flag._
-4. `"default"` - the generic fallback that will always match if no other
-   more specific condition is matched first. Can be a CommonJS or ES module
-   file.
+* `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
+   module file. _This is currently only supported behind the
+   `--experimental-conditional-exports` flag._
+* `"require"` - matched when the package is loaded via `require()`.
+   _This is currently only supported behind the
+   `--experimental-conditional-exports` flag._
 
-> Setting any of the above flagged conditions for a published package is not
-> recommended until they are unflagged to avoid breaking changes to packages in
-> future.
+Condition matching is applied in object order from first to last within the
+`"exports"` object.
+
+> Setting the above conditions for a published package is not recommended until
+> conditional exports have been unflagged to avoid breaking changes to packages.
 
 Using the `"require"` condition it is possible to define a package that will
 have a different exported value for CommonJS and ES modules, which can be a
@@ -369,7 +370,9 @@ hazard in that it can result in having two separate instances of the same
 package in use in an application, which can cause a number of bugs.
 
 Other conditions such as `"browser"`, `"electron"`, `"deno"`, `"react-native"`,
-etc. could be defined in other runtimes or tools.
+etc. could be defined in other runtimes or tools. Condition names must not start
+with `"."` or be numbers. Further restrictions, definitions or guidance on
+condition names may be provided in future.
 
 #### Exports Sugar
 
@@ -1547,13 +1550,13 @@ _defaultEnv_ is the conditional environment name priority array,
 >       1. If _resolved_ is contained in _resolvedTarget_, then
 >          1. Return _resolved_.
 > 1. Otherwise, if _target_ is a non-null Object, then
->    1. If _target_ has an object key matching one of the names in _env_, then
->       1. Let _targetValue_ be the corresponding value of the first object key
->          of _target_ in _env_.
->       1. Let _resolved_ be the result of **PACKAGE_EXPORTS_TARGET_RESOLVE**
->          (_packageURL_, _targetValue_, _subpath_, _env_).
->       1. Assert: _resolved_ is a String.
->       1. Return _resolved_.
+>    1. For each property _p_ of _target_, in object insertion order,
+>       1. If _env_ contains an entry for _p_, then
+>          1. Let _targetValue_ be the value of the _p_ property in _target_.
+>          1. Let _resolved_ be the result of **PACKAGE_EXPORTS_TARGET_RESOLVE**
+>             (_packageURL_, _targetValue_, _subpath_, _env_).
+>          1. Assert: _resolved_ is a String.
+>          1. Return _resolved_.
 > 1. Otherwise, if _target_ is an Array, then
 >    1. For each item _targetValue_ in _target_, do
 >       1. If _targetValue_ is an Array, continue the loop.

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -587,34 +587,28 @@ function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
       }
     }
   } else if (typeof target === 'object' && target !== null) {
-    if (experimentalConditionalExports &&
-        ObjectPrototypeHasOwnProperty(target, 'node')) {
-      try {
-        const result = resolveExportsTarget(pkgPath, target.node, subpath,
-                                            basePath, mappingKey);
-        emitExperimentalWarning('Conditional exports');
-        return result;
-      } catch (e) {
-        if (e.code !== 'MODULE_NOT_FOUND') throw e;
-      }
-    }
-    if (experimentalConditionalExports &&
-        ObjectPrototypeHasOwnProperty(target, 'require')) {
-      try {
-        const result = resolveExportsTarget(pkgPath, target.require, subpath,
-                                            basePath, mappingKey);
-        emitExperimentalWarning('Conditional exports');
-        return result;
-      } catch (e) {
-        if (e.code !== 'MODULE_NOT_FOUND') throw e;
-      }
-    }
-    if (ObjectPrototypeHasOwnProperty(target, 'default')) {
-      try {
-        return resolveExportsTarget(pkgPath, target.default, subpath,
-                                    basePath, mappingKey);
-      } catch (e) {
-        if (e.code !== 'MODULE_NOT_FOUND') throw e;
+    for (const p of ObjectKeys(target)) {
+      switch (p) {
+        case 'node':
+        case 'require':
+          if (!experimentalConditionalExports)
+            continue;
+          try {
+            emitExperimentalWarning('Conditional exports');
+            const result = resolveExportsTarget(pkgPath, target[p], subpath,
+                                                basePath, mappingKey);
+            return result;
+          } catch (e) {
+            if (e.code !== 'MODULE_NOT_FOUND') throw e;
+          }
+          break;
+        case 'default':
+          try {
+            return resolveExportsTarget(pkgPath, target.default, subpath,
+                                        basePath, mappingKey);
+          } catch (e) {
+            if (e.code !== 'MODULE_NOT_FOUND') throw e;
+          }
       }
     }
   }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -26,16 +26,19 @@ const {
   Error,
   JSONParse,
   Map,
+  Number,
   ObjectCreate,
   ObjectDefineProperty,
   ObjectFreeze,
   ObjectGetOwnPropertyDescriptor,
   ObjectGetPrototypeOf,
+  ObjectIs,
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
   ReflectSet,
   SafeMap,
+  String,
   StringPrototypeIndexOf,
   StringPrototypeMatch,
   StringPrototypeSlice,
@@ -557,6 +560,18 @@ function resolveExports(nmPath, request, absoluteRequest) {
   return path.resolve(nmPath, request);
 }
 
+function isArrayIndex(p) {
+  assert(typeof p === 'string');
+  const n = Number(p);
+  if (String(n) !== p)
+    return false;
+  if (ObjectIs(n, +0))
+    return true;
+  if (!Number.isInteger(n))
+    return false;
+  return n >= 0 && n < (2 ** 32) - 1;
+}
+
 function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
   if (typeof target === 'string') {
     if (target.startsWith('./') &&
@@ -587,7 +602,12 @@ function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
       }
     }
   } else if (typeof target === 'object' && target !== null) {
-    for (const p of ObjectKeys(target)) {
+    const keys = ObjectKeys(target);
+    if (keys.some(isArrayIndex)) {
+      throw new ERR_INVALID_PACKAGE_CONFIG(basePath, '"exports" cannot ' +
+          'contain numeric property keys.');
+    }
+    for (const p of keys) {
       switch (p) {
         case 'node':
         case 'require':

--- a/src/env.h
+++ b/src/env.h
@@ -202,7 +202,6 @@ constexpr size_t kFsStatsBufferLength =
   V(crypto_rsa_pss_string, "rsa-pss")                                          \
   V(cwd_string, "cwd")                                                         \
   V(data_string, "data")                                                       \
-  V(default_string, "default")                                                 \
   V(dest_string, "dest")                                                       \
   V(destroyed_string, "destroyed")                                             \
   V(detached_string, "detached")                                               \
@@ -257,7 +256,6 @@ constexpr size_t kFsStatsBufferLength =
   V(http_1_1_string, "http/1.1")                                               \
   V(identity_string, "identity")                                               \
   V(ignore_string, "ignore")                                                   \
-  V(import_string, "import")                                                   \
   V(infoaccess_string, "infoAccess")                                           \
   V(inherit_string, "inherit")                                                 \
   V(input_string, "input")                                                     \

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -921,7 +921,7 @@ bool IsArrayIndex(Environment* env, Local<String> p) {
   Local<Integer> cmp_integer;
   if (!n->ToInteger(context).ToLocal(&cmp_integer))
     return false;
-  return n_dbl >= 0 && n_dbl < (2 ^ 32) - 1;
+  return n_dbl > 0 && n_dbl < (2 ^ 32) - 1;
 }
 
 Maybe<URL> ResolveExportsTarget(Environment* env,

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -9,10 +9,11 @@
 #include "node_watchdog.h"
 #include "node_process.h"
 
+
 #include <sys/stat.h>  // S_IFDIR
 
 #include <algorithm>
-#include <climits>  // PATH_MAX
+#include <cmath> // SIGNBIT
 
 namespace node {
 namespace loader {
@@ -916,6 +917,8 @@ bool IsArrayIndex(Environment* env, Local<String> p) {
   CHECK(n->ToString(context).ToLocal(&cmp_str));
   if (!p->Equals(context, cmp_str).FromJust())
     return false;
+  if (n_dbl == 0 && std::signbit(n_dbl) == false)
+    return true;
   Local<Integer> cmp_integer;
   if (!n->ToInteger(context).ToLocal(&cmp_integer))
     return false;

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -13,7 +13,6 @@
 #include <sys/stat.h>  // S_IFDIR
 
 #include <algorithm>
-#include <cmath> // SIGNBIT
 
 namespace node {
 namespace loader {

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -124,6 +124,11 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
       'ERR_MODULE_NOT_FOUND');
   }));
 
+  // Package export with numeric index properties must throw a validation error
+  loadFixture('pkgexports-numeric').catch(mustCall((err) => {
+    strictEqual(err.code, 'ERR_INVALID_PACKAGE_CONFIG');
+  }));
+
   // Sugar conditional exports main mixed failure case
   loadFixture('pkgexports-sugar-fail').catch(mustCall((err) => {
     strictEqual(err.code, 'ERR_INVALID_PACKAGE_CONFIG');

--- a/test/fixtures/node_modules/pkgexports-numeric/package.json
+++ b/test/fixtures/node_modules/pkgexports-numeric/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "./main.cjs",
+  "exports": {
+    "0": "./should-throw"
+  }
+}

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -18,7 +18,20 @@
     "./nofallback1": [],
     "./nofallback2": [null, {}, "builtin:x"],
     "./nodemodules": "./node_modules/internalpkg/x.js",
-    "./condition": [{ "require": "./sp ce.js" }, "./asdf.js"],
+    "./condition": [{
+      "import": "///overridden",
+      "require": {
+        "require": {
+          "nomatch": "./nothing.js"
+        },
+        "default": "./sp ce.js"
+      },
+      "default": "./asdf.js",
+      "node": "./lib/hole.js",
+      "import": {
+        "nomatch": "./nothing.js"
+      }
+    }],
     "./resolve-self": {
       "require": "./resolve-self.js",
       "import": "./resolve-self.mjs"


### PR DESCRIPTION
This updates the ordering of matching for conditional exports to apply in logical order, as opposed to an invisible priority order of the conditions set by the resolver itself. This effectively makes the logic line up with the intuitive model that @sokra proposed in https://github.com/nodejs/modules/issues/452#issuecomment-562442188.

The main reason is that with many conditions, making sense of what will match becomes almost impossible. Consider for example:

```js
{
  "exports": {
    "browser": "./main-browser.js",
    "production": "./main-production.js",
    "development": "./main-dev.js",
    "node": "./main-node.js",
    "default": "./main.js"
  }
}
```

Strictly speaking, the resolver order of the above would be (assuming either core support for production / development, or through a custom flag): 1. production/development 2. browser/node 3. default.

Yet as a user setting the browser + production condition, there is no clear indication at all that `"browser"` will never be used, and `"production"` will always take priority. With this change, `"browser"` is chosen first whenever browser is enabled.

By moving to object order, the user is in full control of the matching, and can be sure their preferred target condition will be selected first.

The other change is with nesting, for example in:

```js
{
  "exports": {
    "production": {
      "browser": "./asdf.js"
    },
    "default": "./x.js"
  }
}
```

Currently if in the "node" + "production" environment, trying to load the package will throw entirely because we greedily match the `"production"` condition, and then fail to match the browser condition and then bail.

With this PR, the failure on the `"production"` condition will still fall back to trying the `"default"` condition, providing a nicer fallback workflow.

The examples of production / browser are all hypothetical to explain the semantics - the conditions supported remain the same under this PR.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
