### PR TITLE
test: Fix unit test logging with python3

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1534,7 +1534,7 @@ def Main():
   logger.addHandler(ch)
   logger.setLevel(logging.INFO)
   if options.logfile:
-    fh = logging.FileHandler(options.logfile, mode='wb')
+    fh = logging.FileHandler(options.logfile, encoding='utf-8', mode='w')
     logger.addHandler(fh)
 
   workspace = abspath(join(dirname(sys.argv[0]), '..'))


### PR DESCRIPTION
A logfile must be opened as a text file and encoding is specified.
Then it can accept a string. Current behaviour we get,

 Message: 'ok 2834 sequential/test-worker-prof'
 Arguments: ()
 --- Logging error ---
 Traceback (most recent call last):
   File "/usr/lib64/python3.7/logging/__init__.py", line 1037, in emit
     stream.write(msg + self.terminator)
 TypeError: a bytes-like object is required, not 'str'
 Call stack:
   File "tools/test.py", line 1734, in <module>
     sys.exit(Main())
   File "tools/test.py", line 1710, in Main
     if RunTestCases(cases_to_run, options.progress, options.j, options.flaky_tests):
   File "tools/test.py", line 933, in RunTestCases
     return progress.Run(tasks)
   File "tools/test.py", line 141, in Run
     self.RunSingle(False, 0)
   File "tools/test.py", line 202, in RunSingle
     self.HasRun(output)
   File "tools/test.py", line 365, in HasRun
     logger.info('  ---')

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
