### PR TITLE
src: fix console debug output on Windows

### DIFF
--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -468,9 +468,7 @@ void FWrite(FILE* file, const std::string& str) {
   std::vector<wchar_t> wbuf(n);
   MultiByteToWideChar(CP_UTF8, 0, str.data(), str.size(), wbuf.data(), n);
 
-  // Don't include the final null character in the output
-  CHECK_GT(n, 0);
-  WriteConsoleW(handle, wbuf.data(), n - 1, nullptr, nullptr);
+  WriteConsoleW(handle, wbuf.data(), n, nullptr, nullptr);
   return;
 #elif defined(__ANDROID__)
   if (file == stderr) {

--- a/test/parallel/test-http2-debug.js
+++ b/test/parallel/test-http2-debug.js
@@ -12,16 +12,16 @@ const { stdout, stderr } = child_process.spawnSync(process.execPath, [
   path.resolve(__dirname, 'test-http2-ping.js')
 ], { encoding: 'utf8' });
 
-assert(stderr.match(/Setting the NODE_DEBUG environment variable to 'http2' can expose sensitive data \(such as passwords, tokens and authentication headers\) in the resulting log\./),
+assert(stderr.match(/Setting the NODE_DEBUG environment variable to 'http2' can expose sensitive data \(such as passwords, tokens and authentication headers\) in the resulting log\.\r?\n/),
        stderr);
-assert(stderr.match(/Http2Session client \(\d+\) handling data frame for stream \d+/),
+assert(stderr.match(/Http2Session client \(\d+\) handling data frame for stream \d+\r?\n/),
        stderr);
-assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session client \(\d+\)\] reading starting/),
+assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session client \(\d+\)\] reading starting\r?\n/),
        stderr);
-assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session client \(\d+\)\] closed with code 0/),
+assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session client \(\d+\)\] closed with code 0\r?\n/),
        stderr);
-assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session server \(\d+\)\] closed with code 0/),
+assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session server \(\d+\)\] closed with code 0\r?\n/),
        stderr);
-assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session server \(\d+\)\] tearing down stream/),
+assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session server \(\d+\)\] tearing down stream\r?\n/),
        stderr);
 assert.strictEqual(stdout.trim(), '');


### PR DESCRIPTION
The FWrite function on Windows assumed that MultiByteToWideChar
automatically null-terminates the resulting string, but it will only do
so if the size of the source was passed as -1 or null character was
explicitly counted in the size. The FWrite uses std::string and its
`.size()` method which doesn't count the null character even though the
`.data()` method adds it to the resulting string.

https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar#remarks
> MultiByteToWideChar does not null-terminate an output string if the
  input string length is explicitly specified without a terminating null
  character. To null-terminate an output string for this function, the
  application should pass in -1 or explicitly count the terminating null
  character for the input string.

-------------------------------------
Discovered while debugging http2 tests on windows, all native logs were in one line. Hopefully I didn't miss another thing in the MultiByteToWideChar doc, it's quite confusing.

/cc @addaleax 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
