### PR TITLE
test: fix long lines

### DIFF
--- a/test/parallel/test-promises-unhandled-proxy-rejections.js
+++ b/test/parallel/test-promises-unhandled-proxy-rejections.js
@@ -15,7 +15,8 @@ const expectedPromiseWarning = ['Unhandled promise rejection. ' +
   'not handled with .catch(). To terminate the ' +
   'node process on unhandled promise rejection, ' +
   'use the CLI flag `--unhandled-rejections=strict` (see ' +
-  'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)'];
+  'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). ' +
+  '(rejection id: 1)'];
 
 function throwErr() {
   throw new Error('Error from proxy');

--- a/test/parallel/test-promises-unhandled-symbol-rejections.js
+++ b/test/parallel/test-promises-unhandled-symbol-rejections.js
@@ -16,7 +16,8 @@ const expectedPromiseWarning = ['Unhandled promise rejection. ' +
   'not handled with .catch(). To terminate the ' +
   'node process on unhandled promise rejection, ' +
   'use the CLI flag `--unhandled-rejections=strict` (see ' +
-  'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)'];
+  'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). ' +
+  '(rejection id: 1)'];
 
 common.expectWarning({
   DeprecationWarning: expectedDeprecationWarning,


### PR DESCRIPTION
This commit addresses several lines that are unnecessarily longer than the 80 character limit. The only reason they pass linting, I believe, is because they contain URLs.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)