### PR TITLE
lib: enhance use of Error from primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -29,6 +29,8 @@ rules:
       message: "Use `const { Reflect } = primordials;` instead of the global."
     - name: Symbol
       message: "Use `const { Symbol } = primordials;` instead of the global."
+    - name: Error
+      message: "Use `const { Error } = primordials;` instead of the global."
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -24,6 +24,7 @@
 const {
   ArrayIsArray,
   Boolean,
+  Error,
   NumberIsFinite,
   ObjectAssign,
   ObjectKeys,

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  Error,
   ObjectKeys,
   ObjectSetPrototypeOf,
   Symbol,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -21,6 +21,7 @@
 'use strict';
 
 const {
+  Error,
   ObjectAssign,
   ObjectIs,
   ObjectKeys,

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -24,6 +24,7 @@
 const {
   Array,
   ArrayIsArray,
+  Error,
   MathFloor,
   MathMin,
   MathTrunc,

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -23,6 +23,7 @@
 
 const {
   ArrayIsArray,
+  Error,
   NumberIsInteger,
   ObjectAssign,
   ObjectDefineProperty,

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -28,6 +28,7 @@
 
 const {
   Array,
+  Error,
   ObjectDefineProperty,
   ReflectApply,
   Symbol,

--- a/lib/events.js
+++ b/lib/events.js
@@ -24,6 +24,7 @@
 const {
   Array,
   Boolean,
+  Error,
   MathMin,
   NumberIsNaN,
   ObjectCreate,

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  Error,
   MathMax,
   ObjectCreate,
   ObjectDefineProperty,

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  Error,
   FunctionPrototypeBind,
   NumberIsSafeInteger,
   ObjectDefineProperty,

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -44,6 +44,7 @@
 /* global process, getLinkedBinding, getInternalBinding, primordials */
 
 const {
+  Error,
   ReflectGet,
   ObjectCreate,
   ObjectDefineProperty,

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -7,6 +7,7 @@ const {
   ArrayFrom,
   ArrayIsArray,
   Boolean,
+  Error,
   MathFloor,
   Number,
   ObjectDefineProperties,

--- a/lib/internal/error-serdes.js
+++ b/lib/internal/error-serdes.js
@@ -3,6 +3,7 @@
 const Buffer = require('buffer').Buffer;
 const {
   ArrayPrototypeForEach,
+  Error,
   FunctionPrototypeCall,
   ObjectAssign,
   ObjectCreate,

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -12,6 +12,7 @@
 
 const {
   ArrayIsArray,
+  Error,
   MathAbs,
   NumberIsInteger,
   ObjectDefineProperty,

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -4,6 +4,7 @@ const {
   ArrayIsArray,
   BigInt,
   DateNow,
+  Error,
   Number,
   NumberIsFinite,
   ObjectSetPrototypeOf,

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayIsArray,
+  Error,
   MathMax,
   Number,
   ObjectCreate,

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -23,6 +23,7 @@
 
 const {
   ArrayIsArray,
+  Error,
   JSONParse,
   ObjectCreate,
   ObjectDefineProperty,

--- a/lib/internal/per_context/domexception.js
+++ b/lib/internal/per_context/domexception.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  Error,
   ObjectDefineProperties,
   ObjectDefineProperty,
   SafeWeakMap,

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  Error,
   ObjectDefineProperty,
 } = primordials;
 

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayIsArray,
+  Error,
 } = primordials;
 
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;

--- a/lib/internal/source_map/prepare_stack_trace.js
+++ b/lib/internal/source_map/prepare_stack_trace.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  Error,
+} = primordials;
+
 const debug = require('internal/util/debuglog').debuglog('source_map');
 const { findSourceMap } = require('internal/source_map/source_map_cache');
 const { overrideStackTrace } = require('internal/errors');

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -3,6 +3,7 @@
 const {
   ArrayFrom,
   ArrayIsArray,
+  Error,
   ObjectCreate,
   ObjectDefineProperties,
   ObjectDefineProperty,

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -5,6 +5,7 @@ const {
   BigIntPrototypeValueOf,
   BooleanPrototypeValueOf,
   DatePrototypeGetTime,
+  Error,
   NumberIsNaN,
   NumberPrototypeValueOf,
   ObjectGetOwnPropertySymbols,

--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -25,6 +25,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/* eslint-disable no-restricted-globals */
+
 module.exports = { versionCheck };
 
 // Don't execute when required directly instead of being eval'd from

--- a/lib/net.js
+++ b/lib/net.js
@@ -24,6 +24,7 @@
 const {
   ArrayIsArray,
   Boolean,
+  Error,
   Number,
   NumberIsNaN,
   ObjectDefineProperty,

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -43,6 +43,7 @@
 'use strict';
 
 const {
+  Error,
   MathMax,
   NumberIsNaN,
   ObjectAssign,

--- a/lib/util.js
+++ b/lib/util.js
@@ -23,6 +23,7 @@
 
 const {
   ArrayIsArray,
+  Error,
   NumberIsSafeInteger,
   ObjectDefineProperties,
   ObjectDefineProperty,

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -17,6 +17,7 @@
 const {
   Array,
   ArrayBuffer,
+  Error,
   Float32Array,
   Float64Array,
   Int16Array,

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  Error,
   MathMax,
   NumberIsFinite,
   NumberIsNaN,


### PR DESCRIPTION
Hello,
Now, in this PR I have added Error in the primordials eslint
so have created a line in "/lib/.eslintrc.yaml".

```yaml
rules:
  no-restricted-globals:
  - name: Error
        message: "Use `const { Error } = primordials;` instead of the global."
```

And just import Error :).

```js
const {
  // [...]
  Error,
} = primordials;
```

I hope this new PR will help you :x