### PR TITLE
fs: use consistent defaults in sync stat functions

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -922,7 +922,7 @@ function stat(path, options = { bigint: false }, callback) {
   binding.stat(pathModule.toNamespacedPath(path), options.bigint, req);
 }
 
-function fstatSync(fd, options = {}) {
+function fstatSync(fd, options = { bigint: false }) {
   validateInt32(fd, 'fd', 0);
   const ctx = { fd };
   const stats = binding.fstat(fd, options.bigint, undefined, ctx);
@@ -930,7 +930,7 @@ function fstatSync(fd, options = {}) {
   return getStatsFromBinding(stats);
 }
 
-function lstatSync(path, options = {}) {
+function lstatSync(path, options = { bigint: false }) {
   path = getValidatedPath(path);
   const ctx = { path };
   const stats = binding.lstat(pathModule.toNamespacedPath(path),
@@ -939,7 +939,7 @@ function lstatSync(path, options = {}) {
   return getStatsFromBinding(stats);
 }
 
-function statSync(path, options = {}) {
+function statSync(path, options = { bigint: false }) {
   path = getValidatedPath(path);
   const ctx = { path };
   const stats = binding.stat(pathModule.toNamespacedPath(path),


### PR DESCRIPTION
This commit updates the default options used by `statSync()`, `lstatSync()`, and `fstatSync()` to be identical to the defaults used by the callback- and Promise-based versions.

Technically, the binding layer treats `bigint` values of `undefined` and `false` the same, but we might as well be consistent.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)