### PR TITLE
src: set arraybuffer_untransferable_private_symbol

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1213,6 +1213,10 @@ void Initialize(Local<Object> target,
     // TODO(thangktran): drop this check when V8 is pumped to 8.0 .
     if (!array_buffer->IsExternal())
       array_buffer->Externalize(array_buffer->GetBackingStore());
+    array_buffer->SetPrivate(
+        env->context(),
+        env->arraybuffer_untransferable_private_symbol(),
+        True(env->isolate())).Check();
     CHECK(target
               ->Set(env->context(),
                     FIXED_ONE_BYTE_STRING(env->isolate(), "zeroFill"),

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -578,6 +578,9 @@ Http2Session::Http2Session(Environment* env,
     // TODO(thangktran): drop this check when V8 is pumped to 8.0 .
     if (!ab->IsExternal())
       ab->Externalize(ab->GetBackingStore());
+    ab->SetPrivate(env->context(),
+                   env->arraybuffer_untransferable_private_symbol(),
+                   True(env->isolate())).Check();
     js_fields_ab_.Reset(env->isolate(), ab);
     Local<Uint8Array> uint8_arr =
         Uint8Array::New(ab, 0, kSessionUint8FieldCount);


### PR DESCRIPTION
for `ArrayBuffer` whose buffers are not own by `BackingStore`. This
would help us avoid problem with the new V8 BackingStore API where new
`ArrayBuffer` is allocated at the same place of previous `ArrayBuffer`
that is still being tracked in `BackingStore` table.

Ref: https://github.com/nodejs/node/issues/31052

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
