### PR TITLE
errors: make use of "cannot" consistent

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1179,7 +1179,7 @@ To fix the error, open an issue at https://github.com/nodejs/node/issues.
 <a id="ERR_INCOMPATIBLE_OPTION_PAIR"></a>
 ### `ERR_INCOMPATIBLE_OPTION_PAIR`
 
-An option pair is incompatible with each other and can not be used at the same
+An option pair is incompatible with each other and cannot be used at the same
 time.
 
 <a id="ERR_INPUT_TYPE_NOT_ALLOWED"></a>

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -908,7 +908,7 @@ E('ERR_HTTP_INVALID_STATUS_CODE', 'Invalid status code: %s', RangeError);
 E('ERR_HTTP_TRAILER_INVALID',
   'Trailers are invalid with this transfer encoding', Error);
 E('ERR_INCOMPATIBLE_OPTION_PAIR',
-  'Option "%s" can not be used in combination with option "%s"', TypeError);
+  'Option "%s" cannot be used in combination with option "%s"', TypeError);
 E('ERR_INPUT_TYPE_NOT_ALLOWED', '--input-type can only be used with string ' +
   'input via --eval, --print, or STDIN', Error);
 E('ERR_INSPECTOR_ALREADY_CONNECTED', '%s is already connected', Error);

--- a/test/parallel/test-console-tty-colors.js
+++ b/test/parallel/test-console-tty-colors.js
@@ -86,7 +86,7 @@ check(false, false, false);
         });
       },
       {
-        message: 'Option "inspectOptions.color" can not be used in ' +
+        message: 'Option "inspectOptions.color" cannot be used in ' +
                  'combination with option "colorMode"',
         code: 'ERR_INCOMPATIBLE_OPTION_PAIR'
       }

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -1044,7 +1044,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, {
       name: 'TypeError',
       code: 'ERR_INCOMPATIBLE_OPTION_PAIR',
-      message: `Option "${opt1}" can not be used in combination with option ` +
+      message: `Option "${opt1}" cannot be used in combination with option ` +
                `"${opt2}"`
     });
   }


### PR DESCRIPTION
We frequently use the word "cannot" in error messages, this is the only occurrence of "can not". I am not a native English speaker, but according to various resources, the former should generally be preferred over the latter, and is probably what native speakers would expect.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
