### PR TITLE
src: ignore GCC -Wcast-function-type for v8.h

### DIFF
--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -27,7 +27,15 @@
 #include "base_object.h"
 #include "env-inl.h"
 #include "util.h"
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 #include "v8.h"
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 namespace node {
 

--- a/src/node.h
+++ b/src/node.h
@@ -60,7 +60,14 @@
 # define SIGKILL 9
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 #include "v8.h"  // NOLINT(build/include_order)
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 #include "v8-platform.h"  // NOLINT(build/include_order)
 #include "node_version.h"  // NODE_MODULE_VERSION
 

--- a/src/util.h
+++ b/src/util.h
@@ -24,7 +24,14 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 #include "v8.h"
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #include <cassert>
 #include <climits>  // PATH_MAX


### PR DESCRIPTION
This commit suggests that cast-function-type warnings be ignored
from v8.h. Currently, GCC reports a number of warnings like this:
```console
In file included from ../src/util.h:27,
                 from ../src/aliased_buffer.h:7,
                 from ../src/memory_tracker.h:5,
                 from ../src/base_object.h:27,
                 from ../src/async_wrap.h:27,
                 from ../src/req_wrap.h:6,
                 from ../src/req_wrap-inl.h:6,
                 from ../src/connect_wrap.h:6,
                 from ../src/connect_wrap.cc:1:
../deps/v8/include/v8.h: In instantiation of
‘void v8::PersistentBase<T>::SetWeak(
    P*,
    typename v8::WeakCallbackInfo<P>::Callback, v8::WeakCallbackType)
[with
P = node::BaseObject;
T = v8::Object;
typename v8::WeakCallbackInfo<P>::Callback =
    void (*)(const v8::WeakCallbackInfo<node::BaseObject>&)]’:

../src/base_object-inl.h:123:42:   required from here
../deps/v8/include/v8.h:10374:16: warning:
cast between incompatible function types from
‘v8::WeakCallbackInfo<node::BaseObject>::Callback’
{aka ‘void (*)(const v8::WeakCallbackInfo<node::BaseObject>&)’} to
‘Callback’
{aka ‘void (*)(const v8::WeakCallbackInfo<void>&)’}
[-Wcast-function-type]
                reinterpret_cast<Callback>(callback), type);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
The motivation for doing this that it makes it difficult to spot
other warnings that might be important. Since it is v8 that
performs this cast I was not able to find a way around it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
