### PR TITLE
src,http2: simplify native immediate queue running and harden http2 test

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -685,13 +685,11 @@ void Environment::RunAndClearNativeImmediates(bool only_refed) {
     native_immediates_.ConcatMove(std::move(native_immediates_threadsafe_));
   }
 
-  NativeImmediateQueue queue;
-  queue.ConcatMove(std::move(native_immediates_));
-
   auto drain_list = [&]() {
     TryCatchScope try_catch(this);
     DebugSealHandleScope seal_handle_scope(isolate());
-    while (std::unique_ptr<NativeImmediateCallback> head = queue.Shift()) {
+    while (std::unique_ptr<NativeImmediateCallback> head =
+               native_immediates_.Shift()) {
       if (head->is_refed())
         ref_count++;
 
@@ -709,7 +707,7 @@ void Environment::RunAndClearNativeImmediates(bool only_refed) {
     }
     return false;
   };
-  while (queue.size() > 0 && drain_list()) {}
+  while (drain_list()) {}
 
   immediate_info()->ref_count_dec(ref_count);
 


### PR DESCRIPTION
##### test: make test-http2-buffersize more correct

Previously, this code could have closed the server before the
connection was actually received by the server, as the `'close'`
event on the client side can be emitted before the connection
is established.

The following commit exacerbates this problem, so fix the test first.

##### src: simplify native immediate queue running

Make `SetImmediate()` behave more like `process.nextTick()`
(which matches how we use it) by also running tasks that have been
added during previous `SetImmediate()` calls.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
