### PR TITLE
util: add coverage for util.inspect.colors alias setter

### DIFF
--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2724,10 +2724,12 @@ assert.strictEqual(
   );
 }
 
-// Test changing util.inspect.colors colors and aliases. Since this might have
-// side effects, we do it last.
+// Test changing util.inspect.colors colors and aliases.
 {
   const colors = util.inspect.colors;
+
+  const originalValue = colors.gray;
+
   // "grey" is reference-equal alias of "gray".
   assert.strictEqual(colors.grey, colors.gray);
 
@@ -2739,5 +2741,10 @@ assert.strictEqual(
 
   colors.grey = [1, 1];
   assert.deepStrictEqual(colors.grey, [1, 1]);
+  assert.strictEqual(colors.grey, colors.gray);
+
+  // Restore original value to avoid side effects in other tests.
+  colors.gray = originalValue;
+  assert.deepStrictEqual(colors.gray, originalValue);
   assert.strictEqual(colors.grey, colors.gray);
 }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2723,3 +2723,21 @@ assert.strictEqual(
       '\x1B[2mdef: \x1B[33m5\x1B[39m\x1B[22m }'
   );
 }
+
+// Test changing util.inspect.colors colors and aliases. Since this might have
+// side effects, we do it last.
+{
+  const colors = util.inspect.colors;
+  // "grey" is reference-equal alias of "gray".
+  assert.strictEqual(colors.grey, colors.gray);
+
+  // Assigninging one should assign the other. This tests that the alias setter
+  // function keeps things reference-equal.
+  colors.gray = [0, 0];
+  assert.deepStrictEqual(colors.gray, [0, 0]);
+  assert.strictEqual(colors.grey, colors.gray);
+
+  colors.grey = [1, 1];
+  assert.deepStrictEqual(colors.grey, [1, 1]);
+  assert.strictEqual(colors.grey, colors.gray);
+}


### PR DESCRIPTION
Add test to confirm that the setter for aliases in `util.inspect.colors`
keeps the alias reference-equal to the target value.

Refs: https://coverage.nodejs.org/coverage-5b0308cd823a5110/lib/internal/util/inspect.js.html#L357
Refs: https://codecov.io/gh/nodejs/node/src/5b0308cd823a511098dadf9ddd5a35e3a9dbb424/lib/internal/util/inspect.js#L357

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
