### PR TITLE
src: fix compile warnings in node_url.cc

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1203,12 +1203,12 @@ url_data HarvestBase(Environment* env, Local<Object> base_obj) {
   Local<Value> flags =
       base_obj->Get(env->context(), env->flags_string()).ToLocalChecked();
   if (flags->IsInt32())
-    flags->Int32Value(context).To(&base.flags);
+    base.flags = flags->Int32Value(context).FromJust();
 
   Local<Value> port =
       base_obj->Get(env->context(), env->port_string()).ToLocalChecked();
   if (port->IsInt32())
-    port->Int32Value(context).To(&base.port);
+    base.port = port->Int32Value(context).FromJust();
 
   Local<Value> scheme =
       base_obj->Get(env->context(), env->scheme_string()).ToLocalChecked();
@@ -2238,8 +2238,7 @@ void ToUSVString(const FunctionCallbackInfo<Value>& args) {
 
   TwoByteValue value(env->isolate(), args[0]);
 
-  int64_t start;
-  args[1]->IntegerValue(env->context()).To(&start);
+  int64_t start = args[1]->IntegerValue(env->context()).FromJust();
   CHECK_GE(start, 0);
 
   for (size_t i = start; i < value.length(); i++) {


### PR DESCRIPTION
Since for all affected conversions there is a preceding type check,
it’s safe to use `.FromJust()` instead.

This fixes the following compile warnings:

    ../src/node_url.cc: In function ‘void node::url::{anonymous}::ToUSVString(const v8::FunctionCallbackInfo<v8::Value>&)’:
    ../src/node_url.cc:2242:43: warning: ignoring return value of ‘bool v8::Maybe<T>::To(T*) const [with T = long int]’, declared with attribute warn_unused_result [-Wunused-result]
     2242 |   args[1]->IntegerValue(env->context()).To(&start);
          |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
    ../src/node_url.cc: In function ‘node::url::url_data node::url::{anonymous}::HarvestBase(node::Environment*, v8::Local<v8::Object>)’:
    ../src/node_url.cc:1206:34: warning: ignoring return value of ‘bool v8::Maybe<T>::To(T*) const [with T = int]’, declared with attribute warn_unused_result [-Wunused-result]
     1206 |     flags->Int32Value(context).To(&base.flags);
          |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
    ../src/node_url.cc:1211:33: warning: ignoring return value of ‘bool v8::Maybe<T>::To(T*) const [with T = int]’, declared with attribute warn_unused_result [-Wunused-result]
     1211 |     port->Int32Value(context).To(&base.port);
          |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
    ../src/node_url.cc: In function ‘void node::url::{anonymous}::ToUSVString(const v8::FunctionCallbackInfo<v8::Value>&)’:
    ../src/node_url.cc:2245:15: warning: ‘start’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     2245 |   for (size_t i = start; i < value.length(); i++) {
          |               ^

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
