### PR TITLE
lib: add String primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -41,6 +41,8 @@ rules:
       message: "Use `const { RegExp } = primordials;` instead of the global."
     - name: Set
       message: "Use `const { Set } = primordials;` instead of the global."
+    - name: String
+      message: "Use `const { String } = primordials;` instead of the global."
     - name: Symbol
       message: "Use `const { Symbol } = primordials;` instead of the global."
     - name: Uint16Array

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -29,6 +29,7 @@ const {
   ObjectAssign,
   ObjectKeys,
   ObjectSetPrototypeOf,
+  String,
   Symbol
 } = primordials;
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -29,6 +29,7 @@ const {
   Map,
   NumberIsNaN,
   RegExpPrototypeTest,
+  String,
 } = primordials;
 
 const { Buffer } = require('buffer');

--- a/lib/events.js
+++ b/lib/events.js
@@ -36,6 +36,7 @@ const {
   PromiseResolve,
   ReflectApply,
   ReflectOwnKeys,
+  String,
   Symbol,
   SymbolFor,
   SymbolAsyncIterator

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -7,6 +7,7 @@ const {
   ObjectDefineProperty,
   ObjectGetPrototypeOf,
   ObjectKeys,
+  String,
 } = primordials;
 
 const { inspect } = require('internal/util/inspect');

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -52,6 +52,7 @@ const {
   ObjectPrototypeHasOwnProperty,
   ReflectGet,
   SafeSet,
+  String,
 } = primordials;
 
 // Set up process.moduleLoadList.

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -19,12 +19,9 @@ const {
   NumberIsInteger,
   ObjectDefineProperty,
   ObjectKeys,
-<<<<<<< HEAD
   StringPrototypeSlice,
   StringPrototypeStartsWith,
-=======
   String,
->>>>>>> lib: add String primordials
   Symbol,
   SymbolFor,
   WeakMap,

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -19,8 +19,12 @@ const {
   NumberIsInteger,
   ObjectDefineProperty,
   ObjectKeys,
+<<<<<<< HEAD
   StringPrototypeSlice,
   StringPrototypeStartsWith,
+=======
+  String,
+>>>>>>> lib: add String primordials
   Symbol,
   SymbolFor,
   WeakMap,

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -6,6 +6,7 @@ const {
   Map,
   Object,
   Set,
+  String,
   Symbol,
   NumberIsNaN,
 } = primordials;

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -8,6 +8,7 @@ const {
   ObjectCreate,
   ObjectKeys,
   Set,
+  String,
   Symbol,
 } = primordials;
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -39,10 +39,7 @@ const {
   ReflectSet,
   RegExpPrototypeTest,
   SafeMap,
-<<<<<<< HEAD
   SafeWeakMap,
-=======
->>>>>>> lib: add String primordials
   String,
   StringPrototypeIndexOf,
   StringPrototypeLastIndexOf,

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -39,7 +39,10 @@ const {
   ReflectSet,
   RegExpPrototypeTest,
   SafeMap,
+<<<<<<< HEAD
   SafeWeakMap,
+=======
+>>>>>>> lib: add String primordials
   String,
   StringPrototypeIndexOf,
   StringPrototypeLastIndexOf,

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -3,6 +3,7 @@
 const {
   ArrayIsArray,
   Error,
+  String,
 } = primordials;
 
 const assert = require('internal/assert');

--- a/lib/internal/readline/utils.js
+++ b/lib/internal/readline/utils.js
@@ -2,7 +2,7 @@
 
 const {
   String,
-  Symbol
+  Symbol,
 } = primordials;
 
 const kUTF16SurrogateThreshold = 0x10000; // 2 ** 16

--- a/lib/internal/readline/utils.js
+++ b/lib/internal/readline/utils.js
@@ -1,7 +1,13 @@
 'use strict';
 
 const {
+<<<<<<< HEAD
   Symbol,
+=======
+  Boolean,
+  NumberIsInteger,
+  String,
+>>>>>>> lib: add String primordials
 } = primordials;
 
 const kUTF16SurrogateThreshold = 0x10000; // 2 ** 16

--- a/lib/internal/readline/utils.js
+++ b/lib/internal/readline/utils.js
@@ -1,13 +1,8 @@
 'use strict';
 
 const {
-<<<<<<< HEAD
-  Symbol,
-=======
-  Boolean,
-  NumberIsInteger,
   String,
->>>>>>> lib: add String primordials
+  Symbol
 } = primordials;
 
 const kUTF16SurrogateThreshold = 0x10000; // 2 ** 16

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -11,6 +11,7 @@ const {
   ObjectKeys,
   ReflectGetOwnPropertyDescriptor,
   ReflectOwnKeys,
+  String,
   Symbol,
   SymbolIterator,
   SymbolToStringTag,

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -42,6 +42,7 @@ const {
   Set,
   SetPrototype,
   SetPrototypeValues,
+  String,
   StringPrototypeValueOf,
   SymbolPrototypeToString,
   SymbolPrototypeValueOf,

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -9,6 +9,7 @@ const {
   ObjectEntries,
   Promise,
   PromiseResolve,
+  String,
   Symbol,
   SymbolFor,
 } = primordials;

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -28,6 +28,7 @@ const {
   ArrayIsArray,
   ObjectCreate,
   ObjectKeys,
+  String,
 } = primordials;
 
 const { Buffer } = require('buffer');

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -26,6 +26,7 @@ const {
   ArrayIsArray,
   ObjectDefineProperty,
   ObjectFreeze,
+  String,
 } = primordials;
 
 const {

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -4,6 +4,7 @@ const {
   ArrayPrototypePush,
   FunctionPrototypeBind,
   ObjectEntries,
+  String,
   Symbol,
 } = primordials;
 


### PR DESCRIPTION
Hello,
For this PR I have added String in the primordials eslint
And i just have created a line in "/lib/.eslintrc.yaml".
```yaml
rules:
  no-restricted-globals:
  - name: String 
      message: "Use `const { String } = primordials;` instead of the global."
```
And just add String.
```js
const {
  // [...]
  String,
} = primordials;
```
I hope this new PR will help you :x