### PR TITLE
worker: move JoinThread() back into exit callback

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -698,6 +698,8 @@ void Environment::RunAndClearNativeImmediates(bool only_refed) {
       if (head->is_refed() || !only_refed)
         head->Call(this);
 
+      head.reset();  // Destroy now so that this is also observed by try_catch.
+
       if (UNLIKELY(try_catch.HasCaught())) {
         if (!try_catch.HasTerminated() && can_call_into_js())
           errors::TriggerUncaughtException(isolate(), try_catch);

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -438,8 +438,6 @@ void Worker::JoinThread() {
 }
 
 Worker::~Worker() {
-  JoinThread();
-
   Mutex::ScopedLock lock(mutex_);
 
   CHECK(stopped_);
@@ -599,6 +597,7 @@ void Worker::StartThread(const FunctionCallbackInfo<Value>& args) {
         [w = std::unique_ptr<Worker>(w)](Environment* env) {
           if (w->has_ref_)
             env->add_refs(-1);
+          w->JoinThread();
           // implicitly delete w
         });
   }, static_cast<void*>(w)), 0);

--- a/test/parallel/test-worker-exit-event-error.js
+++ b/test/parallel/test-worker-exit-event-error.js
@@ -1,0 +1,8 @@
+'use strict';
+const common = require('../common');
+const { Worker } = require('worker_threads');
+
+process.on('uncaughtException', common.mustCall());
+
+new Worker('', { eval: true })
+  .on('exit', common.mustCall(() => { throw new Error('foo'); }));


### PR DESCRIPTION
##### worker: move JoinThread() back into exit callback

de2c68c7dd17a217a818ea881e433034006fdb4b moved this call to
the destructor, under the assumption that that would essentially
be equivalent to running it as part of the callback since the
worker would be destroyed along with the callback.

However, the actual code in
`Environment::RunAndClearNativeImmediates()` comes with the subtlety
that testing whether a JS exception has been thrown
happens between the invocation of the callback and its destruction,
leaving a possible exception from `JoinThread()` potentially
unhandled (and unintentionally silenced through the `TryCatch`).

This affected exceptions thrown from the `'exit'` event of the
Worker, and made the `parallel/test-worker-message-type-unknown`
test flaky, as the invalid message was sometimes only received
during the Worker thread’s exit handler.

Fix this by moving the `JoinThread()` call back to where it was
before.

Refs: https://github.com/nodejs/node/pull/31386

##### src: harden running native `SetImmediate()`s slightly

Prevent mistakes like the one fixed by the previous commit
by destroying the callback immediately after it has been called.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
