### PR TITLE
lib: move primordials config to a new file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@
 !.eslintrc.yaml
 !.cpplint
 
+# Special eslintrc for primordials
+!lib/.eslintrc.primordials.yaml
+
 # === Rules for root dir ===
 /core
 /vgcore.*

--- a/lib/.eslintrc.primordials.yaml
+++ b/lib/.eslintrc.primordials.yaml
@@ -1,0 +1,26 @@
+rules:
+  no-restricted-globals:
+    - error
+    - name: Array
+      message: "Use `const { Array } = primordials;` instead of the global."
+    - name: BigInt
+      message: "Use `const { BigInt } = primordials;` instead of the global."
+    - name: Boolean
+      message: "Use `const { Boolean } = primordials;` instead of the global."
+    - name: JSON
+      message: "Use `const { JSON } = primordials;` instead of the global."
+    - name: Math
+      message: "Use `const { Math } = primordials;` instead of the global."
+    - name: Number
+      message: "Use `const { Number } = primordials;` instead of the global."
+    - name: Object
+      message: "Use `const { Object } = primordials;` instead of the global."
+    - name: Promise
+      message: "Use `const { Promise } = primordials;` instead of the global."
+    - name: Reflect
+      message: "Use `const { Reflect } = primordials;` instead of the global."
+    - name: Symbol
+      message: "Use `const { Symbol } = primordials;` instead of the global."
+
+globals:
+  primordials: false

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -1,34 +1,15 @@
 env:
   es6: true
 
+extends:
+  - ".eslintrc.primordials.yaml"
+
 rules:
   prefer-object-spread: error
   no-buffer-constructor: error
   no-mixed-operators:
     - error
     - groups: [[ "&&", "||" ]]
-  no-restricted-globals:
-    - error
-    - name: Array
-      message: "Use `const { Array } = primordials;` instead of the global."
-    - name: BigInt
-      message: "Use `const { BigInt } = primordials;` instead of the global."
-    - name: Boolean
-      message: "Use `const { Boolean } = primordials;` instead of the global."
-    - name: JSON
-      message: "Use `const { JSON } = primordials;` instead of the global."
-    - name: Math
-      message: "Use `const { Math } = primordials;` instead of the global."
-    - name: Number
-      message: "Use `const { Number } = primordials;` instead of the global."
-    - name: Object
-      message: "Use `const { Object } = primordials;` instead of the global."
-    - name: Promise
-      message: "Use `const { Promise } = primordials;` instead of the global."
-    - name: Reflect
-      message: "Use `const { Reflect } = primordials;` instead of the global."
-    - name: Symbol
-      message: "Use `const { Symbol } = primordials;` instead of the global."
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error
@@ -59,4 +40,3 @@ globals:
   exports: false
   module: false
   internalBinding: false
-  primordials: false


### PR DESCRIPTION
Hello everyone 😄

This time i just have a proposal to do with @targos. (The idea come from targos)

What about create a new file named .eslintrc.primordials.yaml for example who can contains every rules for the primordials object ?

This will discharge the .eslintrc original and enhance the readibility of this file.

Of course its just a proposal 😄 
It's not a big work. just create a new yaml file and extend this in the old .eslintrc file 

What did you think about that ?