### PR TITLE
tls: simplify errors using ThrowCryptoError

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -966,10 +966,7 @@ void SecureContext::SetCert(const FunctionCallbackInfo<Value>& args) {
 
   if (!rv) {
     unsigned long err = ERR_get_error();  // NOLINT(runtime/int)
-    if (!err) {
-      return env->ThrowError("SSL_CTX_use_certificate_chain");
-    }
-    return ThrowCryptoError(env, err);
+    return ThrowCryptoError(env, err, "SSL_CTX_use_certificate_chain");
   }
 }
 
@@ -1178,11 +1175,7 @@ void SecureContext::SetCipherSuites(const FunctionCallbackInfo<Value>& args) {
   const node::Utf8Value ciphers(args.GetIsolate(), args[0]);
   if (!SSL_CTX_set_ciphersuites(sc->ctx_.get(), *ciphers)) {
     unsigned long err = ERR_get_error();  // NOLINT(runtime/int)
-    if (!err) {
-      // This would be an OpenSSL bug if it happened.
-      return env->ThrowError("Failed to set ciphers");
-    }
-    return ThrowCryptoError(env, err);
+    return ThrowCryptoError(env, err, "Failed to set ciphers");
   }
 #endif
 }
@@ -1200,10 +1193,6 @@ void SecureContext::SetCiphers(const FunctionCallbackInfo<Value>& args) {
   const node::Utf8Value ciphers(args.GetIsolate(), args[0]);
   if (!SSL_CTX_set_cipher_list(sc->ctx_.get(), *ciphers)) {
     unsigned long err = ERR_get_error();  // NOLINT(runtime/int)
-    if (!err) {
-      // This would be an OpenSSL bug if it happened.
-      return env->ThrowError("Failed to set ciphers");
-    }
 
     if (strlen(*ciphers) == 0 && ERR_GET_REASON(err) == SSL_R_NO_CIPHER_MATCH) {
       // TLS1.2 ciphers were deliberately cleared, so don't consider
@@ -1212,7 +1201,7 @@ void SecureContext::SetCiphers(const FunctionCallbackInfo<Value>& args) {
       // that's actually an error.
       return;
     }
-    return ThrowCryptoError(env, err);
+    return ThrowCryptoError(env, err, "Failed to set ciphers");
   }
 }
 
@@ -3022,9 +3011,7 @@ void SSLWrap<Base>::CertCbDone(const FunctionCallbackInfo<Value>& args) {
       // Not clear why sometimes we throw error, and sometimes we call
       // onerror(). Both cause .destroy(), but onerror does a bit more.
       unsigned long err = ERR_get_error();  // NOLINT(runtime/int)
-      if (!err)
-        return env->ThrowError("CertCbDone");
-      return ThrowCryptoError(env, err);
+      return ThrowCryptoError(env, err, "CertCbDone");
     }
   } else {
     // Failure: incorrect SNI context object

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -733,19 +733,14 @@ void SecureContext::SetKey(const FunctionCallbackInfo<Value>& args) {
 
   if (!key) {
     unsigned long err = ERR_get_error();  // NOLINT(runtime/int)
-    if (!err) {
-      return env->ThrowError("PEM_read_bio_PrivateKey");
-    }
-    return ThrowCryptoError(env, err);
+    return ThrowCryptoError(env, err, "PEM_read_bio_PrivateKey");
   }
 
   int rv = SSL_CTX_use_PrivateKey(sc->ctx_.get(), key.get());
 
   if (!rv) {
     unsigned long err = ERR_get_error();  // NOLINT(runtime/int)
-    if (!err)
-      return env->ThrowError("SSL_CTX_use_PrivateKey");
-    return ThrowCryptoError(env, err);
+    return ThrowCryptoError(env, err, "SSL_CTX_use_PrivateKey");
   }
 }
 


### PR DESCRIPTION
Switching to a default message if `err == 0` is already implemented in `ThrowCryptoError`. This should not cause any observable change in behavior.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
