### PR TITLE
lib: replace Float32Array global by the primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -17,6 +17,8 @@ rules:
       message: "Use `const { Boolean } = primordials;` instead of the global."
     - name: Error
       message: "Use `const { Error } = primordials;` instead of the global."
+    - name: Float32Array
+      message: "Use `const { Float32Array } = primordials;` instead of the global."
     - name: JSON
       message: "Use `const { JSON } = primordials;` instead of the global."
     - name: Map

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -2,6 +2,7 @@
 
 const {
   BigInt,
+  Float32Array,
   MathFloor,
   Number,
 } = primordials;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -9,6 +9,7 @@ const {
   DatePrototypeToISOString,
   DatePrototypeToString,
   ErrorPrototypeToString,
+  Float32Array,
   JSONStringify,
   Map,
   MapPrototype,


### PR DESCRIPTION
Hello,
For this PR I have added Float32Array in the primordials eslint
And i just have created a line in "/lib/.eslintrc.yaml".
```yaml
rules:
  no-restricted-globals:
  - name: Float32Array
      message: "Use `const { Float32Array } = primordials;` instead of the global."
```
And just add Set.
```js
const {
  // [...]
  Float32Array,
} = primordials;
```
I hope this new PR will help you :x