### PR TITLE
doc: improve doc net:server.listen

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -241,7 +241,7 @@ added: v0.5.10
 
 * `handle` {Object}
 * `backlog` {number} Common parameter of [`server.listen()`][] functions
-* `callback` {Function} Common parameter of [`server.listen()`][] functions
+* `callback` {Function}
 * Returns: {net.Server}
 
 Start a server listening for connections on a given `handle` that has
@@ -277,7 +277,7 @@ changes:
   * `ipv6Only` {boolean} For TCP servers, setting `ipv6Only` to `true` will
     disable dual-stack support, i.e., binding to host `::` won't make
     `0.0.0.0` be bound. **Default:** `false`.
-* `callback` {Function} Common parameter of [`server.listen()`][]
+* `callback` {Function}
   functions.
 * Returns: {net.Server}
 
@@ -314,7 +314,7 @@ added: v0.1.90
 * `path` {string} Path the server should listen to. See
   [Identifying paths for IPC connections][].
 * `backlog` {number} Common parameter of [`server.listen()`][] functions.
-* `callback` {Function} Common parameter of [`server.listen()`][] functions.
+* `callback` {Function}.
 * Returns: {net.Server}
 
 Start an [IPC][] server listening for connections on the given `path`.
@@ -327,7 +327,7 @@ added: v0.1.90
 * `port` {number}
 * `host` {string}
 * `backlog` {number} Common parameter of [`server.listen()`][] functions.
-* `callback` {Function} Common parameter of [`server.listen()`][] functions.
+* `callback` {Function}.
 * Returns: {net.Server}
 
 Start a TCP server listening for connections on the given `port` and `host`.


### PR DESCRIPTION
Remove line "Common parameter of server.listen() functions."
from net:server.listen callback functions because there is no
need of this line.

Fixes: https://github.com/nodejs/node/issues/31019

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
