### PR TITLE
docs: fix stream async iterator sample

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2650,10 +2650,10 @@ const writable = fs.createWriteStream('./file');
 async function pump(iterable, writable) {
   for await (const chunk of iterable) {
     // Handle backpressure on write().
-    if (writable.destroyed) return;
-    if (!writable.write(chunk)) {}
+    if (!writable.write(chunk)) {
+      if (writable.destroyed) return;
       await once(writable, 'drain');
-    if (writable.destroyed) return;
+    }
   }
   writable.end();
 }

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2647,11 +2647,11 @@ const finished = util.promisify(stream.finished);
 
 const writable = fs.createWriteStream('./file');
 
-async function pump(iterator, writable) {
-  for await (const chunk of iterator) {
+async function pump(iterable, writable) {
+  for await (const chunk of iterable) {
     // Handle backpressure on write().
     if (writable.destroyed) return;
-    if (!writable.write(chunk))
+    if (!writable.write(chunk)) {}
       await once(writable, 'drain');
     if (writable.destroyed) return;
   }
@@ -2661,7 +2661,7 @@ async function pump(iterator, writable) {
 (async function() {
   // Ensure completion without errors.
   await Promise.all([
-    pump(iterator, writable),
+    pump(iterable, writable),
     finished(writable)
   ]);
 })();
@@ -2685,7 +2685,7 @@ const finished = util.promisify(stream.finished);
 const writable = fs.createWriteStream('./file');
 
 (async function() {
-  const readable = Readable.from(iterator);
+  const readable = Readable.from(iterable);
   readable.pipe(writable);
   // Ensure completion without errors.
   await finished(writable);
@@ -2700,7 +2700,7 @@ const pipeline = util.promisify(stream.pipeline);
 const writable = fs.createWriteStream('./file');
 
 (async function() {
-  const readable = Readable.from(iterator);
+  const readable = Readable.from(iterable);
   await pipeline(readable, writable);
 })();
 ```


### PR DESCRIPTION
The for await loop into writable could cause an unhandled exception
in the case where we are waiting for data from the async iterable and
there is no `'error'` handler registered on the writable.

Fixes: https://github.com/nodejs/node/issues/31222

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
