### PR TITLE
lib: delete dead code in SourceMap

### DIFF
--- a/lib/internal/source_map/source_map.js
+++ b/lib/internal/source_map/source_map.js
@@ -121,7 +121,6 @@ class StringCharIterator {
  */
 class SourceMap {
   #payload;
-  #reverseMappingsBySourceURL = [];
   #mappings = [];
   #sources = {};
   #sourceContentByURL = {};
@@ -261,19 +260,6 @@ class SourceMap {
 
       this.#mappings.push([lineNumber, columnNumber, sourceURL,
                            sourceLineNumber, sourceColumnNumber]);
-    }
-
-    for (let i = 0; i < this.#mappings.length; ++i) {
-      const mapping = this.#mappings[i];
-      const url = mapping[2];
-      if (!url)
-        continue;
-      if (!this.#reverseMappingsBySourceURL[url])
-        this.#reverseMappingsBySourceURL[url] = [];
-      const reverseMappings = this.#reverseMappingsBySourceURL[url];
-      const sourceLine = mapping[3];
-      if (!reverseMappings[sourceLine])
-        reverseMappings[sourceLine] = [mapping[0], mapping[1]];
     }
   };
 }


### PR DESCRIPTION
This seems to be a leftover from the chromium project. Nothing uses
`#reverseMappingsBySourceURL`, so constructing it isn't necessary.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
