### PR TITLE
stream: reset flowing state if no 'readable' or 'data' listeners.

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -975,6 +975,8 @@ function updateReadableListening(self) {
     // Crude way to check if we should resume
   } else if (self.listenerCount('data') > 0) {
     self.resume();
+  } else if (!state.readableListening) {
+    state.flowing = null;
   }
 }
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -28,6 +28,7 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   SymbolAsyncIterator,
+  Symbol
 } = primordials;
 
 module.exports = Readable;
@@ -50,6 +51,8 @@ const {
   ERR_METHOD_NOT_IMPLEMENTED,
   ERR_STREAM_UNSHIFT_AFTER_END_EVENT
 } = require('internal/errors').codes;
+
+const kPaused = Symbol('kPaused');
 
 // Lazy loaded to improve the startup performance.
 let StringDecoder;
@@ -126,7 +129,7 @@ function ReadableState(options, stream, isDuplex) {
   this.emittedReadable = false;
   this.readableListening = false;
   this.resumeScheduled = false;
-  this.paused = null;
+  this[kPaused] = null;
 
   // True if the error was already emitted and should not be thrown again
   this.errorEmitted = false;
@@ -170,6 +173,16 @@ function ReadableState(options, stream, isDuplex) {
 ObjectDefineProperty(ReadableState.prototype, 'pipesCount', {
   get() {
     return this.pipes.length;
+  }
+});
+
+// Legacy property for `paused`
+ObjectDefineProperty(ReadableState.prototype, 'paused', {
+  get() {
+    return this[kPaused] !== false;
+  },
+  set(value) {
+    this[kPaused] = Boolean(value);
   }
 });
 
@@ -368,7 +381,7 @@ function chunkInvalid(state, chunk) {
 
 
 Readable.prototype.isPaused = function() {
-  return this._readableState.paused === true;
+  return this._readableState[kPaused] === true;
 };
 
 // Backwards compatibility.
@@ -967,7 +980,7 @@ function updateReadableListening(self) {
   const state = self._readableState;
   state.readableListening = self.listenerCount('readable') > 0;
 
-  if (state.resumeScheduled && state.paused === false) {
+  if (state.resumeScheduled && state[kPaused] === false) {
     // Flowing needs to be set to true now, otherwise
     // the upcoming resume will not flow.
     state.flowing = true;
@@ -997,7 +1010,7 @@ Readable.prototype.resume = function() {
     state.flowing = !state.readableListening;
     resume(this, state);
   }
-  state.paused = false;
+  state[kPaused] = false;
   return this;
 };
 
@@ -1028,7 +1041,7 @@ Readable.prototype.pause = function() {
     this._readableState.flowing = false;
     this.emit('pause');
   }
-  this._readableState.paused = true;
+  this._readableState[kPaused] = true;
   return this;
 };
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -182,7 +182,7 @@ ObjectDefineProperty(ReadableState.prototype, 'paused', {
     return this[kPaused] !== false;
   },
   set(value) {
-    this[kPaused] = Boolean(value);
+    this[kPaused] = !!value;
   }
 });
 
@@ -381,7 +381,8 @@ function chunkInvalid(state, chunk) {
 
 
 Readable.prototype.isPaused = function() {
-  return this._readableState[kPaused] === true;
+  const state = this._readableState;
+  return state[kPaused] === true || state.flowing === false;
 };
 
 // Backwards compatibility.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -126,7 +126,7 @@ function ReadableState(options, stream, isDuplex) {
   this.emittedReadable = false;
   this.readableListening = false;
   this.resumeScheduled = false;
-  this.paused = true;
+  this.paused = null;
 
   // True if the error was already emitted and should not be thrown again
   this.errorEmitted = false;
@@ -368,7 +368,7 @@ function chunkInvalid(state, chunk) {
 
 
 Readable.prototype.isPaused = function() {
-  return this._readableState.flowing === false;
+  return this._readableState.paused === true;
 };
 
 // Backwards compatibility.
@@ -967,7 +967,7 @@ function updateReadableListening(self) {
   const state = self._readableState;
   state.readableListening = self.listenerCount('readable') > 0;
 
-  if (state.resumeScheduled && !state.paused) {
+  if (state.resumeScheduled && state.paused === false) {
     // Flowing needs to be set to true now, otherwise
     // the upcoming resume will not flow.
     state.flowing = true;

--- a/test/parallel/test-stream-readable-data.js
+++ b/test/parallel/test-stream-readable-data.js
@@ -1,0 +1,19 @@
+'use strict';
+const common = require('../common');
+
+const { Readable } = require('stream');
+
+const readable = new Readable({
+  read() {}
+});
+
+function read() {}
+
+readable.setEncoding('utf8');
+readable.on('readable', read);
+readable.removeListener('readable', read);
+
+process.nextTick(function() {
+  readable.on('data', common.mustCall());
+  readable.push('hello');
+});

--- a/test/parallel/test-stream-readable-pause-and-resume.js
+++ b/test/parallel/test-stream-readable-pause-and-resume.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../common');
+const assert = require('assert');
 const { Readable } = require('stream');
 
 let ticks = 18;
@@ -37,4 +38,21 @@ function readAndPause() {
   }, 1); // Only call ondata once
 
   rs.on('data', ondata);
+}
+
+{
+  const readable = new Readable({
+    read() {}
+  });
+
+  function read() {}
+
+  readable.setEncoding('utf8');
+  readable.on('readable', read);
+  readable.removeListener('readable', read);
+  readable.pause();
+
+  process.nextTick(function() {
+    assert(readable.isPaused()); // Throws.
+  });
 }

--- a/test/parallel/test-stream-readable-pause-and-resume.js
+++ b/test/parallel/test-stream-readable-pause-and-resume.js
@@ -53,6 +53,6 @@ function readAndPause() {
   readable.pause();
 
   process.nextTick(function() {
-    assert(readable.isPaused()); // Throws.
+    assert(readable.isPaused());
   });
 }


### PR DESCRIPTION
If we don't have any 'readable' or 'data' listeners and we are not about to resume. Then reset flowing state to initial null state.

Fixes: https://github.com/nodejs/node/issues/24474

I don't feel very confident modifying things here but this seems to solve the issue and doesn't break any existing tests.

I would very much like a CITGM on this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
