### PR TITLE
stream: hide afterWriteTickInfo property

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -60,6 +60,8 @@ const {
 
 const { errorOrDestroy } = destroyImpl;
 
+const kAfterWriteTickInfo = Symbol('kAfterWriteTickInfo');
+
 ObjectSetPrototypeOf(Writable.prototype, Stream.prototype);
 ObjectSetPrototypeOf(Writable, Stream);
 
@@ -148,7 +150,7 @@ function WritableState(options, stream, isDuplex) {
 
   // Storage for data passed to the afterWrite() callback in case of
   // synchronous _write() completion.
-  this.afterWriteTickInfo = null;
+  this[kAfterWriteTickInfo] = null;
 
   this.bufferedRequest = null;
   this.lastBufferedRequest = null;
@@ -184,6 +186,12 @@ function WritableState(options, stream, isDuplex) {
   corkReq.finish = onCorkedFinish.bind(undefined, corkReq, this);
   this.corkedRequestsFree = corkReq;
 }
+
+ObjectDefineProperty(WritableState.prototype, 'afterWriteTickInfo', {
+  enumerable: false,
+  get() { return this[kAfterWriteTickInfo]; },
+  set(val) { this[kAfterWriteTickInfo] = val; },
+});
 
 WritableState.prototype.getBuffer = function getBuffer() {
   var current = this.bufferedRequest;
@@ -487,12 +495,12 @@ function onwrite(stream, er) {
       // the same. In that case, we do not schedule a new nextTick(), but rather
       // just increase a counter, to improve performance and avoid memory
       // allocations.
-      if (state.afterWriteTickInfo !== null &&
-          state.afterWriteTickInfo.cb === cb) {
-        state.afterWriteTickInfo.count++;
+      if (state[kAfterWriteTickInfo] !== null &&
+          state[kAfterWriteTickInfo].cb === cb) {
+        state[kAfterWriteTickInfo].count++;
       } else {
-        state.afterWriteTickInfo = { count: 1, cb, stream, state };
-        process.nextTick(afterWriteTick, state.afterWriteTickInfo);
+        state[kAfterWriteTickInfo] = { count: 1, cb, stream, state };
+        process.nextTick(afterWriteTick, state[kAfterWriteTickInfo]);
       }
     } else {
       afterWrite(stream, state, 1, cb);
@@ -501,7 +509,7 @@ function onwrite(stream, er) {
 }
 
 function afterWriteTick({ stream, state, count, cb }) {
-  state.afterWriteTickInfo = null;
+  state[kAfterWriteTickInfo] = null;
   return afterWrite(stream, state, count, cb);
 }
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -188,7 +188,6 @@ function WritableState(options, stream, isDuplex) {
 }
 
 ObjectDefineProperty(WritableState.prototype, 'afterWriteTickInfo', {
-  enumerable: false,
   get() { return this[kAfterWriteTickInfo]; },
   set(val) { this[kAfterWriteTickInfo] = val; },
 });

--- a/test/parallel/test-json-stringify-stdout.js
+++ b/test/parallel/test-json-stringify-stdout.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// Make sure stdout does not contain circular structures.
+// Regression test for https://github.com/nodejs/node/issues/31277
+
+require('../common');
+
+process.stdout.write('');
+JSON.stringify(process.stdout);


### PR DESCRIPTION
Pull request https://github.com/nodejs/node/pull/30710 has introduced `afterWriteTickInfo` property for optimizing synchronous write completions and it is backported to v12.x as a semver-minor release, but it breaks use case of JSON stringifying writable stream object. This PR hides that property behind a symbol.

Fixes https://github.com/nodejs/node/issues/31277

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)