### PR TITLE
deps: V8: cherry-pick a4545db74e52

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.25',
+    'v8_embedder_string': '-node.26',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/base/platform/platform-freebsd.cc
+++ b/deps/v8/src/base/platform/platform-freebsd.cc
@@ -13,10 +13,12 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/ucontext.h>
+#include <sys/user.h>
 
 #include <sys/fcntl.h>  // open
 #include <sys/mman.h>   // mmap & munmap
 #include <sys/stat.h>   // open
+#include <sys/sysctl.h>
 #include <unistd.h>     // getpagesize
 // If you don't have execinfo.h then you need devel/libexecinfo from ports.
 #include <errno.h>
@@ -46,41 +48,47 @@ static unsigned StringToLong(char* buffer) {
 
 std::vector<OS::SharedLibraryAddress> OS::GetSharedLibraryAddresses() {
   std::vector<SharedLibraryAddress> result;
-  static const int MAP_LENGTH = 1024;
-  int fd = open("/proc/self/maps", O_RDONLY);
-  if (fd < 0) return result;
-  while (true) {
-    char addr_buffer[11];
-    addr_buffer[0] = '0';
-    addr_buffer[1] = 'x';
-    addr_buffer[10] = 0;
-    ssize_t bytes_read = read(fd, addr_buffer + 2, 8);
-    if (bytes_read < 8) break;
-    unsigned start = StringToLong(addr_buffer);
-    bytes_read = read(fd, addr_buffer + 2, 1);
-    if (bytes_read < 1) break;
-    if (addr_buffer[2] != '-') break;
-    bytes_read = read(fd, addr_buffer + 2, 8);
-    if (bytes_read < 8) break;
-    unsigned end = StringToLong(addr_buffer);
-    char buffer[MAP_LENGTH];
-    bytes_read = -1;
-    do {
-      bytes_read++;
-      if (bytes_read >= MAP_LENGTH - 1) break;
-      bytes_read = read(fd, buffer + bytes_read, 1);
-      if (bytes_read < 1) break;
-    } while (buffer[bytes_read] != '\n');
-    buffer[bytes_read] = 0;
-    // Ignore mappings that are not executable.
-    if (buffer[3] != 'x') continue;
-    char* start_of_path = index(buffer, '/');
-    // There may be no filename in this line.  Skip to next.
-    if (start_of_path == nullptr) continue;
-    buffer[bytes_read] = 0;
-    result.push_back(SharedLibraryAddress(start_of_path, start, end));
+  int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_VMMAP, getpid()};
+  size_t miblen = sizeof(mib) / sizeof(mib[0]);
+  size_t buffer_size;
+  if (sysctl(mib, miblen, nullptr, &buffer_size, nullptr, 0) == 0) {
+    // Overallocate the buffer by 1/3 to account for concurrent
+    // kinfo_vmentry change. 1/3 is an arbitrary constant that
+    // works in practice.
+    buffer_size = buffer_size * 4 / 3;
+    std::vector<char> buffer(buffer_size);
+    int ret = sysctl(mib, miblen, buffer.data(), &buffer_size, nullptr, 0);
+
+    if (ret == 0 || (ret == -1 && errno == ENOMEM)) {
+      char* start = buffer.data();
+      char* end = start + buffer_size;
+
+      while (start < end) {
+        struct kinfo_vmentry* map =
+            reinterpret_cast<struct kinfo_vmentry*>(start);
+        const size_t ssize = map->kve_structsize;
+        char* path = map->kve_path;
+
+        CHECK_NE(0, ssize);
+
+        if ((map->kve_protection & KVME_PROT_READ) != 0 &&
+            (map->kve_protection & KVME_PROT_EXEC) != 0 && path[0] != '\0') {
+          char* sep = strrchr(path, '/');
+          std::string lib_name;
+          if (sep != nullptr) {
+            lib_name = std::string(++sep);
+          } else {
+            lib_name = std::string(path);
+          }
+          result.push_back(SharedLibraryAddress(
+              lib_name, reinterpret_cast<uintptr_t>(map->kve_start),
+              reinterpret_cast<uintptr_t>(map->kve_end)));
+        }
+
+        start += ssize;
+      }
+    }
   }
-  close(fd);
   return result;
 }
 


### PR DESCRIPTION
Fix library process mapping for FreeBSD.

Refs: https://github.com/v8/v8/commit/a4545db74e5204125033ccec7294d1b0a8d96389

Original commit message :

    FreeBSD update of process library mapping listing.
    Not best to rely on /proc presence basically when
    the linux compatibily layer is enabled so
    going through more programmatically.

    Change-Id: Ida4973f9da6dec6e9caa6e419f3612ec5ef95048
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1710664
    Reviewed-by: Ulan Degenbaev <ulan@chromium.org>
    Commit-Queue: Ulan Degenbaev <ulan@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#65442}