### PR TITLE
test: check that --insecure-http-parser works

### DIFF
--- a/test/parallel/test-http-insecure-parser.js
+++ b/test/parallel/test-http-insecure-parser.js
@@ -1,0 +1,35 @@
+// Flags: --insecure-http-parser
+
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+
+const server = http.createServer(function(req, res) {
+  assert.strictEqual(req.headers['content-type'], 'text/te\bt');
+  req.pipe(res);
+});
+
+server.listen(0, common.mustCall(function() {
+  const bufs = [];
+  const client = net.connect(
+    this.address().port,
+    function() {
+      client.write(
+        'GET / HTTP/1.1\r\n' +
+        'Content-Type: text/te\x08t\r\n' +
+        'Connection: close\r\n\r\n');
+    }
+  );
+  client.on('data', function(chunk) {
+    bufs.push(chunk);
+  });
+  client.on('end', common.mustCall(function() {
+    const head = Buffer.concat(bufs)
+      .toString('latin1')
+      .split('\r\n')[0];
+    assert.strictEqual(head, 'HTTP/1.1 200 OK');
+    server.close();
+  }));
+}));


### PR DESCRIPTION
Test that using --insecure-http-parser will disable validation of
invalid characters in HTTP headers.

See:
- https://github.com/nodejs/node/pull/30567

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
