### PR TITLE
module: disable exports encapsulation for CJS

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -504,10 +504,6 @@ function applyExports(basePath, expansion) {
                                   basePath, mappingKey);
     }
 
-    // Fallback to CJS main lookup when no main export is defined
-    if (mappingKey === '.')
-      return basePath;
-
     let dirMatch = '';
     for (const candidateKey of ObjectKeys(pkgExports)) {
       if (candidateKey[candidateKey.length - 1] !== '/') continue;
@@ -524,15 +520,8 @@ function applyExports(basePath, expansion) {
                                   subpath, basePath, mappingKey);
     }
   }
-  // Fallback to CJS main lookup when no main export is defined
-  if (mappingKey === '.')
-    return basePath;
-
-  // eslint-disable-next-line no-restricted-syntax
-  const e = new Error(`Package exports for '${basePath}' do not define ` +
-      `a '${mappingKey}' subpath`);
-  e.code = 'MODULE_NOT_FOUND';
-  throw e;
+  // Fallback to normal CJS lookup when no export is defined
+  return basePath + expansion;
 }
 
 // This only applies to requests of a specific form:


### PR DESCRIPTION
Recently, Preact upgraded to using `"exports"` and hit some compatibility issues with user code like `require('preact/package.json')`. As a result Preact now has `"exports": { "./": "./" }` in its package.json, effectively opting out of exports encapsulation entirely to ensure compatibility.

This PR proposes a suggested way to avoid this issue by disabling "exports" encapsulation entirely for CJS require usage.

It's worth noting encapsulation is not a strong encapsulation (URL imports allow getting around it), so that there is no strictness loss here.

I think this approach would be a good compromise to allow adoption without breaking changes in forcing encapsulation for CJS.

//cc @nodejs/modules-active-members 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
