### PR TITLE
os: move tmpDir() to EOL

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -508,14 +508,18 @@ The `Server.listenFD()` method was deprecated and removed. Please use
 ### DEP0022: `os.tmpDir()`
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: End-of-Life.
   - version: v7.0.0
     pr-url: https://github.com/nodejs/node/pull/6739
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-The `os.tmpDir()` API is deprecated. Please use [`os.tmpdir()`][] instead.
+The `os.tmpDir()` API iws deprecated in Node.js 7.0.0 and has since been
+removed. Please use [`os.tmpdir()`][] instead.
 
 <a id="DEP0023"></a>
 ### DEP0023: `os.getNetworkInterfaces()`

--- a/lib/os.js
+++ b/lib/os.js
@@ -83,9 +83,6 @@ getUptime[SymbolToPrimitive] = () => getUptime();
 
 const kEndianness = isBigEndian ? 'BE' : 'LE';
 
-const tmpDirDeprecationMsg =
-  'os.tmpDir() is deprecated. Use os.tmpdir() instead.';
-
 const avgValues = new Float64Array(3);
 
 function loadavg() {
@@ -285,9 +282,6 @@ module.exports = {
   type: getOSType,
   userInfo,
   uptime: getUptime,
-
-  // Deprecated APIs
-  tmpDir: deprecate(tmpdir, tmpDirDeprecationMsg, 'DEP0022')
 };
 
 ObjectDefineProperties(module.exports, {

--- a/lib/os.js
+++ b/lib/os.js
@@ -28,7 +28,6 @@ const {
 
 const { safeGetenv } = internalBinding('credentials');
 const constants = internalBinding('constants').os;
-const { deprecate } = require('internal/util');
 const isWindows = process.platform === 'win32';
 
 const {


### PR DESCRIPTION
The tmpDir alias was deprecated in 7.0.0


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

