### PR TITLE
tools: unify make-v8.sh for ppc64le and s390x

### DIFF
--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -8,35 +8,28 @@ tools/node/fetch_deps.py .
 
 ARCH="`arch`"
 if [[ "$ARCH" == "s390x" ]] || [[ "$ARCH" == "ppc64le" ]]; then
+  TARGET_ARCH=$ARCH
+  if [[ "$ARCH" == "ppc64le" ]]; then
+    TARGET_ARCH="ppc64"
+  fi
   # set paths manually for now to use locally installed gn
   export BUILD_TOOLS=/home/iojs/build-tools
   export LD_LIBRARY_PATH=$BUILD_TOOLS:$LD_LIBRARY_PATH
-  export PATH=$BUILD_TOOLS:$PATH
-  if [[ X"$CXX" != X ]]; then
-    CXX_PATH=`which $CXX |grep g++`
-  fi
-  if [[ X"$CC" != X ]]; then
-    CC_PATH=`which $CC |grep gcc`
-  fi
+  # Avoid linking to ccache symbolic links as ccache decides which
+  # binary to run based on the name of the link (we always name them gcc/g++).
+  CC_PATH=`which -a $CC gcc | grep -v ccache | head -n 1`
+  CXX_PATH=`which -a $CXX g++ | grep -v ccache | head -n 1`
   rm -f "$BUILD_TOOLS/g++"
   rm -f "$BUILD_TOOLS/gcc"
-fi
-if [[ "$ARCH" == "s390x" ]]; then
   ln -s $CXX_PATH "$BUILD_TOOLS/g++"
   ln -s $CC_PATH "$BUILD_TOOLS/gcc"
+  export PATH=$BUILD_TOOLS:$PATH
+
   g++ --version
+  gcc --version
   export PKG_CONFIG_PATH=$BUILD_TOOLS/pkg-config
-  gn gen -v out.gn/$BUILD_ARCH_TYPE --args='is_component_build=false is_debug=false use_goma=false goma_dir="None" use_custom_libcxx=false v8_target_cpu="s390x" target_cpu="s390x"'
+  gn gen -v out.gn/$BUILD_ARCH_TYPE --args="is_component_build=false is_debug=false use_goma=false goma_dir=\"None\" use_custom_libcxx=false v8_target_cpu=\"$TARGET_ARCH\" target_cpu=\"$TARGET_ARCH\""
   ninja -v -C out.gn/$BUILD_ARCH_TYPE d8 cctest inspector-test
-elif [[ "$ARCH" == "ppc64le" ]]; then
-  if [[ X"$CXX" != X ]]; then
-    ln -s /usr/bin/$CXX "$BUILD_TOOLS/g++"
-    ln -s /usr/bin/$CC "$BUILD_TOOLS/gcc"
-  fi
-  g++ --version
-  export PKG_CONFIG_PATH=$BUILD_TOOLS/pkg-config-files
-  gn gen out.gn/$BUILD_ARCH_TYPE --args='is_component_build=false is_debug=false use_goma=false goma_dir="None" use_custom_libcxx=false v8_target_cpu="ppc64" target_cpu="ppc64"'
-  ninja -C out.gn/$BUILD_ARCH_TYPE d8 cctest inspector-test
 else
   PATH=~/_depot_tools:$PATH tools/dev/v8gen.py $BUILD_ARCH_TYPE --no-goma $V8_BUILD_OPTIONS
   PATH=~/_depot_tools:$PATH ninja -C out.gn/$BUILD_ARCH_TYPE/ d8 cctest inspector-test


### PR DESCRIPTION
Refactor `tools/make-v8.sh` to minimise differences between the
`ppc64le` and `s390x` paths to allow us to enable `ccache` on the
`ppc64le` machines in the CI.

This needs to land in all supported release lines tested on before
we can reenable ccache on the `centos7-ppcle` machines (i.e.
reland https://github.com/nodejs/build/pull/1927 which was backed out because the 
divergent `ppc64le` and `s390x` paths through this script
broke `node-test-commit-v8-linux` (https://github.com/nodejs/build/issues/1940)).

Refs: https://github.com/nodejs/build/pull/1927
Refs: https://github.com/nodejs/build/issues/1940

cc @nodejs/platform-ppc @nodejs/platform-s390 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
