### PR TITLE
net: Track state of setNoDelay and prevent unnecessary system calls.

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -257,7 +257,7 @@ function initSocketHandle(self) {
 
 const kBytesRead = Symbol('kBytesRead');
 const kBytesWritten = Symbol('kBytesWritten');
-
+const kSetNoDelay = Symbol('kSetNoDelay');
 
 function Socket(options) {
   if (!(this instanceof Socket)) return new Socket(options);
@@ -271,6 +271,7 @@ function Socket(options) {
   this[kHandle] = null;
   this._parent = null;
   this._host = null;
+  this[kSetNoDelay] = false;
   this[kLastWriteQueueSize] = 0;
   this[kTimeout] = null;
   this[kBuffer] = null;
@@ -488,8 +489,11 @@ Socket.prototype.setNoDelay = function(enable) {
   }
 
   // Backwards compatibility: assume true when `enable` is omitted
-  if (this._handle.setNoDelay)
-    this._handle.setNoDelay(enable === undefined ? true : !!enable);
+  const new_value = enable === undefined ? true : !!enable;
+  if (this._handle.setNoDelay && new_value !== this[kSetNoDelay]) {
+    this[kSetNoDelay] = new_value;
+    this._handle.setNoDelay(new_value);
+  }
 
   return this;
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -489,10 +489,10 @@ Socket.prototype.setNoDelay = function(enable) {
   }
 
   // Backwards compatibility: assume true when `enable` is omitted
-  const new_value = enable === undefined ? true : !!enable;
-  if (this._handle.setNoDelay && new_value !== this[kSetNoDelay]) {
-    this[kSetNoDelay] = new_value;
-    this._handle.setNoDelay(new_value);
+  const newValue = enable === undefined ? true : !!enable;
+  if (this._handle.setNoDelay && newValue !== this[kSetNoDelay]) {
+    this[kSetNoDelay] = newValue;
+    this._handle.setNoDelay(newValue);
   }
 
   return this;

--- a/test/parallel/test-net-socket-setnodelay.js
+++ b/test/parallel/test-net-socket-setnodelay.js
@@ -27,7 +27,7 @@ truthyValues.forEach((testVal) => socket.setNoDelay(testVal));
 
 socket = new net.Socket({
   handle: {
-    setNoDelay: common.mustNotCall(genSetNoDelay(false))
+    setNoDelay: common.mustNotCall()
   }
 });
 falseyValues.forEach((testVal) => socket.setNoDelay(testVal));

--- a/test/parallel/test-net-socket-setnodelay.js
+++ b/test/parallel/test-net-socket-setnodelay.js
@@ -20,17 +20,25 @@ socket.setNoDelay();
 
 socket = new net.Socket({
   handle: {
-    setNoDelay: common.mustCall(genSetNoDelay(true), truthyValues.length)
+    setNoDelay: common.mustCall(genSetNoDelay(true), 1)
   }
 });
 truthyValues.forEach((testVal) => socket.setNoDelay(testVal));
 
 socket = new net.Socket({
   handle: {
-    setNoDelay: common.mustCall(genSetNoDelay(false), falseyValues.length)
+    setNoDelay: common.mustNotCall(genSetNoDelay(false))
   }
 });
 falseyValues.forEach((testVal) => socket.setNoDelay(testVal));
+
+socket = new net.Socket({
+  handle: {
+    setNoDelay: common.mustCall(() => {}, 3)
+  }
+});
+truthyValues.concat(falseyValues).concat(truthyValues)
+  .forEach((testVal) => socket.setNoDelay(testVal));
 
 // If a handler doesn't have a setNoDelay function it shouldn't be called.
 // In the case below, if it is called an exception will be thrown


### PR DESCRIPTION
The state of .setNoDelay() is now tracked and code will prevent repeated
system calls to setsockopt() when the value has already been set to the
desired value for the socket.

Change and expand the appropriate test.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

## Rationale

The reason for this change is that if setNoDelay is set in a HTTP options
request such as in #31539 , there will be repeated syscalls to .setNoDelay(true)
which in turn will cause many calls to `setsockopt()` that are unnecessary since
the socket has already been set to disable Nagle's algorithm.