### PR TITLE
benchmark: add MessagePort benchmark

### DIFF
--- a/benchmark/worker/messageport.js
+++ b/benchmark/worker/messageport.js
@@ -8,9 +8,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-
-  const n = +conf.n;
-
+  const n = conf.n;
   let payload;
 
   switch (conf.payload) {

--- a/benchmark/worker/messageport.js
+++ b/benchmark/worker/messageport.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const common = require('../common.js');
+const path = require('path');
+const { MessageChannel } = require('worker_threads');
+const bench = common.createBenchmark(main, {
+  payload: ['string', 'object'],
+  n: [1e6]
+});
+
+function main(conf) {
+
+  const n = +conf.n;
+  const sends = +conf.sendsPerBroadcast;
+
+  let payload;
+
+  switch (conf.payload) {
+    case 'string':
+      payload = 'hello world!';
+      break;
+    case 'object':
+      payload = { action: 'pewpewpew', powerLevel: 9001 };
+      break;
+    default:
+      throw new Error('Unsupported payload type');
+  }
+
+  const { port1, port2 } = new MessageChannel();
+
+  let messages = 0;
+  port2.onmessage = () => {
+    if (messages++ === n) {
+      bench.end(n);
+      port1.close();
+    } else {
+      write();
+    }
+  };
+  bench.start();
+  write();
+
+  function write() {
+    port1.postMessage(payload);
+  }
+}

--- a/benchmark/worker/messageport.js
+++ b/benchmark/worker/messageport.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common.js');
-const path = require('path');
 const { MessageChannel } = require('worker_threads');
 const bench = common.createBenchmark(main, {
   payload: ['string', 'object'],
@@ -11,7 +10,6 @@ const bench = common.createBenchmark(main, {
 function main(conf) {
 
   const n = +conf.n;
-  const sends = +conf.sendsPerBroadcast;
 
   let payload;
 


### PR DESCRIPTION
Add a raw `MessagePort` benchmark that does not ping back and forth
between different threads, unlike the `echo.js` benchmark, as there
are some performance differences between single-threaded and multi-
threaded operation, and a single-threaded Environment can be somewhat
easier to work with when profiling.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
