### PR TITLE
[v12.x] deps: V8: cherry-pick d89f4ef1cd62

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.24',
+    'v8_embedder_string': '-node.25',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/codegen/s390/macro-assembler-s390.cc
+++ b/deps/v8/src/codegen/s390/macro-assembler-s390.cc
@@ -1336,8 +1336,8 @@ void MacroAssembler::CheckDebugHook(Register fun, Register new_target,
   ExternalReference debug_hook_active =
       ExternalReference::debug_hook_on_function_call_address(isolate());
   Move(r6, debug_hook_active);
-  tm(MemOperand(r6), Operand::Zero());
-  bne(&skip_hook);
+  tm(MemOperand(r6), Operand(0xFF));
+  beq(&skip_hook);
 
   {
     // Load receiver to pass it later to DebugOnFunctionCall hook.


### PR DESCRIPTION
Original commit message:

    S390x: improve performance by skipping Debug Hook if not needed

    Change-Id: Ib4b2821f2941cdc131f9c75b89a3baced7554f8d
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1991802
    Reviewed-by: Junliang Yan <jyan@ca.ibm.com>
    Commit-Queue: Milad Farazmand <miladfar@ca.ibm.com>
    Cr-Commit-Position: refs/heads/master@{#65644}

Refs: https://github.com/v8/v8/commit/d89f4ef1cd629cb169f0d9efcaefd05ebf09fd3d

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
