### PR TITLE
benchmark: use let instead of var

### DIFF
--- a/benchmark/module/module-loader-deep.js
+++ b/benchmark/module/module-loader-deep.js
@@ -19,7 +19,7 @@ function main({ ext, cache, files }) {
     `${benchmarkDirectory}/a.js`,
     'module.exports = {};'
   );
-  for (var i = 0; i <= files; i++) {
+  for (let i = 0; i <= files; i++) {
     fs.mkdirSync(`${benchmarkDirectory}/${i}`);
     fs.writeFileSync(
       `${benchmarkDirectory}/${i}/package.json`,
@@ -37,14 +37,13 @@ function main({ ext, cache, files }) {
 }
 
 function measureDir(cache, files) {
-  var i;
   if (cache) {
-    for (i = 0; i <= files; i++) {
+    for (let i = 0; i <= files; i++) {
       require(`${benchmarkDirectory}/${i}`);
     }
   }
   bench.start();
-  for (i = 0; i <= files; i++) {
+  for (let i = 0; i <= files; i++) {
     require(`${benchmarkDirectory}/${i}`);
   }
   bench.end(files);

--- a/benchmark/module/module-loader.js
+++ b/benchmark/module/module-loader.js
@@ -21,7 +21,7 @@ const bench = common.createBenchmark(main, {
 function main({ n, name, cache, files, dir }) {
   tmpdir.refresh();
   fs.mkdirSync(benchmarkDirectory);
-  for (var i = 0; i <= files; i++) {
+  for (let i = 0; i <= files; i++) {
     fs.mkdirSync(`${benchmarkDirectory}${i}`);
     fs.writeFileSync(
       `${benchmarkDirectory}${i}/package.json`,
@@ -42,15 +42,14 @@ function main({ n, name, cache, files, dir }) {
 }
 
 function measureDir(n, cache, files, name) {
-  var i;
   if (cache) {
-    for (i = 0; i <= files; i++) {
+    for (let i = 0; i <= files; i++) {
       require(`${benchmarkDirectory}${i}${name}`);
     }
   }
   bench.start();
-  for (i = 0; i <= files; i++) {
-    for (var j = 0; j < n; j++)
+  for (let i = 0; i <= files; i++) {
+    for (let j = 0; j < n; j++)
       require(`${benchmarkDirectory}${i}${name}`);
     // Pretend mixed input (otherwise the results are less representative due to
     // highly specialized code).

--- a/benchmark/napi/function_args/index.js
+++ b/benchmark/napi/function_args/index.js
@@ -89,7 +89,7 @@ function main({ n, engine, type }) {
     const args = generateArgs(type);
 
     bench.start();
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       fn.apply(null, args);
     }
     bench.end(n);

--- a/benchmark/napi/function_call/index.js
+++ b/benchmark/napi/function_call/index.js
@@ -29,7 +29,7 @@ try {
 }
 const napi = napi_binding.hello;
 
-var c = 0;
+let c = 0;
 function js() {
   return c++;
 }
@@ -44,7 +44,7 @@ const bench = common.createBenchmark(main, {
 function main({ n, type }) {
   const fn = type === 'cxx' ? cxx : type === 'napi' ? napi : js;
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     fn();
   }
   bench.end(n);

--- a/benchmark/net/net-c2s-cork.js
+++ b/benchmark/net/net-c2s-cork.js
@@ -11,8 +11,8 @@ const bench = common.createBenchmark(main, {
   dur: [5],
 });
 
-var chunk;
-var encoding;
+let chunk;
+let encoding;
 
 function main({ dur, len, type }) {
   switch (type) {

--- a/benchmark/net/net-c2s.js
+++ b/benchmark/net/net-c2s.js
@@ -11,8 +11,8 @@ const bench = common.createBenchmark(main, {
   dur: [5],
 });
 
-var chunk;
-var encoding;
+let chunk;
+let encoding;
 
 function main({ dur, len, type }) {
   switch (type) {

--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -11,8 +11,8 @@ const bench = common.createBenchmark(main, {
   dur: [5],
 });
 
-var chunk;
-var encoding;
+let chunk;
+let encoding;
 
 function main({ dur, len, type }) {
   switch (type) {

--- a/benchmark/net/net-s2c.js
+++ b/benchmark/net/net-s2c.js
@@ -12,10 +12,10 @@ const bench = common.createBenchmark(main, {
   dur: [5]
 });
 
-var chunk;
-var encoding;
-var recvbuf;
-var received = 0;
+let chunk;
+let encoding;
+let recvbuf;
+let received = 0;
 
 function main({ dur, sendchunklen, type, recvbuflen, recvbufgenfn }) {
   if (isFinite(recvbuflen) && recvbuflen > 0)
@@ -38,8 +38,8 @@ function main({ dur, sendchunklen, type, recvbuflen, recvbufgenfn }) {
   }
 
   const reader = new Reader();
-  var writer;
-  var socketOpts;
+  let writer;
+  let socketOpts;
   if (recvbuf === undefined) {
     writer = new Writer();
     socketOpts = { port: PORT };

--- a/benchmark/net/net-wrap-js-stream-passthrough.js
+++ b/benchmark/net/net-wrap-js-stream-passthrough.js
@@ -12,8 +12,8 @@ const bench = common.createBenchmark(main, {
   flags: ['--expose-internals']
 });
 
-var chunk;
-var encoding;
+let chunk;
+let encoding;
 
 function main({ dur, len, type }) {
   // Can only require internals inside main().

--- a/benchmark/net/tcp-raw-c2s.js
+++ b/benchmark/net/tcp-raw-c2s.js
@@ -24,7 +24,7 @@ function main({ dur, len, type }) {
   const PORT = common.PORT;
 
   const serverHandle = new TCP(TCPConstants.SERVER);
-  var err = serverHandle.bind('127.0.0.1', PORT);
+  let err = serverHandle.bind('127.0.0.1', PORT);
   if (err)
     fail(err, 'bind');
 
@@ -38,7 +38,7 @@ function main({ dur, len, type }) {
 
     // The meat of the benchmark is right here:
     bench.start();
-    var bytes = 0;
+    let bytes = 0;
 
     setTimeout(() => {
       // report in Gb/sec
@@ -67,7 +67,7 @@ function main({ dur, len, type }) {
   }
 
   function client(type, len) {
-    var chunk;
+    let chunk;
     switch (type) {
       case 'buf':
         chunk = Buffer.alloc(len, 'x');
@@ -102,7 +102,7 @@ function main({ dur, len, type }) {
     function write() {
       const writeReq = new WriteWrap();
       writeReq.oncomplete = afterWrite;
-      var err;
+      let err;
       switch (type) {
         case 'buf':
           err = clientHandle.writeBuffer(writeReq, chunk);

--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -31,7 +31,7 @@ function main({ dur, len, type }) {
 
   // Server
   const serverHandle = new TCP(TCPConstants.SERVER);
-  var err = serverHandle.bind('127.0.0.1', PORT);
+  let err = serverHandle.bind('127.0.0.1', PORT);
   if (err)
     fail(err, 'bind');
 
@@ -66,7 +66,7 @@ function main({ dur, len, type }) {
   };
 
   // Client
-  var chunk;
+  let chunk;
   switch (type) {
     case 'buf':
       chunk = Buffer.alloc(len, 'x');
@@ -83,7 +83,7 @@ function main({ dur, len, type }) {
 
   const clientHandle = new TCP(TCPConstants.SOCKET);
   const connectReq = new TCPConnectWrap();
-  var bytes = 0;
+  let bytes = 0;
 
   err = clientHandle.connect(connectReq, '127.0.0.1', PORT);
   if (err)
@@ -118,7 +118,7 @@ function main({ dur, len, type }) {
   function write() {
     const writeReq = new WriteWrap();
     writeReq.oncomplete = afterWrite;
-    var err;
+    let err;
     switch (type) {
       case 'buf':
         err = clientHandle.writeBuffer(writeReq, chunk);

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -26,7 +26,7 @@ function main({ dur, len, type }) {
   const PORT = common.PORT;
 
   const serverHandle = new TCP(TCPConstants.SERVER);
-  var err = serverHandle.bind('127.0.0.1', PORT);
+  let err = serverHandle.bind('127.0.0.1', PORT);
   if (err)
     fail(err, 'bind');
 
@@ -38,7 +38,7 @@ function main({ dur, len, type }) {
     if (err)
       fail(err, 'connect');
 
-    var chunk;
+    let chunk;
     switch (type) {
       case 'buf':
         chunk = Buffer.alloc(len, 'x');
@@ -62,7 +62,7 @@ function main({ dur, len, type }) {
       const writeReq = new WriteWrap();
       writeReq.async = false;
       writeReq.oncomplete = afterWrite;
-      var err;
+      let err;
       switch (type) {
         case 'buf':
           err = clientHandle.writeBuffer(writeReq, chunk);
@@ -108,7 +108,7 @@ function main({ dur, len, type }) {
       fail(err, 'connect');
 
     connectReq.oncomplete = function() {
-      var bytes = 0;
+      let bytes = 0;
       clientHandle.onread = function(buffer) {
         // We're not expecting to ever get an EOF from the client.
         // Just lots of data forever.

--- a/benchmark/os/cpus.js
+++ b/benchmark/os/cpus.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n }) {
   bench.start();
-  for (var i = 0; i < n; ++i)
+  for (let i = 0; i < n; ++i)
     cpus();
   bench.end(n);
 }

--- a/benchmark/os/loadavg.js
+++ b/benchmark/os/loadavg.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n }) {
   bench.start();
-  for (var i = 0; i < n; ++i)
+  for (let i = 0; i < n; ++i)
     loadavg();
   bench.end(n);
 }

--- a/benchmark/os/networkInterfaces.js
+++ b/benchmark/os/networkInterfaces.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n }) {
   bench.start();
-  for (var i = 0; i < n; ++i)
+  for (let i = 0; i < n; ++i)
     networkInterfaces();
   bench.end(n);
 }

--- a/benchmark/path/basename-posix.js
+++ b/benchmark/path/basename-posix.js
@@ -19,7 +19,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, pathext }) {
-  var ext;
+  let ext;
   const extIdx = pathext.indexOf('|');
   if (extIdx !== -1) {
     ext = pathext.slice(extIdx + 1);
@@ -27,7 +27,7 @@ function main({ n, pathext }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     posix.basename(i % 3 === 0 ? `${pathext}${i}` : pathext, ext);
   }
   bench.end(n);

--- a/benchmark/path/basename-win32.js
+++ b/benchmark/path/basename-win32.js
@@ -19,7 +19,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, pathext }) {
-  var ext;
+  let ext;
   const extIdx = pathext.indexOf('|');
   if (extIdx !== -1) {
     ext = pathext.slice(extIdx + 1);
@@ -27,7 +27,7 @@ function main({ n, pathext }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     win32.basename(i % 3 === 0 ? `${pathext}${i}` : pathext, ext);
   }
   bench.end(n);

--- a/benchmark/path/dirname-posix.js
+++ b/benchmark/path/dirname-posix.js
@@ -17,7 +17,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     posix.dirname(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/dirname-win32.js
+++ b/benchmark/path/dirname-win32.js
@@ -17,7 +17,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     win32.dirname(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/extname-posix.js
+++ b/benchmark/path/extname-posix.js
@@ -20,7 +20,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     posix.extname(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/extname-win32.js
+++ b/benchmark/path/extname-win32.js
@@ -20,7 +20,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     win32.extname(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/format-posix.js
+++ b/benchmark/path/format-posix.js
@@ -20,7 +20,7 @@ function main({ n, props }) {
   };
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     obj.base = `a${i}${props[2] || ''}`;
     obj.name = `a${i}${props[4] || ''}`;
     posix.format(obj);

--- a/benchmark/path/format-win32.js
+++ b/benchmark/path/format-win32.js
@@ -20,7 +20,7 @@ function main({ n, props }) {
   };
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     obj.base = `a${i}${props[2] || ''}`;
     obj.name = `a${i}${props[4] || ''}`;
     win32.format(obj);

--- a/benchmark/path/isAbsolute-posix.js
+++ b/benchmark/path/isAbsolute-posix.js
@@ -15,7 +15,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     posix.isAbsolute(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/isAbsolute-win32.js
+++ b/benchmark/path/isAbsolute-win32.js
@@ -16,7 +16,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     win32.isAbsolute(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/join-posix.js
+++ b/benchmark/path/join-posix.js
@@ -15,7 +15,7 @@ function main({ n, paths }) {
   const orig = copy[1];
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 3 === 0) {
       copy[1] = `${orig}${i}`;
       posix.join(...copy);

--- a/benchmark/path/join-win32.js
+++ b/benchmark/path/join-win32.js
@@ -15,7 +15,7 @@ function main({ n, paths }) {
   const orig = copy[1];
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 3 === 0) {
       copy[1] = `${orig}${i}`;
       win32.join(...copy);

--- a/benchmark/path/makeLong-win32.js
+++ b/benchmark/path/makeLong-win32.js
@@ -14,7 +14,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     win32._makeLong(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/normalize-posix.js
+++ b/benchmark/path/normalize-posix.js
@@ -16,7 +16,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     posix.normalize(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/normalize-win32.js
+++ b/benchmark/path/normalize-win32.js
@@ -16,7 +16,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, path }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     win32.normalize(i % 3 === 0 ? `${path}${i}` : path);
   }
   bench.end(n);

--- a/benchmark/path/relative-posix.js
+++ b/benchmark/path/relative-posix.js
@@ -16,7 +16,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, paths }) {
-  var to = '';
+  let to = '';
   const delimIdx = paths.indexOf('|');
   if (delimIdx > -1) {
     to = paths.slice(delimIdx + 1);

--- a/benchmark/path/relative-win32.js
+++ b/benchmark/path/relative-win32.js
@@ -14,7 +14,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, paths }) {
-  var to = '';
+  let to = '';
   const delimIdx = paths.indexOf('|');
   if (delimIdx > -1) {
     to = paths.slice(delimIdx + 1);

--- a/benchmark/path/resolve-posix.js
+++ b/benchmark/path/resolve-posix.js
@@ -18,7 +18,7 @@ function main({ n, paths }) {
   const orig = copy[0];
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 3 === 0) {
       copy[0] = `${orig}${i}`;
       posix.resolve(...copy);

--- a/benchmark/path/resolve-win32.js
+++ b/benchmark/path/resolve-win32.js
@@ -18,7 +18,7 @@ function main({ n, paths }) {
   const orig = copy[0];
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 3 === 0) {
       copy[0] = `${orig}${i}`;
       win32.resolve(...copy);

--- a/benchmark/process/bench-hrtime.js
+++ b/benchmark/process/bench-hrtime.js
@@ -10,27 +10,26 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, type }) {
   const hrtime = process.hrtime;
-  var noDead = type === 'bigint' ? hrtime.bigint() : hrtime();
-  var i;
+  let noDead = type === 'bigint' ? hrtime.bigint() : hrtime();
 
   switch (type) {
     case 'raw':
       bench.start();
-      for (i = 0; i < n; i++) {
+      for (let i = 0; i < n; i++) {
         noDead = hrtime();
       }
       bench.end(n);
       break;
     case 'diff':
       bench.start();
-      for (i = 0; i < n; i++) {
+      for (let i = 0; i < n; i++) {
         noDead = hrtime(noDead);
       }
       bench.end(n);
       break;
     case 'bigint':
       bench.start();
-      for (i = 0; i < n; i++) {
+      for (let i = 0; i < n; i++) {
         noDead = hrtime.bigint();
       }
       bench.end(n);

--- a/benchmark/process/memoryUsage.js
+++ b/benchmark/process/memoryUsage.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n }) {
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     process.memoryUsage();
   }
   bench.end(n);

--- a/benchmark/process/next-tick-breadth-args.js
+++ b/benchmark/process/next-tick-breadth-args.js
@@ -6,7 +6,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
-  var j = 0;
+  let j = 0;
 
   function cb1(arg1) {
     j++;
@@ -33,7 +33,7 @@ function main({ n }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 4 === 0)
       process.nextTick(cb4, 3.14, 1024, true, false);
     else if (i % 3 === 0)

--- a/benchmark/process/next-tick-breadth.js
+++ b/benchmark/process/next-tick-breadth.js
@@ -6,7 +6,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
-  var j = 0;
+  let j = 0;
 
   function cb() {
     j++;
@@ -15,7 +15,7 @@ function main({ n }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     process.nextTick(cb);
   }
 }

--- a/benchmark/process/next-tick-exec-args.js
+++ b/benchmark/process/next-tick-exec-args.js
@@ -10,7 +10,7 @@ function main({ n }) {
       bench.end(n);
   }
 
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     if (i % 4 === 0)
       process.nextTick(onNextTick, i, true, 10, 'test');
     else if (i % 3 === 0)

--- a/benchmark/process/next-tick-exec.js
+++ b/benchmark/process/next-tick-exec.js
@@ -10,7 +10,7 @@ function main({ n }) {
       bench.end(n);
   }
 
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     process.nextTick(onNextTick, i);
   }
 

--- a/benchmark/process/queue-microtask-breadth.js
+++ b/benchmark/process/queue-microtask-breadth.js
@@ -6,7 +6,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
-  var j = 0;
+  let j = 0;
 
   function cb() {
     j++;
@@ -15,7 +15,7 @@ function main({ n }) {
   }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     queueMicrotask(cb);
   }
 }

--- a/benchmark/querystring/querystring-parse.js
+++ b/benchmark/querystring/querystring-parse.js
@@ -10,23 +10,23 @@ const bench = common.createBenchmark(main, {
 
 function main({ type, n }) {
   const input = inputs[type];
-  var i;
+
   // Execute the function a "sufficient" number of times before the timed
   // loop to ensure the function is optimized just once.
   if (type === 'multicharsep') {
-    for (i = 0; i < n; i += 1)
+    for (let i = 0; i < n; i += 1)
       querystring.parse(input, '&&&&&&&&&&');
 
     bench.start();
-    for (i = 0; i < n; i += 1)
+    for (let i = 0; i < n; i += 1)
       querystring.parse(input, '&&&&&&&&&&');
     bench.end(n);
   } else {
-    for (i = 0; i < n; i += 1)
+    for (let i = 0; i < n; i += 1)
       querystring.parse(input);
 
     bench.start();
-    for (i = 0; i < n; i += 1)
+    for (let i = 0; i < n; i += 1)
       querystring.parse(input);
     bench.end(n);
   }

--- a/benchmark/querystring/querystring-stringify.js
+++ b/benchmark/querystring/querystring-stringify.js
@@ -38,7 +38,7 @@ function main({ type, n }) {
     querystring.stringify(inputs[name]);
 
   bench.start();
-  for (var i = 0; i < n; i += 1)
+  for (let i = 0; i < n; i += 1)
     querystring.stringify(input);
   bench.end(n);
 }

--- a/benchmark/querystring/querystring-unescapebuffer.js
+++ b/benchmark/querystring/querystring-unescapebuffer.js
@@ -14,7 +14,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ input, n }) {
   bench.start();
-  for (var i = 0; i < n; i += 1)
+  for (let i = 0; i < n; i += 1)
     querystring.unescapeBuffer(input);
   bench.end(n);
 }

--- a/benchmark/streams/creation.js
+++ b/benchmark/streams/creation.js
@@ -13,14 +13,13 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, kind }) {
-  var i = 0;
   switch (kind) {
     case 'duplex':
       new Duplex({});
       new Duplex();
 
       bench.start();
-      for (; i < n; ++i)
+      for (let i = 0; i < n; ++i)
         new Duplex();
       bench.end(n);
       break;
@@ -29,7 +28,7 @@ function main({ n, kind }) {
       new Readable();
 
       bench.start();
-      for (; i < n; ++i)
+      for (let i = 0; i < n; ++i)
         new Readable();
       bench.end(n);
       break;
@@ -38,7 +37,7 @@ function main({ n, kind }) {
       new Writable();
 
       bench.start();
-      for (; i < n; ++i)
+      for (let i = 0; i < n; ++i)
         new Writable();
       bench.end(n);
       break;
@@ -47,7 +46,7 @@ function main({ n, kind }) {
       new Transform();
 
       bench.start();
-      for (; i < n; ++i)
+      for (let i = 0; i < n; ++i)
         new Transform();
       bench.end(n);
       break;

--- a/benchmark/streams/pipe-object-mode.js
+++ b/benchmark/streams/pipe-object-mode.js
@@ -12,7 +12,7 @@ function main({ n }) {
   const r = new Readable({ objectMode: true });
   const w = new Writable({ objectMode: true });
 
-  var i = 0;
+  let i = 0;
 
   r._read = () => r.push(i++ === n ? null : b);
   w._write = (data, enc, cb) => cb();

--- a/benchmark/streams/pipe.js
+++ b/benchmark/streams/pipe.js
@@ -12,7 +12,7 @@ function main({ n }) {
   const r = new Readable();
   const w = new Writable();
 
-  var i = 0;
+  let i = 0;
 
   r._read = () => r.push(i++ === n ? null : b);
   w._write = (data, enc, cb) => cb();

--- a/benchmark/streams/readable-bigread.js
+++ b/benchmark/streams/readable-bigread.js
@@ -14,8 +14,8 @@ function main({ n }) {
   s._read = noop;
 
   bench.start();
-  for (var k = 0; k < n; ++k) {
-    for (var i = 0; i < 1e4; ++i)
+  for (let k = 0; k < n; ++k) {
+    for (let i = 0; i < 1e4; ++i)
       s.push(b);
     while (s.read(128));
   }

--- a/benchmark/streams/readable-bigunevenread.js
+++ b/benchmark/streams/readable-bigunevenread.js
@@ -14,8 +14,8 @@ function main({ n }) {
   s._read = noop;
 
   bench.start();
-  for (var k = 0; k < n; ++k) {
-    for (var i = 0; i < 1e4; ++i)
+  for (let k = 0; k < n; ++k) {
+    for (let i = 0; i < 1e4; ++i)
       s.push(b);
     while (s.read(106));
   }

--- a/benchmark/streams/readable-boundaryread.js
+++ b/benchmark/streams/readable-boundaryread.js
@@ -10,14 +10,14 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, type }) {
   const s = new Readable();
-  var data = 'a'.repeat(32);
+  let data = 'a'.repeat(32);
   if (type === 'buffer')
     data = Buffer.from(data);
   s._read = function() {};
 
   bench.start();
-  for (var k = 0; k < n; ++k) {
-    for (var i = 0; i < 1e4; ++i)
+  for (let k = 0; k < n; ++k) {
+    for (let i = 0; i < 1e4; ++i)
       s.push(data);
     while (s.read(32));
   }

--- a/benchmark/streams/readable-readall.js
+++ b/benchmark/streams/readable-readall.js
@@ -14,8 +14,8 @@ function main({ n }) {
   s._read = noop;
 
   bench.start();
-  for (var k = 0; k < n; ++k) {
-    for (var i = 0; i < 1e4; ++i)
+  for (let k = 0; k < n; ++k) {
+    for (let i = 0; i < 1e4; ++i)
       s.push(b);
     while (s.read());
   }

--- a/benchmark/streams/readable-unevenread.js
+++ b/benchmark/streams/readable-unevenread.js
@@ -14,8 +14,8 @@ function main({ n }) {
   s._read = noop;
 
   bench.start();
-  for (var k = 0; k < n; ++k) {
-    for (var i = 0; i < 1e4; ++i)
+  for (let k = 0; k < n; ++k) {
+    for (let i = 0; i < 1e4; ++i)
       s.push(b);
     while (s.read(12));
   }

--- a/benchmark/string_decoder/string-decoder-create.js
+++ b/benchmark/string_decoder/string-decoder-create.js
@@ -11,7 +11,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ encoding, n }) {
   bench.start();
-  for (var i = 0; i < n; ++i) {
+  for (let i = 0; i < n; ++i) {
     const sd = new StringDecoder(encoding);
     !!sd.encoding;
   }

--- a/benchmark/string_decoder/string-decoder.js
+++ b/benchmark/string_decoder/string-decoder.js
@@ -14,12 +14,11 @@ const ASC_ALPHA = 'Blueberry jam';
 const UTF16_BUF = Buffer.from('Blåbærsyltetøy', 'utf16le');
 
 function main({ encoding, inLen, chunkLen, n }) {
-  var alpha;
-  var buf;
+  let alpha;
+  let buf;
   const chunks = [];
-  var str = '';
+  let str = '';
   const isBase64 = (encoding === 'base64-ascii' || encoding === 'base64-utf8');
-  var i;
 
   if (encoding === 'ascii' || encoding === 'base64-ascii')
     alpha = ASC_ALPHA;
@@ -33,7 +32,7 @@ function main({ encoding, inLen, chunkLen, n }) {
 
   const sd = new StringDecoder(isBase64 ? 'base64' : encoding);
 
-  for (i = 0; i < inLen; ++i) {
+  for (let i = 0; i < inLen; ++i) {
     if (i > 0 && (i % chunkLen) === 0 && !isBase64) {
       if (alpha) {
         chunks.push(Buffer.from(str, encoding));
@@ -46,8 +45,8 @@ function main({ encoding, inLen, chunkLen, n }) {
     if (alpha)
       str += alpha[i % alpha.length];
     else {
-      var start = i;
-      var end = i + 2;
+      let start = i;
+      let end = i + 2;
       if (i % 2 !== 0) {
         ++start;
         ++end;
@@ -77,8 +76,8 @@ function main({ encoding, inLen, chunkLen, n }) {
   const nChunks = chunks.length;
 
   bench.start();
-  for (i = 0; i < n; ++i) {
-    for (var j = 0; j < nChunks; ++j)
+  for (let i = 0; i < n; ++i) {
+    for (let j = 0; j < nChunks; ++j)
       sd.write(chunks[j]);
   }
   bench.end(n);


### PR DESCRIPTION
Use `let` in module, napi, net, os, path, process, querystring, streams
and string_decoder.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
