### PR TITLE
net: Track state of setKeepAlive and prevent unnecessary system calls

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -257,7 +257,7 @@ function initSocketHandle(self) {
 
 const kBytesRead = Symbol('kBytesRead');
 const kBytesWritten = Symbol('kBytesWritten');
-
+const kSetKeepAlive = Symbol('kSetKeepAlive');
 
 function Socket(options) {
   if (!(this instanceof Socket)) return new Socket(options);
@@ -272,6 +272,7 @@ function Socket(options) {
   this._parent = null;
   this._host = null;
   this[kLastWriteQueueSize] = 0;
+  this[kSetKeepAlive] = null;
   this[kTimeout] = null;
   this[kBuffer] = null;
   this[kBufferCb] = null;
@@ -501,8 +502,15 @@ Socket.prototype.setKeepAlive = function(setting, msecs) {
     return this;
   }
 
-  if (this._handle.setKeepAlive)
-    this._handle.setKeepAlive(setting, ~~(msecs / 1000));
+  const newValue = [setting, ~~(msecs / 1000)];
+  if (this._handle.setKeepAlive &&
+   (this[kSetKeepAlive] == null ||
+    this[kSetKeepAlive][0] !== newValue[0] ||
+    this[kSetKeepAlive][1] !== newValue[1])
+  ) {
+    this[kSetKeepAlive] = newValue;
+    this._handle.setKeepAlive(...newValue);
+  }
 
   return this;
 };


### PR DESCRIPTION
The state of .setKeepAlive() is now tracked and code will prevent repeated
system calls to setsockopt() when the value has already been set to the
desired value for the socket.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

## Rationale

The reason for this change is that if keep alive is set for a HTTP Agent, there will 
be repeated calls to `net.Socket.setKeepAlive()` which in turn will cause many calls to 
setsockopt() that are unnecessary since the socket has already been set to 
send keep alive packets.

This is much like #31543 