### PR TITLE
repl: use public getCursorPos()

### DIFF
--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -141,7 +141,7 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
 
   function getPreviewPos() {
     const displayPos = repl._getDisplayPos(`${repl._prompt}${repl.line}`);
-    const cursorPos = repl._getCursorPos();
+    const cursorPos = repl.getCursorPos();
     const rows = 1 + displayPos.rows - cursorPos.rows;
     return { rows, cols: cursorPos.cols };
   }
@@ -528,7 +528,7 @@ function setupReverseSearch(repl) {
       rows = repl._getDisplayPos(`${repl._prompt}${line}`).rows;
       cursorTo(repl.output, promptPos.cols);
     } else if (isInReverseSearch && repl.line !== '') {
-      rows = repl._getCursorPos().rows;
+      rows = repl.getCursorPos().rows;
       cursorTo(repl.output, promptPos.cols);
     }
     if (rows !== 0)
@@ -580,7 +580,7 @@ function setupReverseSearch(repl) {
       if (repl.line !== '') {
         repl.output.write(repl.line);
         if (repl.line.length !== repl.cursor) {
-          const { cols, rows } = repl._getCursorPos();
+          const { cols, rows } = repl.getCursorPos();
           cursorTo(repl.output, cols);
           if (rows !== 0)
             moveCursor(repl.output, 0, rows);


### PR DESCRIPTION
`_getCursorPos()` recently became public API. This commit updates the remaining uses of `_getCursorPos()` to use the public API.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)