### PR TITLE
src: define noreturn attribute for windows

### DIFF
--- a/src/node_api.h
+++ b/src/node_api.h
@@ -18,10 +18,12 @@ struct uv_loop_s;  // Forward declaration.
 # define NAPI_MODULE_EXPORT __attribute__((visibility("default")))
 #endif
 
-#ifdef __GNUC__
-#define NAPI_NO_RETURN __attribute__((noreturn))
+#if defined(__GNUC__)
+# define NAPI_NO_RETURN __attribute__((noreturn))
+#elif defined(_WIN32)
+# define NAPI_NO_RETURN __declspec(noreturn)
 #else
-#define NAPI_NO_RETURN
+# define NAPI_NO_RETURN
 #endif
 
 typedef napi_value (*napi_addon_register_func)(napi_env env,


### PR DESCRIPTION
As MSVC has it's own `noreturn` attribute, wouldn't it be useful to utilize it in `NAPI_NO_RETURN` macro?

I believe it will have almost zero impact for majority of addons, but code analysis tools would be thankful.

I am working on addon written in Swift. It appears that C module importer actually handles noreturn attributes to generate corresponding Swift interface. Which in turn affects type inference. As a result I got different compiler behavior on Windows for exactly same code as on Darwin platform.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]

NOTE: I had 17 failing tests on master _before_ this change. I have 17 failing tests after this change. Took this as "pass". Would be glad if anyone correct me if tests really require attention here.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
