### PR TITLE
doc,net: reword Unix domain path paragraph in net.md

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -26,18 +26,16 @@ sockets on other operating systems.
 [`socket.connect()`][] take a `path` parameter to identify IPC endpoints.
 
 On Unix, the local domain is also known as the Unix domain. The path is a
-filesystem pathname. It gets truncated to a length of
-`sizeof(sockaddr_un.sun_path) - 1`, which varies 91 and 107 bytes depending on
-the operating system. The typical values are 107 on Linux and 103 on macOS. The
-path is subject to the same naming conventions and permissions checks as would
-be done on file creation. If the Unix domain socket (that is visible as a file
-system path) is created and used in conjunction with one of Node.js' API
-abstractions such as [`net.createServer()`][], it will be unlinked as part of
-[`server.close()`][]. On the other hand, if it is created and used outside of
-these abstractions, the user will need to manually remove it. The same applies
-when the path was created by a Node.js API but the program crashes abruptly.
-In short, a Unix domain socket once successfully created will be visible in the
-filesystem, and will persist until unlinked.
+filesystem pathname. It gets truncated to an OS-dependent length of
+`sizeof(sockaddr_un.sun_path) - 1`. Typical values are 107 bytes on Linux and
+103 bytes on macOS. If a Node.js API abstraction creates the Unix domain socket,
+it will unlink the Unix domain socket as well. For example,
+[`net.createServer()`][] may create a Unix domain socket and
+[`server.close()`][] will unlink it. But if a user creates the Unix domain
+socket outside of these abstractions, the user will need to remove it. The same
+applies when a Node.js API creates a Unix domain socket but the program then
+crashes. In short, a Unix domain socket will be visible in the filesystem and
+will persist until unlinked.
 
 On Windows, the local domain is implemented using a named pipe. The path *must*
 refer to an entry in `\\?\pipe\` or `\\.\pipe\`. Any characters are permitted,


### PR DESCRIPTION
Reword the paragraph on Unix domain paths. Hopefully, it is a little bit
more clear and easier to read now.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
