### PR TITLE
lib: enhance use of Map with primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -29,6 +29,8 @@ rules:
       message: "Use `const { Reflect } = primordials;` instead of the global."
     - name: Symbol
       message: "Use `const { Symbol } = primordials;` instead of the global."
+    - name: Map
+      message: "Use `const { Map } = primordials;` instead of the global."
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -25,6 +25,7 @@ const {
   ObjectIs,
   ObjectKeys,
   ObjectPrototypeIsPrototypeOf,
+  Map,
   NumberIsNaN,
   RegExpPrototypeTest,
 } = primordials;

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -28,6 +28,7 @@
 
 const {
   Array,
+  Map,
   ObjectDefineProperty,
   ReflectApply,
   Symbol,

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -25,6 +25,7 @@
 'use strict';
 
 const {
+  Map,
   MathMax,
   NumberIsSafeInteger,
   ObjectCreate,

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -3,6 +3,7 @@
 const {
   JSONParse,
   JSONStringify,
+  Map,
   Symbol,
 } = primordials;
 

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -44,11 +44,12 @@
 /* global process, getLinkedBinding, getInternalBinding, primordials */
 
 const {
-  ReflectGet,
+  Map,
   ObjectCreate,
   ObjectDefineProperty,
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
+  ReflectGet,
   SafeSet,
 } = primordials;
 

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  Map,
   ObjectDefineProperty,
   SafeWeakMap,
 } = primordials;

--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  Map,
   ObjectAssign,
 } = primordials;
 

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  Map,
   ObjectKeys,
   ObjectValues,
 } = primordials;

--- a/lib/internal/cluster/round_robin_handle.js
+++ b/lib/internal/cluster/round_robin_handle.js
@@ -2,6 +2,7 @@
 
 const {
   Boolean,
+  Map,
 } = primordials;
 
 const assert = require('internal/assert');

--- a/lib/internal/cluster/utils.js
+++ b/lib/internal/cluster/utils.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  Map,
+} = primordials;
+
 module.exports = {
   sendHelper,
   internal

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -7,6 +7,7 @@ const {
   ArrayFrom,
   ArrayIsArray,
   Boolean,
+  Map,
   MathFloor,
   Number,
   ObjectDefineProperties,

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -4,6 +4,7 @@
 // https://encoding.spec.whatwg.org
 
 const {
+  Map,
   ObjectCreate,
   ObjectDefineProperties,
   ObjectGetOwnPropertyDescriptors,

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -12,6 +12,7 @@
 
 const {
   ArrayIsArray,
+  Map,
   MathAbs,
   NumberIsInteger,
   ObjectDefineProperty,

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -5,6 +5,7 @@
 const {
   ArrayFrom,
   ArrayIsArray,
+  Map,
   MathMin,
   ObjectAssign,
   ObjectCreate,

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -24,6 +24,7 @@
 const {
   ArrayIsArray,
   JSONParse,
+  Map,
   ObjectCreate,
   ObjectDefineProperty,
   ObjectFreeze,

--- a/lib/internal/process/signal.js
+++ b/lib/internal/process/signal.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const {
+  Map,
+} = primordials;
+
+const {
   errnoException,
 } = require('internal/errors');
 

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -6,6 +6,7 @@ const {
   ObjectKeys,
   ObjectGetOwnPropertyDescriptor,
   ObjectPrototypeHasOwnProperty,
+  Map,
   MapPrototypeEntries,
   WeakMapPrototypeGet,
   uncurryThis,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -3,6 +3,7 @@
 const {
   ArrayFrom,
   ArrayIsArray,
+  Map,
   ObjectCreate,
   ObjectDefineProperties,
   ObjectDefineProperty,

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -5,6 +5,7 @@ const {
   BigIntPrototypeValueOf,
   BooleanPrototypeValueOf,
   DatePrototypeGetTime,
+  Map,
   NumberIsNaN,
   NumberPrototypeValueOf,
   ObjectGetOwnPropertySymbols,

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -10,6 +10,7 @@ const {
   DatePrototypeToString,
   ErrorPrototypeToString,
   JSONStringify,
+  Map,
   MapPrototype,
   MapPrototypeEntries,
   MathFloor,

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -3,6 +3,7 @@
 const {
   ArrayIsArray,
   Boolean,
+  Map,
   NumberIsSafeInteger,
   ObjectDefineProperties,
   ObjectDefineProperty,

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -22,6 +22,7 @@ const {
   Int16Array,
   Int32Array,
   Int8Array,
+  Map,
   ObjectPrototypeToString,
   Symbol,
   Uint16Array,


### PR DESCRIPTION
Hello,
Now, in this PR I have added Map in the primordials eslint
so have created a line in "/lib/.eslintrc.yaml".

```yaml
rules:
  no-restricted-globals:
  - name: Map
        message: "Use `const { Map } = primordials;` instead of the global."
```

And just import Map in some file :).
```js
const {
  // [...]
  Map,
} = primordials;
```
I hope this new PR will help you :x