### PR TITLE
lib: replace BigUInt64Array global by the primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -13,6 +13,8 @@ rules:
       message: "Use `const { Array } = primordials;` instead of the global."
     - name: BigInt
       message: "Use `const { BigInt } = primordials;` instead of the global."
+    - name: BigUint64Array
+      message: "Use `const { BigUint64Array } = primordials;` instead of the global."
     - name: Boolean
       message: "Use `const { Boolean } = primordials;` instead of the global."
     - name: Error

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -6,6 +6,7 @@
 
 const {
   ArrayIsArray,
+  BigUint64Array,
   NumberMAX_SAFE_INTEGER,
   ObjectDefineProperties,
   ObjectDefineProperty,

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -4,6 +4,7 @@ const {
   Array,
   ArrayIsArray,
   BigIntPrototypeValueOf,
+  BigUint64Array,
   BooleanPrototypeValueOf,
   DatePrototypeGetTime,
   DatePrototypeToISOString,


### PR DESCRIPTION
Hello,
For this PR I have added BigUInt64Array in the primordials eslint
And i just have created a line in "/lib/.eslintrc.yaml".

```yaml
rules:
  no-restricted-globals:
  - name: BigUInt64Array
      message: "Use `const { BigUInt64Array } = primordials;` instead of the global."
```

And just add Set.

```js
const {
  // [...]
  BigUInt64Array,
} = primordials;
```

I hope this new PR will help you :x