### PR TITLE
benchmark: use let and const instead of var in cluster

### DIFF
--- a/benchmark/cluster/echo.js
+++ b/benchmark/cluster/echo.js
@@ -19,10 +19,10 @@ if (cluster.isMaster) {
     serialization
   }) {
     const expectedPerBroadcast = sendsPerBroadcast * workers;
-    var readies = 0;
-    var broadcasts = 0;
-    var msgCount = 0;
-    var data;
+    let readies = 0;
+    let broadcasts = 0;
+    let msgCount = 0;
+    let data;
 
     cluster.settings.serialization = serialization;
 
@@ -37,7 +37,7 @@ if (cluster.isMaster) {
         throw new Error('Unsupported payload type');
     }
 
-    for (var i = 0; i < workers; ++i)
+    for (let i = 0; i < workers; ++i)
       cluster.fork().on('online', onOnline).on('message', onMessage);
 
     function onOnline() {
@@ -48,16 +48,15 @@ if (cluster.isMaster) {
     }
 
     function broadcast() {
-      var id;
       if (broadcasts++ === n) {
         bench.end(n);
-        for (id in cluster.workers)
+        for (const id in cluster.workers)
           cluster.workers[id].disconnect();
         return;
       }
-      for (id in cluster.workers) {
+      for (const id in cluster.workers) {
         const worker = cluster.workers[id];
-        for (var i = 0; i < sendsPerBroadcast; ++i)
+        for (let i = 0; i < sendsPerBroadcast; ++i)
           worker.send(data);
       }
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
