### PR TITLE
stream: fix finished w/ 'close' before 'finish'

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -28,10 +28,8 @@ function isWritable(stream) {
 function isWritableFinished(stream) {
   if (stream.writableFinished) return true;
   const wState = stream._writableState;
-  if (wState && wState.finished) return true;
-  if (wState && wState.ended && wState.length === 0 &&
-    !wState.errored) return true;
-  return false;
+  if (!wState || wState.errored) return false;
+  return wState.finished || (wState.ended && wState.length === 0);
 }
 
 function eos(stream, opts, callback) {

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -25,6 +25,15 @@ function isWritable(stream) {
     !!stream._writableState;
 }
 
+function isWritableFinished(stream) {
+  if (stream.writableFinished) return true;
+  const wState = stream._writableState;
+  if (wState && wState.finished) return true;
+  if (wState && wState.ended && wState.length === 0 &&
+    !wState.errored) return true;
+  return false;
+}
+
 function eos(stream, opts, callback) {
   if (arguments.length === 2) {
     callback = opts;
@@ -49,10 +58,11 @@ function eos(stream, opts, callback) {
     if (!stream.writable) onfinish();
   };
 
-  let writableEnded = stream._writableState && stream._writableState.finished;
+  let writableFinished = stream.writableFinished ||
+    (stream._writableState && stream._writableState.finished);
   const onfinish = () => {
     writable = false;
-    writableEnded = true;
+    writableFinished = true;
     if (!readable) callback.call(stream);
   };
 
@@ -75,8 +85,8 @@ function eos(stream, opts, callback) {
         err = new ERR_STREAM_PREMATURE_CLOSE();
       return callback.call(stream, err);
     }
-    if (writable && !writableEnded) {
-      if (!stream._writableState || !stream._writableState.ended)
+    if (writable && !writableFinished) {
+      if (!isWritableFinished(stream))
         err = new ERR_STREAM_PREMATURE_CLOSE();
       return callback.call(stream, err);
     }

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -202,3 +202,16 @@ const { promisify } = require('util');
     assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
   }));
 }
+
+{
+  const w = new Writable({
+    write(chunk, encoding, callback) {
+      setImmediate(callback);
+    }
+  });
+  finished(w, common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
+  }));
+  w.end('asd');
+  w.destroy();
+}


### PR DESCRIPTION
Emitting 'close' before 'finish' on a Writable should result in a premature close error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
