### PR TITLE
[v12.x] src: make --use-largepages a runtime option

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -398,17 +398,6 @@ parser.add_option('--with-etw',
     dest='with_etw',
     help='build with ETW (default is true on Windows)')
 
-parser.add_option('--use-largepages',
-    action='store_true',
-    dest='node_use_large_pages',
-    help='build with Large Pages support. This feature is supported only on Linux kernel' +
-         '>= 2.6.38 with Transparent Huge pages enabled and FreeBSD')
-
-parser.add_option('--use-largepages-script-lld',
-    action='store_true',
-    dest='node_use_large_pages_script_lld',
-    help='link against the LLVM ld linker script. Implies -fuse-ld=lld in the linker flags')
-
 intl_optgroup.add_option('--with-intl',
     action='store',
     dest='with_intl',
@@ -1040,28 +1029,6 @@ def configure_node(o):
        'DTrace is currently only supported on SunOS, MacOS or Linux systems.')
   else:
     o['variables']['node_use_dtrace'] = 'false'
-
-  if options.node_use_large_pages and not flavor in ('linux', 'freebsd', 'mac'):
-    raise Exception(
-      'Large pages are supported only on Linux, FreeBSD and MacOS Systems.')
-  if options.node_use_large_pages and flavor in ('linux', 'freebsd', 'mac'):
-    if options.shared or options.enable_static:
-      raise Exception(
-        'Large pages are supported only while creating node executable.')
-    if target_arch!="x64":
-      raise Exception(
-        'Large pages are supported only x64 platform.')
-    if flavor == 'mac':
-      info('macOS server with 32GB or more is recommended')
-    if flavor == 'linux':
-      # Example full version string: 2.6.32-696.28.1.el6.x86_64
-      FULL_KERNEL_VERSION=os.uname()[2]
-      KERNEL_VERSION=FULL_KERNEL_VERSION.split('-')[0]
-      if KERNEL_VERSION < "2.6.38" and flavor == 'linux':
-        raise Exception(
-          'Large pages need Linux kernel version >= 2.6.38')
-  o['variables']['node_use_large_pages'] = b(options.node_use_large_pages)
-  o['variables']['node_use_large_pages_script_lld'] = b(options.node_use_large_pages_script_lld)
 
   if options.no_ifaddrs:
     o['defines'] += ['SUNOS_NO_IFADDRS']

--- a/configure.py
+++ b/configure.py
@@ -1040,6 +1040,13 @@ def configure_node(o):
   else:
     o['variables']['node_use_dtrace'] = 'false'
 
+  if options.node_use_large_pages or options.node_use_large_pages_script_lld:
+    warn('''The `--use-largepages` and `--use-largepages-script-lld` options
+         have no effect during build time. Support for mapping to large pages is
+         now a runtime option of Node.js. Run `node --use-largepages` or add
+         `--use-largepages` to the `NODE_OPTIONS` environment variable once
+         Node.js is built to enable mapping to large pages.''')
+
   if options.no_ifaddrs:
     o['defines'] += ['SUNOS_NO_IFADDRS']
 

--- a/configure.py
+++ b/configure.py
@@ -398,6 +398,16 @@ parser.add_option('--with-etw',
     dest='with_etw',
     help='build with ETW (default is true on Windows)')
 
+parser.add_option('--use-largepages',
+    action='store_true',
+    dest='node_use_large_pages',
+    help='This option has no effect. --use-largepages is now a runtime option.')
+
+parser.add_option('--use-largepages-script-lld',
+    action='store_true',
+    dest='node_use_large_pages_script_lld',
+    help='This option has no effect. --use-largepages is now a runtime option.')
+
 intl_optgroup.add_option('--with-intl',
     action='store',
     dest='with_intl',

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -833,6 +833,22 @@ environment variables.
 
 See `SSL_CERT_DIR` and `SSL_CERT_FILE`.
 
+### `--use-largepages=mode`
+<!-- YAML
+added: REPLACEME
+-->
+
+Re-map the Node.js static code to large memory pages at startup. If supported on
+the target system, this will cause the Node.js static code to be moved onto 2
+MiB pages instead of 4 KiB pages.
+
+The following values are valid for `mode`:
+* `off`: No mapping will be attempted. This is the default.
+* `on`: If supported by the OS, mapping will be attempted. Failure to map will
+  be ignored and a message will be printed to standard error.
+* `silent`: If supported by the OS, mapping will be attempted. Failure to map
+  will be ignored and will not be reported.
+
 ### `--v8-options`
 <!-- YAML
 added: v0.1.3
@@ -1085,6 +1101,7 @@ Node.js options that are allowed are:
 * `--track-heap-objects`
 * `--unhandled-rejections`
 * `--use-bundled-ca`
+* `--use-largepages`
 * `--use-openssl-ca`
 * `--v8-pool-size`
 * `--zero-fill-buffers`

--- a/doc/node.1
+++ b/doc/node.1
@@ -371,6 +371,16 @@ See
 and
 .Ev SSL_CERT_FILE .
 .
+.It Fl -use-largepages Ns = Ns Ar mode
+Re-map the Node.js static code to large memory pages at startup. If supported on
+the target system, this will cause the Node.js static code to be moved onto 2
+MiB pages instead of 4 KiB pages.
+.Pp
+.Ar mode
+must have one of the following values:
+`off` (the default value, meaning do not map), `on` (map and ignore failure,
+reporting it to stderr), or `silent` (map and silently ignore failure).
+.
 .It Fl -v8-options
 Print V8 command-line options.
 .

--- a/node.gyp
+++ b/node.gyp
@@ -824,10 +824,9 @@
             }],
           ],
         }],
-        [ 'node_use_large_pages=="true" and OS in "linux freebsd mac"', {
+        [ 'OS in "linux freebsd mac" and '
+          'target_arch=="x64"', {
           'defines': [ 'NODE_ENABLE_LARGE_CODE_PAGES=1' ],
-          # The current implementation of Large Pages is under Linux.
-          # Other implementations are possible but not currently supported.
           'sources': [
             'src/large_pages/node_large_page.cc',
             'src/large_pages/node_large_page.h'

--- a/node.gypi
+++ b/node.gypi
@@ -302,8 +302,7 @@
     }],
     [ 'OS=="linux" and '
       'target_arch=="x64" and '
-      'node_use_large_pages=="true" and '
-      'node_use_large_pages_script_lld=="false"', {
+      'llvm_version=="0.0"', {
       'ldflags': [
         '-Wl,-T',
         '<!(realpath src/large_pages/ld.implicit.script)',
@@ -311,8 +310,7 @@
     }],
     [ 'OS=="linux" and '
       'target_arch=="x64" and '
-      'node_use_large_pages=="true" and '
-      'node_use_large_pages_script_lld=="true"', {
+      'llvm_version!="0.0"', {
       'ldflags': [
         '-Wl,-T',
         '<!(realpath src/large_pages/ld.implicit.script.lld)',

--- a/node.gypi
+++ b/node.gypi
@@ -305,7 +305,7 @@
       'llvm_version=="0.0"', {
       'ldflags': [
         '-Wl,-T',
-        '<!(realpath src/large_pages/ld.implicit.script)',
+        '<!(echo "$(pwd)/src/large_pages/ld.implicit.script")',
       ]
     }],
     [ 'OS=="linux" and '
@@ -313,7 +313,7 @@
       'llvm_version!="0.0"', {
       'ldflags': [
         '-Wl,-T',
-        '<!(realpath src/large_pages/ld.implicit.script.lld)',
+        '<!(echo "$(pwd)/src/large_pages/ld.implicit.script.lld")',
       ]
     }],
     [ 'node_use_openssl=="true"', {

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -62,7 +62,7 @@
 // Map a new area and copy the original code there
 // Use mmap using the start address with MAP_FIXED so we get exactly the
 // same virtual address
-// Use madvise with MADV_HUGE_PAGE to use Anonymous 2M Pages
+// Use madvise with MADV_HUGEPAGE to use Anonymous 2M Pages
 // If successful copy the code there and unmap the original region.
 
 extern char __nodetext;
@@ -308,7 +308,7 @@ static bool IsSuperPagesEnabled() {
 // a. map a new area and copy the original code there
 // b. mmap using the start address with MAP_FIXED so we get exactly
 //    the same virtual address (except on macOS).
-// c. madvise with MADV_HUGE_PAGE
+// c. madvise with MADV_HUGEPAGE
 // d. If successful copy the code there and unmap the original region
 int
 #if !defined(__APPLE__)
@@ -333,9 +333,6 @@ MoveTextRegionToLargePages(const text_region& r) {
     PrintSystemError(errno);
     return -1;
   }
-  OnScopeLeave munmap_on_return([nmem, size]() {
-    if (-1 == munmap(nmem, size)) PrintSystemError(errno);
-  });
 
   memcpy(nmem, r.from, size);
 
@@ -352,13 +349,14 @@ MoveTextRegionToLargePages(const text_region& r) {
     return -1;
   }
 
-  ret = madvise(tmem, size, MADV_HUGEPAGE);
+  ret = madvise(tmem, size, 14 /* MADV_HUGEPAGE */);
   if (ret == -1) {
     PrintSystemError(errno);
     ret = munmap(tmem, size);
     if (ret == -1) {
       PrintSystemError(errno);
     }
+    if (-1 == munmap(nmem, size)) PrintSystemError(errno);
     return -1;
   }
   memcpy(start, nmem, size);
@@ -369,6 +367,7 @@ MoveTextRegionToLargePages(const text_region& r) {
               MAP_ALIGNED_SUPER, -1 , 0);
   if (tmem == MAP_FAILED) {
     PrintSystemError(errno);
+    if (-1 == munmap(nmem, size)) PrintSystemError(errno);
     return -1;
   }
 #elif defined(__APPLE__)
@@ -383,6 +382,7 @@ MoveTextRegionToLargePages(const text_region& r) {
               VM_FLAGS_SUPERPAGE_SIZE_2MB, 0);
   if (tmem == MAP_FAILED) {
     PrintSystemError(errno);
+    if (-1 == munmap(nmem, size)) PrintSystemError(errno);
     return -1;
   }
   memcpy(tmem, nmem, size);
@@ -393,6 +393,7 @@ MoveTextRegionToLargePages(const text_region& r) {
     if (ret == -1) {
       PrintSystemError(errno);
     }
+    if (-1 == munmap(nmem, size)) PrintSystemError(errno);
     return -1;
   }
   memcpy(start, tmem, size);
@@ -405,8 +406,10 @@ MoveTextRegionToLargePages(const text_region& r) {
     if (ret == -1) {
       PrintSystemError(errno);
     }
+    if (-1 == munmap(nmem, size)) PrintSystemError(errno);
     return -1;
   }
+  if (-1 == munmap(nmem, size)) PrintSystemError(errno);
   return ret;
 }
 
@@ -418,12 +421,12 @@ int MapStaticCodeToLargePages() {
     return -1;
   }
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
   if (r.from > reinterpret_cast<void*>(&MoveTextRegionToLargePages))
     return MoveTextRegionToLargePages(r);
 
   return -1;
-#elif defined(__FreeBSD__) || defined(__APPLE__)
+#elif defined(__APPLE__)
   return MoveTextRegionToLargePages(r);
 #endif
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -64,7 +64,9 @@
 #include "inspector/worker_inspector.h"  // ParentInspectorHandle
 #endif
 
+#ifdef NODE_ENABLE_LARGE_CODE_PAGES
 #include "large_pages/node_large_page.h"
+#endif
 
 #ifdef NODE_REPORT
 #include "node_report.h"

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -63,6 +63,11 @@ void PerProcessOptions::CheckOptions(std::vector<std::string>* errors) {
                       "used, not both");
   }
 #endif
+  if (use_largepages != "off" &&
+      use_largepages != "on" &&
+      use_largepages != "silent") {
+    errors->push_back("invalid value for --use-largepages");
+  }
   per_isolate->CheckOptions(errors);
 }
 
@@ -745,6 +750,10 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             kAllowedInEnvironment);
 #endif
 #endif
+  AddOption("--use-largepages",
+            "Map the Node.js static code to large pages",
+            &PerProcessOptions::use_largepages,
+            kAllowedInEnvironment);
 
   Insert(iop, &PerProcessOptions::get_per_isolate_options);
 }

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -231,6 +231,7 @@ class PerProcessOptions : public Options {
   bool force_fips_crypto = false;
 #endif
 #endif
+  std::string use_largepages = "off";
 
 #ifdef NODE_REPORT
   std::vector<std::string> cmdline;

--- a/test/parallel/test-startup-large-pages.js
+++ b/test/parallel/test-startup-large-pages.js
@@ -1,0 +1,29 @@
+'use strict';
+
+// Make sure that Node.js runs correctly with the --use-largepages option.
+
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+{
+  const child = spawnSync(process.execPath,
+                          [ '--use-largepages=on', '-p', '42' ]);
+  const stdout = child.stdout.toString().match(/\S+/g);
+  assert.strictEqual(child.status, 0);
+  assert.strictEqual(child.signal, null);
+  assert.strictEqual(stdout.length, 1);
+  assert.strictEqual(stdout[0], '42');
+}
+
+{
+  const child = spawnSync(process.execPath,
+                          [ '--use-largepages=xyzzy', '-p', '42' ]);
+  assert.strictEqual(child.status, 9);
+  assert.strictEqual(child.signal, null);
+  assert.strictEqual(child.stderr.toString().match(/\S+/g).slice(1).join(' '),
+                     'invalid value for --use-largepages');
+}
+
+// TODO(gabrielschulhof): Make assertions about the stderr, which may or may not
+// contain a message indicating that mapping to large pages has failed.


### PR DESCRIPTION
Moves the option that instructs Node.js to-remap its static code to
large pages from a configure-time option to a runtime option. This
should make it easy to assess the performance impact of such a change
without having to custom-build.

PR-URL: https://github.com/nodejs/node/pull/30954
Reviewed-By: @bnoordhuis 
Reviewed-By: @devnexen 
Reviewed-By: @addaleax
Reviewed-By: @cjihrig
Reviewed-By: @gireeshpunathil 
Reviewed-By: @lundibundi 
Co-authored-by: @devnexen

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
