### PR TITLE
doc: add missing man page entries

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -205,6 +205,15 @@ Set the
 .Ar host:port
 to be used when the inspector is activated.
 .
+.It Fl -inspect-publish-uid=stderr,http
+Specify how the inspector WebSocket URL is exposed.
+Valid values are
+.Sy stderr
+and
+.Sy http .
+Default is
+.Sy stderr,http .
+.
 .It Fl -inspect Ns = Ns Ar [host:]port
 Activate inspector on
 .Ar host:port .

--- a/doc/node.1
+++ b/doc/node.1
@@ -110,6 +110,9 @@ Enable FIPS-compliant crypto at startup.
 Requires Node.js to be built with
 .Sy ./configure --openssl-fips .
 .
+.It Fl -enable-source-maps
+Enable experimental Source Map V3 support for stack traces.
+.
 .It Fl -experimental-conditional-exports
 Enable experimental support for "require" and "node" conditional export targets.
 .

--- a/doc/node.1
+++ b/doc/node.1
@@ -150,6 +150,9 @@ Enable experimental WebAssembly System Interface support.
 .It Fl -experimental-wasm-modules
 Enable experimental WebAssembly module support.
 .
+.It Fl -force-context-aware
+Disable loading native addons that are not context-aware.
+.
 .It Fl -force-fips
 Force FIPS-compliant crypto on startup
 (Cannot be disabled from script code).


### PR DESCRIPTION
This PR adds missing entries for `--enable-source-maps`, `--force-context-aware`, and `--inspect-publish-uid` to the man page.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)