### PR TITLE
revert: benchmark: test refactoring

### DIFF
--- a/benchmark/_cli.js
+++ b/benchmark/_cli.js
@@ -6,16 +6,15 @@ const path = require('path');
 // Create an object of all benchmark scripts
 const benchmarks = {};
 fs.readdirSync(__dirname)
-  .filter((name) => {
-    return name !== 'fixtures' &&
-           fs.statSync(path.resolve(__dirname, name)).isDirectory();
-  })
+  .filter((name) => fs.statSync(path.resolve(__dirname, name)).isDirectory())
   .forEach((category) => {
     benchmarks[category] = fs.readdirSync(path.resolve(__dirname, category))
       .filter((filename) => filename[0] !== '.' && filename[0] !== '_');
   });
 
 function CLI(usage, settings) {
+  if (!(this instanceof CLI)) return new CLI(usage, settings);
+
   if (process.argv.length < 3) {
     this.abort(usage); // Abort will exit the process
   }
@@ -23,7 +22,6 @@ function CLI(usage, settings) {
   this.usage = usage;
   this.optional = {};
   this.items = [];
-  this.test = false;
 
   for (const argName of settings.arrayArgs) {
     this.optional[argName] = [];
@@ -36,7 +34,7 @@ function CLI(usage, settings) {
     if (arg === '--') {
       // Only items can follow --
       mode = 'item';
-    } else if (mode === 'both' && arg[0] === '-') {
+    } else if ('both' === mode && arg[0] === '-') {
       // Optional arguments declaration
 
       if (arg[1] === '-') {
@@ -63,8 +61,6 @@ function CLI(usage, settings) {
 
       // The next value can be either an option or an item
       mode = 'both';
-    } else if (arg === 'test') {
-      this.test = true;
     } else if (['both', 'item'].includes(mode)) {
       // item arguments
       this.items.push(arg);
@@ -87,15 +83,9 @@ CLI.prototype.abort = function(msg) {
 CLI.prototype.benchmarks = function() {
   const paths = [];
 
-  if (this.items.includes('all')) {
-    this.items = Object.keys(benchmarks);
-  }
-
   for (const category of this.items) {
-    if (benchmarks[category] === undefined) {
-      console.error(`The "${category}" category does not exist.`);
-      process.exit(1);
-    }
+    if (benchmarks[category] === undefined)
+      continue;
     for (const scripts of benchmarks[category]) {
       if (this.shouldSkip(scripts)) continue;
 

--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -43,8 +43,9 @@ class AutocannonBenchmarker {
     }
     if (!result || !result.requests || !result.requests.average) {
       return undefined;
+    } else {
+      return result.requests.average;
     }
-    return result.requests.average;
   }
 }
 
@@ -76,8 +77,9 @@ class WrkBenchmarker {
     const throughput = match && +match[1];
     if (!isFinite(throughput)) {
       return undefined;
+    } else {
+      return throughput;
     }
-    return throughput;
   }
 }
 
@@ -87,8 +89,7 @@ class WrkBenchmarker {
  */
 class TestDoubleBenchmarker {
   constructor(type) {
-    // `type` is the type of benchmarker. Possible values are 'http' and
-    // 'http2'.
+    // `type` is the type ofbenchmarker. Possible values are 'http' and 'http2'.
     this.name = `test-double-${type}`;
     this.executable = path.resolve(__dirname, '_test-double-benchmarker.js');
     this.present = fs.existsSync(this.executable);
@@ -96,11 +97,10 @@ class TestDoubleBenchmarker {
   }
 
   create(options) {
-    const env = {
+    const env = Object.assign({
       duration: options.duration,
       test_url: `http://127.0.0.1:${options.port}${options.path}`,
-      ...process.env
-    };
+    }, process.env);
 
     const child = child_process.fork(this.executable,
                                      [this.type],
@@ -189,14 +189,13 @@ http_benchmarkers.forEach((benchmarker) => {
 });
 
 exports.run = function(options, callback) {
-  options = {
+  options = Object.assign({
     port: exports.PORT,
     path: '/',
     connections: 100,
     duration: 5,
     benchmarker: exports.default_http_benchmarker,
-    ...options
-  };
+  }, options);
   if (!options.benchmarker) {
     callback(new Error('Could not locate required http benchmarker. See ' +
                        `${requirementsURL} for further instructions.`));
@@ -213,7 +212,6 @@ exports.run = function(options, callback) {
                        'is  not installed'));
     return;
   }
-  process.env.duration = process.env.duration || options.duration || 5;
 
   const benchmarker_start = process.hrtime();
 
@@ -222,8 +220,7 @@ exports.run = function(options, callback) {
   child.stderr.pipe(process.stderr);
 
   let stdout = '';
-  child.stdout.setEncoding('utf8');
-  child.stdout.on('data', (chunk) => stdout += chunk);
+  child.stdout.on('data', (chunk) => stdout += chunk.toString());
 
   child.once('close', (code) => {
     const elapsed = process.hrtime(benchmarker_start);

--- a/benchmark/_test-double-benchmarker.js
+++ b/benchmark/_test-double-benchmarker.js
@@ -7,7 +7,7 @@ if (!['http', 'http2'].includes(myModule)) {
 
 const http = require(myModule);
 
-const duration = +process.env.duration;
+const duration = process.env.duration || 0;
 const url = process.env.test_url;
 
 const start = process.hrtime();
@@ -18,15 +18,13 @@ function request(res, client) {
   res.on('error', () => {});
   res.on('end', () => {
     throughput++;
-    const [sec, nanosec] = process.hrtime(start);
-    const ms = sec * 1000 + nanosec / 1e6;
-    if (ms < duration * 1000) {
+    const diff = process.hrtime(start);
+    if (duration > 0 && diff[0] < duration) {
       run();
     } else {
       console.log(JSON.stringify({ throughput }));
       if (client) {
         client.destroy();
-        process.exit(0);
       }
     }
   });
@@ -35,7 +33,7 @@ function request(res, client) {
 function run() {
   if (http.get) { // HTTP
     http.get(url, request);
-  } else { // HTTP/2
+  } else {        // HTTP/2
     const client = http.connect(url);
     client.on('error', (e) => { throw e; });
     request(client.request(), client);

--- a/benchmark/assert/deepequal-buffer.js
+++ b/benchmark/assert/deepequal-buffer.js
@@ -6,10 +6,12 @@ const bench = common.createBenchmark(main, {
   n: [2e4],
   len: [1e2, 1e3],
   strict: [0, 1],
-  method: ['deepEqual', 'notDeepEqual'],
+  method: [ 'deepEqual', 'notDeepEqual' ],
 });
 
 function main({ len, n, method, strict }) {
+  if (!method)
+    method = 'deepEqual';
   const data = Buffer.allocUnsafe(len + 1);
   const actual = Buffer.alloc(len);
   const expected = Buffer.alloc(len);

--- a/benchmark/assert/deepequal-map.js
+++ b/benchmark/assert/deepequal-map.js
@@ -34,6 +34,8 @@ function main({ n, len, method, strict }) {
   const array = Array(len).fill(1);
 
   switch (method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual_primitiveOnly': {
       const values = array.map((_, i) => [`str_${i}`, 123]);
       benchmark(strict ? deepStrictEqual : deepEqual, n, values);

--- a/benchmark/assert/deepequal-object.js
+++ b/benchmark/assert/deepequal-object.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [5e3],
   size: [1e2, 1e3, 5e4],
   strict: [0, 1],
-  method: ['deepEqual', 'notDeepEqual'],
+  method: [ 'deepEqual', 'notDeepEqual' ],
 });
 
 function createObj(source, add = '') {
@@ -26,6 +26,9 @@ function createObj(source, add = '') {
 function main({ size, n, method, strict }) {
   // TODO: Fix this "hack". `n` should not be manipulated.
   n = Math.min(Math.ceil(n / size), 20);
+
+  if (!method)
+    method = 'deepEqual';
 
   const source = Array.apply(null, Array(size));
   const actual = createObj(source);

--- a/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
@@ -52,6 +52,8 @@ function main({ n, len, primitive, method, strict }) {
   const expectedWrongSet = new Set(expectedWrong);
 
   switch (method) {
+    // Empty string falls through to next line as default, mostly for tests.
+    case '':
     case 'deepEqual_Array':
       run(strict ? deepStrictEqual : deepEqual, n, actual, expected);
       break;

--- a/benchmark/assert/deepequal-prims-and-objs-big-loop.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-loop.js
@@ -13,10 +13,12 @@ const bench = common.createBenchmark(main, {
   primitive: Object.keys(primValues),
   n: [2e4],
   strict: [0, 1],
-  method: ['deepEqual', 'notDeepEqual'],
+  method: [ 'deepEqual', 'notDeepEqual' ],
 });
 
 function main({ n, primitive, method, strict }) {
+  if (!method)
+    method = 'deepEqual';
   const prim = primValues[primitive];
   const actual = prim;
   const expected = prim;

--- a/benchmark/assert/deepequal-set.js
+++ b/benchmark/assert/deepequal-set.js
@@ -34,6 +34,8 @@ function main({ n, len, method, strict }) {
   const array = Array(len).fill(1);
 
   switch (method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual_primitiveOnly': {
       const values = array.map((_, i) => `str_${i}`);
       benchmark(strict ? deepStrictEqual : deepEqual, n, values);

--- a/benchmark/assert/deepequal-typedarrays.js
+++ b/benchmark/assert/deepequal-typedarrays.js
@@ -20,6 +20,8 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ type, n, len, method, strict }) {
+  if (!method)
+    method = 'deepEqual';
   const clazz = global[type];
   const actual = new clazz(len);
   const expected = new clazz(len);

--- a/benchmark/assert/throws.js
+++ b/benchmark/assert/throws.js
@@ -15,6 +15,8 @@ function main({ n, method }) {
   const message = 'failure';
 
   switch (method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'doesNotThrow':
       bench.start();
       for (let i = 0; i < n; ++i) {

--- a/benchmark/async_hooks/http-server.js
+++ b/benchmark/async_hooks/http-server.js
@@ -3,11 +3,10 @@ const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
   asyncHooks: ['init', 'before', 'after', 'all', 'disabled', 'none'],
-  connections: [50, 500],
-  duration: 5
+  connections: [50, 500]
 });
 
-function main({ asyncHooks, connections, duration }) {
+function main({ asyncHooks, connections }) {
   if (asyncHooks !== 'none') {
     let hooks = {
       init() {},
@@ -34,7 +33,6 @@ function main({ asyncHooks, connections, duration }) {
       bench.http({
         connections,
         path,
-        duration
       }, () => {
         server.close();
       });

--- a/benchmark/buffers/buffer-base64-encode.js
+++ b/benchmark/buffers/buffer-base64-encode.js
@@ -25,8 +25,6 @@ const common = require('../common.js');
 const bench = common.createBenchmark(main, {
   len: [64 * 1024 * 1024],
   n: [32]
-}, {
-  test: { len: 256 }
 });
 
 function main({ n, len }) {

--- a/benchmark/buffers/buffer-bytelength.js
+++ b/benchmark/buffers/buffer-bytelength.js
@@ -17,9 +17,9 @@ const chars = [
 
 function main({ n, len, encoding }) {
   let strings = [];
-  let results = [len * 16];
+  let results = [ len * 16 ];
   if (encoding === 'buffer') {
-    strings = [Buffer.alloc(len * 16, 'a')];
+    strings = [ Buffer.alloc(len * 16, 'a') ];
   } else {
     for (const string of chars) {
       // Strings must be built differently, depending on encoding

--- a/benchmark/buffers/buffer-creation.js
+++ b/benchmark/buffers/buffer-creation.js
@@ -16,6 +16,7 @@ const bench = common.createBenchmark(main, {
 function main({ len, n, type }) {
   let fn, i;
   switch (type) {
+    case '':
     case 'fast-alloc':
       fn = Buffer.alloc;
       break;

--- a/benchmark/buffers/buffer-fill.js
+++ b/benchmark/buffers/buffer-fill.js
@@ -22,7 +22,7 @@ function main({ n, type, size }) {
   const buffer = Buffer.allocUnsafe(size);
   const testFunction = new Function('b', `
     for (var i = 0; i < ${n}; i++) {
-      b.${type};
+      b.${type || 'fill(0)'};
     }
   `);
   bench.start();

--- a/benchmark/buffers/buffer-iterate.js
+++ b/benchmark/buffers/buffer-iterate.js
@@ -21,7 +21,7 @@ function main({ size, type, method, n }) {
     Buffer.alloc(size) :
     SlowBuffer(size).fill(0);
 
-  const fn = methods[method];
+  const fn = methods[method || 'for'];
 
   bench.start();
   fn(buffer, n);

--- a/benchmark/buffers/buffer-read-float.js
+++ b/benchmark/buffers/buffer-read-float.js
@@ -9,6 +9,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, type, endian, value }) {
+  type = type || 'Double';
   const buff = Buffer.alloc(8);
   const fn = `read${type}${endian}`;
   const values = {

--- a/benchmark/buffers/buffer-read-with-byteLength.js
+++ b/benchmark/buffers/buffer-read-with-byteLength.js
@@ -19,7 +19,7 @@ function main({ n, buf, type, byteLength }) {
   const buff = buf === 'fast' ?
     Buffer.alloc(8) :
     require('buffer').SlowBuffer(8);
-  const fn = `read${type}`;
+  const fn = `read${type || 'IntBE'}`;
 
   buff.writeDoubleLE(0, 0);
   bench.start();

--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -28,7 +28,7 @@ function main({ n, buf, type }) {
   const buff = buf === 'fast' ?
     Buffer.alloc(8) :
     require('buffer').SlowBuffer(8);
-  const fn = `read${type}`;
+  const fn = `read${type || 'UInt8'}`;
 
   buff.writeDoubleLE(0, 0);
   bench.start();

--- a/benchmark/buffers/buffer-swap.js
+++ b/benchmark/buffers/buffer-swap.js
@@ -76,7 +76,7 @@ function genMethod(method) {
 
 function main({ method, len, n, aligned = 'true' }) {
   const buf = createBuffer(len, aligned === 'true');
-  const bufferSwap = genMethod(method);
+  const bufferSwap = genMethod(method || 'swap16');
 
   bufferSwap(n, buf);
   bench.start();

--- a/benchmark/buffers/buffer-swap.js
+++ b/benchmark/buffers/buffer-swap.js
@@ -7,8 +7,6 @@ const bench = common.createBenchmark(main, {
   method: ['swap16', 'swap32', 'swap64'/* , 'htons', 'htonl', 'htonll' */],
   len: [64, 256, 768, 1024, 2056, 8192],
   n: [1e6]
-}, {
-  test: { len: 16 }
 });
 
 // The htons and htonl methods below are used to benchmark the

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -74,7 +74,7 @@ function main({ n, buf, type }) {
   const buff = buf === 'fast' ?
     Buffer.alloc(8) :
     require('buffer').SlowBuffer(8);
-  const fn = `write${type}`;
+  const fn = `write${type || 'UInt8'}`;
 
   if (!/\d/.test(fn))
     benchSpecialInt(buff, fn, n);

--- a/benchmark/buffers/dataview-set.js
+++ b/benchmark/buffers/dataview-set.js
@@ -40,6 +40,7 @@ const mod = {
 };
 
 function main({ n, type }) {
+  type = type || 'Uint8';
   const ab = new ArrayBuffer(8);
   const dv = new DataView(ab, 0, 8);
   const le = /LE$/.test(type);

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -3,225 +3,222 @@
 const child_process = require('child_process');
 const http_benchmarkers = require('./_http-benchmarkers.js');
 
-class Benchmark {
-  constructor(fn, configs, options) {
-    // Use the file name as the name of the benchmark
-    this.name = require.main.filename.slice(__dirname.length + 1);
-    // Parse job-specific configuration from the command line arguments
-    const parsed_args = this._parseArgs(process.argv.slice(2), configs);
-    this.options = parsed_args.cli;
-    this.extra_options = parsed_args.extra;
-    // The configuration list as a queue of jobs
-    this.queue = this._queue(this.options);
-    // The configuration of the current job, head of the queue
-    this.config = this.queue[0];
-    // Execution arguments i.e. flags used to run the jobs
-    this.flags = [];
-    if (options && options.flags) {
-      this.flags = this.flags.concat(options.flags);
-    }
-    if (process.env.NODE_BENCHMARK_FLAGS) {
-      const flags = process.env.NODE_BENCHMARK_FLAGS.split(/\s+/);
-      this.flags = this.flags.concat(flags);
-    }
-    // Holds process.hrtime value
-    this._time = [0, 0];
-    // Used to make sure a benchmark only start a timer once
-    this._started = false;
-    this._ended = false;
+exports.buildType = process.features.debug ? 'Debug' : 'Release';
 
-    // this._run will use fork() to create a new process for each configuration
-    // combination.
-    if (process.env.hasOwnProperty('NODE_RUN_BENCHMARK_FN')) {
-      process.nextTick(() => fn(this.config));
-    } else {
-      process.nextTick(() => this._run());
-    }
+exports.createBenchmark = function(fn, configs, options) {
+  return new Benchmark(fn, configs, options);
+};
+
+function Benchmark(fn, configs, options) {
+  // Use the file name as the name of the benchmark
+  this.name = require.main.filename.slice(__dirname.length + 1);
+  // Parse job-specific configuration from the command line arguments
+  const parsed_args = this._parseArgs(process.argv.slice(2), configs);
+  this.options = parsed_args.cli;
+  this.extra_options = parsed_args.extra;
+  // The configuration list as a queue of jobs
+  this.queue = this._queue(this.options);
+  // The configuration of the current job, head of the queue
+  this.config = this.queue[0];
+  // Execution arguments i.e. flags used to run the jobs
+  this.flags = [];
+  if (options && options.flags) {
+    this.flags = this.flags.concat(options.flags);
   }
-
-  _parseArgs(argv, configs) {
-    const cliOptions = {};
-    const extraOptions = {};
-    const validArgRE = /^(.+?)=([\s\S]*)$/;
-    // Parse configuration arguments
-    for (const arg of argv) {
-      const match = arg.match(validArgRE);
-      if (!match) {
-        console.error(`bad argument: ${arg}`);
-        process.exit(1);
-      }
-      const config = match[1];
-
-      if (configs[config]) {
-        // Infer the type from the config object and parse accordingly
-        const isNumber = typeof configs[config][0] === 'number';
-        const value = isNumber ? +match[2] : match[2];
-        if (!cliOptions[config])
-          cliOptions[config] = [];
-        cliOptions[config].push(value);
-      } else {
-        extraOptions[config] = match[2];
-      }
-    }
-    return { cli: Object.assign({}, configs, cliOptions), extra: extraOptions };
+  if (process.env.NODE_BENCHMARK_FLAGS) {
+    const flags = process.env.NODE_BENCHMARK_FLAGS.split(/\s+/);
+    this.flags = this.flags.concat(flags);
   }
+  // Holds process.hrtime value
+  this._time = [0, 0];
+  // Used to make sure a benchmark only start a timer once
+  this._started = false;
+  this._ended = false;
 
-  _queue(options) {
-    const queue = [];
-    const keys = Object.keys(options);
-
-    // Perform a depth-first walk though all options to generate a
-    // configuration list that contains all combinations.
-    function recursive(keyIndex, prevConfig) {
-      const key = keys[keyIndex];
-      const values = options[key];
-      const type = typeof values[0];
-
-      for (const value of values) {
-        if (typeof value !== 'number' && typeof value !== 'string') {
-          throw new TypeError(
-            `configuration "${key}" had type ${typeof value}`);
-        }
-        if (typeof value !== type) {
-          // This is a requirement for being able to consistently and
-          // predictably parse CLI provided configuration values.
-          throw new TypeError(`configuration "${key}" has mixed types`);
-        }
-
-        const currConfig = Object.assign({ [key]: value }, prevConfig);
-
-        if (keyIndex + 1 < keys.length) {
-          recursive(keyIndex + 1, currConfig);
-        } else {
-          queue.push(currConfig);
-        }
-      }
-    }
-
-    if (keys.length > 0) {
-      recursive(0, {});
-    } else {
-      queue.push({});
-    }
-
-    return queue;
-  }
-
-  http(options, cb) {
-    const self = this;
-    const http_options = Object.assign({ }, options);
-    http_options.benchmarker = http_options.benchmarker ||
-                              self.config.benchmarker ||
-                              self.extra_options.benchmarker ||
-                              exports.default_http_benchmarker;
-    http_benchmarkers.run(
-      http_options, (error, code, used_benchmarker, result, elapsed) => {
-        if (cb) {
-          cb(code);
-        }
-        if (error) {
-          console.error(error);
-          process.exit(code || 1);
-        }
-        self.config.benchmarker = used_benchmarker;
-        self.report(result, elapsed);
-      }
-    );
-  }
-
-  _run() {
-    const self = this;
-    // If forked, report to the parent.
-    if (process.send) {
-      process.send({
-        type: 'config',
-        name: this.name,
-        queueLength: this.queue.length,
-      });
-    }
-
-    (function recursive(queueIndex) {
-      const config = self.queue[queueIndex];
-
-      // Set NODE_RUN_BENCHMARK_FN to indicate that the child shouldn't
-      // construct a configuration queue, but just execute the benchmark
-      // function.
-      const childEnv = Object.assign({}, process.env);
-      childEnv.NODE_RUN_BENCHMARK_FN = '';
-
-      // Create configuration arguments
-      const childArgs = [];
-      for (const key of Object.keys(config)) {
-        childArgs.push(`${key}=${config[key]}`);
-      }
-      for (const key of Object.keys(self.extra_options)) {
-        childArgs.push(`${key}=${self.extra_options[key]}`);
-      }
-
-      const child = child_process.fork(require.main.filename, childArgs, {
-        env: childEnv,
-        execArgv: self.flags.concat(process.execArgv),
-      });
-      child.on('message', sendResult);
-      child.on('close', (code) => {
-        if (code) {
-          process.exit(code);
-        }
-
-        if (queueIndex + 1 < self.queue.length) {
-          recursive(queueIndex + 1);
-        }
-      });
-    })(0);
-  }
-
-  start() {
-    if (this._started) {
-      throw new Error('Called start more than once in a single benchmark');
-    }
-    this._started = true;
-    this._time = process.hrtime();
-  }
-
-  end(operations) {
-    // Get elapsed time now and do error checking later for accuracy.
-    const elapsed = process.hrtime(this._time);
-
-    if (!this._started) {
-      throw new Error('called end without start');
-    }
-    if (this._ended) {
-      throw new Error('called end multiple times');
-    }
-    if (typeof operations !== 'number') {
-      throw new Error('called end() without specifying operation count');
-    }
-    if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED && operations <= 0) {
-      throw new Error('called end() with operation count <= 0');
-    }
-    if (elapsed[0] === 0 && elapsed[1] === 0) {
-      if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED)
-        throw new Error('insufficient clock precision for short benchmark');
-      // Avoid dividing by zero
-      elapsed[1] = 1;
-    }
-
-    this._ended = true;
-    const time = elapsed[0] + elapsed[1] / 1e9;
-    const rate = operations / time;
-    this.report(rate, elapsed);
-  }
-
-  report(rate, elapsed) {
-    sendResult({
-      name: this.name,
-      conf: this.config,
-      rate: rate,
-      time: elapsed[0] + elapsed[1] / 1e9,
-      type: 'report',
-    });
+  // this._run will use fork() to create a new process for each configuration
+  // combination.
+  if (process.env.hasOwnProperty('NODE_RUN_BENCHMARK_FN')) {
+    process.nextTick(() => fn(this.config));
+  } else {
+    process.nextTick(() => this._run());
   }
 }
+
+Benchmark.prototype._parseArgs = function(argv, configs) {
+  const cliOptions = {};
+  const extraOptions = {};
+  const validArgRE = /^(.+?)=([\s\S]*)$/;
+  // Parse configuration arguments
+  for (const arg of argv) {
+    const match = arg.match(validArgRE);
+    if (!match) {
+      console.error(`bad argument: ${arg}`);
+      process.exit(1);
+    }
+    const config = match[1];
+
+    if (configs[config]) {
+      // Infer the type from the config object and parse accordingly
+      const isNumber = typeof configs[config][0] === 'number';
+      const value = isNumber ? +match[2] : match[2];
+      if (!cliOptions[config])
+        cliOptions[config] = [];
+      cliOptions[config].push(value);
+    } else {
+      extraOptions[config] = match[2];
+    }
+  }
+  return { cli: Object.assign({}, configs, cliOptions), extra: extraOptions };
+};
+
+Benchmark.prototype._queue = function(options) {
+  const queue = [];
+  const keys = Object.keys(options);
+
+  // Perform a depth-first walk though all options to generate a
+  // configuration list that contains all combinations.
+  function recursive(keyIndex, prevConfig) {
+    const key = keys[keyIndex];
+    const values = options[key];
+    const type = typeof values[0];
+
+    for (const value of values) {
+      if (typeof value !== 'number' && typeof value !== 'string') {
+        throw new TypeError(`configuration "${key}" had type ${typeof value}`);
+      }
+      if (typeof value !== type) {
+        // This is a requirement for being able to consistently and predictably
+        // parse CLI provided configuration values.
+        throw new TypeError(`configuration "${key}" has mixed types`);
+      }
+
+      const currConfig = Object.assign({ [key]: value }, prevConfig);
+
+      if (keyIndex + 1 < keys.length) {
+        recursive(keyIndex + 1, currConfig);
+      } else {
+        queue.push(currConfig);
+      }
+    }
+  }
+
+  if (keys.length > 0) {
+    recursive(0, {});
+  } else {
+    queue.push({});
+  }
+
+  return queue;
+};
+
+// Benchmark an http server.
+exports.default_http_benchmarker =
+  http_benchmarkers.default_http_benchmarker;
+exports.PORT = http_benchmarkers.PORT;
+
+Benchmark.prototype.http = function(options, cb) {
+  const self = this;
+  const http_options = Object.assign({ }, options);
+  http_options.benchmarker = http_options.benchmarker ||
+                             self.config.benchmarker ||
+                             self.extra_options.benchmarker ||
+                             exports.default_http_benchmarker;
+  http_benchmarkers.run(
+    http_options, (error, code, used_benchmarker, result, elapsed) => {
+      if (cb) {
+        cb(code);
+      }
+      if (error) {
+        console.error(error);
+        process.exit(code || 1);
+      }
+      self.config.benchmarker = used_benchmarker;
+      self.report(result, elapsed);
+    }
+  );
+};
+
+Benchmark.prototype._run = function() {
+  const self = this;
+  // If forked, report to the parent.
+  if (process.send) {
+    process.send({
+      type: 'config',
+      name: this.name,
+      queueLength: this.queue.length,
+    });
+  }
+
+  (function recursive(queueIndex) {
+    const config = self.queue[queueIndex];
+
+    // Set NODE_RUN_BENCHMARK_FN to indicate that the child shouldn't construct
+    // a configuration queue, but just execute the benchmark function.
+    const childEnv = Object.assign({}, process.env);
+    childEnv.NODE_RUN_BENCHMARK_FN = '';
+
+    // Create configuration arguments
+    const childArgs = [];
+    for (const key of Object.keys(config)) {
+      childArgs.push(`${key}=${config[key]}`);
+    }
+    for (const key of Object.keys(self.extra_options)) {
+      childArgs.push(`${key}=${self.extra_options[key]}`);
+    }
+
+    const child = child_process.fork(require.main.filename, childArgs, {
+      env: childEnv,
+      execArgv: self.flags.concat(process.execArgv),
+    });
+    child.on('message', sendResult);
+    child.on('close', (code) => {
+      if (code) {
+        process.exit(code);
+      }
+
+      if (queueIndex + 1 < self.queue.length) {
+        recursive(queueIndex + 1);
+      }
+    });
+  })(0);
+};
+
+Benchmark.prototype.start = function() {
+  if (this._started) {
+    throw new Error('Called start more than once in a single benchmark');
+  }
+  this._started = true;
+  this._time = process.hrtime();
+};
+
+Benchmark.prototype.end = function(operations) {
+  // Get elapsed time now and do error checking later for accuracy.
+  const elapsed = process.hrtime(this._time);
+
+  if (!this._started) {
+    throw new Error('called end without start');
+  }
+  if (this._ended) {
+    throw new Error('called end multiple times');
+  }
+  if (typeof operations !== 'number') {
+    throw new Error('called end() without specifying operation count');
+  }
+  if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED && operations <= 0) {
+    throw new Error('called end() with operation count <= 0');
+  }
+  if (elapsed[0] === 0 && elapsed[1] === 0) {
+    if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED)
+      throw new Error('insufficient clock precision for short benchmark');
+    // Avoid dividing by zero
+    elapsed[1] = 1;
+  }
+
+  this._ended = true;
+  const time = elapsed[0] + elapsed[1] / 1e9;
+  const rate = operations / time;
+  this.report(rate, elapsed);
+};
 
 function formatResult(data) {
   // Construct configuration string, " A=a, B=b, ..."
@@ -245,6 +242,27 @@ function sendResult(data) {
     console.log(formatResult(data));
   }
 }
+exports.sendResult = sendResult;
+
+Benchmark.prototype.report = function(rate, elapsed) {
+  sendResult({
+    name: this.name,
+    conf: this.config,
+    rate: rate,
+    time: elapsed[0] + elapsed[1] / 1e9,
+    type: 'report',
+  });
+};
+
+exports.binding = function(bindingName) {
+  try {
+    const { internalBinding } = require('internal/test/binding');
+
+    return internalBinding(bindingName);
+  } catch {
+    return process.binding(bindingName);
+  }
+};
 
 const urls = {
   long: 'http://nodejs.org:89/docs/latest/api/foo/bar/qua/13949281/0f28b/' +
@@ -260,6 +278,7 @@ const urls = {
   percent: 'https://%E4%BD%A0/foo',
   dot: 'https://example.org/./a/../b/./c',
 };
+exports.urls = urls;
 
 const searchParams = {
   noencode: 'foo=bar&baz=quux&xyzzy=thud',
@@ -274,6 +293,7 @@ const searchParams = {
   manyblankpairs: '&&&&&&&&&&&&&&&&&&&&&&&&',
   altspaces: 'foo+bar=baz+quux&xyzzy+thud=quuy+quuz&abc=def+ghi',
 };
+exports.searchParams = searchParams;
 
 function getUrlData(withBase) {
   const data = require('../test/fixtures/wpt/url/resources/urltestdata.json');
@@ -288,6 +308,8 @@ function getUrlData(withBase) {
   }
   return result;
 }
+
+exports.urlDataTypes = Object.keys(urls).concat(['wpt']);
 
 /**
  * Generate an array of data for URL benchmarks to use.
@@ -332,27 +354,4 @@ function bakeUrlData(type, e = 0, withBase = false, asUrl = false) {
   }
   return result;
 }
-
-module.exports = {
-  PORT: http_benchmarkers.PORT,
-  bakeUrlData,
-  binding(bindingName) {
-    try {
-      const { internalBinding } = require('internal/test/binding');
-
-      return internalBinding(bindingName);
-    } catch {
-      return process.binding(bindingName);
-    }
-  },
-  buildType: process.features.debug ? 'Debug' : 'Release',
-  createBenchmark(fn, configs, options) {
-    return new Benchmark(fn, configs, options);
-  },
-  // Benchmark an http server.
-  default_http_benchmarker: http_benchmarkers.default_http_benchmarker,
-  sendResult,
-  searchParams,
-  urlDataTypes: Object.keys(urls).concat(['wpt']),
-  urls,
-};
+exports.bakeUrlData = bakeUrlData;

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -4,83 +4,43 @@ const child_process = require('child_process');
 const http_benchmarkers = require('./_http-benchmarkers.js');
 
 class Benchmark {
-  // Used to make sure a benchmark only start a timer once
-  #started = false;
-
-  // Indicate that the benchmark ended
-  #ended = false;
-
-  // Holds process.hrtime value
-  #time = [0, 0];
-
-  // Use the file name as the name of the benchmark
-  name = require.main.filename.slice(__dirname.length + 1);
-
-  // Execution arguments i.e. flags used to run the jobs
-  flags = process.env.NODE_BENCHMARK_FLAGS ?
-    process.env.NODE_BENCHMARK_FLAGS.split(/\s+/) :
-    [];
-
-  constructor(fn, configs, options = {}) {
+  constructor(fn, configs, options) {
+    // Use the file name as the name of the benchmark
+    this.name = require.main.filename.slice(__dirname.length + 1);
     // Parse job-specific configuration from the command line arguments
-    const argv = process.argv.slice(2);
-    const parsed_args = this._parseArgs(argv, configs, options);
+    const parsed_args = this._parseArgs(process.argv.slice(2), configs);
     this.options = parsed_args.cli;
     this.extra_options = parsed_args.extra;
-    if (options.flags) {
-      this.flags = this.flags.concat(options.flags);
-    }
-
     // The configuration list as a queue of jobs
     this.queue = this._queue(this.options);
-
     // The configuration of the current job, head of the queue
     this.config = this.queue[0];
+    // Execution arguments i.e. flags used to run the jobs
+    this.flags = [];
+    if (options && options.flags) {
+      this.flags = this.flags.concat(options.flags);
+    }
+    if (process.env.NODE_BENCHMARK_FLAGS) {
+      const flags = process.env.NODE_BENCHMARK_FLAGS.split(/\s+/);
+      this.flags = this.flags.concat(flags);
+    }
+    // Holds process.hrtime value
+    this._time = [0, 0];
+    // Used to make sure a benchmark only start a timer once
+    this._started = false;
+    this._ended = false;
 
-    process.nextTick(() => {
-      if (process.env.hasOwnProperty('NODE_RUN_BENCHMARK_FN')) {
-        fn(this.config);
-      } else {
-        // _run will use fork() to create a new process for each configuration
-        // combination.
-        this._run();
-      }
-    });
+    // this._run will use fork() to create a new process for each configuration
+    // combination.
+    if (process.env.hasOwnProperty('NODE_RUN_BENCHMARK_FN')) {
+      process.nextTick(() => fn(this.config));
+    } else {
+      process.nextTick(() => this._run());
+    }
   }
 
-  _parseArgs(argv, configs, options) {
+  _parseArgs(argv, configs) {
     const cliOptions = {};
-
-    // Check for the test mode first.
-    const testIndex = argv.indexOf('--test');
-    if (testIndex !== -1) {
-      for (const [key, rawValue] of Object.entries(configs)) {
-        let value = Array.isArray(rawValue) ? rawValue[0] : rawValue;
-        // Set numbers to one by default to reduce the runtime.
-        if (typeof value === 'number') {
-          if (key === 'dur' || key === 'duration') {
-            value = 0.05;
-          } else if (value > 1) {
-            value = 1;
-          }
-        }
-        cliOptions[key] = [value];
-      }
-      // Override specific test options.
-      if (options.test) {
-        for (const [key, value] of Object.entries(options.test)) {
-          cliOptions[key] = Array.isArray(value) ? value : [value];
-        }
-      }
-      argv.splice(testIndex, 1);
-    } else {
-      // Accept single values instead of arrays.
-      for (const [key, value] of Object.entries(configs)) {
-        if (!Array.isArray(value))
-          configs[key] = [value];
-      }
-    }
-
     const extraOptions = {};
     const validArgRE = /^(.+?)=([\s\S]*)$/;
     // Parse configuration arguments
@@ -90,43 +50,45 @@ class Benchmark {
         console.error(`bad argument: ${arg}`);
         process.exit(1);
       }
-      const [, key, value] = match;
-      if (Object.prototype.hasOwnProperty.call(configs, key)) {
-        if (!cliOptions[key])
-          cliOptions[key] = [];
-        cliOptions[key].push(
-          // Infer the type from the config object and parse accordingly
-          typeof configs[key][0] === 'number' ? +value : value
-        );
+      const config = match[1];
+
+      if (configs[config]) {
+        // Infer the type from the config object and parse accordingly
+        const isNumber = typeof configs[config][0] === 'number';
+        const value = isNumber ? +match[2] : match[2];
+        if (!cliOptions[config])
+          cliOptions[config] = [];
+        cliOptions[config].push(value);
       } else {
-        extraOptions[key] = value;
+        extraOptions[config] = match[2];
       }
     }
-    return { cli: { ...configs, ...cliOptions }, extra: extraOptions };
+    return { cli: Object.assign({}, configs, cliOptions), extra: extraOptions };
   }
 
   _queue(options) {
     const queue = [];
     const keys = Object.keys(options);
 
-    // Perform a depth-first walk through all options to generate a
+    // Perform a depth-first walk though all options to generate a
     // configuration list that contains all combinations.
     function recursive(keyIndex, prevConfig) {
       const key = keys[keyIndex];
       const values = options[key];
+      const type = typeof values[0];
 
       for (const value of values) {
         if (typeof value !== 'number' && typeof value !== 'string') {
           throw new TypeError(
             `configuration "${key}" had type ${typeof value}`);
         }
-        if (typeof value !== typeof values[0]) {
+        if (typeof value !== type) {
           // This is a requirement for being able to consistently and
           // predictably parse CLI provided configuration values.
           throw new TypeError(`configuration "${key}" has mixed types`);
         }
 
-        const currConfig = { [key]: value, ...prevConfig };
+        const currConfig = Object.assign({ [key]: value }, prevConfig);
 
         if (keyIndex + 1 < keys.length) {
           recursive(keyIndex + 1, currConfig);
@@ -146,11 +108,12 @@ class Benchmark {
   }
 
   http(options, cb) {
-    const http_options = { ...options };
+    const self = this;
+    const http_options = Object.assign({ }, options);
     http_options.benchmarker = http_options.benchmarker ||
-                               this.config.benchmarker ||
-                               this.extra_options.benchmarker ||
-                               http_benchmarkers.default_http_benchmarker;
+                              self.config.benchmarker ||
+                              self.extra_options.benchmarker ||
+                              exports.default_http_benchmarker;
     http_benchmarkers.run(
       http_options, (error, code, used_benchmarker, result, elapsed) => {
         if (cb) {
@@ -160,13 +123,14 @@ class Benchmark {
           console.error(error);
           process.exit(code || 1);
         }
-        this.config.benchmarker = used_benchmarker;
-        this.report(result, elapsed);
+        self.config.benchmarker = used_benchmarker;
+        self.report(result, elapsed);
       }
     );
   }
 
   _run() {
+    const self = this;
     // If forked, report to the parent.
     if (process.send) {
       process.send({
@@ -176,27 +140,27 @@ class Benchmark {
       });
     }
 
-    const recursive = (queueIndex) => {
-      const config = this.queue[queueIndex];
+    (function recursive(queueIndex) {
+      const config = self.queue[queueIndex];
 
       // Set NODE_RUN_BENCHMARK_FN to indicate that the child shouldn't
       // construct a configuration queue, but just execute the benchmark
       // function.
-      const childEnv = { ...process.env };
+      const childEnv = Object.assign({}, process.env);
       childEnv.NODE_RUN_BENCHMARK_FN = '';
 
       // Create configuration arguments
       const childArgs = [];
-      for (const [key, value] of Object.entries(config)) {
-        childArgs.push(`${key}=${value}`);
+      for (const key of Object.keys(config)) {
+        childArgs.push(`${key}=${config[key]}`);
       }
-      for (const [key, value] of Object.entries(this.extra_options)) {
-        childArgs.push(`${key}=${value}`);
+      for (const key of Object.keys(self.extra_options)) {
+        childArgs.push(`${key}=${self.extra_options[key]}`);
       }
 
       const child = child_process.fork(require.main.filename, childArgs, {
         env: childEnv,
-        execArgv: this.flags.concat(process.execArgv),
+        execArgv: self.flags.concat(process.execArgv),
       });
       child.on('message', sendResult);
       child.on('close', (code) => {
@@ -204,31 +168,29 @@ class Benchmark {
           process.exit(code);
         }
 
-        if (queueIndex + 1 < this.queue.length) {
+        if (queueIndex + 1 < self.queue.length) {
           recursive(queueIndex + 1);
         }
       });
-    };
-
-    recursive(0);
+    })(0);
   }
 
   start() {
-    if (this.#started) {
+    if (this._started) {
       throw new Error('Called start more than once in a single benchmark');
     }
-    this.#started = true;
-    this.#time = process.hrtime();
+    this._started = true;
+    this._time = process.hrtime();
   }
 
   end(operations) {
     // Get elapsed time now and do error checking later for accuracy.
-    const elapsed = process.hrtime(this.#time);
+    const elapsed = process.hrtime(this._time);
 
-    if (!this.#started) {
+    if (!this._started) {
       throw new Error('called end without start');
     }
-    if (this.#ended) {
+    if (this._ended) {
       throw new Error('called end multiple times');
     }
     if (typeof operations !== 'number') {
@@ -244,7 +206,7 @@ class Benchmark {
       elapsed[1] = 1;
     }
 
-    this.#ended = true;
+    this._ended = true;
     const time = elapsed[0] + elapsed[1] / 1e9;
     const rate = operations / time;
     this.report(rate, elapsed);
@@ -254,7 +216,7 @@ class Benchmark {
     sendResult({
       name: this.name,
       conf: this.config,
-      rate,
+      rate: rate,
       time: elapsed[0] + elapsed[1] / 1e9,
       type: 'report',
     });
@@ -372,7 +334,6 @@ function bakeUrlData(type, e = 0, withBase = false, asUrl = false) {
 }
 
 module.exports = {
-  Benchmark,
   PORT: http_benchmarkers.PORT,
   bakeUrlData,
   binding(bindingName) {
@@ -388,6 +349,8 @@ module.exports = {
   createBenchmark(fn, configs, options) {
     return new Benchmark(fn, configs, options);
   },
+  // Benchmark an http server.
+  default_http_benchmarker: http_benchmarkers.default_http_benchmarker,
   sendResult,
   searchParams,
   urlDataTypes: Object.keys(urls).concat(['wpt']),

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -9,7 +9,7 @@ const BenchmarkProgress = require('./_benchmark_progress.js');
 //
 // Parse arguments
 //
-const cli = new CLI(`usage: ./node compare.js [options] [--] <category> ...
+const cli = CLI(`usage: ./node compare.js [options] [--] <category> ...
   Run each benchmark in the <category> directory many times using two different
   node versions. More than one <category> directory can be specified.
   The output is formatted as csv, which can be processed using for

--- a/benchmark/crypto/aes-gcm-throughput.js
+++ b/benchmark/crypto/aes-gcm-throughput.js
@@ -9,6 +9,9 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, len, cipher }) {
+  // Default cipher for tests.
+  if (cipher === '')
+    cipher = 'aes-128-gcm';
   const message = Buffer.alloc(len, 'b');
   const key = crypto.randomBytes(keylen[cipher]);
   const iv = crypto.randomBytes(12);

--- a/benchmark/crypto/cipher-stream.js
+++ b/benchmark/crypto/cipher-stream.js
@@ -3,7 +3,7 @@ const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
   writes: [500],
-  cipher: ['AES192', 'AES256'],
+  cipher: [ 'AES192', 'AES256' ],
   type: ['asc', 'utf', 'buf'],
   len: [2, 1024, 102400, 1024 * 1024],
   api: ['legacy', 'stream']
@@ -12,6 +12,9 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ api, cipher, type, len, writes }) {
+  // Default cipher for tests.
+  if (cipher === '')
+    cipher = 'AES192';
   if (api === 'stream' && /^v0\.[0-8]\./.test(process.version)) {
     console.error('Crypto streams not available until v0.10');
     // Use the legacy, just so that we can compare them.
@@ -25,6 +28,7 @@ function main({ api, cipher, type, len, writes }) {
 
   alice.generateKeys();
   bob.generateKeys();
+
 
   const pubEnc = /^v0\.[0-8]/.test(process.version) ? 'binary' : null;
   const alice_secret = alice.computeSecret(bob.getPublicKey(), pubEnc, 'hex');

--- a/benchmark/crypto/cipher-stream.js
+++ b/benchmark/crypto/cipher-stream.js
@@ -7,8 +7,6 @@ const bench = common.createBenchmark(main, {
   type: ['asc', 'utf', 'buf'],
   len: [2, 1024, 102400, 1024 * 1024],
   api: ['legacy', 'stream']
-}, {
-  flags: ['--no-warnings']
 });
 
 function main({ api, cipher, type, len, writes }) {

--- a/benchmark/es/defaultparams-bench.js
+++ b/benchmark/es/defaultparams-bench.js
@@ -36,6 +36,8 @@ function runDefaultParams(n) {
 
 function main({ n, method }) {
   switch (method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'withoutdefaults':
       runOldStyleDefaults(n);
       break;

--- a/benchmark/es/destructuring-bench.js
+++ b/benchmark/es/destructuring-bench.js
@@ -36,6 +36,8 @@ function runSwapDestructured(n) {
 
 function main({ n, method }) {
   switch (method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'swap':
       runSwapManual(n);
       break;

--- a/benchmark/es/destructuring-object-bench.js
+++ b/benchmark/es/destructuring-object-bench.js
@@ -33,6 +33,8 @@ function runDestructured(n) {
 
 function main({ n, method }) {
   switch (method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'normal':
       runNormal(n);
       break;

--- a/benchmark/es/foreach-bench.js
+++ b/benchmark/es/foreach-bench.js
@@ -54,6 +54,8 @@ function main({ n, count, method }) {
     items[i] = i;
 
   switch (method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'for':
       fn = useFor;
       break;

--- a/benchmark/es/map-bench.js
+++ b/benchmark/es/map-bench.js
@@ -104,6 +104,8 @@ function runMap(n) {
 
 function main({ n, method }) {
   switch (method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'object':
       runObject(n);
       break;

--- a/benchmark/es/restparams-bench.js
+++ b/benchmark/es/restparams-bench.js
@@ -51,6 +51,8 @@ function runUseArguments(n) {
 function main({ n, method }) {
   let fn;
   switch (method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'copy':
       fn = runCopyArguments;
       break;

--- a/benchmark/es/spread-assign.js
+++ b/benchmark/es/spread-assign.js
@@ -18,6 +18,8 @@ function main({ n, context, count, rest, method }) {
   let obj;  // eslint-disable-line no-unused-vars
 
   switch (method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case '_extend':
       bench.start();
       for (let i = 0; i < n; i++)

--- a/benchmark/es/spread-bench.js
+++ b/benchmark/es/spread-bench.js
@@ -32,6 +32,8 @@ function main({ n, context, count, rest, method }) {
     args[i] = i;
 
   switch (method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'apply':
       bench.start();
       for (let i = 0; i < n; i++)

--- a/benchmark/es/string-concatenations.js
+++ b/benchmark/es/string-concatenations.js
@@ -23,6 +23,8 @@ function main({ n, mode }) {
   let string;
 
   switch (mode) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'multi-concat':
       bench.start();
       for (let i = 0; i < n; i++)

--- a/benchmark/es/string-repeat.js
+++ b/benchmark/es/string-repeat.js
@@ -18,6 +18,8 @@ function main({ n, size, encoding, mode }) {
   let str;
 
   switch (mode) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'Array':
       bench.start();
       for (let i = 0; i < n; i++)

--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -11,18 +11,19 @@ tmpdir.refresh();
 const filename = path.resolve(tmpdir.path,
                               `.removeme-benchmark-garbage-${process.pid}`);
 
+let encodingType, encoding, size, filesize;
+
 const bench = common.createBenchmark(main, {
   encodingType: ['buf', 'asc', 'utf'],
-  filesize: [1000 * 1024],
-  highWaterMark: [1024, 4096, 65535, 1024 * 1024],
-  n: 1024
+  filesize: [1000 * 1024 * 1024],
+  size: [1024, 4096, 65535, 1024 * 1024]
 });
 
 function main(conf) {
-  const { encodingType, highWaterMark, filesize } = conf;
-  let { n } = conf;
+  encodingType = conf.encodingType;
+  size = conf.size;
+  filesize = conf.filesize;
 
-  let encoding = '';
   switch (encodingType) {
     case 'buf':
       encoding = null;
@@ -37,38 +38,14 @@ function main(conf) {
       throw new Error(`invalid encodingType: ${encodingType}`);
   }
 
-  // Make file
-  const buf = Buffer.allocUnsafe(filesize);
-  if (encoding === 'utf8') {
-    // ü
-    for (let i = 0; i < buf.length; i++) {
-      buf[i] = i % 2 === 0 ? 0xC3 : 0xBC;
-    }
-  } else if (encoding === 'ascii') {
-    buf.fill('a');
-  } else {
-    buf.fill('x');
-  }
-
-  try { fs.unlinkSync(filename); } catch {}
-  const ws = fs.createWriteStream(filename);
-  ws.on('close', runTest.bind(null, filesize, highWaterMark, encoding, n));
-  ws.on('drain', write);
-  write();
-  function write() {
-    do {
-      n--;
-    } while (false !== ws.write(buf) && n > 0);
-    if (n === 0)
-      ws.end();
-  }
+  makeFile();
 }
 
-function runTest(filesize, highWaterMark, encoding, n) {
-  assert(fs.statSync(filename).size === filesize * n);
+function runTest() {
+  assert(fs.statSync(filename).size === filesize);
   const rs = fs.createReadStream(filename, {
-    highWaterMark,
-    encoding
+    highWaterMark: size,
+    encoding: encoding
   });
 
   rs.on('open', () => {
@@ -85,4 +62,32 @@ function runTest(filesize, highWaterMark, encoding, n) {
     // MB/sec
     bench.end(bytes / (1024 * 1024));
   });
+}
+
+function makeFile() {
+  const buf = Buffer.allocUnsafe(filesize / 1024);
+  if (encoding === 'utf8') {
+    // ü
+    for (let i = 0; i < buf.length; i++) {
+      buf[i] = i % 2 === 0 ? 0xC3 : 0xBC;
+    }
+  } else if (encoding === 'ascii') {
+    buf.fill('a');
+  } else {
+    buf.fill('x');
+  }
+
+  try { fs.unlinkSync(filename); } catch {}
+  let w = 1024;
+  const ws = fs.createWriteStream(filename);
+  ws.on('close', runTest);
+  ws.on('drain', write);
+  write();
+  function write() {
+    do {
+      w--;
+    } while (false !== ws.write(buf) && w > 0);
+    if (w === 0)
+      ws.end();
+  }
 }

--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -14,12 +14,12 @@ const filename = path.resolve(tmpdir.path,
                               `.removeme-benchmark-garbage-${process.pid}`);
 
 const bench = common.createBenchmark(main, {
-  duration: [5],
+  dur: [5],
   len: [1024, 16 * 1024 * 1024],
   concurrent: [1, 10]
 });
 
-function main({ len, duration, concurrent }) {
+function main({ len, dur, concurrent }) {
   try { fs.unlinkSync(filename); } catch {}
   let data = Buffer.alloc(len, 'x');
   fs.writeFileSync(filename, data);
@@ -33,7 +33,7 @@ function main({ len, duration, concurrent }) {
     bench.end(reads);
     try { fs.unlinkSync(filename); } catch {}
     process.exit(0);
-  }, duration * 1000);
+  }, dur * 1000);
 
   function read() {
     fs.readFile(filename, afterRead);

--- a/benchmark/http/chunked.js
+++ b/benchmark/http/chunked.js
@@ -13,11 +13,10 @@ const common = require('../common.js');
 const bench = common.createBenchmark(main, {
   n: [1, 4, 8, 16],
   len: [1, 64, 256],
-  c: [100],
-  duration: 5
+  c: [100]
 });
 
-function main({ len, n, c, duration }) {
+function main({ len, n, c }) {
   const http = require('http');
   const chunk = Buffer.alloc(len, '8');
 
@@ -34,8 +33,7 @@ function main({ len, n, c, duration }) {
 
   server.listen(common.PORT, () => {
     bench.http({
-      connections: c,
-      duration
+      connections: c
     }, () => {
       server.close();
     });

--- a/benchmark/http/cluster.js
+++ b/benchmark/http/cluster.js
@@ -9,15 +9,14 @@ if (cluster.isMaster) {
     // Unicode confuses ab on os x.
     type: ['bytes', 'buffer'],
     len: [4, 1024, 102400],
-    c: [50, 500],
-    duration: 5,
+    c: [50, 500]
   });
 } else {
   const port = parseInt(process.env.PORT || PORT);
   require('../fixtures/simple-http-server.js').listen(port);
 }
 
-function main({ type, len, c, duration }) {
+function main({ type, len, c }) {
   process.env.PORT = PORT;
   let workers = 0;
   const w1 = cluster.fork();
@@ -33,8 +32,7 @@ function main({ type, len, c, duration }) {
 
       bench.http({
         path: path,
-        connections: c,
-        duration
+        connections: c
       }, () => {
         w1.destroy();
         w2.destroy();

--- a/benchmark/http/end-vs-write-end.js
+++ b/benchmark/http/end-vs-write-end.js
@@ -14,11 +14,10 @@ const bench = common.createBenchmark(main, {
   type: ['asc', 'utf', 'buf'],
   len: [64 * 1024, 128 * 1024, 256 * 1024, 1024 * 1024],
   c: [100],
-  method: ['write', 'end'],
-  duration: 5
+  method: ['write', 'end']
 });
 
-function main({ len, type, method, c, duration }) {
+function main({ len, type, method, c }) {
   const http = require('http');
   let chunk;
   switch (type) {
@@ -50,8 +49,7 @@ function main({ len, type, method, c, duration }) {
 
   server.listen(common.PORT, () => {
     bench.http({
-      connections: c,
-      duration
+      connections: c
     }, () => {
       server.close();
     });

--- a/benchmark/http/headers.js
+++ b/benchmark/http/headers.js
@@ -6,10 +6,9 @@ const http = require('http');
 const bench = common.createBenchmark(main, {
   n: [10, 1000],
   len: [1, 100],
-  duration: 5
 });
 
-function main({ len, n, duration }) {
+function main({ len, n }) {
   const headers = {
     'Connection': 'keep-alive',
     'Transfer-Encoding': 'chunked',
@@ -30,8 +29,7 @@ function main({ len, n, duration }) {
   server.listen(common.PORT, () => {
     bench.http({
       path: '/',
-      connections: 10,
-      duration
+      connections: 10
     }, () => {
       server.close();
     });

--- a/benchmark/http/incoming_headers.js
+++ b/benchmark/http/incoming_headers.js
@@ -3,13 +3,12 @@ const common = require('../common.js');
 const http = require('http');
 
 const bench = common.createBenchmark(main, {
-  connections: [50], // Concurrent connections
-  headers: [20], // Number of header lines to append after the common headers
-  w: [0, 6], // Amount of trailing whitespace
-  duration: 5
+  c: [50],     // Concurrent connections
+  n: [20],     // Number of header lines to append after the common headers
+  w: [0, 6],   // Amount of trailing whitespace
 });
 
-function main({ connections, headers, w, duration }) {
+function main({ c, n, w }) {
   const server = http.createServer((req, res) => {
     res.end();
   });
@@ -22,7 +21,7 @@ function main({ connections, headers, w, duration }) {
       'Date': new Date().toString(),
       'Cache-Control': 'no-cache'
     };
-    for (let i = 0; i < headers; i++) {
+    for (let i = 0; i < n; i++) {
       // Note:
       // - autocannon does not send header values with OWS
       // - wrk can only send trailing OWS. This is a side-effect of wrk
@@ -32,9 +31,8 @@ function main({ connections, headers, w, duration }) {
     }
     bench.http({
       path: '/',
-      connections,
-      headers,
-      duration
+      connections: c,
+      headers
     }, () => {
       server.close();
     });

--- a/benchmark/http/set-header.js
+++ b/benchmark/http/set-header.js
@@ -3,8 +3,7 @@ const common = require('../common.js');
 const PORT = common.PORT;
 
 const bench = common.createBenchmark(main, {
-  res: ['normal', 'setHeader', 'setHeaderWH'],
-  duration: 5
+  res: ['normal', 'setHeader', 'setHeaderWH']
 });
 
 const type = 'bytes';
@@ -16,17 +15,16 @@ const c = 50;
 // normal: writeHead(status, {...})
 // setHeader: statusCode = status, setHeader(...) x2
 // setHeaderWH: setHeader(...), writeHead(status, ...)
-function main({ res, duration }) {
+function main({ res }) {
   process.env.PORT = PORT;
   const server = require('../fixtures/simple-http-server.js')
   .listen(PORT)
   .on('listening', () => {
-    const path = `/${type}/${len}/${chunks}/${res}/${chunkedEnc}`;
+    const path = `/${type}/${len}/${chunks}/normal/${chunkedEnc}`;
 
     bench.http({
       path: path,
-      connections: c,
-      duration
+      connections: c
     }, () => {
       server.close();
     });

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -7,20 +7,18 @@ const bench = common.createBenchmark(main, {
   len: [4, 1024, 102400],
   chunks: [1, 4],
   c: [50, 500],
-  chunkedEnc: [1, 0],
-  duration: 5
+  chunkedEnc: [1, 0]
 });
 
-function main({ type, len, chunks, c, chunkedEnc, duration }) {
+function main({ type, len, chunks, c, chunkedEnc, res }) {
   const server = require('../fixtures/simple-http-server.js')
   .listen(common.PORT)
   .on('listening', () => {
     const path = `/${type}/${len}/${chunks}/normal/${chunkedEnc}`;
 
     bench.http({
-      path,
-      connections: c,
-      duration
+      path: path,
+      connections: c
     }, () => {
       server.close();
     });

--- a/benchmark/http2/compat.js
+++ b/benchmark/http2/compat.js
@@ -9,11 +9,10 @@ const bench = common.createBenchmark(main, {
   requests: [100, 1000, 5000],
   streams: [1, 10, 20, 40, 100, 200],
   clients: [2],
-  benchmarker: ['test-double-http2'],
-  duration: 5
+  benchmarker: ['h2load']
 }, { flags: ['--no-warnings'] });
 
-function main({ requests, streams, clients, duration }) {
+function main({ requests, streams, clients }) {
   const http2 = require('http2');
   const server = http2.createServer();
   server.on('request', (req, res) => {
@@ -30,8 +29,7 @@ function main({ requests, streams, clients, duration }) {
       requests,
       maxConcurrentStreams: streams,
       clients,
-      threads: clients,
-      duration
+      threads: clients
     }, () => { server.close(); });
   });
 }

--- a/benchmark/http2/respond-with-fd.js
+++ b/benchmark/http2/respond-with-fd.js
@@ -10,11 +10,10 @@ const bench = common.createBenchmark(main, {
   requests: [100, 1000, 5000],
   streams: [1, 10, 20, 40, 100, 200],
   clients: [2],
-  benchmarker: ['test-double-http2'],
-  duration: 5
+  benchmarker: ['h2load']
 }, { flags: ['--no-warnings'] });
 
-function main({ requests, streams, clients, duration }) {
+function main({ requests, streams, clients }) {
   fs.open(file, 'r', (err, fd) => {
     if (err)
       throw err;
@@ -31,7 +30,6 @@ function main({ requests, streams, clients, duration }) {
         requests,
         maxConcurrentStreams: streams,
         clients,
-        duration,
         threads: clients
       }, () => server.close());
     });

--- a/benchmark/http2/simple.js
+++ b/benchmark/http2/simple.js
@@ -9,11 +9,10 @@ const bench = common.createBenchmark(main, {
   requests: [100, 1000, 5000],
   streams: [1, 10, 20, 40, 100, 200],
   clients: [2],
-  benchmarker: ['test-double-http2'],
-  duration: 5
+  benchmarker: ['h2load']
 }, { flags: ['--no-warnings'] });
 
-function main({ requests, streams, clients, duration }) {
+function main({ requests, streams, clients }) {
   const http2 = require('http2');
   const server = http2.createServer();
   server.on('stream', (stream) => {
@@ -28,7 +27,6 @@ function main({ requests, streams, clients, duration }) {
       requests,
       maxConcurrentStreams: streams,
       clients,
-      duration,
       threads: clients
     }, () => { server.close(); });
   });

--- a/benchmark/http2/write.js
+++ b/benchmark/http2/write.js
@@ -6,11 +6,10 @@ const bench = common.createBenchmark(main, {
   streams: [100, 200, 1000],
   length: [64 * 1024, 128 * 1024, 256 * 1024, 1024 * 1024],
   size: [100000],
-  benchmarker: ['test-double-http2'],
-  duration: 5
+  benchmarker: ['h2load']
 }, { flags: ['--no-warnings'] });
 
-function main({ streams, length, size, duration }) {
+function main({ streams, length, size }) {
   const http2 = require('http2');
   const server = http2.createServer();
   server.on('stream', (stream) => {
@@ -30,7 +29,6 @@ function main({ streams, length, size, duration }) {
     bench.http({
       path: '/',
       requests: 10000,
-      duration,
       maxConcurrentStreams: streams,
     }, () => { server.close(); });
   });

--- a/benchmark/misc/arguments.js
+++ b/benchmark/misc/arguments.js
@@ -34,6 +34,8 @@ function usingPredefined() {
 function main({ n, method, args }) {
   let fn;
   switch (method) {
+    // '' is a default case for tests
+    case '':
     case 'restAndSpread':
       fn = usingRestAndSpread;
       break;

--- a/benchmark/misc/getstringwidth.js
+++ b/benchmark/misc/getstringwidth.js
@@ -10,6 +10,8 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, type }) {
+  // Default value for testing purposes.
+  type = type || 'ascii';
   const { getStringWidth } = require('internal/util/inspect');
 
   const str = ({

--- a/benchmark/misc/object-property-bench.js
+++ b/benchmark/misc/object-property-bench.js
@@ -64,6 +64,8 @@ function runSymbol(n) {
 function main({ n, method }) {
 
   switch (method) {
+    // '' is a default case for tests
+    case '':
     case 'property':
       runProperty(n);
       break;

--- a/benchmark/misc/punycode.js
+++ b/benchmark/misc/punycode.js
@@ -62,6 +62,8 @@ function runICU(n, val) {
 
 function main({ n, val, method }) {
   switch (method) {
+    // '' is a default case for tests
+    case '':
     case 'punycode':
       runPunycode(n, val);
       break;

--- a/benchmark/misc/trace.js
+++ b/benchmark/misc/trace.js
@@ -6,11 +6,7 @@ const bench = common.createBenchmark(main, {
   n: [100000],
   method: ['trace', 'isTraceCategoryEnabled']
 }, {
-  flags: [
-    '--expose-internals',
-    '--no-warnings',
-    '--trace-event-categories', 'foo',
-  ]
+  flags: ['--expose-internals', '--trace-event-categories', 'foo']
 });
 
 const {

--- a/benchmark/misc/trace.js
+++ b/benchmark/misc/trace.js
@@ -41,6 +41,7 @@ function main({ n, method }) {
   } = common.binding('trace_events');
 
   switch (method) {
+    case '':
     case 'trace':
       doTrace(n, trace);
       break;

--- a/benchmark/misc/util-extend-vs-object-assign.js
+++ b/benchmark/misc/util-extend-vs-object-assign.js
@@ -9,6 +9,10 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, type }) {
+  // Default value for tests.
+  if (type === '')
+    type = 'extend';
+
   let fn;
   if (type === 'extend') {
     fn = util._extend;

--- a/benchmark/net/net-c2s.js
+++ b/benchmark/net/net-c2s.js
@@ -9,8 +9,6 @@ const bench = common.createBenchmark(main, {
   len: [64, 102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5],
-}, {
-  test: { len: 1024 }
 });
 
 var chunk;

--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -9,8 +9,6 @@ const bench = common.createBenchmark(main, {
   len: [2, 64, 102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5],
-}, {
-  test: { len: 1024 }
 });
 
 var chunk;

--- a/benchmark/net/net-s2c.js
+++ b/benchmark/net/net-s2c.js
@@ -10,8 +10,6 @@ const bench = common.createBenchmark(main, {
   recvbuflen: [0, 64 * 1024, 1024 * 1024],
   recvbufgenfn: ['true', 'false'],
   dur: [5]
-}, {
-  test: { sendchunklen: 256 }
 });
 
 var chunk;

--- a/benchmark/net/net-wrap-js-stream-passthrough.js
+++ b/benchmark/net/net-wrap-js-stream-passthrough.js
@@ -9,7 +9,6 @@ const bench = common.createBenchmark(main, {
   type: ['utf', 'asc', 'buf'],
   dur: [5],
 }, {
-  test: { len: 64 },
   flags: ['--expose-internals']
 });
 

--- a/benchmark/net/tcp-raw-c2s.js
+++ b/benchmark/net/tcp-raw-c2s.js
@@ -12,10 +12,7 @@ const bench = common.createBenchmark(main, {
   len: [102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5]
-}, {
-  test: { len: 1024 },
-  flags: [ '--expose-internals', '--no-warnings' ]
-});
+}, { flags: [ '--expose-internals', '--no-warnings' ] });
 
 function main({ dur, len, type }) {
   const {

--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -13,7 +13,6 @@ const bench = common.createBenchmark(main, {
   type: ['utf', 'asc', 'buf'],
   dur: [5]
 }, {
-  test: { len: 1024 },
   flags: [ '--expose-internals', '--no-warnings' ]
 });
 

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -13,7 +13,6 @@ const bench = common.createBenchmark(main, {
   type: ['utf', 'asc', 'buf'],
   dur: [5]
 }, {
-  test: { len: 1024 },
   flags: [ '--expose-internals', '--no-warnings' ]
 });
 

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fork = require('child_process').fork;
 const CLI = require('./_cli.js');
 
-const cli = new CLI(`usage: ./node run.js [options] [--] <category> ...
+const cli = CLI(`usage: ./node run.js [options] [--] <category> ...
   Run each benchmark in the <category> directory a single time, more than one
   <category> directory can be specified.
 
@@ -14,9 +14,6 @@ const cli = new CLI(`usage: ./node run.js [options] [--] <category> ...
                             repeated)
   --set    variable=value   set benchmark variable (can be repeated)
   --format [simple|csv]     optional value that specifies the output format
-  test                      only run a single configuration from the options
-                            matrix
-  all                       each benchmark category is run one after the other
 `, { arrayArgs: ['set', 'filter', 'exclude'] });
 const benchmarks = cli.benchmarks();
 
@@ -40,11 +37,7 @@ if (format === 'csv') {
 
 (function recursive(i) {
   const filename = benchmarks[i];
-  const child = fork(
-    path.resolve(__dirname, filename),
-    cli.test ? ['--test'] : [],
-    cli.optional.set
-  );
+  const child = fork(path.resolve(__dirname, filename), cli.optional.set);
 
   if (format !== 'csv') {
     console.log();
@@ -58,10 +51,10 @@ if (format === 'csv') {
     // Construct configuration string, " A=a, B=b, ..."
     let conf = '';
     for (const key of Object.keys(data.conf)) {
-      if (conf !== '')
-        conf += ' ';
       conf += ` ${key}=${JSON.stringify(data.conf[key])}`;
     }
+    // Delete first space of the configuration
+    conf = conf.slice(1);
     if (format === 'csv') {
       // Escape quotes (") for correct csv formatting
       conf = conf.replace(/"/g, '""');

--- a/benchmark/scatter.js
+++ b/benchmark/scatter.js
@@ -7,7 +7,7 @@ const CLI = require('./_cli.js');
 //
 // Parse arguments
 //
-const cli = new CLI(`usage: ./node scatter.js [options] [--] <filename>
+const cli = CLI(`usage: ./node scatter.js [options] [--] <filename>
   Run the benchmark script <filename> many times and output the rate (ops/s)
   together with the benchmark variables as a csv.
 

--- a/benchmark/tls/secure-pair.js
+++ b/benchmark/tls/secure-pair.js
@@ -4,8 +4,6 @@ const bench = common.createBenchmark(main, {
   dur: [5],
   securing: ['SecurePair', 'TLSSocket', 'clear'],
   size: [2, 100, 1024, 1024 * 1024]
-}, {
-  flags: ['--no-warnings']
 });
 
 const fixtures = require('../../test/common/fixtures');

--- a/benchmark/url/url-format.js
+++ b/benchmark/url/url-format.js
@@ -13,7 +13,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ type, n }) {
-  const input = inputs[type];
+  const input = inputs[type] || '';
 
   // Force-optimize url.format() so that the benchmark doesn't get
   // disrupted by the optimizer kicking in halfway through.

--- a/benchmark/url/url-parse.js
+++ b/benchmark/url/url-parse.js
@@ -13,7 +13,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ type, n }) {
-  const input = inputs[type];
+  const input = inputs[type] || '';
 
   bench.start();
   for (let i = 0; i < n; i += 1)

--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -23,7 +23,8 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, type }) {
-  const [first, second] = inputs[type];
+  // For testing, if supplied with an empty type, default to string.
+  const [first, second] = inputs[type || 'string'];
 
   bench.start();
   for (let i = 0; i < n; i++) {

--- a/benchmark/util/inspect-array.js
+++ b/benchmark/util/inspect-array.js
@@ -23,6 +23,8 @@ function main({ n, len, type }) {
       opts = { showHidden: true };
       arr = arr.fill('denseArray');
       break;
+      // For testing, if supplied with an empty type, default to denseArray.
+    case '':
     case 'denseArray':
       arr = arr.fill('denseArray');
       break;

--- a/benchmark/util/type-check.js
+++ b/benchmark/util/type-check.js
@@ -35,6 +35,9 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ type, argument, version, n }) {
+  // For testing, if supplied with an empty type, default to ArrayBufferView.
+  type = type || 'ArrayBufferView';
+
   const util = common.binding('util');
   const types = require('internal/util/types');
 

--- a/benchmark/util/type-check.js
+++ b/benchmark/util/type-check.js
@@ -31,7 +31,7 @@ const bench = common.createBenchmark(main, {
   argument: ['true', 'false-primitive', 'false-object'],
   n: [1e5]
 }, {
-  flags: ['--expose-internals', '--no-warnings']
+  flags: ['--expose-internals']
 });
 
 function main({ type, argument, version, n }) {

--- a/benchmark/writing-and-running-benchmarks.md
+++ b/benchmark/writing-and-running-benchmarks.md
@@ -519,8 +519,7 @@ const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
   kb: [64, 128, 256, 1024],
-  connections: [100, 500],
-  duration: 5
+  connections: [100, 500]
 });
 
 function main(conf) {
@@ -547,8 +546,8 @@ Supported options keys are:
 * `path` - defaults to `/`
 * `connections` - number of concurrent connections to use, defaults to 100
 * `duration` - duration of the benchmark in seconds, defaults to 10
-* `benchmarker` - benchmarker to use, defaults to the first available http
-  benchmarker
+* `benchmarker` - benchmarker to use, defaults to
+`common.default_http_benchmarker`
 
 [autocannon]: https://github.com/mcollina/autocannon
 [wrk]: https://github.com/wg/wrk

--- a/benchmark/zlib/pipe.js
+++ b/benchmark/zlib/pipe.js
@@ -8,11 +8,6 @@ const bench = common.createBenchmark(main, {
   duration: [5],
   type: ['string', 'buffer'],
   algorithm: ['gzip', 'brotli']
-}, {
-  test: {
-    inputLen: 1024,
-    duration: 0.2
-  }
 });
 
 function main({ inputLen, duration, type, algorithm }) {

--- a/test/benchmark/test-benchmark-assert.js
+++ b/test/benchmark/test-benchmark-assert.js
@@ -7,4 +7,15 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('assert');
+runBenchmark(
+  'assert',
+  [
+    'strict=1',
+    'len=1',
+    'method=',
+    'n=1',
+    'primitive=null',
+    'size=1',
+    'type=Int8Array'
+  ]
+);

--- a/test/benchmark/test-benchmark-async-hooks.js
+++ b/test/benchmark/test-benchmark-async-hooks.js
@@ -10,4 +10,11 @@ if (!common.enoughTestMem)
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('async_hooks');
+runBenchmark('async_hooks',
+             [
+               'asyncHooks=all',
+               'connections=50',
+               'method=trackingDisabled',
+               'n=10'
+             ],
+             {});

--- a/test/benchmark/test-benchmark-buffer.js
+++ b/test/benchmark/test-benchmark-buffer.js
@@ -4,4 +4,30 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('buffers', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('buffers',
+             [
+               'aligned=true',
+               'args=1',
+               'buffer=fast',
+               'bytes=0',
+               'byteLength=1',
+               'charsPerLine=6',
+               'difflen=false',
+               'encoding=utf8',
+               'endian=BE',
+               'extraSize=1',
+               'len=256',
+               'linesCount=1',
+               'method=',
+               'n=1',
+               'partial=true',
+               'pieces=1',
+               'pieceSize=1',
+               'search=@',
+               'size=1',
+               'source=array',
+               'type=',
+               'value=0',
+               'withTotalLength=0'
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-child-process.js
+++ b/test/benchmark/test-benchmark-child-process.js
@@ -4,4 +4,12 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('child_process', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('child_process',
+             [
+               'dur=0',
+               'n=1',
+               'len=1',
+               'params=1',
+               'methodName=execSync',
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-cluster.js
+++ b/test/benchmark/test-benchmark-cluster.js
@@ -4,4 +4,9 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('cluster');
+runBenchmark('cluster', [
+  'n=1',
+  'payload=string',
+  'sendsPerBroadcast=1',
+  'serialization=json',
+]);

--- a/test/benchmark/test-benchmark-crypto.js
+++ b/test/benchmark/test-benchmark-crypto.js
@@ -10,4 +10,18 @@ if (common.hasFipsCrypto)
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('crypto', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('crypto',
+             [
+               'algo=sha256',
+               'api=stream',
+               'cipher=',
+               'keylen=1024',
+               'len=1',
+               'n=1',
+               'out=buffer',
+               'size=1',
+               'type=buf',
+               'v=crypto',
+               'writes=1',
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-dgram.js
+++ b/test/benchmark/test-benchmark-dgram.js
@@ -4,7 +4,14 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-// Dgram benchmarks use hardcoded ports. Thus, this test can not be run in
-// parallel with tests that choose random ports.
+// Because the dgram benchmarks use hardcoded ports, this should be in
+// sequential rather than parallel to make sure it does not conflict with
+// tests that choose random available ports.
 
-runBenchmark('dgram');
+runBenchmark('dgram', ['address=true',
+                       'chunks=2',
+                       'dur=0.1',
+                       'len=1',
+                       'n=1',
+                       'num=1',
+                       'type=send']);

--- a/test/benchmark/test-benchmark-dns.js
+++ b/test/benchmark/test-benchmark-dns.js
@@ -4,4 +4,6 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('dns', { ...process.env, NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+const env = { ...process.env, NODEJS_BENCHMARK_ZERO_ALLOWED: 1 };
+
+runBenchmark('dns', ['n=1', 'all=false', 'name=127.0.0.1'], env);

--- a/test/benchmark/test-benchmark-domain.js
+++ b/test/benchmark/test-benchmark-domain.js
@@ -4,4 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('domain');
+runBenchmark('domain', ['n=1', 'args=0']);

--- a/test/benchmark/test-benchmark-es.js
+++ b/test/benchmark/test-benchmark-es.js
@@ -4,4 +4,15 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('es', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('es',
+             [
+               'method=',
+               'count=1',
+               'context=null',
+               'rest=0',
+               'mode=',
+               'n=1',
+               'encoding=ascii',
+               'size=1e1'
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-events.js
+++ b/test/benchmark/test-benchmark-events.js
@@ -4,4 +4,6 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('events', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('events',
+             ['argc=0', 'listeners=1', 'n=1'],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-fs.js
+++ b/test/benchmark/test-benchmark-fs.js
@@ -6,4 +6,19 @@ const runBenchmark = require('../common/benchmark');
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-runBenchmark('fs', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('fs', [
+  'bufferSize=32',
+  'concurrent=1',
+  'dir=.github',
+  'dur=0.1',
+  'encodingType=buf',
+  'filesize=1024',
+  'len=1024',
+  'mode=callback',
+  'n=1',
+  'pathType=relative',
+  'size=1',
+  'statSyncType=fstatSync',
+  'statType=fstat',
+  'withFileTypes=false',
+], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-http.js
+++ b/test/benchmark/test-benchmark-http.js
@@ -11,4 +11,27 @@ if (!common.enoughTestMem)
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('http', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('http',
+             [
+               'benchmarker=test-double-http',
+               'arg=string',
+               'c=1',
+               'chunkedEnc=true',
+               'chunks=0',
+               'dur=0.1',
+               'e=0',
+               'input=keep-alive',
+               'key=""',
+               'len=1',
+               'method=write',
+               'n=1',
+               'res=normal',
+               'type=asc',
+               'url=long',
+               'value=X-Powered-By',
+               'w=0',
+             ],
+             {
+               NODEJS_BENCHMARK_ZERO_ALLOWED: 1,
+               duration: 0
+             });

--- a/test/benchmark/test-benchmark-http2.js
+++ b/test/benchmark/test-benchmark-http2.js
@@ -13,4 +13,17 @@ if (!common.enoughTestMem)
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('http2', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('http2',
+             [
+               'benchmarker=test-double-http2',
+               'clients=1',
+               'length=65536',
+               'n=1',
+               'nheaders=0',
+               'requests=1',
+               'streams=1'
+             ],
+             {
+               NODEJS_BENCHMARK_ZERO_ALLOWED: 1,
+               duration: 0
+             });

--- a/test/benchmark/test-benchmark-misc.js
+++ b/test/benchmark/test-benchmark-misc.js
@@ -4,4 +4,14 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('misc', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('misc', [
+  'concat=0',
+  'dur=0.1',
+  'method=',
+  'n=1',
+  'type=',
+  'code=1',
+  'val=magyarország.icom.museum',
+  'script=test/fixtures/semicolon',
+  'mode=worker'
+], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-module.js
+++ b/test/benchmark/test-benchmark-module.js
@@ -4,4 +4,12 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('module');
+runBenchmark('module', [
+  'cache=true',
+  'dir=rel',
+  'ext=',
+  'fullPath=true',
+  'n=1',
+  'name=/',
+  'useCache=true',
+]);

--- a/test/benchmark/test-benchmark-napi.js
+++ b/test/benchmark/test-benchmark-napi.js
@@ -15,4 +15,10 @@ if (process.features.debug) {
 }
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('napi', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('napi',
+             [
+               'n=1',
+               'engine=v8',
+               'type=String'
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-net.js
+++ b/test/benchmark/test-benchmark-net.js
@@ -8,4 +8,13 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('net', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('net',
+             [
+               'dur=0',
+               'len=1024',
+               'recvbufgenfn=false',
+               'recvbuflen=0',
+               'sendchunklen=256',
+               'type=buf'
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-os.js
+++ b/test/benchmark/test-benchmark-os.js
@@ -4,4 +4,4 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('os');
+runBenchmark('os', ['n=1']);

--- a/test/benchmark/test-benchmark-path.js
+++ b/test/benchmark/test-benchmark-path.js
@@ -4,4 +4,11 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('path', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('path',
+             [
+               'n=1',
+               'path=',
+               'pathext=',
+               'paths=',
+               'props='
+             ], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-process.js
+++ b/test/benchmark/test-benchmark-process.js
@@ -4,4 +4,9 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('process', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('process',
+             [
+               'n=1',
+               'type=raw',
+               'operation=enumerate',
+             ], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-querystring.js
+++ b/test/benchmark/test-benchmark-querystring.js
@@ -4,4 +4,9 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('querystring', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('querystring',
+             [ 'n=1',
+               'input="there is nothing to unescape here"',
+               'type=noencode'
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-streams.js
+++ b/test/benchmark/test-benchmark-streams.js
@@ -4,4 +4,13 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('streams', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('streams',
+             [
+               'kind=duplex',
+               'n=1',
+               'sync=no',
+               'writev=no',
+               'callback=no',
+               'type=buffer',
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-string_decoder.js
+++ b/test/benchmark/test-benchmark-string_decoder.js
@@ -4,4 +4,7 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('string_decoder');
+runBenchmark('string_decoder', ['chunkLen=16',
+                                'encoding=utf8',
+                                'inLen=32',
+                                'n=1']);

--- a/test/benchmark/test-benchmark-timers.js
+++ b/test/benchmark/test-benchmark-timers.js
@@ -4,4 +4,10 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('timers', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('timers',
+             [
+               'direction=start',
+               'n=1',
+               'type=depth',
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-tls.js
+++ b/test/benchmark/test-benchmark-tls.js
@@ -14,4 +14,16 @@ if (!common.enoughTestMem)
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('tls', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('tls',
+             [
+               'concurrency=1',
+               'dur=0.1',
+               'n=1',
+               'size=2',
+               'securing=SecurePair',
+               'type=asc'
+             ],
+             {
+               NODEJS_BENCHMARK_ZERO_ALLOWED: 1,
+               duration: 0
+             });

--- a/test/benchmark/test-benchmark-url.js
+++ b/test/benchmark/test-benchmark-url.js
@@ -4,4 +4,22 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('url', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('url',
+             [
+               'method=legacy',
+               'e=0',
+               'loopMethod=forEach',
+               'accessMethod=get',
+               'type=short',
+               'searchParam=noencode',
+               'href=short',
+               'input=short',
+               'domain=empty',
+               'path=up',
+               'to=ascii',
+               'prop=href',
+               'n=1',
+               'param=one',
+               'withBase=false'
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-util.js
+++ b/test/benchmark/test-benchmark-util.js
@@ -4,4 +4,17 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('util', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('util',
+             ['argument=false',
+              'input=',
+              'method=Array',
+              'n=1',
+              'option=none',
+              'pos=start',
+              'size=1',
+              'type=',
+              'len=1',
+              'version=native',
+              'isProxy=1',
+              'showProxy=1'],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-v8.js
+++ b/test/benchmark/test-benchmark-v8.js
@@ -4,4 +4,9 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('v8', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('v8',
+             [
+               'method=getHeapStatistics',
+               'n=1'
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-vm.js
+++ b/test/benchmark/test-benchmark-vm.js
@@ -4,4 +4,10 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('vm', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('vm',
+             [
+               'breakOnSigint=0',
+               'withSigintListener=0',
+               'n=1'
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-worker.js
+++ b/test/benchmark/test-benchmark-worker.js
@@ -11,4 +11,13 @@ if (!common.enoughTestMem)
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('worker', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('worker',
+             [
+               'n=1',
+               'sendsPerBroadcast=1',
+               'workers=1',
+               'payload=string'
+             ],
+             {
+               NODEJS_BENCHMARK_ZERO_ALLOWED: 1
+             });

--- a/test/benchmark/test-benchmark-zlib.js
+++ b/test/benchmark/test-benchmark-zlib.js
@@ -4,4 +4,17 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('zlib', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('zlib',
+             [
+               'algorithm=brotli',
+               'chunkLen=1024',
+               'duration=0.001',
+               'inputLen=1024',
+               'method=',
+               'n=1',
+               'options=true',
+               'type=Deflate',
+             ],
+             {
+               'NODEJS_BENCHMARK_ZERO_ALLOWED': 1
+             });

--- a/test/common/benchmark.js
+++ b/test/common/benchmark.js
@@ -8,8 +8,13 @@ const path = require('path');
 
 const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
 
-function runBenchmark(name, env) {
-  const argv = ['test'];
+function runBenchmark(name, args, env) {
+  const argv = [];
+
+  for (let i = 0; i < args.length; i++) {
+    argv.push('--set');
+    argv.push(args[i]);
+  }
 
   argv.push(name);
 


### PR DESCRIPTION
This fixes running benchmark tests. Please :+1: this comment to approve fast-tracking.

Example failure:

```
=== release test-benchmark-async-hooks ===                   
Path: benchmark/test-benchmark-async-hooks
Error: wrk failed with 1. Output: Usage: wrk <options> <url>                            
  Options:                                            
    -c, --connections <N>  Connections to keep open   
    -d, --duration    <T>  Duration of test           
    -t, --threads     <N>  Number of threads to use   
                                                      
    -s, --script      <S>  Load Lua script file       
    -H, --header      <H>  Add header to request      
        --latency          Print latency statistics   
        --timeout     <T>  Socket/request timeout     
    -v, --version          Print version details      
                                                      
  Numeric arguments may include a SI unit (1k, 1M, 1G)
  Time arguments may include a time unit (2s, 2m, 2h)

    at ChildProcess.<anonymous> (/home/sqrt/src/node/master/benchmark/_http-benchmarkers.js:235:16)
    at Object.onceWrapper (events.js:428:26)
    at ChildProcess.emit (events.js:321:20)
    at maybeClose (internal/child_process.js:1051:16)
    at Socket.<anonymous> (internal/child_process.js:442:11)
    at Socket.emit (events.js:321:20)
    at Pipe.<anonymous> (net.js:673:12)
assert.js:102
  throw new AssertionError(obj);
  ^

AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

1 !== 0

    at ChildProcess.<anonymous> (/home/sqrt/src/node/master/test/common/benchmark.js:30:12)
    at ChildProcess.emit (events.js:321:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:276:12) {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: 1,
  expected: 0,
  operator: 'strictEqual'
}
Command: out/Release/node /home/sqrt/src/node/master/test/benchmark/test-benchmark-async-hooks.js
[00:00|% 100|+   0|-   1]: Done                              
```

(This is back to working after the revert.)

Refs: https://github.com/nodejs/node/pull/31396

Fyi @bridgear

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
