### PR TITLE
tls: Prevent zero length write() syscalls.

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -721,14 +721,10 @@ int TLSWrap::DoWrite(WriteWrap* w,
       Debug(this, "No pending encrypted output, writing to underlying stream");
       CHECK_NULL(current_empty_write_);
       current_empty_write_ = w;
-      StreamWriteResult res =
-          underlying_stream()->Write(bufs, count, send_handle);
-      if (!res.async) {
-        BaseObjectPtr<TLSWrap> strong_ref{this};
-        env()->SetImmediate([this, strong_ref](Environment* env) {
-          OnStreamAfterWrite(current_empty_write_, 0);
-        });
-      }
+      BaseObjectPtr<TLSWrap> strong_ref{this};
+      env()->SetImmediate([this, strong_ref](Environment* env) {
+        OnStreamAfterWrite(current_empty_write_, 0);
+      });
       return 0;
     }
   }


### PR DESCRIPTION
The current behavior is performing a zero length write()
syscall when the write is empty.

This change removes that behavior and prevents a call
to the kernel.  This change assumes that the zero length
write completed async.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows 