### PR TITLE
test: get lib/wasi.js coverage to 100%

### DIFF
--- a/test/wasi/test-wasi-options-validation.js
+++ b/test/wasi/test-wasi-options-validation.js
@@ -20,3 +20,9 @@ assert.throws(() => { new WASI({ env: 'fhqwhgads' }); },
 // If preopens is not an Object and not undefined, it should throw.
 assert.throws(() => { new WASI({ preopens: 'fhqwhgads' }); },
               { code: 'ERR_INVALID_ARG_TYPE', message: /\bpreopens\b/ });
+
+// If options is provided, but not an object, the constructor should throw.
+[null, 'foo', '', 0, NaN, Symbol(), true, false, () => {}].forEach((value) => {
+  assert.throws(() => { new WASI(value); },
+                { code: 'ERR_INVALID_ARG_TYPE' });
+});


### PR DESCRIPTION
This commit covers the last remaining uncovered code in `lib/wasi.js`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)