### PR TITLE
stream: sync stream unpipe resume

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -739,6 +739,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
           debug('false write response, pause', state.awaitDrainWriters.size);
           state.awaitDrainWriters.add(dest);
         }
+        src.pause();
       }
       if (!ondrain) {
         // When the dest drains, it reduces the awaitDrain counter
@@ -748,7 +749,6 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
         ondrain = pipeOnDrain(src, dest);
         dest.on('drain', ondrain);
       }
-      src.pause();
     }
   }
 

--- a/test/parallel/test-stream-readable-unpipe-resume.js
+++ b/test/parallel/test-stream-readable-unpipe-resume.js
@@ -7,12 +7,12 @@ const stream = require('stream')
 const fs = require('fs');
 const readStream = fs.createReadStream(process.execPath)
 
-const transformStream = new class extends stream.Transform {
-  _transform() {
+const transformStream = new stream.Transform ({
+  transform: common.mustCall(() => {
     readStream.unpipe()
     readStream.resume()
-  }
-}
+  })
+});
 
 readStream.on('end', common.mustCall());
 

--- a/test/parallel/test-stream-readable-unpipe-resume.js
+++ b/test/parallel/test-stream-readable-unpipe-resume.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+
+const stream = require('stream')
+
+const fs = require('fs');
+const readStream = fs.createReadStream('out/Release/node')
+
+const transformStream = new class extends stream.Transform {
+  _transform() {
+    readStream.unpipe()
+    readStream.resume()
+  }
+}
+
+readStream.on('end', common.mustCall());
+
+readStream
+  .pipe(transformStream)
+  .resume()

--- a/test/parallel/test-stream-readable-unpipe-resume.js
+++ b/test/parallel/test-stream-readable-unpipe-resume.js
@@ -5,7 +5,7 @@ const common = require('../common');
 const stream = require('stream')
 
 const fs = require('fs');
-const readStream = fs.createReadStream('out/Release/node')
+const readStream = fs.createReadStream(process.execPath)
 
 const transformStream = new class extends stream.Transform {
   _transform() {

--- a/test/parallel/test-stream-readable-unpipe-resume.js
+++ b/test/parallel/test-stream-readable-unpipe-resume.js
@@ -1,16 +1,15 @@
 'use strict';
 
 const common = require('../common');
-
-const stream = require('stream')
-
+const stream = require('stream');
 const fs = require('fs');
-const readStream = fs.createReadStream(process.execPath)
 
-const transformStream = new stream.Transform ({
+const readStream = fs.createReadStream(process.execPath);
+
+const transformStream = new stream.Transform({
   transform: common.mustCall(() => {
-    readStream.unpipe()
-    readStream.resume()
+    readStream.unpipe();
+    readStream.resume();
   })
 });
 
@@ -18,4 +17,4 @@ readStream.on('end', common.mustCall());
 
 readStream
   .pipe(transformStream)
-  .resume()
+  .resume();


### PR DESCRIPTION
pipe() ondata should not control flow state if cleaned up.

Fixes: https://github.com/nodejs/node/issues/31190

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
