### PR TITLE
stream: fixes async iterator destroyed error propagation

### DIFF
--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -78,18 +78,20 @@ const ReadableStreamAsyncIteratorPrototype = ObjectSetPrototypeOf({
     }
 
     if (this[kStream].destroyed) {
-      // We need to defer via nextTick because if .destroy(err) is
-      // called, the error will be emitted via nextTick, and
-      // we cannot guarantee that there is no error lingering around
-      // waiting to be emitted.
       return new Promise((resolve, reject) => {
-        process.nextTick(() => {
-          if (this[kError]) {
-            reject(this[kError]);
-          } else {
-            resolve(createIterResult(undefined, true));
-          }
-        });
+        if (this[kError]) {
+          reject(this[kError]);
+        } else if (this[kEnded]) {
+          resolve(createIterResult(undefined, true));
+        } else {
+          finished(this[kStream], (err) => {
+            if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
+              reject(err);
+            } else {
+              resolve(createIterResult(undefined, true));
+            }
+          });
+        }
       });
     }
 

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -484,6 +484,22 @@ async function tests() {
       assert.strictEqual(e, err);
     })()]);
   }
+
+  {
+    const r = new Readable({
+      read () {
+      },
+      destroy(err, callback) {
+        setTimeout(() => callback(new Error('asd')), 1);
+      }
+    });
+
+    r.destroy();
+    const it = r[Symbol.asyncIterator]();
+    it.next().catch(common.mustCall((err) => {
+      assert.strictEqual(err.message, 'asd');
+    }));
+  }
 }
 
 {

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -487,7 +487,7 @@ async function tests() {
 
   {
     const r = new Readable({
-      read () {
+      read() {
       },
       destroy(err, callback) {
         setTimeout(() => callback(new Error('asd')), 1);

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -486,18 +486,19 @@ async function tests() {
   }
 
   {
+    const _err = new Error('asd');
     const r = new Readable({
       read() {
       },
       destroy(err, callback) {
-        setTimeout(() => callback(new Error('asd')), 1);
+        setTimeout(() => callback(_err), 1);
       }
     });
 
     r.destroy();
     const it = r[Symbol.asyncIterator]();
     it.next().catch(common.mustCall((err) => {
-      assert.strictEqual(err.message, 'asd');
+      assert.strictEqual(err, _err);
     }));
   }
 }


### PR DESCRIPTION
There was an edge case where if _destroy calls the error callback
later than one tick the iterator would complete early and not
propgate the error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
