### PR TITLE
wasi: throw on failed uvwasi_init()

### DIFF
--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -74,13 +74,46 @@ using v8::ArrayBuffer;
 using v8::BackingStore;
 using v8::BigInt;
 using v8::Context;
+using v8::Exception;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
+using v8::Integer;
+using v8::Isolate;
 using v8::Local;
+using v8::MaybeLocal;
 using v8::Object;
 using v8::String;
 using v8::Uint32;
 using v8::Value;
+
+
+static MaybeLocal<Value> WASIException(Local<Context> context,
+                                       int errorno,
+                                       const char* syscall) {
+  Isolate* isolate = context->GetIsolate();
+  Environment* env = Environment::GetCurrent(context);
+  CHECK_NOT_NULL(env);
+  const char* err_name = uvwasi_embedder_err_code_to_string(errorno);
+  Local<String> js_code = OneByteString(isolate, err_name);
+  Local<String> js_syscall = OneByteString(isolate, syscall);
+  Local<String> js_msg = js_code;
+  js_msg =
+      String::Concat(isolate, js_msg, FIXED_ONE_BYTE_STRING(isolate, ", "));
+  js_msg = String::Concat(isolate, js_msg, js_syscall);
+  Local<Object> e =
+    Exception::Error(js_msg)->ToObject(context)
+      .ToLocalChecked();
+
+  if (e->Set(context,
+             env->errno_string(),
+             Integer::New(isolate, errorno)).IsNothing() ||
+      e->Set(context, env->code_string(), js_code).IsNothing() ||
+      e->Set(context, env->syscall_string(), js_syscall).IsNothing()) {
+    return MaybeLocal<Value>();
+  }
+
+  return e;
+}
 
 
 WASI::WASI(Environment* env,
@@ -89,7 +122,16 @@ WASI::WASI(Environment* env,
   MakeWeak();
   alloc_info_ = MakeAllocator();
   options->allocator = &alloc_info_;
-  CHECK_EQ(uvwasi_init(&uvw_, options), UVWASI_ESUCCESS);
+  int err = uvwasi_init(&uvw_, options);
+  if (err != UVWASI_ESUCCESS) {
+    Local<Context> context = env->context();
+    MaybeLocal<Value> exception = WASIException(context, err, "uvwasi_init");
+
+    if (exception.IsEmpty())
+      return;
+
+    context->GetIsolate()->ThrowException(exception.ToLocalChecked());
+  }
 }
 
 

--- a/test/wasi/test-wasi-options-validation.js
+++ b/test/wasi/test-wasi-options-validation.js
@@ -26,3 +26,8 @@ assert.throws(() => { new WASI({ preopens: 'fhqwhgads' }); },
   assert.throws(() => { new WASI(value); },
                 { code: 'ERR_INVALID_ARG_TYPE' });
 });
+
+// Verify that exceptions thrown from the binding layer are handled.
+assert.throws(() => {
+  new WASI({ preopens: { '/sandbox': '__/not/real/path' } });
+}, { code: 'UVWASI_ENOENT', message: /uvwasi_init/ });


### PR DESCRIPTION
Prior to this commit, if `uvwasi_init()` failed in any way, Node would abort due to a failed `CHECK_EQ()`. This commit changes that behavior to a thrown exception.

Fixes: https://github.com/nodejs/node/issues/30878

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)