### PR TITLE
deps: V8: cherry-pick a494bcfc880c

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,11 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.29',
+<<<<<<< HEAD
+    'v8_embedder_string': '-node.30',
+=======
+    'v8_embedder_string': '-node.28',
+>>>>>>> deps: V8: backport a494bcf
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -3111,7 +3111,7 @@ v8_source_set("v8_base_without_compiler") {
 
     # iOS Xcode simulator builds run on an x64 target. iOS and macOS are both
     # based on Darwin and thus POSIX-compliant to a similar degree.
-    if (is_linux || is_mac || is_ios) {
+    if (is_linux || is_mac || is_ios || target_os == "freebsd") {
       sources += [
         "src/trap-handler/handler-inside-posix.cc",
         "src/trap-handler/handler-inside-posix.h",

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -111,7 +111,7 @@
 #include "src/wasm/wasm-result.h"
 #include "src/wasm/wasm-serialization.h"
 
-#if V8_OS_LINUX || V8_OS_MACOSX
+#if V8_OS_LINUX || V8_OS_MACOSX || V8_OS_FREEBSD
 #include <signal.h>
 #include "include/v8-wasm-trap-handler-posix.h"
 #include "src/trap-handler/handler-inside-posix.h"

--- a/deps/v8/src/trap-handler/handler-inside-posix.cc
+++ b/deps/v8/src/trap-handler/handler-inside-posix.cc
@@ -27,7 +27,7 @@
 
 #include <signal.h>
 
-#ifdef V8_OS_LINUX
+#if defined(V8_OS_LINUX) || defined(V8_OS_FREEBSD)
 #include <ucontext.h>
 #elif V8_OS_MACOSX
 #include <sys/ucontext.h>
@@ -112,6 +112,8 @@ bool TryHandleSignal(int signum, siginfo_t* info, void* context) {
     auto* context_rip = &uc->uc_mcontext.gregs[REG_RIP];
 #elif V8_OS_MACOSX
     auto* context_rip = &uc->uc_mcontext->__ss.__rip;
+#elif V8_OS_FREEBSD
+    auto* context_rip = &uc->uc_mcontext.mc_rip;
 #else
 #error Unsupported platform
 #endif

--- a/deps/v8/src/trap-handler/handler-inside-posix.h
+++ b/deps/v8/src/trap-handler/handler-inside-posix.h
@@ -12,12 +12,12 @@ namespace v8 {
 namespace internal {
 namespace trap_handler {
 
-#if V8_OS_LINUX
+#if V8_OS_LINUX || V8_OS_FREEBSD
 constexpr int kOobSignal = SIGSEGV;
 #elif V8_OS_MACOSX
 constexpr int kOobSignal = SIGBUS;
 #else
-#error Posix trap handlers are only supported on Linux and MacOSX.
+#error Posix trap handlers are only supported on Linux, MacOSX and FreeBSD.
 #endif
 
 void HandleSignal(int signum, siginfo_t* info, void* context);

--- a/deps/v8/src/trap-handler/trap-handler.h
+++ b/deps/v8/src/trap-handler/trap-handler.h
@@ -23,6 +23,8 @@ namespace trap_handler {
 #define V8_TRAP_HANDLER_SUPPORTED true
 #elif V8_TARGET_ARCH_X64 && V8_OS_MACOSX
 #define V8_TRAP_HANDLER_SUPPORTED true
+#elif V8_TARGET_ARCH_X64 && V8_OS_FREEBSD
+#define V8_TRAP_HANDLER_SUPPORTED true
 #else
 #define V8_TRAP_HANDLER_SUPPORTED false
 #endif

--- a/deps/v8/test/unittests/wasm/trap-handler-x64-unittest.cc
+++ b/deps/v8/test/unittests/wasm/trap-handler-x64-unittest.cc
@@ -4,7 +4,7 @@
 
 #include "include/v8config.h"
 
-#if V8_OS_LINUX
+#if V8_OS_LINUX || V8_OS_FREEBSD
 #include <signal.h>
 #include <ucontext.h>
 #elif V8_OS_MACOSX
@@ -41,7 +41,7 @@ namespace wasm {
 namespace {
 constexpr Register scratch = r10;
 bool g_test_handler_executed = false;
-#if V8_OS_LINUX || V8_OS_MACOSX
+#if V8_OS_LINUX || V8_OS_MACOSX || V8_OS_FREEBSD
 struct sigaction g_old_segv_action;
 struct sigaction g_old_fpe_action;
 struct sigaction g_old_bus_action;  // We get SIGBUS on Mac sometimes.
@@ -93,7 +93,7 @@ class TrapHandlerTest : public TestWithIsolate,
 
     InitRecoveryCode();
 
-#if V8_OS_LINUX || V8_OS_MACOSX
+#if V8_OS_LINUX || V8_OS_MACOSX || V8_OS_FREEBSD
     // Set up a signal handler to recover from the expected crash.
     struct sigaction action;
     action.sa_sigaction = SignalHandler;
@@ -121,7 +121,7 @@ class TrapHandlerTest : public TestWithIsolate,
     // Clean up the trap handler
     trap_handler::RemoveTrapHandler();
     if (!g_test_handler_executed) {
-#if V8_OS_LINUX || V8_OS_MACOSX
+#if V8_OS_LINUX || V8_OS_MACOSX || V8_OS_FREEBSD
       // The test handler cleans up the signal handler setup in the test. If the
       // test handler was not called, we have to do the cleanup ourselves.
       CHECK_EQ(0, sigaction(SIGSEGV, &g_old_segv_action, nullptr));
@@ -152,7 +152,7 @@ class TrapHandlerTest : public TestWithIsolate,
         reinterpret_cast<Address>(desc.buffer + recovery_offset);
   }
 
-#if V8_OS_LINUX || V8_OS_MACOSX
+#if V8_OS_LINUX || V8_OS_MACOSX || V8_OS_FREEBSD
   static void SignalHandler(int signal, siginfo_t* info, void* context) {
     if (g_use_as_first_chance_handler) {
       if (v8::TryHandleWebAssemblyTrapPosix(signal, info, context)) {
@@ -171,8 +171,12 @@ class TrapHandlerTest : public TestWithIsolate,
     ucontext_t* uc = reinterpret_cast<ucontext_t*>(context);
 #if V8_OS_LINUX
     uc->uc_mcontext.gregs[REG_RIP] = g_recovery_address;
-#else  // V8_OS_MACOSX
+#elif V8_OS_MACOSX
     uc->uc_mcontext->__ss.__rip = g_recovery_address;
+#elif V8_OS_FREEBSD
+    uc->uc_mcontext.mc_rip = g_recovery_address;
+#else
+#error Unsupported platform
 #endif
   }
 #endif


### PR DESCRIPTION
enabling trap handler on FreeBSD.

Refs: https://github.com/v8/v8/commit/a494bcfc880ca80f95f226871ae1e48141d1f7aa

Original commit message :

    Introducing trap handler support for FreeBSD x64.
    Using proper register (RIP) on this platform.

    Change-Id: Iaa0a25e328bd82c152db0ef3632523fd7d621020
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1857221
    Reviewed-by: Michael Achenbach <machenbach@chromium.org>
    Reviewed-by: Yang Guo <yangguo@chromium.org>
    Reviewed-by: Andreas Haas <ahaas@chromium.org>
    Commit-Queue: Andreas Haas <ahaas@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#64863}