### PR TITLE
errors: remove dead code in ERR_INVALID_ARG_TYPE

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -946,14 +946,7 @@ E('ERR_INVALID_ARG_TYPE',
       const type = name.includes('.') ? 'property' : 'argument';
       msg += `"${name}" ${type} `;
     }
-
-    // determiner: 'must be' or 'must not be'
-    if (typeof expected === 'string' && expected.startsWith('not ')) {
-      msg += 'must not be ';
-      expected = expected.replace(/^not /, '');
-    } else {
-      msg += 'must be ';
-    }
+    msg += 'must be ';
 
     const types = [];
     const instances = [];


### PR DESCRIPTION
Remove unreachable code. As `expected` is converted to an `Array` the 'not ' check will be never executed.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
