### PR TITLE
[v10.x] deps: V8: backport b28637b4fe

### DIFF
--- a/deps/v8/src/compiler/load-elimination.cc
+++ b/deps/v8/src/compiler/load-elimination.cc
@@ -21,7 +21,7 @@ bool IsRename(Node* node) {
   switch (node->opcode()) {
     case IrOpcode::kFinishRegion:
     case IrOpcode::kTypeGuard:
-      return true;
+      return !node->IsDead();
     default:
       return false;
   }

--- a/deps/v8/test/mjsunit/regress/regress-906406.js
+++ b/deps/v8/test/mjsunit/regress/regress-906406.js
@@ -1,0 +1,7 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+for (x = 0; x < 10000; ++x) {
+    [(x) => x, [, 4294967295].find((x) => x), , 2].includes('x', -0);
+}


### PR DESCRIPTION
Original commit message:

    Apply duct-tape to load elimination

    Load elimination is running together with to dead code elimination,
    the latter of which might eliminate allocations (in particular
    FinishRegion nodes). These are treated as alias nodes by load
    elimination, and load elimination does not immediatelly learn that
    a node has been disconnected. This causes load elimination to access
    the inputs of dead code eliminated nodes while resolving renames,
    which causes nullptr dereferences.

    This CL modifies load elimination to not resolve to a nullptr alias
    but simply stop before that.

    Change-Id: If4cef061c7c0e25f353727c9e27f790439b0beb5
    Bug: chromium:906406
    Reviewed-on: https://chromium-review.googlesource.com/c/1346491
    Commit-Queue: Sigurd Schneider <sigurds@chromium.org>
    Reviewed-by: Jaroslav Sevcik <jarin@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#57688}

~~Fixes: https://github.com/nodejs/node/issues/31484~~
V8 CI: https://ci.nodejs.org/job/node-test-commit-v8-linux/2819/