### PR TITLE
src: ignore maybe-uninitialized warning string_search

### DIFF
--- a/src/string_search.h
+++ b/src/string_search.h
@@ -110,7 +110,14 @@ class StringSearch : private StringSearchBase {
   }
 
   size_t Search(Vector subject, size_t index) {
+#if (__GNUC__ >= 8) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     return (this->*strategy_)(subject, index);
+#if (__GNUC__ >= 8) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
   }
 
   static inline int AlphabetSize() {

--- a/src/string_search.h
+++ b/src/string_search.h
@@ -110,14 +110,7 @@ class StringSearch : private StringSearchBase {
   }
 
   size_t Search(Vector subject, size_t index) {
-#if (__GNUC__ >= 8) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
     return (this->*strategy_)(subject, index);
-#if (__GNUC__ >= 8) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
   }
 
   static inline int AlphabetSize() {

--- a/src/string_search.h
+++ b/src/string_search.h
@@ -91,7 +91,7 @@ class StringSearch : private StringSearchBase {
   typedef stringsearch::Vector<const Char> Vector;
 
   explicit StringSearch(Vector pattern)
-      : pattern_(pattern), start_(0) {
+      : StringSearchBase(), pattern_(pattern), start_(0) {
     if (pattern.length() >= kBMMaxShift) {
       start_ = pattern.length() - kBMMaxShift;
     }


### PR DESCRIPTION
Currently, the following compilation warning is generated with GCC
version 8.2.1:
```console
In file included from ../src/node_buffer.cc:29:
../src/string_search.h:
In function ‘size_t node::stringsearch::SearchString(
    node::stringsearch::Vector<const Char>,
    node::stringsearch::Vector<const Char>,
    size_t) [with Char = short unsigned int]’:
../src/string_search.h:113:30: warning:
‘search’ may be used uninitialized in this function
[-Wmaybe-uninitialized]
     return (this->*strategy_)(subject, index);
            ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~

../src/string_search.h:
In function ‘size_t node::stringsearch::SearchString(
    node::stringsearch::Vector<const Char>,
    node::stringsearch::Vector<const Char>,
    size_t) [with Char = unsigned char]’:
../src/string_search.h:113:30:
warning: ‘search’ may be used uninitialized in this function
[-Wmaybe-uninitialized]
     return (this->*strategy_)(subject, index);
            ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
```
The issue here seems to be with the `strategy_` field which is a pointer
to a member function, and it is set in the constructor of StringSearch.
It is always set and I've not been able to work around this warning
so this commit suggests adding a pragma for GCC to ignore the warning.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
