### PR TITLE
worker: reset `Isolate` stack limit after entering `Locker`

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -157,7 +157,7 @@ class WorkerThreadData {
     {
       Locker locker(isolate);
       Isolate::Scope isolate_scope(isolate);
-      // V8 computes its stack limit every time a `Locker` is used based on
+      // V8 computes its stack limit the first time a `Locker` is used based on
       // --stack-size. Reset it to the correct value.
       isolate->SetStackLimit(w->stack_base_);
 

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -245,10 +245,6 @@ void Worker::Run() {
   {
     Locker locker(isolate_);
     Isolate::Scope isolate_scope(isolate_);
-    // V8 computes its stack limit every time a `Locker` is used based on
-    // --stack-size. Reset it to the correct value.
-    isolate_->SetStackLimit(stack_base_);
-
     SealHandleScope outer_seal(isolate_);
 
     DeleteFnPtr<Environment, FreeEnvironment> env_;

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -157,6 +157,9 @@ class WorkerThreadData {
     {
       Locker locker(isolate);
       Isolate::Scope isolate_scope(isolate);
+      // V8 computes its stack limit every time a `Locker` is used based on
+      // --stack-size. Reset it to the correct value.
+      isolate->SetStackLimit(w->stack_base_);
 
       HandleScope handle_scope(isolate);
       isolate_data_.reset(CreateIsolateData(isolate,
@@ -242,6 +245,10 @@ void Worker::Run() {
   {
     Locker locker(isolate_);
     Isolate::Scope isolate_scope(isolate_);
+    // V8 computes its stack limit every time a `Locker` is used based on
+    // --stack-size. Reset it to the correct value.
+    isolate_->SetStackLimit(stack_base_);
+
     SealHandleScope outer_seal(isolate_);
 
     DeleteFnPtr<Environment, FreeEnvironment> env_;

--- a/test/parallel/test-worker-stack-overflow-stack-size.js
+++ b/test/parallel/test-worker-stack-overflow-stack-size.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { once } = require('events');
+const v8 = require('v8');
+const { Worker } = require('worker_threads');
+
+// Verify that Workers don't care about --stack-size, as they have their own
+// fixed and known stack sizes.
+
+async function runWorker() {
+  const empiricalStackDepth = new Uint32Array(new SharedArrayBuffer(4));
+  const worker = new Worker(`
+  const { workerData: { empiricalStackDepth } } = require('worker_threads');
+  function f() {
+    empiricalStackDepth[0]++;
+    f();
+  }
+  f();`, {
+    eval: true,
+    workerData: { empiricalStackDepth }
+  });
+
+  const [ error ] = await once(worker, 'error');
+
+  common.expectsError({
+    constructor: RangeError,
+    message: 'Maximum call stack size exceeded'
+  })(error);
+
+  return empiricalStackDepth[0];
+}
+
+(async function() {
+  v8.setFlagsFromString('--stack-size=500');
+  const w1stack = await runWorker();
+  v8.setFlagsFromString('--stack-size=1000');
+  const w2stack = await runWorker();
+  assert.strictEqual(w1stack, w2stack);
+})().then(common.mustCall());

--- a/test/parallel/test-worker-stack-overflow-stack-size.js
+++ b/test/parallel/test-worker-stack-overflow-stack-size.js
@@ -36,5 +36,8 @@ async function runWorker() {
   const w1stack = await runWorker();
   v8.setFlagsFromString('--stack-size=1000');
   const w2stack = await runWorker();
-  assert.strictEqual(w1stack, w2stack);
+  // Make sure the two stack sizes are within 10 % of each other, i.e. not
+  // affected by the different `--stack-size` settings.
+  assert(Math.max(w1stack, w2stack) / Math.min(w1stack, w2stack) < 1.1,
+         `w1stack = ${w1stack}, w2stack ${w2stack} are too far apart`);
 })().then(common.mustCall());


### PR DESCRIPTION
It turns out that using `v8::Locker` undoes the effects of
passing an explicit stack limit as part of the `Isolate`’s
resource constraints.

Therefore, reset the stack limit manually after entering a Locker.

Refs: https://github.com/nodejs/node/pull/26049#issuecomment-580668530

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
