### PR TITLE
test: improve assertion message in test-dns-any

### DIFF
--- a/test/internet/test-dns-any.js
+++ b/test/internet/test-dns-any.js
@@ -119,8 +119,8 @@ TEST(async function test_google(done) {
   function validateResult(res) {
     const types = processResult(res);
     assert.ok(
-      types.A && types.AAAA && types.MX &&
-      types.NS && types.TXT && types.SOA);
+      types.A && types.AAAA && types.MX && types.NS && types.TXT && types.SOA,
+      `Missing record type, found ${Object.keys(types)}`);
   }
 
   validateResult(await dnsPromises.resolve('google.com', 'ANY'));
@@ -140,7 +140,8 @@ TEST(async function test_google(done) {
 TEST(async function test_sip2sip_for_naptr(done) {
   function validateResult(res) {
     const types = processResult(res);
-    assert.ok(types.A && types.NS && types.NAPTR && types.SOA);
+    assert.ok(types.A && types.NS && types.NAPTR && types.SOA,
+              `Missing record type, found ${Object.keys(types)}`);
   }
 
   validateResult(await dnsPromises.resolve('sip2sip.info', 'ANY'));


### PR DESCRIPTION
Improve error message from "The expression evaluated to a falsy value"
to a message formatted dynamically that lists the record types found so
that someone investigating can look at the code and determine which
values are missing.

This came up because the test failed in nightly master branch CI but
generally passes. It may prove helpful to know what record types were
missing. (All of them? Just one? Something else?)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
