### PR TITLE
test: add test-dns-promises-lookupService

### DIFF
--- a/test/parallel/test-dns-promises-lookupService.js
+++ b/test/parallel/test-dns-promises-lookupService.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+const dnsPromises = require('dns').promises;
+
+dnsPromises.lookupService('127.0.0.1', 22).then(common.mustCall((result) => {
+  assert.strictEqual(result.service, 'ssh');
+  assert.strictEqual(typeof result.hostname, 'string');
+  assert.notStrictEqual(result.hostname.length, 0);
+}));
+
+// Use an IP from the RFC 5737 test range to cause an error.
+// Refs: https://tools.ietf.org/html/rfc5737
+assert.rejects(
+  () => dnsPromises.lookupService('192.0.2.1', 22),
+  { code: /^(?:ENOTFOUND|EAI_AGAIN)$/ }
+);


### PR DESCRIPTION
This adds covereage for the onlookupservice() callback in
lib/internal/dns/promises.js. Because of stubbing in other tests, it is
not currently covered.

This test works on my local development machine with the network turned
off, so I'm putting it in parallel. If CI proves more challenging, it
can be moved to the internet directory instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
