### PR TITLE
win: change to use Python in install tool

### DIFF
--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -38,7 +38,7 @@ echo result of a Chocolatey install. This acceptance occurs whether you know the
 echo license terms or not. Read and understand the license terms of the packages
 echo being installed and their dependencies prior to installation:
 echo - https://chocolatey.org/packages/chocolatey
-echo - https://chocolatey.org/packages/python2
+echo - https://chocolatey.org/packages/python
 echo - https://chocolatey.org/packages/visualstudio2017-workload-vctools
 echo.
 echo This script is provided AS-IS without any warranties of any kind
@@ -52,4 +52,4 @@ pause
 
 cls
 
-"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command Start-Process '%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe' -ArgumentList '-NoProfile -InputFormat None -ExecutionPolicy Bypass -Command iex ((New-Object System.Net.WebClient).DownloadString(''https://chocolatey.org/install.ps1'')); choco upgrade -y python2 visualstudio2017-workload-vctools; Read-Host ''Type ENTER to exit'' ' -Verb RunAs
+"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command Start-Process '%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe' -ArgumentList '-NoProfile -InputFormat None -ExecutionPolicy Bypass -Command iex ((New-Object System.Net.WebClient).DownloadString(''https://chocolatey.org/install.ps1'')); choco upgrade -y python visualstudio2017-workload-vctools; Read-Host ''Type ENTER to exit'' ' -Verb RunAs

--- a/tools/msvs/msi/i18n/en-us.wxl
+++ b/tools/msvs/msi/i18n/en-us.wxl
@@ -12,7 +12,7 @@
     <String Id="NativeToolsDlgTitle">{\WixUI_Font_Title}Tools for Native Modules</String>
     <String Id="NativeToolsDlgDescription">Optionally install the tools necessary to compile native modules.</String>
     <String Id="NativeToolsDlgBannerBitmap">WixUI_Bmp_Banner</String>
-    <String Id="NativeToolsDlgIntro">Some npm modules need to be compiled from C/C++ when installing. If you want to be able to install such modules, some tools (Python 2 and Visual Studio Build Tools) need to be installed.</String>
+    <String Id="NativeToolsDlgIntro">Some npm modules need to be compiled from C/C++ when installing. If you want to be able to install such modules, some tools (Python and Visual Studio Build Tools) need to be installed.</String>
     <String Id="NativeToolsDlgInstallCheckbox">Automatically install the necessary tools. Note that this will also install Chocolatey. The script will pop-up in a new window after the installation completes.</String>
     <String Id="NativeToolsDlgManualDetails">Alternatively, follow the instructions at <![CDATA[<a href="https://github.com/nodejs/node-gyp#on-windows">https://github.com/nodejs/node-gyp#on-windows</a>]]> to install the dependencies yourself.</String>
 


### PR DESCRIPTION
Now our toolchain in Python3 compatible, this need to update.

cc @nodejs/platform-windows 

Related: https://github.com/nodejs/node-gyp/issues/1977#issuecomment-570833317.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


