### PR TITLE
src: fix inspecting `MessagePort` from `init` async hook

### DIFF
--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -61,7 +61,9 @@ class HandleWrap : public AsyncWrap {
   static void HasRef(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static inline bool IsAlive(const HandleWrap* wrap) {
-    return wrap != nullptr && wrap->state_ != kClosed;
+    return wrap != nullptr &&
+        wrap->IsDoneInitializing() &&
+        wrap->state_ != kClosed;
   }
 
   static inline bool HasRef(const HandleWrap* wrap) {

--- a/test/parallel/test-worker-message-port-inspect-during-init-hook.js
+++ b/test/parallel/test-worker-message-port-inspect-during-init-hook.js
@@ -15,7 +15,7 @@ async_hooks.createHook({
   }, 2)
 }).enable();
 
-const { port1, port2 } = new MessageChannel();
+const { port1 } = new MessageChannel();
 const inspection = util.inspect(port1);
 assert(inspection.includes('active: true'));
 assert(inspection.includes('refed: false'));

--- a/test/parallel/test-worker-message-port-inspect-during-init-hook.js
+++ b/test/parallel/test-worker-message-port-inspect-during-init-hook.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+const util = require('util');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+const { MessageChannel } = require('worker_threads');
+
+// Regression test: Inspecting a `MessagePort` object before it is finished
+// constructing does not crash the process.
+
+async_hooks.createHook({
+  init: common.mustCall((id, type, triggerId, resource) => {
+    assert.strictEqual(util.inspect(resource),
+                       'MessagePort { active: true, refed: false }');
+  }, 2)
+}).enable();
+
+const { port1, port2 } = new MessageChannel();
+const inspection = util.inspect(port1);
+assert(inspection.includes('active: true'));
+assert(inspection.includes('refed: false'));


### PR DESCRIPTION
During the `init()` async hook, the C++ object is not finished
creating yet (i.e. it is an `AsyncWrap`, but not yet a `HandleWrap`
or `MessagePort`). Accessing the `handle_` field is not valid
in that case.

However, the custom inspect function for `MessagePort`s calls
`HasRef()` on the object, which would crash when the object
is not fully constructed. Fix that by guarding the access of
the libuv handle on that condition.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
