### PR TITLE
readline: make tab size configurable

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -456,6 +456,9 @@ the current position of the cursor down.
 <!-- YAML
 added: v0.1.98
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/31318
+    description: The `tabSize` option is supported now.
   - version: v8.3.0, 6.11.4
     pr-url: https://github.com/nodejs/node/pull/13497
     description: Remove max limit of `crlfDelay` option.
@@ -499,6 +502,8 @@ changes:
     can both form a complete key sequence using the input read so far and can
     take additional input to complete a longer key sequence).
     **Default:** `500`.
+  * `tabSize` {integer} The number of spaces a tab is equal to (minimum 1).
+    **Default:** `8`.
 
 The `readline.createInterface()` method creates a new `readline.Interface`
 instance.

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -45,7 +45,10 @@ const {
   ERR_INVALID_CURSOR_POS,
   ERR_INVALID_OPT_VALUE
 } = require('internal/errors').codes;
-const { validateString } = require('internal/validators');
+const {
+  validateString,
+  validateUint32,
+} = require('internal/validators');
 const {
   inspect,
   getStringWidth,
@@ -105,6 +108,7 @@ function Interface(input, output, completer, terminal) {
   this._sawKeyPress = false;
   this._previousKey = null;
   this.escapeCodeTimeout = ESCAPE_CODE_TIMEOUT;
+  this.tabSize = 8;
 
   EventEmitter.call(this);
   let historySize;
@@ -118,6 +122,11 @@ function Interface(input, output, completer, terminal) {
     completer = input.completer;
     terminal = input.terminal;
     historySize = input.historySize;
+    if (input.tabSize !== undefined) {
+      const positive = true;
+      validateUint32(input.tabSize, 'tabSize', positive);
+      this.tabSize = input.tabSize;
+    }
     removeHistoryDuplicates = input.removeHistoryDuplicates;
     if (input.prompt !== undefined) {
       prompt = input.prompt;
@@ -718,10 +727,9 @@ Interface.prototype._getDisplayPos = function(str) {
       offset = 0;
       continue;
     }
-    // Tabs must be aligned by an offset of 8.
-    // TODO(BridgeAR): Make the tab size configurable.
+    // Tabs must be aligned by an offset of the tab size.
     if (char === '\t') {
-      offset += 8 - (offset % 8);
+      offset += this.tabSize - (offset % this.tabSize);
       continue;
     }
     const width = getStringWidth(char);


### PR DESCRIPTION
This adds the `tabSize` option to readline to allow different tab
sizes. It also cleans up some code and unifies the linebreak RegExp.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
