### PR TITLE
crypto: fixes performance regression

### DIFF
--- a/lib/internal/streams/lazy_transform.js
+++ b/lib/internal/streams/lazy_transform.js
@@ -19,8 +19,6 @@ module.exports = LazyTransform;
 
 function LazyTransform(options) {
   this._options = options;
-  this.writable = true;
-  this.readable = true;
 }
 ObjectSetPrototypeOf(LazyTransform.prototype, stream.Transform.prototype);
 ObjectSetPrototypeOf(LazyTransform, stream.Transform);


### PR DESCRIPTION
https://github.com/nodejs/node/commit/e559842188f541b884abff2ffad4d2d3e1b841a6
made writable/readable computed with a legacy mode if the properties
are written to.

LazyTransform still unecessarily wrote to these properties causing a performance
regression.

Fixes: https://github.com/nodejs/node/issues/31739

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
