### PR TITLE
lib: replace BigInt64Array global by the primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -13,6 +13,8 @@ rules:
       message: "Use `const { Array } = primordials;` instead of the global."
     - name: BigInt
       message: "Use `const { BigInt } = primordials;` instead of the global."
+    - name: BigInt64Array
+      message: "Use `const { BigInt64Array } = primordials;` instead of the global."
     - name: BigUint64Array
       message: "Use `const { BigUint64Array } = primordials;` instead of the global."
     - name: Boolean

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -3,6 +3,7 @@
 const {
   Array,
   ArrayIsArray,
+  BigInt64Array,
   BigIntPrototypeValueOf,
   BigUint64Array,
   BooleanPrototypeValueOf,


### PR DESCRIPTION
Hello,
For this PR I have added BigInt64Array in the primordials eslint
And i just have created a line in "/lib/.eslintrc.yaml".

```yaml
rules:
  no-restricted-globals:
  - name: BigInt64Array
      message: "Use `const { BigInt64Array } = primordials;` instead of the global."
```

And just add Set.

```js
const {
  // [...]
  BigInt64Array,
} = primordials;
```

I hope this new PR will help you :x