### PR TITLE
zlib: use for...of

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -91,9 +91,7 @@ const codes = {
   Z_VERSION_ERROR: constants.Z_VERSION_ERROR
 };
 
-const ckeys = ObjectKeys(codes);
-for (let ck = 0; ck < ckeys.length; ck++) {
-  const ckey = ckeys[ck];
+for (const ckey of ObjectKeys(codes)) {
   codes[codes[ckey]] = ckey;
 }
 
@@ -911,9 +909,7 @@ ObjectDefineProperties(module.exports, {
 
 // These should be considered deprecated
 // expose all the zlib constants
-const bkeys = ObjectKeys(constants);
-for (let bk = 0; bk < bkeys.length; bk++) {
-  const bkey = bkeys[bk];
+for (const bkey of ObjectKeys(constants)) {
   if (bkey.startsWith('BROTLI')) continue;
   ObjectDefineProperty(module.exports, bkey, {
     enumerable: false, value: constants[bkey], writable: false


### PR DESCRIPTION
Searched for regular expression `for \([^\.]*.length` in `lib` and made changes in `zlib` submodule

Refs: https://github.com/nodejs/node/pull/30910#discussion_r357042420

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
