### PR TITLE
lib: replace Set.prototype by SetPrototype primordials

### DIFF
--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -12,6 +12,7 @@ const {
   ObjectFreeze,
   ObjectGetOwnPropertyDescriptors,
   RegExpPrototypeTest,
+  SetPrototype,
   SetPrototypeHas,
   StringPrototypeReplace,
 } = primordials;
@@ -284,7 +285,7 @@ function buildAllowedFlags() {
   // each object.
   const nodeFlags = ObjectDefineProperties(
     new Set(allowedNodeEnvironmentFlags.map(trimLeadingDashes)),
-    ObjectGetOwnPropertyDescriptors(Set.prototype)
+    ObjectGetOwnPropertyDescriptors(SetPrototype)
   );
 
   class NodeEnvironmentFlagsSet extends Set {


### PR DESCRIPTION
Hello 😄 

Just replaced every Set.prototype by SetPrototype in the lib/* folder
For this, i just have added SetPrototype in the import
```js
const {
  // [...]
  SetPrototype,
} = primordials;
```
I hope this pull request will help you ! :P