### PR TITLE
repl: change preview default in case of custom eval functions

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -596,8 +596,9 @@ changes:
     `SIGINT` is received, such as when `Ctrl+C` is pressed. This cannot be used
     together with a custom `eval` function. **Default:** `false`.
   * `preview` {boolean} Defines if the repl prints autocomplete and output
-    previews or not. **Default:** `true`. If `terminal` is falsy, then there are
-    no previews and the value of `preview` has no effect.
+    previews or not. **Default:** `true` with the default eval function and
+    `false` in case a custom eval function is used. If `terminal` is falsy, then
+    there are no previews and the value of `preview` has no effect.
 * Returns: {repl.REPLServer}
 
 The `repl.start()` method creates and starts a [`repl.REPLServer`][] instance.

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -212,8 +212,9 @@ function REPLServer(prompt,
     }
   }
 
+  // TODO(devsnek): Add a test case for custom eval functions.
   const preview = options.terminal &&
-    (options.preview !== undefined ? !!options.preview : true);
+    (options.preview !== undefined ? !!options.preview : !eval_);
 
   this.inputStream = options.input;
   this.outputStream = options.output;


### PR DESCRIPTION
Custom eval functions might have a very different behavior than the
current implementation and having a preview in such case might be
confusing. This changes the preview default to `false` in case a
custom eval function is used. It is still possible to opt into using
the previews in case that's still desirable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
