### PR TITLE
Fix dispose without checking

### DIFF
--- a/src/node_v8_platform-inl.h
+++ b/src/node_v8_platform-inl.h
@@ -12,6 +12,7 @@
 #include "tracing/node_trace_writer.h"
 #include "tracing/trace_event.h"
 #include "tracing/traced_value.h"
+#include "util.h"
 
 namespace node {
 
@@ -79,8 +80,15 @@ class NodeTraceStateObserver
 };
 
 struct V8Platform {
+  bool initialize_;
+
+  V8Platform()
+      : initialize_(false) {}
+
 #if NODE_USE_V8_PLATFORM
   inline void Initialize(int thread_pool_size) {
+    CHECK(!initialize_);
+    initialize_ = true;
     tracing_agent_ = std::make_unique<tracing::Agent>();
     node::tracing::TraceEventHelper::SetAgent(tracing_agent_.get());
     node::tracing::TracingController* controller =
@@ -99,6 +107,10 @@ struct V8Platform {
   }
 
   inline void Dispose() {
+    if(!initialize_)
+      return;
+    initialize_ = false;
+
     StopTracingAgent();
     platform_->Shutdown();
     delete platform_;


### PR DESCRIPTION
If created platform with CreatePlatform, the crash occurs because it does not check if it was initialized to v8_platform when DisposePlatform was called.

https://github.com/nodejs/node/blob/bd6d6512f02d6fa10a0484577c270bb44f1b750b/src/env.cc#L958
https://github.com/nodejs/node/blob/bd6d6512f02d6fa10a0484577c270bb44f1b750b/src/node_v8_platform-inl.h#L176-L178
