### PR TITLE
test: fix recursive rm test to actually use tmpdir

### DIFF
--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -6,9 +6,12 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const { validateRmdirOptions } = require('internal/fs/utils');
-let count = 0;
 
 tmpdir.refresh();
+
+let count = 0;
+const nextDirPath = (name = 'rmdir-recursive') =>
+  path.join(tmpdir.path, `${name}-${count++}`);
 
 function makeNonEmptyDirectory(depth, files, folders, dirname, createSymLinks) {
   fs.mkdirSync(dirname, { recursive: true });
@@ -89,27 +92,24 @@ function removeAsync(dir) {
 // Test the asynchronous version
 {
   // Create a 4-level folder hierarchy including symlinks
-  let dir = `rmdir-recursive-${count}`;
+  let dir = nextDirPath();
   makeNonEmptyDirectory(4, 10, 2, dir, true);
   removeAsync(dir);
 
   // Create a 2-level folder hierarchy without symlinks
-  count++;
-  dir = `rmdir-recursive-${count}`;
+  dir = nextDirPath();
   makeNonEmptyDirectory(2, 10, 2, dir, false);
   removeAsync(dir);
 
   // Create a flat folder including symlinks
-  count++;
-  dir = `rmdir-recursive-${count}`;
+  dir = nextDirPath();
   makeNonEmptyDirectory(1, 10, 2, dir, true);
   removeAsync(dir);
 }
 
 // Test the synchronous version.
 {
-  count++;
-  const dir = `rmdir-recursive-${count}`;
+  const dir = nextDirPath();
   makeNonEmptyDirectory(4, 10, 2, dir, true);
 
   // Removal should fail without the recursive option set to true.
@@ -132,8 +132,7 @@ function removeAsync(dir) {
 
 // Test the Promises based version.
 (async () => {
-  count++;
-  const dir = `rmdir-recursive-${count}`;
+  const dir = nextDirPath();
   makeNonEmptyDirectory(4, 10, 2, dir, true);
 
   // Removal should fail without the recursive option set to true.


### PR DESCRIPTION
Previously folders were created in the root of the project and would
therefore stay there in case of errors. This changes the test to create
all directories in the temp directory (`tmpdir.path`).

Also a small refactor to contain the directory counter in one place.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
