### PR TITLE
doc: add note regarding net.Socket default timeout

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -895,7 +895,7 @@ added: v0.1.90
 Sets the socket to timeout after `timeout` milliseconds of inactivity on
 the socket. By default `net.Socket` do not have a timeout.
 
- > Note: Prior to Node.js 13.0.0, [`http.Server`][], [`https.Server`][] and
+Prior to Node.js 13.0.0, [`http.Server`][], [`https.Server`][] and
  > [`http2.Http2Server`][] have a different default socket timeout value.
 
 When an idle timeout is triggered the socket will receive a [`'timeout'`][]

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -896,7 +896,7 @@ Sets the socket to timeout after `timeout` milliseconds of inactivity on
 the socket. By default `net.Socket` do not have a timeout.
 
 Prior to Node.js 13.0.0, [`http.Server`][], [`https.Server`][] and
- > [`http2.Http2Server`][] have a different default socket timeout value.
+[`http2.Http2Server`][] have a different default socket timeout value.
 
 When an idle timeout is triggered the socket will receive a [`'timeout'`][]
 event but the connection will not be severed. The user must manually call

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -895,6 +895,9 @@ added: v0.1.90
 Sets the socket to timeout after `timeout` milliseconds of inactivity on
 the socket. By default `net.Socket` do not have a timeout.
 
+ > Note: Prior to Node.js 13.0.0, [`http.Server`][], [`https.Server`][] and
+ > [`http2.Http2Server`][] have a different default socket timeout value.
+
 When an idle timeout is triggered the socket will receive a [`'timeout'`][]
 event but the connection will not be severed. The user must manually call
 [`socket.end()`][] or [`socket.destroy()`][] to end the connection.
@@ -1244,6 +1247,9 @@ Returns `true` if input is a version 6 IP address, otherwise returns `false`.
 [`net.createConnection(port, host)`]: #net_net_createconnection_port_host_connectlistener
 [`net.createServer()`]: #net_net_createserver_options_connectionlistener
 [`new net.Socket(options)`]: #net_new_net_socket_options
+[`http.Server`]: http.html#http_class_http_server
+[`http2.Http2Server`]: http2.html#http2_class_http2server
+[`https.Server`]: https.html#https_class_https_server
 [`readable.setEncoding()`]: stream.html#stream_readable_setencoding_encoding
 [`server.close()`]: #net_server_close_callback
 [`server.getConnections()`]: #net_server_getconnections_callback


### PR DESCRIPTION
Adding a note stating the difference between default timeout on http[2s] servers and on `net.Socket`.

Should be backported to v10 as well.

Fixes: https://github.com/nodejs/node/issues/31378
Fixes: https://github.com/nodejs/node/issues/27556
Refs: https://github.com/nodejs/node/pull/27704

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
