### PR TITLE
[v10.x-staging] v8: fix load elimination liveness checks

### DIFF
--- a/deps/v8/test/mjsunit/regress/regress-906406.js
+++ b/deps/v8/test/mjsunit/regress/regress-906406.js
@@ -1,0 +1,7 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+for (x = 0; x < 10000; ++x) {
+    [(x) => x, [, 4294967295].find((x) => x), , 2].includes('x', -0);
+}


### PR DESCRIPTION
This commit back-ports the implementations of IsRename() and MayAlias()
from the upstream 8.0 branch wholesale. Fixes several bugs where V8's
load elimination pass considered values to be alive when they weren't.

Fixes: https://github.com/nodejs/node/issues/31484

Supersedes #31507.