### PR TITLE
esm: add package type wasm

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1225,7 +1225,7 @@ Module._extensions['.js'] = function(module, filename) {
   if (filename.endsWith('.js')) {
     const pkg = readPackageScope(filename);
     // Function require shouldn't be used in ES modules.
-    if (pkg && pkg.data && pkg.data.type === 'module') {
+    if (pkg && pkg.data && pkg.data.type !== 'commonjs') {
       const parentPath = module.parent && module.parent.filename;
       const packageJsonPath = path.resolve(pkg.path, 'package.json');
       throw new ERR_REQUIRE_ESM(filename, parentPath, packageJsonPath);

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -20,7 +20,6 @@ const { ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
 const wasmFormatMap = {
   '__proto__': null,
   '.cjs': 'commonjs',
-  '.js': 'module',
   '.mjs': 'module',
 };
 

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -14,10 +14,19 @@ const { ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
 
 // const TYPE_NONE = 0;
 // const TYPE_COMMONJS = 1;
-const TYPE_MODULE = 2;
+// const TYPE_MODULE = 2;
+// const TYPE_WASM = 3;
 
-const extensionFormatMap = {
+const wasmFormatMap = {
   '__proto__': null,
+  '.cjs': 'commonjs',
+  '.js': 'module',
+  '.mjs': 'module',
+};
+
+const moduleFormatMap = {
+  '__proto__': null,
+  '': 'module',
   '.cjs': 'commonjs',
   '.js': 'module',
   '.mjs': 'module'
@@ -25,6 +34,7 @@ const extensionFormatMap = {
 
 const legacyExtensionFormatMap = {
   '__proto__': null,
+  '': 'commonjs',
   '.cjs': 'commonjs',
   '.js': 'commonjs',
   '.json': 'commonjs',
@@ -32,11 +42,25 @@ const legacyExtensionFormatMap = {
   '.node': 'commonjs'
 };
 
-if (experimentalWasmModules)
-  extensionFormatMap['.wasm'] = legacyExtensionFormatMap['.wasm'] = 'wasm';
+const formatMaps = [
+  legacyExtensionFormatMap,
+  legacyExtensionFormatMap,
+  moduleFormatMap,
+  experimentalWasmModules ? wasmFormatMap : legacyExtensionFormatMap
+];
 
-if (experimentalJsonModules)
-  extensionFormatMap['.json'] = legacyExtensionFormatMap['.json'] = 'json';
+if (experimentalWasmModules) {
+  wasmFormatMap[''] =
+  wasmFormatMap['.wasm'] =
+  moduleFormatMap['.wasm'] =
+  legacyExtensionFormatMap['.wasm'] = 'wasm';
+}
+
+if (experimentalJsonModules) {
+  wasmFormatMap['.json'] =
+  moduleFormatMap['.json'] =
+  legacyExtensionFormatMap['.json'] = 'json';
+}
 
 function defaultGetFormat(url, context, defaultGetFormat) {
   if (NativeModule.canBeRequiredByUsers(url)) {
@@ -56,10 +80,10 @@ function defaultGetFormat(url, context, defaultGetFormat) {
     const ext = extname(parsed.pathname);
     let format;
     if (ext === '.js' || ext === '') {
-      format = getPackageType(parsed.href) === TYPE_MODULE ?
-        'module' : 'commonjs';
+      const type = getPackageType(parsed.href);
+      format = formatMaps[type][ext];
     } else {
-      format = extensionFormatMap[ext];
+      format = moduleFormatMap[ext];
     }
     if (!format) {
       if (experimentalSpeciferResolution === 'node') {

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -34,7 +34,8 @@ function shouldUseESMLoader(mainPath) {
   if (!mainPath || mainPath.endsWith('.cjs'))
     return false;
   const pkg = readPackageScope(mainPath);
-  return pkg && pkg.data.type === 'module';
+  return pkg && typeof pkg.data.type === 'string' &&
+    pkg.data.type !== 'commonjs';
 }
 
 function runMainESM(mainPath) {

--- a/src/env.h
+++ b/src/env.h
@@ -94,7 +94,7 @@ struct PackageConfig {
   enum class IsValid { Yes, No };
   enum class HasMain { Yes, No };
   enum class HasName { Yes, No };
-  enum PackageType : uint32_t { None = 0, CommonJS, Module };
+  enum PackageType : uint32_t { None = 0, CommonJS, Module, WASM };
 
   const Exists exists;
   const IsValid is_valid;
@@ -377,6 +377,7 @@ constexpr size_t kFsStatsBufferLength =
   V(value_string, "value")                                                     \
   V(verify_error_string, "verifyError")                                        \
   V(version_string, "version")                                                 \
+  V(wasm_string, "wasm")                                                       \
   V(weight_string, "weight")                                                   \
   V(windows_hide_string, "windowsHide")                                        \
   V(windows_verbatim_arguments_string, "windowsVerbatimArguments")             \

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -649,6 +649,8 @@ Maybe<const PackageConfig*> GetPackageConfig(Environment* env,
       pkg_type = PackageType::Module;
     } else if (type_v->StrictEquals(env->commonjs_string())) {
       pkg_type = PackageType::CommonJS;
+    } else if (type_v->StrictEquals(env->wasm_string())) {
+      pkg_type = PackageType::WASM;
     }
     // ignore unknown types for forwards compatibility
   }

--- a/test/es-module/test-esm-wasm.mjs
+++ b/test/es-module/test-esm-wasm.mjs
@@ -1,5 +1,5 @@
 // Flags: --experimental-wasm-modules
-import '../common/index.mjs';
+import { mustCall } from '../common/index.mjs';
 import { path } from '../common/fixtures.mjs';
 import { add, addImported } from '../fixtures/es-modules/simple.wasm';
 import { state } from '../fixtures/es-modules/wasm-dep.mjs';
@@ -16,22 +16,44 @@ strictEqual(state, 'WASM JS Function Executed');
 
 strictEqual(addImported(1), 43);
 
-// Test warning message
-const child = spawn(process.execPath, [
-  '--experimental-wasm-modules',
-  path('/es-modules/wasm-modules.mjs')
-]);
+{
+  // Test warning message
+  const child = spawn(process.execPath, [
+    '--experimental-wasm-modules',
+    path('/es-modules/wasm-modules.mjs')
+  ]);
 
-let stderr = '';
-child.stderr.setEncoding('utf8');
-child.stderr.on('data', (data) => {
-  stderr += data;
-});
-child.on('close', (code, signal) => {
-  strictEqual(code, 0);
-  strictEqual(signal, null);
-  ok(stderr.toString().includes(
-    'ExperimentalWarning: Importing Web Assembly modules is ' +
-    'an experimental feature. This feature could change at any time'
-  ));
-});
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (data) => {
+    stderr += data;
+  });
+  child.on('close', (code, signal) => {
+    strictEqual(code, 0);
+    strictEqual(signal, null);
+    ok(stderr.toString().includes(
+      'ExperimentalWarning: Importing Web Assembly modules is ' +
+      'an experimental feature. This feature could change at any time'
+    ));
+  });
+}
+
+{
+  const entry = path('/es-modules/package-type-wasm/noext-wasm');
+
+  // Run a module that does not have extension.
+  // This is to ensure that "type": "module" applies to extensionless files.
+
+  const child = spawn(process.execPath, ['--experimental-wasm-modules', entry]);
+
+  let stdout = '';
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (data) => {
+    stdout += data;
+  });
+  child.on('close', mustCall((code, signal) => {
+    strictEqual(code, 0);
+    strictEqual(signal, null);
+    strictEqual(stdout, '');
+  }));
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

The main benefit of this is to allow files without an extension to be treated as WASM. This does alter the logic for detecting if something should be treated as going through the ESM loader for the main module slightly by inverting the condition from checking for `"module"` to instead check it doesn't match `"commonjs"`

This remains flagged behind the WASM modules flag