### PR TITLE
src: rename conflicting Reallocate() method

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -117,11 +117,11 @@ void DebuggingArrayBufferAllocator::Free(void* data, size_t size) {
   NodeArrayBufferAllocator::Free(data, size);
 }
 
-void* DebuggingArrayBufferAllocator::Reallocate(void* data,
-                                                size_t old_size,
-                                                size_t size) {
+void* DebuggingArrayBufferAllocator::TryReallocate(void* data,
+                                                   size_t old_size,
+                                                   size_t size) {
   Mutex::ScopedLock lock(mutex_);
-  void* ret = NodeArrayBufferAllocator::Reallocate(data, old_size, size);
+  void* ret = NodeArrayBufferAllocator::TryReallocate(data, old_size, size);
   if (ret == nullptr) {
     if (size == 0)  // i.e. equivalent to free().
       UnregisterPointerInternal(data, old_size);

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -112,7 +112,7 @@ class NodeArrayBufferAllocator : public ArrayBufferAllocator {
   void* AllocateUninitialized(size_t size) override
     { return node::UncheckedMalloc(size); }
   void Free(void* data, size_t) override { free(data); }
-  virtual void* Reallocate(void* data, size_t old_size, size_t size) {
+  virtual void* TryReallocate(void* data, size_t old_size, size_t size) {
     return static_cast<void*>(
         UncheckedRealloc<char>(static_cast<char*>(data), size));
   }
@@ -131,7 +131,7 @@ class DebuggingArrayBufferAllocator final : public NodeArrayBufferAllocator {
   void* Allocate(size_t size) override;
   void* AllocateUninitialized(size_t size) override;
   void Free(void* data, size_t size) override;
-  void* Reallocate(void* data, size_t old_size, size_t size) override;
+  void* TryReallocate(void* data, size_t old_size, size_t size) override;
   void RegisterPointer(void* data, size_t size) override;
   void UnregisterPointer(void* data, size_t size) override;
 


### PR DESCRIPTION
Upcoming V8 changes add v8::ArrayBuffer::Allocator::Reallocate() that
conflicts with our existing Reallocate() method in classes that inherit
from v8::ArrayBuffer::Allocator.

Rename our method to TryReallocate(). That also describes its behavior
more accurately.

Refs: https://chromium-review.googlesource.com/c/v8/v8/+/2007274