### PR TITLE
n-api: keep napi_env alive while it has finalizers

### DIFF
--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -195,9 +195,12 @@ class Finalizer {
       _finalize_callback(finalize_callback),
       _finalize_data(finalize_data),
       _finalize_hint(finalize_hint) {
+    _env->Ref();
   }
 
-  ~Finalizer() = default;
+  ~Finalizer() {
+    _env->Unref();
+  }
 
  public:
   static Finalizer* New(napi_env env,

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -732,7 +732,8 @@ napi_status napi_create_external_buffer(napi_env env,
 
   // The finalizer object will delete itself after invoking the callback.
   v8impl::Finalizer* finalizer = v8impl::Finalizer::New(
-    env, finalize_cb, nullptr, finalize_hint);
+      env, finalize_cb, nullptr, finalize_hint,
+      v8impl::Finalizer::kKeepEnvReference);
 
   auto maybe = node::Buffer::New(isolate,
                                 static_cast<char*>(data),

--- a/test/node-api/test_buffer/test-external-buffer.js
+++ b/test/node-api/test_buffer/test-external-buffer.js
@@ -4,7 +4,7 @@ const common = require('../../common');
 const binding = require(`./build/${common.buildType}/test_buffer`);
 const assert = require('assert');
 
-// Regresion test for https://github.com/nodejs/node/issues/31134:
+// Regression test for https://github.com/nodejs/node/issues/31134
 // Buffers with finalizers are allowed to remain alive until
 // Environment cleanup without crashing the process.
 // The test stores the buffer on `process` to make sure it lives as long as

--- a/test/node-api/test_buffer/test-external-buffer.js
+++ b/test/node-api/test_buffer/test-external-buffer.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const common = require('../../common');
+const binding = require(`./build/${common.buildType}/test_buffer`);
+const assert = require('assert');
+
+// Regresion test for https://github.com/nodejs/node/issues/31134:
+// Buffers with finalizers are allowed to remain alive until
+// Environment cleanup without crashing the process.
+// The test stores the buffer on `process` to make sure it lives as long as
+// the Context does.
+
+process.externalBuffer = binding.newExternalBuffer();
+assert.strictEqual(process.externalBuffer.toString(), binding.theText);


### PR DESCRIPTION
Manage the napi_env refcount from Finalizer instances, as the
finalizer may refer to the napi_env until it is deleted.

Fixes: https://github.com/nodejs/node/issues/31134
Fixes: https://github.com/node-ffi-napi/node-ffi-napi/issues/48

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
