### PR TITLE
build: silence warnings from dependencies

### DIFF
--- a/deps/cares/cares.gyp
+++ b/deps/cares/cares.gyp
@@ -112,7 +112,10 @@
           'defines': [ 'CARES_BUILDING_LIBRARY' ]
         }],
         [ 'OS=="win"', {
-          'defines': [ 'CARES_PULL_WS2TCPIP_H=1' ],
+          'defines': [
+            'CARES_PULL_WS2TCPIP_H=1',
+            '_WINSOCK_DEPRECATED_NO_WARNINGS',
+          ],
           'include_dirs': [ 'config/win32' ],
           'sources': [
             'src/config-win32.h',

--- a/deps/openssl/openssl_common.gypi
+++ b/deps/openssl/openssl_common.gypi
@@ -32,6 +32,7 @@
       'cflags': [
         '-W3', '-wd4090', '-Gs0', '-GF', '-Gy', '-nologo','/O2',
       ],
+      'msvs_disabled_warnings': [4090],
       'link_settings': {
         'libraries': [
           '-lws2_32.lib',


### PR DESCRIPTION
Silence compiler warnings on Windows from our dependencies that are being
shown as `Unchanged files with check annotations` by GitHub in the 
`Files changed` tab on pull requests since we started building via GitHub Actions 
in https://github.com/nodejs/node/pull/31153.

e.g.
![image](https://user-images.githubusercontent.com/5445507/72199732-cf100280-3437-11ea-89e5-ce3eb1efe78b.png)

(I've separately upstreamed a fix for the uvwasi warning: https://github.com/cjihrig/uvwasi/pull/72.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
