### PR TITLE
dns: default to verbatim=true in dns.lookup()

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -125,7 +125,7 @@ section if a custom port is used.
 added: v0.1.90
 changes:
   - version: REPLACEME
-    pr-url: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/31567
     description: The `verbatim` options defaults to `true` now.
   - version: v8.5.0
     pr-url: https://github.com/nodejs/node/pull/14731

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -124,6 +124,9 @@ section if a custom port is used.
 <!-- YAML
 added: v0.1.90
 changes:
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: The `verbatim` options defaults to `true` now.
   - version: v8.5.0
     pr-url: https://github.com/nodejs/node/pull/14731
     description: The `verbatim` option is supported now.
@@ -144,9 +147,7 @@ changes:
   * `verbatim` {boolean} When `true`, the callback receives IPv4 and IPv6
     addresses in the order the DNS resolver returned them. When `false`,
     IPv4 addresses are placed before IPv6 addresses.
-    **Default:** currently `false` (addresses are reordered) but this is
-    expected to change in the not too distant future.
-    New code should use `{ verbatim: true }`.
+    **Default:** `true`.
 * `callback` {Function}
   * `err` {Error}
   * `address` {string} A string representation of an IPv4 or IPv6 address.

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -95,7 +95,7 @@ function lookup(hostname, options, callback) {
   let hints = 0;
   let family = -1;
   let all = false;
-  let verbatim = false;
+  let verbatim = true;
 
   // Parse arguments
   if (hostname && typeof hostname !== 'string') {
@@ -109,7 +109,7 @@ function lookup(hostname, options, callback) {
     hints = options.hints >>> 0;
     family = options.family >>> 0;
     all = options.all === true;
-    verbatim = options.verbatim === true;
+    verbatim = options.verbatim !== false;
 
     validateHints(hints);
   } else {

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -106,7 +106,7 @@ function lookup(hostname, options) {
   var hints = 0;
   var family = -1;
   var all = false;
-  var verbatim = false;
+  var verbatim = true;
 
   // Parse arguments
   if (hostname && typeof hostname !== 'string') {
@@ -115,7 +115,7 @@ function lookup(hostname, options) {
     hints = options.hints >>> 0;
     family = options.family >>> 0;
     all = options.all === true;
-    verbatim = options.verbatim === true;
+    verbatim = options.verbatim !== false;
 
     validateHints(hints);
   } else {


### PR DESCRIPTION
Switch the default from false (reorder the result so that IPv4 addresses
come before IPv6 addresses) to true (return them exactly as the resolver
sent them to us.)

Fixes: https://github.com/nodejs/node/issues/31566
Refs: https://github.com/nodejs/node/issues/6307
Refs: https://github.com/nodejs/node/pull/20710

Passes `make test` on my machine but something tells me the CI results won't be so pretty...