### PR TITLE
readline: remove intermediate variable

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -123,8 +123,7 @@ function Interface(input, output, completer, terminal) {
     terminal = input.terminal;
     historySize = input.historySize;
     if (input.tabSize !== undefined) {
-      const positive = true;
-      validateUint32(input.tabSize, 'tabSize', positive);
+      validateUint32(input.tabSize, 'tabSize', true);
       this.tabSize = input.tabSize;
     }
     removeHistoryDuplicates = input.removeHistoryDuplicates;


### PR DESCRIPTION
This commit removes an extra intermediate variable. This makes the call consistent with other uses of `validateUint32()` in the codebase.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)