### PR TITLE
worker_threads: add support for .cjs extension

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1371,7 +1371,7 @@ E('ERR_WORKER_PATH',
 E('ERR_WORKER_UNSERIALIZABLE_ERROR',
   'Serializing an uncaught exception failed', Error);
 E('ERR_WORKER_UNSUPPORTED_EXTENSION',
-  'The worker script extension must be ".js" or ".mjs". Received "%s"',
+  'The worker script extension must be ".js", ".mjs", or ".cjs". Received "%s"',
   TypeError);
 E('ERR_WORKER_UNSUPPORTED_OPERATION',
   '%s is not supported in workers', TypeError);

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -104,7 +104,7 @@ class Worker extends EventEmitter {
       filename = path.resolve(filename);
 
       const ext = path.extname(filename);
-      if (ext !== '.js' && ext !== '.mjs') {
+      if (!/^\.[cm]?js$/.test(ext)) {
         throw new ERR_WORKER_UNSUPPORTED_EXTENSION(ext);
       }
     }

--- a/test/fixtures/worker-data.cjs
+++ b/test/fixtures/worker-data.cjs
@@ -1,0 +1,3 @@
+const { workerData, parentPort } = require('worker_threads');
+
+parentPort.postMessage(workerData);

--- a/test/parallel/test-worker-cjs-workerdata.js
+++ b/test/parallel/test-worker-cjs-workerdata.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+const workerData = 'Hello from main thread';
+
+const worker = new Worker(fixtures.path('worker-data.cjs'), {
+  workerData
+});
+
+worker.on('message', common.mustCall((message) => {
+  assert.strictEqual(message, workerData);
+}));


### PR DESCRIPTION
This PR allows worker filenames to use `.cjs` extension (in addition of `.js` and `.mjs`).
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
