### PR TITLE
src: remove dead code in InternalMakeCallback

### DIFF
--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -157,7 +157,7 @@ MaybeLocal<Value> InternalMakeCallback(Environment* env,
 
   Local<Function> domain_cb = env->domain_callback();
   MaybeLocal<Value> ret;
-  if (asyncContext.async_id != 0 || domain_cb.IsEmpty() || recv.IsEmpty()) {
+  if (asyncContext.async_id != 0 || domain_cb.IsEmpty()) {
     ret = callback->Call(env->context(), recv, argc, argv);
   } else {
     std::vector<Local<Value>> args(1 + argc);


### PR DESCRIPTION
Remove unneeded condition as the first line in function already ensures that recv can't be empty.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

