### PR TITLE
buffer: improve from() performance

### DIFF
--- a/benchmark/buffers/buffer-from.js
+++ b/benchmark/buffers/buffer-from.js
@@ -12,37 +12,37 @@ const bench = common.createBenchmark(main, {
     'string-utf8',
     'string-base64',
     'object',
+    'uint8array',
+    'uint16array',
   ],
   len: [100, 2048],
   n: [8e5]
 });
 
 function main({ len, n, source }) {
-  const array = new Array(len).fill(42);
-  const arrayBuf = new ArrayBuffer(len);
-  const str = 'a'.repeat(len);
-  const buffer = Buffer.allocUnsafe(len);
-  const uint8array = new Uint8Array(len);
-  const obj = { length: null }; // Results in a new, empty Buffer
-
   let i = 0;
 
   switch (source) {
-    case 'array':
+    case 'array': {
+      const array = new Array(len).fill(42);
       bench.start();
       for (i = 0; i < n; i++) {
         Buffer.from(array);
       }
       bench.end(n);
       break;
-    case 'arraybuffer':
+    }
+    case 'arraybuffer': {
+      const arrayBuf = new ArrayBuffer(len);
       bench.start();
       for (i = 0; i < n; i++) {
         Buffer.from(arrayBuf);
       }
       bench.end(n);
       break;
-    case 'arraybuffer-middle':
+    }
+    case 'arraybuffer-middle': {
+      const arrayBuf = new ArrayBuffer(len);
       const offset = ~~(len / 4);
       const length = ~~(len / 2);
       bench.start();
@@ -51,48 +51,70 @@ function main({ len, n, source }) {
       }
       bench.end(n);
       break;
-    case 'buffer':
+    }
+    case 'buffer': {
+      const buffer = Buffer.allocUnsafe(len);
       bench.start();
       for (i = 0; i < n; i++) {
         Buffer.from(buffer);
       }
       bench.end(n);
       break;
-    case 'uint8array':
+    }
+    case 'uint8array': {
+      const uint8array = new Uint8Array(len);
       bench.start();
       for (i = 0; i < n; i++) {
         Buffer.from(uint8array);
       }
       bench.end(n);
       break;
-    case 'string':
+    }
+    case 'uint16array': {
+      const uint16array = new Uint16Array(len);
+      bench.start();
+      for (i = 0; i < n; i++) {
+        Buffer.from(uint16array);
+      }
+      bench.end(n);
+      break;
+    }
+    case 'string': {
+      const str = 'a'.repeat(len);
       bench.start();
       for (i = 0; i < n; i++) {
         Buffer.from(str);
       }
       bench.end(n);
       break;
-    case 'string-utf8':
+    }
+    case 'string-utf8': {
+      const str = 'a'.repeat(len);
       bench.start();
       for (i = 0; i < n; i++) {
         Buffer.from(str, 'utf8');
       }
       bench.end(n);
       break;
-    case 'string-base64':
+    }
+    case 'string-base64': {
+      const str = 'a'.repeat(len);
       bench.start();
       for (i = 0; i < n; i++) {
         Buffer.from(str, 'base64');
       }
       bench.end(n);
       break;
-    case 'object':
+    }
+    case 'object': {
+      const obj = { length: null }; // Results in a new, empty Buffer
       bench.start();
       for (i = 0; i < n; i++) {
         Buffer.from(obj);
       }
       bench.end(n);
       break;
+    }
     default:
       assert.fail('Should not get here');
   }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -452,14 +452,6 @@ function fromString(string, encoding) {
   return fromStringFast(string, ops);
 }
 
-function fromArrayLike(obj) {
-  const length = obj.length;
-  const b = allocate(length);
-  for (let i = 0; i < length; i++)
-    b[i] = obj[i];
-  return b;
-}
-
 function fromArrayBuffer(obj, byteOffset, length) {
   // Convert byteOffset to integer
   if (byteOffset === undefined) {
@@ -491,17 +483,22 @@ function fromArrayBuffer(obj, byteOffset, length) {
   return new FastBuffer(obj, byteOffset, length);
 }
 
-function fromObject(obj) {
-  if (isUint8Array(obj)) {
-    const b = allocate(obj.length);
-
-    if (b.length === 0)
-      return b;
-
-    _copy(obj, b, 0, 0, obj.length);
+function fromArrayLike(obj) {
+  if (obj.length <= 0)
+    return new FastBuffer();
+  if (obj.length < (Buffer.poolSize >>> 1)) {
+    if (obj.length > (poolSize - poolOffset))
+      createPool();
+    const b = new FastBuffer(allocPool, poolOffset, obj.length);
+    b.set(obj, 0);
+    poolOffset += obj.length;
+    alignPool();
     return b;
   }
+  return new FastBuffer(obj);
+}
 
+function fromObject(obj) {
   if (obj.length !== undefined || isAnyArrayBuffer(obj.buffer)) {
     if (typeof obj.length !== 'number') {
       return new FastBuffer();


### PR DESCRIPTION
Benchmark results:

```
                                                                confidence improvement accuracy (*)   (**)  (***)
 buffers/buffer-from.js n=800000 len=100 source='array'               ***     53.81 %       ±2.01% ±2.70% ±3.59%
 buffers/buffer-from.js n=800000 len=100 source='buffer'              ***     53.09 %       ±1.91% ±2.54% ±3.30%
 buffers/buffer-from.js n=800000 len=100 source='object'              ***     11.22 %       ±2.92% ±3.89% ±5.07%
 buffers/buffer-from.js n=800000 len=100 source='uint16array'         ***     47.57 %       ±1.62% ±2.16% ±2.82%
 buffers/buffer-from.js n=800000 len=100 source='uint8array'          ***     52.46 %       ±1.88% ±2.53% ±3.34%
 buffers/buffer-from.js n=800000 len=2048 source='array'              ***    147.71 %       ±1.20% ±1.61% ±2.13%
 buffers/buffer-from.js n=800000 len=2048 source='buffer'             ***      8.93 %       ±1.23% ±1.64% ±2.14%
 buffers/buffer-from.js n=800000 len=2048 source='object'             ***      8.92 %       ±3.90% ±5.20% ±6.78%
 buffers/buffer-from.js n=800000 len=2048 source='uint16array'        ***    313.08 %       ±1.83% ±2.46% ±3.26%
 buffers/buffer-from.js n=800000 len=2048 source='uint8array'         ***      6.70 %       ±1.64% ±2.20% ±2.89%
 buffers/buffer-from.js n=800000 len=8192 source='array'              ***     47.04 %       ±0.90% ±1.21% ±1.60%
 buffers/buffer-from.js n=800000 len=8192 source='buffer'             ***      6.58 %       ±2.14% ±2.86% ±3.73%
 buffers/buffer-from.js n=800000 len=8192 source='object'             ***     10.50 %       ±2.70% ±3.60% ±4.71%
 buffers/buffer-from.js n=800000 len=8192 source='uint16array'        ***    338.05 %       ±3.12% ±4.21% ±5.58%
 buffers/buffer-from.js n=800000 len=8192 source='uint8array'         ***      5.25 %       ±1.99% ±2.65% ±3.45%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
