### PR TITLE
wasi: fix serdes bugs from snapshot1 migration

### DIFF
--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -545,7 +545,7 @@ void WASI::FdFilestatGet(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wasi, args.This());
   Debug(wasi, "fd_filestat_get(%d, %d)\n", fd, buf);
   GET_BACKING_STORE_OR_RETURN(wasi, args, &memory, &mem_size);
-  CHECK_BOUNDS_OR_RETURN(args, mem_size, buf, 56);
+  CHECK_BOUNDS_OR_RETURN(args, mem_size, buf, 64);
   uvwasi_filestat_t stats;
   uvwasi_errno_t err = uvwasi_fd_filestat_get(&wasi->uvw_, fd, &stats);
 
@@ -553,7 +553,7 @@ void WASI::FdFilestatGet(const FunctionCallbackInfo<Value>& args) {
     wasi->writeUInt64(memory, stats.st_dev, buf);
     wasi->writeUInt64(memory, stats.st_ino, buf + 8);
     wasi->writeUInt8(memory, stats.st_filetype, buf + 16);
-    wasi->writeUInt32(memory, stats.st_nlink, buf + 24);
+    wasi->writeUInt64(memory, stats.st_nlink, buf + 24);
     wasi->writeUInt64(memory, stats.st_size, buf + 32);
     wasi->writeUInt64(memory, stats.st_atim, buf + 40);
     wasi->writeUInt64(memory, stats.st_mtim, buf + 48);
@@ -1069,7 +1069,7 @@ void WASI::PathFilestatGet(const FunctionCallbackInfo<Value>& args) {
         path_len);
   GET_BACKING_STORE_OR_RETURN(wasi, args, &memory, &mem_size);
   CHECK_BOUNDS_OR_RETURN(args, mem_size, path_ptr, path_len);
-  CHECK_BOUNDS_OR_RETURN(args, mem_size, buf_ptr, 56);
+  CHECK_BOUNDS_OR_RETURN(args, mem_size, buf_ptr, 64);
   uvwasi_filestat_t stats;
   uvwasi_errno_t err = uvwasi_path_filestat_get(&wasi->uvw_,
                                                 fd,
@@ -1081,7 +1081,7 @@ void WASI::PathFilestatGet(const FunctionCallbackInfo<Value>& args) {
     wasi->writeUInt64(memory, stats.st_dev, buf_ptr);
     wasi->writeUInt64(memory, stats.st_ino, buf_ptr + 8);
     wasi->writeUInt8(memory, stats.st_filetype, buf_ptr + 16);
-    wasi->writeUInt32(memory, stats.st_nlink, buf_ptr + 24);
+    wasi->writeUInt64(memory, stats.st_nlink, buf_ptr + 24);
     wasi->writeUInt64(memory, stats.st_size, buf_ptr + 32);
     wasi->writeUInt64(memory, stats.st_atim, buf_ptr + 40);
     wasi->writeUInt64(memory, stats.st_mtim, buf_ptr + 48);
@@ -1423,7 +1423,7 @@ void WASI::PollOneoff(const FunctionCallbackInfo<Value>& args) {
         nsubscriptions,
         nevents_ptr);
   GET_BACKING_STORE_OR_RETURN(wasi, args, &memory, &mem_size);
-  CHECK_BOUNDS_OR_RETURN(args, mem_size, in_ptr, nsubscriptions * 56);
+  CHECK_BOUNDS_OR_RETURN(args, mem_size, in_ptr, nsubscriptions * 48);
   CHECK_BOUNDS_OR_RETURN(args, mem_size, out_ptr, nsubscriptions * 32);
   CHECK_BOUNDS_OR_RETURN(args, mem_size, nevents_ptr, 4);
   uvwasi_subscription_t* in =


### PR DESCRIPTION
During the migration to WASI snapshot1, a field was removed from the subscription type. The field was removed from the code, but the bounds checking logic was not updated. This commit updates that check.

Similarly, `__wasi_linkcount_t` changed from a `uint32_t` to a `uint64_t`. However, the bounds checks were missed, and the code was still writing `uint32_t`'s (to the new correct offset) instead of `uint64_t`'s. This commit updates that logic as well.

Refs: https://github.com/nodejs/node/pull/30980

(I've also opened https://github.com/cjihrig/uvwasi/issues/69 to come up with a plan to make this process a bit smoother moving forward.)

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
