### PR TITLE
stream: group all properties using defineProperties

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -25,7 +25,7 @@ const {
   ArrayIsArray,
   NumberIsInteger,
   NumberIsNaN,
-  ObjectDefineProperty,
+  ObjectDefineProperties,
   ObjectSetPrototypeOf,
   SymbolAsyncIterator,
   Symbol
@@ -169,22 +169,6 @@ function ReadableState(options, stream, isDuplex) {
   }
 }
 
-// Legacy getter for `pipesCount`
-ObjectDefineProperty(ReadableState.prototype, 'pipesCount', {
-  get() {
-    return this.pipes.length;
-  }
-});
-
-// Legacy property for `paused`
-ObjectDefineProperty(ReadableState.prototype, 'paused', {
-  get() {
-    return this[kPaused] !== false;
-  },
-  set(value) {
-    this[kPaused] = !!value;
-  }
-});
 
 function Readable(options) {
   if (!(this instanceof Readable))
@@ -209,40 +193,6 @@ function Readable(options) {
 
   Stream.call(this, options);
 }
-
-ObjectDefineProperty(Readable.prototype, 'destroyed', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get() {
-    if (this._readableState === undefined) {
-      return false;
-    }
-    return this._readableState.destroyed;
-  },
-  set(value) {
-    // We ignore the value if the stream
-    // has not been initialized yet
-    if (!this._readableState) {
-      return;
-    }
-
-    // Backward compatibility, the user is explicitly
-    // managing destroyed
-    this._readableState.destroyed = value;
-  }
-});
-
-ObjectDefineProperty(Readable.prototype, 'readableEnded', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get() {
-    return this._readableState ? this._readableState.endEmitted : false;
-  }
-});
 
 Readable.prototype.destroy = destroyImpl.destroy;
 Readable.prototype._undestroy = destroyImpl.undestroy;
@@ -1125,67 +1075,105 @@ Readable.prototype[SymbolAsyncIterator] = function() {
   return createReadableStreamAsyncIterator(this);
 };
 
-ObjectDefineProperty(Readable.prototype, 'readableHighWaterMark', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get: function() {
-    return this._readableState.highWaterMark;
-  }
-});
+// Making it explicit these properties are not enumerable
+// because otherwise some prototype manipulation in
+// userland will fail
+ObjectDefineProperties(Readable.prototype, {
 
-ObjectDefineProperty(Readable.prototype, 'readableBuffer', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get: function() {
-    return this._readableState && this._readableState.buffer;
-  }
-});
-
-ObjectDefineProperty(Readable.prototype, 'readableFlowing', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get: function() {
-    return this._readableState.flowing;
+  readableHighWaterMark: {
+    enumerable: false,
+    get: function() {
+      return this._readableState.highWaterMark;
+    }
   },
-  set: function(state) {
-    if (this._readableState) {
-      this._readableState.flowing = state;
+
+  readableBuffer: {
+    enumerable: false,
+    get: function() {
+      return this._readableState && this._readableState.buffer;
+    }
+  },
+
+  readableFlowing: {
+    enumerable: false,
+    get: function() {
+      return this._readableState.flowing;
+    },
+    set: function(state) {
+      if (this._readableState) {
+        this._readableState.flowing = state;
+      }
+    }
+  },
+
+  readableLength: {
+    enumerable: false,
+    get() {
+      return this._readableState.length;
+    }
+  },
+
+  readableObjectMode: {
+    enumerable: false,
+    get() {
+      return this._readableState ? this._readableState.objectMode : false;
+    }
+  },
+
+  readableEncoding: {
+    enumerable: false,
+    get() {
+      return this._readableState ? this._readableState.encoding : null;
+    }
+  },
+
+  destroyed: {
+    enumerable: false,
+    get() {
+      if (this._readableState === undefined) {
+        return false;
+      }
+      return this._readableState.destroyed;
+    },
+    set(value) {
+      // We ignore the value if the stream
+      // has not been initialized yet
+      if (!this._readableState) {
+        return;
+      }
+
+      // Backward compatibility, the user is explicitly
+      // managing destroyed
+      this._readableState.destroyed = value;
+    }
+  },
+
+  readableEnded: {
+    enumerable: false,
+    get() {
+      return this._readableState ? this._readableState.endEmitted : false;
+    }
+  },
+
+  // Legacy getter for `pipesCount`
+  pipesCount: {
+    get() {
+      return this.pipes.length;
+    }
+  },
+
+  paused: {
+    get() {
+      return this[kPaused] !== false;
+    },
+    set(value) {
+      this[kPaused] = !!value;
     }
   }
 });
 
 // Exposed for testing purposes only.
 Readable._fromList = fromList;
-
-ObjectDefineProperty(Readable.prototype, 'readableLength', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get() {
-    return this._readableState.length;
-  }
-});
-
-ObjectDefineProperty(Readable.prototype, 'readableObjectMode', {
-  enumerable: false,
-  get() {
-    return this._readableState ? this._readableState.objectMode : false;
-  }
-});
-
-ObjectDefineProperty(Readable.prototype, 'readableEncoding', {
-  enumerable: false,
-  get() {
-    return this._readableState ? this._readableState.encoding : null;
-  }
-});
 
 // Pluck off n bytes from an array of buffers.
 // Length is the combined lengths of all the buffers in the list.


### PR DESCRIPTION
Simple refactor. Moved all the property definition into a single block and removed duplicated comments across the file. 