### PR TITLE
build: re-introduce --use-largepages as no-op

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -404,6 +404,16 @@ parser.add_option('--with-etw',
     dest='with_etw',
     help='build with ETW (default is true on Windows)')
 
+parser.add_option('--use-largepages',
+    action='store_true',
+    dest='node_use_large_pages',
+    help='This option has no effect. --use-largepages is now a runtime option.')
+
+parser.add_option('--use-largepages-script-lld',
+    action='store_true',
+    dest='node_use_large_pages_script_lld',
+    help='This option has no effect. --use-largepages is now a runtime option.')
+
 intl_optgroup.add_option('--with-intl',
     action='store',
     dest='with_intl',


### PR DESCRIPTION
Re-introduce the build-time option as a no-op in order to retain
backward compatibility for LTS purposes.

Re: https://github.com/nodejs/node/pull/31063#pullrequestreview-336045756

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
