### PR TITLE
src: fix compiler warning in env.cc

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -943,7 +943,8 @@ void Environment::Exit(int exit_code) {
     if (is_main_thread()) {
       fprintf(stderr, "(node:%d) ", uv_os_getpid());
     } else {
-      fprintf(stderr, "(node:%d, thread:%llu) ", uv_os_getpid(), thread_id());
+      fprintf(stderr, "(node:%d, thread:%" PRIu64 ") ",
+              uv_os_getpid(), thread_id());
     }
 
     fprintf(


### PR DESCRIPTION
This fixes the following warning:

    ../src/env.cc: In member function ‘void node::Environment::Exit(int)’:
    ../src/env.cc:946:77: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
           fprintf(stderr, "(node:%d, thread:%llu) ", uv_os_getpid(), thread_id());
                                                                      ~~~~~~~~~~~^

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
