### PR TITLE
lib: add RegExp primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -31,6 +31,8 @@ rules:
       message: "Use `const { Promise } = primordials;` instead of the global."
     - name: Reflect
       message: "Use `const { Reflect } = primordials;` instead of the global."
+    - name: RegExp
+      message: "Use `const { RegExp } = primordials;` instead of the global."
     - name: Set
       message: "Use `const { Set } = primordials;` instead of the global."
     - name: Symbol

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -25,6 +25,7 @@ const {
   ObjectAssign,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  RegExp,
   Symbol,
   SymbolFor,
 } = primordials;

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  RegExp,
   Symbol,
 } = primordials;
 

--- a/lib/internal/policy/sri.js
+++ b/lib/internal/policy/sri.js
@@ -5,6 +5,7 @@ const {
   ObjectDefineProperty,
   ObjectFreeze,
   ObjectSeal,
+  RegExp,
   RegExpPrototypeExec,
   RegExpPrototypeTest,
   StringPrototypeSlice,

--- a/lib/internal/readline/utils.js
+++ b/lib/internal/readline/utils.js
@@ -3,6 +3,7 @@
 const {
   Boolean,
   NumberIsInteger,
+  RegExp,
 } = primordials;
 
 // Regex used for ansi escape code splitting

--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  RegExp,
+} = primordials;
+
 const { inspect, format, formatWithOptions } = require('internal/util/inspect');
 
 // `debugs` is deliberately initialized to undefined so any call to

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -33,6 +33,7 @@ const {
   ObjectPrototypeHasOwnProperty,
   ObjectPrototypePropertyIsEnumerable,
   ObjectSeal,
+  RegExp,
   RegExpPrototypeToString,
   Set,
   SetPrototype,

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -56,6 +56,7 @@ const {
   ObjectSetPrototypeOf,
   Promise,
   PromiseRace,
+  RegExp,
   Set,
   Symbol,
   WeakSet,


### PR DESCRIPTION
Hello,
For this PR I have added RegExp in the primordials eslint
And i just have created a line in "/lib/.eslintrc.yaml".
```yaml
rules:
  no-restricted-globals:
  - name: RegExp 
      message: "Use `const { RegExp } = primordials;` instead of the global."
`````
And just add RegExp.
```js
const {
  // [...]
  RegExp,
} = primordials;
```
I hope this new PR will help you :x