### PR TITLE
fs: validate the input data before opening file

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -141,10 +141,6 @@ function validateFileHandle(handle) {
 }
 
 async function writeFileHandle(filehandle, data, options) {
-  if (!isArrayBufferView(data)) {
-    validateStringAfterArrayBufferView(data, 'data');
-    data = Buffer.from(data, options.encoding || 'utf8');
-  }
   let remaining = data.length;
   if (remaining === 0) return;
   do {
@@ -495,6 +491,11 @@ async function mkdtemp(prefix, options) {
 async function writeFile(path, data, options) {
   options = getOptions(options, { encoding: 'utf8', mode: 0o666, flag: 'w' });
   const flag = options.flag || 'w';
+
+  if (!isArrayBufferView(data)) {
+    validateStringAfterArrayBufferView(data, 'data');
+    data = Buffer.from(data, options.encoding || 'utf8');
+  }
 
   if (path instanceof FileHandle)
     return writeFileHandle(path, data, options);

--- a/test/parallel/test-fs-append-file.js
+++ b/test/parallel/test-fs-append-file.js
@@ -130,7 +130,7 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
 }
 
 // Test that appendFile does not accept invalid data type (callback API).
-[false, 5, {}, [], null, undefined].forEach((data) => {
+[false, 5, {}, [], null, undefined].forEach(async (data) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     message: /"data"|"buffer"/
@@ -147,15 +147,17 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
     errObj
   );
 
-  assert.rejects(
-    fs.promises.appendFile(filename, data).finally(() => {
-      // The filename shouldn't exist if throwing error.
-      assert.throws(() => fs.statSync(filename), {
-        code: 'ENOENT',
-        message: /no such file or directory/
-      });
-    }),
+  await assert.rejects(
+    fs.promises.appendFile(filename, data),
     errObj
+  );
+  // The filename shouldn't exist if throwing error.
+  assert.throws(
+    () => fs.statSync(filename),
+    {
+      code: 'ENOENT',
+      message: /no such file or directory/
+    }
   );
 });
 

--- a/test/parallel/test-fs-append-file.js
+++ b/test/parallel/test-fs-append-file.js
@@ -129,18 +129,34 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
     .catch(throwNextTick);
 }
 
-// Test that appendFile does not accept numbers (callback API).
+// Test that appendFile does not accept invalid data type (callback API).
 [false, 5, {}, [], null, undefined].forEach((data) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     message: /"data"|"buffer"/
   };
+  const filename = join(tmpdir.path, 'append-invalid-data.txt');
+
   assert.throws(
-    () => fs.appendFile('foobar', data, common.mustNotCall()),
+    () => fs.appendFile(filename, data, common.mustNotCall()),
     errObj
   );
-  assert.throws(() => fs.appendFileSync('foobar', data), errObj);
-  assert.rejects(fs.promises.appendFile('foobar', data), errObj);
+
+  assert.throws(
+    () => fs.appendFileSync(filename, data),
+    errObj
+  );
+
+  assert.rejects(
+    fs.promises.appendFile(filename, data).finally(() => {
+      // The filename shouldn't exist if throwing error.
+      assert.throws(() => fs.statSync(filename), {
+        code: 'ENOENT',
+        message: /no such file or directory/
+      });
+    }),
+    errObj
+  );
 });
 
 // Test that appendFile accepts file descriptors (callback API).


### PR DESCRIPTION
Now running `python tools/test.py test/parallel/test-fs-append-file` in our master branch, there was a file called `foobar` generated, which was caused by this line:

https://github.com/nodejs/node/blob/fb437c49cf52a1519f5f079afce6214bae61dacb/test/parallel/test-fs-append-file.js#L143

This was because firstly we opened `foobar` file and then validating the input data in our `fs.promise` module.

So I think the more reasonable method is validating the input data first and then opening the file, to be consistent with `fs` module.

Refs: https://github.com/nodejs/node/pull/31030

/cc @BridgeAR 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
