### PR TITLE
deps: uvwasi: cherry-pick 7b5b6f9

### DIFF
--- a/deps/uvwasi/src/uv_mapping.c
+++ b/deps/uvwasi/src/uv_mapping.c
@@ -249,8 +249,15 @@ uvwasi_errno_t uvwasi__get_filetype_by_fd(uv_file fd, uvwasi_filetype_t* type) {
 
   r = uv_fs_fstat(NULL, &req, fd, NULL);
   if (r != 0) {
-    *type = UVWASI_FILETYPE_UNKNOWN;
     uv_fs_req_cleanup(&req);
+
+    /* Windows can't stat a TTY. */
+    if (uv_guess_handle(fd) == UV_TTY) {
+      *type = UVWASI_FILETYPE_CHARACTER_DEVICE;
+      return UVWASI_ESUCCESS;
+    }
+
+    *type = UVWASI_FILETYPE_UNKNOWN;
     return uvwasi__translate_uv_error(r);
   }
 


### PR DESCRIPTION
Original commit message:

    allow windows to detect tty types

    uv_fs_fstat() fails on TTYs on Windows. This commit updates
    uvwasi__get_filetype_by_fd() to detect this case and map
    the fd to the WASI character device type.

    Refs: https://github.com/nodejs/node/issues/31461

Fixes: https://github.com/nodejs/node/issues/31461

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)