### PR TITLE
stream: don't emit 'end' after 'error'

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1214,7 +1214,7 @@ function endReadableNT(state, stream) {
   debug('endReadableNT', state.endEmitted, state.length);
 
   // Check that we didn't get one last unshift.
-  if (!state.endEmitted && state.length === 0) {
+  if (!state.errorEmitted && !state.endEmitted && state.length === 0) {
     state.endEmitted = true;
     stream.readable = false;
     stream.emit('end');

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -7,6 +7,8 @@ function destroy(err, cb) {
   const r = this._readableState;
   const w = this._writableState;
 
+  // TODO(ronag): readable & writable = false?
+
   if (err) {
     if (w) {
       w.errored = true;
@@ -15,8 +17,6 @@ function destroy(err, cb) {
       r.errored = true;
     }
   }
-
-  // TODO(ronag): readable & writable = false?
 
   if ((w && w.destroyed) || (r && r.destroyed)) {
     if (cb) {
@@ -130,6 +130,8 @@ function errorOrDestroy(stream, err) {
 
   const r = stream._readableState;
   const w = stream._writableState;
+
+  // TODO(ronag): readable & writable = false?
 
   if ((r && r.autoDestroy) || (w && w.autoDestroy))
     stream.destroy(err);

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -16,6 +16,8 @@ function destroy(err, cb) {
     }
   }
 
+  // TODO(ronag): readable & writable = false?
+
   if ((w && w.destroyed) || (r && r.destroyed)) {
     if (cb) {
       cb(err);

--- a/test/parallel/test-http2-client-destroy.js
+++ b/test/parallel/test-http2-client-destroy.js
@@ -95,7 +95,7 @@ const Countdown = require('../common/countdown');
     });
 
     req.resume();
-    req.on('end', common.mustCall());
+    req.on('end', common.mustNotCall());
     req.on('close', common.mustCall(() => server.close()));
   }));
 }

--- a/test/parallel/test-http2-client-stream-destroy-before-connect.js
+++ b/test/parallel/test-http2-client-stream-destroy-before-connect.js
@@ -50,5 +50,5 @@ server.listen(0, common.mustCall(() => {
 
   req.on('response', common.mustNotCall());
   req.resume();
-  req.on('end', common.mustCall());
+  req.on('end', common.mustNotCall());
 }));

--- a/test/parallel/test-http2-head-request.js
+++ b/test/parallel/test-http2-head-request.js
@@ -10,7 +10,7 @@ const errCheck = common.expectsError({
   name: 'Error',
   code: 'ERR_STREAM_WRITE_AFTER_END',
   message: 'write after end'
-}, 2);
+}, 1);
 
 const {
   HTTP2_HEADER_PATH,
@@ -40,12 +40,6 @@ server.listen(0, () => {
     [HTTP2_HEADER_METHOD]: HTTP2_METHOD_HEAD,
     [HTTP2_HEADER_PATH]: '/'
   });
-
-  // Because it is a HEAD request, the payload is meaningless. The
-  // option.endStream flag is set automatically making the stream
-  // non-writable.
-  req.on('error', errCheck);
-  req.write('data');
 
   req.on('response', common.mustCall((headers, flags) => {
     assert.strictEqual(headers[HTTP2_HEADER_STATUS], 200);

--- a/test/parallel/test-stream-readable-error-end.js
+++ b/test/parallel/test-stream-readable-error-end.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const { Readable } = require('stream');
+const assert = require('assert');
+
+{
+  // Ensure 'end' is not emitted after 'error'.
+  // This test is slightly more complicated than
+  // needed in order to better illustrate the invariant.
+
+  const r = new Readable({ read() {} });
+
+  let errorEmitted = false;
+
+  r.on('data', common.mustCall());
+  r.on('end', () => {
+    assert.strictEqual(!errorEmitted);
+  });
+  r.on('error', () => {
+    errorEmitted = true;
+  });
+  r.push('asd');
+  r.push(null);
+  r.destroy(new Error('kaboom'));
+}

--- a/test/parallel/test-stream-readable-error-end.js
+++ b/test/parallel/test-stream-readable-error-end.js
@@ -2,13 +2,12 @@
 
 const common = require('../common');
 const { Readable } = require('stream');
-const assert = require('assert');
 
 {
   const r = new Readable({ read() {} });
 
-  r.on('data', common.mustCall());
   r.on('end', common.mustNotCall());
+  r.on('data', common.mustCall());
   r.on('error', common.mustCall());
   r.push('asd');
   r.push(null);

--- a/test/parallel/test-stream-readable-error-end.js
+++ b/test/parallel/test-stream-readable-error-end.js
@@ -5,21 +5,11 @@ const { Readable } = require('stream');
 const assert = require('assert');
 
 {
-  // Ensure 'end' is not emitted after 'error'.
-  // This test is slightly more complicated than
-  // needed in order to better illustrate the invariant.
-
   const r = new Readable({ read() {} });
 
-  let errorEmitted = false;
-
   r.on('data', common.mustCall());
-  r.on('end', () => {
-    assert.strictEqual(!errorEmitted);
-  });
-  r.on('error', () => {
-    errorEmitted = true;
-  });
+  r.on('end', common.mustNotCall());
+  r.on('error', common.mustCall());
   r.push('asd');
   r.push(null);
   r.destroy(new Error('kaboom'));

--- a/test/parallel/test-stream-unshift-read-race.js
+++ b/test/parallel/test-stream-unshift-read-race.js
@@ -68,6 +68,9 @@ r._read = function(n) {
 };
 
 function pushError() {
+  r.unshift(Buffer.allocUnsafe(1));
+  w.end();
+
   assert.throws(() => {
     r.push(Buffer.allocUnsafe(1));
   }, {
@@ -85,10 +88,7 @@ w._write = function(chunk, encoding, cb) {
   cb();
 };
 
-r.on('end', common.mustCall(function() {
-  r.unshift(Buffer.allocUnsafe(1));
-  w.end();
-}));
+r.on('end', common.mustNotCall());
 
 r.on('readable', function() {
   let chunk;


### PR DESCRIPTION
Don't emit 'end' after 'error'. There was still a case where this could occur (see test).

Note, that some tests that assume `'end'` after `'error'` needed to be modified.

Refs: https://github.com/nodejs/node/issues/6083

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
