### PR TITLE
lib: move initialization of APIs for changing process state

### DIFF
--- a/lib/internal/bootstrap/switches/does_not_own_process_state.js
+++ b/lib/internal/bootstrap/switches/does_not_own_process_state.js
@@ -1,11 +1,18 @@
 'use strict';
 
 const credentials = internalBinding('credentials');
+const rawMethods = internalBinding('process_methods');
+const {
+  unavailable
+} = require('internal/process/worker_thread_only');
+
+process.abort = unavailable('process.abort()');
+process.chdir = unavailable('process.chdir()');
+process.umask = wrappedUmask;
+process.cwd = rawMethods.cwd;
 
 if (credentials.implementsPosixCredentials) {
   // TODO: this should be detached from ERR_WORKER_UNSUPPORTED_OPERATION
-  const { unavailable } = require('internal/process/worker_thread_only');
-
   process.initgroups = unavailable('process.initgroups()');
   process.setgroups = unavailable('process.setgroups()');
   process.setegid = unavailable('process.setegid()');
@@ -16,3 +23,16 @@ if (credentials.implementsPosixCredentials) {
 
 // ---- keep the attachment of the wrappers above so that it's easier to ----
 // ----              compare the setups side-by-side                    -----
+
+const {
+  codes: { ERR_WORKER_UNSUPPORTED_OPERATION }
+} = require('internal/errors');
+
+function wrappedUmask(mask) {
+  // process.umask() is a read-only operation in workers.
+  if (mask !== undefined) {
+    throw new ERR_WORKER_UNSUPPORTED_OPERATION('Setting process.umask()');
+  }
+
+  return rawMethods.umask(mask);
+}

--- a/lib/internal/bootstrap/switches/does_not_own_process_state.js
+++ b/lib/internal/bootstrap/switches/does_not_own_process_state.js
@@ -2,9 +2,8 @@
 
 const credentials = internalBinding('credentials');
 const rawMethods = internalBinding('process_methods');
-const {
-  unavailable
-} = require('internal/process/worker_thread_only');
+// TODO: this should be detached from ERR_WORKER_UNSUPPORTED_OPERATION
+const { unavailable } = require('internal/process/worker_thread_only');
 
 process.abort = unavailable('process.abort()');
 process.chdir = unavailable('process.chdir()');
@@ -12,7 +11,6 @@ process.umask = wrappedUmask;
 process.cwd = rawMethods.cwd;
 
 if (credentials.implementsPosixCredentials) {
-  // TODO: this should be detached from ERR_WORKER_UNSUPPORTED_OPERATION
   process.initgroups = unavailable('process.initgroups()');
   process.setgroups = unavailable('process.setgroups()');
   process.setegid = unavailable('process.setegid()');

--- a/lib/internal/bootstrap/switches/does_own_process_state.js
+++ b/lib/internal/bootstrap/switches/does_own_process_state.js
@@ -1,6 +1,12 @@
 'use strict';
 
 const credentials = internalBinding('credentials');
+const rawMethods = internalBinding('process_methods');
+
+process.abort = rawMethods.abort;
+process.umask = wrappedUmask;
+process.chdir = wrappedChdir;
+process.cwd = wrappedCwd;
 
 if (credentials.implementsPosixCredentials) {
   const wrapped = wrapPosixCredentialSetters(credentials);
@@ -15,6 +21,11 @@ if (credentials.implementsPosixCredentials) {
 
 // ---- keep the attachment of the wrappers above so that it's easier to ----
 // ----              compare the setups side-by-side                    -----
+
+const {
+  parseMode,
+  validateString
+} = require('internal/validators');
 
 function wrapPosixCredentialSetters(credentials) {
   const {
@@ -93,4 +104,28 @@ function wrapPosixCredentialSetters(credentials) {
     setgid: wrapIdSetter('Group', _setgid),
     setuid: wrapIdSetter('User', _setuid)
   };
+}
+
+// Cache the working directory to prevent lots of lookups. If the working
+// directory is changed by `chdir`, it'll be updated.
+let cachedCwd = '';
+
+function wrappedChdir(directory) {
+  validateString(directory, 'directory');
+  rawMethods.chdir(directory);
+  // Mark cache that it requires an update.
+  cachedCwd = '';
+}
+
+function wrappedUmask(mask) {
+  if (mask !== undefined) {
+    mask = parseMode(mask, 'mask');
+  }
+  return rawMethods.umask(mask);
+}
+
+function wrappedCwd() {
+  if (cachedCwd === '')
+    cachedCwd = rawMethods.cwd();
+  return cachedCwd;
 }

--- a/lib/internal/bootstrap/switches/is_main_thread.js
+++ b/lib/internal/bootstrap/switches/is_main_thread.js
@@ -3,11 +3,6 @@
 const { ObjectDefineProperty } = primordials;
 const rawMethods = internalBinding('process_methods');
 
-process.abort = rawMethods.abort;
-process.umask = wrappedUmask;
-process.chdir = wrappedChdir;
-process.cwd = wrappedCwd;
-
 // TODO(joyeecheung): deprecate and remove these underscore methods
 process._debugProcess = rawMethods._debugProcess;
 process._debugEnd = rawMethods._debugEnd;
@@ -38,34 +33,6 @@ process.on('removeListener', stopListeningIfSignal);
 // ----              compare the setups side-by-side                    -----
 
 const { guessHandleType } = internalBinding('util');
-const {
-  parseMode,
-  validateString
-} = require('internal/validators');
-
-// Cache the working directory to prevent lots of lookups. If the working
-// directory is changed by `chdir`, it'll be updated.
-let cachedCwd = '';
-
-function wrappedChdir(directory) {
-  validateString(directory, 'directory');
-  rawMethods.chdir(directory);
-  // Mark cache that it requires an update.
-  cachedCwd = '';
-}
-
-function wrappedUmask(mask) {
-  if (mask !== undefined) {
-    mask = parseMode(mask, 'mask');
-  }
-  return rawMethods.umask(mask);
-}
-
-function wrappedCwd() {
-  if (cachedCwd === '')
-    cachedCwd = rawMethods.cwd();
-  return cachedCwd;
-}
 
 function createWritableStdioStream(fd) {
   let stream;

--- a/lib/internal/bootstrap/switches/is_not_main_thread.js
+++ b/lib/internal/bootstrap/switches/is_not_main_thread.js
@@ -1,15 +1,6 @@
 'use strict';
 
 const { ObjectDefineProperty } = primordials;
-const rawMethods = internalBinding('process_methods');
-const {
-  unavailable
-} = require('internal/process/worker_thread_only');
-
-process.abort = unavailable('process.abort()');
-process.chdir = unavailable('process.chdir()');
-process.umask = wrappedUmask;
-process.cwd = rawMethods.cwd;
 
 delete process._debugProcess;
 delete process._debugEnd;
@@ -42,9 +33,6 @@ process.removeListener('removeListener', stopListeningIfSignal);
 const {
   createWorkerStdio
 } = require('internal/worker/io');
-const {
-  codes: { ERR_WORKER_UNSUPPORTED_OPERATION }
-} = require('internal/errors');
 
 let workerStdio;
 function lazyWorkerStdio() {
@@ -57,12 +45,3 @@ function getStdout() { return lazyWorkerStdio().stdout; }
 function getStderr() { return lazyWorkerStdio().stderr; }
 
 function getStdin() { return lazyWorkerStdio().stdin; }
-
-function wrappedUmask(mask) {
-  // process.umask() is a read-only operation in workers.
-  if (mask !== undefined) {
-    throw new ERR_WORKER_UNSUPPORTED_OPERATION('Setting process.umask()');
-  }
-
-  return rawMethods.umask(mask);
-}


### PR DESCRIPTION
Whether these APIs should be available for Node.js instances
semantically depends on whether the current Node.js instance
was assigned ownership of process-wide state, and not whether
it refers to the main thread or not.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
