### PR TITLE
esm: better error message for unsupported URL

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1957,6 +1957,11 @@ An attempt was made to load a module with an unknown or unsupported format.
 An invalid or unknown process signal was passed to an API expecting a valid
 signal (such as [`subprocess.kill()`][]).
 
+<a id="ERR_UNSUPPORTED_ESM_URL_SCHEME"></a>
+### `ERR_UNSUPPORTED_ESM_URL_SCHEME`
+
+`import` with URL schemes other than `file` and `data` is unsupported.
+
 <a id="ERR_V8BREAKITERATOR"></a>
 ### `ERR_V8BREAKITERATOR`
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1325,6 +1325,8 @@ E('ERR_UNKNOWN_FILE_EXTENSION',
   TypeError);
 E('ERR_UNKNOWN_MODULE_FORMAT', 'Unknown module format: %s', RangeError);
 E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s', TypeError);
+E('ERR_UNSUPPORTED_ESM_URL_SCHEME', 'Only file and data URLs are supported ' +
+  'by the default ESM loader', Error);
 
 E('ERR_V8BREAKITERATOR',
   'Full ICU data not installed. See https://github.com/nodejs/node/wiki/Intl',

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -21,7 +21,8 @@ const { resolve: moduleWrapResolve,
         getPackageType } = internalBinding('module_wrap');
 const { URL, pathToFileURL, fileURLToPath } = require('internal/url');
 const { ERR_INPUT_TYPE_NOT_ALLOWED,
-        ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
+        ERR_UNKNOWN_FILE_EXTENSION,
+        ERR_UNSUPPORTED_ESM_URL_SCHEME } = require('internal/errors').codes;
 
 const realpathCache = new SafeMap();
 
@@ -52,8 +53,9 @@ if (experimentalJsonModules)
   extensionFormatMap['.json'] = legacyExtensionFormatMap['.json'] = 'json';
 
 function resolve(specifier, parentURL) {
+  let parsed;
   try {
-    const parsed = new URL(specifier);
+    parsed = new URL(specifier);
     if (parsed.protocol === 'data:') {
       const [ , mime ] = /^([^/]+\/[^;,]+)(?:[^,]*?)(;base64)?,/.exec(parsed.pathname) || [ null, null, null ];
       const format = ({
@@ -68,6 +70,8 @@ function resolve(specifier, parentURL) {
       };
     }
   } catch {}
+  if (parsed && parsed.protocol !== 'file:' && parsed.protocol !== 'data:')
+    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME();
   if (NativeModule.canBeRequiredByUsers(specifier)) {
     return {
       url: specifier,

--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -15,8 +15,8 @@ function expectErrorProperty(result, propertyKey, value) {
     }));
 }
 
-function expectMissingModuleError(result) {
-  expectErrorProperty(result, 'code', 'ERR_MODULE_NOT_FOUND');
+function expectModuleError(result, err) {
+  expectErrorProperty(result, 'code', err);
 }
 
 function expectOkNamespace(result) {
@@ -56,10 +56,10 @@ function expectFsNamespace(result) {
   expectFsNamespace(eval('import("fs")'));
   expectFsNamespace(eval('import("fs")'));
 
-  expectMissingModuleError(import('./not-an-existing-module.mjs'));
-  // TODO(jkrems): Right now this doesn't hit a protocol error because the
-  // module resolution step already rejects it. These arguably should be
-  // protocol errors.
-  expectMissingModuleError(import('node:fs'));
-  expectMissingModuleError(import('http://example.com/foo.js'));
+  expectModuleError(import('./not-an-existing-module.mjs'),
+                    'ERR_MODULE_NOT_FOUND');
+  expectModuleError(import('node:fs'),
+                    'ERR_UNSUPPORTED_ESM_URL_SCHEME');
+  expectModuleError(import('http://example.com/foo.js'),
+                    'ERR_UNSUPPORTED_ESM_URL_SCHEME');
 })();


### PR DESCRIPTION
The default ESM loader supports only file and data URLs.
This PR adds better error message for it.

Fixes #31120

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)