### PR TITLE
fs: unset FileHandle fd after close

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -53,6 +53,7 @@ const pathModule = require('path');
 const { promisify } = require('internal/util');
 
 const kHandle = Symbol('kHandle');
+const kFd = Symbol('kFd');
 const { kUsePromises } = binding;
 
 const getDirectoryEntriesPromise = promisify(getDirents);
@@ -60,6 +61,7 @@ const getDirectoryEntriesPromise = promisify(getDirents);
 class FileHandle {
   constructor(filehandle) {
     this[kHandle] = filehandle;
+    this[kFd] = filehandle.fd;
   }
 
   getAsyncId() {
@@ -67,7 +69,7 @@ class FileHandle {
   }
 
   get fd() {
-    return this[kHandle].fd;
+    return this[kFd];
   }
 
   appendFile(data, options) {
@@ -123,6 +125,7 @@ class FileHandle {
   }
 
   close = () => {
+    this[kFd] = -1;
     return this[kHandle].close();
   }
 }

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -205,7 +205,7 @@ class FileHandle final : public AsyncWrap, public StreamBase {
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  int fd() const { return fd_; }
+  int GetFD() override { return fd_; }
 
   // Will asynchronously close the FD and return a Promise that will
   // be resolved once closing is complete.

--- a/test/parallel/test-fs-filehandle-use-after-close.js
+++ b/test/parallel/test-fs-filehandle-use-after-close.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs').promises;
+
+(async () => {
+  const filehandle = await fs.open(__filename);
+
+  assert.notStrictEqual(filehandle.fd, -1);
+  await filehandle.close();
+  assert.strictEqual(filehandle.fd, -1);
+
+  // Open another file handle first. This would typically receive the fd
+  // that `filehandle` previously used. In earlier versions of Node.js, the
+  // .stat() call would then succeed because it still used the original fd;
+  // See https://github.com/nodejs/node/issues/31361 for more details.
+  const otherFilehandle = await fs.open(process.execPath);
+
+  assert.rejects(() => filehandle.stat(), {
+    code: 'EBADF',
+    syscall: 'fstat'
+  });
+
+  await otherFilehandle.close();
+})().then(common.mustCall());


### PR DESCRIPTION
- Do not set the fd as a property on the native object.
- Use the already-existent `GetFD()` method to pass the
  fd from C++ to JS.
- Cache the fd in JS to avoid repeated accesses to the
  C++ getter.
- Set the fd to `-1` after close, thus reliably making
  subsequent calls using the `FileHandle` return `EBADF`.

Fixes: https://github.com/nodejs/node/issues/31361

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
