### PR TITLE
report: add support for Workers

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -296,6 +296,7 @@ is provided below for reference.
       "address": "0x000055fc7b2cb180"
     }
   ],
+  "workers": [],
   "environmentVariables": {
     "REMOTEHOST": "REMOVED",
     "MANPATH": "/opt/rh/devtoolset-3/root/usr/share/man:",
@@ -577,4 +578,24 @@ NODE_OPTIONS="--experimental-report --report-uncaught-exception \
 Specific API documentation can be found under
 [`process API documentation`][] section.
 
+## Interaction with Workers
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/31386
+    description: Workers are now included in the report.
+-->
+
+[`Worker`][] threads can create reports in the same way that the main thread
+does.
+
+Reports will include information on any Workers that are children of the current
+thread as part of the `workers` section, with each Worker generating a report
+in the standard report format.
+
+The thread which is generating the report will wait for the reports from Worker
+threads to finish. However, the latency for this will usually be low, as both
+running JavaScript and the event loop are interrupted to generate the report.
+
 [`process API documentation`]: process.html
+[`Worker`]: worker_threads.html

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -748,6 +748,7 @@ Environment::NativeImmediateQueue::Shift() {
     if (!head_)
       tail_ = nullptr;  // The queue is now empty.
   }
+  size_--;
   return ret;
 }
 
@@ -755,6 +756,7 @@ void Environment::NativeImmediateQueue::Push(
     std::unique_ptr<Environment::NativeImmediateCallback> cb) {
   NativeImmediateCallback* prev_tail = tail_;
 
+  size_++;
   tail_ = cb.get();
   if (prev_tail != nullptr)
     prev_tail->set_next(std::move(cb));
@@ -772,6 +774,10 @@ void Environment::NativeImmediateQueue::ConcatMove(
   tail_ = other.tail_;
   other.tail_ = nullptr;
   other.size_ = 0;
+}
+
+size_t Environment::NativeImmediateQueue::size() const {
+  return size_.load();
 }
 
 template <typename Fn>
@@ -793,6 +799,17 @@ void Environment::SetImmediate(Fn&& cb) {
 template <typename Fn>
 void Environment::SetUnrefImmediate(Fn&& cb) {
   CreateImmediate(std::move(cb), false);
+}
+
+template <typename Fn>
+void Environment::SetImmediateThreadsafe(Fn&& cb) {
+  auto callback = std::make_unique<NativeImmediateCallbackImpl<Fn>>(
+      std::move(cb), false);
+  {
+    Mutex::ScopedLock lock(native_immediates_threadsafe_mutex_);
+    native_immediates_threadsafe_.Push(std::move(callback));
+  }
+  uv_async_send(&task_queues_async_);
 }
 
 Environment::NativeImmediateCallback::NativeImmediateCallback(bool refed)
@@ -1164,7 +1181,7 @@ void Environment::RemoveCleanupHook(void (*fn)(void*), void* arg) {
 inline void Environment::RegisterFinalizationGroupForCleanup(
     v8::Local<v8::FinalizationGroup> group) {
   cleanup_finalization_groups_.emplace_back(isolate(), group);
-  uv_async_send(&cleanup_finalization_groups_async_);
+  uv_async_send(&task_queues_async_);
 }
 
 size_t CleanupHookCallback::Hash::operator()(

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -909,6 +909,11 @@ inline void Environment::remove_sub_worker_context(worker::Worker* context) {
   sub_worker_contexts_.erase(context);
 }
 
+template <typename Fn>
+inline void Environment::ForEachWorker(Fn&& iterator) {
+  for (worker::Worker* w : sub_worker_contexts_) iterator(w);
+}
+
 inline void Environment::add_refs(int64_t diff) {
   task_queues_async_refs_ += diff;
   CHECK_GE(task_queues_async_refs_, 0);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -242,14 +242,6 @@ inline bool ImmediateInfo::has_outstanding() const {
   return fields_[kHasOutstanding] == 1;
 }
 
-inline void ImmediateInfo::count_inc(uint32_t increment) {
-  fields_[kCount] += increment;
-}
-
-inline void ImmediateInfo::count_dec(uint32_t decrement) {
-  fields_[kCount] -= decrement;
-}
-
 inline void ImmediateInfo::ref_count_inc(uint32_t increment) {
   fields_[kRefCount] += increment;
 }
@@ -787,7 +779,6 @@ void Environment::CreateImmediate(Fn&& cb, bool ref) {
   auto callback = std::make_unique<NativeImmediateCallbackImpl<Fn>>(
       std::move(cb), ref);
   native_immediates_.Push(std::move(callback));
-  immediate_info()->count_inc(1);
 }
 
 template <typename Fn>

--- a/src/env.cc
+++ b/src/env.cc
@@ -662,7 +662,6 @@ void Environment::RunAndClearNativeImmediates(bool only_refed) {
   TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
                               "RunAndClearNativeImmediates", this);
   size_t ref_count = 0;
-  size_t count = 0;
 
   NativeImmediateQueue queue;
   queue.ConcatMove(std::move(native_immediates_));
@@ -671,7 +670,6 @@ void Environment::RunAndClearNativeImmediates(bool only_refed) {
     TryCatchScope try_catch(this);
     DebugSealHandleScope seal_handle_scope(isolate());
     while (std::unique_ptr<NativeImmediateCallback> head = queue.Shift()) {
-      count++;
       if (head->is_refed())
         ref_count++;
 
@@ -689,9 +687,10 @@ void Environment::RunAndClearNativeImmediates(bool only_refed) {
   };
   while (queue.size() > 0 && drain_list()) {}
 
-  DCHECK_GE(immediate_info()->count(), count);
-  immediate_info()->count_dec(count);
   immediate_info()->ref_count_dec(ref_count);
+
+  if (immediate_info()->ref_count() == 0)
+    ToggleImmediateRef(false);
 }
 
 
@@ -777,15 +776,12 @@ void Environment::CheckImmediate(uv_check_t* handle) {
   TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
                               "CheckImmediate", env);
 
-  if (env->immediate_info()->count() == 0)
-    return;
-
   HandleScope scope(env->isolate());
   Context::Scope context_scope(env->context());
 
   env->RunAndClearNativeImmediates();
 
-  if (!env->can_call_into_js())
+  if (env->immediate_info()->count() == 0 || !env->can_call_into_js())
     return;
 
   do {

--- a/src/env.h
+++ b/src/env.h
@@ -1430,8 +1430,20 @@ class Environment : public MemoryRetainer {
     Fn callback_;
   };
 
-  std::unique_ptr<NativeImmediateCallback> native_immediate_callbacks_head_;
-  NativeImmediateCallback* native_immediate_callbacks_tail_ = nullptr;
+  class NativeImmediateQueue {
+   public:
+    inline std::unique_ptr<NativeImmediateCallback> Shift();
+    inline void Push(std::unique_ptr<NativeImmediateCallback> cb);
+    // ConcatMove adds elements from 'other' to the end of this list, and clears
+    // 'other' afterwards.
+    inline void ConcatMove(NativeImmediateQueue&& other);
+
+   private:
+    std::unique_ptr<NativeImmediateCallback> head_;
+    NativeImmediateCallback* tail_ = nullptr;
+  };
+
+  NativeImmediateQueue native_immediates_;
 
   void RunAndClearNativeImmediates(bool only_refed = false);
   static void CheckImmediate(uv_check_t* handle);

--- a/src/env.h
+++ b/src/env.h
@@ -736,8 +736,6 @@ class ImmediateInfo : public MemoryRetainer {
   inline uint32_t count() const;
   inline uint32_t ref_count() const;
   inline bool has_outstanding() const;
-  inline void count_inc(uint32_t increment);
-  inline void count_dec(uint32_t decrement);
   inline void ref_count_inc(uint32_t increment);
   inline void ref_count_dec(uint32_t decrement);
 

--- a/src/env.h
+++ b/src/env.h
@@ -1064,6 +1064,8 @@ class Environment : public MemoryRetainer {
   inline void add_sub_worker_context(worker::Worker* context);
   inline void remove_sub_worker_context(worker::Worker* context);
   void stop_sub_worker_contexts();
+  template <typename Fn>
+  inline void ForEachWorker(Fn&& iterator);
   inline bool is_stopping() const;
   inline void set_stopping(bool value);
   inline std::list<node_module>* extra_linked_bindings();

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -900,6 +900,10 @@ void MessagePort::Entangle(MessagePort* a, MessagePortData* b) {
   MessagePortData::Entangle(a->data_.get(), b);
 }
 
+void MessagePort::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackField("data", data_);
+}
+
 Local<FunctionTemplate> GetMessagePortConstructorTemplate(Environment* env) {
   // Factor generating the MessagePort JS constructor into its own piece
   // of code, because it is needed early on in the child environment setup.

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -191,10 +191,7 @@ class MessagePort : public HandleWrap {
   // NULL pointer to the C++ MessagePort object is also detached.
   inline bool IsDetached() const;
 
-  void MemoryInfo(MemoryTracker* tracker) const override {
-    tracker->TrackField("data", data_);
-  }
-
+  void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(MessagePort)
   SET_SELF_SIZE(MessagePort)
 

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -44,6 +44,7 @@ void GetNodeReport(v8::Isolate* isolate,
 // Function declarations - utility functions in src/node_report_utils.cc
 void WalkHandle(uv_handle_t* h, void* arg);
 std::string EscapeJsonChars(const std::string& str);
+std::string Reindent(const std::string& str, int indentation);
 
 template <typename T>
 std::string ValueToHexString(T value) {
@@ -146,6 +147,10 @@ class JSONWriter {
 
   struct Null {};  // Usable as a JSON value.
 
+  struct ForeignJSON {
+    std::string as_string;
+  };
+
  private:
   template <typename T,
             typename test_for_number = typename std::
@@ -160,6 +165,10 @@ class JSONWriter {
   inline void write_value(Null null) { out_ << "null"; }
   inline void write_value(const char* str) { write_string(str); }
   inline void write_value(const std::string& str) { write_string(str); }
+
+  inline void write_value(const ForeignJSON& json) {
+    out_ << Reindent(json.as_string, indent_);
+  }
 
   inline void write_string(const std::string& str) {
     out_ << '"' << EscapeJsonChars(str) << '"';

--- a/src/node_report_utils.cc
+++ b/src/node_report_utils.cc
@@ -263,4 +263,28 @@ std::string EscapeJsonChars(const std::string& str) {
   return ret;
 }
 
+std::string Reindent(const std::string& str, int indent_depth) {
+  std::string indent;
+  for (int i = 0; i < indent_depth; i++) indent += ' ';
+
+  std::string out;
+  std::string::size_type pos = 0;
+  do {
+    std::string::size_type prev_pos = pos;
+    pos = str.find('\n', pos);
+
+    out.append(indent);
+
+    if (pos == std::string::npos) {
+      out.append(str, prev_pos, std::string::npos);
+      break;
+    } else {
+      pos++;
+      out.append(str, prev_pos, pos - prev_pos);
+    }
+  } while (true);
+
+  return out;
+}
+
 }  // namespace report

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -656,6 +656,10 @@ void Worker::Exit(int code) {
   }
 }
 
+void Worker::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackField("parent_port", parent_port_);
+}
+
 namespace {
 
 // Return the MessagePort that is global for this Environment and communicates

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -43,6 +43,9 @@ class Worker : public AsyncWrap {
     tracker->TrackField("parent_port", parent_port_);
   }
 
+  template <typename Fn>
+  inline bool RequestInterrupt(Fn&& cb);
+
   SET_MEMORY_INFO_NAME(Worker)
   SET_SELF_SIZE(Worker)
 
@@ -122,6 +125,14 @@ class Worker : public AsyncWrap {
 
   friend class WorkerThreadData;
 };
+
+template <typename Fn>
+bool Worker::RequestInterrupt(Fn&& cb) {
+  Mutex::ScopedLock lock(mutex_);
+  if (env_ == nullptr) return false;
+  env_->RequestInterrupt(std::move(cb));
+  return true;
+}
 
 }  // namespace worker
 }  // namespace node

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -39,13 +39,10 @@ class Worker : public AsyncWrap {
   // Wait for the worker thread to stop (in a blocking manner).
   void JoinThread();
 
-  void MemoryInfo(MemoryTracker* tracker) const override {
-    tracker->TrackField("parent_port", parent_port_);
-  }
-
   template <typename Fn>
   inline bool RequestInterrupt(Fn&& cb);
 
+  void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(Worker)
   SET_SELF_SIZE(Worker)
 

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -41,7 +41,6 @@ class Worker : public AsyncWrap {
 
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackField("parent_port", parent_port_);
-    tracker->TrackInlineField(&on_thread_finished_, "on_thread_finished_");
   }
 
   SET_MEMORY_INFO_NAME(Worker)
@@ -107,13 +106,13 @@ class Worker : public AsyncWrap {
   // instance refers to it via its [kPort] property.
   MessagePort* parent_port_ = nullptr;
 
-  AsyncRequest on_thread_finished_;
-
   // A raw flag that is used by creator and worker threads to
   // sync up on pre-mature termination of worker  - while in the
   // warmup phase.  Once the worker is fully warmed up, use the
   // async handle of the worker's Environment for the same purpose.
   bool stopped_ = true;
+
+  bool has_ref_ = true;
 
   // The real Environment of the worker object. It has a lesser
   // lifespan than the worker object itself - comes to life

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -53,7 +53,7 @@ function _validateContent(report) {
   // Verify that all sections are present as own properties of the report.
   const sections = ['header', 'javascriptStack', 'nativeStack',
                     'javascriptHeap', 'libuv', 'environmentVariables',
-                    'sharedObjects', 'resourceUsage'];
+                    'sharedObjects', 'resourceUsage', 'workers'];
   if (!isWindows)
     sections.push('userLimits');
 
@@ -74,9 +74,9 @@ function _validateContent(report) {
                         'componentVersions', 'release', 'osName', 'osRelease',
                         'osVersion', 'osMachine', 'cpus', 'host',
                         'glibcVersionRuntime', 'glibcVersionCompiler', 'cwd',
-                        'reportVersion', 'networkInterfaces'];
+                        'reportVersion', 'networkInterfaces', 'threadId'];
   checkForUnknownFields(header, headerFields);
-  assert.strictEqual(header.reportVersion, 1);  // Increment as needed.
+  assert.strictEqual(header.reportVersion, 2);  // Increment as needed.
   assert.strictEqual(typeof header.event, 'string');
   assert.strictEqual(typeof header.trigger, 'string');
   assert(typeof header.filename === 'string' || header.filename === null);
@@ -84,6 +84,7 @@ function _validateContent(report) {
                         'Invalid Date');
   assert(String(+header.dumpEventTimeStamp), header.dumpEventTimeStamp);
   assert(Number.isSafeInteger(header.processId));
+  assert(Number.isSafeInteger(header.threadId) || header.threadId === null);
   assert.strictEqual(typeof header.cwd, 'string');
   assert(Array.isArray(header.commandLine));
   header.commandLine.forEach((arg) => {
@@ -253,6 +254,10 @@ function _validateContent(report) {
   report.sharedObjects.forEach((sharedObject) => {
     assert.strictEqual(typeof sharedObject, 'string');
   });
+
+  // Verify the format of the workers section.
+  assert(Array.isArray(report.workers));
+  report.workers.forEach(_validateContent);
 }
 
 function checkForUnknownFields(actual, expected) {

--- a/test/report/test-report-worker.js
+++ b/test/report/test-report-worker.js
@@ -1,0 +1,50 @@
+// Flags: --experimental-report
+'use strict';
+const common = require('../common');
+common.skipIfReportDisabled();
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+const { once } = require('events');
+const helper = require('../common/report');
+
+async function basic() {
+  // Test that the report includes basic information about Worker threads.
+
+  const w = new Worker(`
+    const { parentPort } = require('worker_threads');
+    parentPort.once('message', () => {
+      /* Wait for message to stop the Worker */
+    });
+  `, { eval: true });
+
+  await once(w, 'online');
+
+  const report = process.report.getReport();
+  helper.validateContent(report);
+  assert.strictEqual(report.workers.length, 1);
+  helper.validateContent(report.workers[0]);
+
+  w.postMessage({});
+
+  await once(w, 'exit');
+}
+
+async function interruptingJS() {
+  // Test that the report also works when Worker threads are busy in JS land.
+
+  const w = new Worker('while (true);', { eval: true });
+
+  await once(w, 'online');
+
+  const report = process.report.getReport();
+  helper.validateContent(report);
+  assert.strictEqual(report.workers.length, 1);
+  helper.validateContent(report.workers[0]);
+
+  await w.terminate();
+}
+
+(async function() {
+  await basic();
+  await interruptingJS();
+})().then(common.mustCall());


### PR DESCRIPTION
Only the last commit is concerned with the report feature itself. The other commits are work leading up to it, making features like this easier to add in general, and related cleanup.

---

##### src: better encapsulate native immediate list

Refactor for clarity and reusability. Make it more obvious that the
list is a FIFO queue.

##### src: exclude C++ SetImmediate() from count

There is no real reason to manage a count manually, given that
checking whether there are C++ callbacks is a single pointer
comparison.

This makes it easier to add other kinds of native C++ callbacks
that are managed in a similar way.

##### src: add a threadsafe variant of SetImmediate()

Add a variant of `SetImmediate()` that can be called from any thread.
This allows removing the `AsyncRequest` abstraction and replaces it
with a more generic mechanism.

##### src: remove AsyncRequest

Remove `AsyncRequest` from the source code, and replace its
usage with threadsafe `SetImmediate()` calls. This has the
advantage of being able to pass in any function, rather than
one that is defined when the `AsyncRequest` is “installed”.

This necessitates two changes:

- The stopping flag (which was only used in one case and ignored
  in the other) is now a direct member of the `Environment` class.
- Workers no longer have their own libuv handles, requiring
  manual management of their libuv ref count.

As a drive-by fix, the `can_call_into_js` variable was turned
into an atomic variable. While there have been no bug reports,
the flag is set from `Stop(env)` calls, which are supposed to
be possible from any thread.

##### src: add interrupts to Environments/Workers

Allow doing what V8’s `v8::Isolate::RequestInterrupt()` does for V8.
This also works when there is no JS code currently executing.

##### src: move MemoryInfo() for worker code to .cc files

This is a) the right thing to do anyway because these functions
can not be inlined by the compiler and b) avoids compilation warnings
in the following commit.

##### report: add support for Workers

Include a report for each sub-Worker of the current Node.js instance.

This adds a feature that is necessary for eventually making the report
feature stable, as was discussed during the last collaborator summit.

Refs: https://github.com/openjs-foundation/summit/pull/240


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
