### PR TITLE
lib: add Int16Array primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -23,6 +23,8 @@ rules:
       message: "Use `const { Error } = primordials;` instead of the global."
     - name: Float32Array
       message: "Use `const { Float32Array } = primordials;` instead of the global."
+    - name: Int16Array
+      message: "Use `const { Int16Array } = primordials;` instead of the global."
     - name: JSON
       message: "Use `const { JSON } = primordials;` instead of the global."
     - name: Map

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -13,6 +13,7 @@ const {
   ErrorPrototypeToString,
   Float32Array,
   FunctionPrototypeToString,
+  Int16Array,
   JSONStringify,
   Map,
   MapPrototype,


### PR DESCRIPTION
Hello,
For this PR I have added Int16Array in the primordials eslint
And i just have created a line in "/lib/.eslintrc.yaml".
```yaml
rules:
  no-restricted-globals:
  - name: Int16Array 
      message: "Use `const { Int16Array } = primordials;` instead of the global."
```
And just add Int16Array .
```js
const {
  // [...]
  Int16Array,
} = primordials;
```
I hope this new PR will help you :x