### PR TITLE
[v12.x backport] n-api: implement napi_is_detached_arraybuffer

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3259,6 +3259,31 @@ that is, created with [`napi_create_external_arraybuffer`][].
 This API represents the invocation of the `ArrayBuffer` detach operation as
 defined in [Section 24.1.1.3][] of the ECMAScript Language Specification.
 
+### napi_is_detached_arraybuffer
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+```C
+napi_status napi_is_detached_arraybuffer(napi_env env,
+                                         napi_value arraybuffer,
+                                         bool* result)
+```
+
+* `[in] env`: The environment that the API is invoked under.
+* `[in] arraybuffer`: The JavaScript `ArrayBuffer` to be checked.
+* `[out] result`: Whether the `arraybuffer` is detached.
+
+Returns `napi_ok` if the API succeeded.
+
+The `ArrayBuffer` is considered detached if its internal data is `null`.
+
+This API represents the invocation of the `ArrayBuffer` `IsDetachedBuffer`
+operation as defined in [Section 24.1.1.2][] of the ECMAScript Language
+Specification.
+
 ## Working with JavaScript Properties
 
 N-API exposes a set of APIs to get and set properties on JavaScript
@@ -5272,6 +5297,7 @@ This API may only be called from the main thread.
 [Section 7]: https://tc39.github.io/ecma262/#sec-abstract-operations
 [Section 8.7]: https://tc39.es/ecma262/#sec-agents
 [Section 9.1.6]: https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+[Section 24.1.1.2]: https://tc39.es/ecma262/#sec-isdetachedbuffer
 [Travis CI]: https://travis-ci.org
 [Visual Studio]: https://visualstudio.microsoft.com
 [Working with JavaScript Properties]: #n_api_working_with_javascript_properties

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -518,6 +518,10 @@ NAPI_EXTERN napi_status napi_get_instance_data(napi_env env,
 // ArrayBuffer detaching
 NAPI_EXTERN napi_status napi_detach_arraybuffer(napi_env env,
                                                 napi_value arraybuffer);
+
+NAPI_EXTERN napi_status napi_is_detached_arraybuffer(napi_env env,
+                                                     napi_value value,
+                                                     bool* result);
 #endif  // NAPI_EXPERIMENTAL
 
 EXTERN_C_END

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -3060,3 +3060,18 @@ napi_status napi_detach_arraybuffer(napi_env env, napi_value arraybuffer) {
 
   return napi_clear_last_error(env);
 }
+
+napi_status napi_is_detached_arraybuffer(napi_env env,
+                                         napi_value arraybuffer,
+                                         bool* result) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, arraybuffer);
+  CHECK_ARG(env, result);
+
+  v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(arraybuffer);
+
+  *result = value->IsArrayBuffer() &&
+            value.As<v8::ArrayBuffer>()->GetContents().Data() == nullptr;
+
+  return napi_clear_last_error(env);
+}

--- a/test/js-native-api/test_typedarray/test.js
+++ b/test/js-native-api/test_typedarray/test.js
@@ -87,8 +87,21 @@ arrayTypes.forEach((currentType) => {
   assert.ok(externalResult instanceof Int8Array);
   assert.strictEqual(externalResult.length, 3);
   assert.strictEqual(externalResult.byteLength, 3);
+  assert.ok(!test_typedarray.IsDetached(buffer.buffer));
   test_typedarray.Detach(buffer);
+  assert.ok(test_typedarray.IsDetached(buffer.buffer));
   assert.ok(externalResult instanceof Int8Array);
   assert.strictEqual(buffer.length, 0);
   assert.strictEqual(buffer.byteLength, 0);
+}
+
+{
+  const buffer = new ArrayBuffer(128);
+  assert.ok(!test_typedarray.IsDetached(buffer));
+}
+
+{
+  const buffer = test_typedarray.NullArrayBuffer();
+  assert.ok(buffer instanceof ArrayBuffer);
+  assert.ok(test_typedarray.IsDetached(buffer));
 }


### PR DESCRIPTION
This implements ArrayBuffer#IsDetachedBuffer operation as per ECMAScript
specification Section 24.1.1.2 https://tc39.es/ecma262/#sec-isdetachedbuffer

Closes: https://github.com/nodejs/node/issues/29955

PR-URL: https://github.com/nodejs/node/pull/30613
Fixes: https://github.com/nodejs/node/issues/29955
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Gus Caplan <me@gus.host>
Reviewed-By: David Carlier <devnexen@gmail.com>
Reviewed-By: Chengzhong Wu <legendecas@gmail.com>
Reviewed-By: Michael Dawson <michael_dawson@ca.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
