### PR TITLE
src: include uv.h in node_binding header

### DIFF
--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -10,6 +10,7 @@
 #include "node.h"
 #define NAPI_EXPERIMENTAL
 #include "node_api.h"
+#include "uv.h"
 
 enum {
   NM_F_BUILTIN = 1 << 0,  // Unused.


### PR DESCRIPTION
This was removed in https://github.com/nodejs/node/commit/3bb085dbad4d23030c731834e35b2804c8a50b23 but is needed by Electron on Windows, as otherwise compilation errors will occur as a result of unknown `libuv` types:

```sh
In file included from ../../third_party/electron_node/src/node_binding.cc:1:
../../third_party/electron_node/src/node_binding.h(76,3): error: unknown type name 'uv_lib_t'
  uv_lib_t lib_;
  ^
```

See https://ci.appveyor.com/project/electron-bot/electron-ljo26/builds/29979721.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
