### PR TITLE
src: remove preview for heap dump utilities

### DIFF
--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -385,15 +385,9 @@ void Initialize(Local<Object> target,
                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
-  env->SetMethodNoSideEffect(target,
-                             "buildEmbedderGraph",
-                             BuildEmbedderGraph);
-  env->SetMethodNoSideEffect(target,
-                             "triggerHeapSnapshot",
-                             TriggerHeapSnapshot);
-  env->SetMethodNoSideEffect(target,
-                             "createHeapSnapshotStream",
-                             CreateHeapSnapshotStream);
+  env->SetMethod(target, "buildEmbedderGraph", BuildEmbedderGraph);
+  env->SetMethod(target, "triggerHeapSnapshot", TriggerHeapSnapshot);
+  env->SetMethod(target, "createHeapSnapshotStream", CreateHeapSnapshotStream);
 
   // Create FunctionTemplate for HeapSnapshotStream
   Local<FunctionTemplate> os = FunctionTemplate::New(env->isolate());


### PR DESCRIPTION
At least `createHeapSnapshotStream()` and `triggerHeapSnapshot()`
do have side effects, and more importantly, they should not be
run transparently. Without this, typing e.g. `v8.getHeapSnapshot()`
into the REPL will result in a crash or infinite loop while the REPL
evaluates the expression for a preview.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
