### PR TITLE
test: add test case for send command error case

### DIFF
--- a/test/sequential/test-inspector-command-error.js
+++ b/test/sequential/test-inspector-command-error.js
@@ -1,0 +1,11 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const inspector = require('internal/util/inspector');
+common.skipIfInspectorDisabled();
+
+inspector.sendInspectorCommand(
+  common.mustCall(() => { throw new Error('test'); }),
+  common.mustCall()
+);


### PR DESCRIPTION
Added test case for a error scenario, which wasn't covered before: https://coverage.nodejs.org/coverage-cc3f2b386c6ee34f/lib/internal/util/inspector.js.html#L21

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)