### PR TITLE
test: cover property n-api null cases

### DIFF
--- a/test/js-native-api/test_object/binding.gyp
+++ b/test/js-native-api/test_object/binding.gyp
@@ -5,6 +5,7 @@
       "sources": [
         "../common.c",
         "../entry_point.c",
+        "test_null.c",
         "test_object.c"
       ]
     }

--- a/test/js-native-api/test_object/test_null.c
+++ b/test/js-native-api/test_object/test_null.c
@@ -1,0 +1,401 @@
+#define NAPI_EXPERIMENTAL
+#include <js_native_api.h>
+
+#include "../common.h"
+#include "test_null.h"
+
+static napi_value SetProperty(napi_env env, napi_callback_info info) {
+  napi_value return_value, object, key;
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NAPI_CALL(env, napi_create_object(env, &object));
+  NAPI_CALL(env,
+      napi_create_string_utf8(env, "someString", NAPI_AUTO_LENGTH, &key));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      napi_set_property(NULL, object, key, object));
+
+  napi_set_property(env, NULL, key, object);
+  add_last_status(env, "objectIsNull", return_value);
+
+  napi_set_property(env, object, NULL, object);
+  add_last_status(env, "keyIsNull", return_value);
+
+  napi_set_property(env, object, key, NULL);
+  add_last_status(env, "valueIsNull", return_value);
+
+  return return_value;
+}
+
+static napi_value GetProperty(napi_env env, napi_callback_info info) {
+  napi_value return_value, object, key, prop;
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NAPI_CALL(env, napi_create_object(env, &object));
+  NAPI_CALL(env,
+      napi_create_string_utf8(env, "someString", NAPI_AUTO_LENGTH, &key));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      napi_get_property(NULL, object, key, &prop));
+
+  napi_get_property(env, NULL, key, &prop);
+  add_last_status(env, "objectIsNull", return_value);
+
+  napi_get_property(env, object, NULL, &prop);
+  add_last_status(env, "keyIsNull", return_value);
+
+  napi_get_property(env, object, key, NULL);
+  add_last_status(env, "valueIsNull", return_value);
+
+  return return_value;
+}
+
+static napi_value TestBoolValuedPropApi(napi_env env,
+    napi_status (*api)(napi_env, napi_value, napi_value, bool*)) {
+  napi_value return_value, object, key;
+  bool result;
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NAPI_CALL(env, napi_create_object(env, &object));
+  NAPI_CALL(env,
+      napi_create_string_utf8(env, "someString", NAPI_AUTO_LENGTH, &key));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      api(NULL, object, key, &result));
+
+  api(env, NULL, key, &result);
+  add_last_status(env, "objectIsNull", return_value);
+
+  api(env, object, NULL, &result);
+  add_last_status(env, "keyIsNull", return_value);
+
+  api(env, object, key, NULL);
+  add_last_status(env, "valueIsNull", return_value);
+
+  return return_value;
+}
+
+static napi_value HasProperty(napi_env env, napi_callback_info info) {
+  return TestBoolValuedPropApi(env, napi_has_property);
+}
+
+static napi_value HasOwnProperty(napi_env env, napi_callback_info info) {
+  return TestBoolValuedPropApi(env, napi_has_own_property);
+}
+
+static napi_value DeleteProperty(napi_env env, napi_callback_info info) {
+  return TestBoolValuedPropApi(env, napi_delete_property);
+}
+
+static napi_value SetNamedProperty(napi_env env, napi_callback_info info) {
+  napi_value return_value, object;
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NAPI_CALL(env, napi_create_object(env, &object));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      napi_set_named_property(NULL, object, "key", object));
+
+  napi_set_named_property(env, NULL, "key", object);
+  add_last_status(env, "objectIsNull", return_value);
+
+  napi_set_named_property(env, object, NULL, object);
+  add_last_status(env, "keyIsNull", return_value);
+
+  napi_set_named_property(env, object, "key", NULL);
+  add_last_status(env, "valueIsNull", return_value);
+
+  return return_value;
+}
+
+static napi_value GetNamedProperty(napi_env env, napi_callback_info info) {
+  napi_value return_value, object, prop;
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NAPI_CALL(env, napi_create_object(env, &object));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      napi_get_named_property(NULL, object, "key", &prop));
+
+  napi_get_named_property(env, NULL, "key", &prop);
+  add_last_status(env, "objectIsNull", return_value);
+
+  napi_get_named_property(env, object, NULL, &prop);
+  add_last_status(env, "keyIsNull", return_value);
+
+  napi_get_named_property(env, object, "key", NULL);
+  add_last_status(env, "valueIsNull", return_value);
+
+  return return_value;
+}
+
+static napi_value HasNamedProperty(napi_env env, napi_callback_info info) {
+  napi_value return_value, object;
+  bool result;
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NAPI_CALL(env, napi_create_object(env, &object));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      napi_has_named_property(NULL, object, "key", &result));
+
+  napi_has_named_property(env, NULL, "key", &result);
+  add_last_status(env, "objectIsNull", return_value);
+
+  napi_has_named_property(env, object, NULL, &result);
+  add_last_status(env, "keyIsNull", return_value);
+
+  napi_has_named_property(env, object, "key", NULL);
+  add_last_status(env, "valueIsNull", return_value);
+
+  return return_value;
+}
+
+static napi_value SetElement(napi_env env, napi_callback_info info) {
+  napi_value return_value, object;
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NAPI_CALL(env, napi_create_object(env, &object));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      napi_set_element(NULL, object, 0, object));
+
+  napi_set_element(env, NULL, 0, object);
+  add_last_status(env, "objectIsNull", return_value);
+
+  napi_set_property(env, object, 0, NULL);
+  add_last_status(env, "valueIsNull", return_value);
+
+  return return_value;
+}
+
+static napi_value GetElement(napi_env env, napi_callback_info info) {
+  napi_value return_value, object, prop;
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NAPI_CALL(env, napi_create_object(env, &object));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      napi_get_element(NULL, object, 0, &prop));
+
+  napi_get_property(env, NULL, 0, &prop);
+  add_last_status(env, "objectIsNull", return_value);
+
+  napi_get_property(env, object, 0, NULL);
+  add_last_status(env, "valueIsNull", return_value);
+
+  return return_value;
+}
+
+static napi_value TestBoolValuedElementApi(napi_env env,
+    napi_status (*api)(napi_env, napi_value, uint32_t, bool*)) {
+  napi_value return_value, object;
+  bool result;
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NAPI_CALL(env, napi_create_object(env, &object));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      api(NULL, object, 0, &result));
+
+  api(env, NULL, 0, &result);
+  add_last_status(env, "objectIsNull", return_value);
+
+  api(env, object, 0, NULL);
+  add_last_status(env, "valueIsNull", return_value);
+
+  return return_value;
+}
+
+static napi_value HasElement(napi_env env, napi_callback_info info) {
+  return TestBoolValuedElementApi(env, napi_has_element);
+}
+
+static napi_value DeleteElement(napi_env env, napi_callback_info info) {
+  return TestBoolValuedElementApi(env, napi_delete_element);
+}
+
+static napi_value DefineProperties(napi_env env, napi_callback_info info) {
+  napi_value object, return_value;
+
+  napi_property_descriptor desc = {
+    "prop", NULL, DefineProperties, NULL, NULL, NULL, napi_enumerable, NULL
+  };
+
+  NAPI_CALL(env, napi_create_object(env, &object));
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      napi_define_properties(NULL, object, 1, &desc));
+
+  napi_define_properties(env, NULL, 1, &desc);
+  add_last_status(env, "objectIsNull", return_value);
+
+  napi_define_properties(env, object, 1, NULL);
+  add_last_status(env, "descriptorListIsNull", return_value);
+
+  desc.utf8name = NULL;
+  napi_define_properties(env, object, 1, NULL);
+  add_last_status(env, "utf8nameIsNull", return_value);
+  desc.utf8name = "prop";
+
+  desc.method = NULL;
+  napi_define_properties(env, object, 1, NULL);
+  add_last_status(env, "methodIsNull", return_value);
+  desc.method = DefineProperties;
+
+  return return_value;
+}
+
+static napi_value GetPropertyNames(napi_env env, napi_callback_info info) {
+  napi_value return_value, props;
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      napi_get_property_names(NULL, return_value, &props));
+
+  napi_get_property_names(env, NULL, &props);
+  add_last_status(env, "objectIsNull", return_value);
+
+  napi_get_property_names(env, return_value, NULL);
+  add_last_status(env, "valueIsNull", return_value);
+
+  return return_value;
+}
+
+static napi_value GetAllPropertyNames(napi_env env, napi_callback_info info) {
+  napi_value return_value, props;
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      napi_get_all_property_names(NULL,
+                                                  return_value,
+                                                  napi_key_own_only,
+                                                  napi_key_writable,
+                                                  napi_key_keep_numbers,
+                                                  &props));
+
+  napi_get_all_property_names(env,
+                              NULL,
+                              napi_key_own_only,
+                              napi_key_writable,
+                              napi_key_keep_numbers,
+                              &props);
+  add_last_status(env, "objectIsNull", return_value);
+
+  napi_get_all_property_names(env,
+                              return_value,
+                              napi_key_own_only,
+                              napi_key_writable,
+                              napi_key_keep_numbers,
+                              NULL);
+  add_last_status(env, "valueIsNull", return_value);
+
+  return return_value;
+}
+
+static napi_value GetPrototype(napi_env env, napi_callback_info info) {
+  napi_value return_value, proto;
+
+  NAPI_CALL(env, napi_create_object(env, &return_value));
+
+  add_returned_status(env,
+                      "envIsNull",
+                      return_value,
+                      "Invalid argument",
+                      napi_invalid_arg,
+                      napi_get_prototype(NULL, return_value, &proto));
+
+  napi_get_prototype(env, NULL, &proto);
+  add_last_status(env, "objectIsNull", return_value);
+
+  napi_get_prototype(env, return_value, NULL);
+  add_last_status(env, "valueIsNull", return_value);
+
+  return return_value;
+}
+
+void init_test_null(napi_env env, napi_value exports) {
+  napi_value test_null;
+
+  const napi_property_descriptor test_null_props[] = {
+    DECLARE_NAPI_PROPERTY("setProperty", SetProperty),
+    DECLARE_NAPI_PROPERTY("getProperty", GetProperty),
+    DECLARE_NAPI_PROPERTY("hasProperty", HasProperty),
+    DECLARE_NAPI_PROPERTY("hasOwnProperty", HasOwnProperty),
+    DECLARE_NAPI_PROPERTY("deleteProperty", DeleteProperty),
+    DECLARE_NAPI_PROPERTY("setNamedProperty", SetNamedProperty),
+    DECLARE_NAPI_PROPERTY("getNamedProperty", GetNamedProperty),
+    DECLARE_NAPI_PROPERTY("hasNamedProperty", HasNamedProperty),
+    DECLARE_NAPI_PROPERTY("setElement", SetElement),
+    DECLARE_NAPI_PROPERTY("getElement", GetElement),
+    DECLARE_NAPI_PROPERTY("hasElement", HasElement),
+    DECLARE_NAPI_PROPERTY("deleteElement", DeleteElement),
+    DECLARE_NAPI_PROPERTY("defineProperties", DefineProperties),
+    DECLARE_NAPI_PROPERTY("getPropertyNames", GetPropertyNames),
+    DECLARE_NAPI_PROPERTY("getAllPropertyNames", GetAllPropertyNames),
+    DECLARE_NAPI_PROPERTY("getPrototype", GetPrototype),
+  };
+
+  NAPI_CALL_RETURN_VOID(env, napi_create_object(env, &test_null));
+  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
+      env, test_null, sizeof(test_null_props) / sizeof(*test_null_props),
+      test_null_props));
+
+  const napi_property_descriptor test_null_set = {
+    "testNull", NULL, NULL, NULL, NULL, test_null, napi_enumerable, NULL
+  };
+
+  NAPI_CALL_RETURN_VOID(env,
+      napi_define_properties(env, exports, 1, &test_null_set));
+}

--- a/test/js-native-api/test_object/test_null.h
+++ b/test/js-native-api/test_object/test_null.h
@@ -1,0 +1,8 @@
+#ifndef TEST_JS_NATIVE_API_TEST_OBJECT_TEST_NULL_H_
+#define TEST_JS_NATIVE_API_TEST_OBJECT_TEST_NULL_H_
+
+#include <js_native_api.h>
+
+void init_test_null(napi_env env, napi_value exports);
+
+#endif  // TEST_JS_NATIVE_API_TEST_OBJECT_TEST_NULL_H_

--- a/test/js-native-api/test_object/test_null.js
+++ b/test/js-native-api/test_object/test_null.js
@@ -1,0 +1,52 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+
+// Test passing NULL to object-related N-APIs.
+const { testNull } = require(`./build/${common.buildType}/test_object`);
+
+const expectedForProperty = {
+  envIsNull: 'Invalid argument',
+  objectIsNull: 'Invalid argument',
+  keyIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument'
+};
+assert.deepStrictEqual(testNull.setProperty(), expectedForProperty);
+assert.deepStrictEqual(testNull.getProperty(), expectedForProperty);
+assert.deepStrictEqual(testNull.hasProperty(), expectedForProperty);
+assert.deepStrictEqual(testNull.hasOwnProperty(), expectedForProperty);
+// It's OK not to want the result of a deletion.
+assert.deepStrictEqual(testNull.deleteProperty(),
+                       Object.assign({},
+                                     expectedForProperty,
+                                     { valueIsNull: 'napi_ok' }));
+assert.deepStrictEqual(testNull.setNamedProperty(), expectedForProperty);
+assert.deepStrictEqual(testNull.getNamedProperty(), expectedForProperty);
+assert.deepStrictEqual(testNull.hasNamedProperty(), expectedForProperty);
+
+const expectedForElement = {
+  envIsNull: 'Invalid argument',
+  objectIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument'
+};
+assert.deepStrictEqual(testNull.setElement(), expectedForElement);
+assert.deepStrictEqual(testNull.getElement(), expectedForElement);
+assert.deepStrictEqual(testNull.hasElement(), expectedForElement);
+// It's OK not to want the result of a deletion.
+assert.deepStrictEqual(testNull.deleteElement(),
+                       Object.assign({},
+                                     expectedForElement,
+                                     { valueIsNull: 'napi_ok' }));
+
+assert.deepStrictEqual(testNull.defineProperties(), {
+  envIsNull: 'Invalid argument',
+  objectIsNull: 'Invalid argument',
+  descriptorListIsNull: 'Invalid argument',
+  utf8nameIsNull: 'Invalid argument',
+  methodIsNull: 'Invalid argument',
+});
+
+// `expectedForElement` also works for the APIs below.
+assert.deepStrictEqual(testNull.getPropertyNames(), expectedForElement);
+assert.deepStrictEqual(testNull.getAllPropertyNames(), expectedForElement);
+assert.deepStrictEqual(testNull.getPrototype(), expectedForElement);

--- a/test/js-native-api/test_object/test_object.c
+++ b/test/js-native-api/test_object/test_object.c
@@ -3,6 +3,7 @@
 #include <js_native_api.h>
 #include "../common.h"
 #include <string.h>
+#include "test_null.h"
 
 static int test_value = 3;
 
@@ -493,6 +494,8 @@ napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NAPI_PROPERTY("TestHasProperty", TestHasProperty),
     DECLARE_NAPI_PROPERTY("TestGetProperty", TestGetProperty),
   };
+
+  init_test_null(env, exports);
 
   NAPI_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));


### PR DESCRIPTION
Add test coverage for passing `NULL` to each parameter of
`napi.*(propert|element)`. In the case of `napi_define_properties` also
test setting various initializer fields to `NULL`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
