### PR TITLE
[v12.x backport] http2: make HTTP2ServerResponse more streams compliant

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -40,7 +40,8 @@ const {
     ERR_HTTP2_STATUS_INVALID,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_CALLBACK,
-    ERR_INVALID_HTTP_TOKEN
+    ERR_INVALID_HTTP_TOKEN,
+    ERR_STREAM_WRITE_AFTER_END
   },
   hideStackFrames
 } = require('internal/errors');
@@ -439,6 +440,7 @@ class Http2ServerResponse extends Stream {
     this[kState] = {
       closed: false,
       ending: false,
+      destroyed: false,
       headRequest: false,
       sendDate: true,
       statusCode: HTTP_STATUS_OK,
@@ -649,23 +651,32 @@ class Http2ServerResponse extends Stream {
   }
 
   write(chunk, encoding, cb) {
+    const state = this[kState];
+
     if (typeof encoding === 'function') {
       cb = encoding;
       encoding = 'utf8';
     }
 
-    if (this[kState].closed) {
-      const err = new ERR_HTTP2_INVALID_STREAM();
+    let err;
+    if (state.ending) {
+      err = new ERR_STREAM_WRITE_AFTER_END();
+    } else if (state.closed) {
+      err = new ERR_HTTP2_INVALID_STREAM();
+    } else if (state.destroyed) {
+      return false;
+    }
+
+    if (err) {
       if (typeof cb === 'function')
         process.nextTick(cb, err);
-      else
-        throw err;
-      return;
+      this.destroy(err);
+      return false;
     }
 
     const stream = this[kStream];
     if (!stream.headersSent)
-      this.writeHead(this[kState].statusCode);
+      this.writeHead(state.statusCode);
     return stream.write(chunk, encoding, cb);
   }
 
@@ -712,8 +723,10 @@ class Http2ServerResponse extends Stream {
   }
 
   destroy(err) {
-    if (this[kState].closed)
+    if (this[kState].destroyed)
       return;
+
+    this[kState].destroyed = true;
     this[kStream].destroy(err);
   }
 

--- a/test/parallel/test-http2-compat-serverresponse-write.js
+++ b/test/parallel/test-http2-compat-serverresponse-write.js
@@ -3,7 +3,6 @@
 const {
   mustCall,
   mustNotCall,
-  expectsError,
   hasCrypto,
   skip
 } = require('../common');
@@ -11,42 +10,64 @@ if (!hasCrypto)
   skip('missing crypto');
 const { createServer, connect } = require('http2');
 const assert = require('assert');
+{
+  const server = createServer();
+  server.listen(0, mustCall(() => {
+    const port = server.address().port;
+    const url = `http://localhost:${port}`;
+    const client = connect(url, mustCall(() => {
+      const request = client.request();
+      request.resume();
+      request.on('end', mustCall());
+      request.on('close', mustCall(() => {
+        client.close();
+      }));
+    }));
 
-const server = createServer();
-server.listen(0, mustCall(() => {
-  const port = server.address().port;
-  const url = `http://localhost:${port}`;
-  const client = connect(url, mustCall(() => {
-    const request = client.request();
-    request.resume();
-    request.on('end', mustCall());
-    request.on('close', mustCall(() => {
-      client.close();
+    server.once('request', mustCall((request, response) => {
+      // response.write() returns true
+      assert(response.write('muahaha', 'utf8', mustCall()));
+
+      response.stream.close(0, mustCall(() => {
+        response.on('error', mustNotCall());
+
+        // response.write() without cb returns error
+        response.write('muahaha', mustCall((err) => {
+          assert.strictEqual(err.code, 'ERR_HTTP2_INVALID_STREAM');
+
+          // response.write() with cb returns falsy value
+          assert(!response.write('muahaha', mustCall()));
+
+          client.destroy();
+          server.close();
+        }));
+      }));
     }));
   }));
+}
 
-  server.once('request', mustCall((request, response) => {
-    // response.write() returns true
-    assert(response.write('muahaha', 'utf8', mustCall()));
+{
+  // Http2ServerResponse.write ERR_STREAM_WRITE_AFTER_END
+  const server = createServer();
+  server.listen(0, mustCall(() => {
+    const port = server.address().port;
+    const url = `http://localhost:${port}`;
+    const client = connect(url, mustCall(() => {
+      const request = client.request();
+      request.resume();
+      request.on('end', mustCall());
+      request.on('close', mustCall(() => {
+        client.close();
+      }));
+    }));
 
-    response.stream.close(0, mustCall(() => {
-      response.on('error', mustNotCall());
-
-      // response.write() without cb returns error
-      expectsError(
-        () => { response.write('muahaha'); },
-        {
-          type: Error,
-          code: 'ERR_HTTP2_INVALID_STREAM',
-          message: 'The stream has been destroyed'
-        }
-      );
-
-      // response.write() with cb returns falsy value
-      assert(!response.write('muahaha', mustCall()));
-
-      client.destroy();
-      server.close();
+    server.once('request', mustCall((request, response) => {
+      response.end();
+      response.write('asd', mustCall((err) => {
+        assert.strictEqual(err.code, 'ERR_STREAM_WRITE_AFTER_END');
+        client.destroy();
+        server.close();
+      }));
     }));
   }));
-}));
+}


### PR DESCRIPTION
HTTP2ServerResponse.write would behave differently than
both http1 and streams. This PR makes it more compliant
with stream.Writable behaviour.

PR-URL: #30964
Refs: #29529

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
