### PR TITLE
src: remove duplicate env field from CryptoJob

### DIFF
--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -32,6 +32,8 @@ class JSStream : public AsyncWrap, public StreamBase {
   SET_MEMORY_INFO_NAME(JSStream)
   SET_SELF_SIZE(JSStream)
 
+  Environment* env() const { return AsyncWrap::env(); }
+
  protected:
   JSStream(Environment* env, v8::Local<v8::Object> obj);
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -6194,9 +6194,8 @@ bool ECDH::IsKeyPairValid() {
 // TODO(addaleax): If there is an `AsyncWrap`, it currently has no access to
 // this object. This makes proper reporting of memory usage impossible.
 struct CryptoJob : public ThreadPoolWork {
-  Environment* const env;
   std::unique_ptr<AsyncWrap> async_wrap;
-  inline explicit CryptoJob(Environment* env) : ThreadPoolWork(env), env(env) {}
+  inline explicit CryptoJob(Environment* env) : ThreadPoolWork(env) {}
   inline void AfterThreadPoolWork(int status) final;
   virtual void AfterThreadPoolWork() = 0;
   static inline void Run(std::unique_ptr<CryptoJob> job, Local<Value> wrap);
@@ -6207,8 +6206,8 @@ void CryptoJob::AfterThreadPoolWork(int status) {
   CHECK(status == 0 || status == UV_ECANCELED);
   std::unique_ptr<CryptoJob> job(this);
   if (status == UV_ECANCELED) return;
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
+  HandleScope handle_scope(env()->isolate());
+  Context::Scope context_scope(env()->context());
   CHECK_EQ(false, async_wrap->persistent().IsWeak());
   AfterThreadPoolWork();
 }
@@ -6249,12 +6248,12 @@ struct RandomBytesJob : public CryptoJob {
 
   inline void AfterThreadPoolWork() override {
     Local<Value> arg = ToResult();
-    async_wrap->MakeCallback(env->ondone_string(), 1, &arg);
+    async_wrap->MakeCallback(env()->ondone_string(), 1, &arg);
   }
 
   inline Local<Value> ToResult() const {
-    if (errors.empty()) return Undefined(env->isolate());
-    return errors.ToException(env).ToLocalChecked();
+    if (errors.empty()) return Undefined(env()->isolate());
+    return errors.ToException(env()).ToLocalChecked();
   }
 };
 
@@ -6306,11 +6305,11 @@ struct PBKDF2Job : public CryptoJob {
 
   inline void AfterThreadPoolWork() override {
     Local<Value> arg = ToResult();
-    async_wrap->MakeCallback(env->ondone_string(), 1, &arg);
+    async_wrap->MakeCallback(env()->ondone_string(), 1, &arg);
   }
 
   inline Local<Value> ToResult() const {
-    return Boolean::New(env->isolate(), success.FromJust());
+    return Boolean::New(env()->isolate(), success.FromJust());
   }
 
   inline void Cleanse() {
@@ -6386,12 +6385,12 @@ struct ScryptJob : public CryptoJob {
 
   inline void AfterThreadPoolWork() override {
     Local<Value> arg = ToResult();
-    async_wrap->MakeCallback(env->ondone_string(), 1, &arg);
+    async_wrap->MakeCallback(env()->ondone_string(), 1, &arg);
   }
 
   inline Local<Value> ToResult() const {
-    if (errors.empty()) return Undefined(env->isolate());
-    return errors.ToException(env).ToLocalChecked();
+    if (errors.empty()) return Undefined(env()->isolate());
+    return errors.ToException(env()).ToLocalChecked();
   }
 
   inline void Cleanse() {
@@ -6720,7 +6719,7 @@ class GenerateKeyPairJob : public CryptoJob {
   inline void AfterThreadPoolWork() override {
     Local<Value> args[3];
     ToResult(&args[0], &args[1], &args[2]);
-    async_wrap->MakeCallback(env->ondone_string(), 3, args);
+    async_wrap->MakeCallback(env()->ondone_string(), 3, args);
   }
 
   inline void ToResult(Local<Value>* err,
@@ -6728,14 +6727,14 @@ class GenerateKeyPairJob : public CryptoJob {
                        Local<Value>* privkey) {
     if (pkey_ && EncodeKeys(pubkey, privkey)) {
       CHECK(errors_.empty());
-      *err = Undefined(env->isolate());
+      *err = Undefined(env()->isolate());
     } else {
       if (errors_.empty())
         errors_.Capture();
       CHECK(!errors_.empty());
-      *err = errors_.ToException(env).ToLocalChecked();
-      *pubkey = Undefined(env->isolate());
-      *privkey = Undefined(env->isolate());
+      *err = errors_.ToException(env()).ToLocalChecked();
+      *pubkey = Undefined(env()->isolate());
+      *privkey = Undefined(env()->isolate());
     }
   }
 
@@ -6744,20 +6743,20 @@ class GenerateKeyPairJob : public CryptoJob {
     if (public_key_encoding_.output_key_object_) {
       // Note that this has the downside of containing sensitive data of the
       // private key.
-      if (!KeyObject::Create(env, kKeyTypePublic, pkey_).ToLocal(pubkey))
+      if (!KeyObject::Create(env(), kKeyTypePublic, pkey_).ToLocal(pubkey))
         return false;
     } else {
-      if (!WritePublicKey(env, pkey_.get(), public_key_encoding_)
+      if (!WritePublicKey(env(), pkey_.get(), public_key_encoding_)
                .ToLocal(pubkey))
         return false;
     }
 
     // Now do the same for the private key.
     if (private_key_encoding_.output_key_object_) {
-      if (!KeyObject::Create(env, kKeyTypePrivate, pkey_).ToLocal(privkey))
+      if (!KeyObject::Create(env(), kKeyTypePrivate, pkey_).ToLocal(privkey))
         return false;
     } else {
-      if (!WritePrivateKey(env, pkey_.get(), private_key_encoding_)
+      if (!WritePrivateKey(env(), pkey_.get(), private_key_encoding_)
                .ToLocal(privkey))
         return false;
     }

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -205,6 +205,8 @@ class FileHandle final : public AsyncWrap, public StreamBase {
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
 
+  Environment* env() const { return AsyncWrap::env(); }
+
   int GetFD() override { return fd_; }
 
   // Will asynchronously close the FD and return a Promise that will

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -458,6 +458,7 @@ class Http2Stream : public AsyncWrap,
 
   nghttp2_stream* operator*();
 
+  Environment* env() const { return AsyncWrap::env(); }
   Http2Session* session() { return session_.get(); }
   const Http2Session* session() const { return session_.get(); }
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -268,6 +268,8 @@ class ThreadPoolWork {
   virtual void DoThreadPoolWork() = 0;
   virtual void AfterThreadPoolWork(int status) = 0;
 
+  inline Environment* env() const { return env_; }
+
  private:
   Environment* env_;
   uv_work_t work_req_;

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -256,6 +256,8 @@ class CompressionStream : public AsyncWrap, public ThreadPoolWork {
     CHECK_EQ(unreported_allocations_, 0);
   }
 
+  Environment* env() const { return AsyncWrap::env(); }
+
   void Close() {
     if (write_in_progress_) {
       pending_close_ = true;

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -296,9 +296,7 @@ class StreamBase : public StreamResource {
       size_t offset = 0,
       StreamBaseJSChecks checks = DONT_SKIP_NREAD_CHECKS);
 
-  // This is named `stream_env` to avoid name clashes, because a lot of
-  // subclasses are also `BaseObject`s.
-  Environment* stream_env() const;
+  Environment* env() const;
 
   // Shut down the current stream. This request can use an existing
   // ShutdownWrap object (that was created in JS), or a new one will be created.

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -16,7 +16,7 @@ namespace node {
 StreamPipe::StreamPipe(StreamBase* source,
                        StreamBase* sink,
                        Local<Object> obj)
-    : AsyncWrap(source->stream_env(), obj, AsyncWrap::PROVIDER_STREAMPIPE) {
+    : AsyncWrap(source->env(), obj, AsyncWrap::PROVIDER_STREAMPIPE) {
   MakeWeak();
 
   CHECK_NOT_NULL(sink);

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -56,6 +56,10 @@ class LibuvStreamWrap : public HandleWrap, public StreamBase {
               size_t count,
               uv_stream_t* send_handle) override;
 
+  inline Environment* env() const {
+    return AsyncWrap::env();
+  }
+
   inline uv_stream_t* stream() const {
     return stream_;
   }

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -56,6 +56,8 @@ class TLSWrap : public AsyncWrap,
                          v8::Local<v8::Context> context,
                          void* priv);
 
+  Environment* env() const { return AsyncWrap::env(); }
+
   // Implement StreamBase:
   bool IsAlive() override;
   bool IsClosing() override;


### PR DESCRIPTION
Alternative take on #31554 that tightens up the use of `env()` getters.

First:

    src: remove duplicate env field from CryptoJob

    Add a `ThreadPoolWork::env()` getter and use that. To fix the diamond
    problem in class CompressionStream that inherits from both AsyncWrap
    and ThreadPoolWork, we add a `CompressionStream::env()` getter that
    delegates to `AsyncWrap::env()`.

And then:

    src: StreamBase::stream_env() -> StreamBase::env()

    Rename `StreamBase::stream_env()` to `StreamBase::env()` and work around
    the diamond problem by adding `env()` getters to several classes.