### PR TITLE
benchmark: clean up config resolution in multiple benchmarks

### DIFF
--- a/benchmark/fs/readfile-partitioned.js
+++ b/benchmark/fs/readfile-partitioned.js
@@ -22,8 +22,7 @@ const bench = common.createBenchmark(main, {
   concurrent: [1, 10]
 });
 
-function main(conf) {
-  const len = +conf.len;
+function main({ len, dur, concurrent }) {
   try { fs.unlinkSync(filename); } catch {}
   let data = Buffer.alloc(len, 'x');
   fs.writeFileSync(filename, data);
@@ -40,7 +39,7 @@ function main(conf) {
     benchEnded = true;
     bench.end(totalOps);
     try { fs.unlinkSync(filename); } catch {}
-  }, +conf.dur * 1000);
+  }, dur * 1000);
 
   function read() {
     fs.readFile(filename, afterRead);
@@ -78,8 +77,7 @@ function main(conf) {
   }
 
   // Start reads
-  let cur = +conf.concurrent;
-  while (cur--) read();
+  while (concurrent-- > 0) read();
 
   // Start a competing zip
   zip();

--- a/benchmark/http/set_header.js
+++ b/benchmark/http/set_header.js
@@ -16,10 +16,7 @@ const bench = common.createBenchmark(main, {
   n: [1e6],
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const value = conf.value;
-
+function main({ n, value }) {
   const og = new OutgoingMessage();
 
   bench.start();

--- a/benchmark/url/legacy-vs-whatwg-url-get-prop.js
+++ b/benchmark/url/legacy-vs-whatwg-url-get-prop.js
@@ -71,9 +71,8 @@ function useWHATWG(data) {
 }
 
 function main({ type, method, e }) {
-  e = +e;
-  var data;
-  var noDead;  // Avoid dead code elimination.
+  let data;
+  let noDead;  // Avoid dead code elimination.
   switch (method) {
     case 'legacy':
       data = common.bakeUrlData(type, e, false, false);

--- a/benchmark/url/legacy-vs-whatwg-url-parse.js
+++ b/benchmark/url/legacy-vs-whatwg-url-parse.js
@@ -46,7 +46,6 @@ function useWHATWGWithoutBase(data) {
 }
 
 function main({ e, method, type, withBase }) {
-  e = +e;
   withBase = withBase === 'true';
   var noDead;  // Avoid dead code elimination.
   var data;

--- a/benchmark/url/legacy-vs-whatwg-url-serialize.js
+++ b/benchmark/url/legacy-vs-whatwg-url-serialize.js
@@ -35,7 +35,6 @@ function useWHATWG(data) {
 }
 
 function main({ type, e, method }) {
-  e = +e;
   const data = common.bakeUrlData(type, e, false, false);
 
   var noDead;  // Avoid dead code elimination.

--- a/benchmark/url/whatwg-url-properties.js
+++ b/benchmark/url/whatwg-url-properties.js
@@ -34,7 +34,6 @@ function get(data, prop) {
 }
 
 function main({ e, type, prop, withBase }) {
-  e = +e;
   withBase = withBase === 'true';
   const data = common.bakeUrlData(type, e, withBase, true);
   switch (prop) {

--- a/benchmark/worker/echo.js
+++ b/benchmark/worker/echo.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../common.js');
+const { Worker } = require('worker_threads');
 const path = require('path');
 const bench = common.createBenchmark(main, {
   workers: [1],
@@ -11,19 +12,14 @@ const bench = common.createBenchmark(main, {
 
 const workerPath = path.resolve(__dirname, '..', 'fixtures', 'echo.worker.js');
 
-function main(conf) {
-  const { Worker } = require('worker_threads');
-
-  const n = +conf.n;
-  const workers = +conf.workers;
-  const sends = +conf.sendsPerBroadcast;
+function main({ n, workers, sendsPerBroadcast: sends, payload: payloadType }) {
   const expectedPerBroadcast = sends * workers;
-  var payload;
-  var readies = 0;
-  var broadcasts = 0;
-  var msgCount = 0;
+  let payload;
+  let readies = 0;
+  let broadcasts = 0;
+  let msgCount = 0;
 
-  switch (conf.payload) {
+  switch (payloadType) {
     case 'string':
       payload = 'hello world!';
       break;


### PR DESCRIPTION
This removes 'to Number' casting in multiple benchmarks (which is
handled by the benchmark runner) and cleans up some var usage in changed
benchmarks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
