### PR TITLE
stream: fix finished writable/readable state

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -13,6 +13,18 @@ function isRequest(stream) {
   return stream.setHeader && typeof stream.abort === 'function';
 }
 
+function isReadable(stream) {
+  return typeof stream.readable === 'boolean' ||
+    typeof stream.readableEnded === 'boolean' ||
+    !!stream._readableState;
+}
+
+function isWritable(stream) {
+  return typeof stream.writable === 'boolean' ||
+    typeof stream.writableEnded === 'boolean' ||
+    !!stream._writableState;
+}
+
 function eos(stream, opts, callback) {
   if (arguments.length === 2) {
     callback = opts;
@@ -28,8 +40,10 @@ function eos(stream, opts, callback) {
 
   callback = once(callback);
 
-  let readable = opts.readable || (opts.readable !== false && stream.readable);
-  let writable = opts.writable || (opts.writable !== false && stream.writable);
+  let readable = opts.readable ||
+    (opts.readable !== false && isReadable(stream));
+  let writable = opts.writable ||
+    (opts.writable !== false && isWritable(stream));
 
   const onlegacyfinish = () => {
     if (!stream.writable) onfinish();

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -193,3 +193,12 @@ const { promisify } = require('util');
     assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
   }));
 }
+
+{
+  const readable = new Readable();
+  readable.readable = false;
+  readable.destroy();
+  finished(readable, common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
+  }));
+}

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -184,3 +184,12 @@ const { promisify } = require('util');
   finished(streamLike, common.mustCall);
   streamLike.emit('close');
 }
+
+{
+  const writable = new Writable({ write() {} });
+  writable.writable = false;
+  writable.destroy();
+  finished(writable, common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
+  }));
+}


### PR DESCRIPTION
writable/readable does not indicate whether as stream is
a Writable/Readable. This implements a better check for
whether a object is a Writable/Readable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
