### PR TITLE
docs: Reword socket.setNoDelay()

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -881,7 +881,7 @@ added: v0.1.90
 
 Enable/disable the use of Nagle's algorithm.
 
-When a TCP connection is created it will have Nagle's algorithm enabled.
+When a TCP connection is created, it will have Nagle's algorithm enabled.
 
 Nagle's algorithm delays data before it is sent via the network. It attempts
 to optimize throughput at the expense of latency.

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -879,15 +879,15 @@ added: v0.1.90
 * `noDelay` {boolean} **Default:** `true`
 * Returns: {net.Socket} The socket itself.
 
-Enable/disable the Nagle algorithm.
+Enable/disable the use of Nagle's algorithm.
 
-When TCP connections are created have the Nagle algorithm enabled.
+When a TCP connection is created it will have Nagle's algorithm enabled.
 
-The Nagle algorithm delays data before it is sent via the network. It attempts
+Nagle's algorithm delays data before it is sent via the network. It attempts
 to optimize throughput at the expense of latency.
 
-Passing `true` for `noDelay` or not passing an argument will disable the Nagle
-algorithm for the socket. Passing `false` for `noDelay` will enable the Nagle
+Passing `true` for `noDelay` or not passing an argument will disable Nagle's
+algorithm for the socket. Passing `false` for `noDelay` will enable Nagle's
 algorithm.
 
 ### `socket.setTimeout(timeout[, callback])`

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -881,7 +881,7 @@ added: v0.1.90
 
 Enable/disable the Nagle algorithm.
 
-TCP connections when they are created have the Nagle algorithm enabled.
+When TCP connections are created have the Nagle algorithm enabled.
 
 The Nagle algorithm delays data before it is sent via the network. It attempts
 to optimize throughput at the expense of latency.

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -879,9 +879,16 @@ added: v0.1.90
 * `noDelay` {boolean} **Default:** `true`
 * Returns: {net.Socket} The socket itself.
 
-Disables the Nagle algorithm. By default TCP connections use the Nagle
-algorithm, they buffer data before sending it off. Setting `true` for
-`noDelay` will immediately fire off data each time `socket.write()` is called.
+Enable/disable the Nagle algorithm.
+
+TCP connections when they are created have the Nagle algorithm enabled.
+
+The Nagle algorithm delays data before it is sent via the network. It attempts
+to optimize throughput at the expense of latency.
+
+Setting `true` for `noDelay` or not passing an argument will disable the Nagle
+algorithm for the socket. Setting `false` for `noDelay` will enable the Nagle
+algorithm.
 
 ### `socket.setTimeout(timeout[, callback])`
 <!-- YAML

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -886,8 +886,8 @@ TCP connections when they are created have the Nagle algorithm enabled.
 The Nagle algorithm delays data before it is sent via the network. It attempts
 to optimize throughput at the expense of latency.
 
-Setting `true` for `noDelay` or not passing an argument will disable the Nagle
-algorithm for the socket. Setting `false` for `noDelay` will enable the Nagle
+Passing `true` for `noDelay` or not passing an argument will disable the Nagle
+algorithm for the socket. Passing `false` for `noDelay` will enable the Nagle
 algorithm.
 
 ### `socket.setTimeout(timeout[, callback])`


### PR DESCRIPTION
Change the description of socket.setNoDelay() to make it clear
that sockets have Nagle's algorithm enabled by default.

Better document the tradeoff of having the algorithm enabled.

Explain the behavior of the function based on the passed arguments.

This change is a follow up of #31539 and incorporates feedback from #7995.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)