### PR TITLE
module: prevent builtins from resolving from disk

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -154,15 +154,16 @@ require(X) from module at path Y
 1. If X is a core module,
    a. return the core module
    b. STOP
-2. If X begins with '/'
+2. If the first '/' separated path segment of X is a core module, THROW "not found"
+3. If X begins with '/'
    a. set Y to be the filesystem root
-3. If X begins with './' or '/' or '../'
+4. If X begins with './' or '/' or '../'
    a. LOAD_AS_FILE(Y + X)
    b. LOAD_AS_DIRECTORY(Y + X)
    c. THROW "not found"
-4. LOAD_SELF_REFERENCE(X, dirname(Y))
-5. LOAD_NODE_MODULES(X, dirname(Y))
-6. THROW "not found"
+5. LOAD_SELF_REFERENCE(X, dirname(Y))
+6. LOAD_NODE_MODULES(X, dirname(Y))
+7. THROW "not found"
 
 LOAD_AS_FILE(X)
 1. If X is a file, load X as JavaScript text.  STOP

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -208,6 +208,11 @@ class NativeModule {
     return mod && mod.canBeRequiredByUsers;
   }
 
+  static isPartOfNamespace(specifier) {
+    const root = specifier.split('/', 1)[0];
+    return this.canBeRequiredByUsers(root);
+  }
+
   // Used by user-land module loaders to compile and load builtins.
   compileForPublicLoader() {
     if (!this.canBeRequiredByUsers) {

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -151,6 +151,8 @@ const getOwn = (target, property, receiver) => {
     undefined;
 };
 
+let unsafeBuiltinResolution;
+
 /**
  * An internal abstraction for the built-in JavaScript modules of Node.js.
  * Be careful not to expose this to user land unless --expose-internals is
@@ -209,6 +211,13 @@ class NativeModule {
   }
 
   static isPartOfNamespace(specifier) {
+    if (unsafeBuiltinResolution === undefined) {
+      unsafeBuiltinResolution = nativeModuleRequire('internal/options')
+        .getOptionValue('--unsafe-builtin-resolution');
+    }
+    if (unsafeBuiltinResolution) {
+      return this.canBeRequiredByUsers(specifier);
+    }
     const root = specifier.split('/', 1)[0];
     return this.canBeRequiredByUsers(root);
   }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -964,9 +964,31 @@ Module._load = function(request, parent, isMain) {
   return module.exports;
 };
 
+function throwModuleNotFound(request, parent) {
+  const requireStack = [];
+  for (let cursor = parent;
+    cursor;
+    cursor = cursor.parent) {
+    requireStack.push(cursor.filename || cursor.id);
+  }
+  let message = `Cannot find module '${request}'`;
+  if (requireStack.length > 0) {
+    message = message + '\nRequire stack:\n- ' + requireStack.join('\n- ');
+  }
+  // eslint-disable-next-line no-restricted-syntax
+  const err = new Error(message);
+  err.code = 'MODULE_NOT_FOUND';
+  err.requireStack = requireStack;
+  throw err;
+}
+
 Module._resolveFilename = function(request, parent, isMain, options) {
   if (NativeModule.canBeRequiredByUsers(request)) {
     return request;
+  }
+
+  if (NativeModule.isPartOfNamespace(request)) {
+    throwModuleNotFound(request, parent);
   }
 
   let paths;
@@ -1019,21 +1041,8 @@ Module._resolveFilename = function(request, parent, isMain, options) {
   // Look up the filename first, since that's the cache key.
   const filename = Module._findPath(request, paths, isMain, false);
   if (filename) return filename;
-  const requireStack = [];
-  for (let cursor = parent;
-    cursor;
-    cursor = cursor.parent) {
-    requireStack.push(cursor.filename || cursor.id);
-  }
-  let message = `Cannot find module '${request}'`;
-  if (requireStack.length > 0) {
-    message = message + '\nRequire stack:\n- ' + requireStack.join('\n- ');
-  }
-  // eslint-disable-next-line no-restricted-syntax
-  const err = new Error(message);
-  err.code = 'MODULE_NOT_FOUND';
-  err.requireStack = requireStack;
-  throw err;
+
+  throwModuleNotFound(request, parent);
 };
 
 

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -34,7 +34,7 @@ function defaultResolve(specifier, { parentURL } = {}, defaultResolve) {
     return { url: specifier };
   if (parsed && parsed.protocol !== 'file:' && parsed.protocol !== 'data:')
     throw new ERR_UNSUPPORTED_ESM_URL_SCHEME();
-  if (NativeModule.canBeRequiredByUsers(specifier)) {
+  if (NativeModule.isPartOfNamespace(specifier)) {
     return {
       url: 'nodejs:' + specifier
     };

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -546,6 +546,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
 
   AddOption("--napi-modules", "", NoOp{}, kAllowedInEnvironment);
 
+  AddOption("--unsafe-builtin-resolution", "",
+            &EnvironmentOptions::unsafe_builtin_resolution,
+            kAllowedInEnvironment);
+
   AddOption("--tls-keylog",
             "log TLS decryption keys to named file for traffic analysis",
             &EnvironmentOptions::tls_keylog, kAllowedInEnvironment);

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -161,6 +161,8 @@ class EnvironmentOptions : public Options {
 
   bool insecure_http_parser = false;
 
+  bool unsafe_builtin_resolution = false;
+
   bool tls_min_v1_0 = false;
   bool tls_min_v1_1 = false;
   bool tls_min_v1_2 = false;

--- a/test/parallel/test-module-builtin-namespace.js
+++ b/test/parallel/test-module-builtin-namespace.js
@@ -1,0 +1,39 @@
+'use strict';
+
+require('../common');
+const path = require('path');
+const fs = require('fs');
+const assert = require('assert');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const tmpDir = tmpdir.path;
+
+const node_modules = path.join(tmpDir, 'node_modules');
+
+fs.mkdirSync(node_modules);
+fs.mkdirSync(path.join(node_modules, 'util'));
+fs.writeFileSync(path.join(node_modules, 'util', 'xyz.js'),
+                 'throw new Error("this should not run")');
+
+fs.writeFileSync(path.join(tmpDir, 'test.js'),
+                 'module.exports = () => require("util/xyz");');
+
+fs.writeFileSync(path.join(tmpDir, 'test.mjs'),
+                 'export default () => import("util/xyz.js");');
+
+{
+  const test = require(path.join(tmpDir, 'test.js'));
+  assert.throws(() => {
+    test();
+  }, {
+    code: 'MODULE_NOT_FOUND',
+  });
+}
+
+(async function testESM() {
+  const { default: test } = await import(path.join(tmpDir, 'test.mjs'));
+  assert.rejects(() => test(), {
+    code: 'ERR_UNKNOWN_BUILTIN_MODULE',
+  });
+}());

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -89,6 +89,7 @@ assert(undocumented.delete('--es-module-specifier-resolution'));
 assert(undocumented.delete('--experimental-worker'));
 assert(undocumented.delete('--no-node-snapshot'));
 assert(undocumented.delete('--loader'));
+assert(undocumented.delete('--unsafe-builtin-resolution'));
 
 assert.strictEqual(undocumented.size, 0,
                    'The following options are not documented as allowed in ' +

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -549,6 +549,7 @@ const errorTests = [
       /^    at .*/,
       /^    at .*/,
       /^    at .*/,
+      /^    at .*/,
       "  code: 'MODULE_NOT_FOUND',",
       "  requireStack: [ '<repl>' ]",
       '}'


### PR DESCRIPTION
Basically if you try to resolve `<builtin>/doesnotexist`, instead of searching for `node_modules/<builtin>/doesnotexist`, it will say the module doesn't exist.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)