### PR TITLE
debug: Fix crash handling null strings

### DIFF
--- a/src/debug_utils-inl.h
+++ b/src/debug_utils-inl.h
@@ -21,7 +21,9 @@ struct ToStringHelper {
                 enable_if<std::is_arithmetic<T>::value, bool>::type,
             typename dummy = bool>
   static std::string Convert(const T& value) { return std::to_string(value); }
-  static std::string Convert(const char* value) { return value; }
+  static std::string Convert(const char* value) {
+    return value ? value : "(null)";
+  }
   static std::string Convert(const std::string& value) { return value; }
   static std::string Convert(bool value) { return value ? "true" : "false"; }
 };

--- a/src/debug_utils-inl.h
+++ b/src/debug_utils-inl.h
@@ -22,7 +22,7 @@ struct ToStringHelper {
             typename dummy = bool>
   static std::string Convert(const T& value) { return std::to_string(value); }
   static std::string Convert(const char* value) {
-    return value ? value : "(null)";
+    return value != nullptr ? value : "(null)";
   }
   static std::string Convert(const std::string& value) { return value; }
   static std::string Convert(bool value) { return value ? "true" : "false"; }

--- a/test/cctest/test_util.cc
+++ b/test/cctest/test_util.cc
@@ -281,6 +281,7 @@ TEST(UtilTest, SPrintF) {
   const char* bar = "bar";
   EXPECT_EQ(SPrintF("%s %s", foo, "bar"), "foo bar");
   EXPECT_EQ(SPrintF("%s %s", foo, bar), "foo bar");
+  EXPECT_EQ(SPrintF("%s", nullptr), "(null)");
 
   EXPECT_EQ(SPrintF("[%% %s %%]", foo), "[% foo %]");
 


### PR DESCRIPTION
When internal debug is enabled output null strings as
"(null)" rather than crashing matching glibc's behavior.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows 