### PR TITLE
esm: implement import.meta.resolve and make nodejs: scheme public

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -156,6 +156,13 @@ Enable experimental Source Map V3 support for stack traces.
 Currently, overriding `Error.prepareStackTrace` is ignored when the
 `--enable-source-maps` flag is set.
 
+### `--experimental-import-meta-resolve`
+<!-- YAML
+added: REPLACEME
+-->
+
+Enable experimental `import.meta.resolve()` support.
+
 ### `--experimental-json-modules`
 <!-- YAML
 added: v12.9.0
@@ -1073,6 +1080,7 @@ Node.js options that are allowed are:
 <!-- node-options-node start -->
 * `--enable-fips`
 * `--enable-source-maps`
+* `--experimental-import-meta-resolve`
 * `--experimental-json-modules`
 * `--experimental-loader`
 * `--experimental-modules`

--- a/doc/node.1
+++ b/doc/node.1
@@ -113,6 +113,9 @@ Requires Node.js to be built with
 .It Fl -enable-source-maps
 Enable experimental Source Map V3 support for stack traces.
 .
+.It Fl -experimental-import-meta-resolve
+Enable experimental ES modules support for import.meta.resolve().
+.
 .It Fl -experimental-json-modules
 Enable experimental JSON interop support for the ES Module loader.
 .

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { NativeModule } = require('internal/bootstrap/loaders');
 const { extname } = require('path');
 const { getOptionValue } = require('internal/options');
 
@@ -39,7 +38,7 @@ if (experimentalJsonModules)
   extensionFormatMap['.json'] = legacyExtensionFormatMap['.json'] = 'json';
 
 function defaultGetFormat(url, context, defaultGetFormat) {
-  if (NativeModule.canBeRequiredByUsers(url)) {
+  if (url.startsWith('nodejs:')) {
     return { format: 'builtin' };
   }
   const parsed = new URL(url);
@@ -73,5 +72,6 @@ function defaultGetFormat(url, context, defaultGetFormat) {
     }
     return { format: format || null };
   }
+  return { format: null };
 }
 exports.defaultGetFormat = defaultGetFormat;

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -94,7 +94,10 @@ class Loader {
       throw new ERR_INVALID_RETURN_PROPERTY_VALUE(
         'string', 'loader resolve', 'url', url);
     }
+    return url;
+  }
 
+  async getFormat(url) {
     const getFormatResponse = await this._getFormat(
       url, {}, defaultGetFormat);
     if (typeof getFormatResponse !== 'object') {
@@ -109,7 +112,7 @@ class Loader {
     }
 
     if (format === 'builtin') {
-      return { url: `node:${url}`, format };
+      return format;
     }
 
     if (this._resolve !== defaultResolve) {
@@ -132,7 +135,7 @@ class Loader {
       );
     }
 
-    return { url, format };
+    return format;
   }
 
   async eval(
@@ -185,7 +188,8 @@ class Loader {
   }
 
   async getModuleJob(specifier, parentURL) {
-    const { url, format } = await this.resolve(specifier, parentURL);
+    const url = await this.resolve(specifier, parentURL);
+    const format = await this.getFormat(url);
     let job = this.moduleMap.get(url);
     // CommonJS will set functions for lazy job evaluation.
     if (typeof job === 'function')

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -29,11 +29,13 @@ function defaultResolve(specifier, { parentURL } = {}, defaultResolve) {
       };
     }
   } catch {}
+  if (parsed && parsed.protocol === 'nodejs:')
+    return { url: specifier };
   if (parsed && parsed.protocol !== 'file:' && parsed.protocol !== 'data:')
     throw new ERR_UNSUPPORTED_ESM_URL_SCHEME();
   if (NativeModule.canBeRequiredByUsers(specifier)) {
     return {
-      url: specifier
+      url: 'nodejs:' + specifier
     };
   }
   if (parentURL && parentURL.startsWith('data:')) {
@@ -58,11 +60,12 @@ function defaultResolve(specifier, { parentURL } = {}, defaultResolve) {
   let url = moduleWrapResolve(specifier, parentURL);
 
   if (isMain ? !preserveSymlinksMain : !preserveSymlinks) {
-    const real = realpathSync(fileURLToPath(url), {
+    const urlPath = fileURLToPath(url);
+    const real = realpathSync(urlPath, {
       [internalFS.realpathCacheKey]: realpathCache
     });
     const old = url;
-    url = pathToFileURL(real);
+    url = pathToFileURL(real + (urlPath.endsWith('/') ? '/' : ''));
     url.search = old.search;
     url.hash = old.hash;
   }

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -8,6 +8,7 @@ const internalFS = require('internal/fs/utils');
 const { NativeModule } = require('internal/bootstrap/loaders');
 const { realpathSync } = require('fs');
 const { getOptionValue } = require('internal/options');
+const { sep } = require('path');
 
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
@@ -65,7 +66,7 @@ function defaultResolve(specifier, { parentURL } = {}, defaultResolve) {
       [internalFS.realpathCacheKey]: realpathCache
     });
     const old = url;
-    url = pathToFileURL(real + (urlPath.endsWith('/') ? '/' : ''));
+    url = pathToFileURL(real + (urlPath.endsWith(sep) ? '/' : ''));
     url.search = old.search;
     url.hash = old.hash;
   }

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -28,6 +28,9 @@ const { ERR_UNKNOWN_BUILTIN_MODULE } = require('internal/errors').codes;
 const { maybeCacheSourceMap } = require('internal/source_map/source_map_cache');
 const moduleWrap = internalBinding('module_wrap');
 const { ModuleWrap } = moduleWrap;
+const { getOptionValue } = require('internal/options');
+const experimentalImportMetaResolve =
+    getOptionValue('--experimental-import-meta-resolve');
 
 const debug = debuglog('esm');
 
@@ -42,16 +45,28 @@ function errPath(url) {
   return url;
 }
 
-function initializeImportMeta(meta, { url }) {
-  meta.url = url;
-}
-
 let esmLoader;
 async function importModuleDynamically(specifier, { url }) {
   if (!esmLoader) {
-    esmLoader = require('internal/process/esm_loader');
+    esmLoader = require('internal/process/esm_loader').ESMLoader;
   }
-  return esmLoader.ESMLoader.import(specifier, url);
+  return esmLoader.import(specifier, url);
+}
+
+function createImportMetaResolve(defaultParentUrl) {
+  return async function resolve(specifier, parentUrl = defaultParentUrl) {
+    if (!esmLoader) {
+      esmLoader = require('internal/process/esm_loader').ESMLoader;
+    }
+    return esmLoader.resolve(specifier, parentUrl);
+  };
+}
+
+function initializeImportMeta(meta, { url }) {
+  // Alphabetical
+  if (experimentalImportMetaResolve)
+    meta.resolve = createImportMetaResolve(url);
+  meta.url = url;
 }
 
 // Strategy for loading a standard JavaScript module
@@ -104,10 +119,10 @@ translators.set('commonjs', function commonjsStrategy(url, isMain) {
 // through normal resolution
 translators.set('builtin', async function builtinStrategy(url) {
   debug(`Translating BuiltinModule ${url}`);
-  // Slice 'node:' scheme
-  const id = url.slice(5);
+  // Slice 'nodejs:' scheme
+  const id = url.slice(7);
   const module = loadNativeModule(id, url, true);
-  if (!module) {
+  if (!url.startsWith('nodejs:') || !module) {
     throw new ERR_UNKNOWN_BUILTIN_MODULE(id);
   }
   debug(`Loading BuiltinModule ${url}`);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -333,6 +333,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental ES Module support for webassembly modules",
             &EnvironmentOptions::experimental_wasm_modules,
             kAllowedInEnvironment);
+  AddOption("--experimental-import-meta-resolve",
+            "experimental ES Module import.meta.resolve() support",
+            &EnvironmentOptions::experimental_import_meta_resolve,
+            kAllowedInEnvironment);
   AddOption("--experimental-policy",
             "use the specified file as a "
             "security policy",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -106,6 +106,7 @@ class EnvironmentOptions : public Options {
   std::string experimental_specifier_resolution;
   std::string es_module_specifier_resolution;
   bool experimental_wasm_modules = false;
+  bool experimental_import_meta_resolve = false;
   std::string module_type;
   std::string experimental_policy;
   std::string experimental_policy_integrity;

--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -55,11 +55,12 @@ function expectFsNamespace(result) {
   expectFsNamespace(import('fs'));
   expectFsNamespace(eval('import("fs")'));
   expectFsNamespace(eval('import("fs")'));
+  expectFsNamespace(import('nodejs:fs'));
 
+  expectModuleError(import('nodejs:unknown'),
+                    'ERR_UNKNOWN_BUILTIN_MODULE');
   expectModuleError(import('./not-an-existing-module.mjs'),
                     'ERR_MODULE_NOT_FOUND');
-  expectModuleError(import('node:fs'),
-                    'ERR_UNSUPPORTED_ESM_URL_SCHEME');
   expectModuleError(import('http://example.com/foo.js'),
                     'ERR_UNSUPPORTED_ESM_URL_SCHEME');
 })();

--- a/test/es-module/test-esm-import-meta-resolve.mjs
+++ b/test/es-module/test-esm-import-meta-resolve.mjs
@@ -1,0 +1,24 @@
+// Flags: --experimental-import-meta-resolve
+import '../common/index.mjs';
+import assert from 'assert';
+
+const dirname = import.meta.url.slice(0, import.meta.url.lastIndexOf('/') + 1);
+const fixtures = dirname.slice(0, dirname.lastIndexOf('/', dirname.length - 2) +
+    1) + 'fixtures/';
+
+(async () => {
+  assert.strictEqual(await import.meta.resolve('./test-esm-import-meta.mjs'),
+                     dirname + 'test-esm-import-meta.mjs');
+  try {
+    await import.meta.resolve('./notfound.mjs');
+    assert.fail();
+  } catch (e) {
+    assert.strictEqual(e.code, 'ERR_MODULE_NOT_FOUND');
+  }
+  assert.strictEqual(
+    await import.meta.resolve('../fixtures/empty-with-bom.txt'),
+    fixtures + 'empty-with-bom.txt');
+  assert.strictEqual(await import.meta.resolve('../fixtures/'), fixtures);
+  assert.strictEqual(await import.meta.resolve('baz/', fixtures),
+                     fixtures + 'node_modules/baz/');
+})();

--- a/test/fixtures/es-module-loaders/example-loader.mjs
+++ b/test/fixtures/es-module-loaders/example-loader.mjs
@@ -11,7 +11,7 @@ baseURL.pathname = process.cwd() + '/';
 export function resolve(specifier, { parentURL = baseURL }, defaultResolve) {
   if (builtinModules.includes(specifier)) {
     return {
-      url: specifier
+      url: 'nodejs:' + specifier
     };
   }
   if (/^\.{1,2}[/]/.test(specifier) !== true && !specifier.startsWith('file:')) {
@@ -27,7 +27,7 @@ export function resolve(specifier, { parentURL = baseURL }, defaultResolve) {
 }
 
 export function getFormat(url, context, defaultGetFormat) {
-  if (builtinModules.includes(url)) {
+  if (url.startsWith('nodejs:') && builtinModules.includes(url.slice(7))) {
     return {
       format: 'builtin'
     };

--- a/test/fixtures/es-module-loaders/loader-unknown-builtin-module.mjs
+++ b/test/fixtures/es-module-loaders/loader-unknown-builtin-module.mjs
@@ -1,14 +1,14 @@
 export async function resolve(specifier, { parentURL }, defaultResolve) {
   if (specifier === 'unknown-builtin-module') {
     return {
-      url: 'unknown-builtin-module'
+      url: 'nodejs:unknown-builtin-module'
     };
   }
   return defaultResolve(specifier, {parentURL}, defaultResolve);
 }
 
 export async function getFormat(url, context, defaultGetFormat) {
-  if (url === 'unknown-builtin-module') {
+  if (url === 'nodejs:unknown-builtin-module') {
     return {
       format: 'builtin'
     };

--- a/test/fixtures/es-module-loaders/not-found-assert-loader.mjs
+++ b/test/fixtures/es-module-loaders/not-found-assert-loader.mjs
@@ -14,8 +14,7 @@ export async function resolve(specifier, { parentURL }, defaultResolve) {
   catch (e) {
     assert.strictEqual(e.code, 'ERR_MODULE_NOT_FOUND');
     return {
-      format: 'builtin',
-      url: 'fs'
+      url: 'nodejs:fs'
     };
   }
   assert.fail(`Module resolution for ${specifier} should be throw ERR_MODULE_NOT_FOUND`);


### PR DESCRIPTION
This PR implements `import.meta.resolve` as an async hook into the module resolver.

This fills the gap of enabling `require.resolve` workflows that aren't currently possible in ES modules, such as locating the exact path of a dependency or local resolution following all the correct resolver resolution rules.

This is a feature that will require alignment with browsers, so I'm opening this now to be able to start those discussions. Marking as blocked on consensus discussions.

Usage examples:

* `await import.meta.resolve('./dep.ext')` -> `file:///path/to/dep.ext`, relative to current module.
* `await import.meta.resolve('./dep.ext', 'file:///different/path/parent')` -> `file:///different/path/dep.ext`, relative to provided parent.
* `await import.meta.resolve('dependency')` -> `file:///path/to/node_modules/dependency/main.js`, as resolved from current module.
* `await import.meta.resolve('dependency', 'file:///different/path/parent')` -> `file:///different/path/node_modules/dependency/main.js`, as resolved from provided module.
* `await import.meta.resolve('./does-not-exist')` -> Throws not found as the default Node.js resolver checks for existence.
* `await import.meta.resolve('fs')` -> `nodejs:fs`

If the Node.js resolver has been hooked by a loader, the corresponding resolve function will be called in `import.meta.resolve`.

This API also makes the `nodejs:fs` internal builtin module scheme public, including the associated changes for this feature.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
