### PR TITLE
fs: change streams to always emit close by default

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -73,10 +73,6 @@ function ReadStream(path, options) {
   if (options.highWaterMark === undefined)
     options.highWaterMark = 64 * 1024;
 
-  // For backwards compat do not emit close on destroy.
-  if (options.emitClose === undefined) {
-    options.emitClose = false;
-  }
   if (options.autoDestroy === undefined) {
     options.autoDestroy = false;
   }
@@ -269,12 +265,8 @@ ReadStream.prototype._destroy = function(err, cb) {
 
 function closeFsStream(stream, cb, err) {
   stream[kFs].close(stream.fd, (er) => {
-    er = er || err;
-    cb(er);
     stream.closed = true;
-    const s = stream._writableState || stream._readableState;
-    if (!er && !s.emitClose)
-      stream.emit('close');
+    cb(er || err);
   });
 
   stream.fd = null;
@@ -298,10 +290,6 @@ function WriteStream(path, options) {
   // Only buffers are supported.
   options.decodeStrings = true;
 
-  // For backwards compat do not emit close on destroy.
-  if (options.emitClose === undefined) {
-    options.emitClose = false;
-  }
   if (options.autoDestroy === undefined) {
     options.autoDestroy = false;
   }

--- a/test/parallel/test-fs-stream-destroy-emit-error.js
+++ b/test/parallel/test-fs-stream-destroy-emit-error.js
@@ -8,13 +8,13 @@ tmpdir.refresh();
 
 {
   const stream = fs.createReadStream(__filename);
-  stream.on('close', common.mustNotCall());
+  stream.on('close', common.mustCall());
   test(stream);
 }
 
 {
   const stream = fs.createWriteStream(`${tmpdir.path}/dummy`);
-  stream.on('close', common.mustNotCall());
+  stream.on('close', common.mustCall());
   test(stream);
 }
 


### PR DESCRIPTION
Previously due to compat reasons 'close' was only emitted if no 'error'.
This removes the compat behavior in order to properly follow expected
streams behavior.

Not sure why this compat behavior has remained for so long but I believe it should be possible to make fs stream consistent with normal streams in a semver-major.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
