### PR TITLE
doc: clarify Worker exit/message event ordering

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -582,6 +582,8 @@ exited by calling [`process.exit()`][], the `exitCode` parameter will be the
 passed exit code. If the worker was terminated, the `exitCode` parameter will
 be `1`.
 
+This is the final event emitted by any `Worker` instance.
+
 ### Event: `'message'`
 <!-- YAML
 added: v10.5.0
@@ -592,6 +594,9 @@ added: v10.5.0
 The `'message'` event is emitted when the worker thread has invoked
 [`require('worker_threads').parentPort.postMessage()`][].
 See the [`port.on('message')`][] event for more details.
+
+All messages sent from the worker thread will be emitted before the
+[`'exit'` event][] is emitted on the `Worker` object.
 
 ### Event: `'online'`
 <!-- YAML


### PR DESCRIPTION
Motivated by the fact that getting this wrong has led to flaky
tests in our test suite.

Refs: https://github.com/nodejs/node/pull/31637

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
