### PR TITLE
stream: async iterator improvements

### DIFF
--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -20,6 +20,8 @@ const kLastPromise = Symbol('lastPromise');
 const kHandlePromise = Symbol('handlePromise');
 const kStream = Symbol('stream');
 
+let Readable;
+
 function createIterResult(value, done) {
   return { value, done };
 }
@@ -145,6 +147,22 @@ const ReadableStreamAsyncIteratorPrototype = ObjectSetPrototypeOf({
 }, AsyncIteratorPrototype);
 
 const createReadableStreamAsyncIterator = (stream) => {
+  if (typeof stream.read !== 'function') {
+    // v1 stream
+
+    if (!Readable) {
+      Readable = require('_stream_readable');
+    }
+
+    const src = stream;
+    stream = new Readable({ objectMode: true }).wrap(src);
+    finished(stream, (err) => {
+      if (typeof src.destroy === 'function') {
+        src.destroy(err);
+      }
+    });
+  }
+
   const iterator = ObjectCreate(ReadableStreamAsyncIteratorPrototype, {
     [kStream]: { value: stream, writable: true },
     [kLastResolve]: { value: null, writable: true },

--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -22,6 +22,15 @@ const kStream = Symbol('stream');
 
 let Readable;
 
+function destroy(stream, err) {
+  // request.destroy just do .end - .abort is what we want
+  if (typeof stream.abort === 'function') return stream.abort();
+  if (stream.req &&
+      typeof stream.req.abort === 'function') return stream.req.abort();
+  if (typeof stream.destroy === 'function') return stream.destroy(err);
+  if (typeof stream.close === 'function') return stream.close();
+}
+
 function createIterResult(value, done) {
   return { value, done };
 }
@@ -141,7 +150,7 @@ const ReadableStreamAsyncIteratorPrototype = ObjectSetPrototypeOf({
           resolve(createIterResult(undefined, true));
         }
       });
-      stream.destroy();
+      destroy(stream);
     });
   },
 }, AsyncIteratorPrototype);
@@ -156,11 +165,7 @@ const createReadableStreamAsyncIterator = (stream) => {
 
     const src = stream;
     stream = new Readable({ objectMode: true }).wrap(src);
-    finished(stream, (err) => {
-      if (typeof src.destroy === 'function') {
-        src.destroy(err);
-      }
-    });
+    finished(stream, (err) => destroy(src, err));
   }
 
   const iterator = ObjectCreate(ReadableStreamAsyncIteratorPrototype, {

--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -11,6 +11,7 @@ const {
 } = primordials;
 
 const finished = require('internal/streams/end-of-stream');
+const destroyImpl = require('internal/streams/destroy');
 
 const kLastResolve = Symbol('lastResolve');
 const kLastReject = Symbol('lastReject');
@@ -21,15 +22,6 @@ const kHandlePromise = Symbol('handlePromise');
 const kStream = Symbol('stream');
 
 let Readable;
-
-function destroy(stream, err) {
-  // request.destroy just do .end - .abort is what we want
-  if (typeof stream.abort === 'function') return stream.abort();
-  if (stream.req &&
-      typeof stream.req.abort === 'function') return stream.req.abort();
-  if (typeof stream.destroy === 'function') return stream.destroy(err);
-  if (typeof stream.close === 'function') return stream.close();
-}
 
 function createIterResult(value, done) {
   return { value, done };
@@ -92,7 +84,7 @@ function finish(self, err) {
         resolve(createIterResult(undefined, true));
       }
     });
-    destroy(stream, err);
+    destroyImpl.destroyer(stream, err);
   });
 }
 
@@ -174,7 +166,7 @@ const createReadableStreamAsyncIterator = (stream) => {
 
     const src = stream;
     stream = new Readable({ objectMode: true }).wrap(src);
-    finished(stream, (err) => destroy(src, err));
+    finished(stream, (err) => destroyImpl.destroyer(src, err));
   }
 
   const iterator = ObjectCreate(ReadableStreamAsyncIteratorPrototype, {

--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -71,6 +71,31 @@ function wrapForNext(lastPromise, iter) {
 const AsyncIteratorPrototype = ObjectGetPrototypeOf(
   ObjectGetPrototypeOf(async function* () {}).prototype);
 
+function finish(self, err) {
+  return new Promise((resolve, reject) => {
+    const stream = self[kStream];
+
+    // TODO(ronag): Remove this check once finished() handles
+    // already ended and/or destroyed streams.
+    const ended = stream.destroyed || stream.readableEnded ||
+      (stream._readableState && stream._readableState.endEmitted);
+
+    if (ended) {
+      resolve(createIterResult(undefined, true));
+      return;
+    }
+
+    finished(stream, (err) => {
+      if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
+        reject(err);
+      } else {
+        resolve(createIterResult(undefined, true));
+      }
+    });
+    destroy(stream, err);
+  });
+}
+
 const ReadableStreamAsyncIteratorPrototype = ObjectSetPrototypeOf({
   get stream() {
     return this[kStream];
@@ -131,27 +156,11 @@ const ReadableStreamAsyncIteratorPrototype = ObjectSetPrototypeOf({
   },
 
   return() {
-    return new Promise((resolve, reject) => {
-      const stream = this[kStream];
+    return finish(this);
+  },
 
-      // TODO(ronag): Remove this check once finished() handles
-      // already ended and/or destroyed streams.
-      const ended = stream.destroyed || stream.readableEnded ||
-        (stream._readableState && stream._readableState.endEmitted);
-      if (ended) {
-        resolve(createIterResult(undefined, true));
-        return;
-      }
-
-      finished(stream, (err) => {
-        if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
-          reject(err);
-        } else {
-          resolve(createIterResult(undefined, true));
-        }
-      });
-      destroy(stream);
-    });
+  throw(err) {
+    return finish(this, err);
   },
 }, AsyncIteratorPrototype);
 

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -151,8 +151,21 @@ function errorOrDestroy(stream, err, sync) {
   }
 }
 
+function isRequest(stream) {
+  return stream && stream.setHeader && typeof stream.abort === 'function';
+}
+
+// Normalize destroy for legacy.
+function destroyer(stream, err) {
+  // request.destroy just do .end - .abort is what we want
+  if (isRequest(stream)) return stream.abort();
+  if (isRequest(stream.req)) return stream.req.abort();
+  if (typeof stream.destroy === 'function') return stream.destroy(err);
+  if (typeof stream.close === 'function') return stream.close();
+}
 
 module.exports = {
+  destroyer,
   destroy,
   undestroy,
   errorOrDestroy

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -28,14 +28,6 @@ function isRequest(stream) {
   return stream && stream.setHeader && typeof stream.abort === 'function';
 }
 
-function destroyStream(stream, err) {
-  // request.destroy just do .end - .abort is what we want
-  if (isRequest(stream)) return stream.abort();
-  if (isRequest(stream.req)) return stream.req.abort();
-  if (typeof stream.destroy === 'function') return stream.destroy(err);
-  if (typeof stream.close === 'function') return stream.close();
-}
-
 function destroyer(stream, reading, writing, callback) {
   callback = once(callback);
 
@@ -57,7 +49,11 @@ function destroyer(stream, reading, writing, callback) {
     if (destroyed) return;
     destroyed = true;
 
-    destroyStream(stream, err);
+    // request.destroy just do .end - .abort is what we want
+    if (isRequest(stream)) return stream.abort();
+    if (isRequest(stream.req)) return stream.req.abort();
+    if (typeof stream.destroy === 'function') return stream.destroy(err);
+    if (typeof stream.close === 'function') return stream.close();
 
     callback(err || new ERR_STREAM_DESTROYED('pipe'));
   };
@@ -101,39 +97,19 @@ function makeAsyncIterable(val) {
     return val;
   } else if (isReadable(val)) {
     // Legacy streams are not Iterable.
-    return _fromReadable(val);
+    return fromReadable(val);
   } else {
     throw new ERR_INVALID_ARG_TYPE(
       'val', ['Readable', 'Iterable', 'AsyncIterable'], val);
   }
 }
 
-async function* _fromReadable(val) {
+async function* fromReadable(val) {
   if (!createReadableStreamAsyncIterator) {
     createReadableStreamAsyncIterator =
       require('internal/streams/async_iterator');
   }
-
-  try {
-    if (typeof val.read !== 'function') {
-      // createReadableStreamAsyncIterator does not support
-      // v1 streams. Convert it into a v2 stream.
-
-      if (!PassThrough) {
-        PassThrough = require('_stream_passthrough');
-      }
-
-      const pt = new PassThrough();
-      val
-        .on('error', (err) => pt.destroy(err))
-        .pipe(pt);
-      yield* createReadableStreamAsyncIterator(pt);
-    } else {
-      yield* createReadableStreamAsyncIterator(val);
-    }
-  } finally {
-    destroyStream(val);
-  }
+  yield* createReadableStreamAsyncIterator(val);
 }
 
 async function pump(iterable, writable, finish) {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -12,6 +12,7 @@ const {
 let eos;
 
 const { once } = require('internal/util');
+const destroyImpl = require('internal/streams/destroy');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_RETURN_VALUE,
@@ -23,10 +24,6 @@ const {
 let EE;
 let PassThrough;
 let createReadableStreamAsyncIterator;
-
-function isRequest(stream) {
-  return stream && stream.setHeader && typeof stream.abort === 'function';
-}
 
 function destroyer(stream, reading, writing, callback) {
   callback = once(callback);
@@ -49,11 +46,7 @@ function destroyer(stream, reading, writing, callback) {
     if (destroyed) return;
     destroyed = true;
 
-    // request.destroy just do .end - .abort is what we want
-    if (isRequest(stream)) return stream.abort();
-    if (isRequest(stream.req)) return stream.req.abort();
-    if (typeof stream.destroy === 'function') return stream.destroy(err);
-    if (typeof stream.close === 'function') return stream.close();
+    destroyImpl.destroyer(stream, err);
 
     callback(err || new ERR_STREAM_DESTROYED('pipe'));
   };

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -1,7 +1,13 @@
 'use strict';
 
 const common = require('../common');
-const { Readable, Transform, PassThrough, pipeline } = require('stream');
+const {
+  Stream,
+  Readable,
+  Transform,
+  PassThrough,
+  pipeline
+} = require('stream');
 const assert = require('assert');
 
 async function tests() {
@@ -12,6 +18,42 @@ async function tests() {
     assert.strictEqual(
       Object.getPrototypeOf(Object.getPrototypeOf(rs[Symbol.asyncIterator]())),
       AsyncIteratorPrototype);
+  }
+
+  {
+    // v1 stream
+
+    const stream = new Stream();
+    stream.destroy = common.mustCall();
+    process.nextTick(() => {
+      stream.emit('data', 'hello');
+      stream.emit('data', 'world');
+      stream.emit('end');
+    });
+
+    let res = '';
+    stream[Symbol.asyncIterator] = Readable.prototype[Symbol.asyncIterator];
+    for await (const d of stream) {
+      res += d;
+    }
+    assert.strictEqual(res, 'helloworld');
+  }
+
+  {
+    // v1 stream error
+
+    const stream = new Stream();
+    stream.close = common.mustCall();
+    process.nextTick(() => {
+      stream.emit('data', 0);
+      stream.emit('data', 1);
+      stream.emit('error', new Error('asd'));
+    });
+
+    const iter = Readable.prototype[Symbol.asyncIterator].call(stream);
+    iter.next().catch(common.mustCall((err) => {
+      assert.strictEqual(err.message, 'asd');
+    }));
   }
 
   {

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -283,6 +283,28 @@ async function tests() {
   }
 
   {
+    // Iterator throw.
+
+    const readable = new Readable({
+      objectMode: true,
+      read() {
+        this.push('hello');
+      }
+    });
+
+    readable.on('error', common.mustCall((err) => {
+      assert.strictEqual(err.message, 'kaboom');
+    }));
+
+    const it = readable[Symbol.asyncIterator]();
+    it.throw(new Error('kaboom')).catch(common.mustCall((err) => {
+      assert.strictEqual(err.message, 'kaboom');
+    }));
+
+    assert.strictEqual(readable.destroyed, true);
+  }
+
+  {
     console.log('destroyed by throw');
     const readable = new Readable({
       objectMode: true,

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -57,6 +57,25 @@ async function tests() {
   }
 
   {
+    // Non standard stream cleanup
+
+    const readable = new Readable({ autoDestroy: false, read() {} });
+    readable.push('asd');
+    readable.push('asd');
+    readable.destroy = null;
+    readable.close = common.mustCall(() => {
+      readable.emit('close');
+    });
+
+    await (async () => {
+      for await (const d of readable) {
+        d;
+        return;
+      }
+    })();
+  }
+
+  {
     const readable = new Readable({ objectMode: true, read() {} });
     readable.push(0);
     readable.push(1);


### PR DESCRIPTION
Includes a few different fixes separated into commits:

- Adds support to create async iterators from v1 streams.
- Normalize destroying non conforming streams.
- Implement throw on the iterator.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
