### PR TITLE
test: fix flaky test-http2-stream-destroy-event-order

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -22,9 +22,6 @@ test-http2-multistream-destroy-on-read-tls: PASS,FLAKY
 # https://github.com/nodejs/node/issues/20750
 test-http2-pipe: PASS,FLAKY
 # https://github.com/nodejs/node/issues/20750
-# https://github.com/nodejs/node/pull/31590
-test-http2-stream-destroy-event-order: PASS,FLAKY
-# https://github.com/nodejs/node/issues/20750
 test-stream-pipeline-http2: PASS,FLAKY
 # https://github.com/nodejs/node/issues/24497
 test-timers-immediate-queue: PASS,FLAKY

--- a/test/parallel/test-http2-stream-destroy-event-order.js
+++ b/test/parallel/test-http2-stream-destroy-event-order.js
@@ -10,6 +10,7 @@ let req;
 const server = http2.createServer();
 server.on('stream', common.mustCall((stream) => {
   stream.on('error', common.mustCall(() => {
+    client.close();
     stream.on('close', common.mustCall(() => {
       server.close();
     }));
@@ -22,8 +23,6 @@ server.listen(0, common.mustCall(() => {
   req = client.request();
   req.resume();
   req.on('error', common.mustCall(() => {
-    req.on('close', common.mustCall(() => {
-      client.close();
-    }));
+    req.on('close', common.mustCall());
   }));
 }));


### PR DESCRIPTION
Alternative to https://github.com/nodejs/node/pull/31590.

It appears that the issue here is that the test falsely assumed that
closing the client (which also currently destroys the socket rather
than gracefully shutting down the connection) would still leave
enough time for the server side to receive the stream error.

Address that by explicitly waiting for the server side to receive the
stream error before closing the client and the connection with it.

Refs: https://github.com/nodejs/node/pull/31590
Refs: https://github.com/nodejs/node/issues/20750

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
