### PR TITLE
Clarify asserting equality of objects and arrays

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1164,8 +1164,8 @@ changes:
 Tests strict equality between the `actual` and `expected` parameters as
 determined by the [SameValue Comparison][].
 
-[`assert.deepStrictEqual()`][] should be used for all objects and all
-arrays, not only nested ones.
+[`assert.deepStrictEqual()`][] should be used for all objects, not only
+nested ones.
 
 ```js
 const assert = require('assert').strict;

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1164,6 +1164,9 @@ changes:
 Tests strict equality between the `actual` and `expected` parameters as
 determined by the [SameValue Comparison][].
 
+[`assert.deepStrictEqual()`][] should be used for all objects and all
+arrays, not only nested ones.
+
 ```js
 const assert = require('assert').strict;
 


### PR DESCRIPTION
Some people might expect `assert.deepStrictEqual()` is to be used only
for nested objects, but that is not correct.

This change adds some clarification, because `assert.deepStrictEqual()` should be
used for all objects and arrays even if they are flat.

See https://github.com/nodejs/node/issues/31263 for further reference.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
