### PR TITLE
crypto: move pbkdf2 without digest to EOL

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -233,6 +233,9 @@ to the `constants` property exposed by the relevant module. For instance,
 ### DEP0009: `crypto.pbkdf2` without digest
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/31166
+    description: End-of-Life (for `digest === null`)
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/22861
     description: Runtime deprecation (for `digest === null`).
@@ -247,7 +250,7 @@ changes:
     description: Runtime deprecation (for `digest === undefined`).
 -->
 
-Type: Runtime
+Type: End-of-Life
 
 Use of the [`crypto.pbkdf2()`][] API without specifying a digest was deprecated
 in Node.js 6.0 because the method defaulted to using the non-recommended
@@ -256,8 +259,10 @@ Node.js 8.0.0, calling `crypto.pbkdf2()` or `crypto.pbkdf2Sync()` with
 `digest` set to `undefined` will throw a `TypeError`.
 
 Beginning in Node.js v11.0.0, calling these functions with `digest` set to
-`null` will print a deprecation warning to align with the behavior when `digest`
+`null` would print a deprecation warning to align with the behavior when `digest`
 is `undefined`.
+
+Now, however, passing either `undefined` or `null` will throw a `TypeError`.
 
 <a id="DEP0010"></a>
 ### DEP0010: `crypto.createCredentials`

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -4,7 +4,6 @@ const { AsyncWrap, Providers } = internalBinding('async_wrap');
 const { Buffer } = require('buffer');
 const { pbkdf2: _pbkdf2 } = internalBinding('crypto');
 const { validateUint32 } = require('internal/validators');
-const { deprecate } = require('internal/util');
 const {
   ERR_CRYPTO_INVALID_DIGEST,
   ERR_CRYPTO_PBKDF2_ERROR,

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -52,17 +52,9 @@ function pbkdf2Sync(password, salt, iterations, keylen, digest) {
   return keybuf.toString(encoding);
 }
 
-const defaultDigest = deprecate(() => 'sha1',
-                                'Calling pbkdf2 or pbkdf2Sync with "digest" ' +
-                                'set to null is deprecated.',
-                                'DEP0009');
-
 function check(password, salt, iterations, keylen, digest) {
-  if (typeof digest !== 'string') {
-    if (digest !== null)
-      throw new ERR_INVALID_ARG_TYPE('digest', ['string', 'null'], digest);
-    digest = defaultDigest();
-  }
+  if (typeof digest !== 'string')
+    throw new ERR_INVALID_ARG_TYPE('digest', 'string', digest);
 
   password = getArrayBufferView(password, 'password');
   salt = getArrayBufferView(salt, 'salt');

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -6,11 +6,6 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-common.expectWarning(
-  'DeprecationWarning',
-  'Calling pbkdf2 or pbkdf2Sync with "digest" set to null is deprecated.',
-  'DEP0009');
-
 //
 // Test PBKDF2 with RFC 6070 test vectors (except #4)
 //
@@ -61,7 +56,7 @@ function ondone(err, key) {
 
 // Error path should not leak memory (check with valgrind).
 assert.throws(
-  () => crypto.pbkdf2('password', 'salt', 1, 20, null),
+  () => crypto.pbkdf2('password', 'salt', 1, 20, 'sha1'),
   {
     code: 'ERR_INVALID_CALLBACK',
     name: 'TypeError'
@@ -127,7 +122,7 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "digest" argument must be of type string or null. ' +
+    message: 'The "digest" argument must be of type string. ' +
              'Received undefined'
   });
 
@@ -136,10 +131,18 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "digest" argument must be of type string or null. ' +
+    message: 'The "digest" argument must be of type string. ' +
              'Received undefined'
   });
 
+assert.throws(
+  () => crypto.pbkdf2Sync('password', 'salt', 8, 8, null),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "digest" argument must be of type string. ' +
+             'Received null'
+  });
 [1, {}, [], true, undefined, null].forEach((input) => {
   const msgPart2 = 'an instance of Buffer, TypedArray, or DataView.' +
                    common.invalidArgTypeHelper(input);


### PR DESCRIPTION
API has been being incrementally deprecated since 6.0.0


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

