### PR TITLE
src: remove duplicate field env in CryptoJob class

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -6194,9 +6194,8 @@ bool ECDH::IsKeyPairValid() {
 // TODO(addaleax): If there is an `AsyncWrap`, it currently has no access to
 // this object. This makes proper reporting of memory usage impossible.
 struct CryptoJob : public ThreadPoolWork {
-  Environment* const env;
   std::unique_ptr<AsyncWrap> async_wrap;
-  inline explicit CryptoJob(Environment* env) : ThreadPoolWork(env), env(env) {}
+  inline explicit CryptoJob(Environment* env) : ThreadPoolWork(env) {}
   inline void AfterThreadPoolWork(int status) final;
   virtual void AfterThreadPoolWork() = 0;
   static inline void Run(std::unique_ptr<CryptoJob> job, Local<Value> wrap);
@@ -6207,8 +6206,8 @@ void CryptoJob::AfterThreadPoolWork(int status) {
   CHECK(status == 0 || status == UV_ECANCELED);
   std::unique_ptr<CryptoJob> job(this);
   if (status == UV_ECANCELED) return;
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
+  HandleScope handle_scope(get_env()->isolate());
+  Context::Scope context_scope(get_env()->context());
   CHECK_EQ(false, async_wrap->persistent().IsWeak());
   AfterThreadPoolWork();
 }
@@ -6249,12 +6248,12 @@ struct RandomBytesJob : public CryptoJob {
 
   inline void AfterThreadPoolWork() override {
     Local<Value> arg = ToResult();
-    async_wrap->MakeCallback(env->ondone_string(), 1, &arg);
+    async_wrap->MakeCallback(get_env()->ondone_string(), 1, &arg);
   }
 
   inline Local<Value> ToResult() const {
-    if (errors.empty()) return Undefined(env->isolate());
-    return errors.ToException(env).ToLocalChecked();
+    if (errors.empty()) return Undefined(get_env()->isolate());
+    return errors.ToException(get_env()).ToLocalChecked();
   }
 };
 
@@ -6306,11 +6305,11 @@ struct PBKDF2Job : public CryptoJob {
 
   inline void AfterThreadPoolWork() override {
     Local<Value> arg = ToResult();
-    async_wrap->MakeCallback(env->ondone_string(), 1, &arg);
+    async_wrap->MakeCallback(get_env()->ondone_string(), 1, &arg);
   }
 
   inline Local<Value> ToResult() const {
-    return Boolean::New(env->isolate(), success.FromJust());
+    return Boolean::New(get_env()->isolate(), success.FromJust());
   }
 
   inline void Cleanse() {
@@ -6386,12 +6385,12 @@ struct ScryptJob : public CryptoJob {
 
   inline void AfterThreadPoolWork() override {
     Local<Value> arg = ToResult();
-    async_wrap->MakeCallback(env->ondone_string(), 1, &arg);
+    async_wrap->MakeCallback(get_env()->ondone_string(), 1, &arg);
   }
 
   inline Local<Value> ToResult() const {
-    if (errors.empty()) return Undefined(env->isolate());
-    return errors.ToException(env).ToLocalChecked();
+    if (errors.empty()) return Undefined(get_env()->isolate());
+    return errors.ToException(get_env()).ToLocalChecked();
   }
 
   inline void Cleanse() {
@@ -6720,7 +6719,7 @@ class GenerateKeyPairJob : public CryptoJob {
   inline void AfterThreadPoolWork() override {
     Local<Value> args[3];
     ToResult(&args[0], &args[1], &args[2]);
-    async_wrap->MakeCallback(env->ondone_string(), 3, args);
+    async_wrap->MakeCallback(get_env()->ondone_string(), 3, args);
   }
 
   inline void ToResult(Local<Value>* err,
@@ -6728,14 +6727,14 @@ class GenerateKeyPairJob : public CryptoJob {
                        Local<Value>* privkey) {
     if (pkey_ && EncodeKeys(pubkey, privkey)) {
       CHECK(errors_.empty());
-      *err = Undefined(env->isolate());
+      *err = Undefined(get_env()->isolate());
     } else {
       if (errors_.empty())
         errors_.Capture();
       CHECK(!errors_.empty());
-      *err = errors_.ToException(env).ToLocalChecked();
-      *pubkey = Undefined(env->isolate());
-      *privkey = Undefined(env->isolate());
+      *err = errors_.ToException(get_env()).ToLocalChecked();
+      *pubkey = Undefined(get_env()->isolate());
+      *privkey = Undefined(get_env()->isolate());
     }
   }
 
@@ -6744,20 +6743,21 @@ class GenerateKeyPairJob : public CryptoJob {
     if (public_key_encoding_.output_key_object_) {
       // Note that this has the downside of containing sensitive data of the
       // private key.
-      if (!KeyObject::Create(env, kKeyTypePublic, pkey_).ToLocal(pubkey))
+      if (!KeyObject::Create(get_env(), kKeyTypePublic, pkey_).ToLocal(pubkey))
         return false;
     } else {
-      if (!WritePublicKey(env, pkey_.get(), public_key_encoding_)
+      if (!WritePublicKey(get_env(), pkey_.get(), public_key_encoding_)
                .ToLocal(pubkey))
         return false;
     }
 
     // Now do the same for the private key.
     if (private_key_encoding_.output_key_object_) {
-      if (!KeyObject::Create(env, kKeyTypePrivate, pkey_).ToLocal(privkey))
+      if (!KeyObject::Create(get_env(), kKeyTypePrivate, pkey_)
+              .ToLocal(privkey))
         return false;
     } else {
-      if (!WritePrivateKey(env, pkey_.get(), private_key_encoding_)
+      if (!WritePrivateKey(get_env(), pkey_.get(), private_key_encoding_)
                .ToLocal(privkey))
         return false;
     }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -6206,8 +6206,8 @@ void CryptoJob::AfterThreadPoolWork(int status) {
   CHECK(status == 0 || status == UV_ECANCELED);
   std::unique_ptr<CryptoJob> job(this);
   if (status == UV_ECANCELED) return;
-  HandleScope handle_scope(get_env()->isolate());
-  Context::Scope context_scope(get_env()->context());
+  HandleScope handle_scope(env()->isolate());
+  Context::Scope context_scope(env()->context());
   CHECK_EQ(false, async_wrap->persistent().IsWeak());
   AfterThreadPoolWork();
 }
@@ -6248,12 +6248,12 @@ struct RandomBytesJob : public CryptoJob {
 
   inline void AfterThreadPoolWork() override {
     Local<Value> arg = ToResult();
-    async_wrap->MakeCallback(get_env()->ondone_string(), 1, &arg);
+    async_wrap->MakeCallback(env()->ondone_string(), 1, &arg);
   }
 
   inline Local<Value> ToResult() const {
-    if (errors.empty()) return Undefined(get_env()->isolate());
-    return errors.ToException(get_env()).ToLocalChecked();
+    if (errors.empty()) return Undefined(env()->isolate());
+    return errors.ToException(env()).ToLocalChecked();
   }
 };
 
@@ -6305,11 +6305,11 @@ struct PBKDF2Job : public CryptoJob {
 
   inline void AfterThreadPoolWork() override {
     Local<Value> arg = ToResult();
-    async_wrap->MakeCallback(get_env()->ondone_string(), 1, &arg);
+    async_wrap->MakeCallback(env()->ondone_string(), 1, &arg);
   }
 
   inline Local<Value> ToResult() const {
-    return Boolean::New(get_env()->isolate(), success.FromJust());
+    return Boolean::New(env()->isolate(), success.FromJust());
   }
 
   inline void Cleanse() {
@@ -6385,12 +6385,12 @@ struct ScryptJob : public CryptoJob {
 
   inline void AfterThreadPoolWork() override {
     Local<Value> arg = ToResult();
-    async_wrap->MakeCallback(get_env()->ondone_string(), 1, &arg);
+    async_wrap->MakeCallback(env()->ondone_string(), 1, &arg);
   }
 
   inline Local<Value> ToResult() const {
-    if (errors.empty()) return Undefined(get_env()->isolate());
-    return errors.ToException(get_env()).ToLocalChecked();
+    if (errors.empty()) return Undefined(env()->isolate());
+    return errors.ToException(env()).ToLocalChecked();
   }
 
   inline void Cleanse() {
@@ -6719,7 +6719,7 @@ class GenerateKeyPairJob : public CryptoJob {
   inline void AfterThreadPoolWork() override {
     Local<Value> args[3];
     ToResult(&args[0], &args[1], &args[2]);
-    async_wrap->MakeCallback(get_env()->ondone_string(), 3, args);
+    async_wrap->MakeCallback(env()->ondone_string(), 3, args);
   }
 
   inline void ToResult(Local<Value>* err,
@@ -6727,14 +6727,14 @@ class GenerateKeyPairJob : public CryptoJob {
                        Local<Value>* privkey) {
     if (pkey_ && EncodeKeys(pubkey, privkey)) {
       CHECK(errors_.empty());
-      *err = Undefined(get_env()->isolate());
+      *err = Undefined(env()->isolate());
     } else {
       if (errors_.empty())
         errors_.Capture();
       CHECK(!errors_.empty());
-      *err = errors_.ToException(get_env()).ToLocalChecked();
-      *pubkey = Undefined(get_env()->isolate());
-      *privkey = Undefined(get_env()->isolate());
+      *err = errors_.ToException(env()).ToLocalChecked();
+      *pubkey = Undefined(env()->isolate());
+      *privkey = Undefined(env()->isolate());
     }
   }
 
@@ -6743,21 +6743,21 @@ class GenerateKeyPairJob : public CryptoJob {
     if (public_key_encoding_.output_key_object_) {
       // Note that this has the downside of containing sensitive data of the
       // private key.
-      if (!KeyObject::Create(get_env(), kKeyTypePublic, pkey_).ToLocal(pubkey))
+      if (!KeyObject::Create(env(), kKeyTypePublic, pkey_).ToLocal(pubkey))
         return false;
     } else {
-      if (!WritePublicKey(get_env(), pkey_.get(), public_key_encoding_)
+      if (!WritePublicKey(env(), pkey_.get(), public_key_encoding_)
                .ToLocal(pubkey))
         return false;
     }
 
     // Now do the same for the private key.
     if (private_key_encoding_.output_key_object_) {
-      if (!KeyObject::Create(get_env(), kKeyTypePrivate, pkey_)
+      if (!KeyObject::Create(env(), kKeyTypePrivate, pkey_)
               .ToLocal(privkey))
         return false;
     } else {
-      if (!WritePrivateKey(get_env(), pkey_.get(), private_key_encoding_)
+      if (!WritePrivateKey(env(), pkey_.get(), private_key_encoding_)
                .ToLocal(privkey))
         return false;
     }

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -264,6 +264,10 @@ class ThreadPoolWork {
   virtual void DoThreadPoolWork() = 0;
   virtual void AfterThreadPoolWork(int status) = 0;
 
+  Environment* get_env() const {
+    return env_;
+  }
+
  private:
   Environment* env_;
   uv_work_t work_req_;

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -264,7 +264,7 @@ class ThreadPoolWork {
   virtual void DoThreadPoolWork() = 0;
   virtual void AfterThreadPoolWork(int status) = 0;
 
-  Environment* get_env() const {
+  Environment* env() const {
     return env_;
   }
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -264,9 +264,7 @@ class ThreadPoolWork {
   virtual void DoThreadPoolWork() = 0;
   virtual void AfterThreadPoolWork(int status) = 0;
 
-  Environment* get_env() const {
-    return env_;
-  }
+  Environment* env() const { return env_; }
 
  private:
   Environment* env_;

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -264,7 +264,7 @@ class ThreadPoolWork {
   virtual void DoThreadPoolWork() = 0;
   virtual void AfterThreadPoolWork(int status) = 0;
 
-  Environment* env() const {
+  Environment* get_env() const {
     return env_;
   }
 


### PR DESCRIPTION
Removed field env from cryptojob class, replaced with function get_env() inherited from ThreadPoolWork

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
