### PR TITLE
doc: reword possessive form of Node.js in docs

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -23,7 +23,7 @@ Break on start in myscript.js:1
 debug>
 ```
 
-Node.js's debugger client is not a full-featured debugger, but simple step and
+The Node.js debugger client is not a full-featured debugger, but simple step and
 inspection are possible.
 
 Inserting the statement `debugger;` into the source code of a script will

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -25,7 +25,7 @@ HTTP message headers are represented by an object like this:
 
 Keys are lowercased. Values are not modified.
 
-In order to support the full spectrum of possible HTTP applications, Node.js's
+In order to support the full spectrum of possible HTTP applications, the Node.js
 HTTP API is very low-level. It deals with stream handling and message
 parsing only. It parses a message into headers and body but it does not
 parse the actual headers or the body.

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -833,7 +833,7 @@ added: v0.7.2
 
 * {number}
 
-The port used by Node.js's debugger when enabled.
+The port used by the Node.js debugger when enabled.
 
 ```js
 process.debugPort = 5858;
@@ -2486,11 +2486,11 @@ cases:
   handler.
 * `2`: Unused (reserved by Bash for builtin misuse)
 * `3` **Internal JavaScript Parse Error**: The JavaScript source code
-  internal in Node.js's bootstrapping process caused a parse error. This
+  internal in the Node.js bootstrapping process caused a parse error. This
   is extremely rare, and generally can only happen during development
   of Node.js itself.
 * `4` **Internal JavaScript Evaluation Failure**: The JavaScript
-  source code internal in Node.js's bootstrapping process failed to
+  source code internal in the Node.js bootstrapping process failed to
   return a function value when evaluated. This is extremely rare, and
   generally can only happen during development of Node.js itself.
 * `5` **Fatal Error**: There was a fatal unrecoverable error in V8.
@@ -2509,7 +2509,7 @@ cases:
 * `9` **Invalid Argument**: Either an unknown option was specified,
   or an option requiring a value was provided without a value.
 * `10` **Internal JavaScript Run-Time Failure**: The JavaScript
-  source code internal in Node.js's bootstrapping process threw an error
+  source code internal in the Node.js bootstrapping process threw an error
   when the bootstrapping function was called. This is extremely rare,
   and generally can only happen during development of Node.js itself.
 * `12` **Invalid Debug Argument**: The `--inspect` and/or `--inspect-brk`

--- a/doc/guides/adding-new-napi-api.md
+++ b/doc/guides/adding-new-napi-api.md
@@ -1,6 +1,6 @@
 # Contributing a new API to N-API
 
-N-API is Node.js's next generation ABI-stable API for native modules.
+N-API is the next-generation ABI-stable API for native modules.
 While improving the API surface is encouraged and welcomed, the following are
 a set of principles and guidelines to keep in mind while adding a new
 N-API API.


### PR DESCRIPTION
Throughout the docs, we sometimes write the possessive of _Node.js_ as
_Node.js'_ and other times as _Node.js's_. The former conforms with some
generally accepted style guides (e.g., Associated Press Stylebook) while
the latter complies with others (e.g., Chicago Manual of Style).

Since there is no clear authoritative answer as to which form is
correct, and since (at least to me) both are visually jarring and
sometimes cause a pause to understand, I'd like to reword things to
eliminate the possessive form where possible.

This pull request contains the remaining instances. The others were handled in #31713.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
