### PR TITLE
test: log errors in test-http2-propagate-session-destroy-code

### DIFF
--- a/test/parallel/test-http2-propagate-session-destroy-code.js
+++ b/test/parallel/test-http2-propagate-session-destroy-code.js
@@ -15,16 +15,16 @@ server.on('error', common.mustNotCall());
 server.on('session', (session) => {
   session.on('close', common.mustCall());
   session.on('error', common.mustCall((err) => {
-    assert(errRegEx.test(err));
+    assert.ok(errRegEx.test(err), `server session err: ${err}`);
     assert.strictEqual(session.closed, false);
     assert.strictEqual(session.destroyed, true);
   }));
 
   session.on('stream', common.mustCall((stream) => {
     stream.on('error', common.mustCall((err) => {
+      assert.ok(errRegEx.test(err), `server stream err: ${err}`);
       assert.strictEqual(session.closed, false);
       assert.strictEqual(session.destroyed, true);
-      assert(errRegEx.test(err));
       assert.strictEqual(stream.rstCode, destroyCode);
     }));
 
@@ -36,7 +36,7 @@ server.listen(0, common.mustCall(() => {
   const session = http2.connect(`http://localhost:${server.address().port}`);
 
   session.on('error', common.mustCall((err) => {
-    assert(errRegEx.test(err));
+    assert.ok(errRegEx.test(err), `client session err: ${err}`);
     assert.strictEqual(session.closed, false);
     assert.strictEqual(session.destroyed, true);
   }));
@@ -44,7 +44,7 @@ server.listen(0, common.mustCall(() => {
   const stream = session.request({ [http2.constants.HTTP2_HEADER_PATH]: '/' });
 
   stream.on('error', common.mustCall((err) => {
-    assert(errRegEx.test(err));
+    assert.ok(errRegEx.test(err), `client stream err: ${err}`);
     assert.strictEqual(stream.rstCode, destroyCode);
   }));
 


### PR DESCRIPTION
Seen this test error a few times on a CI (i.e. https://ci.nodejs.org/job/node-test-binary-windows-js-suites/617/RUN_SUBSET=0,nodes=win10-COMPILED_BY-vs2019/testReport/junit/(root)/test/parallel_test_http2_propagate_session_destroy_code/).
Add a bit of context to errors.

I suspect this is `ECONNRESET` we are getting there as this same test failed on windows with it while I was working on the #30854. If the timings are unlucky the socket would close without ever sending the destroy code. That PR would hopefully fix the error but the logs would be good anyway.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
