### PR TITLE
build: do not use setup-node in build workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,10 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 13
-        uses: actions/setup-node@v1
-        with:
-          node-version: 13.x
       - name: Environment Information
         run: npx envinfo
       - name: Build
@@ -19,10 +15,6 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 13
-        uses: actions/setup-node@v1
-        with:
-          node-version: 13.x
       - name: Environment Information
         run: npx envinfo
       - name: Install deps
@@ -33,10 +25,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 13
-        uses: actions/setup-node@v1
-        with:
-          node-version: 13.x
       - name: Environment Information
         run: npx envinfo
       - name: Build


### PR DESCRIPTION
The [setup-node GitHub Action](https://github.com/actions/setup-node) installs [problem matchers](https://github.com/actions/setup-node/blob/v1.3.0/.github/tsc.json) that happen
to match the warning message format of Visual Studio's C/C++ compiler.
This is resulting in all of our pull requests being annotated with
`Unchanged files with check annotations` which are confusing to new
contributors as they are not due to the changes in the pull request.

![image](https://user-images.githubusercontent.com/5445507/72199732-cf100280-3437-11ea-89e5-ce3eb1efe78b.png)

The action is used to run `npx envinfo` to dump some information into
the logs before the actual build. All [GitHub hosted runners already
have a version of Node.js installed](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners) (12.x at the time of this commit)
which we can use to run `envinfo`. Remove the action to avoid using
the problematic problem matcher.

Fixes: https://github.com/nodejs/node/issues/31347

cc @sam-github @gengjiawen 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
