### PR TITLE
test: add secp224k1 check in crypto-dh-stateless

### DIFF
--- a/test/parallel/test-crypto-dh-stateless.js
+++ b/test/parallel/test-crypto-dh-stateless.js
@@ -196,9 +196,10 @@ for (const [params1, params2] of [
 test(crypto.generateKeyPairSync('ec', { namedCurve: 'secp256k1' }),
      crypto.generateKeyPairSync('ec', { namedCurve: 'secp256k1' }));
 
+const not256k1 = crypto.getCurves().find((c) => /^sec.*(224|384|512)/.test(c));
 assert.throws(() => {
   test(crypto.generateKeyPairSync('ec', { namedCurve: 'secp256k1' }),
-       crypto.generateKeyPairSync('ec', { namedCurve: 'secp224k1' }));
+       crypto.generateKeyPairSync('ec', { namedCurve: not256k1 }));
 }, {
   name: 'Error',
   code: 'ERR_OSSL_EVP_DIFFERENT_PARAMETERS'


### PR DESCRIPTION
This commit adds a check to test-crypto-dh-statless to avoid an error if
the curve secp224k1 is not present. This could occur if node was
configured with shared-openssl.

The use case for this was building on RHEL 8.1 which only has the
following curves:
```console
$ openssl ecparam -list_curves
secp224r1 : NIST/SECG curve over a 224 bit prime field
secp256k1 : SECG curve over a 256 bit prime field
secp384r1 : NIST/SECG curve over a 384 bit prime field
secp521r1 : NIST/SECG curve over a 521 bit prime field
prime256v1: X9.62/SECG curve over a 256 bit prime field
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
