### PR TITLE
process: fix two overflow cases in SourceMap VLQ decoding

### DIFF
--- a/lib/internal/source_map/source_map.js
+++ b/lib/internal/source_map/source_map.js
@@ -310,13 +310,12 @@ function decodeVLQ(stringCharIterator) {
     return result;
   }
 
-  // We need to OR 0x80000000 here to ensure the 32nd bit (the sign bit in a
-  // 32bit int) is always set for negative numbers. If `result` were 1,
-  // (meaning `negate` is true and all other bits were zeros), `result` would
-  // now be 0. But -0 doesn't flip the 32nd bit as intended. All other numbers
-  // will successfully set the 32nd bit without issue, so doing this is a noop
-  // for them.
-  return -result | 0x80000000;
+  // We need to OR here to ensure the 32nd bit (the sign bit in an Int32) is
+  // always set for negative numbers. If `result` were 1, (meaning `negate` is
+  // true and all other bits were zeros), `result` would now be 0. But -0
+  // doesn't flip the 32nd bit as intended. All other numbers will successfully
+  // set the 32nd bit without issue, so doing this is a noop for them.
+  return -result | (1 << 31);
 }
 
 /**

--- a/lib/internal/source_map/source_map.js
+++ b/lib/internal/source_map/source_map.js
@@ -303,8 +303,20 @@ function decodeVLQ(stringCharIterator) {
 
   // Fix the sign.
   const negative = result & 1;
-  result >>= 1;
-  return negative ? -result : result;
+  // Use unsigned right shift, so that the 32nd bit is properly shifted to the
+  // 31st, and the 32nd becomes unset.
+  result >>>= 1;
+  if (!negative) {
+    return result;
+  }
+
+  // We need to OR 0x80000000 here to ensure the 32nd bit (the sign bit in a
+  // 32bit int) is always set for negative numbers. If `result` were 1,
+  // (meaning `negate` is true and all other bits were zeros), `result` would
+  // now be 0. But -0 doesn't flip the 32nd bit as intended. All other numbers
+  // will successfully set the 32nd bit without issue, so doing this is a noop
+  // for them.
+  return -result | 0x80000000;
 }
 
 /**


### PR DESCRIPTION
These both have to do with extremely large numbers, so it's unlikely to cause a problem in practice. Still, correctness.

First, encoding `-2147483648` in VLQ returns the value `"B"`. When decoding, we get the value `1` after reading the base64. We then check if the first bit is set (it is) to see if we should negate it, then we shift all bits right once. Now, `value` will be `0` and `negate` will be `true`. So, we'd return `-0`. Which is a bug! `-0` isn't `-2147483648`, and we've broken a round trip.

Second, encoding any number with the 31st bit set, we'd return the opposite sign. Let's use `1073741824`. Encoding, we get `"ggggggC"`. When decoding, we get the value `-2147483648` after reading the base64. Notice, it's already negative (the 32nd bit is set, because the 31st was set and we shifted everything left once). We'd then check the first bit (it's not) and shift right. But we used `>>`, which does not shift the sign bit. We actually wanted `>>>`, which will. Because of that bug, we get back `-1073741824` instead of the positive `1073741824`. It's even worse if the 32nd and 31st bits are set, `-1610612736` becomes `536870912` after a round trip.

I recently fixed the same two bugs in Closure Compiler: https://github.com/google/closure-compiler/commit/584418eb

/cc @bcoe 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
