### PR TITLE
zlib: allow writes after readable 'end' to finish

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -275,7 +275,7 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
   this._defaultFlushFlag = flush;
   this._finishFlushFlag = finishFlush;
   this._defaultFullFlushFlag = fullFlush;
-  this.once('end', _close.bind(this, this));
+  this.once('end', _close.bind(null, this));
   this._info = opts && opts.info;
 }
 ObjectSetPrototypeOf(ZlibBase.prototype, Transform.prototype);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -275,7 +275,7 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
   this._defaultFlushFlag = flush;
   this._finishFlushFlag = finishFlush;
   this._defaultFullFlushFlag = fullFlush;
-  this.once('end', this.close);
+  this.once('end', _close.bind(this, this));
   this._info = opts && opts.info;
 }
 ObjectSetPrototypeOf(ZlibBase.prototype, Transform.prototype);
@@ -487,7 +487,7 @@ function processChunkSync(self, chunk, flushFlag) {
 
 function processChunk(self, chunk, flushFlag, cb) {
   const handle = self._handle;
-  assert(handle, 'zlib binding closed');
+  if (!handle) return process.nextTick(cb);
 
   handle.buffer = chunk;
   handle.cb = cb;
@@ -513,13 +513,9 @@ function processCallback() {
   const self = this[owner_symbol];
   const state = self._writeState;
 
-  if (self._hadError) {
+  if (self._hadError || self.destroyed) {
     this.buffer = null;
-    return;
-  }
-
-  if (self.destroyed) {
-    this.buffer = null;
+    this.cb();
     return;
   }
 
@@ -539,7 +535,7 @@ function processCallback() {
   }
 
   if (self.destroyed) {
-    return;
+    return this.cb();
   }
 
   // Exhausted the output buffer, or used all the input create a new one.

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -535,7 +535,8 @@ function processCallback() {
   }
 
   if (self.destroyed) {
-    return this.cb();
+    this.cb();
+    return;
   }
 
   // Exhausted the output buffer, or used all the input create a new one.

--- a/test/parallel/test-zlib-write-after-end.js
+++ b/test/parallel/test-zlib-write-after-end.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../common');
+const zlib = require('zlib');
+
+// Regression test for https://github.com/nodejs/node/issues/30976
+// Writes to a stream should finish even after the readable side has been ended.
+
+const data = zlib.deflateRawSync('Welcome');
+
+const inflate = zlib.createInflateRaw();
+
+inflate.resume();
+inflate.write(data, common.mustCall());
+inflate.write(Buffer.from([0x00]), common.mustCall());
+inflate.write(Buffer.from([0x00]), common.mustCall());
+inflate.flush(common.mustCall());


### PR DESCRIPTION
Call the callback for writes that occur after the stream is closed.
This also requires changes to the code to not call `.destroy()`
on the stream in `.on('end')`, and to ignore chunks written
afterwards.

Previously, these writes would just queue up silently, as their
`_write()` callback would never have been called.

/cc @lpinca

Fixes: https://github.com/nodejs/node/issues/30976

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
