### PR TITLE
benchmark: test refactoring

### DIFF
--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -43,9 +43,8 @@ class AutocannonBenchmarker {
     }
     if (!result || !result.requests || !result.requests.average) {
       return undefined;
-    } else {
-      return result.requests.average;
     }
+    return result.requests.average;
   }
 }
 
@@ -77,9 +76,8 @@ class WrkBenchmarker {
     const throughput = match && +match[1];
     if (!isFinite(throughput)) {
       return undefined;
-    } else {
-      return throughput;
     }
+    return throughput;
   }
 }
 
@@ -89,7 +87,8 @@ class WrkBenchmarker {
  */
 class TestDoubleBenchmarker {
   constructor(type) {
-    // `type` is the type ofbenchmarker. Possible values are 'http' and 'http2'.
+    // `type` is the type of benchmarker. Possible values are 'http' and
+    // 'http2'.
     this.name = `test-double-${type}`;
     this.executable = path.resolve(__dirname, '_test-double-benchmarker.js');
     this.present = fs.existsSync(this.executable);
@@ -97,10 +96,11 @@ class TestDoubleBenchmarker {
   }
 
   create(options) {
-    const env = Object.assign({
+    const env = {
       duration: options.duration,
       test_url: `http://127.0.0.1:${options.port}${options.path}`,
-    }, process.env);
+      ...process.env
+    };
 
     const child = child_process.fork(this.executable,
                                      [this.type],
@@ -189,13 +189,14 @@ http_benchmarkers.forEach((benchmarker) => {
 });
 
 exports.run = function(options, callback) {
-  options = Object.assign({
+  options = {
     port: exports.PORT,
     path: '/',
     connections: 100,
     duration: 5,
     benchmarker: exports.default_http_benchmarker,
-  }, options);
+    ...options
+  };
   if (!options.benchmarker) {
     callback(new Error('Could not locate required http benchmarker. See ' +
                        `${requirementsURL} for further instructions.`));
@@ -212,6 +213,7 @@ exports.run = function(options, callback) {
                        'is  not installed'));
     return;
   }
+  process.env.duration = process.env.duration || options.duration || 5;
 
   const benchmarker_start = process.hrtime();
 
@@ -220,7 +222,8 @@ exports.run = function(options, callback) {
   child.stderr.pipe(process.stderr);
 
   let stdout = '';
-  child.stdout.on('data', (chunk) => stdout += chunk.toString());
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => stdout += chunk);
 
   child.once('close', (code) => {
     const elapsed = process.hrtime(benchmarker_start);

--- a/benchmark/_test-double-benchmarker.js
+++ b/benchmark/_test-double-benchmarker.js
@@ -7,7 +7,7 @@ if (!['http', 'http2'].includes(myModule)) {
 
 const http = require(myModule);
 
-const duration = process.env.duration || 0;
+const duration = +process.env.duration;
 const url = process.env.test_url;
 
 const start = process.hrtime();
@@ -18,13 +18,15 @@ function request(res, client) {
   res.on('error', () => {});
   res.on('end', () => {
     throughput++;
-    const diff = process.hrtime(start);
-    if (duration > 0 && diff[0] < duration) {
+    const [sec, nanosec] = process.hrtime(start);
+    const ms = sec * 1000 + nanosec / 1e6;
+    if (ms < duration * 1000) {
       run();
     } else {
       console.log(JSON.stringify({ throughput }));
       if (client) {
         client.destroy();
+        process.exit(0);
       }
     }
   });
@@ -33,7 +35,7 @@ function request(res, client) {
 function run() {
   if (http.get) { // HTTP
     http.get(url, request);
-  } else {        // HTTP/2
+  } else { // HTTP/2
     const client = http.connect(url);
     client.on('error', (e) => { throw e; });
     request(client.request(), client);

--- a/benchmark/assert/deepequal-buffer.js
+++ b/benchmark/assert/deepequal-buffer.js
@@ -6,12 +6,10 @@ const bench = common.createBenchmark(main, {
   n: [2e4],
   len: [1e2, 1e3],
   strict: [0, 1],
-  method: [ 'deepEqual', 'notDeepEqual' ],
+  method: ['deepEqual', 'notDeepEqual'],
 });
 
 function main({ len, n, method, strict }) {
-  if (!method)
-    method = 'deepEqual';
   const data = Buffer.allocUnsafe(len + 1);
   const actual = Buffer.alloc(len);
   const expected = Buffer.alloc(len);

--- a/benchmark/assert/deepequal-map.js
+++ b/benchmark/assert/deepequal-map.js
@@ -34,8 +34,6 @@ function main({ n, len, method, strict }) {
   const array = Array(len).fill(1);
 
   switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual_primitiveOnly': {
       const values = array.map((_, i) => [`str_${i}`, 123]);
       benchmark(strict ? deepStrictEqual : deepEqual, n, values);

--- a/benchmark/assert/deepequal-object.js
+++ b/benchmark/assert/deepequal-object.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [5e3],
   size: [1e2, 1e3, 5e4],
   strict: [0, 1],
-  method: [ 'deepEqual', 'notDeepEqual' ],
+  method: ['deepEqual', 'notDeepEqual'],
 });
 
 function createObj(source, add = '') {
@@ -26,9 +26,6 @@ function createObj(source, add = '') {
 function main({ size, n, method, strict }) {
   // TODO: Fix this "hack". `n` should not be manipulated.
   n = Math.min(Math.ceil(n / size), 20);
-
-  if (!method)
-    method = 'deepEqual';
 
   const source = Array.apply(null, Array(size));
   const actual = createObj(source);

--- a/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
@@ -52,8 +52,6 @@ function main({ n, len, primitive, method, strict }) {
   const expectedWrongSet = new Set(expectedWrong);
 
   switch (method) {
-    // Empty string falls through to next line as default, mostly for tests.
-    case '':
     case 'deepEqual_Array':
       run(strict ? deepStrictEqual : deepEqual, n, actual, expected);
       break;

--- a/benchmark/assert/deepequal-prims-and-objs-big-loop.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-loop.js
@@ -13,12 +13,10 @@ const bench = common.createBenchmark(main, {
   primitive: Object.keys(primValues),
   n: [2e4],
   strict: [0, 1],
-  method: [ 'deepEqual', 'notDeepEqual' ],
+  method: ['deepEqual', 'notDeepEqual'],
 });
 
 function main({ n, primitive, method, strict }) {
-  if (!method)
-    method = 'deepEqual';
   const prim = primValues[primitive];
   const actual = prim;
   const expected = prim;

--- a/benchmark/assert/deepequal-set.js
+++ b/benchmark/assert/deepequal-set.js
@@ -34,8 +34,6 @@ function main({ n, len, method, strict }) {
   const array = Array(len).fill(1);
 
   switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual_primitiveOnly': {
       const values = array.map((_, i) => `str_${i}`);
       benchmark(strict ? deepStrictEqual : deepEqual, n, values);

--- a/benchmark/assert/deepequal-typedarrays.js
+++ b/benchmark/assert/deepequal-typedarrays.js
@@ -20,8 +20,6 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ type, n, len, method, strict }) {
-  if (!method)
-    method = 'deepEqual';
   const clazz = global[type];
   const actual = new clazz(len);
   const expected = new clazz(len);

--- a/benchmark/assert/throws.js
+++ b/benchmark/assert/throws.js
@@ -15,8 +15,6 @@ function main({ n, method }) {
   const message = 'failure';
 
   switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'doesNotThrow':
       bench.start();
       for (let i = 0; i < n; ++i) {

--- a/benchmark/async_hooks/http-server.js
+++ b/benchmark/async_hooks/http-server.js
@@ -3,10 +3,11 @@ const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
   asyncHooks: ['init', 'before', 'after', 'all', 'disabled', 'none'],
-  connections: [50, 500]
+  connections: [50, 500],
+  duration: 5
 });
 
-function main({ asyncHooks, connections }) {
+function main({ asyncHooks, connections, duration }) {
   if (asyncHooks !== 'none') {
     let hooks = {
       init() {},
@@ -33,6 +34,7 @@ function main({ asyncHooks, connections }) {
       bench.http({
         connections,
         path,
+        duration
       }, () => {
         server.close();
       });

--- a/benchmark/buffers/buffer-base64-encode.js
+++ b/benchmark/buffers/buffer-base64-encode.js
@@ -25,6 +25,8 @@ const common = require('../common.js');
 const bench = common.createBenchmark(main, {
   len: [64 * 1024 * 1024],
   n: [32]
+}, {
+  test: { len: 256 }
 });
 
 function main({ n, len }) {

--- a/benchmark/buffers/buffer-bytelength.js
+++ b/benchmark/buffers/buffer-bytelength.js
@@ -17,9 +17,9 @@ const chars = [
 
 function main({ n, len, encoding }) {
   let strings = [];
-  let results = [ len * 16 ];
+  let results = [len * 16];
   if (encoding === 'buffer') {
-    strings = [ Buffer.alloc(len * 16, 'a') ];
+    strings = [Buffer.alloc(len * 16, 'a')];
   } else {
     for (const string of chars) {
       // Strings must be built differently, depending on encoding

--- a/benchmark/buffers/buffer-creation.js
+++ b/benchmark/buffers/buffer-creation.js
@@ -16,7 +16,6 @@ const bench = common.createBenchmark(main, {
 function main({ len, n, type }) {
   let fn, i;
   switch (type) {
-    case '':
     case 'fast-alloc':
       fn = Buffer.alloc;
       break;

--- a/benchmark/buffers/buffer-fill.js
+++ b/benchmark/buffers/buffer-fill.js
@@ -22,7 +22,7 @@ function main({ n, type, size }) {
   const buffer = Buffer.allocUnsafe(size);
   const testFunction = new Function('b', `
     for (var i = 0; i < ${n}; i++) {
-      b.${type || 'fill(0)'};
+      b.${type};
     }
   `);
   bench.start();

--- a/benchmark/buffers/buffer-iterate.js
+++ b/benchmark/buffers/buffer-iterate.js
@@ -21,7 +21,7 @@ function main({ size, type, method, n }) {
     Buffer.alloc(size) :
     SlowBuffer(size).fill(0);
 
-  const fn = methods[method || 'for'];
+  const fn = methods[method];
 
   bench.start();
   fn(buffer, n);

--- a/benchmark/buffers/buffer-read-float.js
+++ b/benchmark/buffers/buffer-read-float.js
@@ -9,7 +9,6 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, type, endian, value }) {
-  type = type || 'Double';
   const buff = Buffer.alloc(8);
   const fn = `read${type}${endian}`;
   const values = {

--- a/benchmark/buffers/buffer-read-with-byteLength.js
+++ b/benchmark/buffers/buffer-read-with-byteLength.js
@@ -19,7 +19,7 @@ function main({ n, buf, type, byteLength }) {
   const buff = buf === 'fast' ?
     Buffer.alloc(8) :
     require('buffer').SlowBuffer(8);
-  const fn = `read${type || 'IntBE'}`;
+  const fn = `read${type}`;
 
   buff.writeDoubleLE(0, 0);
   bench.start();

--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -28,7 +28,7 @@ function main({ n, buf, type }) {
   const buff = buf === 'fast' ?
     Buffer.alloc(8) :
     require('buffer').SlowBuffer(8);
-  const fn = `read${type || 'UInt8'}`;
+  const fn = `read${type}`;
 
   buff.writeDoubleLE(0, 0);
   bench.start();

--- a/benchmark/buffers/buffer-swap.js
+++ b/benchmark/buffers/buffer-swap.js
@@ -76,7 +76,7 @@ function genMethod(method) {
 
 function main({ method, len, n, aligned = 'true' }) {
   const buf = createBuffer(len, aligned === 'true');
-  const bufferSwap = genMethod(method || 'swap16');
+  const bufferSwap = genMethod(method);
 
   bufferSwap(n, buf);
   bench.start();

--- a/benchmark/buffers/buffer-swap.js
+++ b/benchmark/buffers/buffer-swap.js
@@ -7,6 +7,8 @@ const bench = common.createBenchmark(main, {
   method: ['swap16', 'swap32', 'swap64'/* , 'htons', 'htonl', 'htonll' */],
   len: [64, 256, 768, 1024, 2056, 8192],
   n: [1e6]
+}, {
+  test: { len: 16 }
 });
 
 // The htons and htonl methods below are used to benchmark the

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -74,7 +74,7 @@ function main({ n, buf, type }) {
   const buff = buf === 'fast' ?
     Buffer.alloc(8) :
     require('buffer').SlowBuffer(8);
-  const fn = `write${type || 'UInt8'}`;
+  const fn = `write${type}`;
 
   if (!/\d/.test(fn))
     benchSpecialInt(buff, fn, n);

--- a/benchmark/buffers/dataview-set.js
+++ b/benchmark/buffers/dataview-set.js
@@ -40,7 +40,6 @@ const mod = {
 };
 
 function main({ n, type }) {
-  type = type || 'Uint8';
   const ab = new ArrayBuffer(8);
   const dv = new DataView(ab, 0, 8);
   const le = /LE$/.test(type);

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -4,43 +4,83 @@ const child_process = require('child_process');
 const http_benchmarkers = require('./_http-benchmarkers.js');
 
 class Benchmark {
-  constructor(fn, configs, options) {
-    // Use the file name as the name of the benchmark
-    this.name = require.main.filename.slice(__dirname.length + 1);
+  // Used to make sure a benchmark only start a timer once
+  #started = false;
+
+  // Indicate that the benchmark ended
+  #ended = false;
+
+  // Holds process.hrtime value
+  #time = [0, 0];
+
+  // Use the file name as the name of the benchmark
+  name = require.main.filename.slice(__dirname.length + 1);
+
+  // Execution arguments i.e. flags used to run the jobs
+  flags = process.env.NODE_BENCHMARK_FLAGS ?
+    process.env.NODE_BENCHMARK_FLAGS.split(/\s+/) :
+    [];
+
+  constructor(fn, configs, options = {}) {
     // Parse job-specific configuration from the command line arguments
-    const parsed_args = this._parseArgs(process.argv.slice(2), configs);
+    const argv = process.argv.slice(2);
+    const parsed_args = this._parseArgs(argv, configs, options);
     this.options = parsed_args.cli;
     this.extra_options = parsed_args.extra;
-    // The configuration list as a queue of jobs
-    this.queue = this._queue(this.options);
-    // The configuration of the current job, head of the queue
-    this.config = this.queue[0];
-    // Execution arguments i.e. flags used to run the jobs
-    this.flags = [];
-    if (options && options.flags) {
+    if (options.flags) {
       this.flags = this.flags.concat(options.flags);
     }
-    if (process.env.NODE_BENCHMARK_FLAGS) {
-      const flags = process.env.NODE_BENCHMARK_FLAGS.split(/\s+/);
-      this.flags = this.flags.concat(flags);
-    }
-    // Holds process.hrtime value
-    this._time = [0, 0];
-    // Used to make sure a benchmark only start a timer once
-    this._started = false;
-    this._ended = false;
 
-    // this._run will use fork() to create a new process for each configuration
-    // combination.
-    if (process.env.hasOwnProperty('NODE_RUN_BENCHMARK_FN')) {
-      process.nextTick(() => fn(this.config));
-    } else {
-      process.nextTick(() => this._run());
-    }
+    // The configuration list as a queue of jobs
+    this.queue = this._queue(this.options);
+
+    // The configuration of the current job, head of the queue
+    this.config = this.queue[0];
+
+    process.nextTick(() => {
+      if (process.env.hasOwnProperty('NODE_RUN_BENCHMARK_FN')) {
+        fn(this.config);
+      } else {
+        // _run will use fork() to create a new process for each configuration
+        // combination.
+        this._run();
+      }
+    });
   }
 
-  _parseArgs(argv, configs) {
+  _parseArgs(argv, configs, options) {
     const cliOptions = {};
+
+    // Check for the test mode first.
+    const testIndex = argv.indexOf('--test');
+    if (testIndex !== -1) {
+      for (const [key, rawValue] of Object.entries(configs)) {
+        let value = Array.isArray(rawValue) ? rawValue[0] : rawValue;
+        // Set numbers to one by default to reduce the runtime.
+        if (typeof value === 'number') {
+          if (key === 'dur' || key === 'duration') {
+            value = 0.05;
+          } else if (value > 1) {
+            value = 1;
+          }
+        }
+        cliOptions[key] = [value];
+      }
+      // Override specific test options.
+      if (options.test) {
+        for (const [key, value] of Object.entries(options.test)) {
+          cliOptions[key] = Array.isArray(value) ? value : [value];
+        }
+      }
+      argv.splice(testIndex, 1);
+    } else {
+      // Accept single values instead of arrays.
+      for (const [key, value] of Object.entries(configs)) {
+        if (!Array.isArray(value))
+          configs[key] = [value];
+      }
+    }
+
     const extraOptions = {};
     const validArgRE = /^(.+?)=([\s\S]*)$/;
     // Parse configuration arguments
@@ -50,45 +90,43 @@ class Benchmark {
         console.error(`bad argument: ${arg}`);
         process.exit(1);
       }
-      const config = match[1];
-
-      if (configs[config]) {
-        // Infer the type from the config object and parse accordingly
-        const isNumber = typeof configs[config][0] === 'number';
-        const value = isNumber ? +match[2] : match[2];
-        if (!cliOptions[config])
-          cliOptions[config] = [];
-        cliOptions[config].push(value);
+      const [, key, value] = match;
+      if (Object.prototype.hasOwnProperty.call(configs, key)) {
+        if (!cliOptions[key])
+          cliOptions[key] = [];
+        cliOptions[key].push(
+          // Infer the type from the config object and parse accordingly
+          typeof configs[key][0] === 'number' ? +value : value
+        );
       } else {
-        extraOptions[config] = match[2];
+        extraOptions[key] = value;
       }
     }
-    return { cli: Object.assign({}, configs, cliOptions), extra: extraOptions };
+    return { cli: { ...configs, ...cliOptions }, extra: extraOptions };
   }
 
   _queue(options) {
     const queue = [];
     const keys = Object.keys(options);
 
-    // Perform a depth-first walk though all options to generate a
+    // Perform a depth-first walk through all options to generate a
     // configuration list that contains all combinations.
     function recursive(keyIndex, prevConfig) {
       const key = keys[keyIndex];
       const values = options[key];
-      const type = typeof values[0];
 
       for (const value of values) {
         if (typeof value !== 'number' && typeof value !== 'string') {
           throw new TypeError(
             `configuration "${key}" had type ${typeof value}`);
         }
-        if (typeof value !== type) {
+        if (typeof value !== typeof values[0]) {
           // This is a requirement for being able to consistently and
           // predictably parse CLI provided configuration values.
           throw new TypeError(`configuration "${key}" has mixed types`);
         }
 
-        const currConfig = Object.assign({ [key]: value }, prevConfig);
+        const currConfig = { [key]: value, ...prevConfig };
 
         if (keyIndex + 1 < keys.length) {
           recursive(keyIndex + 1, currConfig);
@@ -108,12 +146,11 @@ class Benchmark {
   }
 
   http(options, cb) {
-    const self = this;
-    const http_options = Object.assign({ }, options);
+    const http_options = { ...options };
     http_options.benchmarker = http_options.benchmarker ||
-                              self.config.benchmarker ||
-                              self.extra_options.benchmarker ||
-                              exports.default_http_benchmarker;
+                               this.config.benchmarker ||
+                               this.extra_options.benchmarker ||
+                               http_benchmarkers.default_http_benchmarker;
     http_benchmarkers.run(
       http_options, (error, code, used_benchmarker, result, elapsed) => {
         if (cb) {
@@ -123,14 +160,13 @@ class Benchmark {
           console.error(error);
           process.exit(code || 1);
         }
-        self.config.benchmarker = used_benchmarker;
-        self.report(result, elapsed);
+        this.config.benchmarker = used_benchmarker;
+        this.report(result, elapsed);
       }
     );
   }
 
   _run() {
-    const self = this;
     // If forked, report to the parent.
     if (process.send) {
       process.send({
@@ -140,27 +176,27 @@ class Benchmark {
       });
     }
 
-    (function recursive(queueIndex) {
-      const config = self.queue[queueIndex];
+    const recursive = (queueIndex) => {
+      const config = this.queue[queueIndex];
 
       // Set NODE_RUN_BENCHMARK_FN to indicate that the child shouldn't
       // construct a configuration queue, but just execute the benchmark
       // function.
-      const childEnv = Object.assign({}, process.env);
+      const childEnv = { ...process.env };
       childEnv.NODE_RUN_BENCHMARK_FN = '';
 
       // Create configuration arguments
       const childArgs = [];
-      for (const key of Object.keys(config)) {
-        childArgs.push(`${key}=${config[key]}`);
+      for (const [key, value] of Object.entries(config)) {
+        childArgs.push(`${key}=${value}`);
       }
-      for (const key of Object.keys(self.extra_options)) {
-        childArgs.push(`${key}=${self.extra_options[key]}`);
+      for (const [key, value] of Object.entries(this.extra_options)) {
+        childArgs.push(`${key}=${value}`);
       }
 
       const child = child_process.fork(require.main.filename, childArgs, {
         env: childEnv,
-        execArgv: self.flags.concat(process.execArgv),
+        execArgv: this.flags.concat(process.execArgv),
       });
       child.on('message', sendResult);
       child.on('close', (code) => {
@@ -168,29 +204,31 @@ class Benchmark {
           process.exit(code);
         }
 
-        if (queueIndex + 1 < self.queue.length) {
+        if (queueIndex + 1 < this.queue.length) {
           recursive(queueIndex + 1);
         }
       });
-    })(0);
+    };
+
+    recursive(0);
   }
 
   start() {
-    if (this._started) {
+    if (this.#started) {
       throw new Error('Called start more than once in a single benchmark');
     }
-    this._started = true;
-    this._time = process.hrtime();
+    this.#started = true;
+    this.#time = process.hrtime();
   }
 
   end(operations) {
     // Get elapsed time now and do error checking later for accuracy.
-    const elapsed = process.hrtime(this._time);
+    const elapsed = process.hrtime(this.#time);
 
-    if (!this._started) {
+    if (!this.#started) {
       throw new Error('called end without start');
     }
-    if (this._ended) {
+    if (this.#ended) {
       throw new Error('called end multiple times');
     }
     if (typeof operations !== 'number') {
@@ -206,7 +244,7 @@ class Benchmark {
       elapsed[1] = 1;
     }
 
-    this._ended = true;
+    this.#ended = true;
     const time = elapsed[0] + elapsed[1] / 1e9;
     const rate = operations / time;
     this.report(rate, elapsed);
@@ -216,7 +254,7 @@ class Benchmark {
     sendResult({
       name: this.name,
       conf: this.config,
-      rate: rate,
+      rate,
       time: elapsed[0] + elapsed[1] / 1e9,
       type: 'report',
     });
@@ -334,6 +372,7 @@ function bakeUrlData(type, e = 0, withBase = false, asUrl = false) {
 }
 
 module.exports = {
+  Benchmark,
   PORT: http_benchmarkers.PORT,
   bakeUrlData,
   binding(bindingName) {
@@ -349,8 +388,6 @@ module.exports = {
   createBenchmark(fn, configs, options) {
     return new Benchmark(fn, configs, options);
   },
-  // Benchmark an http server.
-  default_http_benchmarker: http_benchmarkers.default_http_benchmarker,
   sendResult,
   searchParams,
   urlDataTypes: Object.keys(urls).concat(['wpt']),

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -3,222 +3,225 @@
 const child_process = require('child_process');
 const http_benchmarkers = require('./_http-benchmarkers.js');
 
-exports.buildType = process.features.debug ? 'Debug' : 'Release';
+class Benchmark {
+  constructor(fn, configs, options) {
+    // Use the file name as the name of the benchmark
+    this.name = require.main.filename.slice(__dirname.length + 1);
+    // Parse job-specific configuration from the command line arguments
+    const parsed_args = this._parseArgs(process.argv.slice(2), configs);
+    this.options = parsed_args.cli;
+    this.extra_options = parsed_args.extra;
+    // The configuration list as a queue of jobs
+    this.queue = this._queue(this.options);
+    // The configuration of the current job, head of the queue
+    this.config = this.queue[0];
+    // Execution arguments i.e. flags used to run the jobs
+    this.flags = [];
+    if (options && options.flags) {
+      this.flags = this.flags.concat(options.flags);
+    }
+    if (process.env.NODE_BENCHMARK_FLAGS) {
+      const flags = process.env.NODE_BENCHMARK_FLAGS.split(/\s+/);
+      this.flags = this.flags.concat(flags);
+    }
+    // Holds process.hrtime value
+    this._time = [0, 0];
+    // Used to make sure a benchmark only start a timer once
+    this._started = false;
+    this._ended = false;
 
-exports.createBenchmark = function(fn, configs, options) {
-  return new Benchmark(fn, configs, options);
-};
-
-function Benchmark(fn, configs, options) {
-  // Use the file name as the name of the benchmark
-  this.name = require.main.filename.slice(__dirname.length + 1);
-  // Parse job-specific configuration from the command line arguments
-  const parsed_args = this._parseArgs(process.argv.slice(2), configs);
-  this.options = parsed_args.cli;
-  this.extra_options = parsed_args.extra;
-  // The configuration list as a queue of jobs
-  this.queue = this._queue(this.options);
-  // The configuration of the current job, head of the queue
-  this.config = this.queue[0];
-  // Execution arguments i.e. flags used to run the jobs
-  this.flags = [];
-  if (options && options.flags) {
-    this.flags = this.flags.concat(options.flags);
+    // this._run will use fork() to create a new process for each configuration
+    // combination.
+    if (process.env.hasOwnProperty('NODE_RUN_BENCHMARK_FN')) {
+      process.nextTick(() => fn(this.config));
+    } else {
+      process.nextTick(() => this._run());
+    }
   }
-  if (process.env.NODE_BENCHMARK_FLAGS) {
-    const flags = process.env.NODE_BENCHMARK_FLAGS.split(/\s+/);
-    this.flags = this.flags.concat(flags);
-  }
-  // Holds process.hrtime value
-  this._time = [0, 0];
-  // Used to make sure a benchmark only start a timer once
-  this._started = false;
-  this._ended = false;
 
-  // this._run will use fork() to create a new process for each configuration
-  // combination.
-  if (process.env.hasOwnProperty('NODE_RUN_BENCHMARK_FN')) {
-    process.nextTick(() => fn(this.config));
-  } else {
-    process.nextTick(() => this._run());
+  _parseArgs(argv, configs) {
+    const cliOptions = {};
+    const extraOptions = {};
+    const validArgRE = /^(.+?)=([\s\S]*)$/;
+    // Parse configuration arguments
+    for (const arg of argv) {
+      const match = arg.match(validArgRE);
+      if (!match) {
+        console.error(`bad argument: ${arg}`);
+        process.exit(1);
+      }
+      const config = match[1];
+
+      if (configs[config]) {
+        // Infer the type from the config object and parse accordingly
+        const isNumber = typeof configs[config][0] === 'number';
+        const value = isNumber ? +match[2] : match[2];
+        if (!cliOptions[config])
+          cliOptions[config] = [];
+        cliOptions[config].push(value);
+      } else {
+        extraOptions[config] = match[2];
+      }
+    }
+    return { cli: Object.assign({}, configs, cliOptions), extra: extraOptions };
+  }
+
+  _queue(options) {
+    const queue = [];
+    const keys = Object.keys(options);
+
+    // Perform a depth-first walk though all options to generate a
+    // configuration list that contains all combinations.
+    function recursive(keyIndex, prevConfig) {
+      const key = keys[keyIndex];
+      const values = options[key];
+      const type = typeof values[0];
+
+      for (const value of values) {
+        if (typeof value !== 'number' && typeof value !== 'string') {
+          throw new TypeError(
+            `configuration "${key}" had type ${typeof value}`);
+        }
+        if (typeof value !== type) {
+          // This is a requirement for being able to consistently and
+          // predictably parse CLI provided configuration values.
+          throw new TypeError(`configuration "${key}" has mixed types`);
+        }
+
+        const currConfig = Object.assign({ [key]: value }, prevConfig);
+
+        if (keyIndex + 1 < keys.length) {
+          recursive(keyIndex + 1, currConfig);
+        } else {
+          queue.push(currConfig);
+        }
+      }
+    }
+
+    if (keys.length > 0) {
+      recursive(0, {});
+    } else {
+      queue.push({});
+    }
+
+    return queue;
+  }
+
+  http(options, cb) {
+    const self = this;
+    const http_options = Object.assign({ }, options);
+    http_options.benchmarker = http_options.benchmarker ||
+                              self.config.benchmarker ||
+                              self.extra_options.benchmarker ||
+                              exports.default_http_benchmarker;
+    http_benchmarkers.run(
+      http_options, (error, code, used_benchmarker, result, elapsed) => {
+        if (cb) {
+          cb(code);
+        }
+        if (error) {
+          console.error(error);
+          process.exit(code || 1);
+        }
+        self.config.benchmarker = used_benchmarker;
+        self.report(result, elapsed);
+      }
+    );
+  }
+
+  _run() {
+    const self = this;
+    // If forked, report to the parent.
+    if (process.send) {
+      process.send({
+        type: 'config',
+        name: this.name,
+        queueLength: this.queue.length,
+      });
+    }
+
+    (function recursive(queueIndex) {
+      const config = self.queue[queueIndex];
+
+      // Set NODE_RUN_BENCHMARK_FN to indicate that the child shouldn't
+      // construct a configuration queue, but just execute the benchmark
+      // function.
+      const childEnv = Object.assign({}, process.env);
+      childEnv.NODE_RUN_BENCHMARK_FN = '';
+
+      // Create configuration arguments
+      const childArgs = [];
+      for (const key of Object.keys(config)) {
+        childArgs.push(`${key}=${config[key]}`);
+      }
+      for (const key of Object.keys(self.extra_options)) {
+        childArgs.push(`${key}=${self.extra_options[key]}`);
+      }
+
+      const child = child_process.fork(require.main.filename, childArgs, {
+        env: childEnv,
+        execArgv: self.flags.concat(process.execArgv),
+      });
+      child.on('message', sendResult);
+      child.on('close', (code) => {
+        if (code) {
+          process.exit(code);
+        }
+
+        if (queueIndex + 1 < self.queue.length) {
+          recursive(queueIndex + 1);
+        }
+      });
+    })(0);
+  }
+
+  start() {
+    if (this._started) {
+      throw new Error('Called start more than once in a single benchmark');
+    }
+    this._started = true;
+    this._time = process.hrtime();
+  }
+
+  end(operations) {
+    // Get elapsed time now and do error checking later for accuracy.
+    const elapsed = process.hrtime(this._time);
+
+    if (!this._started) {
+      throw new Error('called end without start');
+    }
+    if (this._ended) {
+      throw new Error('called end multiple times');
+    }
+    if (typeof operations !== 'number') {
+      throw new Error('called end() without specifying operation count');
+    }
+    if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED && operations <= 0) {
+      throw new Error('called end() with operation count <= 0');
+    }
+    if (elapsed[0] === 0 && elapsed[1] === 0) {
+      if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED)
+        throw new Error('insufficient clock precision for short benchmark');
+      // Avoid dividing by zero
+      elapsed[1] = 1;
+    }
+
+    this._ended = true;
+    const time = elapsed[0] + elapsed[1] / 1e9;
+    const rate = operations / time;
+    this.report(rate, elapsed);
+  }
+
+  report(rate, elapsed) {
+    sendResult({
+      name: this.name,
+      conf: this.config,
+      rate: rate,
+      time: elapsed[0] + elapsed[1] / 1e9,
+      type: 'report',
+    });
   }
 }
-
-Benchmark.prototype._parseArgs = function(argv, configs) {
-  const cliOptions = {};
-  const extraOptions = {};
-  const validArgRE = /^(.+?)=([\s\S]*)$/;
-  // Parse configuration arguments
-  for (const arg of argv) {
-    const match = arg.match(validArgRE);
-    if (!match) {
-      console.error(`bad argument: ${arg}`);
-      process.exit(1);
-    }
-    const config = match[1];
-
-    if (configs[config]) {
-      // Infer the type from the config object and parse accordingly
-      const isNumber = typeof configs[config][0] === 'number';
-      const value = isNumber ? +match[2] : match[2];
-      if (!cliOptions[config])
-        cliOptions[config] = [];
-      cliOptions[config].push(value);
-    } else {
-      extraOptions[config] = match[2];
-    }
-  }
-  return { cli: Object.assign({}, configs, cliOptions), extra: extraOptions };
-};
-
-Benchmark.prototype._queue = function(options) {
-  const queue = [];
-  const keys = Object.keys(options);
-
-  // Perform a depth-first walk though all options to generate a
-  // configuration list that contains all combinations.
-  function recursive(keyIndex, prevConfig) {
-    const key = keys[keyIndex];
-    const values = options[key];
-    const type = typeof values[0];
-
-    for (const value of values) {
-      if (typeof value !== 'number' && typeof value !== 'string') {
-        throw new TypeError(`configuration "${key}" had type ${typeof value}`);
-      }
-      if (typeof value !== type) {
-        // This is a requirement for being able to consistently and predictably
-        // parse CLI provided configuration values.
-        throw new TypeError(`configuration "${key}" has mixed types`);
-      }
-
-      const currConfig = Object.assign({ [key]: value }, prevConfig);
-
-      if (keyIndex + 1 < keys.length) {
-        recursive(keyIndex + 1, currConfig);
-      } else {
-        queue.push(currConfig);
-      }
-    }
-  }
-
-  if (keys.length > 0) {
-    recursive(0, {});
-  } else {
-    queue.push({});
-  }
-
-  return queue;
-};
-
-// Benchmark an http server.
-exports.default_http_benchmarker =
-  http_benchmarkers.default_http_benchmarker;
-exports.PORT = http_benchmarkers.PORT;
-
-Benchmark.prototype.http = function(options, cb) {
-  const self = this;
-  const http_options = Object.assign({ }, options);
-  http_options.benchmarker = http_options.benchmarker ||
-                             self.config.benchmarker ||
-                             self.extra_options.benchmarker ||
-                             exports.default_http_benchmarker;
-  http_benchmarkers.run(
-    http_options, (error, code, used_benchmarker, result, elapsed) => {
-      if (cb) {
-        cb(code);
-      }
-      if (error) {
-        console.error(error);
-        process.exit(code || 1);
-      }
-      self.config.benchmarker = used_benchmarker;
-      self.report(result, elapsed);
-    }
-  );
-};
-
-Benchmark.prototype._run = function() {
-  const self = this;
-  // If forked, report to the parent.
-  if (process.send) {
-    process.send({
-      type: 'config',
-      name: this.name,
-      queueLength: this.queue.length,
-    });
-  }
-
-  (function recursive(queueIndex) {
-    const config = self.queue[queueIndex];
-
-    // Set NODE_RUN_BENCHMARK_FN to indicate that the child shouldn't construct
-    // a configuration queue, but just execute the benchmark function.
-    const childEnv = Object.assign({}, process.env);
-    childEnv.NODE_RUN_BENCHMARK_FN = '';
-
-    // Create configuration arguments
-    const childArgs = [];
-    for (const key of Object.keys(config)) {
-      childArgs.push(`${key}=${config[key]}`);
-    }
-    for (const key of Object.keys(self.extra_options)) {
-      childArgs.push(`${key}=${self.extra_options[key]}`);
-    }
-
-    const child = child_process.fork(require.main.filename, childArgs, {
-      env: childEnv,
-      execArgv: self.flags.concat(process.execArgv),
-    });
-    child.on('message', sendResult);
-    child.on('close', (code) => {
-      if (code) {
-        process.exit(code);
-      }
-
-      if (queueIndex + 1 < self.queue.length) {
-        recursive(queueIndex + 1);
-      }
-    });
-  })(0);
-};
-
-Benchmark.prototype.start = function() {
-  if (this._started) {
-    throw new Error('Called start more than once in a single benchmark');
-  }
-  this._started = true;
-  this._time = process.hrtime();
-};
-
-Benchmark.prototype.end = function(operations) {
-  // Get elapsed time now and do error checking later for accuracy.
-  const elapsed = process.hrtime(this._time);
-
-  if (!this._started) {
-    throw new Error('called end without start');
-  }
-  if (this._ended) {
-    throw new Error('called end multiple times');
-  }
-  if (typeof operations !== 'number') {
-    throw new Error('called end() without specifying operation count');
-  }
-  if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED && operations <= 0) {
-    throw new Error('called end() with operation count <= 0');
-  }
-  if (elapsed[0] === 0 && elapsed[1] === 0) {
-    if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED)
-      throw new Error('insufficient clock precision for short benchmark');
-    // Avoid dividing by zero
-    elapsed[1] = 1;
-  }
-
-  this._ended = true;
-  const time = elapsed[0] + elapsed[1] / 1e9;
-  const rate = operations / time;
-  this.report(rate, elapsed);
-};
 
 function formatResult(data) {
   // Construct configuration string, " A=a, B=b, ..."
@@ -242,27 +245,6 @@ function sendResult(data) {
     console.log(formatResult(data));
   }
 }
-exports.sendResult = sendResult;
-
-Benchmark.prototype.report = function(rate, elapsed) {
-  sendResult({
-    name: this.name,
-    conf: this.config,
-    rate: rate,
-    time: elapsed[0] + elapsed[1] / 1e9,
-    type: 'report',
-  });
-};
-
-exports.binding = function(bindingName) {
-  try {
-    const { internalBinding } = require('internal/test/binding');
-
-    return internalBinding(bindingName);
-  } catch {
-    return process.binding(bindingName);
-  }
-};
 
 const urls = {
   long: 'http://nodejs.org:89/docs/latest/api/foo/bar/qua/13949281/0f28b/' +
@@ -278,7 +260,6 @@ const urls = {
   percent: 'https://%E4%BD%A0/foo',
   dot: 'https://example.org/./a/../b/./c',
 };
-exports.urls = urls;
 
 const searchParams = {
   noencode: 'foo=bar&baz=quux&xyzzy=thud',
@@ -293,7 +274,6 @@ const searchParams = {
   manyblankpairs: '&&&&&&&&&&&&&&&&&&&&&&&&',
   altspaces: 'foo+bar=baz+quux&xyzzy+thud=quuy+quuz&abc=def+ghi',
 };
-exports.searchParams = searchParams;
 
 function getUrlData(withBase) {
   const data = require('../test/fixtures/wpt/url/resources/urltestdata.json');
@@ -308,8 +288,6 @@ function getUrlData(withBase) {
   }
   return result;
 }
-
-exports.urlDataTypes = Object.keys(urls).concat(['wpt']);
 
 /**
  * Generate an array of data for URL benchmarks to use.
@@ -354,4 +332,27 @@ function bakeUrlData(type, e = 0, withBase = false, asUrl = false) {
   }
   return result;
 }
-exports.bakeUrlData = bakeUrlData;
+
+module.exports = {
+  PORT: http_benchmarkers.PORT,
+  bakeUrlData,
+  binding(bindingName) {
+    try {
+      const { internalBinding } = require('internal/test/binding');
+
+      return internalBinding(bindingName);
+    } catch {
+      return process.binding(bindingName);
+    }
+  },
+  buildType: process.features.debug ? 'Debug' : 'Release',
+  createBenchmark(fn, configs, options) {
+    return new Benchmark(fn, configs, options);
+  },
+  // Benchmark an http server.
+  default_http_benchmarker: http_benchmarkers.default_http_benchmarker,
+  sendResult,
+  searchParams,
+  urlDataTypes: Object.keys(urls).concat(['wpt']),
+  urls,
+};

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -9,7 +9,7 @@ const BenchmarkProgress = require('./_benchmark_progress.js');
 //
 // Parse arguments
 //
-const cli = CLI(`usage: ./node compare.js [options] [--] <category> ...
+const cli = new CLI(`usage: ./node compare.js [options] [--] <category> ...
   Run each benchmark in the <category> directory many times using two different
   node versions. More than one <category> directory can be specified.
   The output is formatted as csv, which can be processed using for

--- a/benchmark/crypto/aes-gcm-throughput.js
+++ b/benchmark/crypto/aes-gcm-throughput.js
@@ -9,9 +9,6 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, len, cipher }) {
-  // Default cipher for tests.
-  if (cipher === '')
-    cipher = 'aes-128-gcm';
   const message = Buffer.alloc(len, 'b');
   const key = crypto.randomBytes(keylen[cipher]);
   const iv = crypto.randomBytes(12);

--- a/benchmark/crypto/cipher-stream.js
+++ b/benchmark/crypto/cipher-stream.js
@@ -3,7 +3,7 @@ const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
   writes: [500],
-  cipher: [ 'AES192', 'AES256' ],
+  cipher: ['AES192', 'AES256'],
   type: ['asc', 'utf', 'buf'],
   len: [2, 1024, 102400, 1024 * 1024],
   api: ['legacy', 'stream']
@@ -12,9 +12,6 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ api, cipher, type, len, writes }) {
-  // Default cipher for tests.
-  if (cipher === '')
-    cipher = 'AES192';
   if (api === 'stream' && /^v0\.[0-8]\./.test(process.version)) {
     console.error('Crypto streams not available until v0.10');
     // Use the legacy, just so that we can compare them.
@@ -28,7 +25,6 @@ function main({ api, cipher, type, len, writes }) {
 
   alice.generateKeys();
   bob.generateKeys();
-
 
   const pubEnc = /^v0\.[0-8]/.test(process.version) ? 'binary' : null;
   const alice_secret = alice.computeSecret(bob.getPublicKey(), pubEnc, 'hex');

--- a/benchmark/crypto/cipher-stream.js
+++ b/benchmark/crypto/cipher-stream.js
@@ -7,6 +7,8 @@ const bench = common.createBenchmark(main, {
   type: ['asc', 'utf', 'buf'],
   len: [2, 1024, 102400, 1024 * 1024],
   api: ['legacy', 'stream']
+}, {
+  flags: ['--no-warnings']
 });
 
 function main({ api, cipher, type, len, writes }) {

--- a/benchmark/es/defaultparams-bench.js
+++ b/benchmark/es/defaultparams-bench.js
@@ -36,8 +36,6 @@ function runDefaultParams(n) {
 
 function main({ n, method }) {
   switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'withoutdefaults':
       runOldStyleDefaults(n);
       break;

--- a/benchmark/es/destructuring-bench.js
+++ b/benchmark/es/destructuring-bench.js
@@ -36,8 +36,6 @@ function runSwapDestructured(n) {
 
 function main({ n, method }) {
   switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'swap':
       runSwapManual(n);
       break;

--- a/benchmark/es/destructuring-object-bench.js
+++ b/benchmark/es/destructuring-object-bench.js
@@ -33,8 +33,6 @@ function runDestructured(n) {
 
 function main({ n, method }) {
   switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'normal':
       runNormal(n);
       break;

--- a/benchmark/es/foreach-bench.js
+++ b/benchmark/es/foreach-bench.js
@@ -54,8 +54,6 @@ function main({ n, count, method }) {
     items[i] = i;
 
   switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'for':
       fn = useFor;
       break;

--- a/benchmark/es/map-bench.js
+++ b/benchmark/es/map-bench.js
@@ -104,8 +104,6 @@ function runMap(n) {
 
 function main({ n, method }) {
   switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'object':
       runObject(n);
       break;

--- a/benchmark/es/restparams-bench.js
+++ b/benchmark/es/restparams-bench.js
@@ -51,8 +51,6 @@ function runUseArguments(n) {
 function main({ n, method }) {
   let fn;
   switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'copy':
       fn = runCopyArguments;
       break;

--- a/benchmark/es/spread-assign.js
+++ b/benchmark/es/spread-assign.js
@@ -18,8 +18,6 @@ function main({ n, context, count, rest, method }) {
   let obj;  // eslint-disable-line no-unused-vars
 
   switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case '_extend':
       bench.start();
       for (let i = 0; i < n; i++)

--- a/benchmark/es/spread-bench.js
+++ b/benchmark/es/spread-bench.js
@@ -32,8 +32,6 @@ function main({ n, context, count, rest, method }) {
     args[i] = i;
 
   switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'apply':
       bench.start();
       for (let i = 0; i < n; i++)

--- a/benchmark/es/string-concatenations.js
+++ b/benchmark/es/string-concatenations.js
@@ -23,8 +23,6 @@ function main({ n, mode }) {
   let string;
 
   switch (mode) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'multi-concat':
       bench.start();
       for (let i = 0; i < n; i++)

--- a/benchmark/es/string-repeat.js
+++ b/benchmark/es/string-repeat.js
@@ -18,8 +18,6 @@ function main({ n, size, encoding, mode }) {
   let str;
 
   switch (mode) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'Array':
       bench.start();
       for (let i = 0; i < n; i++)

--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -14,12 +14,12 @@ const filename = path.resolve(tmpdir.path,
                               `.removeme-benchmark-garbage-${process.pid}`);
 
 const bench = common.createBenchmark(main, {
-  dur: [5],
+  duration: [5],
   len: [1024, 16 * 1024 * 1024],
   concurrent: [1, 10]
 });
 
-function main({ len, dur, concurrent }) {
+function main({ len, duration, concurrent }) {
   try { fs.unlinkSync(filename); } catch {}
   let data = Buffer.alloc(len, 'x');
   fs.writeFileSync(filename, data);
@@ -33,7 +33,7 @@ function main({ len, dur, concurrent }) {
     bench.end(reads);
     try { fs.unlinkSync(filename); } catch {}
     process.exit(0);
-  }, dur * 1000);
+  }, duration * 1000);
 
   function read() {
     fs.readFile(filename, afterRead);

--- a/benchmark/http/chunked.js
+++ b/benchmark/http/chunked.js
@@ -13,10 +13,11 @@ const common = require('../common.js');
 const bench = common.createBenchmark(main, {
   n: [1, 4, 8, 16],
   len: [1, 64, 256],
-  c: [100]
+  c: [100],
+  duration: 5
 });
 
-function main({ len, n, c }) {
+function main({ len, n, c, duration }) {
   const http = require('http');
   const chunk = Buffer.alloc(len, '8');
 
@@ -33,7 +34,8 @@ function main({ len, n, c }) {
 
   server.listen(common.PORT, () => {
     bench.http({
-      connections: c
+      connections: c,
+      duration
     }, () => {
       server.close();
     });

--- a/benchmark/http/cluster.js
+++ b/benchmark/http/cluster.js
@@ -9,14 +9,15 @@ if (cluster.isMaster) {
     // Unicode confuses ab on os x.
     type: ['bytes', 'buffer'],
     len: [4, 1024, 102400],
-    c: [50, 500]
+    c: [50, 500],
+    duration: 5,
   });
 } else {
   const port = parseInt(process.env.PORT || PORT);
   require('../fixtures/simple-http-server.js').listen(port);
 }
 
-function main({ type, len, c }) {
+function main({ type, len, c, duration }) {
   process.env.PORT = PORT;
   let workers = 0;
   const w1 = cluster.fork();
@@ -32,7 +33,8 @@ function main({ type, len, c }) {
 
       bench.http({
         path: path,
-        connections: c
+        connections: c,
+        duration
       }, () => {
         w1.destroy();
         w2.destroy();

--- a/benchmark/http/end-vs-write-end.js
+++ b/benchmark/http/end-vs-write-end.js
@@ -14,10 +14,11 @@ const bench = common.createBenchmark(main, {
   type: ['asc', 'utf', 'buf'],
   len: [64 * 1024, 128 * 1024, 256 * 1024, 1024 * 1024],
   c: [100],
-  method: ['write', 'end']
+  method: ['write', 'end'],
+  duration: 5
 });
 
-function main({ len, type, method, c }) {
+function main({ len, type, method, c, duration }) {
   const http = require('http');
   let chunk;
   switch (type) {
@@ -49,7 +50,8 @@ function main({ len, type, method, c }) {
 
   server.listen(common.PORT, () => {
     bench.http({
-      connections: c
+      connections: c,
+      duration
     }, () => {
       server.close();
     });

--- a/benchmark/http/headers.js
+++ b/benchmark/http/headers.js
@@ -6,9 +6,10 @@ const http = require('http');
 const bench = common.createBenchmark(main, {
   n: [10, 1000],
   len: [1, 100],
+  duration: 5
 });
 
-function main({ len, n }) {
+function main({ len, n, duration }) {
   const headers = {
     'Connection': 'keep-alive',
     'Transfer-Encoding': 'chunked',
@@ -29,7 +30,8 @@ function main({ len, n }) {
   server.listen(common.PORT, () => {
     bench.http({
       path: '/',
-      connections: 10
+      connections: 10,
+      duration
     }, () => {
       server.close();
     });

--- a/benchmark/http/incoming_headers.js
+++ b/benchmark/http/incoming_headers.js
@@ -3,12 +3,13 @@ const common = require('../common.js');
 const http = require('http');
 
 const bench = common.createBenchmark(main, {
-  c: [50],     // Concurrent connections
-  n: [20],     // Number of header lines to append after the common headers
-  w: [0, 6],   // Amount of trailing whitespace
+  connections: [50], // Concurrent connections
+  headers: [20], // Number of header lines to append after the common headers
+  w: [0, 6], // Amount of trailing whitespace
+  duration: 5
 });
 
-function main({ c, n, w }) {
+function main({ connections, headers, w, duration }) {
   const server = http.createServer((req, res) => {
     res.end();
   });
@@ -21,7 +22,7 @@ function main({ c, n, w }) {
       'Date': new Date().toString(),
       'Cache-Control': 'no-cache'
     };
-    for (let i = 0; i < n; i++) {
+    for (let i = 0; i < headers; i++) {
       // Note:
       // - autocannon does not send header values with OWS
       // - wrk can only send trailing OWS. This is a side-effect of wrk
@@ -31,8 +32,9 @@ function main({ c, n, w }) {
     }
     bench.http({
       path: '/',
-      connections: c,
-      headers
+      connections,
+      headers,
+      duration
     }, () => {
       server.close();
     });

--- a/benchmark/http/set-header.js
+++ b/benchmark/http/set-header.js
@@ -3,7 +3,8 @@ const common = require('../common.js');
 const PORT = common.PORT;
 
 const bench = common.createBenchmark(main, {
-  res: ['normal', 'setHeader', 'setHeaderWH']
+  res: ['normal', 'setHeader', 'setHeaderWH'],
+  duration: 5
 });
 
 const type = 'bytes';
@@ -15,16 +16,17 @@ const c = 50;
 // normal: writeHead(status, {...})
 // setHeader: statusCode = status, setHeader(...) x2
 // setHeaderWH: setHeader(...), writeHead(status, ...)
-function main({ res }) {
+function main({ res, duration }) {
   process.env.PORT = PORT;
   const server = require('../fixtures/simple-http-server.js')
   .listen(PORT)
   .on('listening', () => {
-    const path = `/${type}/${len}/${chunks}/normal/${chunkedEnc}`;
+    const path = `/${type}/${len}/${chunks}/${res}/${chunkedEnc}`;
 
     bench.http({
       path: path,
-      connections: c
+      connections: c,
+      duration
     }, () => {
       server.close();
     });

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -7,18 +7,20 @@ const bench = common.createBenchmark(main, {
   len: [4, 1024, 102400],
   chunks: [1, 4],
   c: [50, 500],
-  chunkedEnc: [1, 0]
+  chunkedEnc: [1, 0],
+  duration: 5
 });
 
-function main({ type, len, chunks, c, chunkedEnc, res }) {
+function main({ type, len, chunks, c, chunkedEnc, duration }) {
   const server = require('../fixtures/simple-http-server.js')
   .listen(common.PORT)
   .on('listening', () => {
     const path = `/${type}/${len}/${chunks}/normal/${chunkedEnc}`;
 
     bench.http({
-      path: path,
-      connections: c
+      path,
+      connections: c,
+      duration
     }, () => {
       server.close();
     });

--- a/benchmark/http2/compat.js
+++ b/benchmark/http2/compat.js
@@ -9,10 +9,11 @@ const bench = common.createBenchmark(main, {
   requests: [100, 1000, 5000],
   streams: [1, 10, 20, 40, 100, 200],
   clients: [2],
-  benchmarker: ['h2load']
+  benchmarker: ['test-double-http2'],
+  duration: 5
 }, { flags: ['--no-warnings'] });
 
-function main({ requests, streams, clients }) {
+function main({ requests, streams, clients, duration }) {
   const http2 = require('http2');
   const server = http2.createServer();
   server.on('request', (req, res) => {
@@ -29,7 +30,8 @@ function main({ requests, streams, clients }) {
       requests,
       maxConcurrentStreams: streams,
       clients,
-      threads: clients
+      threads: clients,
+      duration
     }, () => { server.close(); });
   });
 }

--- a/benchmark/http2/respond-with-fd.js
+++ b/benchmark/http2/respond-with-fd.js
@@ -10,10 +10,11 @@ const bench = common.createBenchmark(main, {
   requests: [100, 1000, 5000],
   streams: [1, 10, 20, 40, 100, 200],
   clients: [2],
-  benchmarker: ['h2load']
+  benchmarker: ['test-double-http2'],
+  duration: 5
 }, { flags: ['--no-warnings'] });
 
-function main({ requests, streams, clients }) {
+function main({ requests, streams, clients, duration }) {
   fs.open(file, 'r', (err, fd) => {
     if (err)
       throw err;
@@ -30,6 +31,7 @@ function main({ requests, streams, clients }) {
         requests,
         maxConcurrentStreams: streams,
         clients,
+        duration,
         threads: clients
       }, () => server.close());
     });

--- a/benchmark/http2/simple.js
+++ b/benchmark/http2/simple.js
@@ -9,10 +9,11 @@ const bench = common.createBenchmark(main, {
   requests: [100, 1000, 5000],
   streams: [1, 10, 20, 40, 100, 200],
   clients: [2],
-  benchmarker: ['h2load']
+  benchmarker: ['test-double-http2'],
+  duration: 5
 }, { flags: ['--no-warnings'] });
 
-function main({ requests, streams, clients }) {
+function main({ requests, streams, clients, duration }) {
   const http2 = require('http2');
   const server = http2.createServer();
   server.on('stream', (stream) => {
@@ -27,6 +28,7 @@ function main({ requests, streams, clients }) {
       requests,
       maxConcurrentStreams: streams,
       clients,
+      duration,
       threads: clients
     }, () => { server.close(); });
   });

--- a/benchmark/http2/write.js
+++ b/benchmark/http2/write.js
@@ -6,10 +6,11 @@ const bench = common.createBenchmark(main, {
   streams: [100, 200, 1000],
   length: [64 * 1024, 128 * 1024, 256 * 1024, 1024 * 1024],
   size: [100000],
-  benchmarker: ['h2load']
+  benchmarker: ['test-double-http2'],
+  duration: 5
 }, { flags: ['--no-warnings'] });
 
-function main({ streams, length, size }) {
+function main({ streams, length, size, duration }) {
   const http2 = require('http2');
   const server = http2.createServer();
   server.on('stream', (stream) => {
@@ -29,6 +30,7 @@ function main({ streams, length, size }) {
     bench.http({
       path: '/',
       requests: 10000,
+      duration,
       maxConcurrentStreams: streams,
     }, () => { server.close(); });
   });

--- a/benchmark/misc/arguments.js
+++ b/benchmark/misc/arguments.js
@@ -34,8 +34,6 @@ function usingPredefined() {
 function main({ n, method, args }) {
   let fn;
   switch (method) {
-    // '' is a default case for tests
-    case '':
     case 'restAndSpread':
       fn = usingRestAndSpread;
       break;

--- a/benchmark/misc/getstringwidth.js
+++ b/benchmark/misc/getstringwidth.js
@@ -10,8 +10,6 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, type }) {
-  // Default value for testing purposes.
-  type = type || 'ascii';
   const { getStringWidth } = require('internal/util/inspect');
 
   const str = ({

--- a/benchmark/misc/object-property-bench.js
+++ b/benchmark/misc/object-property-bench.js
@@ -64,8 +64,6 @@ function runSymbol(n) {
 function main({ n, method }) {
 
   switch (method) {
-    // '' is a default case for tests
-    case '':
     case 'property':
       runProperty(n);
       break;

--- a/benchmark/misc/punycode.js
+++ b/benchmark/misc/punycode.js
@@ -62,8 +62,6 @@ function runICU(n, val) {
 
 function main({ n, val, method }) {
   switch (method) {
-    // '' is a default case for tests
-    case '':
     case 'punycode':
       runPunycode(n, val);
       break;

--- a/benchmark/misc/trace.js
+++ b/benchmark/misc/trace.js
@@ -6,7 +6,11 @@ const bench = common.createBenchmark(main, {
   n: [100000],
   method: ['trace', 'isTraceCategoryEnabled']
 }, {
-  flags: ['--expose-internals', '--trace-event-categories', 'foo']
+  flags: [
+    '--expose-internals',
+    '--no-warnings',
+    '--trace-event-categories', 'foo',
+  ]
 });
 
 const {

--- a/benchmark/misc/trace.js
+++ b/benchmark/misc/trace.js
@@ -41,7 +41,6 @@ function main({ n, method }) {
   } = common.binding('trace_events');
 
   switch (method) {
-    case '':
     case 'trace':
       doTrace(n, trace);
       break;

--- a/benchmark/misc/util-extend-vs-object-assign.js
+++ b/benchmark/misc/util-extend-vs-object-assign.js
@@ -9,10 +9,6 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, type }) {
-  // Default value for tests.
-  if (type === '')
-    type = 'extend';
-
   let fn;
   if (type === 'extend') {
     fn = util._extend;

--- a/benchmark/net/net-c2s.js
+++ b/benchmark/net/net-c2s.js
@@ -9,6 +9,8 @@ const bench = common.createBenchmark(main, {
   len: [64, 102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5],
+}, {
+  test: { len: 1024 }
 });
 
 var chunk;

--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -9,6 +9,8 @@ const bench = common.createBenchmark(main, {
   len: [2, 64, 102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5],
+}, {
+  test: { len: 1024 }
 });
 
 var chunk;

--- a/benchmark/net/net-s2c.js
+++ b/benchmark/net/net-s2c.js
@@ -10,6 +10,8 @@ const bench = common.createBenchmark(main, {
   recvbuflen: [0, 64 * 1024, 1024 * 1024],
   recvbufgenfn: ['true', 'false'],
   dur: [5]
+}, {
+  test: { sendchunklen: 256 }
 });
 
 var chunk;

--- a/benchmark/net/net-wrap-js-stream-passthrough.js
+++ b/benchmark/net/net-wrap-js-stream-passthrough.js
@@ -9,6 +9,7 @@ const bench = common.createBenchmark(main, {
   type: ['utf', 'asc', 'buf'],
   dur: [5],
 }, {
+  test: { len: 64 },
   flags: ['--expose-internals']
 });
 

--- a/benchmark/net/tcp-raw-c2s.js
+++ b/benchmark/net/tcp-raw-c2s.js
@@ -12,7 +12,10 @@ const bench = common.createBenchmark(main, {
   len: [102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5]
-}, { flags: [ '--expose-internals', '--no-warnings' ] });
+}, {
+  test: { len: 1024 },
+  flags: [ '--expose-internals', '--no-warnings' ]
+});
 
 function main({ dur, len, type }) {
   const {

--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -13,6 +13,7 @@ const bench = common.createBenchmark(main, {
   type: ['utf', 'asc', 'buf'],
   dur: [5]
 }, {
+  test: { len: 1024 },
   flags: [ '--expose-internals', '--no-warnings' ]
 });
 

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -13,6 +13,7 @@ const bench = common.createBenchmark(main, {
   type: ['utf', 'asc', 'buf'],
   dur: [5]
 }, {
+  test: { len: 1024 },
   flags: [ '--expose-internals', '--no-warnings' ]
 });
 

--- a/benchmark/scatter.js
+++ b/benchmark/scatter.js
@@ -7,7 +7,7 @@ const CLI = require('./_cli.js');
 //
 // Parse arguments
 //
-const cli = CLI(`usage: ./node scatter.js [options] [--] <filename>
+const cli = new CLI(`usage: ./node scatter.js [options] [--] <filename>
   Run the benchmark script <filename> many times and output the rate (ops/s)
   together with the benchmark variables as a csv.
 

--- a/benchmark/tls/secure-pair.js
+++ b/benchmark/tls/secure-pair.js
@@ -4,6 +4,8 @@ const bench = common.createBenchmark(main, {
   dur: [5],
   securing: ['SecurePair', 'TLSSocket', 'clear'],
   size: [2, 100, 1024, 1024 * 1024]
+}, {
+  flags: ['--no-warnings']
 });
 
 const fixtures = require('../../test/common/fixtures');

--- a/benchmark/url/url-format.js
+++ b/benchmark/url/url-format.js
@@ -13,7 +13,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ type, n }) {
-  const input = inputs[type] || '';
+  const input = inputs[type];
 
   // Force-optimize url.format() so that the benchmark doesn't get
   // disrupted by the optimizer kicking in halfway through.

--- a/benchmark/url/url-parse.js
+++ b/benchmark/url/url-parse.js
@@ -13,7 +13,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ type, n }) {
-  const input = inputs[type] || '';
+  const input = inputs[type];
 
   bench.start();
   for (let i = 0; i < n; i += 1)

--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -23,8 +23,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, type }) {
-  // For testing, if supplied with an empty type, default to string.
-  const [first, second] = inputs[type || 'string'];
+  const [first, second] = inputs[type];
 
   bench.start();
   for (let i = 0; i < n; i++) {

--- a/benchmark/util/inspect-array.js
+++ b/benchmark/util/inspect-array.js
@@ -23,8 +23,6 @@ function main({ n, len, type }) {
       opts = { showHidden: true };
       arr = arr.fill('denseArray');
       break;
-      // For testing, if supplied with an empty type, default to denseArray.
-    case '':
     case 'denseArray':
       arr = arr.fill('denseArray');
       break;

--- a/benchmark/util/type-check.js
+++ b/benchmark/util/type-check.js
@@ -35,9 +35,6 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ type, argument, version, n }) {
-  // For testing, if supplied with an empty type, default to ArrayBufferView.
-  type = type || 'ArrayBufferView';
-
   const util = common.binding('util');
   const types = require('internal/util/types');
 

--- a/benchmark/util/type-check.js
+++ b/benchmark/util/type-check.js
@@ -31,7 +31,7 @@ const bench = common.createBenchmark(main, {
   argument: ['true', 'false-primitive', 'false-object'],
   n: [1e5]
 }, {
-  flags: ['--expose-internals']
+  flags: ['--expose-internals', '--no-warnings']
 });
 
 function main({ type, argument, version, n }) {

--- a/benchmark/writing-and-running-benchmarks.md
+++ b/benchmark/writing-and-running-benchmarks.md
@@ -519,7 +519,8 @@ const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
   kb: [64, 128, 256, 1024],
-  connections: [100, 500]
+  connections: [100, 500],
+  duration: 5
 });
 
 function main(conf) {
@@ -546,8 +547,8 @@ Supported options keys are:
 * `path` - defaults to `/`
 * `connections` - number of concurrent connections to use, defaults to 100
 * `duration` - duration of the benchmark in seconds, defaults to 10
-* `benchmarker` - benchmarker to use, defaults to
-`common.default_http_benchmarker`
+* `benchmarker` - benchmarker to use, defaults to the first available http
+  benchmarker
 
 [autocannon]: https://github.com/mcollina/autocannon
 [wrk]: https://github.com/wg/wrk

--- a/benchmark/zlib/pipe.js
+++ b/benchmark/zlib/pipe.js
@@ -8,6 +8,11 @@ const bench = common.createBenchmark(main, {
   duration: [5],
   type: ['string', 'buffer'],
   algorithm: ['gzip', 'brotli']
+}, {
+  test: {
+    inputLen: 1024,
+    duration: 0.2
+  }
 });
 
 function main({ inputLen, duration, type, algorithm }) {

--- a/test/benchmark/test-benchmark-assert.js
+++ b/test/benchmark/test-benchmark-assert.js
@@ -7,15 +7,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark(
-  'assert',
-  [
-    'strict=1',
-    'len=1',
-    'method=',
-    'n=1',
-    'primitive=null',
-    'size=1',
-    'type=Int8Array'
-  ]
-);
+runBenchmark('assert');

--- a/test/benchmark/test-benchmark-async-hooks.js
+++ b/test/benchmark/test-benchmark-async-hooks.js
@@ -10,11 +10,4 @@ if (!common.enoughTestMem)
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('async_hooks',
-             [
-               'asyncHooks=all',
-               'connections=50',
-               'method=trackingDisabled',
-               'n=10'
-             ],
-             {});
+runBenchmark('async_hooks');

--- a/test/benchmark/test-benchmark-buffer.js
+++ b/test/benchmark/test-benchmark-buffer.js
@@ -4,30 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('buffers',
-             [
-               'aligned=true',
-               'args=1',
-               'buffer=fast',
-               'bytes=0',
-               'byteLength=1',
-               'charsPerLine=6',
-               'difflen=false',
-               'encoding=utf8',
-               'endian=BE',
-               'extraSize=1',
-               'len=256',
-               'linesCount=1',
-               'method=',
-               'n=1',
-               'partial=true',
-               'pieces=1',
-               'pieceSize=1',
-               'search=@',
-               'size=1',
-               'source=array',
-               'type=',
-               'value=0',
-               'withTotalLength=0'
-             ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('buffers', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-child-process.js
+++ b/test/benchmark/test-benchmark-child-process.js
@@ -4,12 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('child_process',
-             [
-               'dur=0',
-               'n=1',
-               'len=1',
-               'params=1',
-               'methodName=execSync',
-             ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('child_process', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-cluster.js
+++ b/test/benchmark/test-benchmark-cluster.js
@@ -4,9 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('cluster', [
-  'n=1',
-  'payload=string',
-  'sendsPerBroadcast=1',
-  'serialization=json',
-]);
+runBenchmark('cluster');

--- a/test/benchmark/test-benchmark-crypto.js
+++ b/test/benchmark/test-benchmark-crypto.js
@@ -10,18 +10,4 @@ if (common.hasFipsCrypto)
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('crypto',
-             [
-               'algo=sha256',
-               'api=stream',
-               'cipher=',
-               'keylen=1024',
-               'len=1',
-               'n=1',
-               'out=buffer',
-               'size=1',
-               'type=buf',
-               'v=crypto',
-               'writes=1',
-             ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('crypto', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-dgram.js
+++ b/test/benchmark/test-benchmark-dgram.js
@@ -4,14 +4,7 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-// Because the dgram benchmarks use hardcoded ports, this should be in
-// sequential rather than parallel to make sure it does not conflict with
-// tests that choose random available ports.
+// Dgram benchmarks use hardcoded ports. Thus, this test can not be run in
+// parallel with tests that choose random ports.
 
-runBenchmark('dgram', ['address=true',
-                       'chunks=2',
-                       'dur=0.1',
-                       'len=1',
-                       'n=1',
-                       'num=1',
-                       'type=send']);
+runBenchmark('dgram');

--- a/test/benchmark/test-benchmark-dns.js
+++ b/test/benchmark/test-benchmark-dns.js
@@ -4,6 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-const env = { ...process.env, NODEJS_BENCHMARK_ZERO_ALLOWED: 1 };
-
-runBenchmark('dns', ['n=1', 'all=false', 'name=127.0.0.1'], env);
+runBenchmark('dns', { ...process.env, NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-domain.js
+++ b/test/benchmark/test-benchmark-domain.js
@@ -4,4 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('domain', ['n=1', 'args=0']);
+runBenchmark('domain');

--- a/test/benchmark/test-benchmark-es.js
+++ b/test/benchmark/test-benchmark-es.js
@@ -4,15 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('es',
-             [
-               'method=',
-               'count=1',
-               'context=null',
-               'rest=0',
-               'mode=',
-               'n=1',
-               'encoding=ascii',
-               'size=1e1'
-             ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('es', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-events.js
+++ b/test/benchmark/test-benchmark-events.js
@@ -4,6 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('events',
-             ['argc=0', 'listeners=1', 'n=1'],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('events', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-fs.js
+++ b/test/benchmark/test-benchmark-fs.js
@@ -6,19 +6,4 @@ const runBenchmark = require('../common/benchmark');
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-runBenchmark('fs', [
-  'bufferSize=32',
-  'concurrent=1',
-  'dir=.github',
-  'dur=0.1',
-  'encodingType=buf',
-  'filesize=1024',
-  'len=1024',
-  'mode=callback',
-  'n=1',
-  'pathType=relative',
-  'size=1',
-  'statSyncType=fstatSync',
-  'statType=fstat',
-  'withFileTypes=false',
-], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('fs', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-http.js
+++ b/test/benchmark/test-benchmark-http.js
@@ -11,27 +11,4 @@ if (!common.enoughTestMem)
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('http',
-             [
-               'benchmarker=test-double-http',
-               'arg=string',
-               'c=1',
-               'chunkedEnc=true',
-               'chunks=0',
-               'dur=0.1',
-               'e=0',
-               'input=keep-alive',
-               'key=""',
-               'len=1',
-               'method=write',
-               'n=1',
-               'res=normal',
-               'type=asc',
-               'url=long',
-               'value=X-Powered-By',
-               'w=0',
-             ],
-             {
-               NODEJS_BENCHMARK_ZERO_ALLOWED: 1,
-               duration: 0
-             });
+runBenchmark('http', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-http2.js
+++ b/test/benchmark/test-benchmark-http2.js
@@ -13,17 +13,4 @@ if (!common.enoughTestMem)
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('http2',
-             [
-               'benchmarker=test-double-http2',
-               'clients=1',
-               'length=65536',
-               'n=1',
-               'nheaders=0',
-               'requests=1',
-               'streams=1'
-             ],
-             {
-               NODEJS_BENCHMARK_ZERO_ALLOWED: 1,
-               duration: 0
-             });
+runBenchmark('http2', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-misc.js
+++ b/test/benchmark/test-benchmark-misc.js
@@ -4,14 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('misc', [
-  'concat=0',
-  'dur=0.1',
-  'method=',
-  'n=1',
-  'type=',
-  'code=1',
-  'val=magyarország.icom.museum',
-  'script=test/fixtures/semicolon',
-  'mode=worker'
-], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('misc', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-module.js
+++ b/test/benchmark/test-benchmark-module.js
@@ -4,12 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('module', [
-  'cache=true',
-  'dir=rel',
-  'ext=',
-  'fullPath=true',
-  'n=1',
-  'name=/',
-  'useCache=true',
-]);
+runBenchmark('module');

--- a/test/benchmark/test-benchmark-napi.js
+++ b/test/benchmark/test-benchmark-napi.js
@@ -15,10 +15,4 @@ if (process.features.debug) {
 }
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('napi',
-             [
-               'n=1',
-               'engine=v8',
-               'type=String'
-             ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('napi', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-net.js
+++ b/test/benchmark/test-benchmark-net.js
@@ -8,13 +8,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('net',
-             [
-               'dur=0',
-               'len=1024',
-               'recvbufgenfn=false',
-               'recvbuflen=0',
-               'sendchunklen=256',
-               'type=buf'
-             ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('net', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-os.js
+++ b/test/benchmark/test-benchmark-os.js
@@ -4,4 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('os', ['n=1']);
+runBenchmark('os');

--- a/test/benchmark/test-benchmark-path.js
+++ b/test/benchmark/test-benchmark-path.js
@@ -4,11 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('path',
-             [
-               'n=1',
-               'path=',
-               'pathext=',
-               'paths=',
-               'props='
-             ], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('path', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-process.js
+++ b/test/benchmark/test-benchmark-process.js
@@ -4,9 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('process',
-             [
-               'n=1',
-               'type=raw',
-               'operation=enumerate',
-             ], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('process', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-querystring.js
+++ b/test/benchmark/test-benchmark-querystring.js
@@ -4,9 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('querystring',
-             [ 'n=1',
-               'input="there is nothing to unescape here"',
-               'type=noencode'
-             ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('querystring', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-streams.js
+++ b/test/benchmark/test-benchmark-streams.js
@@ -4,13 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('streams',
-             [
-               'kind=duplex',
-               'n=1',
-               'sync=no',
-               'writev=no',
-               'callback=no',
-               'type=buffer',
-             ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('streams', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-string_decoder.js
+++ b/test/benchmark/test-benchmark-string_decoder.js
@@ -4,7 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('string_decoder', ['chunkLen=16',
-                                'encoding=utf8',
-                                'inLen=32',
-                                'n=1']);
+runBenchmark('string_decoder');

--- a/test/benchmark/test-benchmark-timers.js
+++ b/test/benchmark/test-benchmark-timers.js
@@ -4,10 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('timers',
-             [
-               'direction=start',
-               'n=1',
-               'type=depth',
-             ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('timers', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-tls.js
+++ b/test/benchmark/test-benchmark-tls.js
@@ -14,16 +14,4 @@ if (!common.enoughTestMem)
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('tls',
-             [
-               'concurrency=1',
-               'dur=0.1',
-               'n=1',
-               'size=2',
-               'securing=SecurePair',
-               'type=asc'
-             ],
-             {
-               NODEJS_BENCHMARK_ZERO_ALLOWED: 1,
-               duration: 0
-             });
+runBenchmark('tls', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-url.js
+++ b/test/benchmark/test-benchmark-url.js
@@ -4,22 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('url',
-             [
-               'method=legacy',
-               'e=0',
-               'loopMethod=forEach',
-               'accessMethod=get',
-               'type=short',
-               'searchParam=noencode',
-               'href=short',
-               'input=short',
-               'domain=empty',
-               'path=up',
-               'to=ascii',
-               'prop=href',
-               'n=1',
-               'param=one',
-               'withBase=false'
-             ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('url', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-util.js
+++ b/test/benchmark/test-benchmark-util.js
@@ -4,17 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('util',
-             ['argument=false',
-              'input=',
-              'method=Array',
-              'n=1',
-              'option=none',
-              'pos=start',
-              'size=1',
-              'type=',
-              'len=1',
-              'version=native',
-              'isProxy=1',
-              'showProxy=1'],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('util', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-v8.js
+++ b/test/benchmark/test-benchmark-v8.js
@@ -4,9 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('v8',
-             [
-               'method=getHeapStatistics',
-               'n=1'
-             ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('v8', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-vm.js
+++ b/test/benchmark/test-benchmark-vm.js
@@ -4,10 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('vm',
-             [
-               'breakOnSigint=0',
-               'withSigintListener=0',
-               'n=1'
-             ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('vm', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-worker.js
+++ b/test/benchmark/test-benchmark-worker.js
@@ -11,13 +11,4 @@ if (!common.enoughTestMem)
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('worker',
-             [
-               'n=1',
-               'sendsPerBroadcast=1',
-               'workers=1',
-               'payload=string'
-             ],
-             {
-               NODEJS_BENCHMARK_ZERO_ALLOWED: 1
-             });
+runBenchmark('worker', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-zlib.js
+++ b/test/benchmark/test-benchmark-zlib.js
@@ -4,17 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('zlib',
-             [
-               'algorithm=brotli',
-               'chunkLen=1024',
-               'duration=0.001',
-               'inputLen=1024',
-               'method=',
-               'n=1',
-               'options=true',
-               'type=Deflate',
-             ],
-             {
-               'NODEJS_BENCHMARK_ZERO_ALLOWED': 1
-             });
+runBenchmark('zlib', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/common/benchmark.js
+++ b/test/common/benchmark.js
@@ -8,13 +8,8 @@ const path = require('path');
 
 const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
 
-function runBenchmark(name, args, env) {
-  const argv = [];
-
-  for (let i = 0; i < args.length; i++) {
-    argv.push('--set');
-    argv.push(args[i]);
-  }
+function runBenchmark(name, env) {
+  const argv = ['test'];
 
   argv.push(name);
 


### PR DESCRIPTION
I went ahead and refactored all our benchmark tests. The benchmark suite itself now has a test functionality built-in (using `test`). It is also possible to run all benchmark suites by using `all`. The tests are now run independent from benchmark changes and should always keep on working.

The fixtures directory is now skipped and in case there's a typo for the benchmark, the error message is now more informative.

I removed warnings from benchmark files in case they occurred.

Some tests require special options as a minimum. Those may now be passed through using the `test` option. These values will be used in case the benchmark test is run.

It is now possible to pass through individual configurations instead of having to use an array.

Fixes: https://github.com/nodejs/node/issues/31083

I did not yet find time to clean up the commits.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
