### PR TITLE
tls: Fix crash when internal debug enabled

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -89,7 +89,7 @@ TLSWrap::~TLSWrap() {
 
 
 bool TLSWrap::InvokeQueued(int status, const char* error_str) {
-  Debug(this, "InvokeQueued(%d, %s)", status, error_str);
+  Debug(this, "InvokeQueued(%d, %s)", status, error_str ? error_str : "");
   if (!write_callback_scheduled_)
     return false;
 


### PR DESCRIPTION
When NODE_DEBUG_NATIVE is enabled for tls a debug statement
is sometimes called with error_str set to null, this causes
a crash from glibc since string format parameters should not
be null.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]