### PR TITLE
doc: change error message testing policy

### DIFF
--- a/doc/guides/using-internal-errors.md
+++ b/doc/guides/using-internal-errors.md
@@ -111,8 +111,8 @@ assert.strictEqual(
 ```
 
 In addition, there should also be tests which validate the use of the
-error based on where it is used in the codebase.  For these tests, except in
-special cases, they should only validate that the expected code is received
+error based on where it is used in the codebase.  If the error message is
+static, these tests should only validate that the expected code is received
 and NOT validate the message.  This will reduce the amount of test change
 required when the message for an error changes.
 


### PR DESCRIPTION
Dynamic error messages often contain important information that depends on the context, e.g., which argument caused an `ERR_INVALID_ARG_TYPE`, which type was expected, and which type was received. I don't think that internal breakage when changing a dynamic error message should prevent us from testing such properties properly. (Not to test the error message, but rather the API that uses the error code.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
