### PR TITLE
build: avoid using CMP for BZ2File

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1540,8 +1540,11 @@ def configure_intl(o):
     os.mkdir(icu_tmp_path)
     icu_data_path = os.path.join(icu_tmp_path, icu_data_file_l)
     with open(icu_data_path, 'wb') as outf:
-        with bz2.BZ2File(compressed_data, 'rb') as inf:
+        inf = bz2.BZ2File(compressed_data, 'rb')
+        try:
             shutil.copyfileobj(inf, outf)
+        finally:
+            inf.close()
     # Now, proceed..
 
   # relative to dep..

--- a/configure.py
+++ b/configure.py
@@ -1542,9 +1542,9 @@ def configure_intl(o):
     with open(icu_data_path, 'wb') as outf:
         inf = bz2.BZ2File(compressed_data, 'rb')
         try:
-            shutil.copyfileobj(inf, outf)
+          shutil.copyfileobj(inf, outf)
         finally:
-            inf.close()
+          inf.close()
     # Now, proceed..
 
   # relative to dep..


### PR DESCRIPTION
Some Python distributions do not support
context manager protocol (CMP) for BZ2File.

Fixes #30949

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)