### PR TITLE
readline: add error handling for input stream

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -190,6 +190,10 @@ function Interface(input, output, completer, terminal) {
     this._ttyWrite = _ttyWriteDumb.bind(this);
   }
 
+  function onerror(err) {
+    self.emit('error', err);
+  }
+
   function ondata(data) {
     self._normalWrite(data);
   }
@@ -227,9 +231,12 @@ function Interface(input, output, completer, terminal) {
 
   this[kLineObjectStream] = undefined;
 
+  input.on('error', onerror);
+
   if (!this.terminal) {
     function onSelfCloseWithoutTerminal() {
       input.removeListener('data', ondata);
+      input.removeListener('error', onerror);
       input.removeListener('end', onend);
     }
 
@@ -240,6 +247,7 @@ function Interface(input, output, completer, terminal) {
   } else {
     function onSelfCloseWithTerminal() {
       input.removeListener('keypress', onkeypress);
+      input.removeListener('error', onerror);
       input.removeListener('end', ontermend);
       if (output !== null && output !== undefined) {
         output.removeListener('resize', onresize);
@@ -1098,12 +1106,17 @@ Interface.prototype[SymbolAsyncIterator] = function() {
     });
     const lineListener = (input) => {
       if (!readable.push(input)) {
+        // TODO(rexagod): drain to resume flow
         this.pause();
       }
     };
     const closeListener = () => {
       readable.push(null);
     };
+    const errorListener = (err) => {
+      readable.destroy(err);
+    };
+    this.on('error', errorListener);
     this.on('line', lineListener);
     this.on('close', closeListener);
     this[kLineObjectStream] = readable;

--- a/test/parallel/test-readline-input-onerror.js
+++ b/test/parallel/test-readline-input-onerror.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+const fs = require('fs');
+const readline = require('readline');
+const path = require('path');
+
+async function processLineByLine_SymbolAsyncError(filename) {
+  const fileStream = fs.createReadStream(filename);
+  const rl = readline.createInterface({
+    input: fileStream,
+    crlfDelay: Infinity
+  });
+  // eslint-disable-next-line no-unused-vars
+  for await (const line of rl) {
+    /* check SymbolAsyncIterator `errorListener` */
+  }
+}
+
+const f = path.join(__dirname, 'file.txt');
+
+// catch-able SymbolAsyncIterator `errorListener` error
+processLineByLine_SymbolAsyncError(f).catch(common.expectsError({
+  code: 'ENOENT',
+  message: `ENOENT: no such file or directory, open '${f}'`
+}));
+
+async function processLineByLine_InterfaceErrorEvent(filename) {
+  const fileStream = fs.createReadStream(filename);
+  const rl = readline.createInterface({
+    input: fileStream,
+    crlfDelay: Infinity
+  });
+  rl.on('error', common.expectsError({
+    code: 'ENOENT',
+    message: `ENOENT: no such file or directory, open '${f}'`
+  }));
+}
+
+// check Interface 'error' event
+processLineByLine_InterfaceErrorEvent(f);


### PR DESCRIPTION
This adds support for error handling in readline.createInterface()
for cases where the input object is not supplied, the input stream
is invalid, or the underlying buffer emits an error.

Now, the 'error' emissions by the readline module are thrown but
in order to log those in the specific case of await for loops,
we still need to fix silent rejections (TODO added there) inside
async iterators for the thenables to work.

Fixes: https://github.com/nodejs/node/issues/30831

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
