### PR TITLE
test: show child stderr output in largepages test

### DIFF
--- a/test/parallel/test-startup-large-pages.js
+++ b/test/parallel/test-startup-large-pages.js
@@ -8,7 +8,8 @@ const { spawnSync } = require('child_process');
 
 {
   const child = spawnSync(process.execPath,
-                          [ '--use-largepages=on', '-p', '42' ]);
+                          [ '--use-largepages=on', '-p', '42' ],
+                          { stdio: ['inherit', 'pipe', 'inherit'] });
   const stdout = child.stdout.toString().match(/\S+/g);
   assert.strictEqual(child.status, 0);
   assert.strictEqual(child.signal, null);


### PR DESCRIPTION
The test starts child processes. A recent change is suspected of causing
flaky crashes on one of the alpine buildbots but we can't know for sure
because the test hides the child's stderr.

Refs: https://github.com/nodejs/node/pull/31547#issuecomment-581076515

I propose fast-tracking this.