### PR TITLE
deps: V8: cherry-pick b9d33036e9a8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.27',
+    'v8_embedder_string': '-node.28',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/ast/source-range-ast-visitor.cc
+++ b/deps/v8/src/ast/source-range-ast-visitor.cc
@@ -41,7 +41,14 @@ void SourceRangeAstVisitor::VisitFunctionLiteral(FunctionLiteral* expr) {
 
 void SourceRangeAstVisitor::VisitTryCatchStatement(TryCatchStatement* stmt) {
   AstTraversalVisitor::VisitTryCatchStatement(stmt);
+  MaybeRemoveContinuationRange(stmt->try_block());
   MaybeRemoveContinuationRangeOfAsyncReturn(stmt);
+}
+
+void SourceRangeAstVisitor::VisitTryFinallyStatement(
+    TryFinallyStatement* stmt) {
+  AstTraversalVisitor::VisitTryFinallyStatement(stmt);
+  MaybeRemoveContinuationRange(stmt->try_block());
 }
 
 bool SourceRangeAstVisitor::VisitNode(AstNode* node) {

--- a/deps/v8/src/ast/source-range-ast-visitor.h
+++ b/deps/v8/src/ast/source-range-ast-visitor.h
@@ -38,6 +38,7 @@ class SourceRangeAstVisitor final
   void VisitFunctionLiteral(FunctionLiteral* expr);
   bool VisitNode(AstNode* node);
   void VisitTryCatchStatement(TryCatchStatement* stmt);
+  void VisitTryFinallyStatement(TryFinallyStatement* stmt);
 
   void MaybeRemoveContinuationRange(Statement* last_statement);
   void MaybeRemoveLastContinuationRange(ZonePtrList<Statement>* stmts);

--- a/deps/v8/test/mjsunit/code-coverage-block.js
+++ b/deps/v8/test/mjsunit/code-coverage-block.js
@@ -337,11 +337,7 @@ TestCoverage(
 [{"start":0,"end":849,"count":1},
  {"start":1,"end":801,"count":1},
  {"start":67,"end":87,"count":0},
- {"start":221,"end":222,"count":0},
- {"start":254,"end":274,"count":0},
- {"start":371,"end":372,"count":0},
- {"start":403,"end":404,"count":0},
- {"start":553,"end":554,"count":0}]
+ {"start":254,"end":274,"count":0}]
 );
 
 TestCoverage("try/catch/finally statements with early return",
@@ -358,10 +354,8 @@ TestCoverage("try/catch/finally statements with early return",
 `,
 [{"start":0,"end":449,"count":1},
  {"start":1,"end":151,"count":1},
- {"start":69,"end":70,"count":0},
  {"start":91,"end":150,"count":0},
  {"start":201,"end":401,"count":1},
- {"start":269,"end":270,"count":0},
  {"start":321,"end":400,"count":0}]
 );
 
@@ -393,7 +387,6 @@ TestCoverage(
 `,
 [{"start":0,"end":1099,"count":1},
  {"start":1,"end":151,"count":1},
- {"start":69,"end":70,"count":0},
  {"start":91,"end":150,"count":0},
  {"start":201,"end":351,"count":1},
  {"start":286,"end":350,"count":0},
@@ -401,7 +394,6 @@ TestCoverage(
  {"start":603,"end":700,"count":0},
  {"start":561,"end":568,"count":0},
  {"start":751,"end":1051,"count":1},
- {"start":819,"end":820,"count":0},
  {"start":861,"end":1050,"count":0}]
 );
 
@@ -561,7 +553,6 @@ try {                                     // 0200
 } catch (e) {}                            // 0450
 `,
 [{"start":0,"end":499,"count":1},
- {"start":451,"end":452,"count":0},
  {"start":12,"end":101,"count":1},
  {"start":60,"end":100,"count":0},
  {"start":264,"end":353,"count":1},
@@ -636,7 +627,6 @@ try {                                     // 0200
 } catch (e) {}                            // 0450
 `,
 [{"start":0,"end":499,"count":1},
- {"start":451,"end":452,"count":0},
  {"start":12,"end":101,"count":1},
  {"start":65,"end":100,"count":0},
  {"start":264,"end":353,"count":1},
@@ -1017,7 +1007,6 @@ try {                                     // 0500
 } catch (err) {}                          // 0600
 `,
 [{"start":0,"end":649,"count":1},
- {"start":351,"end":352,"count":0},
  {"start":602,"end":616,"count":0},
  {"start":0,"end":201,"count":2},
  {"start":69,"end":153,"count":1}]
@@ -1093,7 +1082,8 @@ function test(foo = "foodef") {           // 0000
     console.log("test");                  // 0200
   }                                       // 0250
 }                                         // 0300
-test().bar();                             // 0350`,
+test().bar();                             // 0350
+`,
 [{"start":0,"end":399,"count":1},
  {"start":0,"end":301,"count":1},
  {"start":152,"end":253,"count":1}]);
@@ -1105,11 +1095,86 @@ function test(foo = (()=>{})) {           // 0000
   return {foo};                           // 0050
 }                                         // 0100
                                           // 0150
-test(()=>{}).foo();                       // 0200`,
+test(()=>{}).foo();                       // 0200
+`,
 [{"start":0,"end":249,"count":1},
  {"start":0,"end":101,"count":1},
  {"start":21,"end":27,"count":0},
  {"start":205,"end":211,"count":1}]
 );
+
+TestCoverage(
+"https://crbug.com/v8/10030 - original",
+`
+function a (shouldThrow) {                // 0000
+  try {                                   // 0050
+    if (shouldThrow)                      // 0100
+      throw Error('I threw!');            // 0150
+    return 'I ran';                       // 0200
+  } catch(e) {                            // 0250
+    console.info('caught');               // 0300
+  }                                       // 0350
+}                                         // 0400
+a(false);                                 // 0450
+a(true);                                  // 0500
+`,
+[{"start":0,"end":549,"count":1},
+ {"start":0,"end":401,"count":2},
+ {"start":156,"end":353,"count":1}]
+);
+
+TestCoverage(
+"https://crbug.com/v8/10030 - only throw",
+`
+function a (shouldThrow) {                // 0000
+  try {                                   // 0050
+    if (shouldThrow)                      // 0100
+      throw Error('I threw!');            // 0150
+    return 'I ran';                       // 0200
+  } catch(e) {                            // 0250
+    console.info('caught');               // 0300
+  }                                       // 0350
+}                                         // 0400
+a(true);                                  // 0450
+`,
+[{"start":0,"end":499,"count":1},
+ {"start":0,"end":401,"count":1},
+ {"start":180,"end":254,"count":0}]
+);
+
+TestCoverage(
+"https://crbug.com/v8/10030 - finally",
+`
+function a (shouldThrow) {                // 0000
+  try {                                   // 0050
+    return 'I ran';                       // 0100
+  } finally {                             // 0150
+    console.info('finally');              // 0200
+  }                                       // 0250
+}                                         // 0300
+a(false);                                 // 0350
+a(true);                                  // 0400
+`,
+[{"start":0,"end":449,"count":1},
+ {"start":0,"end":301,"count":2}]);
+
+TestCoverage(
+"https://crbug.com/v8/10030 - catch & finally",
+`
+function a (shouldThrow) {                // 0000
+  try {                                   // 0050
+    return 'I ran';                       // 0100
+  } catch (e) {                           // 0150
+    console.info('caught');               // 0200
+  } finally {                             // 0250
+    console.info('finally');              // 0300
+  }                                       // 0350
+}                                         // 0400
+a(false);                                 // 0450
+a(true);                                  // 0500
+`,
+[{"start":0,"end":549,"count":1},
+ {"start":0,"end":401,"count":2},
+ {"start":154,"end":254,"count":0}]);
 
 %DebugToggleBlockCoverage(false);


### PR DESCRIPTION
Original commit message:

    [coverage] Improve whitespace precision of coverage reporting

    This CL improves whitespace precision of coverage around try blocks;
    previously a small portion of whitespace could be reported as uncovered
    between try blocks and catch and/or finally blocks.

    Change-Id: I763ae3d15106c88f2278cf8893c12b0869a62528
    Fixed: v8:10030
    Bug: v8:10030
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1962265
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Reviewed-by: Jakob Gruber <jgruber@chromium.org>
    Commit-Queue: Sigurd Schneider <sigurds@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#65593}

Refs: https://github.com/v8/v8/commit/b9d33036e9a80fff87824f157f68928955842e66

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

refs: #25937

CC: @sigurdschneider
