### PR TITLE
buffer: improve fill(number) performance

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -34,9 +34,12 @@ const {
   ObjectCreate,
   ObjectDefineProperties,
   ObjectDefineProperty,
+  ObjectGetOwnPropertyDescriptor,
+  ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
   SymbolSpecies,
   SymbolToPrimitive,
+  Uint8ArrayPrototype,
 } = primordials;
 
 const {
@@ -100,6 +103,13 @@ const {
   FastBuffer,
   addBufferPrototypeMethods
 } = require('internal/buffer');
+
+const TypedArrayPrototype = ObjectGetPrototypeOf(Uint8ArrayPrototype);
+
+const TypedArrayProto_byteLength =
+      ObjectGetOwnPropertyDescriptor(TypedArrayPrototype,
+                                     'byteLength').get;
+const TypedArrayFill = TypedArrayPrototype.fill;
 
 FastBuffer.prototype.constructor = Buffer;
 Buffer.prototype = FastBuffer.prototype;
@@ -1001,11 +1011,22 @@ function _fill(buf, value, offset, end, encoding) {
       return buf;
   }
 
-  const res = bindingFill(buf, value, offset, end, encoding);
-  if (res < 0) {
-    if (res === -1)
-      throw new ERR_INVALID_ARG_VALUE('value', value);
-    throw new ERR_BUFFER_OUT_OF_BOUNDS();
+
+  if (typeof value === 'number') {
+    // OOB check
+    const byteLen = TypedArrayProto_byteLength.call(buf);
+    const fillLength = end - offset;
+    if (offset > end || fillLength + offset > byteLen)
+      throw new ERR_BUFFER_OUT_OF_BOUNDS();
+
+    TypedArrayFill.call(buf, value, offset, end);
+  } else {
+    const res = bindingFill(buf, value, offset, end, encoding);
+    if (res < 0) {
+      if (res === -1)
+        throw new ERR_INVALID_ARG_VALUE('value', value);
+      throw new ERR_BUFFER_OUT_OF_BOUNDS();
+    }
   }
 
   return buf;


### PR DESCRIPTION
Uses the native `typedArray.fill()` when filling with a number instead of calling into the binding fill function.

Benchmark results:

```
                                                                            confidence improvement accuracy (*)   (**)  (***)
 buffers/buffer-fill.js n=20000 size=65536 type='fill("")'                        ***      4.72 %       ±0.90% ±1.20% ±1.57%
 buffers/buffer-fill.js n=20000 size=65536 type='fill("t", "utf8")'               ***      3.76 %       ±1.00% ±1.34% ±1.74%
 buffers/buffer-fill.js n=20000 size=65536 type='fill("t", 0, "utf8")'            ***      4.30 %       ±0.74% ±0.99% ±1.29%
 buffers/buffer-fill.js n=20000 size=65536 type='fill("t", 0)'                    ***      5.56 %       ±0.90% ±1.20% ±1.56%
 buffers/buffer-fill.js n=20000 size=65536 type='fill("t")'                       ***      4.51 %       ±1.01% ±1.35% ±1.77%
 buffers/buffer-fill.js n=20000 size=65536 type='fill("test")'                             0.18 %       ±0.50% ±0.67% ±0.87%
 buffers/buffer-fill.js n=20000 size=65536 type='fill(0)'                         ***      4.10 %       ±0.84% ±1.12% ±1.46%
 buffers/buffer-fill.js n=20000 size=65536 type='fill(100)'                       ***      4.75 %       ±0.97% ±1.30% ±1.69%
 buffers/buffer-fill.js n=20000 size=65536 type='fill(400)'                       ***      5.17 %       ±1.12% ±1.50% ±1.95%
 buffers/buffer-fill.js n=20000 size=65536 type='fill(Buffer.alloc(1), 0)'                -0.50 %       ±0.66% ±0.88% ±1.15%
 buffers/buffer-fill.js n=20000 size=8192 type='fill("")'                         ***     17.23 %       ±1.65% ±2.20% ±2.86%
 buffers/buffer-fill.js n=20000 size=8192 type='fill("t", "utf8")'                ***     12.32 %       ±1.62% ±2.18% ±2.87%
 buffers/buffer-fill.js n=20000 size=8192 type='fill("t", 0, "utf8")'             ***     13.12 %       ±2.05% ±2.73% ±3.56%
 buffers/buffer-fill.js n=20000 size=8192 type='fill("t", 0)'                     ***     18.16 %       ±1.00% ±1.33% ±1.74%
 buffers/buffer-fill.js n=20000 size=8192 type='fill("t")'                        ***     12.18 %       ±1.64% ±2.18% ±2.86%
 buffers/buffer-fill.js n=20000 size=8192 type='fill("test")'                             -0.34 %       ±1.20% ±1.59% ±2.08%
 buffers/buffer-fill.js n=20000 size=8192 type='fill(0)'                          ***     26.16 %       ±2.99% ±3.99% ±5.21%
 buffers/buffer-fill.js n=20000 size=8192 type='fill(100)'                        ***     28.79 %       ±1.14% ±1.52% ±1.98%
 buffers/buffer-fill.js n=20000 size=8192 type='fill(400)'                        ***     28.91 %       ±1.20% ±1.60% ±2.08%
 buffers/buffer-fill.js n=20000 size=8192 type='fill(Buffer.alloc(1), 0)'                 -0.40 %       ±1.31% ±1.75% ±2.28%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
