### PR TITLE
lib: replace Error.captureStackTrace by the primordials

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -22,6 +22,7 @@
 
 const {
   Error,
+  ErrorCaptureStackTrace,
   ObjectAssign,
   ObjectIs,
   ObjectKeys,
@@ -271,7 +272,7 @@ function getErrMessage(message, fn) {
   // instead of an error.
   const err = {};
   // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(err, fn);
+  ErrorCaptureStackTrace(err, fn);
   Error.stackTraceLimit = tmpLimit;
 
   overrideStackTrace.set(err, (_, stack) => stack);

--- a/lib/events.js
+++ b/lib/events.js
@@ -25,6 +25,7 @@ const {
   Array,
   Boolean,
   Error,
+  ErrorCaptureStackTrace,
   MathMin,
   NumberIsNaN,
   ObjectCreate,
@@ -286,7 +287,7 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
       try {
         const capture = {};
         // eslint-disable-next-line no-restricted-syntax
-        Error.captureStackTrace(capture, EventEmitter.prototype.emit);
+        ErrorCaptureStackTrace(capture, EventEmitter.prototype.emit);
         ObjectDefineProperty(er, kEnhanceStackBeforeInspector, {
           value: enhanceStackTrace.bind(this, er, capture),
           configurable: true

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -2,6 +2,7 @@
 
 const {
   Error,
+  ErrorCaptureStackTrace,
   MathMax,
   ObjectCreate,
   ObjectDefineProperty,
@@ -422,7 +423,7 @@ class AssertionError extends Error {
     this.expected = expected;
     this.operator = operator;
     // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(this, stackStartFn || stackStartFunction);
+    ErrorCaptureStackTrace(this, stackStartFn || stackStartFunction);
     // Create error message including the error code in the name.
     this.stack;
     // Reset the name.

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {
-  Error,
+  ErrorCaptureStackTrace,
   FunctionPrototypeBind,
   NumberIsSafeInteger,
   ObjectDefineProperty,
@@ -105,7 +105,7 @@ function fatalError(e) {
   } else {
     const o = { message: e };
     // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(o, fatalError);
+    ErrorCaptureStackTrace(o, fatalError);
     process._rawDebug(o.stack);
   }
 

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -7,7 +7,7 @@ const {
   ArrayFrom,
   ArrayIsArray,
   Boolean,
-  Error,
+  ErrorCaptureStackTrace,
   Map,
   MathFloor,
   Number,
@@ -345,7 +345,7 @@ const consoleMethods = {
       message: this[kFormatForStderr](args)
     };
     // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(err, trace);
+    ErrorCaptureStackTrace(err, trace);
     this.error(err.stack);
   },
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -13,6 +13,7 @@
 const {
   ArrayIsArray,
   Error,
+  ErrorCaptureStackTrace,
   Map,
   MathAbs,
   NumberIsInteger,
@@ -295,7 +296,7 @@ function addCodeToName(err, name, code) {
   // Set the stack
   if (excludedStackFn !== undefined) {
     // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(err, excludedStackFn);
+    ErrorCaptureStackTrace(err, excludedStackFn);
   }
   // Add the error code to the name to include it in the stack trace.
   err.name = `${name} [${code}]`;
@@ -433,7 +434,7 @@ function uvException(ctx) {
   }
 
   // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(err, excludedStackFn || uvException);
+  ErrorCaptureStackTrace(err, excludedStackFn || uvException);
   return err;
 }
 
@@ -476,7 +477,7 @@ function uvExceptionWithHostPort(err, syscall, address, port) {
   }
 
   // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(ex, excludedStackFn || uvExceptionWithHostPort);
+  ErrorCaptureStackTrace(ex, excludedStackFn || uvExceptionWithHostPort);
   return ex;
 }
 
@@ -505,7 +506,7 @@ function errnoException(err, syscall, original) {
   ex.syscall = syscall;
 
   // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(ex, excludedStackFn || errnoException);
+  ErrorCaptureStackTrace(ex, excludedStackFn || errnoException);
   return ex;
 }
 
@@ -554,7 +555,7 @@ function exceptionWithHostPort(err, syscall, address, port, additional) {
   }
 
   // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(ex, excludedStackFn || exceptionWithHostPort);
+  ErrorCaptureStackTrace(ex, excludedStackFn || exceptionWithHostPort);
   return ex;
 }
 
@@ -600,7 +601,7 @@ function dnsException(code, syscall, hostname) {
   }
 
   // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(ex, excludedStackFn || dnsException);
+  ErrorCaptureStackTrace(ex, excludedStackFn || dnsException);
   return ex;
 }
 

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -4,7 +4,7 @@ const {
   ArrayIsArray,
   BigInt,
   DateNow,
-  Error,
+  ErrorCaptureStackTrace,
   Number,
   NumberIsFinite,
   ObjectSetPrototypeOf,
@@ -226,7 +226,7 @@ function handleErrorFromBinding(ctx) {
   if (ctx.errno !== undefined) {  // libuv error numbers
     const err = uvException(ctx);
     // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(err, handleErrorFromBinding);
+    ErrorCaptureStackTrace(err, handleErrorFromBinding);
     throw err;
   }
   if (ctx.error !== undefined) {  // Errors created in C++ land.
@@ -234,7 +234,7 @@ function handleErrorFromBinding(ctx) {
     // usually caused by memory problems. We need to figure out proper error
     // code(s) for this.
     // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(ctx.error, handleErrorFromBinding);
+    ErrorCaptureStackTrace(ctx.error, handleErrorFromBinding);
     throw ctx.error;
   }
 }

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -3,6 +3,7 @@
 const {
   ArrayIsArray,
   Error,
+  ErrorCaptureStackTrace,
 } = primordials;
 
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
@@ -121,7 +122,7 @@ function emitWarning(warning, type, code, ctor, now) {
     if (code !== undefined) warning.code = code;
     if (detail !== undefined) warning.detail = detail;
     // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(warning, ctor || process.emitWarning);
+    ErrorCaptureStackTrace(warning, ctor || process.emitWarning);
   } else if (!(warning instanceof Error)) {
     throw new ERR_INVALID_ARG_TYPE('warning', ['Error', 'string'], warning);
   }


### PR DESCRIPTION
Just replaced every Error.captureStackTrace by ErrorCaptureStackTrace in the lib/* folder
For this, i just have added ErrorCaptureStackTrace in the import

```js
const {
  // [...]
  ErrorCaptureStackTrace ,
} = primordials;
```

Of course i have removed unused import of Error 😄
I hope this will be helpful for you 😃 