### PR TITLE
test: changed the buffer offset

### DIFF
--- a/test/addons/buffer-free-callback/test.js
+++ b/test/addons/buffer-free-callback/test.js
@@ -16,20 +16,24 @@ function check(size, alignment, offset) {
   global.gc();
 }
 
+// NOTE: If adding more check() test cases,
+// be sure to not duplicate alignment/offset.
+// Refs: https://github.com/nodejs/node/issues/31061#issuecomment-568612283
+
 check(64, 1, 0);
 
 // Buffers can have weird sizes.
-check(97, 1, 0);
+check(97, 1, 1);
 
 // Buffers can be unaligned
 check(64, 8, 0);
 check(64, 16, 0);
 check(64, 8, 1);
 check(64, 16, 1);
-check(97, 8, 1);
-check(97, 16, 1);
 check(97, 8, 3);
 check(97, 16, 3);
+check(97, 8, 5);
+check(97, 16, 5);
 
 // Empty ArrayBuffer does not allocate data, worth checking
-check(0, 1, 0);
+check(0, 1, 2);


### PR DESCRIPTION
to avoid problem with the new behaviour of new V8 BackingStore API. By
changing the offset, the base address of each test case will be
different.

Fixes: https://github.com/nodejs/node/issues/31061

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
