### PR TITLE
doc: list largepage values in --help

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -754,7 +754,10 @@ PerProcessOptionsParser::PerProcessOptionsParser(
 #endif
 #endif
   AddOption("--use-largepages",
-            "Map the Node.js static code to large pages",
+            "Map the Node.js static code to large pages. Options are "
+            "'off' (the default value, meaning do not map), "
+            "'on' (map and ignore failure, reporting it to stderr), "
+            "or 'silent' (map and silently ignore failure)",
             &PerProcessOptions::use_largepages,
             kAllowedInEnvironment);
 


### PR DESCRIPTION
This commit adds the supported `--use-largepages` values to the `--help` menu.

Fixes: https://github.com/nodejs/node/issues/31533

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)