### PR TITLE
errors: support prepareSourceMap with source-maps

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -52,6 +52,23 @@ const prepareStackTrace = (globalThis, error, trace) => {
     return f(error, trace);
   }
 
+  const globalOverride =
+    maybeOverridePrepareStackTrace(globalThis, error, trace);
+  if (globalOverride) return globalOverride;
+
+  // Normal error formatting:
+  //
+  // Error: Message
+  //     at function (file)
+  //     at file
+  const errorString = ErrorToString.call(error);
+  if (trace.length === 0) {
+    return errorString;
+  }
+  return `${errorString}\n    at ${trace.join('\n    at ')}`;
+};
+
+const maybeOverridePrepareStackTrace = (globalThis, error, trace) => {
   // Polyfill of V8's Error.prepareStackTrace API.
   // https://crbug.com/v8/7848
   // `globalThis` is the global that contains the constructor which
@@ -66,18 +83,8 @@ const prepareStackTrace = (globalThis, error, trace) => {
     return MainContextError.prepareStackTrace(error, trace);
   }
 
-  // Normal error formatting:
-  //
-  // Error: Message
-  //     at function (file)
-  //     at file
-  const errorString = ErrorToString.call(error);
-  if (trace.length === 0) {
-    return errorString;
-  }
-  return `${errorString}\n    at ${trace.join('\n    at ')}`;
+  return null;
 };
-
 
 let excludedStackFn;
 
@@ -692,6 +699,7 @@ module.exports = {
   // This is exported only to facilitate testing.
   E,
   prepareStackTrace,
+  maybeOverridePrepareStackTrace,
   overrideStackTrace,
   kEnhanceStackBeforeInspector,
   fatalExceptionStackEnhancers

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -699,6 +699,7 @@ module.exports = {
   SystemError,
   // This is exported only to facilitate testing.
   E,
+  kNoOverride,
   prepareStackTrace,
   maybeOverridePrepareStackTrace,
   overrideStackTrace,

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -43,6 +43,7 @@ const { kMaxLength } = internalBinding('buffer');
 const MainContextError = Error;
 const ErrorToString = Error.prototype.toString;
 const overrideStackTrace = new WeakMap();
+const kNoOverride = Symbol('kNoOverride');
 const prepareStackTrace = (globalThis, error, trace) => {
   // API for node internals to override error stack formatting
   // without interfering with userland code.
@@ -54,7 +55,7 @@ const prepareStackTrace = (globalThis, error, trace) => {
 
   const globalOverride =
     maybeOverridePrepareStackTrace(globalThis, error, trace);
-  if (globalOverride) return globalOverride;
+  if (globalOverride !== kNoOverride) return globalOverride;
 
   // Normal error formatting:
   //
@@ -83,7 +84,7 @@ const maybeOverridePrepareStackTrace = (globalThis, error, trace) => {
     return MainContextError.prepareStackTrace(error, trace);
   }
 
-  return null;
+  return kNoOverride;
 };
 
 let excludedStackFn;

--- a/lib/internal/source_map/prepare_stack_trace.js
+++ b/lib/internal/source_map/prepare_stack_trace.js
@@ -3,6 +3,7 @@
 const debug = require('internal/util/debuglog').debuglog('source_map');
 const { findSourceMap } = require('internal/source_map/source_map_cache');
 const {
+  kNoOverride,
   overrideStackTrace,
   maybeOverridePrepareStackTrace
 } = require('internal/errors');
@@ -22,7 +23,7 @@ const prepareStackTrace = (globalThis, error, trace) => {
 
   const globalOverride =
     maybeOverridePrepareStackTrace(globalThis, error, trace);
-  if (globalOverride) return globalOverride;
+  if (globalOverride !== kNoOverride) return globalOverride;
 
   const { SourceMap } = require('internal/source_map/source_map');
   const errorString = ErrorToString.call(error);

--- a/lib/internal/source_map/prepare_stack_trace.js
+++ b/lib/internal/source_map/prepare_stack_trace.js
@@ -2,7 +2,10 @@
 
 const debug = require('internal/util/debuglog').debuglog('source_map');
 const { findSourceMap } = require('internal/source_map/source_map_cache');
-const { overrideStackTrace } = require('internal/errors');
+const {
+  overrideStackTrace,
+  maybeOverridePrepareStackTrace
+} = require('internal/errors');
 
 // Create a prettified stacktrace, inserting context from source maps
 // if possible.
@@ -17,11 +20,9 @@ const prepareStackTrace = (globalThis, error, trace) => {
     return f(error, trace);
   }
 
-  // `globalThis` is the global that contains the constructor which
-  // created `error`.
-  if (typeof globalThis.Error.prepareStackTrace === 'function') {
-    return globalThis.Error.prepareStackTrace(error, trace);
-  }
+  const globalOverride =
+    maybeOverridePrepareStackTrace(globalThis, error, trace);
+  if (globalOverride) return globalOverride;
 
   const { SourceMap } = require('internal/source_map/source_map');
   const errorString = ErrorToString.call(error);

--- a/lib/internal/source_map/prepare_stack_trace.js
+++ b/lib/internal/source_map/prepare_stack_trace.js
@@ -17,6 +17,12 @@ const prepareStackTrace = (globalThis, error, trace) => {
     return f(error, trace);
   }
 
+  // `globalThis` is the global that contains the constructor which
+  // created `error`.
+  if (typeof globalThis.Error.prepareStackTrace === 'function') {
+    return globalThis.Error.prepareStackTrace(error, trace);
+  }
+
   const { SourceMap } = require('internal/source_map/source_map');
   const errorString = ErrorToString.call(error);
 

--- a/test/parallel/test-error-prepare-stack-trace.js
+++ b/test/parallel/test-error-prepare-stack-trace.js
@@ -1,0 +1,19 @@
+// Flags: --enable-source-maps
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// Error.prepareStackTrace() can be overridden with source maps enabled.
+{
+  let prepareCalled = false;
+  Error.prepareStackTrace = (_error, trace) => {
+    prepareCalled = true;
+  };
+  try {
+    throw new Error('foo');
+  } catch (err) {
+    err.stack;
+  }
+  assert(prepareCalled);
+}


### PR DESCRIPTION
Adds support for `Error.prepareStackTrace` override, when `--enable-source-maps` is set.

See related #31132

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
