### PR TITLE
test: improve logged errors

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -30,7 +30,7 @@ const fs = require('fs');
 // Do not require 'os' until needed so that test-os-checked-fucnction can
 // monkey patch it. If 'os' is required here, that test will fail.
 const path = require('path');
-const { inspect } = require('util');
+const util = require('util');
 const { isMainThread } = require('worker_threads');
 
 const tmpdir = require('./tmpdir');
@@ -88,7 +88,7 @@ if (process.argv.length === 2 &&
           (process.features.inspector || !flag.startsWith('--inspect'))) {
         console.log(
           'NOTE: The test started as a child_process using these flags:',
-          inspect(flags),
+          util.inspect(flags),
           'Use NODE_SKIP_FLAG_CHECK to run the test with the original flags.'
         );
         const args = [...flags, ...process.execArgv, ...process.argv.slice(1)];
@@ -129,7 +129,7 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
   process.on('exit', () => {
     // Iterate through handles to make sure nothing crashes
     for (const k in initHandles)
-      inspect(initHandles[k]);
+      util.inspect(initHandles[k]);
   });
 
   const _queueDestroyAsyncId = async_wrap.queueDestroyAsyncId;
@@ -139,7 +139,7 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
       process._rawDebug();
       throw new Error(`same id added to destroy list twice (${id})`);
     }
-    destroyListList[id] = inspect(new Error());
+    destroyListList[id] = util.inspect(new Error());
     _queueDestroyAsyncId(id);
   };
 
@@ -151,7 +151,10 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
         process._rawDebug(`Previous stack:\n${initHandles[id].stack}\n`);
         throw new Error(`init called twice for same id (${id})`);
       }
-      initHandles[id] = { resource, stack: inspect(new Error()).substr(6) };
+      initHandles[id] = {
+        resource,
+        stack: util.inspect(new Error()).substr(6)
+      };
     },
     before() { },
     after() { },
@@ -161,7 +164,7 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
         process._rawDebug();
         throw new Error(`destroy called for same id (${id})`);
       }
-      destroydIdsList[id] = inspect(new Error());
+      destroydIdsList[id] = util.inspect(new Error());
     },
   }).enable();
 }
@@ -345,7 +348,7 @@ function _mustCallInner(fn, criteria = 1, field) {
   const context = {
     [field]: criteria,
     actual: 0,
-    stack: inspect(new Error()),
+    stack: util.inspect(new Error()),
     name: fn.name || '<anonymous>'
   };
 
@@ -511,7 +514,7 @@ function expectWarning(nameOrMap, expected, code) {
       if (!catchWarning[warning.name]) {
         throw new TypeError(
           `"${warning.name}" was triggered without being expected.\n` +
-          inspect(warning)
+          util.inspect(warning)
         );
       }
       catchWarning[warning.name](warning);
@@ -532,7 +535,7 @@ function expectsError(validator, exact) {
     if (args.length !== 1) {
       // Do not use `assert.strictEqual()` to prevent `inspect` from
       // always being called.
-      assert.fail(`Expected one argument, got ${inspect(args)}`);
+      assert.fail(`Expected one argument, got ${util.inspect(args)}`);
     }
     const error = args.pop();
     const descriptor = Object.getOwnPropertyDescriptor(error, 'message');
@@ -661,9 +664,9 @@ function invalidArgTypeHelper(input) {
     if (input.constructor && input.constructor.name) {
       return ` Received an instance of ${input.constructor.name}`;
     }
-    return ` Received ${inspect(input, { depth: -1 })}`;
+    return ` Received ${util.inspect(input, { depth: -1 })}`;
   }
-  let inspected = inspect(input, { colors: false });
+  let inspected = util.inspect(input, { colors: false });
   if (inspected.length > 25)
     inspected = `${inspected.slice(0, 25)}...`;
   return ` Received type ${typeof input} (${inspected})`;

--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const fsPromises = fs.promises;
 const path = require('path');
 const vm = require('vm');
+const { inspect } = require('util');
 
 // https://github.com/w3c/testharness.js/blob/master/testharness.js
 // TODO: get rid of this half-baked harness in favor of the one
@@ -354,7 +355,7 @@ class WPTRunner {
         this.fail(filename, {
           name: '',
           message: err.message,
-          stack: err.stack
+          stack: inspect(err)
         }, 'UNCAUGHT');
         this.inProgress.delete(filename);
       }

--- a/test/fixtures/uncaught-exceptions/domain.js
+++ b/test/fixtures/uncaught-exceptions/domain.js
@@ -2,7 +2,7 @@ const domain = require('domain');
 
 var d = domain.create();
 d.on('error', function(err) {
-  console.log('[ignored]', err.stack);
+  console.log('[ignored]', err);
 });
 
 d.run(function() {

--- a/test/message/vm_display_runtime_error.js
+++ b/test/message/vm_display_runtime_error.js
@@ -28,7 +28,7 @@ console.error('beginning');
 try {
   vm.runInThisContext('throw new Error("boo!")', { filename: 'test.vm' });
 } catch (err) {
-  console.error(err.stack);
+  console.error(err);
 }
 
 vm.runInThisContext('throw new Error("spooky!")', { filename: 'test.vm' });

--- a/test/message/vm_display_syntax_error.js
+++ b/test/message/vm_display_syntax_error.js
@@ -28,7 +28,7 @@ console.error('beginning');
 try {
   vm.runInThisContext('var 4;', { filename: 'foo.vm', displayErrors: true });
 } catch (err) {
-  console.error(err.stack);
+  console.error(err);
 }
 
 vm.runInThisContext('var 5;', { filename: 'test.vm' });

--- a/test/parallel/test-assert-if-error.js
+++ b/test/parallel/test-assert-if-error.js
@@ -83,7 +83,7 @@ assert.ifError(undefined);
   } catch (e) {
     threw = true;
     assert.strictEqual(e.message, 'Missing expected exception.');
-    assert(!e.stack.includes('throws'), e.stack);
+    assert(!e.stack.includes('throws'), e);
   }
   assert(threw);
 }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -401,7 +401,7 @@ assert.throws(
     threw = true;
     assert.ok(e.message.includes(rangeError.message));
     assert.ok(e instanceof assert.AssertionError);
-    assert.ok(!e.stack.includes('doesNotThrow'), e.stack);
+    assert.ok(!e.stack.includes('doesNotThrow'), e);
   }
   assert.ok(threw);
 }

--- a/test/parallel/test-http-request-agent.js
+++ b/test/parallel/test-http-request-agent.js
@@ -34,7 +34,7 @@ server.listen(0, common.mustCall(function() {
     res.resume();
     server.close();
   })).on('error', function(e) {
-    console.error(e.stack);
+    console.error(e);
     process.exit(1);
   });
 }));

--- a/test/parallel/test-http-unix-socket.js
+++ b/test/parallel/test-http-unix-socket.js
@@ -69,7 +69,7 @@ server.listen(common.PIPE, common.mustCall(function() {
   }));
 
   req.on('error', function(e) {
-    assert.fail(e.stack);
+    assert.fail(e);
   });
 
   req.end();

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -2,6 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 const domain = require('domain');
+const { inspect } = require('util');
 
 common.disableCrashOnUnhandledRejection();
 
@@ -14,8 +15,8 @@ const asyncTest = (function() {
 
   function fail(error) {
     const stack = currentTest ?
-      `${error.stack}\nFrom previous event:\n${currentTest.stack}` :
-      error.stack;
+      `${inspect(error)}\nFrom previous event:\n${currentTest.stack}` :
+      inspect(error);
 
     if (currentTest)
       process.stderr.write(`'${currentTest.description}' failed\n\n`);
@@ -44,11 +45,11 @@ const asyncTest = (function() {
   }
 
   return function asyncTest(description, fn) {
-    const stack = new Error().stack.split('\n').slice(1).join('\n');
+    const stack = inspect(new Error()).split('\n').slice(1).join('\n');
     asyncTestQueue.push({
       action: fn,
-      stack: stack,
-      description: description
+      stack,
+      description
     });
     if (!asyncTestsEnabled) {
       asyncTestsEnabled = true;

--- a/test/parallel/test-tls-min-max-version.js
+++ b/test/parallel/test-tls-min-max-version.js
@@ -1,6 +1,7 @@
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+const { inspect } = require('util');
 
 // Check min/max protocol versions.
 
@@ -16,7 +17,7 @@ function test(cmin, cmax, cprot, smin, smax, sprot, proto, cerr, serr) {
   // Report where test was called from. Strip leading garbage from
   //     at Object.<anonymous> (file:line)
   // from the stack location, we only want the file:line part.
-  const where = (new Error()).stack.split('\n')[2].replace(/[^(]*/, '');
+  const where = inspect(new Error()).split('\n')[2].replace(/[^(]*/, '');
   connect({
     client: {
       checkServerIdentity: (servername, cert) => { },

--- a/test/parallel/test-tls-securepair-server.js
+++ b/test/parallel/test-tls-securepair-server.js
@@ -37,7 +37,7 @@ const key = fixtures.readKey('rsa_private.pem');
 const cert = fixtures.readKey('rsa_cert.crt');
 
 function log(a) {
-  console.error(`***server*** ${a}`);
+  console.error('***server***', a);
 }
 
 const server = net.createServer(common.mustCall(function(socket) {
@@ -74,21 +74,18 @@ const server = net.createServer(common.mustCall(function(socket) {
   pair.cleartext.on('error', function(err) {
     log('got error: ');
     log(err);
-    log(err.stack);
     socket.destroy();
   });
 
   pair.encrypted.on('error', function(err) {
     log('encrypted error: ');
     log(err);
-    log(err.stack);
     socket.destroy();
   });
 
   socket.on('error', function(err) {
     log('socket error: ');
     log(err);
-    log(err.stack);
     socket.destroy();
   });
 
@@ -99,7 +96,6 @@ const server = net.createServer(common.mustCall(function(socket) {
   pair.on('error', function(err) {
     log('secure error: ');
     log(err);
-    log(err.stack);
     socket.destroy();
   });
 }));

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -1,7 +1,10 @@
 'use strict';
 const common = require('../common');
-if (!common.hasCrypto) common.skip('missing crypto');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
 const fixtures = require('../common/fixtures');
+const { inspect } = require('util');
 
 // Test cipher: option for TLS.
 
@@ -12,7 +15,7 @@ const {
 
 function test(cciphers, sciphers, cipher, cerr, serr) {
   assert(cipher || cerr || serr, 'test missing any expectations');
-  const where = (new Error()).stack.split('\n')[2].replace(/[^(]*/, '');
+  const where = inspect(new Error()).split('\n')[2].replace(/[^(]*/, '');
   connect({
     client: {
       checkServerIdentity: (servername, cert) => { },

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -22,7 +22,7 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-
+const { inspect } = require('util');
 const vm = require('vm');
 const Script = vm.Script;
 let script = new Script('"passed";');
@@ -59,7 +59,7 @@ try {
 } catch (e) {
   gh1140Exception = e;
   assert.ok(/expected-filename/.test(e.stack),
-            `expected appearance of filename in Error stack: ${e.stack}`);
+            `expected appearance of filename in Error stack: ${inspect(e)}`);
 }
 // This is outside of catch block to confirm catch block ran.
 assert.strictEqual(gh1140Exception.toString(), 'Error');


### PR DESCRIPTION
To indicate which lines are test lines and which are from Node.js core,
it's good to rely upon `util.inspect()` while inspecting errors. Using it also logs error properties and provides more informations about the error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
