### PR TITLE
embedding: allow NewContext to create inspectable context

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -405,7 +405,7 @@ Local<Context> NewContext(Isolate* isolate,
   return context;
 }
 
-Local<Context> NewContext(Environment *env,
+Local<Context> NewContext(Environment* env,
                           Local<ObjectTemplate> object_template,
                           bool initialize) {
   v8::EscapableHandleScope scope(env->isolate());

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -405,6 +405,33 @@ Local<Context> NewContext(Isolate* isolate,
   return context;
 }
 
+Local<Context> NewContext(Environment *env,
+                          Local<ObjectTemplate> object_template,
+                          bool initialize) {
+  v8::EscapableHandleScope scope(env->isolate());
+  auto context = Context::New(env->isolate(), nullptr, object_template);
+  if (context.IsEmpty()) return context;
+
+  if (initialize && !InitializeContext(context)) {
+    return Local<Context>();
+  }
+
+  v8::Local<v8::String> name;
+
+  {
+    // A consstructor name should be invoked in the newly created context
+    // to prevent access check failures.
+    v8::Context::Scope scope(context);
+    name = context->Global()->GetConstructorName();
+  }
+
+  Utf8Value name_val(env->isolate(), name);
+  ContextInfo info(*name_val);
+  env->AssignToContext(context, info);
+
+  return scope.Escape(context);
+}
+
 // This runs at runtime, regardless of whether the context
 // is created from a snapshot.
 void InitializeContextRuntime(Local<Context> context) {

--- a/src/node.h
+++ b/src/node.h
@@ -350,6 +350,12 @@ NODE_EXTERN v8::Local<v8::Context> NewContext(
     v8::Local<v8::ObjectTemplate> object_template =
         v8::Local<v8::ObjectTemplate>());
 
+// Create a new context for an existing environment.
+// This add several fields to make inspector work properly.
+NODE_EXTERN v8::Local<v8::Context> NewContext(Environment *env,
+    v8::Local<v8::ObjectTemplate> object_template,
+    bool initialize = false);
+
 // Runs Node.js-specific tweaks on an already constructed context
 // Return value indicates success of operation
 NODE_EXTERN bool InitializeContext(v8::Local<v8::Context> context);

--- a/src/node.h
+++ b/src/node.h
@@ -352,7 +352,7 @@ NODE_EXTERN v8::Local<v8::Context> NewContext(
 
 // Create a new context for an existing environment.
 // This add several fields to make inspector work properly.
-NODE_EXTERN v8::Local<v8::Context> NewContext(Environment *env,
+NODE_EXTERN v8::Local<v8::Context> NewContext(Environment* env,
     v8::Local<v8::ObjectTemplate> object_template,
     bool initialize = false);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

NodeJS should allow C++ users to create contexts, whose compiled script can be debugged through the inspector agent. Currently this functionality is only available for JavaScript modules through VM module. Unfortunately, VM creates a context whose global is completely new and hidden ``v8::FunctionTemplate``. C++ users might already have ``v8::FunctionTemplate`` or ``v8::ObjectTemplate`` from which they create a context.

The only option now is to call V8 API directly: ``v8::Context::New(...)``. The created context is not associated with any ``node::Environment`` and code executed in that context cannot be debugged in the inspector agent (the context is missing ``debug_context_id`` as this is provided when the agent is notified by ``ContextCreated``). This might actually be an intended behavior. The ``node::NewContext`` also create a context and do not report it to any agent (agent is a part of ``node::Environment`` and ``node::NewContext`` does not access any environments.

This is a proposal of a new feature to allow mitigate that gap. It provides another form of ``node::NewContext`` where ``node::Environment`` is accepted as the first parameter instead of ``v8::Isolate``. When such an environment is available, it will create a context with a specific ``v8::ObjectTemplate`` and then call ``v8::Environment::AssignToContext``. The latter will report the newly created context to the environment's inspector agent (if one is available) and add some embedders properties to allow proper handling of stack traces.

Without this feature, C++ modules can create ``v8::Context`` and use ``v8::ScriptCompiler`` to compile functions and scripts. Those scripts are not reported to the inspector agent and functions has ``[[FunctionLocation]]`` internal slot set to ``<unknown>`` even when ``v8::Source`` specify resource name, line and column offset, etc. If a context is reported to the inspector agent, it receives a ``debug_context_id``. If this is available, compilation of new scripts and functions in that context will report to the inspector agent, which will send the source to the inspector frontend. Furthermore, the environment that has setup ``PrepareStackTraceCallback`` calls for ``Environment::GetCurrent(context)``. If an exception occurs into a context not assigned to environment, stack trace would be ignored, even when it is available.

This feature can be implemented using the following principles:
- Additive: do not change any behavior and code of existing NodeJS implementation;
- Minimal: do not add large amount of new code;
- Efficient: does not require additional variables, objects, etc to be stored into memory; does not require additional processing when the feature is not used;
- Useful: it allows access to huge amount of V8 API. C++ addons can use that API now, but with a limitation towards debugging and stack trace generation.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
