### PR TITLE
http: decode username and password before encoding

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2155,6 +2155,10 @@ This can be overridden for servers and client requests by passing the
 <!-- YAML
 added: v0.3.6
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/31450
+    description: When used with a `URL` object, the authentication fields will
+                 now be percent-decoded.
   - version: v13.3.0
     pr-url: https://github.com/nodejs/node/pull/30570
     description: The `maxHeaderSize` option is supported now.

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -470,6 +470,12 @@ the URL, use the [`url.search`][] setter. See [`URLSearchParams`][]
 documentation for details.
 
 #### `url.username`
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/31450
+    description: When used with `http.request()`, this field will now be
+                 percent-decoded.
 
 * {string}
 
@@ -488,7 +494,8 @@ console.log(myURL.href);
 Any invalid URL characters appearing in the value assigned the `username`
 property will be [percent-encoded][]. The selection of which
 characters to percent-encode may vary somewhat from what the [`url.parse()`][]
-and [`url.format()`][] methods would produce.
+and [`url.format()`][] methods would produce. When used with
+[`http.request()`][], this field will be percent-decoded.
 
 #### `url.toString()`
 
@@ -1316,6 +1323,7 @@ console.log(myURL.origin);
 [`TypeError`]: errors.html#errors_class_typeerror
 [`URLSearchParams`]: #url_class_urlsearchparams
 [`array.toString()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toString
+[`http.request()`]: http.html#http_http_request_options_callback
 [`new URL()`]: #url_constructor_new_url_input_base
 [`querystring`]: querystring.html
 [`require('url').format()`]: #url_url_format_url_options

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -476,6 +476,7 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/31450
     description: When used with `http.request()`, this field will now be
                  percent-decoded.
+-->
 
 * {string}
 

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1284,7 +1284,8 @@ function urlToOptions(url) {
     options.port = Number(url.port);
   }
   if (url.username || url.password) {
-    options.auth = `${url.username}:${url.password}`;
+    options.auth =
+      `${decodeURIComponent(url.username)}:${decodeURIComponent(url.password)}`;
   }
   return options;
 }

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1265,6 +1265,10 @@ function domainToUnicode(domain) {
   return _domainToUnicode(`${domain}`);
 }
 
+function decodeAuth(str) {
+  return decodeURIComponent(str).replace(':', '%3A').replace('/', '%2F');
+}
+
 // Utility function that converts a URL object into an ordinary
 // options object as expected by the http.request and https.request
 // APIs.
@@ -1284,8 +1288,7 @@ function urlToOptions(url) {
     options.port = Number(url.port);
   }
   if (url.username || url.password) {
-    options.auth =
-      `${decodeURIComponent(url.username)}:${decodeURIComponent(url.password)}`;
+    options.auth = `${decodeAuth(url.username)}:${decodeAuth(url.password)}`;
   }
   return options;
 }

--- a/test/parallel/test-http-url-username.js
+++ b/test/parallel/test-http-url-username.js
@@ -1,0 +1,33 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const MakeDuplexPair = require('../common/duplexpair');
+
+// Test that usernames from URLs are URL-decoded, as they should be.
+
+{
+  const url = new URL('http://localhost');
+  url.username = 'test@test';
+  url.password = '123456';
+
+  const server = http.createServer(
+    common.mustCall((req, res) => {
+      assert.strictEqual(
+        req.headers.authorization,
+        'Basic ' + Buffer.from('test@test:123456').toString('base64'));
+      res.statusCode = 200;
+      res.end();
+    }));
+
+  const { clientSide, serverSide } = MakeDuplexPair();
+  server.emit('connection', serverSide);
+
+  const req = http.request(url, {
+    createConnection: common.mustCall(() => clientSide)
+  }, common.mustCall((res) => {
+    res.resume();  // We don’t actually care about contents.
+    res.on('end', common.mustCall());
+  }));
+  req.end();
+}

--- a/test/parallel/test-http-url-username.js
+++ b/test/parallel/test-http-url-username.js
@@ -8,14 +8,14 @@ const MakeDuplexPair = require('../common/duplexpair');
 
 {
   const url = new URL('http://localhost');
-  url.username = 'test@test';
-  url.password = '123456';
+  url.username = 'test@test"';
+  url.password = '123456^';
 
   const server = http.createServer(
     common.mustCall((req, res) => {
       assert.strictEqual(
         req.headers.authorization,
-        'Basic ' + Buffer.from('test@test:123456').toString('base64'));
+        'Basic ' + Buffer.from('test@test":123456^').toString('base64'));
       res.statusCode = 200;
       res.end();
     }));


### PR DESCRIPTION
@nodejs/url @nodejs/security I’m marking this as blocked, because I’d like somebody to take a look at this who is somewhat familiar with the security implications of this – there are no obvious downsides to me here, but I know this can be quite a sensitive area.

Fixes: https://github.com/nodejs/node/issues/31439

/cc @izonder

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
