### PR TITLE
doc: document process.{stderr.fd, stdin.fd, stdout.fd}

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2158,6 +2158,14 @@ a [Writable][] stream.
 `process.stderr` differs from other Node.js streams in important ways. See
 [note on process I/O][] for more information.
 
+### `process.stderr.fd`
+
+* {number}
+
+This property refers to the value of underlying file descriptor
+(in POSIX) or handle (an abstract resource reference in Windows) of
+`process.stderr`. In `worker_thread`s, this field does not exist.
+
 ## `process.stdin`
 
 * {Stream}
@@ -2191,6 +2199,14 @@ In "old" streams mode the `stdin` stream is paused by default, so one
 must call `process.stdin.resume()` to read from it. Note also that calling
 `process.stdin.resume()` itself would switch stream to "old" mode.
 
+### `process.stdin.fd`
+
+* {number}
+
+This property refers to the value of underlying file descriptor
+(in POSIX) or handle (an abstract resource reference in Windows) of
+`process.stdin`. In `worker_thread`s, this field does not exist.
+
 ## `process.stdout`
 
 * {Stream}
@@ -2208,6 +2224,14 @@ process.stdin.pipe(process.stdout);
 
 `process.stdout` differs from other Node.js streams in important ways. See
 [note on process I/O][] for more information.
+
+### `process.stdout.fd`
+
+* {number}
+
+This property refers to the value of underlying file descriptor
+(in POSIX) or handle (an abstract resource reference in Windows) of
+`process.stdout`. In `worker_thread`s, this field does not exist.
 
 ### A note on process I/O
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2163,7 +2163,7 @@ a [Writable][] stream.
 * {number}
 
 This property refers to the value of underlying file descriptor of
-`process.stderr`. The value is fixed at `2`. In `worker_thread`s,
+`process.stderr`. The value is fixed at `2`. In [`Worker`][] threads,
 this field does not exist.
 
 ## `process.stdin`
@@ -2204,7 +2204,7 @@ must call `process.stdin.resume()` to read from it. Note also that calling
 * {number}
 
 This property refers to the value of underlying file descriptor of
-`process.stdin`. The value is fixed at `0`. In `worker_thread`s,
+`process.stdin`. The value is fixed at `0`. In [`Worker`][] threads,
 this field does not exist.
 
 ## `process.stdout`
@@ -2230,7 +2230,7 @@ process.stdin.pipe(process.stdout);
 * {number}
 
 This property refers to the value of underlying file descriptor of
-`process.stdout`. The value is fixed at `1`. In `worker_thread`s,
+`process.stdout`. The value is fixed at `1`. In [`Worker`][] threads,
 this field does not exist.
 
 ### A note on process I/O

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2162,9 +2162,9 @@ a [Writable][] stream.
 
 * {number}
 
-This property refers to the value of underlying file descriptor
-(in POSIX) or handle (an abstract resource reference in Windows) of
-`process.stderr`. In `worker_thread`s, this field does not exist.
+This property refers to the value of underlying file descriptor of
+`process.stderr`. The value is fixed at `2`. In `worker_thread`s,
+this field does not exist.
 
 ## `process.stdin`
 
@@ -2203,9 +2203,9 @@ must call `process.stdin.resume()` to read from it. Note also that calling
 
 * {number}
 
-This property refers to the value of underlying file descriptor
-(in POSIX) or handle (an abstract resource reference in Windows) of
-`process.stdin`. In `worker_thread`s, this field does not exist.
+This property refers to the value of underlying file descriptor of
+`process.stdin`. The value is fixed at `0`. In `worker_thread`s,
+this field does not exist.
 
 ## `process.stdout`
 
@@ -2229,9 +2229,9 @@ process.stdin.pipe(process.stdout);
 
 * {number}
 
-This property refers to the value of underlying file descriptor
-(in POSIX) or handle (an abstract resource reference in Windows) of
-`process.stdout`. In `worker_thread`s, this field does not exist.
+This property refers to the value of underlying file descriptor of
+`process.stdout`. The value is fixed at `1`. In `worker_thread`s,
+this field does not exist.
 
 ### A note on process I/O
 


### PR DESCRIPTION
1. This was reported many times by users - as undocumented public fields
2. Because of 1, their `undefined` status in worker threads could not be documented too.

Fixes: https://github.com/nodejs/node/issues/28386
Refs: https://github.com/nodejs/node/pull/31292
Refs: https://github.com/nodejs/help/issues/2136

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
