### PR TITLE
deps: V8: bump v8_embedder_string for 0e21c1e637bf

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.25',
+    'v8_embedder_string': '-node.26',
 
     ##### V8 defaults for Node.js #####
 


### PR DESCRIPTION
0e21c1e637bf6d844473d09dca3508f2bf547b89 has landed without a proper `v8_embedder_string` bump, this is a follow-up fix.

Refs: 0e21c1e637bf6d844473d09dca3508f2bf547b89
Refs: https://github.com/nodejs/node/pull/31007

The alternative would be to revert 0e21c1e637bf6d844473d09dca3508f2bf547b89  (PR: #31098) and re-land #31007. Filing both to speed up things.
