### PR TITLE
tools: replace deprecated iteritems() for items()

### DIFF
--- a/tools/gyp/pylib/gyp/generator/compile_commands_json.py
+++ b/tools/gyp/pylib/gyp/generator/compile_commands_json.py
@@ -43,7 +43,7 @@ def CalculateVariables(default_variables, params):
 
 def AddCommandsForTarget(cwd, target, params, per_config_commands):
   output_dir = params['generator_flags']['output_dir']
-  for configuration_name, configuration in target['configurations'].iteritems():
+  for configuration_name, configuration in target['configurations'].items():
     builddir_name = os.path.join(output_dir, configuration_name)
 
     if IsMac(params):
@@ -92,7 +92,7 @@ def AddCommandsForTarget(cwd, target, params, per_config_commands):
 
 def GenerateOutput(target_list, target_dicts, data, params):
   per_config_commands = {}
-  for qualified_target, target in target_dicts.iteritems():
+  for qualified_target, target in target_dicts.items():
     build_file, target_name, toolset = (
         gyp.common.ParseQualifiedTarget(qualified_target))
     if IsMac(params):
@@ -102,7 +102,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
     AddCommandsForTarget(cwd, target, params, per_config_commands)
 
   output_dir = params['generator_flags']['output_dir']
-  for configuration_name, commands in per_config_commands.iteritems():
+  for configuration_name, commands in per_config_commands.items():
     filename = os.path.join(output_dir,
                             configuration_name,
                             'compile_commands.json')


### PR DESCRIPTION
This is a Built-In change in Python 3 used by compile_commands_json.py
to generate compile_commands_json.json. Node.js dropped Python 2 support
in this script, `items()` works as expected replacement.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)