### PR TITLE
[v12.x backport] deps: V8: cherry-pick 0dfd9ea51241

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.30',
+    'v8_embedder_string': '-node.31',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -4087,6 +4087,7 @@ void ParserBase<Impl>::ParseFunctionBody(
       inner_body.Rewind();
       inner_body.Add(inner_block);
       inner_block->set_scope(inner_scope);
+      impl()->RecordBlockSourceRange(inner_block, scope()->end_position());
       if (!impl()->HasCheckedSyntax()) {
         const AstRawString* conflict = inner_scope->FindVariableDeclaredIn(
             function_scope, VariableMode::kLastLexicalVariableMode);

--- a/deps/v8/test/mjsunit/code-coverage-block.js
+++ b/deps/v8/test/mjsunit/code-coverage-block.js
@@ -1097,4 +1097,41 @@ f(43);                                    // 0450
  {"start":204,"end":226,"count":1}]
 );
 
+TestCoverage(
+"https://crbug.com/v8/9857",
+`function foo() {function bar() {}}; foo()`,
+[{"start":0,"end":41,"count":1},
+  {"start":0,"end":34,"count":1},
+  {"start":16,"end":33,"count":0}]
+);
+
+TestCoverage(
+"https://crbug.com/v8/9952",
+`
+function test(foo = "foodef") {           // 0000
+  return {bar};                           // 0050
+                                          // 0100
+  function bar() {                        // 0150
+    console.log("test");                  // 0200
+  }                                       // 0250
+}                                         // 0300
+test().bar();                             // 0350`,
+[{"start":0,"end":399,"count":1},
+ {"start":0,"end":301,"count":1},
+ {"start":152,"end":253,"count":1}]);
+
+TestCoverage(
+"https://crbug.com/v8/9952",
+`
+function test(foo = (()=>{})) {           // 0000
+  return {foo};                           // 0050
+}                                         // 0100
+                                          // 0150
+test(()=>{}).foo();                       // 0200`,
+[{"start":0,"end":249,"count":1},
+ {"start":0,"end":101,"count":1},
+ {"start":21,"end":27,"count":0},
+ {"start":205,"end":211,"count":1}]
+);
+
 %DebugToggleBlockCoverage(false);


### PR DESCRIPTION
Original commit message:

    [coverage] Fix coverage with default arguments

    In the presence of default arguments, the body of the function gets
    wrapped into another block. This caused our trailing-range-after-return
    optimization to not apply, because the wrapper block had no source
    range assigned. This CL correctly assignes a source range to that block,
    which allows already present code to handle it correctly.

    Note that this is not a real coverage bug; we've just been reporting
    whitespace as uncovered. We're fixing it for consistency.

    Originally reported on github.com/bcoe/c8/issues/66

    Bug: v8:9952
    Change-Id: Iab3905f558eb99126e0dad8072d03d0a312fdcd3
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1903430
    Commit-Queue: Sigurd Schneider <sigurds@chromium.org>
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Reviewed-by: Jakob Gruber <jgruber@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#64836}

Refs: https://github.com/v8/v8/commit/0dfd9ea51241bebf724f2eb8d6d0158a014f866a

PR-URL: https://github.com/nodejs/node/pull/30713
Reviewed-By: Michaël Zasso <targos@protonmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Jiawen Geng <technicalcute@gmail.com>
Reviewed-By: Rich Trott <rtrott@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
