### PR TITLE
stream: move _writableState.buffer to EOL

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -82,6 +82,9 @@ The `_linklist` module is deprecated. Please use a userland alternative.
 ### DEP0003: `_writableState.buffer`
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/31165
+    description: End-of-Life
   - version:
     - v4.8.6
     - v6.12.0
@@ -92,10 +95,10 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-The `_writableState.buffer` property is deprecated. Use the
-`_writableState.getBuffer()` method instead.
+The `_writableState.buffer` has been removed. Use `_writableState.getBuffer()`
+instead.
 
 <a id="DEP0004"></a>
 ### DEP0004: `CryptoStream.prototype.readyState`

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -37,7 +37,6 @@ const {
 module.exports = Writable;
 Writable.WritableState = WritableState;
 
-const internalUtil = require('internal/util');
 const EE = require('events');
 const Stream = require('stream');
 const { Buffer } = require('buffer');
@@ -194,13 +193,6 @@ WritableState.prototype.getBuffer = function getBuffer() {
   }
   return out;
 };
-
-ObjectDefineProperty(WritableState.prototype, 'buffer', {
-  get: internalUtil.deprecate(function writableStateBufferGetter() {
-    return this.getBuffer();
-  }, '_writableState.buffer is deprecated. Use _writableState.getBuffer ' +
-     'instead.', 'DEP0003')
-});
 
 // Test _writableState for inheritance to account for Duplex streams,
 // whose prototype chain only points to Readable.


### PR DESCRIPTION
API was deprecated back in the 0.11 days.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
