### PR TITLE
module: Refine and unify exports resolution error handling

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1319,6 +1319,12 @@ An invalid HTTP token was supplied.
 
 An IP address is not valid.
 
+<a id="ERR_INVALID_MODULE_SPECIFIER"></a>
+### `ERR_INVALID_MODULE_SPECIFIER`
+
+The imported module string is an invalid URL, package name, or package subpath
+specifier.
+
 <a id="ERR_INVALID_OPT_VALUE"></a>
 ### `ERR_INVALID_OPT_VALUE`
 
@@ -1333,6 +1339,12 @@ An invalid or unknown file encoding was passed.
 ### `ERR_INVALID_PACKAGE_CONFIG`
 
 An invalid `package.json` file was found which failed parsing.
+
+<a id="ERR_INVALID_PACKAGE_TARGET"></a>
+### `ERR_INVALID_PACKAGE_TARGET`
+
+The `package.json` [exports][] field contains an invalid target mapping value
+for the attempted module resolution.
 
 <a id="ERR_INVALID_PERFORMANCE_MARK"></a>
 ### `ERR_INVALID_PERFORMANCE_MARK`
@@ -1639,6 +1651,13 @@ A non-context-aware native addon was loaded in a process that disallows them.
 ### `ERR_OUT_OF_RANGE`
 
 A given value is out of the accepted range.
+
+<a id="ERR_PKG_PATH_NOT_EXPORTED"></a>
+### `ERR_PKG_PATH_NOT_EXPORTED`
+
+The `package.json` [exports][] field does not export the requested subpath.
+Because exports are encapsulated, private internal modules that are not exported
+cannot be imported through the package resolution, unless using an absolute URL.
 
 <a id="ERR_REQUIRE_ESM"></a>
 ### `ERR_REQUIRE_ESM`
@@ -2505,6 +2524,7 @@ such as `process.stdout.on('data')`.
 [crypto digest algorithm]: crypto.html#crypto_crypto_gethashes
 [domains]: domain.html
 [event emitter-based]: events.html#events_class_eventemitter
+[exports]: esm.html#esm_package_exports
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
 [policy]: policy.html
 [stream-based]: stream.html

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1652,8 +1652,8 @@ A non-context-aware native addon was loaded in a process that disallows them.
 
 A given value is out of the accepted range.
 
-<a id="ERR_PKG_PATH_NOT_EXPORTED"></a>
-### `ERR_PKG_PATH_NOT_EXPORTED`
+<a id="ERR_PACKAGE_PATH_NOT_EXPORTED"></a>
+### `ERR_PACKAGE_PATH_NOT_EXPORTED`
 
 The `package.json` [exports][] field does not export the requested subpath.
 Because exports are encapsulated, private internal modules that are not exported

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -13,6 +13,7 @@
 const {
   ArrayIsArray,
   Error,
+  JSON,
   Map,
   MathAbs,
   NumberIsInteger,
@@ -22,6 +23,7 @@ const {
   SymbolFor,
   WeakMap,
 } = primordials;
+const sep = process.platform === 'win32' ? '\\' : '/';
 
 const messages = new Map();
 const codes = {};
@@ -1073,6 +1075,11 @@ E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s', TypeError);
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent', TypeError);
 E('ERR_INVALID_HTTP_TOKEN', '%s must be a valid HTTP token ["%s"]', TypeError);
 E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s', TypeError);
+E('ERR_INVALID_MODULE_SPECIFIER', (pkgPath, subpath) => {
+  assert(subpath !== '.');
+  return `Package subpath '${subpath}' is not a valid module request for the ` +
+      `"exports" resolution of ${pkgPath}${sep}package.json`;
+}, TypeError);
 E('ERR_INVALID_OPT_VALUE', (name, value) =>
   `The value "${String(value)}" is invalid for option "${name}"`,
   TypeError,
@@ -1080,7 +1087,17 @@ E('ERR_INVALID_OPT_VALUE', (name, value) =>
 E('ERR_INVALID_OPT_VALUE_ENCODING',
   'The value "%s" is invalid for option "encoding"', TypeError);
 E('ERR_INVALID_PACKAGE_CONFIG',
-  'Invalid package config for \'%s\', %s', Error);
+  `Invalid package config %s${sep}package.json, %s`, Error);
+E('ERR_INVALID_PACKAGE_TARGET', (pkgPath, key, subpath, target) => {
+  if (key === '.') {
+    return `Invalid "exports" main target ${JSON.stringify(target)} defined ` +
+      `in the package config ${pkgPath}${sep}package.json`;
+  } else {
+    return `Invalid "exports" target ${JSON.stringify(target)} defined for '${
+      key.slice(0, -subpath.length || key.length)}' in the package config ${
+      pkgPath}${sep}package.json`;
+  }
+}, Error);
 E('ERR_INVALID_PERFORMANCE_MARK',
   'The "%s" performance mark has not been set', Error);
 E('ERR_INVALID_PROTOCOL',
@@ -1225,6 +1242,14 @@ E('ERR_OUT_OF_RANGE',
     msg += ` It must be ${range}. Received ${received}`;
     return msg;
   }, RangeError);
+E('ERR_PKG_PATH_NOT_EXPORTED', (pkgPath, subpath) => {
+  if (subpath === '.') {
+    return `No "exports" main resolved in ${pkgPath}${sep}package.json`;
+  } else {
+    return `Package subpath '${subpath}' is not defined by "exports" in ${
+      pkgPath}${sep}package.json`;
+  }
+}, Error);
 E('ERR_REQUIRE_ESM',
   (filename, parentPath = null, packageJsonPath = null) => {
     let msg = `Must use import to load ES Module: ${filename}`;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -25,6 +25,8 @@ const {
   WeakMap,
 } = primordials;
 
+const sep = process.platform === 'win32' ? '\\' : '/';
+
 const messages = new Map();
 const codes = {};
 
@@ -711,8 +713,6 @@ module.exports = {
   kEnhanceStackBeforeInspector,
   fatalExceptionStackEnhancers
 };
-
-const { sep } = require('path');
 
 // To declare an error message, use the E(sym, val, def) function above. The sym
 // must be an upper case string. The val can be either a function or a string.

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1094,7 +1094,7 @@ E('ERR_INVALID_PACKAGE_TARGET', (pkgPath, key, subpath, target) => {
       `in the package config ${pkgPath}${sep}package.json`;
   } else {
     return `Invalid "exports" target ${JSON.stringify(target)} defined for '${
-      key.slice(0, -subpath.length || key.length)}' in the package config ${
+      StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the package config ${
       pkgPath}${sep}package.json`;
   }
 }, Error);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -19,6 +19,7 @@ const {
   NumberIsInteger,
   ObjectDefineProperty,
   ObjectKeys,
+  StringPrototypeSlice,
   Symbol,
   SymbolFor,
   WeakMap,
@@ -1094,8 +1095,8 @@ E('ERR_INVALID_PACKAGE_TARGET', (pkgPath, key, subpath, target) => {
       `in the package config ${pkgPath}${sep}package.json`;
   } else {
     return `Invalid "exports" target ${JSON.stringify(target)} defined for '${
-      StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the package config ${
-      pkgPath}${sep}package.json`;
+      StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +
+      `package config ${pkgPath}${sep}package.json`;
   }
 }, Error);
 E('ERR_INVALID_PERFORMANCE_MARK',

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -24,7 +24,7 @@ const {
   SymbolFor,
   WeakMap,
 } = primordials;
-const sep = process.platform === 'win32' ? '\\' : '/';
+const { sep } = require('path');
 
 const messages = new Map();
 const codes = {};
@@ -1243,7 +1243,7 @@ E('ERR_OUT_OF_RANGE',
     msg += ` It must be ${range}. Received ${received}`;
     return msg;
   }, RangeError);
-E('ERR_PKG_PATH_NOT_EXPORTED', (pkgPath, subpath) => {
+E('ERR_PACKAGE_PATH_NOT_EXPORTED', (pkgPath, subpath) => {
   if (subpath === '.') {
     return `No "exports" main resolved in ${pkgPath}${sep}package.json`;
   } else {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -13,7 +13,7 @@
 const {
   ArrayIsArray,
   Error,
-  JSON,
+  JSONStringify,
   Map,
   MathAbs,
   NumberIsInteger,
@@ -1091,10 +1091,10 @@ E('ERR_INVALID_PACKAGE_CONFIG',
   `Invalid package config %s${sep}package.json, %s`, Error);
 E('ERR_INVALID_PACKAGE_TARGET', (pkgPath, key, subpath, target) => {
   if (key === '.') {
-    return `Invalid "exports" main target ${JSON.stringify(target)} defined ` +
+    return `Invalid "exports" main target ${JSONStringify(target)} defined ` +
       `in the package config ${pkgPath}${sep}package.json`;
   } else {
-    return `Invalid "exports" target ${JSON.stringify(target)} defined for '${
+    return `Invalid "exports" target ${JSONStringify(target)} defined for '${
       StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +
       `package config ${pkgPath}${sep}package.json`;
   }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -24,7 +24,6 @@ const {
   SymbolFor,
   WeakMap,
 } = primordials;
-const { sep } = require('path');
 
 const messages = new Map();
 const codes = {};
@@ -712,6 +711,8 @@ module.exports = {
   kEnhanceStackBeforeInspector,
   fatalExceptionStackEnhancers
 };
+
+const { sep } = require('path');
 
 // To declare an error message, use the E(sym, val, def) function above. The sym
 // must be an upper case string. The val can be either a function or a string.

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -571,11 +571,11 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
                                  pkgPathPath.length - 1) !== -1)
         resolvedTarget = undefined;
     }
-    if (subpath.length > 0 && ! StringPrototypeEndsWith(target, '/'))
+    if (subpath.length > 0 && target[target.length - 1] !== '/')
       resolvedTarget = undefined;
     if (resolvedTarget === undefined)
-      throw new ERR_INVALID_PACKAGE_TARGET(StringPrototypeSlice(baseUrl.pathname, 0, -1),
-                                           mappingKey, subpath, target);
+      throw new ERR_INVALID_PACKAGE_TARGET(StringPrototypeSlice(baseUrl.pathname
+        , 0, -1), mappingKey, subpath, target);
     const resolved = new URL(subpath, resolvedTarget);
     const resolvedPath = resolved.pathname;
     if (StringPrototypeStartsWith(resolvedPath, resolvedTargetPath) &&
@@ -583,12 +583,12 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
                                pkgPathPath.length - 1) === -1) {
       return fileURLToPath(resolved);
     }
-    throw new ERR_INVALID_MODULE_SPECIFIER(StringPrototypeSlice(baseUrl.pathname, 0, -1),
-                                           mappingKey);
+    throw new ERR_INVALID_MODULE_SPECIFIER(StringPrototypeSlice(baseUrl.pathname
+      , 0, -1), mappingKey);
   } else if (ArrayIsArray(target)) {
     if (target.length === 0)
-      throw new ERR_INVALID_PACKAGE_TARGET(StringPrototypeSlice(baseUrl.pathname, 0, -1),
-                                           mappingKey, subpath, target);
+      throw new ERR_INVALID_PACKAGE_TARGET(StringPrototypeSlice(baseUrl.pathname
+        , 0, -1), mappingKey, subpath, target);
     for (const targetValue of target) {
       try {
         return resolveExportsTarget(baseUrl, targetValue, subpath, mappingKey);
@@ -629,11 +629,11 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
           }
       }
     }
-    throw new ERR_PKG_PATH_NOT_EXPORTED(StringPrototypeSlice(baseUrl.pathname, 0, -1),
-                                        mappingKey + subpath);
+    throw new ERR_PKG_PATH_NOT_EXPORTED(
+      StringPrototypeSlice(baseUrl.pathname, 0, -1), mappingKey + subpath);
   }
-  throw new ERR_INVALID_PACKAGE_TARGET(StringPrototypeSlice(baseUrl.pathname, 0, -1),
-                                       mappingKey, subpath, target);
+  throw new ERR_INVALID_PACKAGE_TARGET(
+    StringPrototypeSlice(baseUrl.pathname, 0, -1), mappingKey, subpath, target);
 }
 
 Module._findPath = function(request, paths, isMain) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -563,7 +563,7 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
   if (typeof target === 'string') {
     let resolvedTarget, resolvedTargetPath;
     const pkgPathPath = baseUrl.pathname;
-    if (target.startsWith('./')) {
+    if (StringPrototypeStartsWith(target, './')) {
       resolvedTarget = new URL(target, baseUrl);
       resolvedTargetPath = resolvedTarget.pathname;
       if (!StringPrototypeStartsWith(resolvedTargetPath, pkgPathPath) ||
@@ -571,10 +571,10 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
                                  pkgPathPath.length - 1) !== -1)
         resolvedTarget = undefined;
     }
-    if (subpath.length > 0 && !target.endsWith('/'))
+    if (subpath.length > 0 && ! StringPrototypeEndsWith(target, '/'))
       resolvedTarget = undefined;
     if (resolvedTarget === undefined)
-      throw new ERR_INVALID_PACKAGE_TARGET(baseUrl.pathname.slice(0, -1),
+      throw new ERR_INVALID_PACKAGE_TARGET(StringPrototypeSlice(baseUrl.pathname, 0, -1),
                                            mappingKey, subpath, target);
     const resolved = new URL(subpath, resolvedTarget);
     const resolvedPath = resolved.pathname;
@@ -583,11 +583,11 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
                                pkgPathPath.length - 1) === -1) {
       return fileURLToPath(resolved);
     }
-    throw new ERR_INVALID_MODULE_SPECIFIER(baseUrl.pathname.slice(0, -1),
+    throw new ERR_INVALID_MODULE_SPECIFIER(StringPrototypeSlice(baseUrl.pathname, 0, -1),
                                            mappingKey);
   } else if (ArrayIsArray(target)) {
     if (target.length === 0)
-      throw new ERR_INVALID_PACKAGE_TARGET(baseUrl.pathname.slice(0, -1),
+      throw new ERR_INVALID_PACKAGE_TARGET(StringPrototypeSlice(baseUrl.pathname, 0, -1),
                                            mappingKey, subpath, target);
     for (const targetValue of target) {
       try {
@@ -629,10 +629,10 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
           }
       }
     }
-    throw new ERR_PKG_PATH_NOT_EXPORTED(baseUrl.pathname.slice(0, -1),
+    throw new ERR_PKG_PATH_NOT_EXPORTED(StringPrototypeSlice(baseUrl.pathname, 0, -1),
                                         mappingKey + subpath);
   }
-  throw new ERR_INVALID_PACKAGE_TARGET(baseUrl.pathname.slice(0, -1),
+  throw new ERR_INVALID_PACKAGE_TARGET(StringPrototypeSlice(baseUrl.pathname, 0, -1),
                                        mappingKey, subpath, target);
 }
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -87,7 +87,7 @@ const {
   ERR_INVALID_PACKAGE_CONFIG,
   ERR_INVALID_PACKAGE_TARGET,
   ERR_INVALID_MODULE_SPECIFIER,
-  ERR_PKG_PATH_NOT_EXPORTED,
+  ERR_PACKAGE_PATH_NOT_EXPORTED,
   ERR_REQUIRE_ESM
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
@@ -524,7 +524,7 @@ function applyExports(basePath, expansion) {
     }
   }
 
-  throw new ERR_PKG_PATH_NOT_EXPORTED(basePath, mappingKey);
+  throw new ERR_PACKAGE_PATH_NOT_EXPORTED(basePath, mappingKey);
 }
 
 // This only applies to requests of a specific form:
@@ -593,7 +593,7 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
       try {
         return resolveExportsTarget(baseUrl, targetValue, subpath, mappingKey);
       } catch (e) {
-        if (e.code !== 'ERR_PKG_PATH_NOT_EXPORTED' &&
+        if (e.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED' &&
             e.code !== 'ERR_INVALID_PACKAGE_TARGET')
           throw e;
       }
@@ -617,7 +617,7 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
             return resolveExportsTarget(baseUrl, target[p], subpath,
                                         mappingKey);
           } catch (e) {
-            if (e.code !== 'ERR_PKG_PATH_NOT_EXPORTED') throw e;
+            if (e.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw e;
           }
           break;
         case 'default':
@@ -625,11 +625,11 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
             return resolveExportsTarget(baseUrl, target.default, subpath,
                                         mappingKey);
           } catch (e) {
-            if (e.code !== 'ERR_PKG_PATH_NOT_EXPORTED') throw e;
+            if (e.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw e;
           }
       }
     }
-    throw new ERR_PKG_PATH_NOT_EXPORTED(
+    throw new ERR_PACKAGE_PATH_NOT_EXPORTED(
       StringPrototypeSlice(baseUrl.pathname, 0, -1), mappingKey + subpath);
   }
   throw new ERR_INVALID_PACKAGE_TARGET(

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -85,6 +85,9 @@ const {
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_OPT_VALUE,
   ERR_INVALID_PACKAGE_CONFIG,
+  ERR_INVALID_PACKAGE_TARGET,
+  ERR_INVALID_MODULE_SPECIFIER,
+  ERR_PKG_PATH_NOT_EXPORTED,
   ERR_REQUIRE_ESM
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
@@ -501,12 +504,8 @@ function applyExports(basePath, expansion) {
     if (ObjectPrototypeHasOwnProperty(pkgExports, mappingKey)) {
       const mapping = pkgExports[mappingKey];
       return resolveExportsTarget(pathToFileURL(basePath + '/'), mapping, '',
-                                  basePath, mappingKey);
+                                  mappingKey);
     }
-
-    // Fallback to CJS main lookup when no main export is defined
-    if (mappingKey === '.')
-      return basePath;
 
     let dirMatch = '';
     for (const candidateKey of ObjectKeys(pkgExports)) {
@@ -521,18 +520,11 @@ function applyExports(basePath, expansion) {
       const mapping = pkgExports[dirMatch];
       const subpath = StringPrototypeSlice(mappingKey, dirMatch.length);
       return resolveExportsTarget(pathToFileURL(basePath + '/'), mapping,
-                                  subpath, basePath, mappingKey);
+                                  subpath, mappingKey);
     }
   }
-  // Fallback to CJS main lookup when no main export is defined
-  if (mappingKey === '.')
-    return basePath;
 
-  // eslint-disable-next-line no-restricted-syntax
-  const e = new Error(`Package exports for '${basePath}' do not define ` +
-      `a '${mappingKey}' subpath`);
-  e.code = 'MODULE_NOT_FOUND';
-  throw e;
+  throw new ERR_PKG_PATH_NOT_EXPORTED(basePath, mappingKey);
 }
 
 // This only applies to requests of a specific form:
@@ -567,39 +559,53 @@ function isArrayIndex(p) {
   return n >= 0 && n < (2 ** 32) - 1;
 }
 
-function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
+function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
   if (typeof target === 'string') {
-    if (target.startsWith('./') &&
-        (subpath.length === 0 || target.endsWith('/'))) {
-      const resolvedTarget = new URL(target, pkgPath);
-      const pkgPathPath = pkgPath.pathname;
-      const resolvedTargetPath = resolvedTarget.pathname;
-      if (StringPrototypeStartsWith(resolvedTargetPath, pkgPathPath) &&
+    let resolvedTarget, resolvedTargetPath;
+    const pkgPathPath = baseUrl.pathname;
+    if (target.startsWith('./')) {
+      resolvedTarget = new URL(target, baseUrl);
+      resolvedTargetPath = resolvedTarget.pathname;
+      if (!StringPrototypeStartsWith(resolvedTargetPath, pkgPathPath) ||
           StringPrototypeIndexOf(resolvedTargetPath, '/node_modules/',
-                                 pkgPathPath.length - 1) === -1) {
-        const resolved = new URL(subpath, resolvedTarget);
-        const resolvedPath = resolved.pathname;
-        if (StringPrototypeStartsWith(resolvedPath, resolvedTargetPath) &&
-            StringPrototypeIndexOf(resolvedPath, '/node_modules/',
-                                   pkgPathPath.length - 1) === -1) {
-          return fileURLToPath(resolved);
-        }
-      }
+                                 pkgPathPath.length - 1) !== -1)
+        resolvedTarget = undefined;
     }
+    if (subpath.length > 0 && !target.endsWith('/'))
+      resolvedTarget = undefined;
+    if (resolvedTarget === undefined)
+      throw new ERR_INVALID_PACKAGE_TARGET(baseUrl.pathname.slice(0, -1),
+                                           mappingKey, subpath, target);
+    const resolved = new URL(subpath, resolvedTarget);
+    const resolvedPath = resolved.pathname;
+    if (StringPrototypeStartsWith(resolvedPath, resolvedTargetPath) &&
+        StringPrototypeIndexOf(resolvedPath, '/node_modules/',
+                               pkgPathPath.length - 1) === -1) {
+      return fileURLToPath(resolved);
+    }
+    throw new ERR_INVALID_MODULE_SPECIFIER(baseUrl.pathname.slice(0, -1),
+                                           mappingKey);
   } else if (ArrayIsArray(target)) {
+    if (target.length === 0)
+      throw new ERR_INVALID_PACKAGE_TARGET(baseUrl.pathname.slice(0, -1),
+                                           mappingKey, subpath, target);
     for (const targetValue of target) {
-      if (ArrayIsArray(targetValue)) continue;
       try {
-        return resolveExportsTarget(pkgPath, targetValue, subpath, basePath,
-                                    mappingKey);
+        return resolveExportsTarget(baseUrl, targetValue, subpath, mappingKey);
       } catch (e) {
-        if (e.code !== 'MODULE_NOT_FOUND') throw e;
+        if (e.code !== 'ERR_PKG_PATH_NOT_EXPORTED' &&
+            e.code !== 'ERR_INVALID_PACKAGE_TARGET')
+          throw e;
       }
     }
+    // Throw last fallback error
+    resolveExportsTarget(baseUrl, target[target.length - 1], subpath,
+                         mappingKey);
+    assert(false);
   } else if (typeof target === 'object' && target !== null) {
     const keys = ObjectKeys(target);
     if (keys.some(isArrayIndex)) {
-      throw new ERR_INVALID_PACKAGE_CONFIG(basePath, '"exports" cannot ' +
+      throw new ERR_INVALID_PACKAGE_CONFIG(baseUrl, '"exports" cannot ' +
           'contain numeric property keys.');
     }
     for (const p of keys) {
@@ -608,34 +614,26 @@ function resolveExportsTarget(pkgPath, target, subpath, basePath, mappingKey) {
         case 'require':
           try {
             emitExperimentalWarning('Conditional exports');
-            const result = resolveExportsTarget(pkgPath, target[p], subpath,
-                                                basePath, mappingKey);
-            return result;
+            return resolveExportsTarget(baseUrl, target[p], subpath,
+                                        mappingKey);
           } catch (e) {
-            if (e.code !== 'MODULE_NOT_FOUND') throw e;
+            if (e.code !== 'ERR_PKG_PATH_NOT_EXPORTED') throw e;
           }
           break;
         case 'default':
           try {
-            return resolveExportsTarget(pkgPath, target.default, subpath,
-                                        basePath, mappingKey);
+            return resolveExportsTarget(baseUrl, target.default, subpath,
+                                        mappingKey);
           } catch (e) {
-            if (e.code !== 'MODULE_NOT_FOUND') throw e;
+            if (e.code !== 'ERR_PKG_PATH_NOT_EXPORTED') throw e;
           }
       }
     }
+    throw new ERR_PKG_PATH_NOT_EXPORTED(baseUrl.pathname.slice(0, -1),
+                                        mappingKey + subpath);
   }
-  let e;
-  if (mappingKey !== '.') {
-    // eslint-disable-next-line no-restricted-syntax
-    e = new Error(`Package exports for '${basePath}' do not define a ` +
-        `valid '${mappingKey}' target${subpath ? ' for ' + subpath : ''}`);
-  } else {
-    // eslint-disable-next-line no-restricted-syntax
-    e = new Error(`No valid exports main found for '${basePath}'`);
-  }
-  e.code = 'MODULE_NOT_FOUND';
-  throw e;
+  throw new ERR_INVALID_PACKAGE_TARGET(baseUrl.pathname.slice(0, -1),
+                                       mappingKey, subpath, target);
 }
 
 Module._findPath = function(request, paths, isMain) {

--- a/src/env.h
+++ b/src/env.h
@@ -221,6 +221,7 @@ constexpr size_t kFsStatsBufferLength =
   V(duration_string, "duration")                                               \
   V(emit_warning_string, "emitWarning")                                        \
   V(empty_object_string, "{}")                                                 \
+  V(empty_string, "")                                                          \
   V(encoding_string, "encoding")                                               \
   V(entries_string, "entries")                                                 \
   V(entry_type_string, "entryType")                                            \

--- a/src/env.h
+++ b/src/env.h
@@ -221,7 +221,6 @@ constexpr size_t kFsStatsBufferLength =
   V(duration_string, "duration")                                               \
   V(emit_warning_string, "emitWarning")                                        \
   V(empty_object_string, "{}")                                                 \
-  V(empty_string, "")                                                          \
   V(encoding_string, "encoding")                                               \
   V(entries_string, "entries")                                                 \
   V(entry_type_string, "entryType")                                            \

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -859,7 +859,7 @@ void ThrowExportsNotFound(Environment* env,
   const std::string msg = "Package subpath '" + subpath + "' is not defined" +
       " by \"exports\" in " + pjson_url.ToFilePath() + " imported from " +
       base.ToFilePath();
-  node::THROW_ERR_PKG_PATH_NOT_EXPORTED(env, msg.c_str());
+  node::THROW_ERR_PACKAGE_PATH_NOT_EXPORTED(env, msg.c_str());
 }
 
 void ThrowSubpathInvalid(Environment* env,
@@ -1001,7 +1001,7 @@ Maybe<URL> ResolveExportsTarget(Environment* env,
             Utf8Value code_utf8(env->isolate(),
                                 code->ToString(context).ToLocalChecked());
             std::string code_str(*code_utf8, code_utf8.length());
-            if (code_str == "ERR_PKG_PATH_NOT_EXPORTED" ||
+            if (code_str == "ERR_PACKAGE_PATH_NOT_EXPORTED" ||
                 code_str == "ERR_INVALID_PACKAGE_TARGET") {
               continue;
             }
@@ -1051,7 +1051,7 @@ Maybe<URL> ResolveExportsTarget(Environment* env,
             Utf8Value code_utf8(env->isolate(),
                                 code->ToString(context).ToLocalChecked());
             std::string code_str(*code_utf8, code_utf8.length());
-            if (code_str == "ERR_PKG_PATH_NOT_EXPORTED") continue;
+            if (code_str == "ERR_PACKAGE_PATH_NOT_EXPORTED") continue;
             try_catch.ReThrow();
             return Nothing<URL>();
           }
@@ -1146,7 +1146,7 @@ Maybe<URL> PackageMainResolve(Environment* env,
       }
       std::string msg = "No \"exports\" main resolved in " +
           pjson_url.ToFilePath();
-      node::THROW_ERR_PKG_PATH_NOT_EXPORTED(env, msg.c_str());
+      node::THROW_ERR_PACKAGE_PATH_NOT_EXPORTED(env, msg.c_str());
     }
     if (pcfg.has_main == HasMain::Yes) {
       URL resolved(pcfg.main, pjson_url);

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -856,10 +856,20 @@ void ThrowExportsNotFound(Environment* env,
                           const std::string& subpath,
                           const URL& pjson_url,
                           const URL& base) {
-  const std::string msg = "Package exports for " +
-      pjson_url.ToFilePath() + " do not define a '" + subpath +
-      "' subpath, imported from " + base.ToFilePath();
-  node::THROW_ERR_MODULE_NOT_FOUND(env, msg.c_str());
+  const std::string msg = "Package subpath '" + subpath + "' is not defined" +
+      " by \"exports\" in " + pjson_url.ToFilePath() + " imported from " +
+      base.ToFilePath();
+  node::THROW_ERR_PKG_PATH_NOT_EXPORTED(env, msg.c_str());
+}
+
+void ThrowSubpathInvalid(Environment* env,
+                         const std::string& subpath,
+                         const URL& pjson_url,
+                         const URL& base) {
+  const std::string msg = "Package subpath '" + subpath + "' is not a valid " +
+      "module request for the \"exports\" resolution of " +
+      pjson_url.ToFilePath() + " imported from " + base.ToFilePath();
+  node::THROW_ERR_INVALID_MODULE_SPECIFIER(env, msg.c_str());
 }
 
 void ThrowExportsInvalid(Environment* env,
@@ -868,14 +878,15 @@ void ThrowExportsInvalid(Environment* env,
                          const URL& pjson_url,
                          const URL& base) {
   if (subpath.length()) {
-    const std::string msg = "Cannot resolve package exports target '" + target +
-        "' matched for '" + subpath + "' in " + pjson_url.ToFilePath() +
-        ", imported from " + base.ToFilePath();
-    node::THROW_ERR_MODULE_NOT_FOUND(env, msg.c_str());
+    const std::string msg = "Invalid \"exports\" target \"" + target +
+        "\" defined for '" + subpath + "' in the package config " +
+        pjson_url.ToFilePath() + " imported from " + base.ToFilePath();
+    node::THROW_ERR_INVALID_PACKAGE_TARGET(env, msg.c_str());
   } else {
-    const std::string msg = "Cannot resolve package main '" + target + "' in" +
-        pjson_url.ToFilePath() + ", imported from " + base.ToFilePath();
-    node::THROW_ERR_MODULE_NOT_FOUND(env, msg.c_str());
+    const std::string msg = "Invalid \"exports\" main target " + target +
+        " defined in the package config " + pjson_url.ToFilePath() +
+        " imported from " + base.ToFilePath();
+    node::THROW_ERR_INVALID_PACKAGE_TARGET(env, msg.c_str());
   }
 }
 
@@ -885,14 +896,18 @@ void ThrowExportsInvalid(Environment* env,
                          const URL& pjson_url,
                          const URL& base) {
   Local<String> target_string;
-  if (target->ToString(env->context()).ToLocal(&target_string)) {
-    Utf8Value target_utf8(env->isolate(), target_string);
-    std::string target_str(*target_utf8, target_utf8.length());
-    if (target->IsArray()) {
-      target_str = '[' + target_str + ']';
-    }
-    ThrowExportsInvalid(env, subpath, target_str, pjson_url, base);
+  if (target->IsObject()) {
+    target_string = v8::JSON::Stringify(env->context(), target.As<v8::Object>(),
+                                        env->empty_string()).ToLocalChecked();
+  } else {
+    target_string = target->ToString(env->context()).ToLocalChecked();
   }
+  Utf8Value target_utf8(env->isolate(), target_string);
+  std::string target_str(*target_utf8, target_utf8.length());
+  if (target->IsArray()) {
+    target_str = '[' + target_str + ']';
+  }
+  ThrowExportsInvalid(env, subpath, target_str, pjson_url, base);
 }
 
 Maybe<URL> ResolveExportsTargetString(Environment* env,
@@ -900,18 +915,13 @@ Maybe<URL> ResolveExportsTargetString(Environment* env,
                                       const std::string& subpath,
                                       const std::string& match,
                                       const URL& pjson_url,
-                                      const URL& base,
-                                      bool throw_invalid = true) {
+                                      const URL& base) {
   if (target.substr(0, 2) != "./") {
-    if (throw_invalid) {
-      ThrowExportsInvalid(env, match, target, pjson_url, base);
-    }
+    ThrowExportsInvalid(env, match, target, pjson_url, base);
     return Nothing<URL>();
   }
   if (subpath.length() > 0 && target.back() != '/') {
-    if (throw_invalid) {
-      ThrowExportsInvalid(env, match, target, pjson_url, base);
-    }
+    ThrowExportsInvalid(env, match, target, pjson_url, base);
     return Nothing<URL>();
   }
   URL resolved(target, pjson_url);
@@ -920,9 +930,7 @@ Maybe<URL> ResolveExportsTargetString(Environment* env,
   if (resolved_path.find(pkg_path) != 0 ||
       resolved_path.find("/node_modules/", pkg_path.length() - 1) !=
       std::string::npos) {
-    if (throw_invalid) {
-      ThrowExportsInvalid(env, match, target, pjson_url, base);
-    }
+    ThrowExportsInvalid(env, match, target, pjson_url, base);
     return Nothing<URL>();
   }
   if (subpath.length() == 0) return Just(resolved);
@@ -931,9 +939,7 @@ Maybe<URL> ResolveExportsTargetString(Environment* env,
   if (subpath_resolved_path.find(resolved_path) != 0 ||
       subpath_resolved_path.find("/node_modules/", pkg_path.length() - 1)
       != std::string::npos) {
-    if (throw_invalid) {
-      ThrowExportsInvalid(env, match, target + subpath, pjson_url, base);
-    }
+    ThrowSubpathInvalid(env, match + subpath, pjson_url, base);
     return Nothing<URL>();
   }
   return Just(subpath_resolved);
@@ -955,7 +961,7 @@ bool IsArrayIndex(Environment* env, Local<Value> p) {
   if (!n->ToInteger(context).ToLocal(&cmp_integer)) {
     return false;
   }
-  return n_dbl > 0 && n_dbl < (2 ^ 32) - 1;
+  return n_dbl > 0 && n_dbl < (1LL << 32) - 1;
 }
 
 Maybe<URL> ResolveExportsTarget(Environment* env,
@@ -963,15 +969,14 @@ Maybe<URL> ResolveExportsTarget(Environment* env,
                                 Local<Value> target,
                                 const std::string& subpath,
                                 const std::string& pkg_subpath,
-                                const URL& base,
-                                bool throw_invalid = true) {
+                                const URL& base) {
   Isolate* isolate = env->isolate();
   Local<Context> context = env->context();
   if (target->IsString()) {
     Utf8Value target_utf8(isolate, target.As<v8::String>());
     std::string target_str(*target_utf8, target_utf8.length());
     Maybe<URL> resolved = ResolveExportsTargetString(env, target_str, subpath,
-        pkg_subpath, pjson_url, base, throw_invalid);
+        pkg_subpath, pjson_url, base);
     if (resolved.IsNothing()) {
       return Nothing<URL>();
     }
@@ -980,40 +985,50 @@ Maybe<URL> ResolveExportsTarget(Environment* env,
       Local<Array> target_arr = target.As<Array>();
       const uint32_t length = target_arr->Length();
       if (length == 0) {
-        if (throw_invalid) {
-          ThrowExportsInvalid(env, pkg_subpath, target, pjson_url, base);
-        }
+        ThrowExportsInvalid(env, pkg_subpath, target, pjson_url, base);
         return Nothing<URL>();
       }
       for (uint32_t i = 0; i < length; i++) {
         auto target_item = target_arr->Get(context, i).ToLocalChecked();
-        if (!target_item->IsArray()) {
+        {
+          TryCatchScope try_catch(env);
           Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url,
-              target_item, subpath, pkg_subpath, base, false);
-          if (resolved.IsNothing()) continue;
+              target_item, subpath, pkg_subpath, base);
+          if (resolved.IsNothing()) {
+            CHECK(try_catch.HasCaught() && !try_catch.Exception().IsEmpty());
+            auto e = try_catch.Exception()->ToObject(context).ToLocalChecked();
+            auto code = e->Get(context, env->code_string()).ToLocalChecked();
+            Utf8Value code_utf8(env->isolate(),
+                                code->ToString(context).ToLocalChecked());
+            std::string code_str(*code_utf8, code_utf8.length());
+            if (code_str == "ERR_PKG_PATH_NOT_EXPORTED" ||
+                code_str == "ERR_INVALID_PACKAGE_TARGET") {
+              continue;
+            }
+            try_catch.ReThrow();
+            return Nothing<URL>();
+          }
+          CHECK(!try_catch.HasCaught());
           return FinalizeResolution(env, resolved.FromJust(), base);
         }
       }
-      if (throw_invalid) {
-        auto invalid = target_arr->Get(context, length - 1).ToLocalChecked();
-        Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url, invalid,
-            subpath, pkg_subpath, base, true);
-        CHECK(resolved.IsNothing());
-      }
+      auto invalid = target_arr->Get(context, length - 1).ToLocalChecked();
+      Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url, invalid,
+          subpath, pkg_subpath, base);
+      CHECK(resolved.IsNothing());
       return Nothing<URL>();
   } else if (target->IsObject()) {
     Local<Object> target_obj = target.As<Object>();
     Local<Array> target_obj_keys =
         target_obj->GetOwnPropertyNames(context).ToLocalChecked();
     Local<Value> conditionalTarget;
-    bool matched = false;
     for (uint32_t i = 0; i < target_obj_keys->Length(); ++i) {
       Local<Value> key =
           target_obj_keys->Get(context, i).ToLocalChecked();
       if (IsArrayIndex(env, key)) {
-        const std::string msg = "Invalid package config for " +
-            pjson_url.ToFilePath() + ", \"exports\" cannot contain numeric " +
-            "property keys.";
+        const std::string msg = "Invalid package config " +
+            pjson_url.ToFilePath() + " imported from " + base.ToFilePath() +
+            ". \"exports\" cannot contain numeric property keys.";
         node::THROW_ERR_INVALID_PACKAGE_CONFIG(env, msg.c_str());
         return Nothing<URL>();
       }
@@ -1024,35 +1039,53 @@ Maybe<URL> ResolveExportsTarget(Environment* env,
                          key->ToString(context).ToLocalChecked());
       std::string key_str(*key_utf8, key_utf8.length());
       if (key_str == "node" || key_str == "import") {
-        matched = true;
         conditionalTarget = target_obj->Get(context, key).ToLocalChecked();
-        Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url,
-            conditionalTarget, subpath, pkg_subpath, base, false);
-        if (!resolved.IsNothing()) {
+        {
+          TryCatchScope try_catch(env);
+          Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url,
+              conditionalTarget, subpath, pkg_subpath, base);
+          if (resolved.IsNothing()) {
+            CHECK(try_catch.HasCaught() && !try_catch.Exception().IsEmpty());
+            auto e = try_catch.Exception()->ToObject(context).ToLocalChecked();
+            auto code = e->Get(context, env->code_string()).ToLocalChecked();
+            Utf8Value code_utf8(env->isolate(),
+                                code->ToString(context).ToLocalChecked());
+            std::string code_str(*code_utf8, code_utf8.length());
+            if (code_str == "ERR_PKG_PATH_NOT_EXPORTED") continue;
+            try_catch.ReThrow();
+            return Nothing<URL>();
+          }
+          CHECK(!try_catch.HasCaught());
           ProcessEmitExperimentalWarning(env, "Conditional exports");
           return resolved;
         }
       } else if (key_str == "default") {
-        matched = true;
         conditionalTarget = target_obj->Get(context, key).ToLocalChecked();
-        Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url,
-            conditionalTarget, subpath, pkg_subpath, base, false);
-        if (!resolved.IsNothing()) {
+        {
+          TryCatchScope try_catch(env);
+          Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url,
+              conditionalTarget, subpath, pkg_subpath, base);
+          if (resolved.IsNothing()) {
+            CHECK(try_catch.HasCaught() && !try_catch.Exception().IsEmpty());
+            auto e = try_catch.Exception()->ToObject(context).ToLocalChecked();
+            auto code = e->Get(context, env->code_string()).ToLocalChecked();
+            Utf8Value code_utf8(env->isolate(),
+                                code->ToString(context).ToLocalChecked());
+            std::string code_str(*code_utf8, code_utf8.length());
+            if (code_str == "ERR_PACKAGE_PATH_NOT_EXPORTED") continue;
+            try_catch.ReThrow();
+            return Nothing<URL>();
+          }
+          CHECK(!try_catch.HasCaught());
           ProcessEmitExperimentalWarning(env, "Conditional exports");
           return resolved;
         }
       }
     }
-    if (matched && throw_invalid) {
-      Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url,
-          conditionalTarget, subpath, pkg_subpath, base, true);
-      CHECK(resolved.IsNothing());
-      return Nothing<URL>();
-    }
+    ThrowExportsNotFound(env, pkg_subpath, pjson_url, base);
+    return Nothing<URL>();
   }
-  if (throw_invalid) {
-    ThrowExportsInvalid(env, pkg_subpath, target, pjson_url, base);
-  }
+  ThrowExportsInvalid(env, pkg_subpath, target, pjson_url, base);
   return Nothing<URL>();
 }
 
@@ -1074,8 +1107,8 @@ Maybe<bool> IsConditionalExportsMainSugar(Environment* env,
     if (i == 0) {
       isConditionalSugar = curIsConditionalSugar;
     } else if (isConditionalSugar != curIsConditionalSugar) {
-      const std::string msg = "Cannot resolve package exports in " +
-        pjson_url.ToFilePath() + ", imported from " + base.ToFilePath() + ". " +
+      const std::string msg = "Invalid package config " + pjson_url.ToFilePath()
+        + " imported from " + base.ToFilePath() + ". " +
         "\"exports\" cannot contain some keys starting with '.' and some not." +
         " The exports object must either be an object of package subpath keys" +
         " or an object of main entry condition name keys only.";
@@ -1100,8 +1133,7 @@ Maybe<URL> PackageMainResolve(Environment* env,
       if (isConditionalExportsMainSugar.IsNothing())
         return Nothing<URL>();
       if (isConditionalExportsMainSugar.FromJust()) {
-        return ResolveExportsTarget(env, pjson_url, exports, "", "", base,
-                                    true);
+        return ResolveExportsTarget(env, pjson_url, exports, "", "", base);
       } else if (exports->IsObject()) {
         Local<Object> exports_obj = exports.As<Object>();
         if (exports_obj->HasOwnProperty(env->context(), env->dot_string())
@@ -1109,10 +1141,12 @@ Maybe<URL> PackageMainResolve(Environment* env,
           Local<Value> target =
               exports_obj->Get(env->context(), env->dot_string())
               .ToLocalChecked();
-          return ResolveExportsTarget(env, pjson_url, target, "", "", base,
-                                      true);
+          return ResolveExportsTarget(env, pjson_url, target, "", "", base);
         }
       }
+      std::string msg = "No \"exports\" main resolved in " +
+          pjson_url.ToFilePath();
+      node::THROW_ERR_PKG_PATH_NOT_EXPORTED(env, msg.c_str());
     }
     if (pcfg.has_main == HasMain::Yes) {
       URL resolved(pcfg.main, pjson_url);
@@ -1204,39 +1238,6 @@ Maybe<URL> PackageExportsResolve(Environment* env,
   return Nothing<URL>();
 }
 
-Maybe<URL> ResolveSelf(Environment* env,
-                       const std::string& pkg_name,
-                       const std::string& pkg_subpath,
-                       const URL& base) {
-  const PackageConfig* pcfg;
-  if (GetPackageScopeConfig(env, base, base).To(&pcfg) &&
-      pcfg->exists == Exists::Yes) {
-    // TODO(jkrems): Find a way to forward the pair/iterator already generated
-    // while executing GetPackageScopeConfig
-    URL pjson_url("");
-    bool found_pjson = false;
-    for (auto it = env->package_json_cache.begin();
-          it != env->package_json_cache.end();
-          ++it) {
-      if (&it->second == pcfg) {
-        pjson_url = URL::FromFilePath(it->first);
-        found_pjson = true;
-      }
-    }
-    if (!found_pjson || pcfg->name != pkg_name) return Nothing<URL>();
-    if (pcfg->exports.IsEmpty()) return Nothing<URL>();
-    if (pkg_subpath == "./") {
-      return Just(URL("./", pjson_url));
-    } else if (!pkg_subpath.length()) {
-      return PackageMainResolve(env, pjson_url, *pcfg, base);
-    } else {
-      return PackageExportsResolve(env, pjson_url, pkg_subpath, *pcfg, base);
-    }
-  }
-
-  return Nothing<URL>();
-}
-
 Maybe<URL> PackageResolve(Environment* env,
                           const std::string& specifier,
                           const URL& base) {
@@ -1277,10 +1278,32 @@ Maybe<URL> PackageResolve(Environment* env,
     pkg_subpath = "." + specifier.substr(sep_index);
   }
 
-  Maybe<URL> self_url = ResolveSelf(env, pkg_name, pkg_subpath, base);
-  if (self_url.IsJust()) {
-    ProcessEmitExperimentalWarning(env, "Package name self resolution");
-    return self_url;
+  // ResolveSelf
+  const PackageConfig* pcfg;
+  if (GetPackageScopeConfig(env, base, base).To(&pcfg) &&
+      pcfg->exists == Exists::Yes) {
+    // TODO(jkrems): Find a way to forward the pair/iterator already generated
+    // while executing GetPackageScopeConfig
+    URL pjson_url("");
+    bool found_pjson = false;
+    for (auto it = env->package_json_cache.begin();
+          it != env->package_json_cache.end();
+          ++it) {
+      if (&it->second == pcfg) {
+        pjson_url = URL::FromFilePath(it->first);
+        found_pjson = true;
+      }
+    }
+    if (found_pjson && pcfg->name == pkg_name && !pcfg->exports.IsEmpty()) {
+      ProcessEmitExperimentalWarning(env, "Package name self resolution");
+      if (pkg_subpath == "./") {
+        return Just(URL("./", pjson_url));
+      } else if (!pkg_subpath.length()) {
+        return PackageMainResolve(env, pjson_url, *pcfg, base);
+      } else {
+        return PackageExportsResolve(env, pjson_url, pkg_subpath, *pcfg, base);
+      }
+    }
   }
 
   URL pjson_url("./node_modules/" + pkg_name + "/package.json", &base);

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -997,11 +997,18 @@ Maybe<URL> ResolveExportsTarget(Environment* env,
           Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url,
               target_item, subpath, pkg_subpath, base);
           if (resolved.IsNothing()) {
-            CHECK(try_catch.HasCaught() && !try_catch.Exception().IsEmpty());
-            auto e = try_catch.Exception()->ToObject(context).ToLocalChecked();
-            auto code = e->Get(context, env->code_string()).ToLocalChecked();
-            Utf8Value code_utf8(env->isolate(),
-                                code->ToString(context).ToLocalChecked());
+            CHECK(try_catch.HasCaught());
+            if (try_catch.Exception().IsEmpty()) return Nothing<URL>();
+            Local<Object> e;
+            if (!try_catch.Exception()->ToObject(context).ToLocal(&e))
+              return Nothing<URL>();
+            Local<Value> code;
+            if (!e->Get(context, env->code_string()).ToLocal(&code))
+              return Nothing<URL>();
+            Local<String> code_string;
+            if (!code->ToString(context).ToLocal(&code_string))
+              return Nothing<URL>();
+            Utf8Value code_utf8(env->isolate(), code_string);
             if (strcmp(*code_utf8, "ERR_PACKAGE_PATH_NOT_EXPORTED") == 0 ||
                 strcmp(*code_utf8, "ERR_INVALID_PACKAGE_TARGET") == 0) {
               continue;
@@ -1046,11 +1053,18 @@ Maybe<URL> ResolveExportsTarget(Environment* env,
           Maybe<URL> resolved = ResolveExportsTarget(env, pjson_url,
               conditionalTarget, subpath, pkg_subpath, base);
           if (resolved.IsNothing()) {
-            CHECK(try_catch.HasCaught() && !try_catch.Exception().IsEmpty());
-            auto e = try_catch.Exception()->ToObject(context).ToLocalChecked();
-            auto code = e->Get(context, env->code_string()).ToLocalChecked();
-            Utf8Value code_utf8(env->isolate(),
-                                code->ToString(context).ToLocalChecked());
+            CHECK(try_catch.HasCaught());
+            if (try_catch.Exception().IsEmpty()) return Nothing<URL>();
+            Local<Object> e;
+            if (!try_catch.Exception()->ToObject(context).ToLocal(&e))
+              return Nothing<URL>();
+            Local<Value> code;
+            if (!e->Get(context, env->code_string()).ToLocal(&code))
+              return Nothing<URL>();
+            Local<String> code_string;
+            if (!code->ToString(context).ToLocal(&code_string))
+              return Nothing<URL>();
+            Utf8Value code_utf8(env->isolate(), code_string);
             if (strcmp(*code_utf8, "ERR_PACKAGE_PATH_NOT_EXPORTED") == 0)
               continue;
             try_catch.ReThrow();

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -43,7 +43,8 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_OSSL_EVP_INVALID_DIGEST, Error)                                      \
   V(ERR_INVALID_ARG_TYPE, TypeError)                                         \
   V(ERR_INVALID_MODULE_SPECIFIER, TypeError)                                 \
-  V(ERR_INVALID_PACKAGE_CONFIG, SyntaxError)                                 \
+  V(ERR_INVALID_PACKAGE_CONFIG, Error)                                       \
+  V(ERR_INVALID_PACKAGE_TARGET, Error)                                       \
   V(ERR_INVALID_TRANSFER_OBJECT, TypeError)                                  \
   V(ERR_MEMORY_ALLOCATION_FAILED, Error)                                     \
   V(ERR_MISSING_ARGS, TypeError)                                             \
@@ -53,6 +54,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_NON_CONTEXT_AWARE_DISABLED, Error)                                   \
   V(ERR_MODULE_NOT_FOUND, Error)                                             \
   V(ERR_OUT_OF_RANGE, RangeError)                                            \
+  V(ERR_PKG_PATH_NOT_EXPORTED, Error)                                        \
   V(ERR_SCRIPT_EXECUTION_INTERRUPTED, Error)                                 \
   V(ERR_SCRIPT_EXECUTION_TIMEOUT, Error)                                     \
   V(ERR_STRING_TOO_LONG, Error)                                              \

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -54,7 +54,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_NON_CONTEXT_AWARE_DISABLED, Error)                                   \
   V(ERR_MODULE_NOT_FOUND, Error)                                             \
   V(ERR_OUT_OF_RANGE, RangeError)                                            \
-  V(ERR_PKG_PATH_NOT_EXPORTED, Error)                                        \
+  V(ERR_PACKAGE_PATH_NOT_EXPORTED, Error)                                    \
   V(ERR_SCRIPT_EXECUTION_INTERRUPTED, Error)                                 \
   V(ERR_SCRIPT_EXECUTION_TIMEOUT, Error)                                     \
   V(ERR_STRING_TOO_LONG, Error)                                              \

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -87,7 +87,7 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
 
   for (const [specifier, subpath] of undefinedExports) {
     loadFixture(specifier).catch(mustCall((err) => {
-      strictEqual(err.code, 'ERR_PKG_PATH_NOT_EXPORTED');
+      strictEqual(err.code, 'ERR_PACKAGE_PATH_NOT_EXPORTED');
       assertStartsWith(err.message, 'Package subpath ');
       assertIncludes(err.message, subpath);
     }));
@@ -113,7 +113,7 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
   // of falling back to main
   if (isRequire) {
     loadFixture('pkgexports-main').catch(mustCall((err) => {
-      strictEqual(err.code, 'ERR_PKG_PATH_NOT_EXPORTED');
+      strictEqual(err.code, 'ERR_PACKAGE_PATH_NOT_EXPORTED');
       assertStartsWith(err.message, 'No "exports" main ');
     }));
   }

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -32,7 +32,7 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     ['pkgexports/resolve-self', isRequire ?
       { default: 'self-cjs' } : { default: 'self-mjs' }],
     // Resolve self sugar
-    ['pkgexports-sugar', { default: 'main' }]
+    ['pkgexports-sugar', { default: 'main' }],
   ]);
 
   for (const [validSpecifier, expected] of validSpecifiers) {
@@ -53,48 +53,59 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     // Sugar cases still encapsulate
     ['pkgexports-sugar/not-exported.js', './not-exported.js'],
     ['pkgexports-sugar2/not-exported.js', './not-exported.js'],
+    // Conditional exports with no match are "not exported" errors
+    ['pkgexports/invalid1', './invalid1'],
+    ['pkgexports/invalid4', './invalid4'],
   ]);
 
   const invalidExports = new Map([
-    // Even though 'pkgexports/sub/asdf.js' works, alternate "path-like"
-    // variants do not to prevent confusion and accidental loopholes.
-    ['pkgexports/sub/./../asdf.js', './sub/./../asdf.js'],
+    // Directory mappings require a trailing / to work
+    ['pkgexports/missingtrailer/x', './missingtrailer/'],
     // This path steps back inside the package but goes through an exports
     // target that escapes the package, so we still catch that as invalid
-    ['pkgexports/belowdir/pkgexports/asdf.js', './belowdir/pkgexports/asdf.js'],
+    ['pkgexports/belowdir/pkgexports/asdf.js', './belowdir/'],
     // This target file steps below the package
     ['pkgexports/belowfile', './belowfile'],
-    // Directory mappings require a trailing / to work
-    ['pkgexports/missingtrailer/x', './missingtrailer/x'],
     // Invalid target handling
     ['pkgexports/null', './null'],
-    ['pkgexports/invalid1', './invalid1'],
     ['pkgexports/invalid2', './invalid2'],
     ['pkgexports/invalid3', './invalid3'],
-    ['pkgexports/invalid4', './invalid4'],
     // Missing / invalid fallbacks
     ['pkgexports/nofallback1', './nofallback1'],
     ['pkgexports/nofallback2', './nofallback2'],
     // Reaching into nested node_modules
     ['pkgexports/nodemodules', './nodemodules'],
+    // Self resolve invalid
+    ['pkgexports/resolve-self-invalid', './invalid2'],
+  ]);
+
+  const invalidSpecifiers = new Map([
+    // Even though 'pkgexports/sub/asdf.js' works, alternate "path-like"
+    // variants do not to prevent confusion and accidental loopholes.
+    ['pkgexports/sub/./../asdf.js', './sub/./../asdf.js'],
   ]);
 
   for (const [specifier, subpath] of undefinedExports) {
     loadFixture(specifier).catch(mustCall((err) => {
-      strictEqual(err.code, (isRequire ? '' : 'ERR_') + 'MODULE_NOT_FOUND');
-      assertStartsWith(err.message, 'Package exports');
-      assertIncludes(err.message, `do not define a '${subpath}' subpath`);
+      strictEqual(err.code, 'ERR_PKG_PATH_NOT_EXPORTED');
+      assertStartsWith(err.message, 'Package subpath ');
+      assertIncludes(err.message, subpath);
     }));
   }
 
   for (const [specifier, subpath] of invalidExports) {
     loadFixture(specifier).catch(mustCall((err) => {
-      strictEqual(err.code, (isRequire ? '' : 'ERR_') + 'MODULE_NOT_FOUND');
-      assertStartsWith(err.message, (isRequire ? 'Package exports' :
-        'Cannot resolve'));
-      assertIncludes(err.message, isRequire ?
-        `do not define a valid '${subpath}' target` :
-        `matched for '${subpath}'`);
+      strictEqual(err.code, 'ERR_INVALID_PACKAGE_TARGET');
+      assertStartsWith(err.message, 'Invalid "exports"');
+      assertIncludes(err.message, subpath);
+    }));
+  }
+
+  for (const [specifier, subpath] of invalidSpecifiers) {
+    loadFixture(specifier).catch(mustCall((err) => {
+      strictEqual(err.code, 'ERR_INVALID_MODULE_SPECIFIER');
+      assertStartsWith(err.message, 'Package subpath ');
+      assertIncludes(err.message, subpath);
     }));
   }
 
@@ -102,8 +113,8 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
   // of falling back to main
   if (isRequire) {
     loadFixture('pkgexports-main').catch(mustCall((err) => {
-      strictEqual(err.code, 'MODULE_NOT_FOUND');
-      assertStartsWith(err.message, 'No valid export');
+      strictEqual(err.code, 'ERR_PKG_PATH_NOT_EXPORTED');
+      assertStartsWith(err.message, 'No "exports" main ');
     }));
   }
 
@@ -130,8 +141,7 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
   // Sugar conditional exports main mixed failure case
   loadFixture('pkgexports-sugar-fail').catch(mustCall((err) => {
     strictEqual(err.code, 'ERR_INVALID_PACKAGE_CONFIG');
-    assertStartsWith(err.message, (isRequire ? 'Invalid package' :
-      'Cannot resolve'));
+    assertStartsWith(err.message, 'Invalid package');
     assertIncludes(err.message, '"exports" cannot contain some keys starting ' +
     'with \'.\' and some not. The exports object must either be an object of ' +
     'package subpath keys or an object of main entry condition name keys ' +

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -35,6 +35,10 @@
     "./resolve-self": {
       "require": "./resolve-self.js",
       "import": "./resolve-self.mjs"
+    },
+    "./resolve-self-invalid": {
+      "require": "./resolve-self-invalid.js",
+      "import": "./resolve-self-invalid.mjs"
     }
   }
 }

--- a/test/fixtures/node_modules/pkgexports/resolve-self-invalid.js
+++ b/test/fixtures/node_modules/pkgexports/resolve-self-invalid.js
@@ -1,0 +1,1 @@
+require('pkg-exports/invalid2');

--- a/test/fixtures/node_modules/pkgexports/resolve-self-invalid.mjs
+++ b/test/fixtures/node_modules/pkgexports/resolve-self-invalid.mjs
@@ -1,0 +1,1 @@
+import 'pkg-exports/invalid2';


### PR DESCRIPTION
This PR includes a number of refinements to the error handling of exports resolutions in the ES module resolver:

* Exports resolution error messages and codes are fully unified between the CJS and ESM resolver implementations, with the only difference that the ESM resolver errors include an `imported from ...` part since they don't have natural error stacks like `require()` does.
* The _MODULE_NOT_FOUND_ errors from "exports" resolution are split up into three separate errors: _ERR_INVALID_PACKAGE_TARGET_, _ERR_INVALID_MODULE_SPECIFIER_, and _ERR_PACKAGE_PATH_NOT_EXPORTED_. Previously we wanted to try to maintain unification on the _MODULE_NOT_FOUND_ error, but we already have _ERR_INVALID_PACKAGE_CONFIG_ and _ERR_INVALID_MODULE_SPECIFIER_ to track, such that this unification has become restricting I think.
* _ERR_INVALID_PACKAGE_TARGET_ is thrown whenever the exports resolution value in the package.json itself is invalid. This includes values that fail validation like `invalid:url` or backtrack below the package boundary like `../../../outside`.
* _ERR_INVALID_MODULE_SPECIFIER_ is extended to throw for cases like `"exports": { "./sub/": "./sub/" }` where the user attempts to require eg `pkg/sub/../../../asdf` or `pkg/sub/node_modules/...` etc. The error thus distinguishes that the fault is with the requestor, not the package.json itself.
* _ERR_PACKAGE_PATH_NOT_EXPORTED_ is thrown whenever trying to import an export from a package that is not defined. These are effectively the _encapsulation errors_ for "exports".

The main semantic changes in this PR are then the following:
1. Conditional exports fallbacks (as introduced by logical conditional exports ordering in https://github.com/nodejs/node/pull/31008) are then restricted only to apply to _ERR_PACKAGE_PATH_NOT_EXPORTED_ errors, and not the other classes of errors. This much more clearly ensures that only those conditions not defined to match fall through. For a contrived example: `"exports": { "node": { "node": "not:valid" }, "default": "./valid.js" }` would before this PR always return the `valid.js` path, but after this PR always throw an _ERR_INVALID_PACKAGE_TARGET_ error for the `not:valid` path. On the other hand, `"exports": { "node": { "never": "./never.js" }, "default": "./valid.js" }` would fall through the _"never"_ path fine. Array fallbacks continue to fall back on the validation errors though as designed.
2. Whenever "exports" is set, we no longer fall back to trying the main. If there is no main defined by exports - either because there is no `"."` entry, or because there is no conditional resolution for the `"."` entry (eg `"exports": {  "never": "./never.js" }`), the _ERR_PACKAGE_PATH_NOT_EXPORTED_ error will immediately throw without doing any `"main"` or `"index.js"` lookups. This makes "exports" **exhaustive** in its definition of the package resolution, and simplifies the error handling consistency for exports in turn.

Since its original proposal, `"exports"` has very much turned into a full replacement for `"main"`. Having self-resolve entirely reliant on this field being set is also in line with this. I understand (2) may be the most controversial part of this PR with the biggest user-facing consequences, so I expect we should discuss this further in the next meeting. This PR can be adjusted further based on any resolutions. The logic connects around the error handling hence the monolith here.

In addition, this PR fixes https://github.com/nodejs/node/issues/31510 and the incorrect use of XOR instead of bit shift described in https://github.com/nodejs/node/pull/31008#pullrequestreview-352499949.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
