### PR TITLE
test: allow disabling crypto tests

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -570,6 +570,10 @@ If set, `NODE_COMMON_PORT`'s value overrides the `common.PORT` default value of
 
 If set, command line arguments passed to individual tests are not validated.
 
+### `NODE_SKIP_CRYPTO`
+
+If set, crypto tests are skipped.
+
 ### `NODE_TEST_KNOWN_GLOBALS`
 
 A comma-separated list of variables names that are appended to the global

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -48,7 +48,8 @@ if (isMainThread)
 
 const noop = () => {};
 
-const hasCrypto = Boolean(process.versions.openssl);
+const hasCrypto = Boolean(process.versions.openssl) &&
+                  !process.env.NODE_SKIP_CRYPTO;
 
 // Check for flags. Skip this for workers (both, the `cluster` module and
 // `worker_threads`) and child processes.


### PR DESCRIPTION
This PR adds a new environment variable to the test suit: `NODE_SKIP_CRYPTO`. Right now whether or not crypto tests can be run is solely determined by whether or not `openssl` is defined on the `process` object, which is true for Electron.js since many consumers use it to determine the presence of crypto even though we use BoringSSL and thus experience incompatibilities.

This new option would allow us to more effectively run our own smoke tests of Node.js' test suite without needing to manually disable every crypto test individually.

cc @tniessen 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
