### PR TITLE
benchmark: benchmarking impacts of async hooks on promises

### DIFF
--- a/benchmark/async_hooks/http-server.js
+++ b/benchmark/async_hooks/http-server.js
@@ -26,15 +26,15 @@ function main({ asyncHooks, connections }) {
     }
   }
   const server = require('../fixtures/simple-http-server.js')
-  .listen(common.PORT)
-  .on('listening', () => {
-    const path = '/buffer/4/4/normal/1';
+    .listen(common.PORT)
+    .on('listening', () => {
+      const path = '/buffer/4/4/normal/1';
 
-    bench.http({
-      connections,
-      path,
-    }, () => {
-      server.close();
+      bench.http({
+        connections,
+        path,
+      }, () => {
+        server.close();
+      });
     });
-  });
 }

--- a/benchmark/async_hooks/promises.js
+++ b/benchmark/async_hooks/promises.js
@@ -1,0 +1,39 @@
+'use strict';
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  n: [1e6],
+  method: [
+    'trackingEnabled',
+    'trackingDisabled',
+  ]
+});
+
+async function run(n) {
+  for (let i = 0; i < n; i++) {
+    await new Promise((resolve) => resolve())
+    .then(() => { throw new Error('foobar'); })
+    .catch((e) => e);
+  }
+}
+
+function main({ n, method }) {
+  const hook = require('async_hooks').createHook({ promiseResolve() {} });
+  switch (method) {
+    case 'trackingEnabled':
+      hook.enable();
+      bench.start();
+      run(n).then(() => {
+        bench.end(n);
+      });
+      break;
+    case 'trackingDisabled':
+      bench.start();
+      run(n).then(() => {
+        bench.end(n);
+      });
+      break;
+    default:
+      throw new Error(`Unsupported method "${method}"`);
+  }
+}


### PR DESCRIPTION
Refs: https://github.com/nodejs/diagnostics/issues/124

FWIW, following is the result of the benchmark:

```
async_hooks/promises.js asyncHooks="enabled" n=1000000: 143,333.79312043046
async_hooks/promises.js asyncHooks="disabled" n=1000000: 394,449.2637313192
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
