### PR TITLE
[v10.x backport] doc: allow <code> in header elements

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -56,7 +56,7 @@ dns.resolve4('archive.org', (err, addresses) => {
 There are subtle consequences in choosing one over the other, please consult
 the [Implementation considerations section][] for more information.
 
-## Class: dns.Resolver
+## Class: `dns.Resolver`
 <!-- YAML
 added: v8.3.0
 -->
@@ -97,7 +97,7 @@ The following methods from the `dns` module are available:
 * [`resolver.reverse()`][`dns.reverse()`]
 * [`resolver.setServers()`][`dns.setServers()`]
 
-### resolver.cancel()
+### `resolver.cancel()`
 <!-- YAML
 added: v8.3.0
 -->
@@ -105,7 +105,7 @@ added: v8.3.0
 Cancel all outstanding DNS queries made by this resolver. The corresponding
 callbacks will be called with an error with code `ECANCELLED`.
 
-## dns.getServers()
+## `dns.getServers()`
 <!-- YAML
 added: v0.11.3
 -->
@@ -126,7 +126,7 @@ section if a custom port is used.
 ]
 ```
 
-## dns.lookup(hostname[, options], callback)
+## `dns.lookup(hostname[, options], callback)`
 <!-- YAML
 added: v0.1.90
 changes:
@@ -212,7 +212,7 @@ configured. Loopback addresses are not considered.
 found, then return IPv4 mapped IPv6 addresses. Note that it is not supported
 on some operating systems (e.g FreeBSD 10.1).
 
-## dns.lookupService(address, port, callback)
+## `dns.lookupService(address, port, callback)`
 <!-- YAML
 added: v0.11.14
 -->
@@ -243,7 +243,7 @@ dns.lookupService('127.0.0.1', 22, (err, hostname, service) => {
 If this method is invoked as its [`util.promisify()`][]ed version, it returns a
 `Promise` for an `Object` with `hostname` and `service` properties.
 
-## dns.resolve(hostname[, rrtype], callback)
+## `dns.resolve(hostname[, rrtype], callback)`
 <!-- YAML
 added: v0.1.27
 -->
@@ -275,7 +275,7 @@ records. The type and structure of individual results varies based on `rrtype`:
 On error, `err` is an [`Error`][] object, where `err.code` is one of the
 [DNS error codes](#dns_error_codes).
 
-## dns.resolve4(hostname[, options], callback)
+## `dns.resolve4(hostname[, options], callback)`
 <!-- YAML
 added: v0.1.16
 changes:
@@ -299,7 +299,7 @@ Uses the DNS protocol to resolve a IPv4 addresses (`A` records) for the
 will contain an array of IPv4 addresses (e.g.
 `['74.125.79.104', '74.125.79.105', '74.125.79.106']`).
 
-## dns.resolve6(hostname[, options], callback)
+## `dns.resolve6(hostname[, options], callback)`
 <!-- YAML
 added: v0.1.16
 changes:
@@ -322,7 +322,7 @@ Uses the DNS protocol to resolve a IPv6 addresses (`AAAA` records) for the
 `hostname`. The `addresses` argument passed to the `callback` function
 will contain an array of IPv6 addresses.
 
-## dns.resolveAny(hostname, callback)
+## `dns.resolveAny(hostname, callback)`
 
 * `hostname` {string}
 * `callback` {Function}
@@ -371,7 +371,7 @@ DNS server operators may choose not to respond to `ANY`
 queries. It may be better to call individual methods like [`dns.resolve4()`][],
 [`dns.resolveMx()`][], and so on. For more details, see [RFC 8482][].
 
-## dns.resolveCname(hostname, callback)
+## `dns.resolveCname(hostname, callback)`
 <!-- YAML
 added: v0.3.2
 -->
@@ -385,7 +385,7 @@ Uses the DNS protocol to resolve `CNAME` records for the `hostname`. The
 will contain an array of canonical name records available for the `hostname`
 (e.g. `['bar.example.com']`).
 
-## dns.resolveMx(hostname, callback)
+## `dns.resolveMx(hostname, callback)`
 <!-- YAML
 added: v0.1.27
 -->
@@ -399,7 +399,7 @@ Uses the DNS protocol to resolve mail exchange records (`MX` records) for the
 contain an array of objects containing both a `priority` and `exchange`
 property (e.g. `[{priority: 10, exchange: 'mx.example.com'}, ...]`).
 
-## dns.resolveNaptr(hostname, callback)
+## `dns.resolveNaptr(hostname, callback)`
 <!-- YAML
 added: v0.9.12
 -->
@@ -431,7 +431,7 @@ function will contain an array of objects with the following properties:
 }
 ```
 
-## dns.resolveNs(hostname, callback)
+## `dns.resolveNs(hostname, callback)`
 <!-- YAML
 added: v0.1.90
 -->
@@ -445,7 +445,7 @@ Uses the DNS protocol to resolve name server records (`NS` records) for the
 contain an array of name server records available for `hostname`
 (e.g. `['ns1.example.com', 'ns2.example.com']`).
 
-## dns.resolvePtr(hostname, callback)
+## `dns.resolvePtr(hostname, callback)`
 <!-- YAML
 added: v6.0.0
 -->
@@ -458,7 +458,7 @@ Uses the DNS protocol to resolve pointer records (`PTR` records) for the
 `hostname`. The `addresses` argument passed to the `callback` function will
 be an array of strings containing the reply records.
 
-## dns.resolveSoa(hostname, callback)
+## `dns.resolveSoa(hostname, callback)`
 <!-- YAML
 added: v0.11.10
 -->
@@ -492,7 +492,7 @@ be an object with the following properties:
 }
 ```
 
-## dns.resolveSrv(hostname, callback)
+## `dns.resolveSrv(hostname, callback)`
 <!-- YAML
 added: v0.1.27
 -->
@@ -520,7 +520,7 @@ be an array of objects with the following properties:
 }
 ```
 
-## dns.resolveTxt(hostname, callback)
+## `dns.resolveTxt(hostname, callback)`
 <!-- YAML
 added: v0.1.27
 -->
@@ -536,7 +536,7 @@ two-dimensional array of the text records available for `hostname` (e.g.
 one record. Depending on the use case, these could be either joined together or
 treated separately.
 
-## dns.reverse(ip, callback)
+## `dns.reverse(ip, callback)`
 <!-- YAML
 added: v0.1.16
 -->
@@ -551,7 +551,7 @@ array of hostnames.
 On error, `err` is an [`Error`][] object, where `err.code` is
 one of the [DNS error codes][].
 
-## dns.setServers(servers)
+## `dns.setServers(servers)`
 <!-- YAML
 added: v0.11.3
 -->
@@ -594,7 +594,7 @@ The `dns.promises` API provides an alternative set of asynchronous DNS methods
 that return `Promise` objects rather than using callbacks. The API is accessible
 via `require('dns').promises`.
 
-### Class: dnsPromises.Resolver
+### Class: `dnsPromises.Resolver`
 <!-- YAML
 added: v10.6.0
 -->
@@ -640,7 +640,7 @@ The following methods from the `dnsPromises` API are available:
 * [`resolver.reverse()`][`dnsPromises.reverse()`]
 * [`resolver.setServers()`][`dnsPromises.setServers()`]
 
-### dnsPromises.getServers()
+### `dnsPromises.getServers()`
 <!-- YAML
 added: v10.6.0
 -->
@@ -661,7 +661,7 @@ section if a custom port is used.
 ]
 ```
 
-### dnsPromises.lookup(hostname[, options])
+### `dnsPromises.lookup(hostname[, options])`
 <!-- YAML
 added: v10.6.0
 -->
@@ -724,7 +724,7 @@ dnsPromises.lookup('example.com', options).then((result) => {
 });
 ```
 
-### dnsPromises.lookupService(address, port)
+### `dnsPromises.lookupService(address, port)`
 <!-- YAML
 added: v10.6.0
 -->
@@ -749,7 +749,7 @@ dnsPromises.lookupService('127.0.0.1', 22).then((result) => {
 });
 ```
 
-### dnsPromises.resolve(hostname[, rrtype])
+### `dnsPromises.resolve(hostname[, rrtype])`
 <!-- YAML
 added: v10.6.0
 -->
@@ -778,7 +778,7 @@ based on `rrtype`:
 On error, the `Promise` is rejected with an [`Error`][] object, where `err.code`
 is one of the [DNS error codes](#dns_error_codes).
 
-### dnsPromises.resolve4(hostname[, options])
+### `dnsPromises.resolve4(hostname[, options])`
 <!-- YAML
 added: v10.6.0
 -->
@@ -793,7 +793,7 @@ Uses the DNS protocol to resolve IPv4 addresses (`A` records) for the
 `hostname`. On success, the `Promise` is resolved with an array of IPv4
 addresses (e.g. `['74.125.79.104', '74.125.79.105', '74.125.79.106']`).
 
-### dnsPromises.resolve6(hostname[, options])
+### `dnsPromises.resolve6(hostname[, options])`
 <!-- YAML
 added: v10.6.0
 -->
@@ -808,7 +808,7 @@ Uses the DNS protocol to resolve IPv6 addresses (`AAAA` records) for the
 `hostname`. On success, the `Promise` is resolved with an array of IPv6
 addresses.
 
-### dnsPromises.resolveAny(hostname)
+### `dnsPromises.resolveAny(hostname)`
 <!-- YAML
 added: v10.6.0
 -->
@@ -852,7 +852,7 @@ Here is an example of the result object:
     minttl: 60 } ]
 ```
 
-### dnsPromises.resolveCname(hostname)
+### `dnsPromises.resolveCname(hostname)`
 <!-- YAML
 added: v10.6.0
 -->
@@ -862,7 +862,7 @@ Uses the DNS protocol to resolve `CNAME` records for the `hostname`. On success,
 the `Promise` is resolved with an array of canonical name records available for
 the `hostname` (e.g. `['bar.example.com']`).
 
-### dnsPromises.resolveMx(hostname)
+### `dnsPromises.resolveMx(hostname)`
 <!-- YAML
 added: v10.6.0
 -->
@@ -873,7 +873,7 @@ Uses the DNS protocol to resolve mail exchange records (`MX` records) for the
 containing both a `priority` and `exchange` property (e.g.
 `[{priority: 10, exchange: 'mx.example.com'}, ...]`).
 
-### dnsPromises.resolveNaptr(hostname)
+### `dnsPromises.resolveNaptr(hostname)`
 <!-- YAML
 added: v10.6.0
 -->
@@ -902,7 +902,7 @@ of objects with the following properties:
 }
 ```
 
-### dnsPromises.resolveNs(hostname)
+### `dnsPromises.resolveNs(hostname)`
 <!-- YAML
 added: v10.6.0
 -->
@@ -913,7 +913,7 @@ Uses the DNS protocol to resolve name server records (`NS` records) for the
 records available for `hostname` (e.g.
 `['ns1.example.com', 'ns2.example.com']`).
 
-### dnsPromises.resolvePtr(hostname)
+### `dnsPromises.resolvePtr(hostname)`
 <!-- YAML
 added: v10.6.0
 -->
@@ -923,7 +923,7 @@ Uses the DNS protocol to resolve pointer records (`PTR` records) for the
 `hostname`. On success, the `Promise` is resolved with an array of strings
 containing the reply records.
 
-### dnsPromises.resolveSoa(hostname)
+### `dnsPromises.resolveSoa(hostname)`
 <!-- YAML
 added: v10.6.0
 -->
@@ -954,7 +954,7 @@ following properties:
 }
 ```
 
-### dnsPromises.resolveSrv(hostname)
+### `dnsPromises.resolveSrv(hostname)`
 <!-- YAML
 added: v10.6.0
 -->
@@ -979,7 +979,7 @@ the following properties:
 }
 ```
 
-### dnsPromises.resolveTxt(hostname)
+### `dnsPromises.resolveTxt(hostname)`
 <!-- YAML
 added: v10.6.0
 -->
@@ -992,7 +992,7 @@ of the text records available for `hostname` (e.g.
 one record. Depending on the use case, these could be either joined together or
 treated separately.
 
-### dnsPromises.reverse(ip)
+### `dnsPromises.reverse(ip)`
 <!-- YAML
 added: v10.6.0
 -->
@@ -1004,7 +1004,7 @@ array of hostnames.
 On error, the `Promise` is rejected with an [`Error`][] object, where `err.code`
 is one of the [DNS error codes](#dns_error_codes).
 
-### dnsPromises.setServers(servers)
+### `dnsPromises.setServers(servers)`
 <!-- YAML
 added: v10.6.0
 -->

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -20,18 +20,28 @@ body {
   background: #fff;
 }
 
-h1 { font-size: 2.5rem }
-h2 { font-size: 2rem }
-h3 { font-size: 1.75rem }
-h4 { font-size: 1.5rem }
-h5 { font-size: 1.25rem }
-h6 { font-size: 1rem }
+h1, h1 code { font-size: 2.5rem; }
+h2, h2 code { font-size: 2rem; }
+h3, h3 code { font-size: 1.75rem; }
+h4, h4 code { font-size: 1.5rem; }
+h5, h5 code { font-size: 1.25rem; }
+h6, h6 code { font-size: 1rem; }
 
-h1, h2, h3, h4, h5, h6 {
-  margin: 1.5rem 0 1rem;
-  text-rendering: optimizeLegibility;
+h1, h1 code,
+h2, h2 code,
+h3, h3 code,
+h4, h4 code,
+h5, h5 code,
+h6, h6 code {
+  background-color: inherit;
+  color: inherit;
+  font-family: inherit;
   font-weight: 700;
+  line-height: inherit;
+  margin: 1.5rem 0 1rem;
+  padding: inherit;
   position: relative;
+  text-rendering: optimizeLegibility;
 }
 
 pre, tt, code, .pre, span.type, a.type {


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/31086:

First commit:

    doc: allow <code> in header elements
    
    Allow use of <code> in header elements without styling side effects. We
    can add styling later if desired. The goal here is to allow code to be
    set off in markdown without needing to escape characters and do lint
    exceptions for terms. This is probably a win in terms of accessibility
    too although it would be moreso if we had some visual differentiation
    for <code> inside of headers. As mentioned above, that can always be
    added at a later time.

Second commit:

    doc,dns: use code markup/markdown in headers
    
    This will allow us to lint for use of `hostname` in prose without
    flagging `hostname` in code within headers. This also allows us to
    remove backslash escaping for `[` and `]` inside of header code, which
    makes the bare markdown more readable.

Remaining commits from the PR omitted as these two are the most important ones and the remaining ones are quite tedious to work through.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
