### PR TITLE
https-agent: fix issue where creating connection modifies arguments

### DIFF
--- a/lib/https.js
+++ b/lib/https.js
@@ -95,9 +95,11 @@ function createConnection(port, host, options) {
   if (port !== null && typeof port === 'object') {
     options = port;
   } else if (host !== null && typeof host === 'object') {
-    options = host;
+    options = { ...host };
   } else if (options === null || typeof options !== 'object') {
     options = {};
+  } else {
+    options = { ...options };
   }
 
   if (typeof port === 'number') {

--- a/test/parallel/test-https-agent-create-connection.js
+++ b/test/parallel/test-https-agent-create-connection.js
@@ -132,3 +132,27 @@ function createServer() {
     }));
   }));
 }
+
+// `options` should not be modified
+{
+  const server = createServer();
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    const host = 'localhost';
+    const options = {
+      port: 3000,
+      rejectUnauthorized: false
+    };
+
+    const socket = agent.createConnection(port, host, options);
+    socket.on('connect', common.mustCall((data) => {
+      socket.end();
+    }));
+    socket.on('end', common.mustCall(() => {
+      assert.deepStrictEqual(options, {
+        port: 3000, rejectUnauthorized: false
+      });
+      server.close();
+    }));
+  }));
+}


### PR DESCRIPTION
Previously, when passing options object to the agent.createConnection
method, the same options object got modified within the method. Now,
any modification will happen on only a copy of the object.

Fixes: https://github.com/nodejs/node/issues/31119

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
