### PR TITLE
test: fix test-heapdump-worker

### DIFF
--- a/test/pummel/test-heapdump-worker.js
+++ b/test/pummel/test-heapdump-worker.js
@@ -9,7 +9,6 @@ const worker = new Worker('setInterval(() => {}, 100);', { eval: true });
 validateSnapshotNodes('Node / Worker', [
   {
     children: [
-      { node_name: 'Node / AsyncRequest', edge_name: 'on_thread_finished_' },
       { node_name: 'Node / MessagePort', edge_name: 'parent_port' },
       { node_name: 'Worker', edge_name: 'wrapped' }
     ]


### PR DESCRIPTION
This test was broken by de2c68c7dd17a217a818ea881e433034006fdb4b.

Refs: https://github.com/nodejs/node/pull/31386

/cc @trott

Also, this fix is almost identical to ed60e863e74786dfb1f868f2a17c939843b64c25 … maybe we should have at least one platform/job running the full test suite in CI?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
