### PR TITLE
support maxConnections event on net server

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -97,7 +97,7 @@ Emitted when a new connection is made. `socket` is an instance of
 added: REPLACEME
 -->
 
-Emitted when the server has reached his connection limit defined in [`server.maxConnections`][].
+Emitted when the server has reached its connection limit defined in [`server.maxConnections`][].
 
 ### Event: `'error'`
 <!-- YAML

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -92,6 +92,13 @@ added: v0.1.90
 Emitted when a new connection is made. `socket` is an instance of
 `net.Socket`.
 
+### Event: `'maxConnections'`
+<!-- YAML
+added: REPLACEME
+-->
+
+Emitted when the server has reached his connection limit defined in [`server.maxConnections`][].
+
 ### Event: `'error'`
 <!-- YAML
 added: v0.1.90
@@ -1251,6 +1258,7 @@ Returns `true` if input is a version 6 IP address, otherwise returns `false`.
 [`server.listen(handle)`]: #net_server_listen_handle_backlog_callback
 [`server.listen(options)`]: #net_server_listen_options_callback
 [`server.listen(path)`]: #net_server_listen_path_backlog_callback
+[`server.maxConnections`]: #net_server_maxconnections
 [`socket(7)`]: http://man7.org/linux/man-pages/man7/socket.7.html
 [`socket.connect()`]: #net_socket_connect
 [`socket.connect(options)`]: #net_socket_connect_options_connectlistener

--- a/lib/net.js
+++ b/lib/net.js
@@ -1535,6 +1535,7 @@ function onconnection(err, clientHandle) {
   }
 
   if (self.maxConnections && self._connections >= self.maxConnections) {
+    self.emit('maxConnections');
     clientHandle.close();
     return;
   }

--- a/test/parallel/test-net-server-max-connections.js
+++ b/test/parallel/test-net-server-max-connections.js
@@ -44,6 +44,7 @@ server.listen(0, function() {
 
 server.maxConnections = N / 2;
 
+server.on('maxConnections', common.mustCall(N / 2));
 
 function makeConnection(index) {
   const c = net.createConnection(server.address().port);

--- a/test/parallel/test-net-server-max-connections.js
+++ b/test/parallel/test-net-server-max-connections.js
@@ -44,7 +44,7 @@ server.listen(0, function() {
 
 server.maxConnections = N / 2;
 
-server.on('maxConnections', common.mustCall(N / 2));
+server.on('maxConnections', common.mustCall(server.maxConnections));
 
 function makeConnection(index) {
   const c = net.createConnection(server.address().port);

--- a/test/parallel/test-net-stream.js
+++ b/test/parallel/test-net-stream.js
@@ -47,7 +47,7 @@ const buf = Buffer.alloc(SIZE, 'a');
 const server = net.createServer(function(socket) {
   socket.setNoDelay();
 
-  socket.on('error', function(err) {
+  socket.on('error', function() {
     socket.destroy();
   }).on('close', function() {
     server.close();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

I think this could help with the developer experience, when the server connection limit is reached there is not feedback.

At this point, the event is emitted every new connection over the limit, I mean, if the limit is 10, and we get 12 connections, the event will be emitted twice.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
