### PR TITLE
src: enable stack trace printing for V8 check failures

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -513,6 +513,14 @@ TracingController* NodePlatform::GetTracingController() {
   return tracing_controller_;
 }
 
+Platform::StackTracePrinter NodePlatform::GetStackTracePrinter() {
+  return []() {
+    fprintf(stderr, "\n");
+    DumpBacktrace(stderr);
+    fflush(stderr);
+  };
+}
+
 template <class T>
 TaskQueue<T>::TaskQueue()
     : lock_(), tasks_available_(), tasks_drained_(),

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -174,6 +174,8 @@ class NodePlatform : public MultiIsolatePlatform {
   std::shared_ptr<v8::TaskRunner> GetForegroundTaskRunner(
       v8::Isolate* isolate) override;
 
+  Platform::StackTracePrinter GetStackTracePrinter() override;
+
  private:
   IsolatePlatformDelegate* ForIsolate(v8::Isolate* isolate);
   std::shared_ptr<PerIsolatePlatformData> ForNodeIsolate(v8::Isolate* isolate);


### PR DESCRIPTION
Example output:

    $ ./node --expose-gc test/addons/buffer-free-callback/test.js

    #
    # Fatal error in , line 0
    # Check failed: result.second.
    #
    #
    #
    #FailureMessage Object: 0x7ffebd956860
     1: 0x56290a45b105  [./node]
     2: 0x56290b305b77 V8_Fatal(char const*, ...) [./node]
     3: 0x56290a82702d v8::internal::GlobalBackingStoreRegistry::Register(std::shared_ptr<v8::internal::BackingStore>) [./node]
     4: 0x56290a59a1de v8::ArrayBuffer::GetBackingStore() [./node]
     5: 0x56290a3cb63f node::Buffer::New(node::Environment*, char*, unsigned long, void (*)(char*, void*), void*) [./node]
     6: 0x56290a3cbcdc node::Buffer::New(v8::Isolate*, char*, unsigned long, void (*)(char*, void*), void*) [./node]
     7: 0x7fdeabdfdf89 Alloc(v8::FunctionCallbackInfo<v8::Value> const&) [/home/xxxx/src/node/master/test/addons/buffer-free-callback/build/Release/binding.node]
     8: 0x56290a5ca077  [./node]
     9: 0x56290a5cbf97 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [./node]
    10: 0x56290ad99539  [./node]
    Illegal instruction (core dumped)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
