### PR TITLE
build: switch realpath to pwd

### DIFF
--- a/node.gypi
+++ b/node.gypi
@@ -319,7 +319,7 @@
       'llvm_version!="0.0"', {
       'ldflags': [
         '-Wl,-T',
-        '<!(echo "$(pwd)/src/large_pages/ld.implicit.script")',
+        '<!(echo "$(pwd)/src/large_pages/ld.implicit.script.lld")',
       ]
     }],
     [ 'node_use_openssl=="true"', {

--- a/node.gypi
+++ b/node.gypi
@@ -311,7 +311,7 @@
       'llvm_version=="0.0"', {
       'ldflags': [
         '-Wl,-T',
-        '<!(realpath src/large_pages/ld.implicit.script)',
+        '<!(echo "$(pwd)/src/large_pages/ld.implicit.script")',
       ]
     }],
     [ 'OS=="linux" and '
@@ -319,7 +319,7 @@
       'llvm_version!="0.0"', {
       'ldflags': [
         '-Wl,-T',
-        '<!(realpath src/large_pages/ld.implicit.script.lld)',
+        '<!(echo "$(pwd)/src/large_pages/ld.implicit.script")',
       ]
     }],
     [ 'node_use_openssl=="true"', {


### PR DESCRIPTION
Our test coverage linux machine doesn't have the `realpath` bin, which I believe comes in as part of `coreutils`?

This became an issue in #30954, which I believe caused `realpath` to start getting invoked on these machines for the first time.

I _believe_ we can simply swap out the use of `realpath` to `pwd`, for our purposes.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
