### PR TITLE
errors: add ERR_INVALID_OPT_TYPE and support options in validators.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1303,6 +1303,11 @@ An invalid HTTP token was supplied.
 
 An IP address is not valid.
 
+<a id="ERR_INVALID_OPT_TYPE"></a>
+### `ERR_INVALID_OPT_TYPE`
+
+An option of the wrong type was passed in an options object.
+
 <a id="ERR_INVALID_OPT_VALUE"></a>
 ### `ERR_INVALID_OPT_VALUE`
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -686,6 +686,114 @@ const fatalExceptionStackEnhancers = {
   }
 };
 
+const invalidValueTypeError = (name, expected, actual, valueType) => {
+  assert(typeof name === 'string', "'name' must be a string");
+  if (!ArrayIsArray(expected)) {
+    expected = [expected];
+  }
+
+  let msg = 'The ';
+  if (valueType !== undefined) {
+    msg += `"${name}" ${valueType} `;
+  } else if (name.endsWith(' argument')) {
+    // For cases like 'first argument'
+    msg += `${name} `;
+  } else {
+    const type = name.includes('.') ? 'property' : 'argument';
+    msg += `"${name}" ${type} `;
+  }
+  msg += 'must be ';
+
+  const types = [];
+  const instances = [];
+  const other = [];
+
+  for (const value of expected) {
+    assert(typeof value === 'string',
+           'All expected entries have to be of type string');
+    if (kTypes.includes(value)) {
+      types.push(value.toLowerCase());
+    } else if (classRegExp.test(value)) {
+      instances.push(value);
+    } else {
+      assert(value !== 'object',
+             'The value "object" should be written as "Object"');
+      other.push(value);
+    }
+  }
+
+  // Special handle `object` in case other instances are allowed to outline
+  // the differences between each other.
+  if (instances.length > 0) {
+    const pos = types.indexOf('object');
+    if (pos !== -1) {
+      types.splice(pos, 1);
+      instances.push('Object');
+    }
+  }
+
+  if (types.length > 0) {
+    if (types.length > 2) {
+      const last = types.pop();
+      msg += `one of type ${types.join(', ')}, or ${last}`;
+    } else if (types.length === 2) {
+      msg += `one of type ${types[0]} or ${types[1]}`;
+    } else {
+      msg += `of type ${types[0]}`;
+    }
+    if (instances.length > 0 || other.length > 0)
+      msg += ' or ';
+  }
+
+  if (instances.length > 0) {
+    if (instances.length > 2) {
+      const last = instances.pop();
+      msg += `an instance of ${instances.join(', ')}, or ${last}`;
+    } else {
+      msg += `an instance of ${instances[0]}`;
+      if (instances.length === 2) {
+        msg += ` or ${instances[1]}`;
+      }
+    }
+    if (other.length > 0)
+      msg += ' or ';
+  }
+
+  if (other.length > 0) {
+    if (other.length > 2) {
+      const last = other.pop();
+      msg += `one of ${other.join(', ')}, or ${last}`;
+    } else if (other.length === 2) {
+      msg += `one of ${other[0]} or ${other[1]}`;
+    } else {
+      if (other[0].toLowerCase() !== other[0])
+        msg += 'an ';
+      msg += `${other[0]}`;
+    }
+  }
+
+  if (actual == null) {
+    msg += `. Received ${actual}`;
+  } else if (typeof actual === 'function' && actual.name) {
+    msg += `. Received function ${actual.name}`;
+  } else if (typeof actual === 'object') {
+    if (actual.constructor && actual.constructor.name) {
+      msg += `. Received an instance of ${actual.constructor.name}`;
+    } else {
+      const inspected = lazyInternalUtilInspect()
+        .inspect(actual, { depth: -1 });
+      msg += `. Received ${inspected}`;
+    }
+  } else {
+    let inspected = lazyInternalUtilInspect()
+      .inspect(actual, { colors: false });
+    if (inspected.length > 25)
+      inspected = `${inspected.slice(0, 25)}...`;
+    msg += `. Received type ${typeof actual} (${inspected})`;
+  }
+  return msg;
+};
+
 module.exports = {
   addCodeToName, // Exported for NghttpError
   codes,
@@ -931,112 +1039,9 @@ E('ERR_INVALID_ADDRESS_FAMILY', function(addressType, host, port) {
   this.port = port;
   return `Invalid address family: ${addressType} ${host}:${port}`;
 }, RangeError);
-E('ERR_INVALID_ARG_TYPE',
-  (name, expected, actual) => {
-    assert(typeof name === 'string', "'name' must be a string");
-    if (!ArrayIsArray(expected)) {
-      expected = [expected];
-    }
-
-    let msg = 'The ';
-    if (name.endsWith(' argument')) {
-      // For cases like 'first argument'
-      msg += `${name} `;
-    } else {
-      const type = name.includes('.') ? 'property' : 'argument';
-      msg += `"${name}" ${type} `;
-    }
-    msg += 'must be ';
-
-    const types = [];
-    const instances = [];
-    const other = [];
-
-    for (const value of expected) {
-      assert(typeof value === 'string',
-             'All expected entries have to be of type string');
-      if (kTypes.includes(value)) {
-        types.push(value.toLowerCase());
-      } else if (classRegExp.test(value)) {
-        instances.push(value);
-      } else {
-        assert(value !== 'object',
-               'The value "object" should be written as "Object"');
-        other.push(value);
-      }
-    }
-
-    // Special handle `object` in case other instances are allowed to outline
-    // the differences between each other.
-    if (instances.length > 0) {
-      const pos = types.indexOf('object');
-      if (pos !== -1) {
-        types.splice(pos, 1);
-        instances.push('Object');
-      }
-    }
-
-    if (types.length > 0) {
-      if (types.length > 2) {
-        const last = types.pop();
-        msg += `one of type ${types.join(', ')}, or ${last}`;
-      } else if (types.length === 2) {
-        msg += `one of type ${types[0]} or ${types[1]}`;
-      } else {
-        msg += `of type ${types[0]}`;
-      }
-      if (instances.length > 0 || other.length > 0)
-        msg += ' or ';
-    }
-
-    if (instances.length > 0) {
-      if (instances.length > 2) {
-        const last = instances.pop();
-        msg += `an instance of ${instances.join(', ')}, or ${last}`;
-      } else {
-        msg += `an instance of ${instances[0]}`;
-        if (instances.length === 2) {
-          msg += ` or ${instances[1]}`;
-        }
-      }
-      if (other.length > 0)
-        msg += ' or ';
-    }
-
-    if (other.length > 0) {
-      if (other.length > 2) {
-        const last = other.pop();
-        msg += `one of ${other.join(', ')}, or ${last}`;
-      } else if (other.length === 2) {
-        msg += `one of ${other[0]} or ${other[1]}`;
-      } else {
-        if (other[0].toLowerCase() !== other[0])
-          msg += 'an ';
-        msg += `${other[0]}`;
-      }
-    }
-
-    if (actual == null) {
-      msg += `. Received ${actual}`;
-    } else if (typeof actual === 'function' && actual.name) {
-      msg += `. Received function ${actual.name}`;
-    } else if (typeof actual === 'object') {
-      if (actual.constructor && actual.constructor.name) {
-        msg += `. Received an instance of ${actual.constructor.name}`;
-      } else {
-        const inspected = lazyInternalUtilInspect()
-          .inspect(actual, { depth: -1 });
-        msg += `. Received ${inspected}`;
-      }
-    } else {
-      let inspected = lazyInternalUtilInspect()
-        .inspect(actual, { colors: false });
-      if (inspected.length > 25)
-        inspected = `${inspected.slice(0, 25)}...`;
-      msg += `. Received type ${typeof actual} (${inspected})`;
-    }
-    return msg;
-  }, TypeError);
+E('ERR_INVALID_ARG_TYPE', (name, expected, actual) =>
+  invalidValueTypeError(name, expected, actual),
+  TypeError);
 E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
   let inspected = lazyInternalUtilInspect().inspect(value);
   if (inspected.length > 128) {
@@ -1070,6 +1075,9 @@ E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s', TypeError);
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent', TypeError);
 E('ERR_INVALID_HTTP_TOKEN', '%s must be a valid HTTP token ["%s"]', TypeError);
 E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s', TypeError);
+E('ERR_INVALID_OPT_TYPE', (name, expected, actual) =>
+  invalidValueTypeError(name, expected, actual, 'option'),
+  TypeError);
 E('ERR_INVALID_OPT_VALUE', (name, value) =>
   `The value "${String(value)}" is invalid for option "${name}"`,
   TypeError,

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -11,6 +11,8 @@ const {
   codes: {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
+    ERR_INVALID_OPT_TYPE,
+    ERR_INVALID_OPT_VALUE,
     ERR_OUT_OF_RANGE,
     ERR_UNKNOWN_SIGNAL
   }
@@ -67,65 +69,84 @@ function parseFileMode(value, name, def) {
   throw new ERR_INVALID_ARG_VALUE(name, value, modeDesc);
 }
 
+const handleValueName = (name) => {
+  let TypeErr = ERR_INVALID_ARG_TYPE;
+  let ValueErr = ERR_INVALID_ARG_VALUE;
+  if (typeof name === 'object') {
+    if (name.type === 'option') {
+      TypeErr = ERR_INVALID_OPT_TYPE;
+      ValueErr = ERR_INVALID_OPT_VALUE;
+    }
+    name = name.name;
+  }
+  return { valueName: name, TypeErr, ValueErr };
+};
+
 const validateInteger = hideStackFrames(
   (value, name, min = NumberMIN_SAFE_INTEGER, max = NumberMAX_SAFE_INTEGER) => {
+    const { valueName, TypeErr } = handleValueName(name);
     if (typeof value !== 'number')
-      throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+      throw new TypeErr(valueName, 'number', value);
     if (!NumberIsInteger(value))
-      throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
+      throw new ERR_OUT_OF_RANGE(valueName, 'an integer', value);
     if (value < min || value > max)
-      throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
+      throw new ERR_OUT_OF_RANGE(valueName, `>= ${min} && <= ${max}`, value);
   }
 );
 
 const validateInt32 = hideStackFrames(
   (value, name, min = -2147483648, max = 2147483647) => {
     // The defaults for min and max correspond to the limits of 32-bit integers.
+    const { valueName, TypeErr } = handleValueName(name);
     if (!isInt32(value)) {
       if (typeof value !== 'number') {
-        throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+        throw new TypeErr(valueName, 'number', value);
       }
       if (!NumberIsInteger(value)) {
-        throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
+        throw new ERR_OUT_OF_RANGE(valueName, 'an integer', value);
       }
-      throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
+      throw new ERR_OUT_OF_RANGE(valueName, `>= ${min} && <= ${max}`, value);
     }
     if (value < min || value > max) {
-      throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
+      throw new ERR_OUT_OF_RANGE(valueName, `>= ${min} && <= ${max}`, value);
     }
   }
 );
 
 const validateUint32 = hideStackFrames((value, name, positive) => {
+  const { valueName, TypeErr } = handleValueName(name);
   if (!isUint32(value)) {
     if (typeof value !== 'number') {
-      throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+      throw new TypeErr(valueName, 'number', value);
     }
     if (!NumberIsInteger(value)) {
-      throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
+      throw new ERR_OUT_OF_RANGE(valueName, 'an integer', value);
     }
     const min = positive ? 1 : 0;
     // 2 ** 32 === 4294967296
-    throw new ERR_OUT_OF_RANGE(name, `>= ${min} && < 4294967296`, value);
+    throw new ERR_OUT_OF_RANGE(valueName, `>= ${min} && < 4294967296`, value);
   }
   if (positive && value === 0) {
-    throw new ERR_OUT_OF_RANGE(name, '>= 1 && < 4294967296', value);
+    throw new ERR_OUT_OF_RANGE(valueName, '>= 1 && < 4294967296', value);
   }
 });
 
 function validateString(value, name) {
+  const { valueName, TypeErr } = handleValueName(name);
   if (typeof value !== 'string')
-    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
+    throw new TypeErr(valueName, 'string', value);
 }
 
 function validateNumber(value, name) {
+  const { valueName, TypeErr } = handleValueName(name);
   if (typeof value !== 'number')
-    throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+    throw new TypeErr(valueName, 'number', value);
 }
 
 function validateSignalName(signal, name = 'signal') {
+  const { valueName, TypeErr } = handleValueName(name);
   if (typeof signal !== 'string')
-    throw new ERR_INVALID_ARG_TYPE(name, 'string', signal);
+    throw new TypeErr(valueName, 'string', signal);
 
   if (signals[signal] === undefined) {
     if (signals[signal.toUpperCase()] !== undefined) {
@@ -138,11 +159,9 @@ function validateSignalName(signal, name = 'signal') {
 }
 
 const validateBuffer = hideStackFrames((buffer, name = 'buffer') => {
-  if (!isArrayBufferView(buffer)) {
-    throw new ERR_INVALID_ARG_TYPE(name,
-                                   ['Buffer', 'TypedArray', 'DataView'],
-                                   buffer);
-  }
+  const { valueName, TypeErr } = handleValueName(name);
+  if (!isArrayBufferView(buffer))
+    throw new TypeErr(valueName, ['Buffer', 'TypedArray', 'DataView'], buffer);
 });
 
 function validateEncoding(data, encoding) {


### PR DESCRIPTION
Description in the commit messages.

Also, I considered adding helper functions like `validateBufferOpt` to avoid having to write an object with `type: 'option'` every time, WDYT?
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added (do we have a doc for validators.js?)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @BridgeAR
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
