### PR TITLE
lib: add Int32Array primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -24,7 +24,7 @@ rules:
     - name: Float32Array
       message: "Use `const { Float32Array } = primordials;` instead of the global."
     - name: Int32Array
-      message: "Use ``const { Int32Array } = primordials;` instead of the global."
+      message: "Use `const { Int32Array } = primordials;` instead of the global."
     - name: JSON
       message: "Use `const { JSON } = primordials;` instead of the global."
     - name: Map

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -23,6 +23,8 @@ rules:
       message: "Use `const { Error } = primordials;` instead of the global."
     - name: Float32Array
       message: "Use `const { Float32Array } = primordials;` instead of the global."
+    - name: Int32Array
+      message: "Use ``const { Int32Array } = primordials;` instead of the global."
     - name: JSON
       message: "Use `const { JSON } = primordials;` instead of the global."
     - name: Map

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -13,6 +13,7 @@ const {
   ErrorPrototypeToString,
   Float32Array,
   FunctionPrototypeToString,
+  Int32Array,
   JSONStringify,
   Map,
   MapPrototype,


### PR DESCRIPTION
Hello,
For this PR I have added Int32Array in the primordials eslint
And i just have created a line in "/lib/.eslintrc.yaml".
```yaml
rules:
  no-restricted-globals:
  - name: Int32Array 
      message: "Use `const { Int32Array } = primordials;` instead of the global."
```
And just add Int32Array .
```js
const {
  // [...]
  Int32Array,
} = primordials;
```
I hope this new PR will help you :x