### PR TITLE
test,dns: add coverage for dns exception

### DIFF
--- a/test/parallel/test-dns-resolve-promises.js
+++ b/test/parallel/test-dns-resolve-promises.js
@@ -1,0 +1,20 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('assert');
+const { internalBinding } = require('internal/test/binding');
+const cares = internalBinding('cares_wrap');
+const { UV_EPERM } = internalBinding('uv');
+const dnsPromises = require('dns').promises;
+
+// Stub cares to force an error so we can test DNS error code path.
+cares.ChannelWrap.prototype.queryA = () => UV_EPERM;
+
+assert.rejects(
+  dnsPromises.resolve('example.org'),
+  {
+    code: 'EPERM',
+    syscall: 'queryA',
+    hostname: 'example.org'
+  }
+);


### PR DESCRIPTION
Add test coverage for dns.promises.resolve() handling an exception from
c-ares.

Refs: https://coverage.nodejs.org/coverage-d213f21c72f77da6/lib/internal/dns/promises.js.html#L198

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
