### PR TITLE
benchmark: use let instead of var in child_process

### DIFF
--- a/benchmark/child_process/child-process-exec-stdout.js
+++ b/benchmark/child_process/child-process-exec-stdout.js
@@ -19,7 +19,7 @@ function childProcessExecStdout({ dur, len }) {
   const cmd = `yes "${'.'.repeat(len)}"`;
   const child = exec(cmd, { 'stdio': ['ignore', 'pipe', 'ignore'] });
 
-  var bytes = 0;
+  let bytes = 0;
   child.stdout.on('data', (msg) => {
     bytes += msg.length;
   });

--- a/benchmark/child_process/child-process-read-ipc.js
+++ b/benchmark/child_process/child-process-read-ipc.js
@@ -26,7 +26,7 @@ if (process.argv[2] === 'child') {
     const child = spawn(process.argv[0],
                         [process.argv[1], 'child', len], options);
 
-    var bytes = 0;
+    let bytes = 0;
     child.on('message', (msg) => { bytes += msg.length; });
 
     setTimeout(() => {

--- a/benchmark/child_process/child-process-read.js
+++ b/benchmark/child_process/child-process-read.js
@@ -24,7 +24,7 @@ function main({ dur, len }) {
   const options = { 'stdio': ['ignore', 'pipe', 'ignore'] };
   const child = child_process.spawn('yes', [msg], options);
 
-  var bytes = 0;
+  let bytes = 0;
   child.stdout.on('data', (msg) => {
     bytes += msg.length;
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

I am getting this error here when running benchmarks though:
![Screenshot from 2019-12-20 21-05-44](https://user-images.githubusercontent.com/15520377/71289259-0590bb00-236d-11ea-96a8-98d693a5d692.png)

I ran the benchmark with:
```bash
$ node benchmark/run.js child_process
```
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->