### PR TITLE
test: fix flaky test-memory-usage

### DIFF
--- a/test/parallel/test-memory-usage.js
+++ b/test/parallel/test-memory-usage.js
@@ -19,6 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// Flags: --no-concurrent-array-buffer-freeing
 'use strict';
 const common = require('../common');
 const assert = require('assert');
@@ -41,5 +42,5 @@ if (r.arrayBuffers > 0) {
   assert(after.external - r.external >= size,
          `${after.external} - ${r.external} >= ${size}`);
   assert.strictEqual(after.arrayBuffers - r.arrayBuffers, size,
-                     `${after.arrayBuffers} - ${r.arrayBuffers} >= ${size}`);
+                     `${after.arrayBuffers} - ${r.arrayBuffers} === ${size}`);
 }


### PR DESCRIPTION
abe6a2e3d1c268f introduced a test that verifies that ArrayBuffer
allocations are tracked. However, V8 supports concurrent freeing
of such allocations on background threads, meaning that the results
may be subject to race conditions sometimes.

Disabling concurrent freeing makes the test pass consistently.

Refs: https://github.com/nodejs/node/pull/31550

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
