### PR TITLE
test: add coverage for vm: Module and SyntheticModule

### DIFF
--- a/test/parallel/test-vm-module-basic.js
+++ b/test/parallel/test-vm-module-basic.js
@@ -4,7 +4,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { SourceTextModule, SyntheticModule, createContext } = require('vm');
+const { Module, SourceTextModule, SyntheticModule, createContext } = require('vm');
 const util = require('util');
 
 (async function test1() {
@@ -107,3 +107,42 @@ const util = require('util');
   assert.notStrictEqual(dep, undefined);
   assert.strictEqual(dep, m.dependencySpecifiers);
 }
+
+// Check the impossibility of creating an abstract instance of the Module.
+{
+  assert.throws(
+    () => {
+      new Module();
+    },
+    /^TypeError: Module is not a constructor$/
+  );
+
+}
+
+// Check to throws invalid exportNames
+{
+  assert.throws(
+    () => {
+      new SyntheticModule(undefined, () => {}, {});
+    },
+  );
+}
+
+// Check to throws invalid evaluateCallback
+{
+  assert.throws(
+    () => {
+      new SyntheticModule([], undefined, {});
+    },
+  );
+}
+
+// Check to throws invalid options
+{
+  assert.throws(
+    () => {
+      new SyntheticModule([], () => {}, null);
+    },
+  );
+}
+

--- a/test/parallel/test-vm-module-basic.js
+++ b/test/parallel/test-vm-module-basic.js
@@ -4,7 +4,12 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { Module, SourceTextModule, SyntheticModule, createContext } = require('vm');
+const {
+  Module,
+  SourceTextModule,
+  SyntheticModule,
+  createContext
+} = require('vm');
 const util = require('util');
 
 (async function test1() {
@@ -110,39 +115,35 @@ const util = require('util');
 
 // Check the impossibility of creating an abstract instance of the Module.
 {
-  assert.throws(
-    () => {
-      new Module();
-    },
-    /^TypeError: Module is not a constructor$/
-  );
-
+  common.expectsError(() => new Module(), {
+    message: 'Module is not a constructor',
+    type: TypeError
+  });
 }
 
 // Check to throws invalid exportNames
 {
-  assert.throws(
-    () => {
-      new SyntheticModule(undefined, () => {}, {});
-    },
-  );
+  common.expectsError(() => new SyntheticModule(undefined, () => {}, {}), {
+    message: 'The "exportNames" argument must be an Array of strings.' +
+      ' Received undefined',
+    type: TypeError
+  });
 }
 
 // Check to throws invalid evaluateCallback
 {
-  assert.throws(
-    () => {
-      new SyntheticModule([], undefined, {});
-    },
-  );
+  common.expectsError(() => new SyntheticModule([], undefined, {}), {
+    message: 'The "evaluateCallback" argument must be of type function.' +
+      ' Received undefined',
+    type: TypeError
+  });
 }
 
 // Check to throws invalid options
 {
-  assert.throws(
-    () => {
-      new SyntheticModule([], () => {}, null);
-    },
-  );
+  common.expectsError(() => new SyntheticModule([], () => {}, null), {
+    message: 'The "options" argument must be of type object.' +
+      ' Received null',
+    type: TypeError
+  });
 }
-


### PR DESCRIPTION
code and learn task for additional coverage for situation when
creating an abstract instance of the Module and  SyntheticModule throws exception if invalid params in constructor

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
