### PR TITLE
src: remove node::InitializeV8Platform()

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -360,11 +360,6 @@ MultiIsolatePlatform* CreatePlatform(
   return new NodePlatform(thread_pool_size, tracing_controller);
 }
 
-MultiIsolatePlatform* InitializeV8Platform(int thread_pool_size) {
-  per_process::v8_platform.Initialize(thread_pool_size);
-  return per_process::v8_platform.Platform();
-}
-
 void FreePlatform(MultiIsolatePlatform* platform) {
   delete platform;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -332,8 +332,8 @@ Environment::Environment(IsolateData* isolate_data,
 
   if (tracing::AgentWriterHandle* writer = GetTracingAgentWriter()) {
     trace_state_observer_ = std::make_unique<TrackingTraceStateObserver>(this);
-    TracingController* tracing_controller = writer->GetTracingController();
-    tracing_controller->AddTraceStateObserver(trace_state_observer_.get());
+    if (TracingController* tracing_controller = writer->GetTracingController())
+      tracing_controller->AddTraceStateObserver(trace_state_observer_.get());
   }
 
   destroy_async_id_list_.reserve(512);
@@ -409,8 +409,8 @@ Environment::~Environment() {
   if (trace_state_observer_) {
     tracing::AgentWriterHandle* writer = GetTracingAgentWriter();
     CHECK_NOT_NULL(writer);
-    TracingController* tracing_controller = writer->GetTracingController();
-    tracing_controller->RemoveTraceStateObserver(trace_state_observer_.get());
+    if (TracingController* tracing_controller = writer->GetTracingController())
+      tracing_controller->RemoveTraceStateObserver(trace_state_observer_.get());
   }
 
   delete[] http_parser_buffer_;

--- a/src/node.cc
+++ b/src/node.cc
@@ -1077,7 +1077,8 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
   V8::SetEntropySource(crypto::EntropySource);
 #endif  // HAVE_OPENSSL
 
-  InitializeV8Platform(per_process::cli_options->v8_thread_pool_size);
+  per_process::v8_platform.Initialize(
+      per_process::cli_options->v8_thread_pool_size);
   V8::Initialize();
   performance::performance_v8_start = PERFORMANCE_NOW();
   per_process::v8_initialized = true;

--- a/src/node.h
+++ b/src/node.h
@@ -401,7 +401,6 @@ NODE_EXTERN MultiIsolatePlatform* GetMainThreadMultiIsolatePlatform();
 NODE_EXTERN MultiIsolatePlatform* CreatePlatform(
     int thread_pool_size,
     node::tracing::TracingController* tracing_controller);
-MultiIsolatePlatform* InitializeV8Platform(int thread_pool_size);
 NODE_EXTERN void FreePlatform(MultiIsolatePlatform* platform);
 
 NODE_EXTERN void EmitBeforeExit(Environment* env);

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -80,9 +80,13 @@ class NodeZeroIsolateTestFixture : public ::testing::Test {
 
     tracing_agent = std::make_unique<node::tracing::Agent>();
     node::tracing::TraceEventHelper::SetAgent(tracing_agent.get());
+    node::tracing::TracingController* tracing_controller =
+        tracing_agent->GetTracingController();
     CHECK_EQ(0, uv_loop_init(&current_loop));
-    platform.reset(static_cast<node::NodePlatform*>(
-          node::InitializeV8Platform(4)));
+    static constexpr int kV8ThreadPoolSize = 4;
+    platform.reset(
+        new node::NodePlatform(kV8ThreadPoolSize, tracing_controller));
+    v8::V8::InitializePlatform(platform.get());
     v8::V8::Initialize();
   }
 
@@ -108,7 +112,7 @@ class NodeTestFixture : public NodeZeroIsolateTestFixture {
 
   void SetUp() override {
     NodeZeroIsolateTestFixture::SetUp();
-    isolate_ = NewIsolate(allocator.get(), &current_loop);
+    isolate_ = NewIsolate(allocator.get(), &current_loop, platform.get());
     CHECK_NOT_NULL(isolate_);
     isolate_->Enter();
   }


### PR DESCRIPTION
This API method was introduced in commit 90ae4bd ("src: add
InitializeV8Platform function") from July 2018 but wasn't properly
exported and therefore not usable on Windows or with shared library
builds.

The motivation from the commit log is mainly about making it easier
to wire up the cctests and there are better ways to do that.

Refs: #31217