### PR TITLE
Revert "deps: V8: cherry-pick 687d865fe251"

### DIFF
--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -2761,14 +2761,6 @@ HeapObject Heap::AlignWithFiller(HeapObject object, int object_size,
 
 void* Heap::AllocateExternalBackingStore(
     const std::function<void*(size_t)>& allocate, size_t byte_length) {
-  size_t new_space_backing_store_bytes =
-      new_space()->ExternalBackingStoreBytes();
-  if (new_space_backing_store_bytes >= 2 * kMaxSemiSpaceSize &&
-      new_space_backing_store_bytes >= byte_length) {
-    // Performing a young generation GC amortizes over the allocated backing
-    // store bytes and may free enough external bytes for this allocation.
-    CollectGarbage(NEW_SPACE, GarbageCollectionReason::kExternalMemoryPressure);
-  }
   // TODO(ulan): Perform GCs proactively based on the byte_length and
   // the current external backing store counters.
   void* result = allocate(byte_length);

--- a/deps/v8/src/heap/heap.h
+++ b/deps/v8/src/heap/heap.h
@@ -1793,6 +1793,10 @@ class Heap {
 
   void FinalizePartialMap(Map map);
 
+  // Allocate empty fixed typed array of given type.
+  V8_WARN_UNUSED_RESULT AllocationResult
+  AllocateEmptyFixedTypedArray(ExternalArrayType array_type);
+
   void set_force_oom(bool value) { force_oom_ = value; }
 
   // ===========================================================================

--- a/deps/v8/src/heap/spaces.h
+++ b/deps/v8/src/heap/spaces.h
@@ -2804,14 +2804,14 @@ class V8_EXPORT_PRIVATE NewSpace
   void Shrink();
 
   // Return the allocated bytes in the active semispace.
-  size_t Size() final {
+  size_t Size() override {
     DCHECK_GE(top(), to_space_.page_low());
     return to_space_.pages_used() *
                MemoryChunkLayout::AllocatableMemoryInDataPage() +
            static_cast<size_t>(top() - to_space_.page_low());
   }
 
-  size_t SizeOfObjects() final { return Size(); }
+  size_t SizeOfObjects() override { return Size(); }
 
   // Return the allocatable capacity of a semispace.
   size_t Capacity() {
@@ -2829,36 +2829,28 @@ class V8_EXPORT_PRIVATE NewSpace
 
   // Committed memory for NewSpace is the committed memory of both semi-spaces
   // combined.
-  size_t CommittedMemory() final {
+  size_t CommittedMemory() override {
     return from_space_.CommittedMemory() + to_space_.CommittedMemory();
   }
 
-  size_t MaximumCommittedMemory() final {
+  size_t MaximumCommittedMemory() override {
     return from_space_.MaximumCommittedMemory() +
            to_space_.MaximumCommittedMemory();
   }
 
   // Approximate amount of physical memory committed for this space.
-  size_t CommittedPhysicalMemory() final;
+  size_t CommittedPhysicalMemory() override;
 
   // Return the available bytes without growing.
-  size_t Available() final {
+  size_t Available() override {
     DCHECK_GE(Capacity(), Size());
     return Capacity() - Size();
   }
 
-  size_t ExternalBackingStoreBytes(ExternalBackingStoreType type) const final {
+  size_t ExternalBackingStoreBytes(
+      ExternalBackingStoreType type) const override {
     DCHECK_EQ(0, from_space_.ExternalBackingStoreBytes(type));
     return to_space_.ExternalBackingStoreBytes(type);
-  }
-
-  size_t ExternalBackingStoreBytes() {
-    size_t result = 0;
-    for (int i = 0; i < ExternalBackingStoreType::kNumTypes; i++) {
-      result +=
-          ExternalBackingStoreBytes(static_cast<ExternalBackingStoreType>(i));
-    }
-    return result;
   }
 
   size_t AllocatedSinceLastGC() {

--- a/deps/v8/test/cctest/heap/test-heap.cc
+++ b/deps/v8/test/cctest/heap/test-heap.cc
@@ -6823,27 +6823,6 @@ TEST(CodeObjectRegistry) {
   CHECK(MemoryChunk::FromAddress(code2_address)->Contains(code2_address));
 }
 
-TEST(Regress9701) {
-  ManualGCScope manual_gc_scope;
-  if (!FLAG_incremental_marking) return;
-  CcTest::InitializeVM();
-  Heap* heap = CcTest::heap();
-  // Start with an empty new space.
-  CcTest::CollectGarbage(NEW_SPACE);
-  CcTest::CollectGarbage(NEW_SPACE);
-
-  int mark_sweep_count_before = heap->ms_count();
-  // Allocate many short living array buffers.
-  for (int i = 0; i < 1000; i++) {
-    HandleScope scope(heap->isolate());
-    CcTest::i_isolate()->factory()->NewJSArrayBufferAndBackingStore(
-        64 * KB, InitializedFlag::kZeroInitialized);
-  }
-  int mark_sweep_count_after = heap->ms_count();
-  // We expect only scavenges, no full GCs.
-  CHECK_EQ(mark_sweep_count_before, mark_sweep_count_after);
-}
-
 }  // namespace heap
 }  // namespace internal
 }  // namespace v8


### PR DESCRIPTION
This reverts commit 0e21c1e637bf6d844473d09dca3508f2bf547b89.

It landed without a proper `v8_embedder_string` bump, reverting to re-land #31007 cleanly after that.

Refs: 0e21c1e637bf6d844473d09dca3508f2bf547b89
Refs: https://github.com/nodejs/node/pull/31007

Possible alternative actions:
1) revert and re-land -- this approach
2) just bump the `v8_embedder_string` separately (PR: #31096)
3) do nothing at all (as @addaleax mentioned, `v8_embedder_string` has been just updated by another V8 patch).

Either of those seems fine to me, opening all the possible ones to speed up things.