### PR TITLE
fs: add statfs to fs

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -5236,10 +5236,10 @@ changes:
 
 The `Promise` is resolved with the [`fs.Stats`][] object for the given `path`.
 
-<<<<<<< HEAD
-
 ### `fsPromises.statfs(path[, options])`
-
+<!-- YAML
+added: REPLACEME
+-->
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1011,13 +1011,13 @@ numeric values will be `bigint` instead of `number`.
 
 ```console
 StatFs {
-  bavail: 61058895,
-  bfree: 61058895,
-  blocks: 121938943,
+  type: 1397114950,
   bsize: 4096,
-  ffree: 1000000,
+  blocks: 121938943,
+  bfree: 61058895,
+  bavail: 61058895,
   files: 999,
-  type: 1397114950
+  ffree: 1000000
 }
 ```
 
@@ -1025,13 +1025,13 @@ StatFs {
 
 ```console
 StatFs {
-  bavail: 61058895n,
-  bfree: 61058895n,
-  blocks: 121938943n,
+  type: 1397114950n,
   bsize: 4096n,
-  ffree: 1000000n,
+  blocks: 121938943n,
+  bfree: 61058895n,
+  bavail: 61058895n,
   files: 999n,
-  type: 1397114950n
+  ffree: 1000000n
 }
 ```
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1001,6 +1001,90 @@ The times in the stat object have the following semantics:
 Prior to Node.js 0.12, the `ctime` held the `birthtime` on Windows systems. As
 of 0.12, `ctime` is not "creation time", and on Unix systems, it never was.
 
+## Class: `fs.StatFs`
+
+Provides information about a mounted filesystem.
+
+Objects returned from [`fs.statfs()`][] and its synchronous counterpart are of
+this type. If `bigint` in the `options` passed to those methods is true, the
+numeric values will be `bigint` instead of `number`.
+
+```console
+StatFs {
+  type: 1397114950,
+  bsize: 4096,
+  blocks: 121938943,
+  bfree: 61058895,
+  bavail: 61058895,
+  files: 999,
+  ffree: 1000000,
+  spare: [ 0, 0, 0, 0 ]
+}
+```
+
+`bigint` version:
+
+```console
+StatFs {
+  type: 1397114950n,
+  bsize: 4096n,
+  blocks: 121938943n,
+  bfree: 61058895n,
+  bavail: 61058895n,
+  files: 999n,
+  ffree: 1000000n,
+  spare: [ 0n, 0n, 0n, 0n ]
+}
+```
+
+### `statfs.type`
+
+* {number|bigint}
+
+Type of filesystem.
+
+### `statfs.bsize`
+
+* {number|bigint}
+
+Optimal transfer block size.
+
+### `statfs.blocks`
+
+* {number|bigint}
+
+Total data blocks in filesystem.
+
+### `statfs.bfree`
+
+* {number|bigint}
+
+Free blocks in filesystem.
+
+### `statfs.bavail`
+
+* {number|bigint}
+
+Free blocks available to unprivileged user.
+
+### `statfs.files`
+
+* {number|bigint}
+
+Total file nodes in filesystem.
+
+### `statfs.ffree`
+
+* {number|bigint}
+
+Free file nodes in filesystem.
+
+### `statfs.spare`
+
+* {Array}
+
+Padding bytes reserved for future use.
+
 ## Class: `fs.WriteStream`
 <!-- YAML
 added: v0.1.93
@@ -3465,6 +3549,34 @@ changes:
 
 Synchronous stat(2).
 
+## `fs.statfs(path[, options], callback)`
+<!-- YAML
+added: REPLACEME
+-->
+* `path` {string|Buffer|URL}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    [`fs.StatFs`][] object should be `bigint`. **Default:** `false`.
+* `callback` {Function}
+  * `err` {Error}
+  * `stats` {fs.StatFs}
+
+Asynchronous statfs(2). The callback gets two arguments `(err, stats)` where
+`stats` is an [`fs.StatFs`][] object.
+
+Returns information about the mounted filesystem which contains `path`.
+
+In case of an error, the `err.code` will be one of [Common System Errors][].
+
+## `fs.statfsSync(path[, options])`
+* `path` {string|Buffer|URL}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    [`fs.StatFs`][] object should be `bigint`. **Default:** `false`.
+* Returns: {fs.StatFs}
+
+Synchronous statfs(2).
+
 ## `fs.symlink(target, path[, type], callback)`
 <!-- YAML
 added: v0.1.31
@@ -5124,7 +5236,19 @@ changes:
 
 The `Promise` is resolved with the [`fs.Stats`][] object for the given `path`.
 
-### `fsPromises.symlink(target, path[, type])`
+<<<<<<< HEAD
+
+### `fsPromises.statfs(path[, options])`
+
+* `path` {string|Buffer|URL}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    [`fs.StatFs`][] object should be `bigint`. **Default:** `false`.
+* Returns: {Promise}
+
+The `Promise` is resolved with the [`fs.StatFs`][] object for the given `path`.
+
+### `fsPromises.symlink(target, path\[, type\])`
 <!-- YAML
 added: v10.0.0
 -->
@@ -5586,6 +5710,7 @@ the file contents.
 [`fs.Dirent`]: #fs_class_fs_dirent
 [`fs.FSWatcher`]: #fs_class_fs_fswatcher
 [`fs.Stats`]: #fs_class_fs_stats
+[`fs.StatFs`]: #fs_class_fs_statfs
 [`fs.access()`]: #fs_fs_access_path_mode_callback
 [`fs.chmod()`]: #fs_fs_chmod_path_mode_callback
 [`fs.chown()`]: #fs_fs_chown_path_uid_gid_callback
@@ -5609,6 +5734,7 @@ the file contents.
 [`fs.realpath()`]: #fs_fs_realpath_path_options_callback
 [`fs.rmdir()`]: #fs_fs_rmdir_path_options_callback
 [`fs.stat()`]: #fs_fs_stat_path_options_callback
+[`fs.statfs()`]: #fs_fs_statfs_path_options_callback
 [`fs.symlink()`]: #fs_fs_symlink_target_path_type_callback
 [`fs.utimes()`]: #fs_fs_utimes_path_atime_mtime_callback
 [`fs.watch()`]: #fs_fs_watch_filename_options_listener

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1011,13 +1011,13 @@ numeric values will be `bigint` instead of `number`.
 
 ```console
 StatFs {
-  type: 1397114950,
-  bsize: 4096,
-  blocks: 121938943,
-  bfree: 61058895,
   bavail: 61058895,
+  bfree: 61058895,
+  blocks: 121938943,
+  bsize: 4096,
+  ffree: 1000000,
   files: 999,
-  ffree: 1000000
+  type: 1397114950
 }
 ```
 
@@ -1025,39 +1025,15 @@ StatFs {
 
 ```console
 StatFs {
-  type: 1397114950n,
-  bsize: 4096n,
-  blocks: 121938943n,
-  bfree: 61058895n,
   bavail: 61058895n,
+  bfree: 61058895n,
+  blocks: 121938943n,
+  bsize: 4096n,
+  ffree: 1000000n,
   files: 999n,
-  ffree: 1000000n
+  type: 1397114950n
 }
 ```
-
-### `statfs.type`
-
-* {number|bigint}
-
-Type of filesystem.
-
-### `statfs.bsize`
-
-* {number|bigint}
-
-Optimal transfer block size.
-
-### `statfs.blocks`
-
-* {number|bigint}
-
-Total data blocks in filesystem.
-
-### `statfs.bfree`
-
-* {number|bigint}
-
-Free blocks in filesystem.
 
 ### `statfs.bavail`
 
@@ -1065,17 +1041,41 @@ Free blocks in filesystem.
 
 Free blocks available to unprivileged user.
 
-### `statfs.files`
+### `statfs.bfree`
 
 * {number|bigint}
 
-Total file nodes in filesystem.
+Free blocks in filesystem.
+
+### `statfs.blocks`
+
+* {number|bigint}
+
+Total data blocks in filesystem.
+
+### `statfs.bsize`
+
+* {number|bigint}
+
+Optimal transfer block size.
 
 ### `statfs.ffree`
 
 * {number|bigint}
 
 Free file nodes in filesystem.
+
+### `statfs.files`
+
+* {number|bigint}
+
+Total file nodes in filesystem.
+
+### `statfs.type`
+
+* {number|bigint}
+
+Type of filesystem.
 
 ## Class: `fs.WriteStream`
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1006,7 +1006,7 @@ of 0.12, `ctime` is not "creation time", and on Unix systems, it never was.
 Provides information about a mounted filesystem.
 
 Objects returned from [`fs.statfs()`][] and its synchronous counterpart are of
-this type. If `bigint` in the `options` passed to those methods is true, the
+this type. If `bigint` in the `options` passed to those methods is `true`, the
 numeric values will be `bigint` instead of `number`.
 
 ```console
@@ -5248,7 +5248,7 @@ added: REPLACEME
 
 The `Promise` is resolved with the [`fs.StatFs`][] object for the given `path`.
 
-### `fsPromises.symlink(target, path\[, type\])`
+### `fsPromises.symlink(target, path[, type])`
 <!-- YAML
 added: v10.0.0
 -->

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1017,8 +1017,7 @@ StatFs {
   bfree: 61058895,
   bavail: 61058895,
   files: 999,
-  ffree: 1000000,
-  spare: [ 0, 0, 0, 0 ]
+  ffree: 1000000
 }
 ```
 
@@ -1032,8 +1031,7 @@ StatFs {
   bfree: 61058895n,
   bavail: 61058895n,
   files: 999n,
-  ffree: 1000000n,
-  spare: [ 0n, 0n, 0n, 0n ]
+  ffree: 1000000n
 }
 ```
 
@@ -1078,12 +1076,6 @@ Total file nodes in filesystem.
 * {number|bigint}
 
 Free file nodes in filesystem.
-
-### `statfs.spare`
-
-* {Array}
-
-Padding bytes reserved for future use.
 
 ## Class: `fs.WriteStream`
 <!-- YAML
@@ -3553,6 +3545,7 @@ Synchronous stat(2).
 <!-- YAML
 added: REPLACEME
 -->
+
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
@@ -3569,6 +3562,10 @@ Returns information about the mounted filesystem which contains `path`.
 In case of an error, the `err.code` will be one of [Common System Errors][].
 
 ## `fs.statfsSync(path[, options])`
+<!-- YAML
+added: REPLACME
+-->
+
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
@@ -5240,6 +5237,7 @@ The `Promise` is resolved with the [`fs.Stats`][] object for the given `path`.
 <!-- YAML
 added: REPLACEME
 -->
+
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -943,9 +943,7 @@ function statfs(path, options = { bigint: false }, callback) {
     options = {};
   }
 
-  if (typeof callback !== 'function') {
-    throw new ERR_INVALID_CALLBACK(callback);
-  }
+  callback = maybeCallback(callback);
 
   const oncompleteCallback = (err, statsArray) => {
     if (err) return callback(err);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -76,6 +76,7 @@ const {
   Dirent,
   getDirents,
   getOptions,
+  getStatFsFromBinding,
   getValidatedPath,
   getValidMode,
   handleErrorFromBinding,
@@ -173,6 +174,19 @@ function makeStatsCallback(cb) {
   return (err, stats) => {
     if (err) return cb(err);
     cb(err, getStatsFromBinding(stats));
+  };
+}
+
+// Special case of `makeCallback()` specific to async `statfs()`. Transforms
+// the array passed to the callback to a javascript object
+function makeStatfsCallback(cb) {
+  if (typeof cb !== 'function') {
+    throw new ERR_INVALID_CALLBACK(cb);
+  }
+
+  return (err, statsArray) => {
+    if (err) return cb(err);
+    cb(err, getStatFsFromBinding(statsArray));
   };
 }
 
@@ -936,6 +950,19 @@ function stat(path, options = { bigint: false }, callback) {
   binding.stat(pathModule.toNamespacedPath(path), options.bigint, req);
 }
 
+function statfs(path, options = { bigint: false }, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
+  callback = makeStatfsCallback(callback);
+  path = getValidatedPath(path);
+  const req = new FSReqCallback(options.bigint);
+  req.oncomplete = callback;
+  binding.statfs(pathModule.toNamespacedPath(path), options.bigint, req);
+}
+
 function fstatSync(fd, options = { bigint: false }) {
   validateInt32(fd, 'fd', 0);
   const ctx = { fd };
@@ -960,6 +987,15 @@ function statSync(path, options = { bigint: false }) {
                              options.bigint, undefined, ctx);
   handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
+}
+
+function statfsSync(path, options = { bigint: false }) {
+  path = getValidatedPath(path);
+  const ctx = { path };
+  const stats = binding.statfs(pathModule.toNamespacedPath(path),
+                               options.bigint, undefined, ctx);
+  handleErrorFromBinding(ctx);
+  return getStatFsFromBinding(stats);
 }
 
 function readlink(path, options, callback) {
@@ -1920,7 +1956,9 @@ module.exports = fs = {
   rmdir,
   rmdirSync,
   stat,
+  statfs,
   statSync,
+  statfsSync,
   symlink,
   symlinkSync,
   truncate,

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -177,19 +177,6 @@ function makeStatsCallback(cb) {
   };
 }
 
-// Special case of `makeCallback()` specific to async `statfs()`. Transforms
-// the array passed to the callback to a javascript object
-function makeStatfsCallback(cb) {
-  if (typeof cb !== 'function') {
-    throw new ERR_INVALID_CALLBACK(cb);
-  }
-
-  return (err, statsArray) => {
-    if (err) return cb(err);
-    cb(err, getStatFsFromBinding(statsArray));
-  };
-}
-
 const isFd = isUint32;
 
 function isFileType(stats, fileType) {
@@ -956,10 +943,17 @@ function statfs(path, options = { bigint: false }, callback) {
     options = {};
   }
 
-  callback = makeStatfsCallback(callback);
+  if (typeof callback !== 'function') {
+    throw new ERR_INVALID_CALLBACK(callback);
+  }
+
+  const oncompleteCallback = (err, statsArray) => {
+    if (err) return callback(err);
+    callback(err, getStatFsFromBinding(statsArray));
+  };
   path = getValidatedPath(path);
   const req = new FSReqCallback(options.bigint);
-  req.oncomplete = callback;
+  req.oncomplete = oncompleteCallback;
   binding.statfs(pathModule.toNamespacedPath(path), options.bigint, req);
 }
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -33,6 +33,7 @@ const {
   getDirents,
   getOptions,
   getStatsFromBinding,
+  getStatFsFromBinding,
   getValidatedPath,
   getValidMode,
   nullCheck,
@@ -405,6 +406,13 @@ async function stat(path, options = { bigint: false }) {
   return getStatsFromBinding(result);
 }
 
+async function statfs(path, options = { bigint: false }) {
+  path = getValidatedPath(path);
+  const result = await binding.statfs(pathModule.toNamespacedPath(path),
+                                      options.bigint, kUsePromises);
+  return getStatFsFromBinding(result);
+}
+
 async function link(existingPath, newPath) {
   existingPath = getValidatedPath(existingPath, 'existingPath');
   newPath = getValidatedPath(newPath, 'newPath');
@@ -536,6 +544,7 @@ module.exports = {
     symlink,
     lstat,
     stat,
+    statfs,
     link,
     unlink,
     chmod,

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -458,6 +458,25 @@ function getStatsFromBinding(stats, offset = 0) {
   );
 }
 
+function StatFs(type, bsize, blocks, bfree, bavail, files, ffree,
+                spare1, spare2, spare3, spare4) {
+  this.type = type;
+  this.bsize = bsize;
+  this.blocks = blocks;
+  this.bfree = bfree;
+  this.bavail = bavail;
+  this.files = files;
+  this.ffree = ffree;
+  this.spare = [ spare1, spare2, spare3, spare4 ];
+}
+
+function getStatFsFromBinding(stats) {
+  return new StatFs(
+    stats[0], stats[1], stats[2], stats[3], stats[4], stats[5],
+    stats[6], stats[7], stats[8], stats[9], stats[10]
+  );
+}
+
 function stringToFlags(flags) {
   if (typeof flags === 'number') {
     return flags;
@@ -669,6 +688,7 @@ module.exports = {
   getDirent,
   getDirents,
   getOptions,
+  getStatFsFromBinding,
   getValidatedPath,
   getValidMode,
   handleErrorFromBinding,

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -458,8 +458,8 @@ function getStatsFromBinding(stats, offset = 0) {
   );
 }
 
-function StatFs(type, bsize, blocks, bfree, bavail, files, ffree,
-                spare1, spare2, spare3, spare4) {
+function StatFs(type, bsize, blocks, bfree,
+                bavail, files, ffree) {
   this.type = type;
   this.bsize = bsize;
   this.blocks = blocks;
@@ -467,13 +467,12 @@ function StatFs(type, bsize, blocks, bfree, bavail, files, ffree,
   this.bavail = bavail;
   this.files = files;
   this.ffree = ffree;
-  this.spare = [ spare1, spare2, spare3, spare4 ];
 }
 
 function getStatFsFromBinding(stats) {
   return new StatFs(
-    stats[0], stats[1], stats[2], stats[3], stats[4], stats[5],
-    stats[6], stats[7], stats[8], stats[9], stats[10]
+    stats[0], stats[1], stats[2], stats[3],
+    stats[4], stats[5], stats[6]
   );
 }
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -615,6 +615,14 @@ inline AliasedBigUint64Array* Environment::fs_stats_field_bigint_array() {
   return &fs_stats_field_bigint_array_;
 }
 
+inline AliasedFloat64Array* Environment::fs_statfs_field_array() {
+  return &fs_statfs_field_array_;
+}
+
+inline AliasedBigUint64Array* Environment::fs_statfs_field_bigint_array() {
+  return &fs_statfs_field_bigint_array_;
+}
+
 inline std::vector<std::unique_ptr<fs::FileHandleReadWrap>>&
 Environment::file_handle_read_wrap_freelist() {
   return file_handle_read_wrap_freelist_;

--- a/src/env.cc
+++ b/src/env.cc
@@ -309,6 +309,8 @@ Environment::Environment(IsolateData* isolate_data,
       thread_id_(thread_id == kNoThreadId ? AllocateThreadId() : thread_id),
       fs_stats_field_array_(isolate_, kFsStatsBufferLength),
       fs_stats_field_bigint_array_(isolate_, kFsStatsBufferLength),
+      fs_statfs_field_array_(isolate_, kFsStatfsBufferLength),
+      fs_statfs_field_bigint_array_(isolate_, kFsStatfsBufferLength),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
   HandleScope handle_scope(isolate());
@@ -1068,6 +1070,9 @@ void Environment::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("fs_stats_field_array", fs_stats_field_array_);
   tracker->TrackField("fs_stats_field_bigint_array",
                       fs_stats_field_bigint_array_);
+  tracker->TrackField("fs_statfs_field_array", fs_statfs_field_array_);
+  tracker->TrackField("fs_statfs_field_bigint_array",
+                      fs_statfs_field_bigint_array_);
   tracker->TrackField("cleanup_hooks", cleanup_hooks_);
   tracker->TrackField("async_hooks", async_hooks_);
   tracker->TrackField("immediate_info", immediate_info_);

--- a/src/env.h
+++ b/src/env.h
@@ -135,6 +135,24 @@ enum class FsStatsOffset {
 constexpr size_t kFsStatsBufferLength =
     static_cast<size_t>(FsStatsOffset::kFsStatsFieldsNumber) * 2;
 
+enum class FsStatfsOffset {
+  kType = 0,
+  kBSize,
+  kBlocks,
+  kBFree,
+  kBAvail,
+  kFiles,
+  kFFree,
+  kSpare1,
+  kSpare2,
+  kSpare3,
+  kSpare4,
+  kFsStatFsFieldsNumber
+};
+
+constexpr size_t kFsStatfsBufferLength =
+    static_cast<size_t>(FsStatfsOffset::kFsStatFsFieldsNumber);
+
 // PER_ISOLATE_* macros: We have a lot of per-isolate properties
 // and adding and maintaining their getters and setters by hand would be
 // difficult so let's make the preprocessor generate them for us.
@@ -1025,6 +1043,9 @@ class Environment : public MemoryRetainer {
   inline AliasedFloat64Array* fs_stats_field_array();
   inline AliasedBigUint64Array* fs_stats_field_bigint_array();
 
+  inline AliasedFloat64Array* fs_statfs_field_array();
+  inline AliasedBigUint64Array* fs_statfs_field_bigint_array();
+
   inline std::vector<std::unique_ptr<fs::FileHandleReadWrap>>&
       file_handle_read_wrap_freelist();
 
@@ -1385,6 +1406,9 @@ class Environment : public MemoryRetainer {
 
   AliasedFloat64Array fs_stats_field_array_;
   AliasedBigUint64Array fs_stats_field_bigint_array_;
+
+  AliasedFloat64Array fs_statfs_field_array_;
+  AliasedBigUint64Array fs_statfs_field_bigint_array_;
 
   std::vector<std::unique_ptr<fs::FileHandleReadWrap>>
       file_handle_read_wrap_freelist_;

--- a/src/env.h
+++ b/src/env.h
@@ -143,10 +143,6 @@ enum class FsStatfsOffset {
   kBAvail,
   kFiles,
   kFFree,
-  kSpare1,
-  kSpare2,
-  kSpare3,
-  kSpare4,
   kFsStatFsFieldsNumber
 };
 

--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -143,16 +143,12 @@ void FillStatfsArray(AliasedBufferBase<NativeT, V8T>* fields,
   SET_FIELD(kBAvail, s->f_bavail);
   SET_FIELD(kFiles, s->f_files);
   SET_FIELD(kFFree, s->f_ffree);
-  SET_FIELD(kSpare1, s->f_spare[0]);
-  SET_FIELD(kSpare2, s->f_spare[1]);
-  SET_FIELD(kSpare3, s->f_spare[2]);
-  SET_FIELD(kSpare4, s->f_spare[3]);
 #undef SET_FIELD
 }
 
 v8::Local<v8::Value> FillGlobalStatfsArray(Environment* env,
-                                          const bool use_bigint,
-                                          const uv_statfs_t* s) {
+                                           const bool use_bigint,
+                                           const uv_statfs_t* s) {
   if (use_bigint) {
     auto* const arr = env->fs_statfs_field_bigint_array();
     FillStatfsArray(arr, s);

--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -129,6 +129,41 @@ v8::Local<v8::Value> FillGlobalStatsArray(Environment* env,
   }
 }
 
+template <typename NativeT, typename V8T>
+void FillStatfsArray(AliasedBufferBase<NativeT, V8T>* fields,
+                     const uv_statfs_t* s) {
+#define SET_FIELD(field, stat)                                                \
+  fields->SetValue(static_cast<size_t>(FsStatfsOffset::field),                \
+                   static_cast<NativeT>(stat))
+
+  SET_FIELD(kType, s->f_type);
+  SET_FIELD(kBSize, s->f_bsize);
+  SET_FIELD(kBlocks, s->f_blocks);
+  SET_FIELD(kBFree, s->f_bfree);
+  SET_FIELD(kBAvail, s->f_bavail);
+  SET_FIELD(kFiles, s->f_files);
+  SET_FIELD(kFFree, s->f_ffree);
+  SET_FIELD(kSpare1, s->f_spare[0]);
+  SET_FIELD(kSpare2, s->f_spare[1]);
+  SET_FIELD(kSpare3, s->f_spare[2]);
+  SET_FIELD(kSpare4, s->f_spare[3]);
+#undef SET_FIELD
+}
+
+v8::Local<v8::Value> FillGlobalStatfsArray(Environment* env,
+                                          const bool use_bigint,
+                                          const uv_statfs_t* s) {
+  if (use_bigint) {
+    auto* const arr = env->fs_statfs_field_bigint_array();
+    FillStatfsArray(arr, s);
+    return arr->GetJSArray();
+  } else {
+    auto* const arr = env->fs_statfs_field_array();
+    FillStatfsArray(arr, s);
+    return arr->GetJSArray();
+  }
+}
+
 template <typename AliasedBufferT>
 FSReqPromise<AliasedBufferT>*
 FSReqPromise<AliasedBufferT>::New(Environment* env, bool use_bigint) {
@@ -160,7 +195,10 @@ FSReqPromise<AliasedBufferT>::FSReqPromise(
   : FSReqBase(env, obj, AsyncWrap::PROVIDER_FSREQPROMISE, use_bigint),
     stats_field_array_(
         env->isolate(),
-        static_cast<size_t>(FsStatsOffset::kFsStatsFieldsNumber)) {}
+        static_cast<size_t>(FsStatsOffset::kFsStatsFieldsNumber)),
+    statfs_field_array_(
+        env->isolate(),
+        static_cast<size_t>(FsStatfsOffset::kFsStatFsFieldsNumber)) {}
 
 template <typename AliasedBufferT>
 void FSReqPromise<AliasedBufferT>::Reject(v8::Local<v8::Value> reject) {
@@ -193,6 +231,12 @@ void FSReqPromise<AliasedBufferT>::ResolveStat(const uv_stat_t* stat) {
 }
 
 template <typename AliasedBufferT>
+void FSReqPromise<AliasedBufferT>::ResolveStatfs(const uv_statfs_t* stat) {
+  FillStatfsArray(&statfs_field_array_, stat);
+  Resolve(statfs_field_array_.GetJSArray());
+}
+
+template <typename AliasedBufferT>
 void FSReqPromise<AliasedBufferT>::SetReturnValue(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Local<v8::Value> val =
@@ -206,6 +250,7 @@ template <typename AliasedBufferT>
 void FSReqPromise<AliasedBufferT>::MemoryInfo(MemoryTracker* tracker) const {
   FSReqBase::MemoryInfo(tracker);
   tracker->TrackField("stats_field_array", stats_field_array_);
+  tracker->TrackField("statfs_field_array", statfs_field_array_);
 }
 
 FSReqBase* GetReqWrap(Environment* env, v8::Local<v8::Value> value,

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -587,7 +587,7 @@ void AfterStatfs(uv_fs_t* req) {
   FSReqAfterScope after(req_wrap, req);
 
   if (after.Proceed()) {
-    req_wrap->ResolveStatfs(reinterpret_cast<uv_statfs_t*>(req->ptr));
+    req_wrap->ResolveStatfs(static_cast<uv_statfs_t*>(req->ptr));
   }
 }
 

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -59,6 +59,7 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
   virtual void Reject(v8::Local<v8::Value> reject) = 0;
   virtual void Resolve(v8::Local<v8::Value> value) = 0;
   virtual void ResolveStat(const uv_stat_t* stat) = 0;
+  virtual void ResolveStatfs(const uv_statfs_t* stat) = 0;
   virtual void SetReturnValue(
       const v8::FunctionCallbackInfo<v8::Value>& args) = 0;
 
@@ -104,6 +105,7 @@ class FSReqCallback final : public FSReqBase {
   void Reject(v8::Local<v8::Value> reject) override;
   void Resolve(v8::Local<v8::Value> value) override;
   void ResolveStat(const uv_stat_t* stat) override;
+  void ResolveStatfs(const uv_statfs_t* stat) override;
   void SetReturnValue(const v8::FunctionCallbackInfo<v8::Value>& args) override;
 
   SET_MEMORY_INFO_NAME(FSReqCallback)
@@ -123,6 +125,14 @@ inline v8::Local<v8::Value> FillGlobalStatsArray(Environment* env,
                                                  const uv_stat_t* s,
                                                  const bool second = false);
 
+template <typename NativeT, typename V8T>
+void FillStatfsArray(AliasedBufferBase<NativeT, V8T>* fields,
+                     const uv_statfs_t* s);
+
+inline v8::Local<v8::Value> FillGlobalStatfsArray(Environment* env,
+                                                  const bool use_bigint,
+                                                  const uv_statfs_t* s);
+
 template <typename AliasedBufferT>
 class FSReqPromise final : public FSReqBase {
  public:
@@ -132,6 +142,7 @@ class FSReqPromise final : public FSReqBase {
   inline void Reject(v8::Local<v8::Value> reject) override;
   inline void Resolve(v8::Local<v8::Value> value) override;
   inline void ResolveStat(const uv_stat_t* stat) override;
+  inline void ResolveStatfs(const uv_statfs_t* stat) override;
   inline void SetReturnValue(
       const v8::FunctionCallbackInfo<v8::Value>& args) override;
   inline void MemoryInfo(MemoryTracker* tracker) const override;
@@ -151,6 +162,7 @@ class FSReqPromise final : public FSReqBase {
 
   bool finished_ = false;
   AliasedBufferT stats_field_array_;
+  AliasedBufferT statfs_field_array_;
 };
 
 class FSReqAfterScope final {

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -92,7 +92,6 @@ function verifyStatfsObject(stat) {
   assert.strictEqual(typeof stat.bavail, 'number');
   assert.strictEqual(typeof stat.files, 'number');
   assert.strictEqual(typeof stat.ffree, 'number');
-  assert.ok(stat.spare instanceof Array);
 }
 
 async function getHandle(dest) {

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -26,6 +26,7 @@ const {
   rename,
   rmdir,
   stat,
+  statfs,
   symlink,
   truncate,
   unlink,
@@ -82,6 +83,18 @@ function verifyStatObject(stat) {
   assert.strictEqual(typeof stat.mode, 'number');
 }
 
+function verifyStatfsObject(stat) {
+  assert.strictEqual(typeof stat, 'object');
+  assert.strictEqual(typeof stat.type, 'number');
+  assert.strictEqual(typeof stat.bsize, 'number');
+  assert.strictEqual(typeof stat.blocks, 'number');
+  assert.strictEqual(typeof stat.bfree, 'number');
+  assert.strictEqual(typeof stat.bavail, 'number');
+  assert.strictEqual(typeof stat.files, 'number');
+  assert.strictEqual(typeof stat.ffree, 'number');
+  assert.ok(stat.spare instanceof Array);
+}
+
 async function getHandle(dest) {
   await copyFile(fixtures.path('baz.js'), dest);
   await access(dest);
@@ -124,6 +137,12 @@ async function getHandle(dest) {
       await handle.datasync();
       await handle.sync();
       await handle.close();
+    }
+
+    // file system stats
+    {
+      const statFs = await statfs(dest);
+      verifyStatfsObject(statFs);
     }
 
     // Test fs.read promises when length to read is zero bytes

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -83,15 +83,17 @@ function verifyStatObject(stat) {
   assert.strictEqual(typeof stat.mode, 'number');
 }
 
-function verifyStatfsObject(stat) {
+function verifyStatfsObject(stat, isBigint = false) {
+  const valueType = isBigint ? 'bigint' : 'number';
+  
   assert.strictEqual(typeof stat, 'object');
-  assert.strictEqual(typeof stat.type, 'number');
-  assert.strictEqual(typeof stat.bsize, 'number');
-  assert.strictEqual(typeof stat.blocks, 'number');
-  assert.strictEqual(typeof stat.bfree, 'number');
-  assert.strictEqual(typeof stat.bavail, 'number');
-  assert.strictEqual(typeof stat.files, 'number');
-  assert.strictEqual(typeof stat.ffree, 'number');
+  assert.strictEqual(typeof stat.type, valueType);
+  assert.strictEqual(typeof stat.bsize, valueType);
+  assert.strictEqual(typeof stat.blocks, valueType);
+  assert.strictEqual(typeof stat.bfree, valueType);
+  assert.strictEqual(typeof stat.bavail, valueType);
+  assert.strictEqual(typeof stat.files, valueType);
+  assert.strictEqual(typeof stat.ffree, valueType);
 }
 
 async function getHandle(dest) {
@@ -142,6 +144,12 @@ async function getHandle(dest) {
     {
       const statFs = await statfs(dest);
       verifyStatfsObject(statFs);
+    }
+
+    // file system stats bigint
+    {
+      const statFs = await statfs(dest, { bigint: true });
+      verifyStatfsObject(statFs, true);
     }
 
     // Test fs.read promises when length to read is zero bytes

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -85,7 +85,7 @@ function verifyStatObject(stat) {
 
 function verifyStatfsObject(stat, isBigint = false) {
   const valueType = isBigint ? 'bigint' : 'number';
-  
+
   assert.strictEqual(typeof stat, 'object');
   assert.strictEqual(typeof stat.type, valueType);
   assert.strictEqual(typeof stat.bsize, valueType);
@@ -140,13 +140,13 @@ async function getHandle(dest) {
       await handle.close();
     }
 
-    // file system stats
+    // File system stats
     {
       const statFs = await statfs(dest);
       verifyStatfsObject(statFs);
     }
 
-    // file system stats bigint
+    // File system stats bigint
     {
       const statFs = await statfs(dest, { bigint: true });
       verifyStatfsObject(statFs, true);

--- a/test/parallel/test-fs-statfs.js
+++ b/test/parallel/test-fs-statfs.js
@@ -12,8 +12,6 @@ fs.statfs(__filename, common.mustCall(function(err, stats) {
     assert.ok(stats.hasOwnProperty(k));
     assert.strictEqual(typeof stats[k], 'number', `${k} should be a number`);
   });
-  assert.ok(stats.hasOwnProperty('spare'));
-  assert.ok(stats.spare instanceof Array);
   // Confirm that we are not running in the context of the internal binding
   // layer.
   // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1

--- a/test/parallel/test-fs-statfs.js
+++ b/test/parallel/test-fs-statfs.js
@@ -6,12 +6,13 @@ const fs = require('fs');
 
 function verifyStatFsObject(statfs, isBigint = false) {
   const valueType = isBigint ? 'bigint' : 'number';
-  
+
   [
     'type', 'bsize', 'blocks', 'bfree', 'bavail', 'files', 'ffree'
   ].forEach((k) => {
     assert.ok(statfs.hasOwnProperty(k));
-    assert.strictEqual(typeof statfs[k], valueType, `${k} should be a ${valueType}`);
+    assert.strictEqual(typeof statfs[k], valueType,
+                       `${k} should be a ${valueType}`);
   });
 }
 

--- a/test/parallel/test-fs-statfs.js
+++ b/test/parallel/test-fs-statfs.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+
+const assert = require('assert');
+const fs = require('fs');
+
+fs.statfs(__filename, common.mustCall(function(err, stats) {
+  assert.ifError(err);
+  [
+    'type', 'bsize', 'blocks', 'bfree', 'bavail', 'files', 'ffree'
+  ].forEach((k) => {
+    assert.ok(stats.hasOwnProperty(k));
+    assert.strictEqual(typeof stats[k], 'number', `${k} should be a number`);
+  });
+  assert.ok(stats.hasOwnProperty('spare'));
+  assert.ok(stats.spare instanceof Array);
+  // Confirm that we are not running in the context of the internal binding
+  // layer.
+  // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1
+  assert.strictEqual(this, undefined);
+}));
+
+[false, 1, {}, [], null, undefined].forEach((input) => {
+  assert.throws(
+    () => fs.statfs(input, common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError'
+    }
+  );
+  assert.throws(
+    () => fs.statfsSync(input),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError'
+    }
+  );
+});
+
+// Should not throw an error
+fs.statfs(__filename, undefined, common.mustCall(() => {}));

--- a/test/parallel/test-fs-statfs.js
+++ b/test/parallel/test-fs-statfs.js
@@ -4,19 +4,46 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-fs.statfs(__filename, common.mustCall(function(err, stats) {
-  assert.ifError(err);
+function verifyStatFsObject(statfs, isBigint = false) {
+  const valueType = isBigint ? 'bigint' : 'number';
+  
   [
     'type', 'bsize', 'blocks', 'bfree', 'bavail', 'files', 'ffree'
   ].forEach((k) => {
-    assert.ok(stats.hasOwnProperty(k));
-    assert.strictEqual(typeof stats[k], 'number', `${k} should be a number`);
+    assert.ok(statfs.hasOwnProperty(k));
+    assert.strictEqual(typeof statfs[k], valueType, `${k} should be a ${valueType}`);
   });
+}
+
+fs.statfs(__filename, common.mustCall(function(err, stats) {
+  assert.ifError(err);
+  verifyStatFsObject(stats);
   // Confirm that we are not running in the context of the internal binding
   // layer.
   // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1
   assert.strictEqual(this, undefined);
 }));
+
+fs.statfs(__filename, { bigint: true }, function(err, stats) {
+  assert.ifError(err);
+  verifyStatFsObject(stats, true);
+  // Confirm that we are not running in the context of the internal binding
+  // layer.
+  // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1
+  assert.strictEqual(this, undefined);
+});
+
+// Synchronous
+{
+  const statFsObj = fs.statfsSync(__filename);
+  verifyStatFsObject(statFsObj);
+}
+
+// Synchronous Bigint
+{
+  const statFsBigIntObj = fs.statfsSync(__filename, { bigint: true });
+  verifyStatFsObject(statFsBigIntObj, true);
+}
 
 [false, 1, {}, [], null, undefined].forEach((input) => {
   assert.throws(

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -79,6 +79,7 @@ const customTypesMap = {
   'fs.FSWatcher': 'fs.html#fs_class_fs_fswatcher',
   'fs.ReadStream': 'fs.html#fs_class_fs_readstream',
   'fs.Stats': 'fs.html#fs_class_fs_stats',
+  'fs.StatFs': 'fs.html#fs_class_fs_statfs',
   'fs.WriteStream': 'fs.html#fs_class_fs_writestream',
 
   'http.Agent': 'http.html#http_class_http_agent',


### PR DESCRIPTION
Add support for statfs system call to the fs module using
uv_fs_statfs() function from libuv.

Refs: https://github.com/nodejs/node/issues/10745

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
