### PR TITLE
test: improve test-fs-stat-bigint

### DIFF
--- a/test/parallel/test-fs-stat-bigint.js
+++ b/test/parallel/test-fs-stat-bigint.js
@@ -13,25 +13,23 @@ tmpdir.refresh();
 
 let testIndex = 0;
 
-// It's possible that the file stats are updated between the two statSync()
-// calls so allow for a small difference.
-const allowableDelta = 5;
-
 function getFilename() {
   const filename = path.join(tmpdir.path, `test-file-${++testIndex}`);
   fs.writeFileSync(filename, 'test');
   return filename;
 }
 
-function verifyStats(bigintStats, numStats) {
+function verifyStats(bigintStats, numStats, allowableDelta) {
+  // allowableDelta: It's possible that the file stats are updated between the
+  // two stat() calls so allow for a small difference.
   for (const key of Object.keys(numStats)) {
     const val = numStats[key];
     if (isDate(val)) {
       const time = val.getTime();
       const time2 = bigintStats[key].getTime();
       assert(
-        Math.abs(time - time2) < allowableDelta,
-        `difference of ${key}.getTime() should < ${allowableDelta}.\n` +
+        time - time2 <= allowableDelta,
+        `difference of ${key}.getTime() should <= ${allowableDelta}.\n` +
         `Number version ${time}, BigInt version ${time2}n`);
     } else if (key === 'mode') {
       assert.strictEqual(bigintStats[key], BigInt(val));
@@ -71,15 +69,16 @@ function verifyStats(bigintStats, numStats) {
       const msFromNum = numStats[key];
 
       assert(
-        Math.abs(msFromNum - Number(msFromBigInt)) < allowableDelta,
+        msFromNum - Number(msFromBigInt) <= allowableDelta,
         `Number version ${key} = ${msFromNum}, ` +
-        `BigInt version ${key} = ${msFromBigInt}n`);
+        `BigInt version ${key} = ${msFromBigInt}n, ` +
+        `Allowable delta = ${allowableDelta}`);
 
       assert(
-        Math.abs(msFromNum - Number(msFromBigIntNs)) < allowableDelta,
+        msFromNum - Number(msFromBigIntNs) <= allowableDelta,
         `Number version ${key} = ${msFromNum}, ` +
         `BigInt version ${nsKey} = ${nsFromBigInt}n` +
-        ` = ${msFromBigIntNs}ms`);
+        ` = ${msFromBigIntNs}ms, Allowable delta = ${allowableDelta}`);
     } else if (Number.isSafeInteger(val)) {
       assert.strictEqual(
         bigintStats[key], BigInt(val),
@@ -88,92 +87,102 @@ function verifyStats(bigintStats, numStats) {
       );
     } else {
       assert(
-        Math.abs(Number(bigintStats[key]) - val) < 1,
+        Number(bigintStats[key]) - val < 1,
         `${key} is not a safe integer, difference should < 1.\n` +
         `Number version ${val}, BigInt version ${bigintStats[key]}n`);
     }
   }
 }
 
+const runSyncTest = (func, arg) => {
+  const startTime = process.hrtime.bigint();
+  const bigintStats = func(arg, { bigint: true });
+  const numStats = func(arg);
+  const endTime = process.hrtime.bigint();
+  const allowableDelta = Math.ceil(Number(endTime - startTime) / 1e6);
+  verifyStats(bigintStats, numStats, allowableDelta);
+};
+
 {
   const filename = getFilename();
-  const bigintStats = fs.statSync(filename, { bigint: true });
-  const numStats = fs.statSync(filename);
-  verifyStats(bigintStats, numStats);
+  runSyncTest(fs.statSync, filename);
 }
 
 if (!common.isWindows) {
   const filename = getFilename();
   const link = `${filename}-link`;
   fs.symlinkSync(filename, link);
-  const bigintStats = fs.lstatSync(link, { bigint: true });
-  const numStats = fs.lstatSync(link);
-  verifyStats(bigintStats, numStats);
+  runSyncTest(fs.lstatSync, link);
 }
 
 {
   const filename = getFilename();
   const fd = fs.openSync(filename, 'r');
-  const bigintStats = fs.fstatSync(fd, { bigint: true });
-  const numStats = fs.fstatSync(fd);
-  verifyStats(bigintStats, numStats);
+  runSyncTest(fs.fstatSync, fd);
   fs.closeSync(fd);
 }
 
+const runCallbackTest = (func, arg, done) => {
+  const startTime = process.hrtime.bigint();
+  func(arg, { bigint: true }, common.mustCall((err, bigintStats) => {
+    func(arg, common.mustCall((err, numStats) => {
+      const endTime = process.hrtime.bigint();
+      const allowableDelta = Math.ceil(Number(endTime - startTime) / 1e6);
+      verifyStats(bigintStats, numStats, allowableDelta);
+      if (done) {
+        done();
+      }
+    }));
+  }));
+};
+
 {
   const filename = getFilename();
-  fs.stat(filename, { bigint: true }, (err, bigintStats) => {
-    fs.stat(filename, (err, numStats) => {
-      verifyStats(bigintStats, numStats);
-    });
-  });
+  runCallbackTest(fs.stat, filename);
 }
 
 if (!common.isWindows) {
   const filename = getFilename();
   const link = `${filename}-link`;
   fs.symlinkSync(filename, link);
-  fs.lstat(link, { bigint: true }, (err, bigintStats) => {
-    fs.lstat(link, (err, numStats) => {
-      verifyStats(bigintStats, numStats);
-    });
-  });
+  runCallbackTest(fs.lstat, link);
 }
 
 {
   const filename = getFilename();
   const fd = fs.openSync(filename, 'r');
-  fs.fstat(fd, { bigint: true }, (err, bigintStats) => {
-    fs.fstat(fd, (err, numStats) => {
-      verifyStats(bigintStats, numStats);
-      fs.closeSync(fd);
-    });
-  });
+  runCallbackTest(fs.fstat, fd, () => { fs.closeSync(fd); });
 }
 
-(async function() {
+const runPromiseTest = async (func, arg) => {
+  const startTime = process.hrtime.bigint();
+  const bigintStats = await func(arg, { bigint: true });
+  const numStats = await func(arg);
+  const endTime = process.hrtime.bigint();
+  const allowableDelta = Math.ceil(Number(endTime - startTime) / 1e6);
+  verifyStats(bigintStats, numStats, allowableDelta);
+};
+
+{
   const filename = getFilename();
-  const bigintStats = await promiseFs.stat(filename, { bigint: true });
-  const numStats = await promiseFs.stat(filename);
-  verifyStats(bigintStats, numStats);
-})();
+  runPromiseTest(promiseFs.stat, filename);
+}
 
 if (!common.isWindows) {
-  (async function() {
-    const filename = getFilename();
-    const link = `${filename}-link`;
-    fs.symlinkSync(filename, link);
-    const bigintStats = await promiseFs.lstat(link, { bigint: true });
-    const numStats = await promiseFs.lstat(link);
-    verifyStats(bigintStats, numStats);
-  })();
+  const filename = getFilename();
+  const link = `${filename}-link`;
+  fs.symlinkSync(filename, link);
+  runPromiseTest(promiseFs.lstat, link);
 }
 
 (async function() {
   const filename = getFilename();
   const handle = await promiseFs.open(filename, 'r');
+  const startTime = process.hrtime.bigint();
   const bigintStats = await handle.stat({ bigint: true });
   const numStats = await handle.stat();
-  verifyStats(bigintStats, numStats);
+  const endTime = process.hrtime.bigint();
+  const allowableDelta = Math.ceil(Number(endTime - startTime) / 1e6);
+  verifyStats(bigintStats, numStats, allowableDelta);
   await handle.close();
 })();


### PR DESCRIPTION
Remove magic number and measure amount of difference should be allowable
between consecutive stat() calls.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
