### PR TITLE
stream: support passing generator functions into pipeline

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1568,6 +1568,9 @@ changes:
   * Returns: {Stream|Iterable|AsyncIterable}
 * `...streams` {Stream|Function}
   * `source` {AsyncIterable}
+  * Returns: {Stream|AsyncIterable}
+* `destination` {Stream|Function}
+  * `source` {AsyncIterable}
   * Returns: {Stream|AsyncIterable|Promise}
 * `callback` {Function} Called when the pipeline is fully done.
   * `err` {Error}

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1565,13 +1565,13 @@ changes:
 -->
 
 * `source` {Stream|Iterable|AsyncIterable|Function}
-  * Returns: {Stream|Iterable|AsyncIterable}
+  * Returns: {Iterable|AsyncIterable}
 * `...streams` {Stream|Function}
   * `source` {AsyncIterable}
-  * Returns: {Stream|AsyncIterable}
+  * Returns: {AsyncIterable}
 * `destination` {Stream|Function}
   * `source` {AsyncIterable}
-  * Returns: {Stream|AsyncIterable|Promise}
+  * Returns: {AsyncIterable|Promise}
 * `callback` {Function} Called when the pipeline is fully done.
   * `err` {Error}
 * Returns: {Stream}

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1574,6 +1574,7 @@ changes:
   * Returns: {AsyncIterable|Promise}
 * `callback` {Function} Called when the pipeline is fully done.
   * `err` {Error}
+  * `val` Resolved value of `Promise` returned by `destination`.
 * Returns: {Stream}
 
 A module method to pipe between streams and generators forwarding errors and

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1642,7 +1642,7 @@ async function run() {
       const fd = await fs.open('archive.tar', 'w');
       try {
         for await (const chunk of source) {
-          fs.write(fd, chunk);
+          await fs.write(fd, chunk);
         }
       } finally {
         await fs.close(fd);

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1555,7 +1555,7 @@ const cleanup = finished(rs, (err) => {
 });
 ```
 
-### `stream.pipeline(source, ...streams, callback)`
+### `stream.pipeline(source, ...transforms, destination, callback)`
 <!-- YAML
 added: v10.0.0
 changes:
@@ -1566,7 +1566,7 @@ changes:
 
 * `source` {Stream|Iterable|AsyncIterable|Function}
   * Returns: {Iterable|AsyncIterable}
-* `...streams` {Stream|Function}
+* `...transforms` {Stream|Function}
   * `source` {AsyncIterable}
   * Returns: {AsyncIterable}
 * `destination` {Stream|Function}
@@ -2883,7 +2883,7 @@ contain multi-byte characters.
 [`stream.cork()`]: #stream_writable_cork
 [`stream.finished()`]: #stream_stream_finished_stream_options_callback
 [`stream.pipe()`]: #stream_readable_pipe_destination_options
-[`stream.pipeline()`]: #stream_stream_pipeline_source_streams_callback
+[`stream.pipeline()`]: #stream_stream_pipeline_source_transforms_destination_callback
 [`stream.uncork()`]: #stream_writable_uncork
 [`stream.unpipe()`]: #stream_readable_unpipe_destination
 [`stream.wrap()`]: #stream_readable_wrap_stream

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1561,7 +1561,7 @@ added: v10.0.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/31223
-    description: Add support for functions generators and async generators.
+    description: Add support for async generators.
 -->
 
 * `source` {Stream|Iterable|AsyncIterable|Function}
@@ -2747,7 +2747,7 @@ const pipeline = util.promisify(stream.pipeline);
 const writable = fs.createWriteStream('./file');
 
 (async function() {
-  await pipeline(iterator, writable);
+  await pipeline(iterable, writable);
 })();
 ```
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1561,7 +1561,7 @@ added: v10.0.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/31223
-    description: Add support for functions and generators.
+    description: Add support for functions generators and async generators.
 -->
 
 * `source` {Stream|Iterable|AsyncIterable|Function}

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -118,7 +118,7 @@ async function* _fromReadable(val) {
     }
 
     val = val
-      .on('error', err => val.destroy(err))
+      .on('error', (err) => val.destroy(err))
       .pipe(new PassThrough());
   }
 
@@ -195,13 +195,13 @@ function pipeline(...streams) {
         ret = stream();
         if (!isIterable(ret)) {
           throw new ERR_INVALID_RETURN_VALUE(
-            'Iterable, AsyncIterable, Stream', 'source', ret);
+            'Iterable, AsyncIterable or Stream', 'source', ret);
         }
       } else if (isIterable(stream) || isReadable(stream)) {
         ret = stream;
       } else {
         throw new ERR_INVALID_ARG_TYPE(
-          `source`, ['Stream', 'Iterable', 'AsyncIterable', 'Function'],
+          'source', ['Stream', 'Iterable', 'AsyncIterable', 'Function'],
           stream);
       }
     } else if (typeof stream === 'function') {
@@ -232,7 +232,7 @@ function pipeline(...streams) {
           pump(ret, pt, finish);
         } else {
           throw new ERR_INVALID_RETURN_VALUE(
-            'AsyncIterable, Promise', `destination`, ret);
+            'AsyncIterable or Promise', 'destination', ret);
         }
 
         ret = pt;

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -97,15 +97,9 @@ function makeAsyncIterable(val, name) {
     return val;
   } else if (isReadable(val)) {
     return _fromReadable(val);
-  } else if (isPromise(val)) {
-    // Generator will subscribe to the promise in a lazy fashion
-    // while the promise executes eagerly. Thus we need to register
-    // a rejection handler to avoid unhandled rejection errors.
-    val.catch(nop);
-    return _fromPromise(val);
   } else {
     throw new ERR_INVALID_RETURN_VALUE(
-      'AsyncIterable, Readable or Promise', name, val);
+      'AsyncIterable, Readable', name, val);
   }
 }
 

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -21,8 +21,8 @@ const {
 } = require('internal/errors').codes;
 
 let EE;
-let Readable;
-let Passthrough;
+let PassThrough;
+let createReadableStreamAsyncIterator;
 
 function nop() {}
 
@@ -96,6 +96,7 @@ function makeAsyncIterable(val, name) {
   if (isIterable(val)) {
     return val;
   } else if (isReadable(val)) {
+    // Legacy streams are not Iterable.
     return _fromReadable(val);
   } else {
     throw new ERR_INVALID_RETURN_VALUE(
@@ -103,28 +104,21 @@ function makeAsyncIterable(val, name) {
   }
 }
 
-async function* _fromPromise(val) {
-  yield await val;
-}
-
 async function* _fromReadable(val) {
-  if (isReadable(val)) {
-    // Legacy streams are not Iterable.
+  if (!createReadableStreamAsyncIterator) {
+    createReadableStreamAsyncIterator =
+      require('internal/streams/async_iterator');
+  }
 
-    if (!Readable) {
-      Readable = require('_stream_readable');
+  try {
+    const it = createReadableStreamAsyncIterator(val);
+    while (true) {
+      const { value, done } = await it.next();
+      if (done) return;
+      yield value;
     }
-
-    try {
-      const it = Readable.prototype[SymbolAsyncIterator].call(val);
-      while (true) {
-        const { value, done } = await it.next();
-        if (done) return;
-        yield value;
-      }
-    } finally {
-      val.destroy();
-    }
+  } finally {
+    val.destroy();
   }
 }
 
@@ -200,12 +194,14 @@ function pipeline(...streams) {
           stream);
       }
     } else if (typeof stream === 'function') {
-      ret = stream(makeAsyncIterable(ret, `streams[${i - 1}]`));
+      ret = makeAsyncIterable(ret, `streams[${i - 1}]`);
+      ret = stream(ret);
     } else if (isStream(stream)) {
       if (isReadable(ret)) {
         ret.pipe(stream);
       } else {
-        pump(makeAsyncIterable(ret, `streams[${i - 1}]`), stream, finish);
+        ret = makeAsyncIterable(ret, `streams[${i - 1}]`);
+        pump(ret, stream, finish);
       }
       ret = stream;
     } else {
@@ -215,11 +211,11 @@ function pipeline(...streams) {
   }
 
   if (!isStream(ret)) {
-    if (!Passthrough) {
-      Passthrough = require('_stream_passthrough');
+    if (!PassThrough) {
+      PassThrough = require('_stream_passthrough');
     }
 
-    const pt = new Passthrough();
+    const pt = new PassThrough();
 
     if (isPromise(ret)) {
       // Finish eagerly

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -109,23 +109,29 @@ async function* _fromReadable(val) {
       require('internal/streams/async_iterator');
   }
 
-  if (typeof val.read !== 'function') {
-    // createReadableStreamAsyncIterator does not support
-    // v1 streams. Convert it into a v2 stream.
-
-    if (!PassThrough) {
-      PassThrough = require('_stream_passthrough');
-    }
-
-    val = val
-      .on('error', (err) => val.destroy(err))
-      .pipe(new PassThrough());
-  }
-
   try {
-    yield* createReadableStreamAsyncIterator(val);
+    if (typeof val.read !== 'function') {
+      // createReadableStreamAsyncIterator does not support
+      // v1 streams. Convert it into a v2 stream.
+
+      if (!PassThrough) {
+        PassThrough = require('_stream_passthrough');
+      }
+
+      const pt = new PassThrough();
+      val
+        .on('error', (err) => pt.destroy(err))
+        .pipe(pt);
+      yield* createReadableStreamAsyncIterator(pt);
+    } else {
+      yield* createReadableStreamAsyncIterator(val);
+    }
   } finally {
-    val.destroy();
+    if (typeof val.destroy === 'function') {
+      val.destroy();
+    } else if (typeof val.close === 'function') {
+      val.close();
+    }
   }
 }
 

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -23,6 +23,8 @@ const {
 let EE;
 let Readable;
 
+function nop() {}
+
 function isRequest(stream) {
   return stream && stream.setHeader && typeof stream.abort === 'function';
 }
@@ -95,6 +97,10 @@ function makeAsyncIterable(val, name) {
   } else if (isReadable(val)) {
     return _fromReadable(val);
   } else if (isPromise(val)) {
+    // Generator will subscribe to the promise in a lazy fashion
+    // while the promise executes eagerly. Thus we need to register
+    // a rejection handler to avoid unhandled rejection errors.
+    val.catch(nop);
     return _fromPromise(val);
   } else {
     throw new ERR_INVALID_RETURN_VALUE(

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -24,8 +24,6 @@ let EE;
 let PassThrough;
 let createReadableStreamAsyncIterator;
 
-function nop() {}
-
 function isRequest(stream) {
   return stream && stream.setHeader && typeof stream.abort === 'function';
 }
@@ -109,6 +107,19 @@ async function* _fromReadable(val) {
   if (!createReadableStreamAsyncIterator) {
     createReadableStreamAsyncIterator =
       require('internal/streams/async_iterator');
+  }
+
+  if (typeof val.read !== 'function') {
+    // createReadableStreamAsyncIterator does not support
+    // v1 streams. Convert it into a v2 stream.
+
+    if (!PassThrough) {
+      PassThrough = require('_stream_passthrough');
+    }
+
+    val = val
+      .on('error', err => val.destroy(err))
+      .pipe(new PassThrough());
   }
 
   try {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -99,8 +99,8 @@ function makeAsyncIterable(val, name) {
     // Legacy streams are not Iterable.
     return _fromReadable(val);
   } else {
-    throw new ERR_INVALID_RETURN_VALUE(
-      'AsyncIterable, Readable', name, val);
+    throw new ERR_INVALID_ARG_TYPE(
+      'val', ['Readable', 'Iterable', 'AsyncIterable'], val);
   }
 }
 
@@ -186,53 +186,64 @@ function pipeline(...streams) {
     if (i === 0) {
       if (typeof stream === 'function') {
         ret = stream();
+        if (!isIterable(ret)) {
+          throw new ERR_INVALID_RETURN_VALUE(
+            'Iterable, AsyncIterable, Stream', 'source', ret);
+        }
       } else if (isIterable(stream) || isReadable(stream)) {
         ret = stream;
       } else {
         throw new ERR_INVALID_ARG_TYPE(
-          `streams[${i}]`, ['Stream', 'Iterable', 'AsyncIterable', 'Function'],
+          `source`, ['Stream', 'Iterable', 'AsyncIterable', 'Function'],
           stream);
       }
     } else if (typeof stream === 'function') {
-      ret = makeAsyncIterable(ret, `streams[${i - 1}]`);
+      ret = makeAsyncIterable(ret);
       ret = stream(ret);
+
+      if (reading) {
+        if (!isIterable(ret)) {
+          throw new ERR_INVALID_RETURN_VALUE(
+            'AsyncIterable', `transform[${i - 1}]`, ret);
+        }
+      } else if (!isStream(ret)) {
+        if (!PassThrough) {
+          PassThrough = require('_stream_passthrough');
+        }
+
+        const pt = new PassThrough();
+        if (isPromise(ret)) {
+          ret
+            .then((val) => {
+              pt.end(val);
+              finish(null, val, true);
+            })
+            .catch((err) => {
+              finish(err, null, true);
+            });
+        } else if (isIterable(ret, true)) {
+          pump(ret, pt, finish);
+        } else {
+          throw new ERR_INVALID_RETURN_VALUE(
+            'AsyncIterable, Promise', `destination`, ret);
+        }
+
+        ret = pt;
+        wrap(ret, true, false, true);
+      }
     } else if (isStream(stream)) {
       if (isReadable(ret)) {
         ret.pipe(stream);
       } else {
-        ret = makeAsyncIterable(ret, `streams[${i - 1}]`);
+        ret = makeAsyncIterable(ret);
         pump(ret, stream, finish);
       }
       ret = stream;
     } else {
+      const name = reading ? `transform[${i - 1}]` : 'destination';
       throw new ERR_INVALID_ARG_TYPE(
-        `streams[${i}]`, ['Stream', 'Function'], ret);
+        name, ['Stream', 'Function'], ret);
     }
-  }
-
-  if (!isStream(ret)) {
-    if (!PassThrough) {
-      PassThrough = require('_stream_passthrough');
-    }
-
-    const pt = new PassThrough();
-
-    if (isPromise(ret)) {
-      // Finish eagerly
-      ret
-        .then((val) => {
-          pt.end(val);
-          finish(null, val, true);
-        })
-        .catch((err) => {
-          finish(err, null, true);
-        });
-    } else {
-      pump(makeAsyncIterable(ret, `streams[${streams.length - 1}]`), pt, finish);
-    }
-
-    ret = pt;
-    wrap(ret, true, false, true);
   }
 
   return ret;

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -89,6 +89,63 @@ function isIterable(obj, isAsync) {
   return !!(obj[SymbolAsyncIterator] || obj[SymbolIterator]);
 }
 
+
+function makeAsyncIterable(val, name) {
+  if (isIterable(val)) {
+    return val;
+  } else if (isReadable(val)) {
+    return _fromReadable(val);
+  } else if (isPromise(val)) {
+    return _fromPromise(val);
+  } else {
+    throw new ERR_INVALID_RETURN_VALUE(
+      'AsyncIterable, Readable or Promise', name, val);
+  }
+}
+
+async function* _fromPromise(val) {
+  yield await val;
+}
+
+async function* _fromReadable(val) {
+  if (isReadable(val)) {
+    // Legacy streams are not Iterable.
+
+    if (!Readable) {
+      Readable = require('_stream_readable');
+    }
+
+    try {
+      const it = Readable.prototype[SymbolAsyncIterator].call(val);
+      while (true) {
+        const { value, done } = await it.next();
+        if (done) return;
+        yield value;
+      }
+    } finally {
+      val.destroy();
+    }
+  }
+}
+
+async function pump(iterable, writable, finish) {
+  if (!EE) {
+    EE = require('events');
+  }
+  try {
+    for await (const chunk of iterable) {
+      if (!writable.write(chunk)) {
+        if (writable.destroyed) return;
+        await EE.once(writable, 'drain');
+      }
+    }
+    writable.end();
+  } catch (err) {
+    finish(err);
+  }
+}
+
+
 function pipeline(...streams) {
   const callback = once(popCallback(streams));
 
@@ -117,63 +174,10 @@ function pipeline(...streams) {
     }
   }
 
-  async function pump(iterable, writable) {
-    if (!EE) {
-      EE = require('events');
-    }
-    try {
-      for await (const chunk of iterable) {
-        if (!writable.write(chunk)) {
-          if (writable.destroyed) return;
-          await EE.once(writable, 'drain');
-        }
-      }
-      writable.end();
-    } catch (err) {
-      finish(err);
-    }
-  }
-
   function wrap(stream, reading, writing, final) {
     destroys.push(destroyer(stream, reading, writing, (err) => {
       finish(err, null, final);
     }));
-  }
-
-  function makeAsyncIterable(val, name) {
-    if (isIterable(val)) {
-      return val;
-    } else if (isReadable(val)) {
-      return _fromReadable(val);
-    } else if (isPromise(val)) {
-      return _fromPromise(val);
-    } else {
-      throw new ERR_INVALID_RETURN_VALUE(
-        'AsyncIterable, Readable or Promise', name, val);
-    }
-  }
-
-  async function* _fromPromise(val) {
-    yield await val;
-  }
-
-  async function* _fromReadable(val) {
-    if (isReadable(val)) {
-      // Legacy streams are not Iterable.
-
-      if (!Readable) {
-        Readable = require('_stream_readable');
-      }
-
-      wrap(val, true, false, false);
-
-      const it = Readable.prototype[SymbolAsyncIterator].call(val);
-      while (true) {
-        const { value, done } = await it.next();
-        if (done) return;
-        yield value;
-      }
-    }
   }
 
   let ret;
@@ -202,7 +206,7 @@ function pipeline(...streams) {
       if (isReadable(ret)) {
         ret.pipe(stream);
       } else {
-        pump(makeAsyncIterable(ret, `streams[${i - 1}]`), stream);
+        pump(makeAsyncIterable(ret, `streams[${i - 1}]`), stream, finish);
       }
       ret = stream;
     } else {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -5,16 +5,23 @@
 
 const {
   ArrayIsArray,
+  SymbolAsyncIterator,
+  SymbolIterator
 } = primordials;
 
 let eos;
 
 const { once } = require('internal/util');
 const {
+  ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_RETURN_VALUE,
   ERR_INVALID_CALLBACK,
   ERR_MISSING_ARGS,
   ERR_STREAM_DESTROYED
 } = require('internal/errors').codes;
+
+let EE;
+let Readable;
 
 function isRequest(stream) {
   return stream && stream.setHeader && typeof stream.abort === 'function';
@@ -50,10 +57,6 @@ function destroyer(stream, reading, writing, callback) {
   };
 }
 
-function pipe(from, to) {
-  return from.pipe(to);
-}
-
 function popCallback(streams) {
   // Streams should never be an empty array. It should always contain at least
   // a single stream. Therefore optimize for the average case instead of
@@ -63,8 +66,31 @@ function popCallback(streams) {
   return streams.pop();
 }
 
+function isPromise(obj) {
+  return !!(obj && typeof obj.then === 'function');
+}
+
+function isReadable(obj) {
+  return !!(obj && typeof obj.pipe === 'function');
+}
+
+function isWritable(obj) {
+  return !!(obj && typeof obj.write === 'function');
+}
+
+function isStream(obj) {
+  return isReadable(obj) || isWritable(obj);
+}
+
+function isIterable(obj, isAsync) {
+  if (!obj) return false;
+  if (isAsync === true) return !!obj[SymbolAsyncIterator];
+  if (isAsync === false) return !!obj[SymbolIterator];
+  return !!(obj[SymbolAsyncIterator] || obj[SymbolIterator]);
+}
+
 function pipeline(...streams) {
-  const callback = popCallback(streams);
+  const callback = once(popCallback(streams));
 
   if (ArrayIsArray(streams[0])) streams = streams[0];
 
@@ -73,25 +99,141 @@ function pipeline(...streams) {
   }
 
   let error;
-  const destroys = streams.map(function(stream, i) {
-    const reading = i < streams.length - 1;
-    const writing = i > 0;
-    return destroyer(stream, reading, writing, function(err) {
-      if (!error) error = err;
-      if (err) {
-        for (const destroy of destroys) {
-          destroy(err);
+  const destroys = [];
+
+  function finish(err, val, final) {
+    if (!error && err) {
+      error = err;
+    }
+
+    if (error || final) {
+      for (const destroy of destroys) {
+        destroy(error);
+      }
+    }
+
+    if (final) {
+      callback(error, val);
+    }
+  }
+
+  async function pump(iterable, writable) {
+    if (!EE) {
+      EE = require('events');
+    }
+    try {
+      for await (const chunk of iterable) {
+        if (!writable.write(chunk)) {
+          if (writable.destroyed) return;
+          await EE.once(writable, 'drain');
         }
       }
-      if (reading) return;
-      for (const destroy of destroys) {
-        destroy();
-      }
-      callback(error);
-    });
-  });
+      writable.end();
+    } catch (err) {
+      finish(err);
+    }
+  }
 
-  return streams.reduce(pipe);
+  function wrap(stream, reading, writing, final) {
+    destroys.push(destroyer(stream, reading, writing, (err) => {
+      finish(err, null, final);
+    }));
+  }
+
+  function makeAsyncIterable(val, name) {
+    if (isIterable(val)) {
+      return val;
+    } else if (isReadable(val)) {
+      return _fromReadable(val);
+    } else if (isPromise(val)) {
+      return _fromPromise(val);
+    } else {
+      throw new ERR_INVALID_RETURN_VALUE(
+        'AsyncIterable, Readable or Promise', name, val);
+    }
+  }
+
+  async function* _fromPromise(val) {
+    yield await val;
+  }
+
+  async function* _fromReadable(val) {
+    if (isReadable(val)) {
+      // Legacy streams are not Iterable.
+
+      if (!Readable) {
+        Readable = require('_stream_readable');
+      }
+
+      wrap(val, true, false, false);
+
+      const it = Readable.prototype[SymbolAsyncIterator].call(val);
+      while (true) {
+        const { value, done } = await it.next();
+        if (done) return;
+        yield value;
+      }
+    }
+  }
+
+  let ret;
+  for (let i = 0; i < streams.length; i++) {
+    const stream = streams[i];
+    const reading = i < streams.length - 1;
+    const writing = i > 0;
+
+    if (isStream(stream)) {
+      wrap(stream, reading, writing, !reading);
+    }
+
+    if (i === 0) {
+      if (typeof stream === 'function') {
+        ret = stream();
+      } else if (isIterable(stream) || isReadable(stream)) {
+        ret = stream;
+      } else {
+        throw new ERR_INVALID_ARG_TYPE(
+          `streams[${i}]`, ['Stream', 'Iterable', 'AsyncIterable', 'Function'],
+          stream);
+      }
+    } else if (typeof stream === 'function') {
+      ret = stream(makeAsyncIterable(ret, `streams[${i - 1}]`));
+    } else if (isStream(stream)) {
+      if (isReadable(ret)) {
+        ret.pipe(stream);
+      } else {
+        pump(makeAsyncIterable(ret, `streams[${i - 1}]`), stream);
+      }
+      ret = stream;
+    } else {
+      throw new ERR_INVALID_ARG_TYPE(
+        `streams[${i}]`, ['Stream', 'Function'], ret);
+    }
+  }
+
+  if (!isStream(ret)) {
+    if (!Readable) {
+      Readable = require('_stream_readable');
+    }
+
+    if (isPromise(ret)) {
+      // Finish eagerly
+      ret
+        .then((val) => {
+          finish(null, val, true);
+        })
+        .catch((err) => {
+          finish(err, null, true);
+        });
+    }
+
+    ret = Readable
+      .from(makeAsyncIterable(ret, `streams[${streams.length - 1}]`));
+
+    wrap(ret, true, false, true);
+  }
+
+  return ret;
 }
 
 module.exports = pipeline;

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -28,6 +28,14 @@ function isRequest(stream) {
   return stream && stream.setHeader && typeof stream.abort === 'function';
 }
 
+function destroyStream(stream, err) {
+  // request.destroy just do .end - .abort is what we want
+  if (isRequest(stream)) return stream.abort();
+  if (isRequest(stream.req)) return stream.req.abort();
+  if (typeof stream.destroy === 'function') return stream.destroy(err);
+  if (typeof stream.close === 'function') return stream.close();
+}
+
 function destroyer(stream, reading, writing, callback) {
   callback = once(callback);
 
@@ -49,10 +57,7 @@ function destroyer(stream, reading, writing, callback) {
     if (destroyed) return;
     destroyed = true;
 
-    // request.destroy just do .end - .abort is what we want
-    if (isRequest(stream)) return stream.abort();
-    if (isRequest(stream.req)) return stream.req.abort();
-    if (typeof stream.destroy === 'function') return stream.destroy(err);
+    destroyStream(stream, err);
 
     callback(err || new ERR_STREAM_DESTROYED('pipe'));
   };
@@ -127,11 +132,7 @@ async function* _fromReadable(val) {
       yield* createReadableStreamAsyncIterator(val);
     }
   } finally {
-    if (typeof val.destroy === 'function') {
-      val.destroy();
-    } else if (typeof val.close === 'function') {
-      val.close();
-    }
+    destroyStream(val);
   }
 }
 

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -201,7 +201,7 @@ function pipeline(...streams) {
           throw new ERR_INVALID_RETURN_VALUE(
             'AsyncIterable', `transform[${i - 1}]`, ret);
         }
-      } else if (!isStream(ret)) {
+      } else {
         if (!PassThrough) {
           PassThrough = require('_stream_passthrough');
         }

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -216,7 +216,7 @@ function pipeline(...streams) {
       ret = stream(ret);
 
       if (reading) {
-        if (!isIterable(ret)) {
+        if (!isIterable(ret, true)) {
           throw new ERR_INVALID_RETURN_VALUE(
             'AsyncIterable', `transform[${i - 1}]`, ret);
         }

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -87,12 +87,13 @@ function isStream(obj) {
 
 function isIterable(obj, isAsync) {
   if (!obj) return false;
-  if (isAsync === true) return !!obj[SymbolAsyncIterator];
-  if (isAsync === false) return !!obj[SymbolIterator];
-  return !!(obj[SymbolAsyncIterator] || obj[SymbolIterator]);
+  if (isAsync === true) return typeof obj[SymbolAsyncIterator] === 'function';
+  if (isAsync === false) return typeof obj[SymbolIterator] === 'function';
+  return typeof obj[SymbolAsyncIterator] === 'function' ||
+    typeof obj[SymbolIterator] === 'function';
 }
 
-function makeAsyncIterable(val, name) {
+function makeAsyncIterable(val) {
   if (isIterable(val)) {
     return val;
   } else if (isReadable(val)) {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -111,12 +111,7 @@ async function* _fromReadable(val) {
   }
 
   try {
-    const it = createReadableStreamAsyncIterator(val);
-    while (true) {
-      const { value, done } = await it.next();
-      if (done) return;
-      yield value;
-    }
+    yield* createReadableStreamAsyncIterator(val);
   } finally {
     val.destroy();
   }

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -22,6 +22,7 @@ const {
 
 let EE;
 let Readable;
+let Passthrough;
 
 function nop() {}
 
@@ -220,24 +221,27 @@ function pipeline(...streams) {
   }
 
   if (!isStream(ret)) {
-    if (!Readable) {
-      Readable = require('_stream_readable');
+    if (!Passthrough) {
+      Passthrough = require('_stream_passthrough');
     }
+
+    const pt = new Passthrough();
 
     if (isPromise(ret)) {
       // Finish eagerly
       ret
         .then((val) => {
+          pt.end(val);
           finish(null, val, true);
         })
         .catch((err) => {
           finish(err, null, true);
         });
+    } else {
+      pump(makeAsyncIterable(ret, `streams[${streams.length - 1}]`), pt, finish);
     }
 
-    ret = Readable
-      .from(makeAsyncIterable(ret, `streams[${streams.length - 1}]`));
-
+    ret = pt;
     wrap(ret, true, false, true);
   }
 

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -89,7 +89,6 @@ function isIterable(obj, isAsync) {
   return !!(obj[SymbolAsyncIterator] || obj[SymbolIterator]);
 }
 
-
 function makeAsyncIterable(val, name) {
   if (isIterable(val)) {
     return val;
@@ -144,7 +143,6 @@ async function pump(iterable, writable, finish) {
     finish(err);
   }
 }
-
 
 function pipeline(...streams) {
   const callback = once(popCallback(streams));

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -852,3 +852,24 @@ const { promisify } = require('util');
     assert.strictEqual(res, 'HELLOWORLD');
   }));
 }
+
+{
+  // Ensure no unhandled rejection from async function.
+
+  let res = '';
+  const ret = pipeline(async function*() {
+    await Promise.resolve();
+    yield 'hello';
+    yield 'world';
+  }, async function() {
+    throw new Error('kaboom');
+  }, async function*(source) {
+    for await (const chunk of source) {
+      res += chunk;
+    }
+  }, common.mustCall((err) => {
+    assert.strictEqual(err.message, 'kaboom');
+    assert.strictEqual(res, '');
+  }));
+  ret.resume();
+}

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -785,11 +785,7 @@ const { promisify } = require('util');
   process.nextTick(() => {
     s.emit('error', new Error('kaboom'));
   });
-  let ret = '';
   pipeline(s, async function(source) {
-    for await (const chunk of source) {
-      ret += chunk;
-    }
   }, common.mustCall((err) => {
     assert.strictEqual(err.message, 'kaboom');
   }));

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -633,9 +633,9 @@ const { promisify } = require('util');
 {
   // AsyncIterable destination is returned and finalizes.
 
-  const ret = pipeline(async function() {
+  const ret = pipeline(async function*() {
     await Promise.resolve();
-    return ['hello'];
+    yield 'hello';
   }, async function*(source) {
     for await (const chunk of source) {
       chunk;
@@ -651,7 +651,7 @@ const { promisify } = require('util');
   // AsyncFunction destination is not returned and error is
   // propagated.
 
-  const ret = pipeline(async function() {
+  const ret = pipeline(async function*() {
     await Promise.resolve();
     throw new Error('kaboom');
   }, async function*(source) {
@@ -667,7 +667,7 @@ const { promisify } = require('util');
 
 {
   const s = new PassThrough();
-  pipeline(async function() {
+  pipeline(async function*() {
     throw new Error('kaboom');
   }, s, common.mustCall((err) => {
     assert.strictEqual(err.message, 'kaboom');
@@ -861,7 +861,7 @@ const { promisify } = require('util');
     await Promise.resolve();
     yield 'hello';
     yield 'world';
-  }, async function() {
+  }, async function*() {
     throw new Error('kaboom');
   }, async function*(source) {
     for await (const chunk of source) {

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -891,20 +891,11 @@ const { promisify } = require('util');
 {
   // Ensure no unhandled rejection from async function.
 
-  let res = '';
-  const ret = pipeline(async function*() {
-    await Promise.resolve();
+  pipeline(async function*() {
     yield 'hello';
-    yield 'world';
-  }, async function*() {
+  }, async function(source) {
     throw new Error('kaboom');
-  }, async function*(source) {
-    for await (const chunk of source) {
-      res += chunk;
-    }
   }, common.mustCall((err) => {
     assert.strictEqual(err.message, 'kaboom');
-    assert.strictEqual(res, '');
   }));
-  ret.resume();
 }

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -830,6 +830,18 @@ const { promisify } = require('util');
 }
 
 {
+  const s = new PassThrough();
+  assert.throws(() => {
+    pipeline(s, function*(source) {
+    }, () => {});
+  }, (err) => {
+    assert.strictEqual(err.code, 'ERR_INVALID_RETURN_VALUE');
+    assert.strictEqual(s.destroyed, false);
+    return true;
+  });
+}
+
+{
   let res = '';
   pipeline(async function*() {
     await Promise.resolve();

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -516,3 +516,278 @@ const { promisify } = require('util');
     }).on('error', common.mustNotCall());
   });
 }
+
+{
+  let res = '';
+  const w = new Writable({
+    write(chunk, encoding, callback) {
+      res += chunk;
+      callback();
+    }
+  });
+  pipeline(function*() {
+    yield 'hello';
+    yield 'world';
+  }(), w, common.mustCall((err) => {
+    assert.ok(!err);
+    assert.strictEqual(res, 'helloworld');
+  }));
+}
+
+{
+  let res = '';
+  const w = new Writable({
+    write(chunk, encoding, callback) {
+      res += chunk;
+      callback();
+    }
+  });
+  pipeline(async function*() {
+    await Promise.resolve();
+    yield 'hello';
+    yield 'world';
+  }(), w, common.mustCall((err) => {
+    assert.ok(!err);
+    assert.strictEqual(res, 'helloworld');
+  }));
+}
+
+{
+  let res = '';
+  const w = new Writable({
+    write(chunk, encoding, callback) {
+      res += chunk;
+      callback();
+    }
+  });
+  pipeline(function*() {
+    yield 'hello';
+    yield 'world';
+  }, w, common.mustCall((err) => {
+    assert.ok(!err);
+    assert.strictEqual(res, 'helloworld');
+  }));
+}
+
+{
+  let res = '';
+  const w = new Writable({
+    write(chunk, encoding, callback) {
+      res += chunk;
+      callback();
+    }
+  });
+  pipeline(async function*() {
+    await Promise.resolve();
+    yield 'hello';
+    yield 'world';
+  }, w, common.mustCall((err) => {
+    assert.ok(!err);
+    assert.strictEqual(res, 'helloworld');
+  }));
+}
+
+{
+  let res = '';
+  pipeline(async function*() {
+    await Promise.resolve();
+    yield 'hello';
+    yield 'world';
+  }, async function*(source) {
+    for await (const chunk of source) {
+      yield chunk.toUpperCase();
+    }
+  }, async function(source) {
+    for await (const chunk of source) {
+      res += chunk;
+    }
+  }, common.mustCall((err) => {
+    assert.ok(!err);
+    assert.strictEqual(res, 'HELLOWORLD');
+  }));
+}
+
+{
+  pipeline(async function*() {
+    await Promise.resolve();
+    yield 'hello';
+    yield 'world';
+  }, async function*(source) {
+    const ret = [];
+    for await (const chunk of source) {
+      ret.push(chunk.toUpperCase());
+    }
+    yield ret;
+  }, async function(source) {
+    let ret = '';
+    for await (const chunk of source) {
+      ret += chunk;
+    }
+    return ret;
+  }, common.mustCall((err, val) => {
+    assert.ok(!err);
+    assert.strictEqual(val, 'HELLOWORLD');
+  }));
+}
+
+{
+  // AsyncIterable destination is returned and finalizes.
+
+  const ret = pipeline(async function() {
+    await Promise.resolve();
+    return ['hello'];
+  }, async function*(source) {
+    for await (const chunk of source) {
+      chunk;
+    }
+  }, common.mustCall((err) => {
+    assert.strictEqual(err, undefined);
+  }));
+  ret.resume();
+  assert.strictEqual(typeof ret.pipe, 'function');
+}
+
+{
+  // AsyncFunction destination is not returned and error is
+  // propagated.
+
+  const ret = pipeline(async function() {
+    await Promise.resolve();
+    throw new Error('kaboom');
+  }, async function*(source) {
+    for await (const chunk of source) {
+      chunk;
+    }
+  }, common.mustCall((err) => {
+    assert.strictEqual(err.message, 'kaboom');
+  }));
+  ret.resume();
+  assert.strictEqual(typeof ret.pipe, 'function');
+}
+
+{
+  const s = new PassThrough();
+  pipeline(async function() {
+    throw new Error('kaboom');
+  }, s, common.mustCall((err) => {
+    assert.strictEqual(err.message, 'kaboom');
+    assert.strictEqual(s.destroyed, true);
+  }));
+}
+
+{
+  const s = new PassThrough();
+  pipeline(async function*() {
+    throw new Error('kaboom');
+  }(), s, common.mustCall((err) => {
+    assert.strictEqual(err.message, 'kaboom');
+    assert.strictEqual(s.destroyed, true);
+  }));
+}
+
+{
+  const s = new PassThrough();
+  pipeline(function*() {
+    throw new Error('kaboom');
+  }, s, common.mustCall((err, val) => {
+    assert.strictEqual(err.message, 'kaboom');
+    assert.strictEqual(s.destroyed, true);
+  }));
+}
+
+{
+  const s = new PassThrough();
+  pipeline(function*() {
+    throw new Error('kaboom');
+  }(), s, common.mustCall((err, val) => {
+    assert.strictEqual(err.message, 'kaboom');
+    assert.strictEqual(s.destroyed, true);
+  }));
+}
+
+{
+  const s = new PassThrough();
+  pipeline(async function*() {
+    await Promise.resolve();
+    yield 'hello';
+    yield 'world';
+  }, s, async function(source) {
+    for await (const chunk of source) {
+      chunk;
+      throw new Error('kaboom');
+    }
+  }, common.mustCall((err, val) => {
+    assert.strictEqual(err.message, 'kaboom');
+    assert.strictEqual(s.destroyed, true);
+  }));
+}
+
+{
+  const s = new PassThrough();
+  const ret = pipeline(function() {
+    return ['hello', 'world'];
+  }, s, async function*(source) {
+    for await (const chunk of source) {
+      chunk;
+      throw new Error('kaboom');
+    }
+  }, common.mustCall((err) => {
+    assert.strictEqual(err.message, 'kaboom');
+    assert.strictEqual(s.destroyed, true);
+  }));
+  ret.resume();
+  assert.strictEqual(typeof ret.pipe, 'function');
+}
+
+{
+  const s = new PassThrough();
+  s.push('asd');
+  s.push(null);
+  s[Symbol.asyncIterator] = null;
+  let ret = '';
+  pipeline(s, async function(source) {
+    for await (const chunk of source) {
+      ret += chunk;
+    }
+  }, common.mustCall((err) => {
+    assert.strictEqual(err, undefined);
+    assert.strictEqual(ret, 'asd');
+    assert.strictEqual(s.destroyed, true);
+  }));
+}
+
+{
+  const s = new PassThrough();
+  assert.throws(() => {
+    pipeline(function(source) {
+    }, s, () => {});
+  }, (err) => {
+    assert.strictEqual(err.code, 'ERR_INVALID_RETURN_VALUE');
+    assert.strictEqual(s.destroyed, false);
+    return true;
+  });
+}
+
+{
+  const s = new PassThrough();
+  assert.throws(() => {
+    pipeline(s, function(source) {
+    }, s, () => {});
+  }, (err) => {
+    assert.strictEqual(err.code, 'ERR_INVALID_RETURN_VALUE');
+    assert.strictEqual(s.destroyed, false);
+    return true;
+  });
+}
+
+{
+  const s = new PassThrough();
+  assert.throws(() => {
+    pipeline(s, function(source) {
+    }, () => {});
+  }, (err) => {
+    assert.strictEqual(err.code, 'ERR_INVALID_RETURN_VALUE');
+    assert.strictEqual(s.destroyed, false);
+    return true;
+  });
+}

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -766,6 +766,7 @@ const { promisify } = require('util');
     s.emit('data', 'asd');
     s.emit('end');
   });
+  s.close = common.mustCall();
   let ret = '';
   pipeline(s, async function(source) {
     for await (const chunk of source) {
@@ -785,6 +786,7 @@ const { promisify } = require('util');
   process.nextTick(() => {
     s.emit('error', new Error('kaboom'));
   });
+  s.destroy = common.mustCall();
   pipeline(s, async function(source) {
   }, common.mustCall((err) => {
     assert.strictEqual(err.message, 'kaboom');

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -28,6 +28,8 @@ const customTypesMap = {
 
   'AsyncIterator': 'https://tc39.github.io/ecma262/#sec-asynciterator-interface',
 
+  'AsyncIterable': 'https://tc39.github.io/ecma262/#sec-asynciterable-interface',
+
   'bigint': `${jsDocPrefix}Reference/Global_Objects/BigInt`,
 
   'Iterable':


### PR DESCRIPTION
Add support for generators and functions in `pipeline`.

This makes it possible to do the following:

```js
await pipeline(
  async function* () {
    yield await read();
  },
  async function*(source) {
    await for (const chunk of source) {
      yield chunk;
    }
  },
  async function(source) {
    await for (const chunk of source) {
      await write(chunk):
    }
  }
);
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
