### PR TITLE
doc: fix code display in header glitch

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -40,7 +40,6 @@ h6, h6 code {
   line-height: inherit;
   position: relative;
   margin: 1.5rem 0 1rem;
-  padding: inherit;
   text-rendering: optimizeLegibility;
 }
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/31451

@GeoffreyBooth @nodejs/website 


Before:
---
<img width="967" alt="before" src="https://user-images.githubusercontent.com/718899/72892200-cc7c9b00-3cca-11ea-944c-37a46a94b6fc.png">

After:
---
<img width="971" alt="after" src="https://user-images.githubusercontent.com/718899/72892211-d1414f00-3cca-11ea-9f6f-3ddb37c439ef.png">




<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
