### PR TITLE
stream: improve writable.write() performance

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -33,6 +33,7 @@ function Benchmark(fn, configs, options) {
   this._time = [0, 0];
   // Used to make sure a benchmark only start a timer once
   this._started = false;
+  this._ended = false;
 
   // this._run will use fork() to create a new process for each configuration
   // combination.
@@ -197,6 +198,9 @@ Benchmark.prototype.end = function(operations) {
   if (!this._started) {
     throw new Error('called end without start');
   }
+  if (this._ended) {
+    throw new Error('called end multiple times');
+  }
   if (typeof operations !== 'number') {
     throw new Error('called end() without specifying operation count');
   }
@@ -210,6 +214,7 @@ Benchmark.prototype.end = function(operations) {
     elapsed[1] = 1;
   }
 
+  this._ended = true;
   const time = elapsed[0] + elapsed[1] / 1e9;
   const rate = operations / time;
   this.report(rate, elapsed);

--- a/benchmark/streams/writable-manywrites.js
+++ b/benchmark/streams/writable-manywrites.js
@@ -35,8 +35,10 @@ function main({ n, sync, writev, callback }) {
   let k = 0;
   function run() {
     while (k++ < n && s.write(b, cb));
-    if (k >= n)
+    if (k >= n) {
       bench.end(n);
+      s.removeListener('drain', run);
+    }
   }
   s.on('drain', run);
   run();

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -261,7 +261,6 @@ Writable.prototype.pipe = function() {
 
 Writable.prototype.write = function(chunk, encoding, cb) {
   const state = this._writableState;
-  var ret = false;
   const isBuf = !state.objectMode && Stream._isUint8Array(chunk);
 
   // Do not use Object.getPrototypeOf as it is slower since V8 7.3.
@@ -271,16 +270,16 @@ Writable.prototype.write = function(chunk, encoding, cb) {
 
   if (typeof encoding === 'function') {
     cb = encoding;
-    encoding = null;
+    encoding = state.defaultEncoding;
+  } else {
+    if (!encoding)
+      encoding = state.defaultEncoding;
+    if (typeof cb !== 'function')
+      cb = nop;
   }
 
   if (isBuf)
     encoding = 'buffer';
-  else if (!encoding)
-    encoding = state.defaultEncoding;
-
-  if (typeof cb !== 'function')
-    cb = nop;
 
   let err;
   if (state.ending) {
@@ -289,19 +288,24 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     err = new ERR_STREAM_DESTROYED('write');
   } else if (chunk === null) {
     err = new ERR_STREAM_NULL_VALUES();
-  } else if (!isBuf && typeof chunk !== 'string' && !state.objectMode) {
-    err = new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
   } else {
-    state.pendingcb++;
-    ret = writeOrBuffer(this, state, chunk, encoding, cb);
+    if (!isBuf && !state.objectMode) {
+      if (typeof chunk !== 'string') {
+        err = new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
+      } else if (encoding !== 'buffer' && state.decodeStrings !== false) {
+        chunk = Buffer.from(chunk, encoding);
+        encoding = 'buffer';
+      }
+    }
+    if (err === undefined) {
+      state.pendingcb++;
+      return writeOrBuffer(this, state, chunk, encoding, cb);
+    }
   }
 
-  if (err) {
-    process.nextTick(cb, err);
-    errorOrDestroy(this, err, true);
-  }
-
-  return ret;
+  process.nextTick(cb, err);
+  errorOrDestroy(this, err, true);
+  return false;
 };
 
 Writable.prototype.cork = function() {
@@ -376,13 +380,6 @@ ObjectDefineProperty(Writable.prototype, 'writableCorked', {
 // in the queue, and wait our turn.  Otherwise, call _write
 // If we return false, then we need a drain event, so set that flag.
 function writeOrBuffer(stream, state, chunk, encoding, cb) {
-  if (!state.objectMode &&
-      state.decodeStrings !== false &&
-      encoding !== 'buffer' &&
-      typeof chunk === 'string') {
-    chunk = Buffer.from(chunk, encoding);
-    encoding = 'buffer';
-  }
   const len = state.objectMode ? 1 : chunk.length;
 
   state.length += len;


### PR DESCRIPTION
Benchmark results:

```
                                                                                   confidence improvement accuracy (*)   (**)  (***)
 streams/writable-manywrites.js callback='no' writev='no' sync='no' n=40000000                    0.72 %       ±1.42% ±1.89% ±2.46%
 streams/writable-manywrites.js callback='no' writev='no' sync='yes' n=40000000          ***      2.82 %       ±0.54% ±0.72% ±0.94%
 streams/writable-manywrites.js callback='no' writev='yes' sync='no' n=40000000                   1.04 %       ±1.11% ±1.47% ±1.92%
 streams/writable-manywrites.js callback='no' writev='yes' sync='yes' n=40000000         ***      3.18 %       ±0.69% ±0.92% ±1.20%
 streams/writable-manywrites.js callback='yes' writev='no' sync='no' n=40000000                  -0.39 %       ±1.56% ±2.09% ±2.73%
 streams/writable-manywrites.js callback='yes' writev='no' sync='yes' n=40000000         ***      7.03 %       ±0.83% ±1.11% ±1.45%
 streams/writable-manywrites.js callback='yes' writev='yes' sync='no' n=40000000         ***      2.28 %       ±1.06% ±1.41% ±1.83%
 streams/writable-manywrites.js callback='yes' writev='yes' sync='yes' n=40000000        ***      8.46 %       ±0.89% ±1.18% ±1.55%
```

There is also a change to the benchmark runner to ensure that `end()` is not called multiple times. This was happening in the `Writable` benchmark and was at least causing weird display issues (e.g. improper fraction for # of configs, completion percentage bouncing back and forth, etc.) when using benchmark/compare.js and showing progress.

The reason why that was happening was that `process.send()` is used to send the result, which is async and gives individual benchmarks time to call `.end()` again before the process actually exits.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
