### PR TITLE
doc: explain `hex` encoding in Buffer API

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -203,7 +203,23 @@ The character encodings currently supported by Node.js include:
 
 * `'binary'`: Alias for `'latin1'`.
 
-* `'hex'`: Encode each byte as two hexadecimal characters.
+* `'hex'`: Encode each byte as two hexadecimal characters. Data truncation
+  may occur for unsanitized input. For example:
+
+```js
+Buffer.from('1ag', 'hex');
+// Prints <Buffer 1a>, data truncated when first non-hexa-decimal value
+// ('g') encountered
+
+Buffer.from('1a7g', 'hex');
+// Prints <Buffer 1a> , data truncated when data ends in single digit ('7').
+
+Buffer.from('1634', 'hex');
+// Prints <Buffer 16 34> , fully qualified hexadecimal data
+
+Buffer.from((163).toString(16), 'hex');
+// Prints <Buffer a3> , sanitized hexadecimal data
+```
 
 Modern Web browsers follow the [WHATWG Encoding Standard][] which aliases
 both `'latin1'` and `'ISO-8859-1'` to `'win-1252'`. This means that while doing

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -209,13 +209,13 @@ The character encodings currently supported by Node.js include:
 ```js
 Buffer.from('1ag', 'hex');
 // Prints <Buffer 1a>, data truncated when first non-hexadecimal value
-// ('g') encountered
+// ('g') encountered.
 
 Buffer.from('1a7g', 'hex');
 // Prints <Buffer 1a>, data truncated when data ends in single digit ('7').
 
 Buffer.from('1634', 'hex');
-// Prints <Buffer 16 34>, fully qualified hexadecimal data
+// Prints <Buffer 16 34>, all data represented.
 ```
 
 Modern Web browsers follow the [WHATWG Encoding Standard][] which aliases

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -216,9 +216,6 @@ Buffer.from('1a7g', 'hex');
 
 Buffer.from('1634', 'hex');
 // Prints <Buffer 16 34>, fully qualified hexadecimal data
-
-Buffer.from((163).toString(16), 'hex');
-// Prints <Buffer a3>, sanitized hexadecimal data
 ```
 
 Modern Web browsers follow the [WHATWG Encoding Standard][] which aliases

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -208,17 +208,17 @@ The character encodings currently supported by Node.js include:
 
 ```js
 Buffer.from('1ag', 'hex');
-// Prints <Buffer 1a>, data truncated when first non-hexa-decimal value
+// Prints <Buffer 1a>, data truncated when first non-hexadecimal value
 // ('g') encountered
 
 Buffer.from('1a7g', 'hex');
-// Prints <Buffer 1a> , data truncated when data ends in single digit ('7').
+// Prints <Buffer 1a>, data truncated when data ends in single digit ('7').
 
 Buffer.from('1634', 'hex');
-// Prints <Buffer 16 34> , fully qualified hexadecimal data
+// Prints <Buffer 16 34>, fully qualified hexadecimal data
 
 Buffer.from((163).toString(16), 'hex');
-// Prints <Buffer a3> , sanitized hexadecimal data
+// Prints <Buffer a3>, sanitized hexadecimal data
 ```
 
 Modern Web browsers follow the [WHATWG Encoding Standard][] which aliases


### PR DESCRIPTION
fixes: https://github.com/nodejs/node/issues/29786
refs: https://github.com/nodejs/node/pull/29792
refs: https://github.com/nodejs/node/issues/24491

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
