### PR TITLE
test: fix flaky test-fs-promises-file-handle-close

### DIFF
--- a/test/parallel/test-fs-promises-file-handle-close.js
+++ b/test/parallel/test-fs-promises-file-handle-close.js
@@ -27,13 +27,16 @@ async function doOpen() {
   return fh;
 }
 
-// Perform the file open assignment within a block.
-// When the block scope exits, the file handle will
-// be eligible for garbage collection.
-{
-  doOpen().then(common.mustCall((fd) => {
-    assert.strictEqual(typeof fd, 'object');
-  }));
-}
+doOpen().then(common.mustCall((fd) => {
+  assert.strictEqual(typeof fd, 'object');
+})).then(common.mustCall(() => {
+  setImmediate(() => {
+    // The FileHandle should be out-of-scope and no longer accessed now.
+    global.gc();
 
-setTimeout(() => global.gc(), 10);
+    // Wait an extra event loop turn, as the warning is emitted from the
+    // native layer in an unref()'ed setImmediate() callback.
+    setImmediate(common.mustCall());
+  });
+}));
+

--- a/test/parallel/test-fs-promises-file-handle-close.js
+++ b/test/parallel/test-fs-promises-file-handle-close.js
@@ -39,4 +39,3 @@ doOpen().then(common.mustCall((fd) => {
     setImmediate(common.mustCall());
   });
 }));
-


### PR DESCRIPTION
Sometimes, the expected warnings were not emitted.
To harden the test:

- Instead of relying on a timeout that raced against the file being
  opened, wait until the file is opened and then schedule GC
  after that.
- Explicitly keep the event loop alive for one turn to make sure
  the warning is being seen.

---

Example failure: https://ci.nodejs.org/job/node-test-commit-linux-containered/17920/nodes=ubuntu1804_sharedlibs_debug_x64/testReport/junit/(root)/test/parallel_test_fs_promises_file_handle_close/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
