### PR TITLE
src: use uv_guess_handle() to detect TTYs

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -109,9 +109,6 @@
 #include <unistd.h>        // STDIN_FILENO, STDERR_FILENO
 #endif
 
-#ifdef __PASE__
-#include <sys/ioctl.h>  // ioctl
-#endif
 // ========== global C++ headers ==========
 
 #include <cerrno>
@@ -589,14 +586,7 @@ inline void PlatformInit() {
     while (s.flags == -1 && errno == EINTR);  // NOLINT
     CHECK_NE(s.flags, -1);
 
-#ifdef __PASE__
-    // On IBMi PASE isatty() always returns true for stdin, stdout and stderr.
-    // Use ioctl() instead to identify whether it's actually a TTY.
-    if (ioctl(fd, TXISATTY + 0x81, nullptr) == -1 && errno == ENOTTY)
-      continue;
-#else
-    if (!isatty(fd)) continue;
-#endif
+    if (uv_guess_handle(fd) != UV_TTY) continue;
     s.isatty = true;
 
     do


### PR DESCRIPTION
The first commit is the libuv update from https://github.com/nodejs/node/pull/31332, and can be ignored for the purposes of this PR.

This commit drops the use of `isatty()` and IBMi specific code in favor of `uv_guess_handle()` now that the relevant IBMi changes have been upstreamed.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)