### PR TITLE
doc: fix createDiffieHellman generator type

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1855,8 +1855,7 @@ added: v0.5.0
 -->
 
 * `primeLength` {number}
-* `generator` {number | string | Buffer | TypedArray | DataView} **Default:**
-  `2`
+* `generator` {number} **Default:** `2`
 * Returns: {DiffieHellman}
 
 Creates a `DiffieHellman` key exchange object and generates a prime of


### PR DESCRIPTION
OpenSSL does not provide a straight-forward way to implement a non-integer generator, so `createDiffieHellman` never supported anything other than a number as the generator. (This only applies to the signature where the first argument is the size of the prime, and therefore a number.)

Refs: https://github.com/nodejs/node-v0.x-archive/pull/7086
Refs: https://github.com/nodejs/node/pull/21782

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
