### PR TITLE
lib: enhance use of WeakSet with primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -29,6 +29,8 @@ rules:
       message: "Use `const { Reflect } = primordials;` instead of the global."
     - name: Symbol
       message: "Use `const { Symbol } = primordials;` instead of the global."
+    - name: WeakSet
+      message: "Use `const { WeakSet } = primordials;` instead of the global."
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -56,6 +56,7 @@ const {
   Promise,
   PromiseRace,
   Symbol,
+  WeakSet,
 } = primordials;
 
 const {


### PR DESCRIPTION
Hello,
Now, in this PR I have added WeakSet in the primordials eslint
so have created a line in "/lib/.eslintrc.yaml".

```yaml
rules:
  no-restricted-globals:
  - name: WeakSet 
        message: "Use `const { WeakSet } = primordials;` instead of the global."
```

And just import WeakSet in one file actually like that :).

```js
const {
  // [...]
  WeakSet,
} = primordials;
```

I hope this new PR will help you :x