### PR TITLE
test: improve flaky http2-stream-destroy-event-order

### DIFF
--- a/test/parallel/test-http2-stream-destroy-event-order.js
+++ b/test/parallel/test-http2-stream-destroy-event-order.js
@@ -23,7 +23,16 @@ server.listen(0, common.mustCall(() => {
   req.resume();
   req.on('error', common.mustCall(() => {
     req.on('close', common.mustCall(() => {
-      client.close();
+      // TODO(lundibundi): fix flakiness of this use case, the setTimeout must
+      // not be needed here. Specifically if the settings frame on the client
+      // is 'delayed' and only comes after we have already called
+      // `req.close(2)` then the 'close' event will be emitted before the
+      // stream has got a chance to write the rst to the underlying socket
+      // (even though FlushRstStream and SendPendingData have been called) and
+      // since we are destroying a session here it will never be written
+      // resulting in a 'clean' stream close on the server side and therefore a
+      // timeout because there will be no error.
+      setTimeout(() => client.close(), 0);
     }));
   }));
 }));


### PR DESCRIPTION
This doesn't properly fix the issue, it only significantly reduces
(removes?) the flakiness of the test.

The setTimeout must not be needed here. Specifically if the settings
frame on the client is 'delayed' and only comes after we have already
called `req.close(2)` then the 'close' event will be emitted before the
stream has got a chance to write the rst to the underlying socket (even
though FlushRstStream and SendPendingData have been called) and since we
are destroying a session here it will never be written resulting in a
'clean' stream close on the server side and therefore a timeout because
there will be no error.

-----------------
Looks like we are not correctly waiting for the rst frame to be sent and I assume the time it takes to read the settings frame delays the write just enough to not get written at all. I will try to investigate this further but at least this should improve our CI so that it won't fail with this test almost every time.
This patch reduces the flakiness from 1 failed in 10 runs to 0/2000 on my windows machine.

The debug native logs can be found: 
[http2-destroy-event-order-success.txt](https://github.com/nodejs/node/files/4139102/http2-destroy-event-order-success.txt) 
[http2-destroy-event-order-fail.txt](https://github.com/nodejs/node/files/4139103/http2-destroy-event-order-fail.txt).




/cc @nodejs/testing @jasnell @addaleax 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
