### PR TITLE
src: reduce large pages code duplication

### DIFF
--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -100,6 +100,8 @@ inline uintptr_t hugepage_align_down(uintptr_t addr) {
 // This is also handling the case where the first line is not the binary.
 
 static struct text_region FindNodeTextRegion() {
+  struct text_region nregion;
+  nregion.found_text_region = false;
 #if defined(__linux__)
   std::ifstream ifs;
   std::string map_line;
@@ -107,9 +109,6 @@ static struct text_region FindNodeTextRegion() {
   std::string dev;
   char dash;
   uintptr_t start, end, offset, inode;
-  struct text_region nregion;
-
-  nregion.found_text_region = false;
 
   ifs.open("/proc/self/maps");
   if (!ifs) {
@@ -161,9 +160,6 @@ static struct text_region FindNodeTextRegion() {
 
   ifs.close();
 #elif defined(__FreeBSD__)
-  struct text_region nregion;
-  nregion.found_text_region = false;
-
   std::string exename;
   {
     char selfexe[PATH_MAX];
@@ -220,8 +216,6 @@ static struct text_region FindNodeTextRegion() {
     start += cursz;
   }
 #elif defined(__APPLE__)
-  struct text_region nregion;
-  nregion.found_text_region = false;
   struct vm_region_submap_info_64 map;
   mach_msg_type_number_t count = VM_REGION_SUBMAP_INFO_COUNT_64;
   vm_address_t addr = 0UL;


### PR DESCRIPTION
Declaring and initializing a `struct text_region` is common to all
three implementations of the large pages mapping code. Let's make it
unconditional.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
