### PR TITLE
lib: add Uint16Array primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -35,6 +35,8 @@ rules:
       message: "Use `const { Set } = primordials;` instead of the global."
     - name: Symbol
       message: "Use `const { Symbol } = primordials;` instead of the global."
+    - name: Uint16Array
+      message: "Use `const { Uint16Array } = primordials;` instead of the global."
     - name: WeakMap
       message: "Use `const { WeakMap } = primordials;` instead of the global."
     - name: WeakSet

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -42,6 +42,7 @@ const {
   SymbolPrototypeValueOf,
   SymbolIterator,
   SymbolToStringTag,
+  Uint16Array,
   uncurryThis,
 } = primordials;
 


### PR DESCRIPTION
Hello,
For this PR I have added Uint16Array in the primordials eslint
And i just have created a line in "/lib/.eslintrc.yaml".
```yaml
rules:
  no-restricted-globals:
  - name: Uint16Array 
      message: "Use `const { Uint16Array } = primordials;` instead of the global."
```
And just add Uint16Array.
```js
const {
  // [...]
  Uint16Array,
} = primordials;
```
I hope this new PR will help you :x