### PR TITLE
http: make --insecure-http-parser configurable per-stream or per-server

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2031,6 +2031,9 @@ Found'`.
 <!-- YAML
 added: v0.1.13
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/?????
+    description: The `insecureHTTPParser` option is supported now.
   - version: v13.3.0
     pr-url: https://github.com/nodejs/node/pull/30570
     description: The `maxHeaderSize` option is supported now.
@@ -2046,6 +2049,10 @@ changes:
   * `ServerResponse` {http.ServerResponse} Specifies the `ServerResponse` class
     to be used. Useful for extending the original `ServerResponse`. **Default:**
     `ServerResponse`.
+  * `insecureHTTPParser` {boolean} Optionally overrides the value of
+    [`--insecure-http-parser`][] for requests received by this server, i.e.
+    whether to accept invalid HTTP headers that must manually be sanitized.
+    **Default:** false.
   * `maxHeaderSize` {number} Optionally overrides the value of
     [`--max-http-header-size`][] for requests received by this server, i.e.
     the maximum length of request headers in bytes.
@@ -2155,6 +2162,9 @@ This can be overridden for servers and client requests by passing the
 <!-- YAML
 added: v0.3.6
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/?????
+    description: The `insecureHTTPParser` option is supported now.
   - version: v13.3.0
     pr-url: https://github.com/nodejs/node/pull/30570
     description: The `maxHeaderSize` option is supported now.
@@ -2191,6 +2201,9 @@ changes:
     request to. **Default:** `'localhost'`.
   * `hostname` {string} Alias for `host`. To support [`url.parse()`][],
     `hostname` will be used if both `host` and `hostname` are specified.
+  * `insecureHTTPParser` {boolean} Optionally overrides the value of
+    [`--insecure-http-parser`][] for requests received from the server, i.e.
+    whether to accept invalid HTTP headers that must manually be sanitized.
   * `localAddress` {string} Local interface to bind for network connections.
   * `lookup` {Function} Custom lookup function. **Default:** [`dns.lookup()`][].
   * `maxHeaderSize` {number} Optionally overrides the value of
@@ -2364,6 +2377,7 @@ will be emitted in the following order:
 Setting the `timeout` option or using the `setTimeout()` function will
 not abort the request or do anything besides add a `'timeout'` event.
 
+[`--insecure-http-parser`]: cli.html#cli_insecure_http_parser
 [`--max-http-header-size`]: cli.html#cli_max_http_header_size_size
 [`'checkContinue'`]: #http_event_checkcontinue
 [`'request'`]: #http_event_request

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2049,10 +2049,10 @@ changes:
   * `ServerResponse` {http.ServerResponse} Specifies the `ServerResponse` class
     to be used. Useful for extending the original `ServerResponse`. **Default:**
     `ServerResponse`.
-  * `insecureHTTPParser` {boolean} Optionally overrides the value of
-    [`--insecure-http-parser`][] for requests received by this server, i.e.
-    whether to accept invalid HTTP headers that must manually be sanitized.
-    **Default:** false.
+  * `insecureHTTPParser` {boolean} Use an insecure HTTP parser that accepts
+    invalid HTTP headers when `true`. Using the insecure parser should be
+    avoided, see [`--insecure-http-parser`][] for more information.
+    **Default:** `false`
   * `maxHeaderSize` {number} Optionally overrides the value of
     [`--max-http-header-size`][] for requests received by this server, i.e.
     the maximum length of request headers in bytes.
@@ -2201,9 +2201,10 @@ changes:
     request to. **Default:** `'localhost'`.
   * `hostname` {string} Alias for `host`. To support [`url.parse()`][],
     `hostname` will be used if both `host` and `hostname` are specified.
-  * `insecureHTTPParser` {boolean} Optionally overrides the value of
-    [`--insecure-http-parser`][] for requests received from the server, i.e.
-    whether to accept invalid HTTP headers that must manually be sanitized.
+  * `insecureHTTPParser` {boolean} Use an insecure HTTP parser that accepts
+    invalid HTTP headers when `true`. Using the insecure parser should be
+    avoided, see [`--insecure-http-parser`][] for more information.
+    **Default:** `false`
   * `localAddress` {string} Local interface to bind for network connections.
   * `lookup` {Function} Custom lookup function. **Default:** [`dns.lookup()`][].
   * `maxHeaderSize` {number} Optionally overrides the value of

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2051,7 +2051,7 @@ changes:
     `ServerResponse`.
   * `insecureHTTPParser` {boolean} Use an insecure HTTP parser that accepts
     invalid HTTP headers when `true`. Using the insecure parser should be
-    avoided, see [`--insecure-http-parser`][] for more information.
+    avoided. See [`--insecure-http-parser`][] for more information.
     **Default:** `false`
   * `maxHeaderSize` {number} Optionally overrides the value of
     [`--max-http-header-size`][] for requests received by this server, i.e.
@@ -2203,7 +2203,7 @@ changes:
     `hostname` will be used if both `host` and `hostname` are specified.
   * `insecureHTTPParser` {boolean} Use an insecure HTTP parser that accepts
     invalid HTTP headers when `true`. Using the insecure parser should be
-    avoided, see [`--insecure-http-parser`][] for more information.
+    avoided. See [`--insecure-http-parser`][] for more information.
     **Default:** `false`
   * `localAddress` {string} Local interface to bind for network connections.
   * `lookup` {Function} Custom lookup function. **Default:** [`dns.lookup()`][].

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2032,7 +2032,7 @@ Found'`.
 added: v0.1.13
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/?????
+    pr-url: https://github.com/nodejs/node/pull/31448
     description: The `insecureHTTPParser` option is supported now.
   - version: v13.3.0
     pr-url: https://github.com/nodejs/node/pull/30570
@@ -2163,7 +2163,7 @@ This can be overridden for servers and client requests by passing the
 added: v0.3.6
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/?????
+    pr-url: https://github.com/nodejs/node/pull/31448
     description: The `insecureHTTPParser` option is supported now.
   - version: v13.3.0
     pr-url: https://github.com/nodejs/node/pull/30570

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -187,6 +187,14 @@ function ClientRequest(input, options, cb) {
     validateInteger(maxHeaderSize, 'maxHeaderSize', 0);
   this.maxHeaderSize = maxHeaderSize;
 
+  const insecureHTTPParser = options.insecureHTTPParser;
+  if (insecureHTTPParser !== undefined &&
+      typeof insecureHTTPParser !== 'boolean') {
+    throw new ERR_INVALID_ARG_TYPE(
+      'insecureHTTPParser', 'boolean', insecureHTTPParser);
+  }
+  this.insecureHTTPParser = insecureHTTPParser;
+
   this.path = options.path || '/';
   if (cb) {
     this.once('response', cb);
@@ -683,7 +691,8 @@ function tickOnSocket(req, socket) {
   parser.initialize(HTTPParser.RESPONSE,
                     new HTTPClientAsyncResource('HTTPINCOMINGMESSAGE', req),
                     req.maxHeaderSize || 0,
-                    isLenient());
+                    req.insecureHTTPParser === undefined ?
+                      isLenient() : req.insecureHTTPParser);
   parser.socket = socket;
   parser.outgoing = req;
   req.parser = parser;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -335,6 +335,14 @@ function Server(options, requestListener) {
     validateInteger(maxHeaderSize, 'maxHeaderSize', 0);
   this.maxHeaderSize = maxHeaderSize;
 
+  const insecureHTTPParser = options.insecureHTTPParser;
+  if (insecureHTTPParser !== undefined &&
+      typeof insecureHTTPParser !== 'boolean') {
+    throw new ERR_INVALID_ARG_TYPE(
+      'insecureHTTPParser', 'boolean', insecureHTTPParser);
+  }
+  this.insecureHTTPParser = insecureHTTPParser;
+
   net.Server.call(this, { allowHalfOpen: true });
 
   if (requestListener) {
@@ -416,7 +424,8 @@ function connectionListenerInternal(server, socket) {
     HTTPParser.REQUEST,
     new HTTPServerAsyncResource('HTTPINCOMINGMESSAGE', socket),
     server.maxHeaderSize || 0,
-    isLenient(),
+    server.insecureHTTPParser === undefined ?
+      isLenient() : server.insecureHTTPParser,
   );
   parser.socket = socket;
 

--- a/test/parallel/test-http-insecure-parser-per-stream.js
+++ b/test/parallel/test-http-insecure-parser-per-stream.js
@@ -1,0 +1,82 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const MakeDuplexPair = require('../common/duplexpair');
+
+// Test that setting the `maxHeaderSize` option works on a per-stream-basis.
+
+// Test 1: The server sends an invalid header.
+{
+  const { clientSide, serverSide } = MakeDuplexPair();
+
+  const req = http.request({
+    createConnection: common.mustCall(() => clientSide),
+    insecureHTTPParser: true
+  }, common.mustCall((res) => {
+    assert.strictEqual(res.headers.hello, 'foo\x08foo');
+    res.resume();  // We don’t actually care about contents.
+    res.on('end', common.mustCall());
+  }));
+  req.end();
+
+  serverSide.resume();  // Dump the request
+  serverSide.end('HTTP/1.1 200 OK\r\n' +
+                 'Hello: foo\x08foo\r\n' +
+                 'Content-Length: 0\r\n' +
+                 '\r\n\r\n');
+}
+
+// Test 2: The same as Test 1 except without the option, to make sure it fails.
+{
+  const { clientSide, serverSide } = MakeDuplexPair();
+
+  const req = http.request({
+    createConnection: common.mustCall(() => clientSide)
+  }, common.mustNotCall());
+  req.end();
+  req.on('error', common.mustCall());
+
+  serverSide.resume();  // Dump the request
+  serverSide.end('HTTP/1.1 200 OK\r\n' +
+                 'Hello: foo\x08foo\r\n' +
+                 'Content-Length: 0\r\n' +
+                 '\r\n\r\n');
+}
+
+// Test 3: The client sends an invalid header.
+{
+  const testData = 'Hello, World!\n';
+  const server = http.createServer(
+    { insecureHTTPParser: true },
+    common.mustCall((req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/plain');
+      res.end(testData);
+    }));
+
+  server.on('clientError', common.mustNotCall());
+
+  const { clientSide, serverSide } = MakeDuplexPair();
+  serverSide.server = server;
+  server.emit('connection', serverSide);
+
+  clientSide.write('GET / HTTP/1.1\r\n' +
+                   'Hello: foo\x08foo\r\n' +
+                   '\r\n\r\n');
+}
+
+// Test 4: The same as Test 3 except without the option, to make sure it fails.
+{
+  const server = http.createServer(common.mustNotCall());
+
+  server.on('clientError', common.mustCall());
+
+  const { clientSide, serverSide } = MakeDuplexPair();
+  serverSide.server = server;
+  server.emit('connection', serverSide);
+
+  clientSide.write('GET / HTTP/1.1\r\n' +
+                   'Hello: foo\x08foo\r\n' +
+                   '\r\n\r\n');
+}


### PR DESCRIPTION
From the issue:

> Some servers deviate from HTTP spec enougth that Node.js can't
> communicate with them, but "work" when `--insecure-http-parser`
> is enabled globally. It would be useful to be able to use this
> mode, as a client, only when connecting to known bad servers.

This is largely equivalent to https://github.com/nodejs/node/pull/31446
in terms of code changes.

Fixes: https://github.com/nodejs/node/issues/31440
Refs: https://github.com/nodejs/node/pull/31446

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
