### PR TITLE
build: add GitHub actions to run linters

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 13
         uses: actions/setup-node@v1
         with:
           node-version: 13.x
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 13
         uses: actions/setup-node@v1
         with:
           node-version: 13.x
@@ -33,7 +33,7 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 13
         uses: actions/setup-node@v1
         with:
           node-version: 13.x
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 10
       uses: actions/setup-node@v1
       with:
         node-version: 10.x
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 10
       uses: actions/setup-node@v1
       with:
         node-version: 10.x
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 10
       uses: actions/setup-node@v1
       with:
         node-version: 10.x

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,3 +41,39 @@ jobs:
         run: npx envinfo
       - name: Build
         run: ./configure && make -j8
+  lint-addon-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - name: Lint addon docs
+      run: NODE=$(which node) make lint-addon-docs
+  lint-cpp:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Lint C/C++ files
+      run: make lint-cpp
+  lint-md:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - name: Lint docs
+      run: NODE=$(which node) make lint-md
+  lint-js:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - name: Lint JavaScript files
+      run: NODE=$(which node) make lint-js


### PR DESCRIPTION
Add jobs to our GitHub Actions workflow to run our various lint Makefile 
targets. The `setup-node` action used to run the JavaScript linter contains 
[problem matchers for eslint](https://github.com/actions/setup-node/blob/master/.github/eslint-stylish.json) that will annotate the files in a pull request if 
there are failures.

The Python linting has been left out as I believe it's being included as part of
https://github.com/nodejs/node/pull/29474.

See https://github.com/richardlau/node-1/pull/3/files for an example of the 
annotations for lint-js failures. 
![image](https://user-images.githubusercontent.com/5445507/72212685-5f058900-34d8-11ea-808e-6df86796515b.png)

We may be able to create problem matchers for the cpplint.py and markdown 
linters in the future based on 
https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
