### PR TITLE
doc,test: add server.timeout property to http2 public API

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1797,8 +1797,27 @@ on the `Http2Server` after `msecs` milliseconds.
 
 The given callback is registered as a listener on the `'timeout'` event.
 
-In case of no callback function were assigned, a new `ERR_INVALID_CALLBACK`
+In case if `callback` is not a function, a new `ERR_INVALID_CALLBACK`
 error will be thrown.
+
+#### `server.timeout`
+<!-- YAML
+added: v8.4.0
+changes:
+  - version: v13.0.0
+    pr-url: https://github.com/nodejs/node/pull/27558
+    description: The default timeout changed from 120s to 0 (no timeout).
+-->
+
+* {number} Timeout in milliseconds. **Default:** 0 (no timeout)
+
+The number of milliseconds of inactivity before a socket is presumed
+to have timed out.
+
+A value of `0` will disable the timeout behavior on incoming connections.
+
+The socket timeout logic is set up on connection, so changing this
+value only affects new connections to the server, not any existing connections.
 
 ### Class: `Http2SecureServer`
 <!-- YAML
@@ -1943,8 +1962,27 @@ on the `Http2SecureServer` after `msecs` milliseconds.
 
 The given callback is registered as a listener on the `'timeout'` event.
 
-In case of no callback function were assigned, a new `ERR_INVALID_CALLBACK`
+In case if `callback` is not a function, a new `ERR_INVALID_CALLBACK`
 error will be thrown.
+
+#### `server.timeout`
+<!-- YAML
+added: v8.4.0
+changes:
+  - version: v13.0.0
+    pr-url: https://github.com/nodejs/node/pull/27558
+    description: The default timeout changed from 120s to 0 (no timeout).
+-->
+
+* {number} Timeout in milliseconds. **Default:** 0 (no timeout)
+
+The number of milliseconds of inactivity before a socket is presumed
+to have timed out.
+
+A value of `0` will disable the timeout behavior on incoming connections.
+
+The socket timeout logic is set up on connection, so changing this
+value only affects new connections to the server, not any existing connections.
 
 ### `http2.createServer(options[, onRequestHandler])`
 <!-- YAML

--- a/test/parallel/test-http2-server-timeout.js
+++ b/test/parallel/test-http2-server-timeout.js
@@ -5,21 +5,27 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const http2 = require('http2');
 
-const server = http2.createServer();
-server.setTimeout(common.platformTimeout(50));
+function testServerTimeout(setTimeoutFn) {
+  const server = http2.createServer();
+  setTimeoutFn(server);
 
-const onServerTimeout = common.mustCall((session) => {
-  session.close();
-});
+  const onServerTimeout = common.mustCall((session) => {
+    session.close();
+  });
 
-server.on('stream', common.mustNotCall());
-server.once('timeout', onServerTimeout);
+  server.on('stream', common.mustNotCall());
+  server.once('timeout', onServerTimeout);
 
-server.listen(0, common.mustCall(() => {
-  const url = `http://localhost:${server.address().port}`;
-  const client = http2.connect(url);
-  client.on('close', common.mustCall(() => {
-    const client2 = http2.connect(url);
-    client2.on('close', common.mustCall(() => server.close()));
+  server.listen(0, common.mustCall(() => {
+    const url = `http://localhost:${server.address().port}`;
+    const client = http2.connect(url);
+    client.on('close', common.mustCall(() => {
+      const client2 = http2.connect(url);
+      client2.on('close', common.mustCall(() => server.close()));
+    }));
   }));
-}));
+}
+
+const timeout = common.platformTimeout(50);
+testServerTimeout((server) => server.setTimeout(timeout));
+testServerTimeout((server) => server.timeout = timeout);


### PR DESCRIPTION
Both `http` and `https` modules have `server.timeout` property in public API, while `http2` only has `server.setTimeout` method documented. This PR adds documentation section and test
for `server.timeout` in `http2` module, so it becomes consistent with `http` and `https`.

Also improves description of `callback` argument in documentation for `server.setTimeout()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
