### PR TITLE
doc,src,test: assign missing deprecation code

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2583,8 +2583,8 @@ accordingly instead to avoid the ambigiuty.
 To maintain existing behaviour `response.finished` should be replaced with
 `response.writableEnded`.
 
-<a id="DEP00XX"></a>
-### DEP00XX: Closing fs.FileHandle on garbage collection
+<a id="DEP0137"></a>
+### DEP0137: Closing fs.FileHandle on garbage collection
 <!-- YAML
 changes:
   - version: REPLACEME

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -218,7 +218,7 @@ inline void FileHandle::Close() {
           "Please close FileHandle objects explicitly using "
           "FileHandle.prototype.close(). In the future, an error will be "
           "thrown if a file descriptor is closed during garbage collection.",
-          "DEP00XX").IsNothing();
+          "DEP0137").IsNothing();
     }
   });
 }

--- a/test/parallel/test-fs-filehandle.js
+++ b/test/parallel/test-fs-filehandle.js
@@ -32,7 +32,7 @@ common.expectWarning({
   'Warning': [
     `Closing file descriptor ${fdnum} on garbage collection`
   ],
-  'DeprecationWarning': [[deprecationWarning, 'DEP00XX']]
+  'DeprecationWarning': [[deprecationWarning, 'DEP0137']]
 });
 
 global.gc();

--- a/test/parallel/test-fs-promises-file-handle-close.js
+++ b/test/parallel/test-fs-promises-file-handle-close.js
@@ -21,7 +21,7 @@ async function doOpen() {
 
   common.expectWarning({
     Warning: [[`Closing file descriptor ${fh.fd} on garbage collection`]],
-    DeprecationWarning: [[warning, 'DEP00XX']]
+    DeprecationWarning: [[warning, 'DEP0137']]
   });
 
   return fh;


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/28396

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)