### PR TITLE
util: fix inspection of typed arrays with unusual length

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -818,7 +818,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
         return `${braces[0]}]`;
       // Special handle the value. The original value is required below. The
       // bound function is required to reconstruct missing information.
-      formatter = formatTypedArray.bind(null, bound);
+      formatter = formatTypedArray.bind(null, bound, size);
       extrasType = kArrayExtrasType;
     } else if (isMapIterator(value)) {
       keys = getKeys(value, ctx.showHidden);
@@ -1401,8 +1401,8 @@ function formatArray(ctx, value, recurseTimes) {
   return output;
 }
 
-function formatTypedArray(value, ctx, ignored, recurseTimes) {
-  const maxLength = MathMin(MathMax(0, ctx.maxArrayLength), value.length);
+function formatTypedArray(value, length, ctx, ignored, recurseTimes) {
+  const maxLength = MathMin(MathMax(0, ctx.maxArrayLength), length);
   const remaining = value.length - maxLength;
   const output = new Array(maxLength);
   const elementFormatter = value.length > 0 && typeof value[0] === 'number' ?

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -312,6 +312,12 @@ assert(!/Object/.test(
   );
 });
 
+{
+  const brokenLength = new Float32Array(2);
+  Object.defineProperty(brokenLength, 'length', { value: -1 });
+  assert.strictEqual(inspect(brokenLength), 'Float32Array(2) [ 0n, 0n ]');
+}
+
 assert.strictEqual(
   util.inspect(Object.create({}, {
     visible: { value: 1, enumerable: true },


### PR DESCRIPTION
This makes sure `util.inspect()` does not throw in case the typed
array's length property was set to something invalid. Instead,
always use the original information.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
