### PR TITLE
benchmark: include writev & callback in benchmark

### DIFF
--- a/benchmark/streams/writable-manywrites.js
+++ b/benchmark/streams/writable-manywrites.js
@@ -6,10 +6,13 @@ const Writable = require('stream').Writable;
 const bench = common.createBenchmark(main, {
   n: [2e6],
   sync: ['yes', 'no'],
-  writev: ['yes', 'no']
+  writev: ['yes', 'no'],
+  callback: ['yes', 'no']
 });
 
-function main({ n, sync, writev }) {
+function nop() {}
+
+function main({ n, sync, writev, callback }) {
   const b = Buffer.allocUnsafe(1024);
   const s = new Writable();
   sync = sync === 'yes';
@@ -30,11 +33,13 @@ function main({ n, sync, writev }) {
     };
   }
 
+  const cb = callback === 'yes' ? nop : null;
+
   bench.start();
 
   let k = 0;
   function run() {
-    while (k++ < n && s.write(b));
+    while (k++ < n && s.write(b, cb));
     if (k >= n)
       bench.end(n);
   }

--- a/benchmark/streams/writable-manywrites.js
+++ b/benchmark/streams/writable-manywrites.js
@@ -5,19 +5,30 @@ const Writable = require('stream').Writable;
 
 const bench = common.createBenchmark(main, {
   n: [2e6],
-  sync: ['yes', 'no']
+  sync: ['yes', 'no'],
+  writev: ['yes', 'no']
 });
 
-function main({ n, sync }) {
+function main({ n, sync, writev }) {
   const b = Buffer.allocUnsafe(1024);
   const s = new Writable();
   sync = sync === 'yes';
-  s._write = function(chunk, encoding, cb) {
-    if (sync)
-      cb();
-    else
-      process.nextTick(cb);
-  };
+
+  if (writev === 'yes') {
+    s._writev = function(chunks, cb) {
+      if (sync)
+        cb();
+      else
+        process.nextTick(cb);
+    };
+  } else {
+    s._write = function(chunk, encoding, cb) {
+      if (sync)
+        cb();
+      else
+        process.nextTick(cb);
+    };
+  }
 
   bench.start();
 

--- a/benchmark/streams/writable-manywrites.js
+++ b/benchmark/streams/writable-manywrites.js
@@ -20,7 +20,7 @@ function main({ n, sync, writev, callback }) {
       cb();
     else
       process.nextTick(cb);
-  }
+  };
 
   if (writev === 'yes') {
     s._writev = (chunks, cb) => writecb(cb);

--- a/test/benchmark/test-benchmark-streams.js
+++ b/test/benchmark/test-benchmark-streams.js
@@ -9,6 +9,8 @@ runBenchmark('streams',
                'kind=duplex',
                'n=1',
                'sync=no',
+               'writev=no',
+               'callback=no',
                'type=buffer',
              ],
              { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });


### PR DESCRIPTION
Currently we only consider write when benchmarking.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
