### PR TITLE
test: mark additional tests as flaky on Windows

### DIFF
--- a/test/async-hooks/async-hooks.status
+++ b/test/async-hooks/async-hooks.status
@@ -7,6 +7,8 @@ prefix async-hooks
 [true] # This section applies to all platforms
 
 [$system==win32]
+# https://github.com/nodejs/node/issues/29852
+test-statwatcher: PASS,FLAKY
 
 [$system==linux]
 

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -21,6 +21,13 @@ test-http2-compat-client-upload-reject: PASS,FLAKY
 test-http2-multistream-destroy-on-read-tls: PASS,FLAKY
 # https://github.com/nodejs/node/issues/20750
 test-http2-pipe: PASS,FLAKY
+# https://github.com/nodejs/node/issues/20750
+# https://github.com/nodejs/node/pull/31590
+test-http2-stream-destroy-event-order: PASS,FLAKY
+# https://github.com/nodejs/node/issues/20750
+test-stream-pipeline-http2: PASS,FLAKY
+# https://github.com/nodejs/node/issues/24497
+test-timers-immediate-queue: PASS,FLAKY
 # https://github.com/nodejs/node/issues/23277
 test-worker-memory: PASS,FLAKY
 # https://github.com/nodejs/node/issues/30846


### PR DESCRIPTION
Basically, any of the tests that failed in the runs for
https://github.com/nodejs/node/pull/31602 which was not already
marked as flaky.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
