### PR TITLE
doc: add missing code formatting in vm.md

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -106,8 +106,8 @@ added: v10.6.0
 
 * Returns: {Buffer}
 
-Creates a code cache that can be used with the Script constructor's
-`cachedData` option. Returns a Buffer. This method may be called at any
+Creates a code cache that can be used with the `Script` constructor's
+`cachedData` option. Returns a `Buffer`. This method may be called at any
 time and any number of times.
 
 ```js
@@ -632,8 +632,8 @@ added: REPLACEME
 
 * Returns: {Buffer}
 
-Creates a code cache that can be used with the SourceTextModule constructor's
-`cachedData` option. Returns a Buffer. This method may be called any number
+Creates a code cache that can be used with the `SourceTextModule` constructor's
+`cachedData` option. Returns a `Buffer`. This method may be called any number
 of times before the module has been evaluated.
 
 ```js


### PR DESCRIPTION
This commit adds missing code formatting in a few places in
the vm module documentation.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

👍 here if you're OK with fast tracking this.