### PR TITLE
module: self resolve bug fixes and esm ordering

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1207,7 +1207,8 @@ _defaultEnv_ is the conditional environment name priority array,
 >    encoded strings for _"/"_ or _"\\"_, then
 >    1. Throw an _Invalid Specifier_ error.
 > 1. Set _selfUrl_ to the result of
->    **SELF_REFERENCE_RESOLE**(_packageName_, _packageSubpath_, _parentURL_).
+>    **SELF_REFERENCE_RESOLE**(_packageName_, _packageSubpath_, _parentURL_,
+>    **true**).
 > 1. If _selfUrl_ isn't empty, return _selfUrl_.
 > 1. If _packageSubpath_ is _undefined_ and _packageName_ is a Node.js builtin
 >    module, then
@@ -1230,14 +1231,21 @@ _defaultEnv_ is the conditional environment name priority array,
 >             1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_,
 >                _packageSubpath_, _pjson.exports_).
 >       1. Return the URL resolution of _packageSubpath_ in _packageURL_.
+> 1. Set _selfUrl_ to the result of
+>    **SELF_REFERENCE_RESOLE**(_packageName_, _packageSubpath_, _parentURL_,
+>    **false**).
+> 1. If _selfUrl_ isn't empty, return _selfUrl_.
 > 1. Throw a _Module Not Found_ error.
 
-**SELF_REFERENCE_RESOLVE**(_packageName_, _packageSubpath_, _parentURL_)
+**SELF_REFERENCE_RESOLVE**(_packageName_, _packageSubpath_, _parentURL_,
+                           _encapsulated_)
 
 > 1. Let _packageURL_ be the result of **READ_PACKAGE_SCOPE**(_parentURL_).
 > 1. If _packageURL_ is **null**, then
->    1. Return an empty result.
+>    1. Return **undefined**.
 > 1. Let _pjson_ be the result of **READ_PACKAGE_JSON**(_packageURL_).
+> 1. If _encapsulated_ is **true** and _pjson_ does not include an
+>    _"exports"_ property, then return **undefined**.
 > 1. If _pjson.name_ is equal to _packageName_, then
 >    1. If _packageSubpath_ is _undefined_, then
 >       1. Return the result of **PACKAGE_MAIN_RESOLVE**(_packageURL_, _pjson_).
@@ -1248,7 +1256,7 @@ _defaultEnv_ is the conditional environment name priority array,
 >             1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _subpath_,
 >                _pjson.exports_).
 >       1. Return the URL resolution of _subpath_ in _packageURL_.
-> 1. Otherwise return an empty result.
+> 1. Otherwise, return **undefined**.
 
 **PACKAGE_MAIN_RESOLVE**(_packageURL_, _pjson_)
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1237,15 +1237,14 @@ _defaultEnv_ is the conditional environment name priority array,
 > 1. If _selfUrl_ isn't empty, return _selfUrl_.
 > 1. Throw a _Module Not Found_ error.
 
-**SELF_REFERENCE_RESOLVE**(_packageName_, _packageSubpath_, _parentURL_,
-                           _encapsulated_)
+**SELF_REFERENCE_RESOLVE**(_packageName_, _packageSubpath_, _parentURL_)
 
 > 1. Let _packageURL_ be the result of **READ_PACKAGE_SCOPE**(_parentURL_).
 > 1. If _packageURL_ is **null**, then
 >    1. Return **undefined**.
 > 1. Let _pjson_ be the result of **READ_PACKAGE_JSON**(_packageURL_).
-> 1. If _encapsulated_ is **true** and _pjson_ does not include an
->    _"exports"_ property, then return **undefined**.
+> 1. If _pjson_ does not include an _"exports"_ property, then
+>    1. Return **undefined**.
 > 1. If _pjson.name_ is equal to _packageName_, then
 >    1. If _packageSubpath_ is _undefined_, then
 >       1. Return the result of **PACKAGE_MAIN_RESOLVE**(_packageURL_, _pjson_).

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1207,8 +1207,7 @@ _defaultEnv_ is the conditional environment name priority array,
 >    encoded strings for _"/"_ or _"\\"_, then
 >    1. Throw an _Invalid Specifier_ error.
 > 1. Set _selfUrl_ to the result of
->    **SELF_REFERENCE_RESOLE**(_packageName_, _packageSubpath_, _parentURL_,
->    **true**).
+>    **SELF_REFERENCE_RESOLVE**(_packageName_, _packageSubpath_, _parentURL_).
 > 1. If _selfUrl_ isn't empty, return _selfUrl_.
 > 1. If _packageSubpath_ is _undefined_ and _packageName_ is a Node.js builtin
 >    module, then
@@ -1231,10 +1230,6 @@ _defaultEnv_ is the conditional environment name priority array,
 >             1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_,
 >                _packageSubpath_, _pjson.exports_).
 >       1. Return the URL resolution of _packageSubpath_ in _packageURL_.
-> 1. Set _selfUrl_ to the result of
->    **SELF_REFERENCE_RESOLE**(_packageName_, _packageSubpath_, _parentURL_,
->    **false**).
-> 1. If _selfUrl_ isn't empty, return _selfUrl_.
 > 1. Throw a _Module Not Found_ error.
 
 **SELF_REFERENCE_RESOLVE**(_packageName_, _packageSubpath_, _parentURL_)

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1206,6 +1206,9 @@ _defaultEnv_ is the conditional environment name priority array,
 > 1. If _packageSubpath_ contains any _"."_ or _".."_ segments or percent
 >    encoded strings for _"/"_ or _"\\"_, then
 >    1. Throw an _Invalid Specifier_ error.
+> 1. Set _selfUrl_ to the result of
+>    **SELF_REFERENCE_RESOLE**(_packageName_, _packageSubpath_, _parentURL_).
+> 1. If _selfUrl_ isn't empty, return _selfUrl_.
 > 1. If _packageSubpath_ is _undefined_ and _packageName_ is a Node.js builtin
 >    module, then
 >    1. Return the string _"node:"_ concatenated with _packageSpecifier_.
@@ -1227,29 +1230,24 @@ _defaultEnv_ is the conditional environment name priority array,
 >             1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_,
 >                _packageSubpath_, _pjson.exports_).
 >       1. Return the URL resolution of _packageSubpath_ in _packageURL_.
-> 1. Set _selfUrl_ to the result of
->    **SELF_REFERENCE_RESOLE**(_packageSpecifier_, _parentURL_).
-> 1. If _selfUrl_ isn't empty, return _selfUrl_.
 > 1. Throw a _Module Not Found_ error.
 
-**SELF_REFERENCE_RESOLVE**(_specifier_, _parentURL_)
+**SELF_REFERENCE_RESOLVE**(_packageName_, _packageSubpath_, _parentURL_)
 
 > 1. Let _packageURL_ be the result of **READ_PACKAGE_SCOPE**(_parentURL_).
 > 1. If _packageURL_ is **null**, then
 >    1. Return an empty result.
 > 1. Let _pjson_ be the result of **READ_PACKAGE_JSON**(_packageURL_).
-> 1. Set _name_ to _pjson.name_.
-> 1. If _name_ is empty, then return an empty result.
-> 1. If _name_ is equal to _specifier_, then
->    1. Return the result of **PACKAGE_MAIN_RESOLVE**(_packageURL_, _pjson_).
-> 1. If _specifier_ starts with _name_ followed by "/", then
->    1. Set _subpath_ to everything after the "/".
->    1. If _pjson_ is not **null** and _pjson_ has an _"exports"_ key, then
->       1. Let _exports_ be _pjson.exports_.
->       1. If _exports_ is not **null** or **undefined**, then
->          1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _subpath_,
->             _pjson.exports_).
->    1. Return the URL resolution of _subpath_ in _packageURL_.
+> 1. If _pjson.name_ is equal to _packageName_, then
+>    1. If _packageSubpath_ is _undefined_, then
+>       1. Return the result of **PACKAGE_MAIN_RESOLVE**(_packageURL_, _pjson_).
+>    1. Otherwise,
+>       1. If _pjson_ is not **null** and _pjson_ has an _"exports"_ key, then
+>          1. Let _exports_ be _pjson.exports_.
+>          1. If _exports_ is not **null** or **undefined**, then
+>             1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _subpath_,
+>                _pjson.exports_).
+>       1. Return the URL resolution of _subpath_ in _packageURL_.
 > 1. Otherwise return an empty result.
 
 **PACKAGE_MAIN_RESOLVE**(_packageURL_, _pjson_)

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -160,9 +160,10 @@ require(X) from module at path Y
    a. LOAD_AS_FILE(Y + X)
    b. LOAD_AS_DIRECTORY(Y + X)
    c. THROW "not found"
-4. LOAD_NODE_MODULES(X, dirname(Y))
-5. LOAD_SELF_REFERENCE(X, dirname(Y))
-6. THROW "not found"
+4. LOAD_SELF_REFERENCE(X, dirname(Y), true)
+5. LOAD_NODE_MODULES(X, dirname(Y))
+6. LOAD_SELF_REFERENCE(X, dirname(Y), false)
+7. THROW "not found"
 
 LOAD_AS_FILE(X)
 1. If X is a file, load X as JavaScript text.  STOP
@@ -203,11 +204,12 @@ NODE_MODULES_PATHS(START)
    d. let I = I - 1
 5. return DIRS
 
-LOAD_SELF_REFERENCE(X, START)
+LOAD_SELF_REFERENCE(X, START, ENCAPSULATED)
 1. Find the closest package scope to START.
-2. If no scope was found, throw "not found".
-3. If the name in `package.json` isn't a prefix of X, throw "not found".
-4. Otherwise, resolve the remainder of X relative to this package as if it
+2. If no scope was found, return.
+3. If ENCAPSULATED is true and the `package.json` has no "exports", return.
+4. If the name in `package.json` isn't a prefix of X, throw "not found".
+5. Otherwise, resolve the remainder of X relative to this package as if it
    was loaded via `LOAD_NODE_MODULES` with a name in `package.json`.
 ```
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -160,9 +160,8 @@ require(X) from module at path Y
    a. LOAD_AS_FILE(Y + X)
    b. LOAD_AS_DIRECTORY(Y + X)
    c. THROW "not found"
-4. LOAD_SELF_REFERENCE(X, dirname(Y), true)
+4. LOAD_SELF_REFERENCE(X, dirname(Y))
 5. LOAD_NODE_MODULES(X, dirname(Y))
-6. LOAD_SELF_REFERENCE(X, dirname(Y), false)
 7. THROW "not found"
 
 LOAD_AS_FILE(X)
@@ -204,10 +203,10 @@ NODE_MODULES_PATHS(START)
    d. let I = I - 1
 5. return DIRS
 
-LOAD_SELF_REFERENCE(X, START, ENCAPSULATED)
+LOAD_SELF_REFERENCE(X, START)
 1. Find the closest package scope to START.
 2. If no scope was found, return.
-3. If ENCAPSULATED is true and the `package.json` has no "exports", return.
+3. If the `package.json` has no "exports", return.
 4. If the name in `package.json` isn't a prefix of X, throw "not found".
 5. Otherwise, resolve the remainder of X relative to this package as if it
    was loaded via `LOAD_NODE_MODULES` with a name in `package.json`.

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -431,12 +431,12 @@ function resolveBasePath(basePath, exts, isMain, trailingSlash, request) {
   return filename;
 }
 
-function trySelf(paths, exts, isMain, trailingSlash, request) {
+function trySelf(parentPath, isMain, request) {
   if (!experimentalSelf) {
     return false;
   }
 
-  const { data: pkg, path: basePath } = readPackageScope(paths[0]);
+  const { data: pkg, path: basePath } = readPackageScope(parentPath) || {};
   if (!pkg) return false;
   if (typeof pkg.name !== 'string') return false;
 
@@ -449,12 +449,15 @@ function trySelf(paths, exts, isMain, trailingSlash, request) {
     return false;
   }
 
-  if (exts === undefined)
-    exts = ObjectKeys(Module._extensions);
-
-  if (expansion) {
-    // Use exports
-    const fromExports = applyExports(basePath, expansion);
+  const exts = ObjectKeys(Module._extensions);
+  const fromExports = applyExports(basePath, expansion);
+  // Use exports
+  if (fromExports) {
+    let trailingSlash = request.length > 0 &&
+        request.charCodeAt(request.length - 1) === CHAR_FORWARD_SLASH;
+    if (!trailingSlash) {
+      trailingSlash = /(?:^|\/)\.?\.$/.test(request);
+    }
     return resolveBasePath(fromExports, exts, isMain, trailingSlash, request);
   } else {
     // Use main field
@@ -700,13 +703,6 @@ Module._findPath = function(request, paths, isMain) {
       Module._pathCache[cacheKey] = filename;
       return filename;
     }
-  }
-
-  const selfFilename = trySelf(paths, exts, isMain, trailingSlash, request);
-  if (selfFilename) {
-    emitExperimentalWarning('Package name self resolution');
-    Module._pathCache[cacheKey] = selfFilename;
-    return selfFilename;
   }
 
   return false;
@@ -1008,24 +1004,32 @@ Module._resolveFilename = function(request, parent, isMain, options) {
 
   // Look up the filename first, since that's the cache key.
   const filename = Module._findPath(request, paths, isMain);
-  if (!filename) {
-    const requireStack = [];
-    for (let cursor = parent;
-      cursor;
-      cursor = cursor.parent) {
-      requireStack.push(cursor.filename || cursor.id);
+  if (filename) return filename;
+  if (parent && parent.filename) {
+    const filename = trySelf(parent.filename, isMain, request);
+    if (filename) {
+      emitExperimentalWarning('Package name self resolution');
+      const cacheKey = request + '\x00' +
+          (paths.length === 1 ? paths[0] : paths.join('\x00'));
+      Module._pathCache[cacheKey] = filename;
+      return filename;
     }
-    let message = `Cannot find module '${request}'`;
-    if (requireStack.length > 0) {
-      message = message + '\nRequire stack:\n- ' + requireStack.join('\n- ');
-    }
-    // eslint-disable-next-line no-restricted-syntax
-    const err = new Error(message);
-    err.code = 'MODULE_NOT_FOUND';
-    err.requireStack = requireStack;
-    throw err;
   }
-  return filename;
+  const requireStack = [];
+  for (let cursor = parent;
+    cursor;
+    cursor = cursor.parent) {
+    requireStack.push(cursor.filename || cursor.id);
+  }
+  let message = `Cannot find module '${request}'`;
+  if (requireStack.length > 0) {
+    message = message + '\nRequire stack:\n- ' + requireStack.join('\n- ');
+  }
+  // eslint-disable-next-line no-restricted-syntax
+  const err = new Error(message);
+  err.code = 'MODULE_NOT_FOUND';
+  err.requireStack = requireStack;
+  throw err;
 };
 
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -431,13 +431,13 @@ function resolveBasePath(basePath, exts, isMain, trailingSlash, request) {
   return filename;
 }
 
-function trySelf(parentPath, isMain, request, encapsulated) {
+function trySelf(parentPath, isMain, request) {
   if (!experimentalSelf) {
     return false;
   }
 
   const { data: pkg, path: basePath } = readPackageScope(parentPath) || {};
-  if (!pkg || (encapsulated && 'exports' in pkg === false)) return false;
+  if (!pkg || 'exports' in pkg === false) return false;
   if (typeof pkg.name !== 'string') return false;
 
   let expansion;
@@ -1002,19 +1002,6 @@ Module._resolveFilename = function(request, parent, isMain, options) {
     paths = Module._resolveLookupPaths(request, parent);
   }
 
-  // Look up the filename first, since that's the cache key.
-  if (parent && parent.filename) {
-    const filename = trySelf(parent.filename, isMain, request, true);
-    if (filename) {
-      emitExperimentalWarning('Package name self resolution');
-      const cacheKey = request + '\x00' +
-          (paths.length === 1 ? paths[0] : paths.join('\x00'));
-      Module._pathCache[cacheKey] = filename;
-      return filename;
-    }
-  }
-  const filename = Module._findPath(request, paths, isMain, false);
-  if (filename) return filename;
   if (parent && parent.filename) {
     const filename = trySelf(parent.filename, isMain, request);
     if (filename) {
@@ -1025,6 +1012,10 @@ Module._resolveFilename = function(request, parent, isMain, options) {
       return filename;
     }
   }
+
+  // Look up the filename first, since that's the cache key.
+  const filename = Module._findPath(request, paths, isMain, false);
+  if (filename) return filename;
   const requireStack = [];
   for (let cursor = parent;
     cursor;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -431,13 +431,13 @@ function resolveBasePath(basePath, exts, isMain, trailingSlash, request) {
   return filename;
 }
 
-function trySelf(parentPath, isMain, request) {
+function trySelf(parentPath, isMain, request, encapsulated) {
   if (!experimentalSelf) {
     return false;
   }
 
   const { data: pkg, path: basePath } = readPackageScope(parentPath) || {};
-  if (!pkg) return false;
+  if (!pkg || (encapsulated && 'exports' in pkg === false)) return false;
   if (typeof pkg.name !== 'string') return false;
 
   let expansion;
@@ -1003,7 +1003,17 @@ Module._resolveFilename = function(request, parent, isMain, options) {
   }
 
   // Look up the filename first, since that's the cache key.
-  const filename = Module._findPath(request, paths, isMain);
+  if (parent && parent.filename) {
+    const filename = trySelf(parent.filename, isMain, request, true);
+    if (filename) {
+      emitExperimentalWarning('Package name self resolution');
+      const cacheKey = request + '\x00' +
+          (paths.length === 1 ? paths[0] : paths.join('\x00'));
+      Module._pathCache[cacheKey] = filename;
+      return filename;
+    }
+  }
+  const filename = Module._findPath(request, paths, isMain, false);
   if (filename) return filename;
   if (parent && parent.filename) {
     const filename = trySelf(parent.filename, isMain, request);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -829,6 +829,7 @@ static void InternalModuleReadJSON(const FunctionCallbackInfo<Value>& args) {
 
   const size_t size = offset - start;
   if (size == 0 || (
+    size == SearchString(&chars[start], size, "\"name\"") &&
     size == SearchString(&chars[start], size, "\"main\"") &&
     size == SearchString(&chars[start], size, "\"exports\"") &&
     size == SearchString(&chars[start], size, "\"type\""))) {

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -176,7 +176,7 @@ function assertIncludes(actual, expected) {
     '/node_modules/pkgexports/resolve-self.js',
     'Package name self resolution',
   ],
-].forEach(([flag, file, message], index) => {
+].forEach(([flag, file, message]) => {
   const child = spawn(process.execPath, [flag, path(file)]);
 
   let stderr = '';
@@ -185,7 +185,6 @@ function assertIncludes(actual, expected) {
     stderr += data;
   });
   child.on('close', (code, signal) => {
-    console.log(stderr.toString());
     strictEqual(code, 0);
     strictEqual(signal, null);
     ok(stderr.toString().includes(

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -22,8 +22,6 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     // Fallbacks
     ['pkgexports/fallbackdir/asdf.js', { default: 'asdf' }],
     ['pkgexports/fallbackfile', { default: 'asdf' }],
-    // Dot main
-    ['pkgexports', { default: 'asdf' }],
     // Conditional split for require
     ['pkgexports/condition', isRequire ? { default: 'encoded path' } :
       { default: 'asdf' }],
@@ -32,6 +30,11 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     // Conditional object exports sugar
     ['pkgexports-sugar2', isRequire ? { default: 'not-exported' } :
       { default: 'main' }],
+    // Resolve self
+    ['pkgexports/resolve-self', isRequire ?
+      { default: 'self-cjs' } : { default: 'self-mjs' }],
+    // Resolve self sugar
+    ['pkgexports-sugar', { default: 'main' }]
   ]);
 
   for (const [validSpecifier, expected] of validSpecifiers) {
@@ -139,7 +142,7 @@ const { requireFromInside, importFromInside } = fromInside;
     // A file not visible from outside of the package
     ['../not-exported.js', { default: 'not-exported' }],
     // Part of the public interface
-    ['@pkgexports/name/valid-cjs', { default: 'asdf' }],
+    ['pkgexports/valid-cjs', { default: 'asdf' }],
   ]);
   for (const [validSpecifier, expected] of validSpecifiers) {
     if (validSpecifier === null) continue;
@@ -173,7 +176,7 @@ function assertIncludes(actual, expected) {
     '/node_modules/pkgexports/resolve-self.js',
     'Package name self resolution',
   ],
-].forEach(([flag, file, message]) => {
+].forEach(([flag, file, message], index) => {
   const child = spawn(process.execPath, [flag, path(file)]);
 
   let stderr = '';
@@ -182,6 +185,7 @@ function assertIncludes(actual, expected) {
     stderr += data;
   });
   child.on('close', (code, signal) => {
+    console.log(stderr.toString());
     strictEqual(code, 0);
     strictEqual(signal, null);
     ok(stderr.toString().includes(

--- a/test/fixtures/node_modules/pkgexports-main/package.json
+++ b/test/fixtures/node_modules/pkgexports-main/package.json
@@ -1,6 +1,6 @@
 {
   "main": "./main.cjs",
   "exports": {
-    "module": "./module.mjs"
+    "import": "./module.mjs"
   }
 }

--- a/test/fixtures/node_modules/pkgexports-sugar/main.js
+++ b/test/fixtures/node_modules/pkgexports-sugar/main.js
@@ -1,1 +1,10 @@
+const assert = require('assert');
 module.exports = 'main';
+
+// Test self-resolve
+require('@exports/sugar');
+
+// Test self-resolve dynamic import
+import('@exports/sugar').then(impt => {
+  assert.strictEqual(impt.default, 'main');
+});

--- a/test/fixtures/node_modules/pkgexports-sugar/package.json
+++ b/test/fixtures/node_modules/pkgexports-sugar/package.json
@@ -1,3 +1,4 @@
 {
+  "name": "@exports/sugar",
   "exports": "./main.js"
 }

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "@pkgexports/name",
-  "main": "./asdf.js",
+  "name": "pkg-exports",
   "exports": {
     "./hole": "./lib/hole.js",
     "./space": "./sp%20ce.js",
@@ -19,6 +18,10 @@
     "./nofallback1": [],
     "./nofallback2": [null, {}, "builtin:x"],
     "./nodemodules": "./node_modules/internalpkg/x.js",
-    "./condition": [{ "require": "./sp ce.js" }, "./asdf.js"]
+    "./condition": [{ "require": "./sp ce.js" }, "./asdf.js"],
+    "./resolve-self": {
+      "require": "./resolve-self.js",
+      "import": "./resolve-self.mjs"
+    }
   }
 }

--- a/test/fixtures/node_modules/pkgexports/resolve-self.js
+++ b/test/fixtures/node_modules/pkgexports/resolve-self.js
@@ -1,1 +1,2 @@
-require('@pkgexports/name/valid-cjs')
+require('pkg-exports/valid-cjs');
+module.exports = 'self-cjs';

--- a/test/fixtures/node_modules/pkgexports/resolve-self.mjs
+++ b/test/fixtures/node_modules/pkgexports/resolve-self.mjs
@@ -1,0 +1,2 @@
+import 'pkg-exports/valid-cjs';
+export default 'self-mjs';


### PR DESCRIPTION
This resolves the self-resolve bugs https://github.com/nodejs/node/issues/30633 and https://github.com/nodejs/node/issues/30602. In addition the ESM implementation of self-resolve is slightly adjusted to apply before the node_modules lookup for better encapsulation, while the CJS implementation is left after the node_modules lookup for backwards compatibility.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
