### PR TITLE
stream: simplify Writable.write

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -261,12 +261,6 @@ Writable.prototype.pipe = function() {
 
 Writable.prototype.write = function(chunk, encoding, cb) {
   const state = this._writableState;
-  const isBuf = !state.objectMode && Stream._isUint8Array(chunk);
-
-  // Do not use Object.getPrototypeOf as it is slower since V8 7.3.
-  if (isBuf && !(chunk instanceof Buffer)) {
-    chunk = Stream._uint8ArrayToBuffer(chunk);
-  }
 
   if (typeof encoding === 'function') {
     cb = encoding;
@@ -278,9 +272,6 @@ Writable.prototype.write = function(chunk, encoding, cb) {
       cb = nop;
   }
 
-  if (isBuf)
-    encoding = 'buffer';
-
   let err;
   if (state.ending) {
     err = new ERR_STREAM_WRITE_AFTER_END();
@@ -288,24 +279,31 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     err = new ERR_STREAM_DESTROYED('write');
   } else if (chunk === null) {
     err = new ERR_STREAM_NULL_VALUES();
-  } else {
-    if (!isBuf && !state.objectMode) {
-      if (typeof chunk !== 'string') {
-        err = new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
-      } else if (encoding !== 'buffer' && state.decodeStrings !== false) {
+  } else if (!state.objectMode) {
+    if (typeof chunk === 'string') {
+      if (state.decodeStrings !== false) {
         chunk = Buffer.from(chunk, encoding);
         encoding = 'buffer';
       }
-    }
-    if (err === undefined) {
-      state.pendingcb++;
-      return writeOrBuffer(this, state, chunk, encoding, cb);
+    } else if (chunk instanceof Buffer) {
+      encoding = 'buffer';
+    } else if (Stream._isUint8Array(chunk)) {
+      chunk = Stream._uint8ArrayToBuffer(chunk);
+      encoding = 'buffer';
+    } else {
+      err = new ERR_INVALID_ARG_TYPE(
+        'chunk', ['string', 'Buffer', 'Uint8Array'], chunk);
     }
   }
 
-  process.nextTick(cb, err);
-  errorOrDestroy(this, err, true);
-  return false;
+  if (err) {
+    process.nextTick(cb, err);
+    errorOrDestroy(this, err, true);
+    return false;
+  } else {
+    state.pendingcb++;
+    return writeOrBuffer(this, state, chunk, encoding, cb);
+  }
 };
 
 Writable.prototype.cork = function() {

--- a/test/parallel/test-net-write-arguments.js
+++ b/test/parallel/test-net-write-arguments.js
@@ -33,6 +33,6 @@ socket.on('error', common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
     message: 'The "chunk" argument must be of type string or an instance of ' +
-              `Buffer.${common.invalidArgTypeHelper(value)}`
+              `Buffer or Uint8Array.${common.invalidArgTypeHelper(value)}`
   }));
 });


### PR DESCRIPTION
Simplifies `Writable.write` ~~and adds an optimization where if you pass `'buffer'` as the `encoding` parameter to `write(chunk, encoding, cb)` it will bypass a slow path where we check whether `chunk` is a `Buffer` or not.~~

https://github.com/nodejs/node/pull/31146#issuecomment-570176575

<details>
```js
 streams/writable-manywrites.js sync='no' n=2000000                  0.98 %       ±2.18% ±2.88% ±3.72%
 streams/writable-manywrites.js sync='yes' n=2000000        ***     30.92 %       ±4.45% ±5.93% ±7.76%
````
</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
