### PR TITLE
lib: Enhance use of Set with primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -29,6 +29,8 @@ rules:
       message: "Use `const { Reflect } = primordials;` instead of the global."
     - name: Symbol
       message: "Use `const { Symbol } = primordials;` instead of the global."
+    - name: Set
+      message: "Use `const { Set } = primordials;` instead of the global."
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -27,6 +27,7 @@ const {
   NumberIsNaN,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  Set,
   SymbolAsyncIterator,
   Symbol
 } = primordials;

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -8,6 +8,7 @@
 
 const {
   Promise,
+  Set,
 } = primordials;
 
 const { Buffer } = require('buffer');

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -12,6 +12,7 @@ const {
   ObjectPrototypeHasOwnProperty,
   Promise,
   ReflectGetPrototypeOf,
+  Set,
   Symbol,
 } = primordials;
 

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -6,6 +6,7 @@ const {
   Number,
   ObjectCreate,
   ObjectKeys,
+  Set,
   Symbol,
 } = primordials;
 

--- a/lib/internal/inspector_async_hook.js
+++ b/lib/internal/inspector_async_hook.js
@@ -3,6 +3,10 @@
 let hook;
 let config;
 
+const {
+  Set,
+} = primordials;
+
 function lazyHookCreation() {
   const inspector = internalBinding('inspector');
   const { createHook } = require('async_hooks');

--- a/lib/internal/modules/esm/create_dynamic_module.js
+++ b/lib/internal/modules/esm/create_dynamic_module.js
@@ -5,6 +5,7 @@ const {
   ArrayPrototypeMap,
   JSONStringify,
   ObjectCreate,
+  Set,
 } = primordials;
 
 const debug = require('internal/util/debuglog').debuglog('esm');

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -12,6 +12,7 @@ const {
   ObjectFreeze,
   ObjectGetOwnPropertyDescriptors,
   RegExpPrototypeTest,
+  Set,
   SetPrototypeHas,
   StringPrototypeReplace,
 } = primordials;

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -2,6 +2,7 @@
 
 const {
   MathMin,
+  Set,
   Symbol,
 } = primordials;
 

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -12,6 +12,7 @@ const {
   ObjectSetPrototypeOf,
   Promise,
   ReflectConstruct,
+  Set,
   Symbol,
   SymbolFor,
 } = primordials;

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -14,6 +14,7 @@ const {
   ObjectPrototypeHasOwnProperty,
   ObjectPrototypePropertyIsEnumerable,
   ObjectPrototypeToString,
+  Set,
   StringPrototypeValueOf,
   SymbolPrototypeValueOf,
   SymbolToStringTag,

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -33,6 +33,7 @@ const {
   ObjectPrototypePropertyIsEnumerable,
   ObjectSeal,
   RegExpPrototypeToString,
+  Set,
   SetPrototype,
   SetPrototypeValues,
   StringPrototypeValueOf,

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -7,6 +7,7 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectKeys,
+  Set,
   Symbol,
 } = primordials;
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -55,6 +55,7 @@ const {
   ObjectSetPrototypeOf,
   Promise,
   PromiseRace,
+  Set,
   Symbol,
 } = primordials;
 

--- a/lib/trace_events.js
+++ b/lib/trace_events.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayIsArray,
+  Set,
   Symbol,
 } = primordials;
 


### PR DESCRIPTION
Hello :D (i'm back)
For this PR I have added Set in the primordials eslint

And i just have created a line in "/lib/.eslintrc.yaml".

```yaml
rules:
  no-restricted-globals:
  - name: Set
        message: "Use `const { Set } = primordials;` instead of the global."
```

And just add Set.
```js
const {
  // [...]
  Set,
} = primordials;
```
I hope this new PR will help you :x