### PR TITLE
vm: lazily initialize primordials for vm contexts

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -405,9 +405,9 @@ MaybeLocal<Object> GetPerContextExports(Local<Context> context) {
     return handle_scope.Escape(existing_value.As<Object>());
 
   Local<Object> exports = Object::New(isolate);
-  if (context->Global()->SetPrivate(context, key, exports).IsNothing())
+  if (context->Global()->SetPrivate(context, key, exports).IsNothing() ||
+      !InitializePrimordials(context))
     return MaybeLocal<Object>();
-  InitializePrimordials(context);
   return handle_scope.Escape(exports);
 }
 

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -407,6 +407,7 @@ MaybeLocal<Object> GetPerContextExports(Local<Context> context) {
   Local<Object> exports = Object::New(isolate);
   if (context->Global()->SetPrivate(context, key, exports).IsNothing())
     return MaybeLocal<Object>();
+  InitializePrimordials(context);
   return handle_scope.Escape(exports);
 }
 
@@ -461,49 +462,50 @@ bool InitializeContextForSnapshot(Local<Context> context) {
 
   context->SetEmbedderData(ContextEmbedderIndex::kAllowWasmCodeGeneration,
                            True(isolate));
+  return InitializePrimordials(context);
+}
 
-  {
-    // Run per-context JS files.
-    Context::Scope context_scope(context);
-    Local<Object> exports;
+bool InitializePrimordials(Local<Context> context) {
+  // Run per-context JS files.
+  Isolate* isolate = context->GetIsolate();
+  Context::Scope context_scope(context);
+  Local<Object> exports;
 
-    Local<String> primordials_string =
-        FIXED_ONE_BYTE_STRING(isolate, "primordials");
-    Local<String> global_string = FIXED_ONE_BYTE_STRING(isolate, "global");
-    Local<String> exports_string = FIXED_ONE_BYTE_STRING(isolate, "exports");
+  Local<String> primordials_string =
+      FIXED_ONE_BYTE_STRING(isolate, "primordials");
+  Local<String> global_string = FIXED_ONE_BYTE_STRING(isolate, "global");
+  Local<String> exports_string = FIXED_ONE_BYTE_STRING(isolate, "exports");
 
-    // Create primordials first and make it available to per-context scripts.
-    Local<Object> primordials = Object::New(isolate);
-    if (!primordials->SetPrototype(context, Null(isolate)).FromJust() ||
-        !GetPerContextExports(context).ToLocal(&exports) ||
-        !exports->Set(context, primordials_string, primordials).FromJust()) {
+  // Create primordials first and make it available to per-context scripts.
+  Local<Object> primordials = Object::New(isolate);
+  if (!primordials->SetPrototype(context, Null(isolate)).FromJust() ||
+      !GetPerContextExports(context).ToLocal(&exports) ||
+      !exports->Set(context, primordials_string, primordials).FromJust()) {
+    return false;
+  }
+
+  static const char* context_files[] = {"internal/per_context/primordials",
+                                        "internal/per_context/domexception",
+                                        "internal/per_context/messageport",
+                                        nullptr};
+
+  for (const char** module = context_files; *module != nullptr; module++) {
+    std::vector<Local<String>> parameters = {
+        global_string, exports_string, primordials_string};
+    Local<Value> arguments[] = {context->Global(), exports, primordials};
+    MaybeLocal<Function> maybe_fn =
+        native_module::NativeModuleEnv::LookupAndCompile(
+            context, *module, &parameters, nullptr);
+    if (maybe_fn.IsEmpty()) {
       return false;
     }
-
-    static const char* context_files[] = {"internal/per_context/primordials",
-                                          "internal/per_context/domexception",
-                                          "internal/per_context/messageport",
-                                          nullptr};
-
-    for (const char** module = context_files; *module != nullptr; module++) {
-      std::vector<Local<String>> parameters = {
-          global_string, exports_string, primordials_string};
-      Local<Value> arguments[] = {context->Global(), exports, primordials};
-      MaybeLocal<Function> maybe_fn =
-          native_module::NativeModuleEnv::LookupAndCompile(
-              context, *module, &parameters, nullptr);
-      if (maybe_fn.IsEmpty()) {
-        return false;
-      }
-      Local<Function> fn = maybe_fn.ToLocalChecked();
-      MaybeLocal<Value> result =
-          fn->Call(context, Undefined(isolate),
-                   arraysize(arguments), arguments);
-      // Execution failed during context creation.
-      // TODO(joyeecheung): deprecate this signature and return a MaybeLocal.
-      if (result.IsEmpty()) {
-        return false;
-      }
+    Local<Function> fn = maybe_fn.ToLocalChecked();
+    MaybeLocal<Value> result =
+        fn->Call(context, Undefined(isolate), arraysize(arguments), arguments);
+    // Execution failed during context creation.
+    // TODO(joyeecheung): deprecate this signature and return a MaybeLocal.
+    if (result.IsEmpty()) {
+      return false;
     }
   }
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -185,8 +185,11 @@ MaybeLocal<Context> ContextifyContext::CreateV8Context(
 
   object_template->SetHandler(config);
   object_template->SetHandler(indexed_config);
-
-  Local<Context> ctx = NewContext(env->isolate(), object_template);
+  Local<Context> ctx = Context::New(env->isolate(), nullptr, object_template);
+  if (ctx.IsEmpty()) return MaybeLocal<Context>();
+  // Only partially initialize the context - the primordials are left out
+  // and only initialized when necessary.
+  InitializeContextRuntime(ctx);
 
   if (ctx.IsEmpty()) {
     return MaybeLocal<Context>();

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -99,6 +99,7 @@ std::string GetProcessTitle(const char* default_title);
 std::string GetHumanReadableProcessName();
 
 void InitializeContextRuntime(v8::Local<v8::Context>);
+bool InitializePrimordials(v8::Local<v8::Context> context);
 
 namespace task_queue {
 void PromiseRejectCallback(v8::PromiseRejectMessage message);


### PR DESCRIPTION
Lazily initialize primordials when cross-context support for
builtins is needed to fix the performance regression in context
creation.

Fixes: https://github.com/nodejs/node/issues/29842

local benchmark results

```
                            confidence improvement accuracy (*)    (**)   (***)
 vm/create-context.js n=100        ***    485.26 %      ±15.48% ±21.32% ±29.29%
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
