### PR TITLE
dgram: test to add and to drop specific membership

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -856,13 +856,11 @@ Socket.prototype.addSourceSpecificMembership = function(sourceAddress,
   healthCheck(this);
 
   if (typeof sourceAddress !== 'string') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'sourceAddress',
-                               'string');
+    throw new ERR_INVALID_ARG_TYPE('sourceAddress', 'string', sourceAddress);
   }
 
   if (typeof groupAddress !== 'string') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'groupAddress',
-                               'string');
+    throw new ERR_INVALID_ARG_TYPE('groupAddress', 'string', groupAddress);
   }
 
   const err =
@@ -881,13 +879,11 @@ Socket.prototype.dropSourceSpecificMembership = function(sourceAddress,
   healthCheck(this);
 
   if (typeof sourceAddress !== 'string') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'sourceAddress',
-                               'string');
+    throw new ERR_INVALID_ARG_TYPE('sourceAddress', 'string', sourceAddress);
   }
 
   if (typeof groupAddress !== 'string') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'groupAddress',
-                               'string');
+    throw new ERR_INVALID_ARG_TYPE('groupAddress', 'string', groupAddress);
   }
 
   const err =

--- a/test/parallel/test-dgram-membership.js
+++ b/test/parallel/test-dgram-membership.js
@@ -84,7 +84,8 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
     socket.addSourceSpecificMembership(0, multicastAddress);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /^The "sourceAddress" argument must be of type string\. Received type number$/
+    message: 'The "sourceAddress" argument must be of type string. ' +
+    'Received type number (0)'
   });
   socket.close();
 }
@@ -96,7 +97,8 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
     socket.addSourceSpecificMembership(multicastAddress, 0);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /^The "groupAddress" argument must be of type string\. Received type number$/
+    message: 'The "groupAddress" argument must be of type string. ' +
+    'Received type number (0)'
   });
   socket.close();
 }
@@ -120,7 +122,8 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
     socket.dropSourceSpecificMembership(0, multicastAddress);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /^The "sourceAddress" argument must be of type string\. Received type number$/
+    message: 'The "sourceAddress" argument must be of type string. ' +
+    'Received type number (0)'
   });
   socket.close();
 }
@@ -132,7 +135,8 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
     socket.dropSourceSpecificMembership(multicastAddress, 0);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /^The "groupAddress" argument must be of type string\. Received type number$/
+    message: 'The "groupAddress" argument must be of type string. ' +
+    'Received type number (0)'
   });
   socket.close();
 }

--- a/test/parallel/test-dgram-membership.js
+++ b/test/parallel/test-dgram-membership.js
@@ -76,3 +76,75 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
                 /^Error: dropMembership EINVAL$/);
   socket.close();
 }
+
+// addSourceSpecificMembership with invalid sourceAddress should throw
+{
+  const socket = setup();
+  assert.throws(() => {
+    socket.addSourceSpecificMembership(0, multicastAddress);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: /^The "sourceAddress" argument must be of type string\. Received type number$/
+  });
+  socket.close();
+}
+
+// addSourceSpecificMembership with invalid sourceAddress should throw
+{
+  const socket = setup();
+  assert.throws(() => {
+    socket.addSourceSpecificMembership(multicastAddress, 0);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: /^The "groupAddress" argument must be of type string\. Received type number$/
+  });
+  socket.close();
+}
+
+// addSourceSpecificMembership with invalid groupAddress should throw
+{
+  const socket = setup();
+  assert.throws(() => {
+    socket.addSourceSpecificMembership(multicastAddress, '0');
+  }, {
+    code: 'EINVAL',
+    message: 'addSourceSpecificMembership EINVAL'
+  });
+  socket.close();
+}
+
+// dropSourceSpecificMembership with invalid sourceAddress should throw
+{
+  const socket = setup();
+  assert.throws(() => {
+    socket.dropSourceSpecificMembership(0, multicastAddress);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: /^The "sourceAddress" argument must be of type string\. Received type number$/
+  });
+  socket.close();
+}
+
+// dropSourceSpecificMembership with invalid groupAddress should throw
+{
+  const socket = setup();
+  assert.throws(() => {
+    socket.dropSourceSpecificMembership(multicastAddress, 0);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: /^The "groupAddress" argument must be of type string\. Received type number$/
+  });
+  socket.close();
+}
+
+// dropSourceSpecificMembership with invalid UDP should throw
+{
+  const socket = setup();
+  assert.throws(() => {
+    socket.dropSourceSpecificMembership(multicastAddress, '0');
+  }, {
+    code: 'EINVAL',
+    message: 'dropSourceSpecificMembership EINVAL'
+  });
+  socket.close();
+}


### PR DESCRIPTION
Code and learn task for additional coverage for situation when
methods addSourceSpecificMembership and dropSourceSpecificMembership of the dgram module 
called with incorrect sourceAddress and groupAddress arguments.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
