### PR TITLE
stream: replace Function.prototype by FunctionPrototype

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -27,6 +27,7 @@
 
 const {
   Array,
+  FunctionPrototype,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   Symbol,
@@ -205,7 +206,7 @@ ObjectDefineProperty(WritableState.prototype, 'buffer', {
 // whose prototype chain only points to Readable.
 var realHasInstance;
 if (typeof Symbol === 'function' && SymbolHasInstance) {
-  realHasInstance = Function.prototype[SymbolHasInstance];
+  realHasInstance = FunctionPrototype[SymbolHasInstance];
   ObjectDefineProperty(Writable, SymbolHasInstance, {
     value: function(object) {
       if (realHasInstance.call(this, object))


### PR DESCRIPTION
Hello 😄

Just replaced every Function.prototype by FunctionPrototype in the lib/* folder
For this, i just have added FunctionPrototype in the import
```js
const {
  // [...]
  FunctionPrototype,
} = primordials;
```
I hope this pull request will help you ! :P