### PR TITLE
esm: empty ext from pkg type/main doesnt affect format

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1153,15 +1153,13 @@ updates.
 In the following algorithms, all subroutine errors are propagated as errors
 of these top-level routines unless stated otherwise.
 
-_isMain_ is **true** when resolving the Node.js application entry point.
-
 _defaultEnv_ is the conditional environment name priority array,
 `["node", "import"]`.
 
 <details>
 <summary>Resolver algorithm specification</summary>
 
-**ESM_RESOLVE**(_specifier_, _parentURL_, _isMain_)
+**ESM_RESOLVE**(_specifier_, _parentURL_)
 
 > 1. Let _resolvedURL_ be **undefined**.
 > 1. If _specifier_ is a valid URL, then
@@ -1182,7 +1180,7 @@ _defaultEnv_ is the conditional environment name priority array,
 > 1. If the file at _resolvedURL_ does not exist, then
 >    1. Throw a _Module Not Found_ error.
 > 1. Set _resolvedURL_ to the real path of _resolvedURL_.
-> 1. Let _format_ be the result of **ESM_FORMAT**(_resolvedURL_, _isMain_).
+> 1. Let _format_ be the result of **ESM_FORMAT**(_resolvedURL_).
 > 1. Load _resolvedURL_ as module format, _format_.
 
 **PACKAGE_RESOLVE**(_packageSpecifier_, _parentURL_)
@@ -1333,20 +1331,20 @@ _defaultEnv_ is the conditional environment name priority array,
 >       1. Return _resolved_.
 > 1. Throw a _Module Not Found_ error.
 
-**ESM_FORMAT**(_url_, _isMain_)
+**ESM_FORMAT**(_url_)
 
-> 1. Assert: _url_ corresponds to an existing file.
+> 1. Assert: _url_ corresponds to an existing file pathname.
 > 1. Let _pjson_ be the result of **READ_PACKAGE_SCOPE**(_url_).
 > 1. If _url_ ends in _".mjs"_, then
 >    1. Return _"module"_.
 > 1. If _url_ ends in _".cjs"_, then
 >    1. Return _"commonjs"_.
 > 1. If _pjson?.type_ exists and is _"module"_, then
->    1. If _isMain_ is **true** or _url_ ends in _".js"_, then
+>    1. If _url_ ends in _".js"_ or lacks a file extension, then
 >       1. Return _"module"_.
 >    1. Throw an _Unsupported File Extension_ error.
 > 1. Otherwise,
->    1. If _isMain_ is **true**, then
+>    1. If _url_ lacks a file extension, then
 >       1. Return _"commonjs"_.
 >    1. Throw an _Unsupported File Extension_ error.
 

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -106,9 +106,12 @@ function resolve(specifier, parentURL) {
   }
 
   const ext = extname(url.pathname);
-  let format = extensionFormatMap[ext];
-  if (ext === '.js' || (!format && isMain))
+  let format;
+  if (ext === '.js' || ext === '') {
     format = getPackageType(url.href) === TYPE_MODULE ? 'module' : 'commonjs';
+  } else {
+    format = extensionFormatMap[ext];
+  }
   if (!format) {
     if (experimentalSpeciferResolution === 'node') {
       process.emitWarning(

--- a/test/es-module/test-esm-unknown-main.js
+++ b/test/es-module/test-esm-unknown-main.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const { spawn } = require('child_process');
+const assert = require('assert');
+
+{
+  const entry = fixtures.path(
+    '/es-modules/package-type-module/extension.unknown'
+  );
+  const child = spawn(process.execPath, [entry]);
+  let stdout = '';
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (data) => {
+    stdout += data;
+  });
+  child.stderr.on('data', (data) => {
+    stderr += data;
+  });
+  child.on('close', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 1);
+    assert.strictEqual(signal, null);
+    assert.strictEqual(stdout, '');
+    assert.ok(stderr.indexOf('ERR_UNKNOWN_FILE_EXTENSION') !== -1);
+  }));
+}
+{
+  const entry = fixtures.path(
+    '/es-modules/package-type-module/imports-unknownext.mjs'
+  );
+  const child = spawn(process.execPath, [entry]);
+  let stdout = '';
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (data) => {
+    stdout += data;
+  });
+  child.stderr.on('data', (data) => {
+    stderr += data;
+  });
+  child.on('close', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 1);
+    assert.strictEqual(signal, null);
+    assert.strictEqual(stdout, '');
+    assert.ok(stderr.indexOf('ERR_UNKNOWN_FILE_EXTENSION') !== -1);
+  }));
+}
+{
+  const entry = fixtures.path('/es-modules/package-type-module/noext-esm');
+  const child = spawn(process.execPath, [entry]);
+  let stdout = '';
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (data) => {
+    stdout += data;
+  });
+  child.on('close', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+    assert.strictEqual(stdout, 'executed\n');
+  }));
+}
+{
+  const entry = fixtures.path(
+    '/es-modules/package-type-module/imports-noext.mjs'
+  );
+  const child = spawn(process.execPath, [entry]);
+  let stdout = '';
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (data) => {
+    stdout += data;
+  });
+  child.on('close', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+    assert.strictEqual(stdout, 'executed\n');
+  }));
+}

--- a/test/fixtures/es-modules/package-type-module/extension.unknown
+++ b/test/fixtures/es-modules/package-type-module/extension.unknown
@@ -1,0 +1,1 @@
+throw new Error('NO, NEVER');

--- a/test/fixtures/es-modules/package-type-module/imports-noext.mjs
+++ b/test/fixtures/es-modules/package-type-module/imports-noext.mjs
@@ -1,0 +1,1 @@
+import './noext-esm';

--- a/test/fixtures/es-modules/package-type-module/imports-unknownext.mjs
+++ b/test/fixtures/es-modules/package-type-module/imports-unknownext.mjs
@@ -1,0 +1,1 @@
+import './extension.unknown';


### PR DESCRIPTION
BREAKING (kind of a bugfix? unclear)

This ensures files with unknown extensions like `extension.unknown` are not
loaded as CJS/ESM when imported as a main entry point and makes
sure that those files would maintain the same format even if loaded
after the main entrypoint.

Added tests for importing missing extension and unknown extension after entrypoint along the way.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
