### PR TITLE
stream: clean up definition using defineProperties

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -27,7 +27,7 @@
 'use strict';
 
 const {
-  ObjectDefineProperty,
+  ObjectDefineProperties,
   ObjectKeys,
   ObjectSetPrototypeOf,
 } = primordials;
@@ -70,63 +70,60 @@ function Duplex(options) {
   }
 }
 
-ObjectDefineProperty(Duplex.prototype, 'writableHighWaterMark', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get() {
-    return this._writableState && this._writableState.highWaterMark;
-  }
-});
+ObjectDefineProperties(Duplex.prototype, {
 
-ObjectDefineProperty(Duplex.prototype, 'writableBuffer', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get: function() {
-    return this._writableState && this._writableState.getBuffer();
-  }
-});
+  destroyed: {
+    get() {
+      if (this._readableState === undefined ||
+        this._writableState === undefined) {
+        return false;
+      }
+      return this._readableState.destroyed && this._writableState.destroyed;
+    },
+    set(value) {
+      // Backward compatibility, the user is explicitly
+      // managing destroyed
+      if (this._readableState && this._writableState) {
+        this._readableState.destroyed = value;
+        this._writableState.destroyed = value;
+      }
+    }
+  },
 
-ObjectDefineProperty(Duplex.prototype, 'writableLength', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get() {
-    return this._writableState && this._writableState.length;
-  }
-});
+  writableHighWaterMark: {
+    get() {
+      return this._writableState && this._writableState.highWaterMark;
+    }
+  },
 
-ObjectDefineProperty(Duplex.prototype, 'writableFinished', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get() {
-    return this._writableState ? this._writableState.finished : false;
-  }
-});
+  writableBuffer: {
+    get() {
+      return this._writableState && this._writableState.getBuffer();
+    }
+  },
 
-ObjectDefineProperty(Duplex.prototype, 'writableCorked', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get() {
-    return this._writableState ? this._writableState.corked : 0;
-  }
-});
+  writableLength: {
+    get() {
+      return this._writableState && this._writableState.length;
+    }
+  },
 
-ObjectDefineProperty(Duplex.prototype, 'writableEnded', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get() {
-    return this._writableState ? this._writableState.ending : false;
+  writableFinished: {
+    get() {
+      return this._writableState ? this._writableState.finished : false;
+    }
+  },
+
+  writableCorked: {
+    get() {
+      return this._writableState ? this._writableState.corked : 0;
+    }
+  },
+
+  writableEnded: {
+    get() {
+      return this._writableState ? this._writableState.ending : false;
+    }
   }
 });
 
@@ -144,30 +141,3 @@ function onend() {
 function onEndNT(self) {
   self.end();
 }
-
-ObjectDefineProperty(Duplex.prototype, 'destroyed', {
-  // Making it explicit this property is not enumerable
-  // because otherwise some prototype manipulation in
-  // userland will fail
-  enumerable: false,
-  get() {
-    if (this._readableState === undefined ||
-        this._writableState === undefined) {
-      return false;
-    }
-    return this._readableState.destroyed && this._writableState.destroyed;
-  },
-  set(value) {
-    // We ignore the value if the stream
-    // has not been initialized yet
-    if (this._readableState === undefined ||
-        this._writableState === undefined) {
-      return;
-    }
-
-    // Backward compatibility, the user is explicitly
-    // managing destroyed
-    this._readableState.destroyed = value;
-    this._writableState.destroyed = value;
-  }
-});


### PR DESCRIPTION
This is the final clean up for `Duplex` streams. Refs: https://github.com/nodejs/node/pull/31187

cc @nodejs/streams 

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)