### PR TITLE
src: fix ignore GCC -Wcast-function-type for older compilers

### DIFF
--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -28,12 +28,12 @@
 #include "env-inl.h"
 #include "util.h"
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if (__GNUC__ >= 8) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
 #include "v8.h"
-#if defined(__GNUC__) && !defined(__clang__)
+#if (__GNUC__ >= 8) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/node.h
+++ b/src/node.h
@@ -60,14 +60,15 @@
 # define SIGKILL 9
 #endif
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if (__GNUC__ >= 8) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
 #include "v8.h"  // NOLINT(build/include_order)
-#if defined(__GNUC__) && !defined(__clang__)
+#if (__GNUC__ >= 8) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
+
 #include "v8-platform.h"  // NOLINT(build/include_order)
 #include "node_version.h"  // NODE_MODULE_VERSION
 

--- a/src/util.h
+++ b/src/util.h
@@ -24,12 +24,12 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if (__GNUC__ >= 8) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
 #include "v8.h"
-#if defined(__GNUC__) && !defined(__clang__)
+#if (__GNUC__ >= 8) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/31517

I don't have an easy access to pre-8 GCC compiler so I haven't explicitly tested this. Perhaps @mscdex can check if this fixes your issue?


GCC8 changelog https://gcc.gnu.org/gcc-8/changes.html which denotes the addition of `Wcast-function-type`.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
