### PR TITLE
src,test,tools: forbid usage of v8::Persistent

### DIFF
--- a/src/api/async_resource.cc
+++ b/src/api/async_resource.cc
@@ -24,7 +24,6 @@ AsyncResource::AsyncResource(Isolate* isolate,
 
 AsyncResource::~AsyncResource() {
   EmitAsyncDestroy(env_, async_context_);
-  resource_.Reset();
 }
 
 MaybeLocal<Value> AsyncResource::MakeCallback(Local<Function> callback,

--- a/src/node.h
+++ b/src/node.h
@@ -893,7 +893,7 @@ class NODE_EXTERN AsyncResource {
 
  private:
   Environment* env_;
-  v8::Persistent<v8::Object> resource_;
+  v8::Global<v8::Object> resource_;
   async_context async_context_;
 };
 

--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -65,6 +65,7 @@ class ObjectWrap {
   }
 
 
+  // NOLINTNEXTLINE(runtime/v8_persistent)
   inline v8::Persistent<v8::Object>& persistent() {
     return handle_;
   }
@@ -122,6 +123,7 @@ class ObjectWrap {
     delete wrap;
   }
 
+  // NOLINTNEXTLINE(runtime/v8_persistent)
   v8::Persistent<v8::Object> handle_;
 };
 

--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -14,7 +14,7 @@ struct async_req {
   int input;
   int output;
   v8::Isolate* isolate;
-  v8::Persistent<v8::Function> callback;
+  v8::Global<v8::Function> callback;
   node::async_context context;
 };
 
@@ -61,7 +61,6 @@ void AfterAsync(uv_work_t* r) {
   v8::SealHandleScope seal_handle_scope(isolate);
   // cleanup
   node::EmitAsyncDestroy(isolate, req->context);
-  req->callback.Reset();
   delete req;
 
   if (try_catch.HasCaught()) {

--- a/test/addons/callback-scope/binding.cc
+++ b/test/addons/callback-scope/binding.cc
@@ -31,7 +31,7 @@ void RunInCallbackScope(const v8::FunctionCallbackInfo<v8::Value>& args) {
     args.GetReturnValue().Set(ret.ToLocalChecked());
 }
 
-static v8::Persistent<v8::Promise::Resolver> persistent;
+static v8::Global<v8::Promise::Resolver> persistent;
 
 static void Callback(uv_work_t* req, int ignored) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();

--- a/test/addons/callback-scope/binding.cc
+++ b/test/addons/callback-scope/binding.cc
@@ -4,6 +4,7 @@
 
 #include <assert.h>
 #include <vector>
+#include <memory>
 
 namespace {
 
@@ -31,16 +32,14 @@ void RunInCallbackScope(const v8::FunctionCallbackInfo<v8::Value>& args) {
     args.GetReturnValue().Set(ret.ToLocalChecked());
 }
 
-static v8::Global<v8::Promise::Resolver> persistent;
-
 static void Callback(uv_work_t* req, int ignored) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::HandleScope scope(isolate);
   node::CallbackScope callback_scope(isolate, v8::Object::New(isolate),
                                      node::async_context{0, 0});
-
-  v8::Local<v8::Promise::Resolver> local =
-      v8::Local<v8::Promise::Resolver>::New(isolate, persistent);
+  std::unique_ptr<v8::Global<v8::Promise::Resolver>> persistent {
+      static_cast<v8::Global<v8::Promise::Resolver>*>(req->data) };
+  v8::Local<v8::Promise::Resolver> local = persistent->Get(isolate);
   local->Resolve(isolate->GetCurrentContext(),
                  v8::Undefined(isolate)).ToChecked();
   delete req;
@@ -49,20 +48,21 @@ static void Callback(uv_work_t* req, int ignored) {
 static void TestResolveAsync(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
 
-  if (persistent.IsEmpty()) {
-    persistent.Reset(isolate, v8::Promise::Resolver::New(
-        isolate->GetCurrentContext()).ToLocalChecked());
+  v8::Global<v8::Promise::Resolver>* persistent =
+      new v8::Global<v8::Promise::Resolver>(
+          isolate,
+          v8::Promise::Resolver::New(
+              isolate->GetCurrentContext()).ToLocalChecked());
 
-    uv_work_t* req = new uv_work_t;
+  uv_work_t* req = new uv_work_t;
+  req->data = static_cast<void*>(persistent);
 
-    uv_queue_work(node::GetCurrentEventLoop(isolate),
-                  req,
-                  [](uv_work_t*) {},
-                  Callback);
-  }
+  uv_queue_work(node::GetCurrentEventLoop(isolate),
+                req,
+                [](uv_work_t*) {},
+                Callback);
 
-  v8::Local<v8::Promise::Resolver> local =
-      v8::Local<v8::Promise::Resolver>::New(isolate, persistent);
+  v8::Local<v8::Promise::Resolver> local = persistent->Get(isolate);
 
   args.GetReturnValue().Set(local->GetPromise());
 }

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -321,6 +321,7 @@ _ERROR_CATEGORIES = [
     'runtime/string',
     'runtime/threadsafe_fn',
     'runtime/vlog',
+    'runtime/v8_persistent',
     'whitespace/blank_line',
     'whitespace/braces',
     'whitespace/comma',
@@ -626,6 +627,8 @@ _SEARCH_C_FILE = re.compile(r'\b(?:LINT_C_FILE|'
 _SEARCH_KERNEL_FILE = re.compile(r'\b(?:LINT_KERNEL_FILE)')
 
 _NULL_TOKEN_PATTERN = re.compile(r'\bNULL\b')
+
+_V8_PERSISTENT_PATTERN = re.compile(r'\bv8::Persistent\b')
 
 _RIGHT_LEANING_POINTER_PATTERN = re.compile(r'[^=|(,\s><);&?:}]'
                                             r'(?<!(sizeof|return))'
@@ -4547,6 +4550,28 @@ def CheckNullTokens(filename, clean_lines, linenum, error):
     error(filename, linenum, 'readability/null_usage', 2,
           'Use nullptr instead of NULL')
 
+def CheckV8PersistentTokens(filename, clean_lines, linenum, error):
+  """Check v8::Persistent usage.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+
+  # Avoid preprocessor lines
+  if Match(r'^\s*#', line):
+    return
+
+  if line.find('/*') >= 0 or line.find('*/') >= 0:
+    return
+
+  for match in _V8_PERSISTENT_PATTERN.finditer(line):
+    error(filename, linenum, 'runtime/v8_persistent', 2,
+          'Use v8::Global instead of v8::Persistent')
+
 def CheckLeftLeaningPointer(filename, clean_lines, linenum, error):
   """Check for left-leaning pointer placement.
 
@@ -4723,6 +4748,7 @@ def CheckStyle(filename, clean_lines, linenum, file_extension, nesting_state,
   CheckCheck(filename, clean_lines, linenum, error)
   CheckAltTokens(filename, clean_lines, linenum, error)
   CheckNullTokens(filename, clean_lines, linenum, error)
+  CheckV8PersistentTokens(filename, clean_lines, linenum, error)
   CheckLeftLeaningPointer(filename, clean_lines, linenum, error)
   classinfo = nesting_state.InnermostClass()
   if classinfo:


### PR DESCRIPTION
#### src,test: use v8::Global instead of v8::Persistent

This is in preparation for a lint rule forbidding usage of `v8::Persistent`.

#### doc: avoid using v8::Persistent in addon docs

Use `v8::Global` where possible. For examples where it applies, 
also clean up the code and make the code multi-threading-ready,
for those where that isn’t easily possible, add a warning about that.

#### tools,src: forbid usage of v8::Persistent

`v8::Persistent` comes with the surprising catch that it requires manual cleanup. `v8::Global` doesn’t, making it easier to use, and additionally provides move semantics. New code should always use `v8::Global`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
