### PR TITLE
fs: recursion should bail on permission error

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1247,6 +1247,7 @@ int MKDirpSync(uv_loop_t* loop,
         case UV_EPERM: {
           uv_fs_req_cleanup(req);
           return err;
+          break;
         }
         default:
           uv_fs_req_cleanup(req);
@@ -1323,6 +1324,7 @@ int MKDirpAsync(uv_loop_t* loop,
         case UV_EACCES:
         case UV_EPERM: {
           req_wrap->continuation_data()->Done(err);
+          uv_fs_req_cleanup(req);
           break;
         }
         default:

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1246,6 +1246,9 @@ int MKDirpSync(uv_loop_t* loop,
         case UV_EPERM: {
           return err;
         }
+        case UV_EACCES: {
+          return err;
+        }
         default:
           uv_fs_req_cleanup(req);
           int orig_err = err;
@@ -1319,6 +1322,10 @@ int MKDirpAsync(uv_loop_t* loop,
           break;
         }
         case UV_EPERM: {
+          req_wrap->continuation_data()->Done(err);
+          break;
+        }
+        case UV_EACCES: {
           req_wrap->continuation_data()->Done(err);
           break;
         }

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1243,10 +1243,9 @@ int MKDirpSync(uv_loop_t* loop,
           }
           break;
         }
+        case UV_EACCES:
         case UV_EPERM: {
-          return err;
-        }
-        case UV_EACCES: {
+          uv_fs_req_cleanup(req);
           return err;
         }
         default:
@@ -1321,11 +1320,8 @@ int MKDirpAsync(uv_loop_t* loop,
                       req_wrap->continuation_data()->mode(), nullptr);
           break;
         }
+        case UV_EACCES:
         case UV_EPERM: {
-          req_wrap->continuation_data()->Done(err);
-          break;
-        }
-        case UV_EACCES: {
           req_wrap->continuation_data()->Done(err);
           break;
         }

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1226,11 +1226,17 @@ int MKDirpSync(uv_loop_t* loop,
     int err = uv_fs_mkdir(loop, req, next_path.c_str(), mode, nullptr);
     while (true) {
       switch (err) {
+        // Note: uv_fs_req_cleanup in terminal paths will be called by
+        // ~FSReqWrapSync():
         case 0:
           if (continuation_data.paths().size() == 0) {
             return 0;
           }
           break;
+        case UV_EACCES:
+        case UV_EPERM: {
+          return err;
+        }
         case UV_ENOENT: {
           std::string dirname = next_path.substr(0,
                                         next_path.find_last_of(kPathSeparator));
@@ -1241,12 +1247,6 @@ int MKDirpSync(uv_loop_t* loop,
             err = UV_EEXIST;
             continue;
           }
-          break;
-        }
-        case UV_EACCES:
-        case UV_EPERM: {
-          uv_fs_req_cleanup(req);
-          return err;
           break;
         }
         default:
@@ -1296,6 +1296,8 @@ int MKDirpAsync(uv_loop_t* loop,
 
     while (true) {
       switch (err) {
+        // Note: uv_fs_req_cleanup in terminal paths will be called by
+        // FSReqAfterScope::~FSReqAfterScope()
         case 0: {
           if (req_wrap->continuation_data()->paths().size() == 0) {
             req_wrap->continuation_data()->Done(0);
@@ -1304,6 +1306,11 @@ int MKDirpAsync(uv_loop_t* loop,
             MKDirpAsync(loop, req, path.c_str(),
                         req_wrap->continuation_data()->mode(), nullptr);
           }
+          break;
+        }
+        case UV_EACCES:
+        case UV_EPERM: {
+          req_wrap->continuation_data()->Done(err);
           break;
         }
         case UV_ENOENT: {
@@ -1319,12 +1326,6 @@ int MKDirpAsync(uv_loop_t* loop,
           uv_fs_req_cleanup(req);
           MKDirpAsync(loop, req, path.c_str(),
                       req_wrap->continuation_data()->mode(), nullptr);
-          break;
-        }
-        case UV_EACCES:
-        case UV_EPERM: {
-          req_wrap->continuation_data()->Done(err);
-          uv_fs_req_cleanup(req);
           break;
         }
         default:

--- a/test/parallel/test-fs-mkdir-recursive-eaccess.js
+++ b/test/parallel/test-fs-mkdir-recursive-eaccess.js
@@ -36,7 +36,7 @@ function makeDirectoryReadOnly(dir) {
 
 function makeDirectoryWritable(dir) {
   if (common.isWindows) {
-    execSync(`icacls ${dir} /inheritance:e`);
+    execSync(`icacls ${dir} /grant "everyone":W`);
   }
 }
 

--- a/test/parallel/test-fs-mkdir-recursive-eaccess.js
+++ b/test/parallel/test-fs-mkdir-recursive-eaccess.js
@@ -28,8 +28,10 @@ let n = 0;
   fs.chmodSync(dir, '444');
   let err = null;
   try {
+    console.log('31: mkdirsync');
     fs.mkdirSync(path.join(dir, '/foo'), { recursive: true });
   } catch (_err) {
+    console.log('34: mkdirsync', err);
     err = _err;
   }
   assert(err);
@@ -42,7 +44,9 @@ let n = 0;
   const dir = path.join(tmpdir.path, `mkdirp_${n++}`);
   fs.mkdirSync(dir);
   fs.chmodSync(dir, '444');
+  console.log('47: mkdir');
   fs.mkdir(path.join(dir, '/bar'), { recursive: true }, (err) => {
+    console.log('49: mkdir', err);
     assert(err);
     assert.strictEqual(err.code, 'EACCES');
     assert(err.path);

--- a/test/parallel/test-fs-mkdir-recursive-eaccess.js
+++ b/test/parallel/test-fs-mkdir-recursive-eaccess.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// Test that mkdir with recursive option returns appropriate error
+// when executed on folder it does not have permission to access.
+// Ref: https://github.com/nodejs/node/issues/31481
+
+const common = require('../common');
+
+if (!common.isWindows && process.getuid() === 0)
+  common.skip('as this test should not be run as `root`');
+
+if (common.isIBMi)
+  common.skip('IBMi has a different access permission mechanism');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+let n = 0;
+
+// Synchronous API should return an EACCESS error with path populated.
+{
+  const dir = path.join(tmpdir.path, `mkdirp_${n++}`);
+  fs.mkdirSync(dir);
+  fs.chmodSync(dir, '444');
+  let err = null;
+  try {
+    fs.mkdirSync(path.join(dir, '/foo'), { recursive: true });
+  } catch (_err) {
+    err = _err;
+  }
+  assert(err);
+  assert.strictEqual(err.code, 'EACCES');
+  assert(err.path);
+}
+
+// Asynchronous API should return an EACCESS error with path populated.
+{
+  const dir = path.join(tmpdir.path, `mkdirp_${n++}`);
+  fs.mkdirSync(dir);
+  fs.chmodSync(dir, '444');
+  fs.mkdir(path.join(dir, '/bar'), { recursive: true }, (err) => {
+    assert(err);
+    assert.strictEqual(err.code, 'EACCES');
+    assert(err.path);
+  });
+}

--- a/test/parallel/test-fs-mkdir-recursive-eaccess.js
+++ b/test/parallel/test-fs-mkdir-recursive-eaccess.js
@@ -28,10 +28,8 @@ let n = 0;
   fs.chmodSync(dir, '444');
   let err = null;
   try {
-    console.log('31: mkdirsync');
     fs.mkdirSync(path.join(dir, '/foo'), { recursive: true });
   } catch (_err) {
-    console.log('34: mkdirsync', err);
     err = _err;
   }
   assert(err);
@@ -44,9 +42,7 @@ let n = 0;
   const dir = path.join(tmpdir.path, `mkdirp_${n++}`);
   fs.mkdirSync(dir);
   fs.chmodSync(dir, '444');
-  console.log('47: mkdir');
   fs.mkdir(path.join(dir, '/bar'), { recursive: true }, (err) => {
-    console.log('49: mkdir', err);
     assert(err);
     assert.strictEqual(err.code, 'EACCES');
     assert(err.path);


### PR DESCRIPTION
When creating directories recursively, the logic should bail immediately on UV_EACCES and bubble the error to the user.

Fixes: #31481

CC: @isaacs

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
