### PR TITLE
lib: enhance use of WeakMap with primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -29,6 +29,8 @@ rules:
       message: "Use `const { Reflect } = primordials;` instead of the global."
     - name: Symbol
       message: "Use `const { Symbol } = primordials;` instead of the global."
+    - name: WeakMap
+      message: "Use `const { WeakMap } = primordials;` instead of the global."
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -17,6 +17,7 @@ const {
   ReflectOwnKeys,
   Symbol,
   SymbolHasInstance,
+  WeakMap,
 } = primordials;
 
 const { trace } = internalBinding('trace_events');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -18,6 +18,7 @@ const {
   ObjectKeys,
   Symbol,
   SymbolFor,
+  WeakMap,
 } = primordials;
 
 const messages = new Map();

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -2,6 +2,7 @@
 
 const {
   ObjectDefineProperty,
+  WeakMap,
 } = primordials;
 
 const {

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -7,6 +7,7 @@ const {
   ObjectGetOwnPropertyDescriptor,
   ObjectPrototypeHasOwnProperty,
   MapPrototypeEntries,
+  WeakMap,
   WeakMapPrototypeGet,
   uncurryThis,
 } = primordials;

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -7,6 +7,7 @@ const {
   ObjectDefineProperty,
   SafePromise,
   Symbol,
+  WeakMap,
 } = primordials;
 
 const { isContext } = internalBinding('contextify');


### PR DESCRIPTION
Hello,
Now, I have added WeakMap in the primordials eslint
so have created a line in "/lib/.eslintrc.yaml".

```yaml
rules:
  no-restricted-globals:
  - name: WeakMap 
        message: "Use `const { WeakMap } = primordials;` instead of the global."
```

And just import WeakMap in one file actually like that :).

```js
const {
  // [...]
  WeakMap,
} = primordials;
```

Thanks to allow me to create some PR btw 😄 
I hope this will be helpful for you