### PR TITLE
lib: replace Float64Array global by the primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -23,6 +23,8 @@ rules:
       message: "Use `const { Error } = primordials;` instead of the global."
     - name: Float32Array
       message: "Use `const { Float32Array } = primordials;` instead of the global."
+    - name: Float64Array
+      message: "Use `const { Float64Array } = primordials;` instead of the global."
     - name: JSON
       message: "Use `const { JSON } = primordials;` instead of the global."
     - name: Map

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -3,6 +3,7 @@
 const {
   BigInt,
   Float32Array,
+  Float64Array,
   MathFloor,
   Number,
 } = primordials;

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -7,6 +7,7 @@
 const {
   ArrayIsArray,
   BigUint64Array,
+  Float64Array,
   NumberMAX_SAFE_INTEGER,
   ObjectDefineProperties,
   ObjectDefineProperty,

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -12,6 +12,7 @@ const {
   DatePrototypeToString,
   ErrorPrototypeToString,
   Float32Array,
+  Float64Array,
   FunctionPrototypeToString,
   JSONStringify,
   Map,

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -4,6 +4,7 @@
 
 const {
   ArrayIsArray,
+  Float64Array,
   MathMax,
   ObjectCreate,
   ObjectEntries,

--- a/lib/os.js
+++ b/lib/os.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  Float64Array,
   ObjectDefineProperties,
   SymbolToPrimitive,
 } = primordials;


### PR DESCRIPTION
Hello,
For this PR I have added Float64Array in the primordials eslint
And i just have created a line in "/lib/.eslintrc.yaml".
```yaml
rules:
  no-restricted-globals:
  - name: Float64Array 
      message: "Use `const { Float64Array } = primordials;` instead of the global."
```
And just add Float64Array.
```js
const {
  // [...]
  Float64Array,
} = primordials;
```
I hope this new PR will help you :x