### PR TITLE
test: fix flaky parallel/test-repl-history-navigation test

### DIFF
--- a/test/parallel/test-repl-history-navigation.js
+++ b/test/parallel/test-repl-history-navigation.js
@@ -434,12 +434,7 @@ const tests = [
         if (completions++ === 0) {
           callback(null, [[`${WAIT}WOW`], line]);
         } else {
-          setTimeout(
-            callback,
-            1000,
-            null,
-            [[`${WAIT}WOW`], line]
-          ).unref();
+          setTimeout(callback, 1000, null, [[`${WAIT}WOW`], line]).unref();
         }
       } else {
         callback(null, [[' Always visible'], line]);

--- a/test/parallel/test-repl-history-navigation.js
+++ b/test/parallel/test-repl-history-navigation.js
@@ -18,7 +18,6 @@ const defaultHistoryPath = path.join(tmpdir.path, '.node_repl_history');
 // Create an input stream specialized for testing an array of actions
 class ActionStream extends stream.Stream {
   run(data) {
-    let reallyWait = true;
     const _iter = data[Symbol.iterator]();
     const doAction = () => {
       const next = _iter.next();
@@ -34,12 +33,7 @@ class ActionStream extends stream.Stream {
       } else {
         this.emit('data', `${action}`);
       }
-      if (action === WAIT && reallyWait) {
-        setTimeout(doAction, common.platformTimeout(50));
-        reallyWait = false;
-      } else {
-        setImmediate(doAction);
-      }
+      setImmediate(doAction);
     };
     doAction();
   }
@@ -66,6 +60,8 @@ const prompt = '> ';
 const WAIT = '€';
 
 const prev = process.features.inspector;
+
+let completions = 0;
 
 const tests = [
   { // Creates few history to navigate for
@@ -435,12 +431,16 @@ const tests = [
     env: { NODE_REPL_HISTORY: defaultHistoryPath },
     completer(line, callback) {
       if (line.endsWith(WAIT)) {
-        setTimeout(
-          callback,
-          common.platformTimeout(40),
-          null,
-          [[`${WAIT}WOW`], line]
-        );
+        if (completions++ === 0) {
+          callback(null, [[`${WAIT}WOW`], line]);
+        } else {
+          setTimeout(
+            callback,
+            1000,
+            null,
+            [[`${WAIT}WOW`], line]
+          ).unref();
+        }
       } else {
         callback(null, [[' Always visible'], line]);
       }


### PR DESCRIPTION
Two scenarios should be tested:

1. The completion is triggered and the result is printed before the
   next invocation.
2. The completion is triggered multiple times right after each other
   without waiting for the result. In that case only the last result
   should be printed.

The first scenario did not need a timeout while the latter did not
need a timeout for the second invocation.

Fixes: #31094 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
