### PR TITLE
fs: add fs/promises alias module

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4237,7 +4237,7 @@ this API: [`fs.writev()`][].
 
 The `fs.promises` API provides an alternative set of asynchronous file system
 methods that return `Promise` objects rather than using callbacks. The
-API is accessible via `require('fs').promises`.
+API is accessible via `require('fs').promises` or `require('fs/promises')`.
 
 ### class: `FileHandle`
 <!-- YAML

--- a/lib/fs/promises.js
+++ b/lib/fs/promises.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('internal/fs/promises').exports;

--- a/node.gyp
+++ b/node.gyp
@@ -51,6 +51,7 @@
       'lib/domain.js',
       'lib/events.js',
       'lib/fs.js',
+      'lib/fs/promises.js',
       'lib/http.js',
       'lib/http2.js',
       'lib/_http_agent.js',

--- a/test/es-module/test-esm-fs-promises.mjs
+++ b/test/es-module/test-esm-fs-promises.mjs
@@ -1,0 +1,5 @@
+import '../common/index.mjs';
+import { stat } from 'fs/promises';
+
+// Should not reject.
+stat(new URL(import.meta.url));

--- a/test/parallel/test-fs-promises-exists.js
+++ b/test/parallel/test-fs-promises-exists.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.strictEqual(require('fs/promises'), require('fs').promises);


### PR DESCRIPTION
This restores `fs/promises` in node core. It can't be overridden by a file on disk in a version of node that has it. It will fail to load on a version of node that doesn't have it because the `fs` module on npm is locked. It is not a new core module, it is a child of the fs module, so the concern about namespacing shouldn't apply.

Fixes #21014 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)