### PR TITLE
http: Add noDelay to http.request() options.

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2213,6 +2213,8 @@ changes:
     **Default:** 8192 (8KB).
   * `method` {string} A string specifying the HTTP request method. **Default:**
     `'GET'`.
+  * `noDelay` {boolean} A boolean with which to call [`socket.setNoDelay()`][]
+    when a socket connection is established.
   * `path` {string} Request path. Should include query string if any.
     E.G. `'/index.html?page=12'`. An exception is thrown when the request path
     contains illegal characters. Currently, only spaces are rejected but that

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -164,6 +164,9 @@ function ClientRequest(input, options, cb) {
 
   this.socketPath = options.socketPath;
 
+  if (options.noDelay !== undefined)
+    this._deferToConnect('setNoDelay', [options.noDelay]);
+
   if (options.timeout !== undefined)
     this.timeout = getTimerDuration(options.timeout, 'timeout');
 


### PR DESCRIPTION
Add the noDelay option to the http.request() options such that
.setNoDelay() will be called once a socket is obtained.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)