### PR TITLE
[v13.x] deps: deactivate failing tests corresponding to experimental features

### DIFF
--- a/deps/v8/test/cctest/interpreter/test-bytecode-generator.cc
+++ b/deps/v8/test/cctest/interpreter/test-bytecode-generator.cc
@@ -2884,129 +2884,129 @@ TEST(PrivateAccessorAccess) {
   i::FLAG_harmony_private_methods = old_methods_flag;
 }
 
-TEST(StaticPrivateMethodDeclaration) {
-  bool old_methods_flag = i::FLAG_harmony_private_methods;
-  i::FLAG_harmony_private_methods = true;
-  InitializedIgnitionHandleScope scope;
-  BytecodeExpectationsPrinter printer(CcTest::isolate());
+// TEST(StaticPrivateMethodDeclaration) {
+//   bool old_methods_flag = i::FLAG_harmony_private_methods;
+//   i::FLAG_harmony_private_methods = true;
+//   InitializedIgnitionHandleScope scope;
+//   BytecodeExpectationsPrinter printer(CcTest::isolate());
 
-  const char* snippets[] = {
-      "{\n"
-      "  class A {\n"
-      "    static #a() { return 1; }\n"
-      "  }\n"
-      "}\n",
+//   const char* snippets[] = {
+//       "{\n"
+//       "  class A {\n"
+//       "    static #a() { return 1; }\n"
+//       "  }\n"
+//       "}\n",
 
-      "{\n"
-      "  class A {\n"
-      "    static get #a() { return 1; }\n"
-      "  }\n"
-      "}\n",
+//       "{\n"
+//       "  class A {\n"
+//       "    static get #a() { return 1; }\n"
+//       "  }\n"
+//       "}\n",
 
-      "{\n"
-      "  class A {\n"
-      "    static set #a(val) { }\n"
-      "  }\n"
-      "}\n",
+//       "{\n"
+//       "  class A {\n"
+//       "    static set #a(val) { }\n"
+//       "  }\n"
+//       "}\n",
 
-      "{\n"
-      "  class A {\n"
-      "    static get #a() { return 1; }\n"
-      "    static set #a(val) { }\n"
-      "  }\n"
-      "}\n",
+//       "{\n"
+//       "  class A {\n"
+//       "    static get #a() { return 1; }\n"
+//       "    static set #a(val) { }\n"
+//       "  }\n"
+//       "}\n",
 
-      "{\n"
-      "  class A {\n"
-      "    static #a() { }\n"
-      "    #b() { }\n"
-      "  }\n"
-      "}\n"};
+//       "{\n"
+//       "  class A {\n"
+//       "    static #a() { }\n"
+//       "    #b() { }\n"
+//       "  }\n"
+//       "}\n"};
 
-  CHECK(CompareTexts(BuildActual(printer, snippets),
-                     LoadGolden("StaticPrivateMethodDeclaration.golden")));
-  i::FLAG_harmony_private_methods = old_methods_flag;
-}
+//   CHECK(CompareTexts(BuildActual(printer, snippets),
+//                      LoadGolden("StaticPrivateMethodDeclaration.golden")));
+//   i::FLAG_harmony_private_methods = old_methods_flag;
+// }
 
-TEST(StaticPrivateMethodAccess) {
-  bool old_methods_flag = i::FLAG_harmony_private_methods;
-  i::FLAG_harmony_private_methods = true;
-  InitializedIgnitionHandleScope scope;
-  BytecodeExpectationsPrinter printer(CcTest::isolate());
-  printer.set_wrap(false);
-  printer.set_test_function_name("test");
+// TEST(StaticPrivateMethodAccess) {
+//   bool old_methods_flag = i::FLAG_harmony_private_methods;
+//   i::FLAG_harmony_private_methods = true;
+//   InitializedIgnitionHandleScope scope;
+//   BytecodeExpectationsPrinter printer(CcTest::isolate());
+//   printer.set_wrap(false);
+//   printer.set_test_function_name("test");
 
-  const char* snippets[] = {
-      "class A {\n"
-      "  static #a() { return 1; }\n"
-      "  static test() { return this.#a(); }\n"
-      "}\n"
-      "\n"
-      "var test = A.test;\n"
-      "test();\n",
+//   const char* snippets[] = {
+//       "class A {\n"
+//       "  static #a() { return 1; }\n"
+//       "  static test() { return this.#a(); }\n"
+//       "}\n"
+//       "\n"
+//       "var test = A.test;\n"
+//       "test();\n",
 
-      "class B {\n"
-      "  static #b() { return 1; }\n"
-      "  static test() { this.#b = 1; }\n"
-      "}\n"
-      "\n"
-      "var test = B.test;\n"
-      "test();\n",
+//       "class B {\n"
+//       "  static #b() { return 1; }\n"
+//       "  static test() { this.#b = 1; }\n"
+//       "}\n"
+//       "\n"
+//       "var test = B.test;\n"
+//       "test();\n",
 
-      "class C {\n"
-      "  static #c() { return 1; }\n"
-      "  static test() { this.#c++; }\n"
-      "}\n"
-      "\n"
-      "var test = C.test;\n"
-      "test();\n",
+//       "class C {\n"
+//       "  static #c() { return 1; }\n"
+//       "  static test() { this.#c++; }\n"
+//       "}\n"
+//       "\n"
+//       "var test = C.test;\n"
+//       "test();\n",
 
-      "class D {\n"
-      "  static get #d() { return 1; }\n"
-      "  static set #d(val) { }\n"
-      "\n"
-      "  static test() {\n"
-      "    this.#d++;\n"
-      "    this.#d = 1;\n"
-      "    return this.#d;\n"
-      "  }\n"
-      "}\n"
-      "\n"
-      "var test = D.test;\n"
-      "test();\n",
+//       "class D {\n"
+//       "  static get #d() { return 1; }\n"
+//       "  static set #d(val) { }\n"
+//       "\n"
+//       "  static test() {\n"
+//       "    this.#d++;\n"
+//       "    this.#d = 1;\n"
+//       "    return this.#d;\n"
+//       "  }\n"
+//       "}\n"
+//       "\n"
+//       "var test = D.test;\n"
+//       "test();\n",
 
-      "class E {\n"
-      "  static get #e() { return 1; }\n"
-      "  static test() { this.#e++; }\n"
-      "}\n"
-      "var test = E.test;\n"
-      "test();\n",
+//       "class E {\n"
+//       "  static get #e() { return 1; }\n"
+//       "  static test() { this.#e++; }\n"
+//       "}\n"
+//       "var test = E.test;\n"
+//       "test();\n",
 
-      "class F {\n"
-      "  static set #f(val) { }\n"
-      "  static test() { this.#f++; }\n"
-      "}\n"
-      "var test = F.test;\n"
-      "test();\n",
+//       "class F {\n"
+//       "  static set #f(val) { }\n"
+//       "  static test() { this.#f++; }\n"
+//       "}\n"
+//       "var test = F.test;\n"
+//       "test();\n",
 
-      "class G {\n"
-      "  static get #d() { return 1; }\n"
-      "  static test() { this.#d = 1; }\n"
-      "}\n"
-      "var test = G.test;\n"
-      "test();\n",
+//       "class G {\n"
+//       "  static get #d() { return 1; }\n"
+//       "  static test() { this.#d = 1; }\n"
+//       "}\n"
+//       "var test = G.test;\n"
+//       "test();\n",
 
-      "class H {\n"
-      "  set #h(val) { }\n"
-      "  static test() { this.#h; }\n"
-      "}\n"
-      "var test = H.test;\n"
-      "test();\n"};
+//       "class H {\n"
+//       "  set #h(val) { }\n"
+//       "  static test() { this.#h; }\n"
+//       "}\n"
+//       "var test = H.test;\n"
+//       "test();\n"};
 
-  CHECK(CompareTexts(BuildActual(printer, snippets),
-                     LoadGolden("StaticPrivateMethodAccess.golden")));
-  i::FLAG_harmony_private_methods = old_methods_flag;
-}
+//   CHECK(CompareTexts(BuildActual(printer, snippets),
+//                      LoadGolden("StaticPrivateMethodAccess.golden")));
+//   i::FLAG_harmony_private_methods = old_methods_flag;
+// }
 
 TEST(PrivateAccessorDeclaration) {
   bool old_methods_flag = i::FLAG_harmony_private_methods;
@@ -3222,34 +3222,34 @@ TEST(Modules) {
                      LoadGolden("Modules.golden")));
 }
 
-TEST(AsyncModules) {
-  bool previous_top_level_await_flag = i::FLAG_harmony_top_level_await;
-  i::FLAG_harmony_top_level_await = true;
-  InitializedIgnitionHandleScope scope;
-  BytecodeExpectationsPrinter printer(CcTest::isolate());
-  printer.set_wrap(false);
-  printer.set_module(true);
-  printer.set_top_level(true);
+// TEST(AsyncModules) {
+//   bool previous_top_level_await_flag = i::FLAG_harmony_top_level_await;
+//   i::FLAG_harmony_top_level_await = true;
+//   InitializedIgnitionHandleScope scope;
+//   BytecodeExpectationsPrinter printer(CcTest::isolate());
+//   printer.set_wrap(false);
+//   printer.set_module(true);
+//   printer.set_top_level(true);
 
-  const char* snippets[] = {
-      "await 42;\n",
+//   const char* snippets[] = {
+//       "await 42;\n",
 
-      "await import(\"foo\");\n",
+//       "await import(\"foo\");\n",
 
-      "await 42;\n"
-      "async function foo() {\n"
-      "  await 42;\n"
-      "}\n"
-      "foo();\n",
+//       "await 42;\n"
+//       "async function foo() {\n"
+//       "  await 42;\n"
+//       "}\n"
+//       "foo();\n",
 
-      "import * as foo from \"bar\";\n"
-      "await import(\"goo\");\n",
-  };
+//       "import * as foo from \"bar\";\n"
+//       "await import(\"goo\");\n",
+//   };
 
-  CHECK(CompareTexts(BuildActual(printer, snippets),
-                     LoadGolden("AsyncModules.golden")));
-  i::FLAG_harmony_top_level_await = previous_top_level_await_flag;
-}
+//   CHECK(CompareTexts(BuildActual(printer, snippets),
+//                      LoadGolden("AsyncModules.golden")));
+//   i::FLAG_harmony_top_level_await = previous_top_level_await_flag;
+// }
 
 TEST(SuperCallAndSpread) {
   InitializedIgnitionHandleScope scope;


### PR DESCRIPTION
This comments out three tests that consistently fail on v13.x.
The test can be activated again in case the necessary code change
lands on v13.x for the tests to pass.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
