### PR TITLE
util: improve prototype inspection using `inspect()` and `showHidden`

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -470,10 +470,10 @@ function getConstructorName(obj, ctx, recurseTimes, protoProps) {
         typeof descriptor.value === 'function' &&
         descriptor.value.name !== '') {
       if (protoProps !== undefined &&
-          !builtInObjects.has(descriptor.value.name)) {
-        const isProto = firstProto !== undefined;
+         (firstProto !== obj ||
+         !builtInObjects.has(descriptor.value.name))) {
         addPrototypeProperties(
-          ctx, tmp, obj, recurseTimes, isProto, protoProps);
+          ctx, tmp, firstProto || tmp, recurseTimes, protoProps);
       }
       return descriptor.value.name;
     }
@@ -511,12 +511,12 @@ function getConstructorName(obj, ctx, recurseTimes, protoProps) {
 // This function has the side effect of adding prototype properties to the
 // `output` argument (which is an array). This is intended to highlight user
 // defined prototype properties.
-function addPrototypeProperties(ctx, main, obj, recurseTimes, isProto, output) {
+function addPrototypeProperties(ctx, main, obj, recurseTimes, output) {
   let depth = 0;
   let keys;
   let keySet;
   do {
-    if (!isProto) {
+    if (depth !== 0 || main === obj) {
       obj = ObjectGetPrototypeOf(obj);
       // Stop as soon as a null prototype is encountered.
       if (obj === null) {
@@ -529,8 +529,6 @@ function addPrototypeProperties(ctx, main, obj, recurseTimes, isProto, output) {
           builtInObjects.has(descriptor.value.name)) {
         return;
       }
-    } else {
-      isProto = false;
     }
 
     if (depth === 0) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1696,7 +1696,8 @@ util.inspect(process);
     '      1,',
     '      2,',
     '      [length]: 2',
-    '    ]',
+    '    ],',
+    "    [Symbol(Symbol.toStringTag)]: 'Set Iterator'",
     '  } => <ref *1> [Map Iterator] {',
     '    Uint8Array(0) [',
     '      [BYTES_PER_ELEMENT]: 1,',
@@ -1708,7 +1709,8 @@ util.inspect(process);
     '        foo: true',
     '      }',
     '    ],',
-    '    [Circular *1]',
+    '    [Circular *1],',
+    "    [Symbol(Symbol.toStringTag)]: 'Map Iterator'",
     '  }',
     '}'
   ].join('\n');
@@ -1735,7 +1737,10 @@ util.inspect(process);
     '    [byteOffset]: 0,',
     '    [buffer]: ArrayBuffer { byteLength: 0, foo: true }',
     '  ],',
-    '  [Set Iterator] { [ 1, 2, [length]: 2 ] } => <ref *1> [Map Iterator] {',
+    '  [Set Iterator] {',
+    '    [ 1, 2, [length]: 2 ],',
+    "    [Symbol(Symbol.toStringTag)]: 'Set Iterator'",
+    '  } => <ref *1> [Map Iterator] {',
     '    Uint8Array(0) [',
     '      [BYTES_PER_ELEMENT]: 1,',
     '      [length]: 0,',
@@ -1743,7 +1748,8 @@ util.inspect(process);
     '      [byteOffset]: 0,',
     '      [buffer]: ArrayBuffer { byteLength: 0, foo: true }',
     '    ],',
-    '    [Circular *1]',
+    '    [Circular *1],',
+    "    [Symbol(Symbol.toStringTag)]: 'Map Iterator'",
     '  }',
     '}'
   ].join('\n');
@@ -1773,7 +1779,9 @@ util.inspect(process);
     '  [Set Iterator] {',
     '    [ 1,',
     '      2,',
-    '      [length]: 2 ] } => <ref *1> [Map Iterator] {',
+    '      [length]: 2 ],',
+    '    [Symbol(Symbol.toStringTag)]:',
+    "     'Set Iterator' } => <ref *1> [Map Iterator] {",
     '    Uint8Array(0) [',
     '      [BYTES_PER_ELEMENT]: 1,',
     '      [length]: 0,',
@@ -1782,7 +1790,9 @@ util.inspect(process);
     '      [buffer]: ArrayBuffer {',
     '        byteLength: 0,',
     '        foo: true } ],',
-    '    [Circular *1] } }'
+    '    [Circular *1],',
+    '    [Symbol(Symbol.toStringTag)]:',
+    "     'Map Iterator' } }"
   ].join('\n');
 
   assert.strict.equal(out, expected);
@@ -2680,5 +2690,12 @@ assert.strictEqual(
     '  \x1B[2m[xyz]: \x1B[36m[Getter]\x1B[39m\x1B[22m,\n' +
     '  \x1B[2m[def]: \x1B[36m[Getter/Setter]\x1B[39m\x1B[22m\n' +
     '}'
+  );
+
+  const obj = Object.create({ abc: true, def: 5, toString() {} });
+  assert.strictEqual(
+    inspect(obj, { showHidden: true, colors: true }),
+    '{ \x1B[2mabc: \x1B[33mtrue\x1B[39m\x1B[22m, ' +
+      '\x1B[2mdef: \x1B[33m5\x1B[39m\x1B[22m }'
   );
 }


### PR DESCRIPTION
The fast path for the prototype inspection had a bug that caused some
prototype properties to be skipped that should in fact be inspected.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
