### PR TITLE
fs: set path when mkdir recursive called on file

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1278,6 +1278,7 @@ int MKDirpSync(uv_loop_t* loop,
           }
           break;
         case UV_EACCES:
+        case UV_ENOTDIR:
         case UV_EPERM: {
           return err;
         }
@@ -1356,6 +1357,7 @@ int MKDirpAsync(uv_loop_t* loop,
           break;
         }
         case UV_EACCES:
+        case UV_ENOTDIR:
         case UV_EPERM: {
           req_wrap->continuation_data()->Done(err);
           break;
@@ -1398,7 +1400,6 @@ int MKDirpAsync(uv_loop_t* loop,
             }
             // verify that the path pointed to is actually a directory.
             if (err == 0 && !S_ISDIR(req->statbuf.st_mode)) err = UV_EEXIST;
-            uv_fs_req_cleanup(req);
             req_wrap->continuation_data()->Done(err);
           }});
           if (err < 0) req_wrap->continuation_data()->Done(err);

--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -148,6 +148,7 @@ function nextdir() {
       message: /ENOTDIR: .*mkdir/,
       name: 'Error',
       syscall: 'mkdir',
+      path: pathname // See: https://github.com/nodejs/node/issues/28015
     }
   );
 }
@@ -187,6 +188,11 @@ function nextdir() {
     assert.strictEqual(err.code, 'ENOTDIR');
     assert.strictEqual(err.syscall, 'mkdir');
     assert.strictEqual(fs.existsSync(pathname), false);
+    // See: https://github.com/nodejs/node/issues/28015
+    // The path field varies slightly in Windows errors, vs., other platforms
+    // see: https://github.com/libuv/libuv/issues/2661, for this reason we
+    // use startsWith() rather than comparing to the full "pathname".
+    assert(err.path.startsWith(filename));
   }));
 }
 


### PR DESCRIPTION
Similar fix to #31505, we should bail early if mkdir recursive is called on a file path.

Fixes: #28015

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
