### PR TITLE
n-api: free instance data as reference

### DIFF
--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -8,6 +8,49 @@
 
 static napi_status napi_clear_last_error(napi_env env);
 
+namespace v8impl {
+
+class RefTracker {
+ public:
+  RefTracker() {}
+  virtual ~RefTracker() {}
+  virtual void Finalize(bool isEnvTeardown) {}
+
+  typedef RefTracker RefList;
+
+  inline void Link(RefList* list) {
+    prev_ = list;
+    next_ = list->next_;
+    if (next_ != nullptr) {
+      next_->prev_ = this;
+    }
+    list->next_ = this;
+  }
+
+  inline void Unlink() {
+    if (prev_ != nullptr) {
+      prev_->next_ = next_;
+    }
+    if (next_ != nullptr) {
+      next_->prev_ = prev_;
+    }
+    prev_ = nullptr;
+    next_ = nullptr;
+  }
+
+  static void FinalizeAll(RefList* list) {
+    while (list->next_ != nullptr) {
+      list->next_->Finalize(true);
+    }
+  }
+
+ private:
+  RefList* next_ = nullptr;
+  RefList* prev_ = nullptr;
+};
+
+}  // end of namespace v8impl
+
 struct napi_env__ {
   explicit napi_env__(v8::Local<v8::Context> context)
       : isolate(context->GetIsolate()),
@@ -22,11 +65,6 @@ struct napi_env__ {
     // `napi_finalizer` deleted them subsequently.
     v8impl::RefTracker::FinalizeAll(&finalizing_reflist);
     v8impl::RefTracker::FinalizeAll(&reflist);
-    if (instance_data.finalize_cb != nullptr) {
-      CallIntoModuleThrow([&](napi_env env) {
-        instance_data.finalize_cb(env, instance_data.data, instance_data.hint);
-      });
-    }
   }
   v8::Isolate* const isolate;  // Shortcut for context()->GetIsolate()
   v8impl::Persistent<v8::Context> context_persistent;
@@ -76,11 +114,7 @@ struct napi_env__ {
   int open_handle_scopes = 0;
   int open_callback_scopes = 0;
   int refs = 1;
-  struct {
-    void* data = nullptr;
-    void* hint = nullptr;
-    napi_finalize finalize_cb = nullptr;
-  } instance_data;
+  void* instance_data = nullptr;
 };
 
 static inline napi_status napi_clear_last_error(napi_env env) {

--- a/src/js_native_api_v8_internals.h
+++ b/src/js_native_api_v8_internals.h
@@ -28,45 +28,6 @@
 
 namespace v8impl {
 
-class RefTracker {
- public:
-  RefTracker() {}
-  virtual ~RefTracker() {}
-  virtual void Finalize(bool isEnvTeardown) {}
-
-  typedef RefTracker RefList;
-
-  inline void Link(RefList* list) {
-    prev_ = list;
-    next_ = list->next_;
-    if (next_ != nullptr) {
-      next_->prev_ = this;
-    }
-    list->next_ = this;
-  }
-
-  inline void Unlink() {
-    if (prev_ != nullptr) {
-      prev_->next_ = next_;
-    }
-    if (next_ != nullptr) {
-      next_->prev_ = prev_;
-    }
-    prev_ = nullptr;
-    next_ = nullptr;
-  }
-
-  static void FinalizeAll(RefList* list) {
-    while (list->next_ != nullptr) {
-      list->next_->Finalize(true);
-    }
-  }
-
- private:
-  RefList* next_ = nullptr;
-  RefList* prev_ = nullptr;
-};
-
 template <typename T>
 using Persistent = v8::Global<T>;
 

--- a/test/node-api/test_instance_data/addon.c
+++ b/test/node-api/test_instance_data/addon.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+#define NAPI_EXPERIMENTAL
+#include <node_api.h>
+
+static void addon_free(napi_env env, void* data, void* hint) {
+  napi_ref* ref = data;
+  napi_delete_reference(env, *ref);
+  free(ref);
+  fprintf(stderr, "addon_free");
+}
+
+napi_value addon_new(napi_env env, napi_value exports, bool ref_first) {
+  napi_ref* ref = malloc(sizeof(*ref));
+  if (ref_first) {
+    napi_create_reference(env, exports, 1, ref);
+    napi_set_instance_data(env, ref, addon_free, NULL);
+  } else {
+    napi_set_instance_data(env, ref, addon_free, NULL);
+    napi_create_reference(env, exports, 1, ref);
+  }
+  return exports;
+}

--- a/test/node-api/test_instance_data/binding.gyp
+++ b/test/node-api/test_instance_data/binding.gyp
@@ -5,6 +5,20 @@
       "sources": [
         "test_instance_data.c"
       ]
-    }
+    },
+    {
+      "target_name": "test_set_then_ref",
+      "sources": [
+        "addon.c",
+        "test_set_then_ref.c",
+      ]
+    },
+    {
+      "target_name": "test_ref_then_set",
+      "sources": [
+        "addon.c",
+        "test_ref_then_set.c",
+      ]
+    },
   ]
 }

--- a/test/node-api/test_instance_data/test.js
+++ b/test/node-api/test_instance_data/test.js
@@ -24,12 +24,32 @@ if (module.parent) {
 } else {
   // When launched as a script, run tests in either a child process or in a
   // worker thread.
+  const assert = require('assert');
   const requireAs = require('../../common/require-as');
   const runOptions = { stdio: ['inherit', 'pipe', 'inherit'] };
+  const { spawnSync } = require('child_process');
 
   // Run tests in a child process.
   requireAs(__filename, ['--expose-gc'], runOptions, 'child');
 
   // Run tests in a worker thread in a child process.
   requireAs(__filename, ['--expose-gc'], runOptions, 'worker');
+
+  function testProcessExit(addonName) {
+    // Make sure that process exit is clean when the instance data has
+    // references to JS objects.
+    const path = require
+      .resolve(`./build/${common.buildType}/${addonName}`)
+      // Replace any backslashes with double backslashes because they'll be re-
+      // interpreted back to single backslashes in the command line argument
+      // to the child process. Windows needs this.
+      .replace(/\\/g, '\\\\');
+    const child = spawnSync(process.execPath, ['-e', `require('${path}');`]);
+    assert.strictEqual(child.signal, null);
+    assert.strictEqual(child.status, 0);
+    assert.strictEqual(child.stderr.toString(), 'addon_free');
+  }
+
+  testProcessExit('test_ref_then_set');
+  testProcessExit('test_set_then_ref');
 }

--- a/test/node-api/test_instance_data/test_ref_then_set.c
+++ b/test/node-api/test_instance_data/test_ref_then_set.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stdlib.h>
+#define NAPI_EXPERIMENTAL
+#include <node_api.h>
+
+napi_value addon_new(napi_env env, napi_value exports, bool ref_first);
+
+// static napi_value
+NAPI_MODULE_INIT(/*napi_env env, napi_value exports */) {
+  return addon_new(env, exports, true);
+}

--- a/test/node-api/test_instance_data/test_set_then_ref.c
+++ b/test/node-api/test_instance_data/test_set_then_ref.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stdlib.h>
+#define NAPI_EXPERIMENTAL
+#include <node_api.h>
+
+napi_value addon_new(napi_env env, napi_value exports, bool ref_first);
+
+// static napi_value
+NAPI_MODULE_INIT(/*napi_env env, napi_value exports */) {
+  return addon_new(env, exports, false);
+}


### PR DESCRIPTION
Instance data associated with a `napi_env` is no longer stored on the
env itself but is instead rendered as a reference. Since
`v8impl::Reference` is tied to a JS object, this modification factors
out the `v8impl::Reference` refcounting and the deletion process into
a base class for `v8impl::Reference`, called `v8impl::RefBase`. The
instance data is then stored as a `v8impl::RefBase`, along with other
references, preventing a segfault that arises from the fact that, up
until now, upon `napi_env` destruction, the instance data was freed
after all references had already been forcefully freed. If the addon
freed a reference during the `napi_set_instance_data` finalizer
callback, such a reference had already been freed during environment
teardown, causing a double free.

Re: https://github.com/nodejs/node-addon-api/pull/663

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
