### PR TITLE
src: Modernized unique_ptr construction

### DIFF
--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -107,7 +107,7 @@ NativeSymbolDebuggingContext::New() {
 
 std::unique_ptr<NativeSymbolDebuggingContext>
 NativeSymbolDebuggingContext::New() {
-  return std::unique_ptr<NativeSymbolDebuggingContext>();
+  return std::make_unique<NativeSymbolDebuggingContext>();
 }
 
 #endif  // HAVE_EXECINFO_H

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -100,16 +100,14 @@ class PosixSymbolDebuggingContext final : public NativeSymbolDebuggingContext {
 
 std::unique_ptr<NativeSymbolDebuggingContext>
 NativeSymbolDebuggingContext::New() {
-  return std::unique_ptr<NativeSymbolDebuggingContext>(
-      new PosixSymbolDebuggingContext());
+  return std::make_unique<PosixSymbolDebuggingContext>();
 }
 
 #else  // HAVE_EXECINFO_H
 
 std::unique_ptr<NativeSymbolDebuggingContext>
 NativeSymbolDebuggingContext::New() {
-  return std::unique_ptr<NativeSymbolDebuggingContext>(
-      new NativeSymbolDebuggingContext());
+  return std::unique_ptr<NativeSymbolDebuggingContext>();
 }
 
 #endif  // HAVE_EXECINFO_H


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]

A simple first contribution.

std::unique_ptr's constructor can lead to memory leaks if the constructed value, allocated through `new`, throws an exception or something that causes an immediate backtrace on the callstack.

std::make_unique prevents this by allocating the memory for you, making it safer. Not only does it make it safer, it also makes it more readable.

I'm not sure whether I followed every guideline with this, but I hope I did.