### PR TITLE
benchmark: add benchmark on async_hooks enabled http server

### DIFF
--- a/benchmark/async_hooks/http-server.js
+++ b/benchmark/async_hooks/http-server.js
@@ -1,0 +1,34 @@
+'use strict';
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  asyncHooks: ['enabed', 'disabled', 'none'],
+  c: [50, 500]
+});
+
+function main({ asyncHooks, c }) {
+  if (asyncHooks !== 'none') {
+    const hook = require('async_hooks').createHook({
+      init() {},
+      before() {},
+      after() {},
+      destroy() {},
+      promiseResolve() {}
+    });
+    if (asyncHooks === 'enabed') {
+      hook.enable();
+    }
+  }
+  const server = require('../fixtures/simple-http-server.js')
+  .listen(common.PORT)
+  .on('listening', () => {
+    const path = '/buffer/4/4/normal/1';
+
+    bench.http({
+      path: path,
+      connections: c
+    }, () => {
+      server.close();
+    });
+  });
+}

--- a/benchmark/async_hooks/http-server.js
+++ b/benchmark/async_hooks/http-server.js
@@ -2,20 +2,26 @@
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  asyncHooks: ['enabed', 'disabled', 'none'],
-  c: [50, 500]
+  asyncHooks: ['init', 'before', 'after', 'all', 'disabled', 'none'],
+  connections: [50, 500]
 });
 
-function main({ asyncHooks, c }) {
+function main({ asyncHooks, connections }) {
   if (asyncHooks !== 'none') {
-    const hook = require('async_hooks').createHook({
+    let hooks = {
       init() {},
       before() {},
       after() {},
       destroy() {},
       promiseResolve() {}
-    });
-    if (asyncHooks === 'enabed') {
+    };
+    if (asyncHooks !== 'all' || asyncHooks !== 'disabled') {
+      hooks = {
+        [asyncHooks]: () => {}
+      };
+    }
+    const hook = require('async_hooks').createHook(hooks);
+    if (asyncHooks !== 'disabled') {
       hook.enable();
     }
   }
@@ -25,8 +31,8 @@ function main({ asyncHooks, c }) {
     const path = '/buffer/4/4/normal/1';
 
     bench.http({
-      path: path,
-      connections: c
+      connections,
+      path,
     }, () => {
       server.close();
     });

--- a/test/benchmark/test-benchmark-async-hooks.js
+++ b/test/benchmark/test-benchmark-async-hooks.js
@@ -13,6 +13,8 @@ const runBenchmark = require('../common/benchmark');
 runBenchmark('async_hooks',
              [
                'method=trackingDisabled',
-               'n=10'
+               'n=10',
+               'asyncHooks=enabled',
+               'c=50'
              ],
              {});

--- a/test/benchmark/test-benchmark-async-hooks.js
+++ b/test/benchmark/test-benchmark-async-hooks.js
@@ -14,7 +14,7 @@ runBenchmark('async_hooks',
              [
                'method=trackingDisabled',
                'n=10',
-               'asyncHooks=enabled',
-               'c=50'
+               'asyncHooks=all',
+               'connections=50'
              ],
              {});

--- a/test/benchmark/test-benchmark-async-hooks.js
+++ b/test/benchmark/test-benchmark-async-hooks.js
@@ -12,9 +12,9 @@ const runBenchmark = require('../common/benchmark');
 
 runBenchmark('async_hooks',
              [
-               'method=trackingDisabled',
-               'n=10',
                'asyncHooks=all',
-               'connections=50'
+               'connections=50',
+               'method=trackingDisabled',
+               'n=10'
              ],
              {});


### PR DESCRIPTION
Refs: https://github.com/nodejs/diagnostics/issues/124

FWIW following is the result of the benchmark:

```
async_hooks/http-server.js connections=50 asyncHooks="init" benchmarker="autocannon": 31,934.4
async_hooks/http-server.js connections=500 asyncHooks="init" benchmarker="autocannon": 31,830.4
async_hooks/http-server.js connections=50 asyncHooks="before" benchmarker="autocannon": 33,041.6
async_hooks/http-server.js connections=500 asyncHooks="before" benchmarker="autocannon": 30,643.2
async_hooks/http-server.js connections=50 asyncHooks="after" benchmarker="autocannon": 32,300.8
async_hooks/http-server.js connections=500 asyncHooks="after" benchmarker="autocannon": 29,969.6
async_hooks/http-server.js connections=50 asyncHooks="all" benchmarker="autocannon": 33,208
async_hooks/http-server.js connections=500 asyncHooks="all" benchmarker="autocannon": 32,388.8
async_hooks/http-server.js connections=50 asyncHooks="disabled" benchmarker="autocannon": 34,539.2
async_hooks/http-server.js connections=500 asyncHooks="disabled" benchmarker="autocannon": 32,571.2
async_hooks/http-server.js connections=50 asyncHooks="none" benchmarker="autocannon": 34,468.81
async_hooks/http-server.js connections=500 asyncHooks="none" benchmarker="autocannon": 31,824
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
