### PR TITLE
src: add build Github Action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: 13.x
+      - name: Environment Information
+        run: npx envinfo
+      - name: Build
+        run: ./configure && make -j2
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: 13.x
+      - name: Environment Information
+        run: npx envinfo
+      - name: Install deps
+        run: choco install nasm
+      - name: Build
+        run: ./vcbuild.bat
+  build-macOS:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: 13.x
+      - name: Environment Information
+        run: npx envinfo
+      - name: Build
+        run: ./configure && make -j8


### PR DESCRIPTION
Fix #31017 

Currently not able to reuse common steps. See https://github.community/t5/GitHub-Actions/reusing-sharing-inheriting-steps-between-jobs-declarations/m-p/37849#M3100.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
