### PR TITLE
stream: finished should invoke callback for closed streams

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -147,6 +147,9 @@ function ReadableState(options, stream, isDuplex) {
   // Indicates whether the stream has errored.
   this.errored = false;
 
+  // Indicates whether the stream has finished destroying.
+  this.closed = false;
+
   // Crypto is kind of old and crusty.  Historically, its default string
   // encoding is 'binary' so we have to make this configurable.
   // Everything else in the universe uses 'utf8', though.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -175,6 +175,9 @@ function WritableState(options, stream, isDuplex) {
   // is disabled we need a way to tell whether the stream has failed.
   this.errored = false;
 
+  // Indicates whether the stream has finished destroying.
+  this.closed = false;
+
   // Count buffered requests
   this.bufferedRequestCount = 0;
 

--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -67,16 +67,6 @@ function finish(self, err) {
   return new Promise((resolve, reject) => {
     const stream = self[kStream];
 
-    // TODO(ronag): Remove this check once finished() handles
-    // already ended and/or destroyed streams.
-    const ended = stream.destroyed || stream.readableEnded ||
-      (stream._readableState && stream._readableState.endEmitted);
-
-    if (ended) {
-      resolve(createIterResult(undefined, true));
-      return;
-    }
-
     finished(stream, (err) => {
       if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
         reject(err);

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -48,6 +48,13 @@ function destroy(err, cb) {
       }
     }
 
+    if (w) {
+      w.closed = true;
+    }
+    if (r) {
+      r.closed = true;
+    }
+
     if (cb) {
       // Invoke callback before scheduling emitClose so that callback
       // can schedule before.
@@ -101,6 +108,7 @@ function undestroy() {
   const w = this._writableState;
 
   if (r) {
+    r.closed = false;
     r.destroyed = false;
     r.errored = false;
     r.reading = false;
@@ -110,6 +118,7 @@ function undestroy() {
   }
 
   if (w) {
+    w.closed = false;
     w.destroyed = false;
     w.errored = false;
     w.ended = false;

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -88,13 +88,8 @@ function eos(stream, opts, callback) {
         err = new ERR_STREAM_PREMATURE_CLOSE();
       return callback.call(stream, err);
     }
-<<<<<<< HEAD
     if (writable && !writableFinished) {
       if (!isWritableFinished(stream))
-=======
-    if (writable && !writableEnded) {
-      if (!wState || !wState.ended)
->>>>>>> stream: finished should invoke callback for closed streams
         err = new ERR_STREAM_PREMATURE_CLOSE();
       return callback.call(stream, err);
     }

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -32,6 +32,8 @@ function isWritableFinished(stream) {
   return wState.finished || (wState.ended && wState.length === 0);
 }
 
+function nop() {}
+
 function eos(stream, opts, callback) {
   if (arguments.length === 2) {
     callback = opts;
@@ -52,12 +54,15 @@ function eos(stream, opts, callback) {
   let writable = opts.writable ||
     (opts.writable !== false && isWritable(stream));
 
+  const wState = stream._writableState;
+  const rState = stream._readableState;
+
   const onlegacyfinish = () => {
     if (!stream.writable) onfinish();
   };
 
   let writableFinished = stream.writableFinished ||
-    (stream._writableState && stream._writableState.finished);
+    (rState && rState.finished);
   const onfinish = () => {
     writable = false;
     writableFinished = true;
@@ -65,7 +70,7 @@ function eos(stream, opts, callback) {
   };
 
   let readableEnded = stream.readableEnded ||
-    (stream._readableState && stream._readableState.endEmitted);
+    (rState && rState.endEmitted);
   const onend = () => {
     readable = false;
     readableEnded = true;
@@ -79,12 +84,17 @@ function eos(stream, opts, callback) {
   const onclose = () => {
     let err;
     if (readable && !readableEnded) {
-      if (!stream._readableState || !stream._readableState.ended)
+      if (!rState || !rState.ended)
         err = new ERR_STREAM_PREMATURE_CLOSE();
       return callback.call(stream, err);
     }
+<<<<<<< HEAD
     if (writable && !writableFinished) {
       if (!isWritableFinished(stream))
+=======
+    if (writable && !writableEnded) {
+      if (!wState || !wState.ended)
+>>>>>>> stream: finished should invoke callback for closed streams
         err = new ERR_STREAM_PREMATURE_CLOSE();
       return callback.call(stream, err);
     }
@@ -99,7 +109,7 @@ function eos(stream, opts, callback) {
     stream.on('abort', onclose);
     if (stream.req) onrequest();
     else stream.on('request', onrequest);
-  } else if (writable && !stream._writableState) { // legacy streams
+  } else if (writable && !wState) { // legacy streams
     stream.on('end', onlegacyfinish);
     stream.on('close', onlegacyfinish);
   }
@@ -114,7 +124,24 @@ function eos(stream, opts, callback) {
   if (opts.error !== false) stream.on('error', onerror);
   stream.on('close', onclose);
 
+  const closed = (wState && wState.closed) || (rState && rState.closed) ||
+    (wState && wState.errorEmitted) || (rState && rState.errorEmitted) ||
+    (wState && wState.finished) || (rState && rState.endEmitted) ||
+    (rState && stream.req && stream.aborted);
+
+  if (closed) {
+    // TODO(ronag): Re-throw error if errorEmitted?
+    // TODO(ronag): Throw premature close as if finished was called?
+    // before being closed? i.e. if closed but not errored, ended or finished.
+    // TODO(ronag): Throw some kind of error? Does it make sense
+    // to call finished() on a "finished" stream?
+    process.nextTick(() => {
+      callback();
+    });
+  }
+
   return function() {
+    callback = nop;
     stream.removeListener('aborted', onclose);
     stream.removeListener('complete', onfinish);
     stream.removeListener('abort', onclose);


### PR DESCRIPTION
Previously finished(stream, cb) would not invoke the callback for streams
that have already finished, ended or errored before being
passed to finished(stream, cb).

Ref: https://github.com/nodejs/node/pull/31508
Ref: https://github.com/nodejs/node/pull/31314#issuecomment-578397279

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
