### PR TITLE
crypto: assign and use ERR_CRYPTO_UNKNOWN_CIPHER

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -831,7 +831,7 @@ A signing `key` was not provided to the [`sign.sign()`][] method.
 [`crypto.timingSafeEqual()`][] was called with `Buffer`, `TypedArray`, or
 `DataView` arguments of different lengths.
 
-<a id="ERR_CRYPTO_UNKNOWN_CIPHRE"></a>
+<a id="ERR_CRYPTO_UNKNOWN_CIPHER"></a>
 ### `ERR_CRYPTO_UNKNOWN_CIPHER`
 
 An unknown cipher was specified.

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -831,6 +831,11 @@ A signing `key` was not provided to the [`sign.sign()`][] method.
 [`crypto.timingSafeEqual()`][] was called with `Buffer`, `TypedArray`, or
 `DataView` arguments of different lengths.
 
+<a id="ERR_CRYPTO_UNKNOWN_CIPHRE"></a>
+### `ERR_CRYPTO_UNKNOWN_CIPHER`
+
+An unknown cipher was specified.
+
 <a id="ERR_CRYPTO_UNKNOWN_DH_GROUP"></a>
 ### `ERR_CRYPTO_UNKNOWN_DH_GROUP`
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3549,7 +3549,7 @@ static NonCopyableMaybe<PrivateKeyEncodingConfig> GetPrivateKeyEncodingFromJs(
                                       args[*offset].As<String>());
         result.cipher_ = EVP_get_cipherbyname(*cipher_name);
         if (result.cipher_ == nullptr) {
-          env->ThrowError("Unknown cipher");
+          THROW_ERR_CRYPTO_UNKNOWN_CIPHER(env);
           return NonCopyableMaybe<PrivateKeyEncodingConfig>();
         }
         needs_passphrase = true;
@@ -4055,7 +4055,7 @@ void CipherBase::Init(const char* cipher_type,
 
   const EVP_CIPHER* const cipher = EVP_get_cipherbyname(cipher_type);
   if (cipher == nullptr)
-    return env()->ThrowError("Unknown cipher");
+    return THROW_ERR_CRYPTO_UNKNOWN_CIPHER(env());
 
   unsigned char key[EVP_MAX_KEY_LENGTH];
   unsigned char iv[EVP_MAX_IV_LENGTH];
@@ -4119,7 +4119,7 @@ void CipherBase::InitIv(const char* cipher_type,
 
   const EVP_CIPHER* const cipher = EVP_get_cipherbyname(cipher_type);
   if (cipher == nullptr) {
-    return env()->ThrowError("Unknown cipher");
+    return THROW_ERR_CRYPTO_UNKNOWN_CIPHER(env());
   }
 
   const int expected_iv_len = EVP_CIPHER_iv_length(cipher);

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -39,6 +39,7 @@ void PrintErrorString(const char* format, ...);
   V(ERR_BUFFER_TOO_LARGE, Error)                                             \
   V(ERR_CONSTRUCT_CALL_REQUIRED, TypeError)                                  \
   V(ERR_CONSTRUCT_CALL_INVALID, TypeError)                                   \
+  V(ERR_CRYPTO_UNKNOWN_CIPHER, Error)                                        \
   V(ERR_CRYPTO_UNKNOWN_DH_GROUP, Error)                                      \
   V(ERR_INVALID_ARG_VALUE, TypeError)                                        \
   V(ERR_OSSL_EVP_INVALID_DIGEST, Error)                                      \
@@ -90,6 +91,7 @@ void PrintErrorString(const char* format, ...);
     "Buffer is not available for the current Context")                       \
   V(ERR_CONSTRUCT_CALL_INVALID, "Constructor cannot be called")              \
   V(ERR_CONSTRUCT_CALL_REQUIRED, "Cannot call constructor without `new`")    \
+  V(ERR_CRYPTO_UNKNOWN_CIPHER, "Unknown cipher")                             \
   V(ERR_CRYPTO_UNKNOWN_DH_GROUP, "Unknown DH group")                         \
   V(ERR_INVALID_TRANSFER_OBJECT, "Found invalid object in transferList")     \
   V(ERR_MEMORY_ALLOCATION_FAILED, "Failed to allocate memory")               \

--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -210,7 +210,11 @@ for (let n = 1; n < 256; n += 1) {
   // Passing an invalid cipher name should throw.
   assert.throws(
     () => crypto.createCipheriv('aes-127', Buffer.alloc(16), null),
-    /Unknown cipher/);
+    {
+      name: 'Error',
+      code: 'ERR_CRYPTO_UNKNOWN_CIPHER',
+      message: 'Unknown cipher'
+    });
 
   // Passing a key with an invalid length should throw.
   assert.throws(

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -822,6 +822,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }
   }), {
     name: 'Error',
+    code: 'ERR_CRYPTO_UNKNOWN_CIPHER',
     message: 'Unknown cipher'
   });
 


### PR DESCRIPTION
This replaces `Error`s with the message `'Unknown cipher'` with new errors with the same message, but assigns a new code `ERR_CRYPTO_UNKNOWN_CIPHER`. This should not break existing applications since it only adds the `.code` property, and should therefore not be semver-major.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
