### PR TITLE
stream: simplify isBuf

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -323,7 +323,7 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     errorOrDestroy(this, err);
   } else if (isBuf || validChunk(this, state, chunk, cb)) {
     state.pendingcb++;
-    ret = writeOrBuffer(this, state, isBuf, chunk, encoding, cb);
+    ret = writeOrBuffer(this, state, chunk, encoding, cb);
   }
 
   return ret;
@@ -367,15 +367,6 @@ ObjectDefineProperty(Writable.prototype, 'writableBuffer', {
   }
 });
 
-function decodeChunk(state, chunk, encoding) {
-  if (!state.objectMode &&
-      state.decodeStrings !== false &&
-      typeof chunk === 'string') {
-    chunk = Buffer.from(chunk, encoding);
-  }
-  return chunk;
-}
-
 ObjectDefineProperty(Writable.prototype, 'writableEnded', {
   // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
@@ -409,14 +400,13 @@ ObjectDefineProperty(Writable.prototype, 'writableCorked', {
 // If we're already writing something, then just put this
 // in the queue, and wait our turn.  Otherwise, call _write
 // If we return false, then we need a drain event, so set that flag.
-function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
-  if (!isBuf) {
-    var newChunk = decodeChunk(state, chunk, encoding);
-    if (chunk !== newChunk) {
-      isBuf = true;
-      encoding = 'buffer';
-      chunk = newChunk;
-    }
+function writeOrBuffer(stream, state, chunk, encoding, cb) {
+  if (!state.objectMode &&
+      state.decodeStrings !== false &&
+      encoding !== 'buffer' &&
+      typeof chunk === 'string') {
+    chunk = Buffer.from(chunk, encoding);
+    encoding = 'buffer';
   }
   const len = state.objectMode ? 1 : chunk.length;
 
@@ -432,7 +422,6 @@ function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
     state.lastBufferedRequest = {
       chunk,
       encoding,
-      isBuf,
       callback: cb,
       next: null
     };
@@ -561,7 +550,7 @@ function clearBuffer(stream, state) {
     var allBuffers = true;
     while (entry) {
       buffer[count] = entry;
-      if (!entry.isBuf)
+      if (entry.encoding !== 'buffer')
         allBuffers = false;
       entry = entry.next;
       count += 1;


### PR DESCRIPTION
simplify chunk encoding handling

```js
 streams/writable-manywrites.js writev='no' sync='no' n=2000000                  -0.41 %       ±2.03% ±2.69% ±3.47%
 streams/writable-manywrites.js writev='no' sync='yes' n=2000000         ***      6.00 %       ±2.58% ±3.46% ±4.58%
 streams/writable-manywrites.js writev='yes' sync='no' n=2000000                  2.18 %       ±2.43% ±3.22% ±4.15%
 streams/writable-manywrites.js writev='yes' sync='yes' n=2000000                -1.24 %       ±3.16% ±4.25% ±5.60%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
