### PR TITLE
fs: don't emit 'close' twice if emitClose enabled

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -272,7 +272,8 @@ function closeFsStream(stream, cb, err) {
     er = er || err;
     cb(er);
     stream.closed = true;
-    if (!er)
+    const s = stream._writableState || stream._readableState;
+    if (!er && !s.emitClose)
       stream.emit('close');
   });
 

--- a/test/parallel/test-file-write-stream4.js
+++ b/test/parallel/test-file-write-stream4.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const path = require('path');
+const fs = require('fs');
+
+const tmpdir = require('../common/tmpdir');
+
+const filepath = path.join(tmpdir.path, 'write_pos.txt');
+fs.mkdirSync(tmpdir.path, { recursive: true });
+
+const fileReadStream = fs.createReadStream(process.execPath);
+const fileWriteStream = fs.createWriteStream(filepath, {
+  emitClose: true
+});
+
+fileReadStream.pipe(fileWriteStream);
+fileWriteStream.on('close', common.mustCall());

--- a/test/parallel/test-file-write-stream4.js
+++ b/test/parallel/test-file-write-stream4.js
@@ -1,4 +1,8 @@
 'use strict';
+
+// Test that 'close' emits once and not twice when `emitClose: true` is set.
+// Refs: https://github.com/nodejs/node/issues/31366
+
 const common = require('../common');
 const path = require('path');
 const fs = require('fs');

--- a/test/parallel/test-file-write-stream4.js
+++ b/test/parallel/test-file-write-stream4.js
@@ -4,9 +4,9 @@ const path = require('path');
 const fs = require('fs');
 
 const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const filepath = path.join(tmpdir.path, 'write_pos.txt');
-fs.mkdirSync(tmpdir.path, { recursive: true });
 
 const fileReadStream = fs.createReadStream(process.execPath);
 const fileWriteStream = fs.createWriteStream(filepath, {


### PR DESCRIPTION
fs streams have some backwards compat behavior that does not
behave well if emitClose: true is passed in options. This
fixes this edge case until the backwards compat is removed.

Fixes: https://github.com/nodejs/node/issues/31366

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
