### PR TITLE
stream: fix finished w/ 'close' before 'end'

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -34,6 +34,13 @@ function isWritableFinished(stream) {
 
 function nop() {}
 
+function isReadableEnded(stream) {
+  if (stream.readableEnded) return true;
+  const rState = stream._readableState;
+  if (!rState || rState.errored) return false;
+  return rState.endEmitted || (rState.ended && rState.length === 0);
+}
+
 function eos(stream, opts, callback) {
   if (arguments.length === 2) {
     callback = opts;
@@ -84,7 +91,7 @@ function eos(stream, opts, callback) {
   const onclose = () => {
     let err;
     if (readable && !readableEnded) {
-      if (!rState || !rState.ended)
+      if (!isReadableEnded(stream))
         err = new ERR_STREAM_PREMATURE_CLOSE();
       return callback.call(stream, err);
     }

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -26,23 +26,37 @@ let PassThrough;
 let createReadableStreamAsyncIterator;
 
 function destroyer(stream, reading, writing, callback) {
-  callback = once(callback);
-  let destroyed = false;
-
-  if (eos === undefined) eos = require('internal/streams/end-of-stream');
-  eos(stream, { readable: reading, writable: writing }, (err) => {
-    if (destroyed) return;
-    destroyed = true;
+  const _destroy = once((err) => {
     destroyImpl.destroyer(stream, err);
     callback(err);
   });
 
-  return (err) => {
-    if (destroyed) return;
-    destroyed = true;
-    destroyImpl.destroyer(stream, err);
-    callback(err || new ERR_STREAM_DESTROYED('pipe'));
-  };
+  if (eos === undefined) eos = require('internal/streams/end-of-stream');
+  eos(stream, { readable: reading, writable: writing }, (err) => {
+    const rState = stream._readableState;
+    if (
+      err &&
+      err.code === 'ERR_STREAM_PREMATURE_CLOSE' &&
+      reading &&
+      (rState && rState.ended && !rState.errored && !rState.errorEmitted)
+    ) {
+      // Some readable streams will emit 'close' before 'end'. However, since
+      // this is on the readable side 'end' should still be emitted if the
+      // stream has been ended and no error emitted. This should be allowed in
+      // favor of backwards compatibility. Since the stream is piped to a
+      // destination this should not result in any observable difference.
+      // We don't need to check if this is a writable premature close since
+      // eos will only fail with premature close on the reading side for
+      // duplex streams.
+      stream
+        .once('end', _destroy)
+        .once('error', _destroy);
+    } else {
+      _destroy(err);
+    }
+  });
+
+  return (err) => _destroy(err || new ERR_STREAM_DESTROYED('pipe'));
 }
 
 function popCallback(streams) {

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -342,3 +342,13 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   d._writableState.errored = true;
   d.emit('close');
 }
+
+{
+  const r = new Readable();
+  finished(r, common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
+  }));
+  r.push('asd');
+  r.push(null);
+  r.destroy();
+}

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -922,3 +922,21 @@ const { promisify } = require('util');
   }));
   src.end();
 }
+
+{
+  // Make sure 'close' before 'end' finishes without error
+  // if readable has received eof.
+  // Ref: https://github.com/nodejs/node/issues/29699
+  const r = new Readable();
+  const w = new Writable({
+    write(chunk, encoding, cb) {
+      cb();
+    }
+  });
+  pipeline(r, w, (err) => {
+    assert.strictEqual(err, undefined);
+  });
+  r.push('asd');
+  r.push(null);
+  r.emit('close');
+}


### PR DESCRIPTION
Emitting 'close' before 'end' on a Readable should result in a premature close error.

This is related to the one that caused trouble in https://github.com/nodejs/node/issues/29699. Includes the fix proposed in https://github.com/nodejs/node/pull/29724.

Related discussion: https://github.com/nodejs/node/pull/29724/files#r329128356

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
