### PR TITLE
n-api: track refs using ListNode and ListHead

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -197,13 +197,15 @@ class RefBase : protected Finalizer, RefTracker {
        : Finalizer(env, finalize_callback, finalize_data, finalize_hint),
         _refcount(initial_refcount),
         _delete_self(delete_self) {
-    Link(finalize_callback == nullptr
-        ? &env->reflist
-        : &env->finalizing_reflist);
+    if (finalize_callback == nullptr) {
+      env->reflist.PushFront(this);
+    } else {
+      env->finalizing_reflist.PushFront(this);
+    }
   }
 
  public:
-  static RefBase* New(napi_env env,
+  static inline RefBase* New(napi_env env,
                       uint32_t initial_refcount,
                       bool delete_self,
                       napi_finalize finalize_callback,

--- a/src/js_native_api_v8_internals.h
+++ b/src/js_native_api_v8_internals.h
@@ -33,6 +33,13 @@ using Persistent = v8::Global<T>;
 
 using PersistentToLocal = node::PersistentToLocal;
 
+// We use the Node.js doubly-linked list implementation.
+template <typename T>
+using ListNode = node::ListNode<T>;
+
+template <typename T, ListNode<T> (T::*M)>
+using ListHead = node::ListHead<T, M>;
+
 }  // end of namespace v8impl
 
 #endif  // SRC_JS_NATIVE_API_V8_INTERNALS_H_


### PR DESCRIPTION
Switch to the Node.js doubly-linked list implementation.

Fixes: https://github.com/nodejs/node/issues/31639

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Unfortunately, it looks like this introduces some perf regressions:

```
                                                               confidence improvement accuracy (*)   (**)   (***)
 napi/function_args n=1 engine='napi' type='1000Numbers'                     -3.29 %       ±5.40% ±7.23%  ±9.51%
 napi/function_args n=1 engine='napi' type='100Numbers'                      -1.43 %       ±4.28% ±5.70%  ±7.42%
 napi/function_args n=1 engine='napi' type='10Numbers'                        4.78 %       ±5.50% ±7.34%  ±9.62%
 napi/function_args n=1 engine='napi' type='Array'                           -1.40 %       ±4.00% ±5.32%  ±6.92%
 napi/function_args n=1 engine='napi' type='Number'                           1.32 %       ±4.54% ±6.05%  ±7.90%
 napi/function_args n=1 engine='napi' type='Object'                          -1.89 %       ±5.70% ±7.64% ±10.06%
 napi/function_args n=1 engine='napi' type='String'                           1.29 %       ±3.35% ±4.46%  ±5.81%
 napi/function_args n=1 engine='napi' type='Typedarray'                       2.08 %       ±5.24% ±6.98%  ±9.13%
 napi/function_args n=1 engine='v8' type='1000Numbers'                **      3.64 %       ±2.16% ±2.87%  ±3.74%
 napi/function_args n=1 engine='v8' type='100Numbers'                         0.47 %       ±4.21% ±5.60%  ±7.29%
 napi/function_args n=1 engine='v8' type='10Numbers'                          0.19 %       ±4.14% ±5.51%  ±7.18%
 napi/function_args n=1 engine='v8' type='Array'                              0.82 %       ±3.23% ±4.30%  ±5.60%
 napi/function_args n=1 engine='v8' type='Number'                            -2.68 %       ±3.20% ±4.28%  ±5.61%
 napi/function_args n=1 engine='v8' type='Object'                            -2.03 %       ±2.99% ±3.98%  ±5.19%
 napi/function_args n=1 engine='v8' type='String'                             1.97 %       ±2.98% ±3.99%  ±5.23%
 napi/function_args n=1 engine='v8' type='Typedarray'                         1.49 %       ±3.99% ±5.32%  ±6.94%
 napi/function_args n=10 engine='napi' type='1000Numbers'                    -3.06 %       ±5.27% ±7.06%  ±9.29%
 napi/function_args n=10 engine='napi' type='100Numbers'                      2.17 %       ±3.25% ±4.34%  ±5.67%
 napi/function_args n=10 engine='napi' type='10Numbers'                       1.88 %       ±4.58% ±6.09%  ±7.94%
 napi/function_args n=10 engine='napi' type='Array'                           0.36 %       ±2.61% ±3.48%  ±4.54%
 napi/function_args n=10 engine='napi' type='Number'                          0.11 %       ±4.89% ±6.53%  ±8.53%
 napi/function_args n=10 engine='napi' type='Object'                         -1.14 %       ±3.75% ±5.00%  ±6.52%
 napi/function_args n=10 engine='napi' type='String'                          0.27 %       ±4.35% ±5.80%  ±7.55%
 napi/function_args n=10 engine='napi' type='Typedarray'                      0.20 %       ±3.05% ±4.06%  ±5.28%
 napi/function_args n=10 engine='v8' type='1000Numbers'                       0.55 %       ±6.30% ±8.39% ±10.92%
 napi/function_args n=10 engine='v8' type='100Numbers'                        2.38 %       ±3.24% ±4.32%  ±5.62%
 napi/function_args n=10 engine='v8' type='10Numbers'                         3.04 %       ±3.66% ±4.88%  ±6.36%
 napi/function_args n=10 engine='v8' type='Array'                            -0.19 %       ±5.56% ±7.44%  ±9.76%
 napi/function_args n=10 engine='v8' type='Number'                           -0.26 %       ±3.27% ±4.35%  ±5.66%
 napi/function_args n=10 engine='v8' type='Object'                            0.99 %       ±3.73% ±4.96%  ±6.46%
 napi/function_args n=10 engine='v8' type='String'                           -1.37 %       ±2.70% ±3.60%  ±4.69%
 napi/function_args n=10 engine='v8' type='Typedarray'                        1.93 %       ±3.49% ±4.64%  ±6.04%
 napi/function_args n=100 engine='napi' type='1000Numbers'           ***     -5.72 %       ±0.75% ±1.00%  ±1.30%
 napi/function_args n=100 engine='napi' type='100Numbers'              *     -3.14 %       ±2.54% ±3.38%  ±4.41%
 napi/function_args n=100 engine='napi' type='10Numbers'                     -1.61 %       ±3.39% ±4.51%  ±5.88%
 napi/function_args n=100 engine='napi' type='Array'                         -0.44 %       ±3.09% ±4.12%  ±5.37%
 napi/function_args n=100 engine='napi' type='Number'                         0.38 %       ±4.14% ±5.51%  ±7.17%
 napi/function_args n=100 engine='napi' type='Object'                         0.22 %       ±2.60% ±3.46%  ±4.51%
 napi/function_args n=100 engine='napi' type='String'                         0.27 %       ±3.03% ±4.03%  ±5.25%
 napi/function_args n=100 engine='napi' type='Typedarray'                    -1.16 %       ±3.29% ±4.38%  ±5.72%
 napi/function_args n=100 engine='v8' type='1000Numbers'                     -0.64 %       ±1.03% ±1.36%  ±1.78%
 napi/function_args n=100 engine='v8' type='100Numbers'                       1.76 %       ±2.88% ±3.84%  ±5.00%
 napi/function_args n=100 engine='v8' type='10Numbers'                       -1.32 %       ±4.36% ±5.80%  ±7.56%
 napi/function_args n=100 engine='v8' type='Array'                            1.07 %       ±2.09% ±2.78%  ±3.63%
 napi/function_args n=100 engine='v8' type='Number'                           2.12 %       ±3.16% ±4.23%  ±5.55%
 napi/function_args n=100 engine='v8' type='Object'                           0.91 %       ±2.54% ±3.39%  ±4.42%
 napi/function_args n=100 engine='v8' type='String'                          -0.75 %       ±2.52% ±3.36%  ±4.38%
 napi/function_args n=100 engine='v8' type='Typedarray'                       1.02 %       ±2.45% ±3.26%  ±4.24%
 napi/function_args n=1000 engine='napi' type='1000Numbers'          ***     -7.15 %       ±0.46% ±0.61%  ±0.80%
 napi/function_args n=1000 engine='napi' type='100Numbers'           ***     -6.15 %       ±2.11% ±2.81%  ±3.66%
 napi/function_args n=1000 engine='napi' type='10Numbers'                    -1.32 %       ±2.94% ±3.91%  ±5.10%
 napi/function_args n=1000 engine='napi' type='Array'                         0.35 %       ±0.96% ±1.27%  ±1.65%
 napi/function_args n=1000 engine='napi' type='Number'                       -0.24 %       ±2.51% ±3.35%  ±4.37%
 napi/function_args n=1000 engine='napi' type='Object'                       -1.52 %       ±2.71% ±3.61%  ±4.69%
 napi/function_args n=1000 engine='napi' type='String'                       -0.64 %       ±2.97% ±3.95%  ±5.15%
 napi/function_args n=1000 engine='napi' type='Typedarray'                   -2.23 %       ±2.42% ±3.22%  ±4.19%
 napi/function_args n=1000 engine='v8' type='1000Numbers'                    -0.34 %       ±6.23% ±8.29% ±10.79%
 napi/function_args n=1000 engine='v8' type='100Numbers'                      0.95 %       ±2.29% ±3.05%  ±3.97%
 napi/function_args n=1000 engine='v8' type='10Numbers'                      -2.14 %       ±2.22% ±2.96%  ±3.85%
 napi/function_args n=1000 engine='v8' type='Array'                          -0.00 %       ±1.10% ±1.47%  ±1.91%
 napi/function_args n=1000 engine='v8' type='Number'                         -0.37 %       ±3.05% ±4.06%  ±5.29%
 napi/function_args n=1000 engine='v8' type='Object'                         -0.06 %       ±2.56% ±3.41%  ±4.44%
 napi/function_args n=1000 engine='v8' type='String'                   *     -2.32 %       ±2.30% ±3.07%  ±3.99%
 napi/function_args n=1000 engine='v8' type='Typedarray'                      0.46 %       ±2.71% ±3.61%  ±4.70%
 napi/function_args n=10000 engine='napi' type='1000Numbers'         ***     -6.92 %       ±0.40% ±0.53%  ±0.69%
 napi/function_args n=10000 engine='napi' type='100Numbers'          ***     -5.76 %       ±0.52% ±0.70%  ±0.91%
 napi/function_args n=10000 engine='napi' type='10Numbers'            **     -2.92 %       ±2.02% ±2.69%  ±3.50%
 napi/function_args n=10000 engine='napi' type='Array'                       -0.04 %       ±1.63% ±2.19%  ±2.88%
 napi/function_args n=10000 engine='napi' type='Number'                       0.36 %       ±2.01% ±2.68%  ±3.49%
 napi/function_args n=10000 engine='napi' type='Object'                      -0.18 %       ±0.74% ±0.99%  ±1.29%
 napi/function_args n=10000 engine='napi' type='String'                      -0.42 %       ±1.31% ±1.74%  ±2.27%
 napi/function_args n=10000 engine='napi' type='Typedarray'                  -0.53 %       ±1.20% ±1.59%  ±2.07%
 napi/function_args n=10000 engine='v8' type='1000Numbers'                    1.90 %       ±2.36% ±3.17%  ±4.20%
 napi/function_args n=10000 engine='v8' type='100Numbers'                     0.68 %       ±0.84% ±1.12%  ±1.47%
 napi/function_args n=10000 engine='v8' type='10Numbers'                     -0.77 %       ±2.03% ±2.70%  ±3.51%
 napi/function_args n=10000 engine='v8' type='Array'                         -1.23 %       ±2.66% ±3.57%  ±4.71%
 napi/function_args n=10000 engine='v8' type='Number'                         2.46 %       ±3.12% ±4.15%  ±5.41%
 napi/function_args n=10000 engine='v8' type='Object'                         0.15 %       ±1.15% ±1.53%  ±2.01%
 napi/function_args n=10000 engine='v8' type='String'                        -1.86 %       ±2.11% ±2.81%  ±3.66%
 napi/function_args n=10000 engine='v8' type='Typedarray'                     1.21 %       ±2.30% ±3.06%  ±3.98%
 napi/function_args n=100000 engine='napi' type='1000Numbers'        ***     -7.76 %       ±0.19% ±0.26%  ±0.33%
 napi/function_args n=100000 engine='napi' type='100Numbers'         ***     -5.08 %       ±0.33% ±0.44%  ±0.57%
 napi/function_args n=100000 engine='napi' type='10Numbers'          ***     -1.88 %       ±0.65% ±0.88%  ±1.15%
 napi/function_args n=100000 engine='napi' type='Array'                       0.00 %       ±1.04% ±1.38%  ±1.80%
 napi/function_args n=100000 engine='napi' type='Number'                     -1.72 %       ±3.12% ±4.20%  ±5.57%
 napi/function_args n=100000 engine='napi' type='Object'                     -0.44 %       ±0.70% ±0.93%  ±1.21%
 napi/function_args n=100000 engine='napi' type='String'                      0.91 %       ±1.04% ±1.40%  ±1.85%
 napi/function_args n=100000 engine='napi' type='Typedarray'                  0.14 %       ±0.68% ±0.91%  ±1.18%
 napi/function_args n=100000 engine='v8' type='1000Numbers'            *     -0.52 %       ±0.44% ±0.59%  ±0.77%
 napi/function_args n=100000 engine='v8' type='100Numbers'           ***     -2.61 %       ±0.31% ±0.41%  ±0.54%
 napi/function_args n=100000 engine='v8' type='10Numbers'                    -0.78 %       ±1.44% ±1.92%  ±2.50%
 napi/function_args n=100000 engine='v8' type='Array'                        -0.13 %       ±1.37% ±1.82%  ±2.37%
 napi/function_args n=100000 engine='v8' type='Number'                 *     -2.19 %       ±1.94% ±2.61%  ±3.44%
 napi/function_args n=100000 engine='v8' type='Object'                        0.51 %       ±1.58% ±2.11%  ±2.75%
 napi/function_args n=100000 engine='v8' type='String'                 *     -1.35 %       ±1.25% ±1.67%  ±2.21%
 napi/function_args n=100000 engine='v8' type='Typedarray'                   -0.80 %       ±0.96% ±1.27%  ±1.66%
 napi/function_call n=1000000 type='cxx'                                      0.15 %       ±1.34% ±1.79%  ±2.35%
 napi/function_call n=1000000 type='js'                                       0.66 %       ±0.73% ±0.97%  ±1.26%
 napi/function_call n=1000000 type='napi'                            ***    -13.50 %       ±1.84% ±2.45%  ±3.21%
 napi/function_call n=10000000 type='cxx'                                    -0.10 %       ±1.17% ±1.56%  ±2.03%
 napi/function_call n=10000000 type='js'                                      0.14 %       ±0.22% ±0.30%  ±0.39%
 napi/function_call n=10000000 type='napi'                           ***    -16.14 %       ±1.67% ±2.22%  ±2.89%
 napi/function_call n=50000000 type='cxx'                                    -0.33 %       ±1.24% ±1.65%  ±2.16%
 napi/function_call n=50000000 type='js'                                     -0.06 %       ±0.27% ±0.35%  ±0.46%
 napi/function_call n=50000000 type='napi'                           ***    -16.61 %       ±1.00% ±1.34%  ±1.74%
 napi/ref n=10000000                                                         -0.54 %       ±0.55% ±0.74%  ±0.96%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case there are 106 comparisons, you can thus
expect the following amount of false-positive results:
  5.30 false positives, when considering a   5% risk acceptance (*, **, ***),
  1.06 false positives, when considering a   1% risk acceptance (**, ***),
  0.11 false positives, when considering a 0.1% risk acceptance (***)
```