### PR TITLE
test: remove common.PORT from some pummel tests

### DIFF
--- a/test/pummel/test-net-pause.js
+++ b/test/pummel/test-net-pause.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
@@ -43,7 +43,7 @@ const server = net.createServer((connection) => {
 });
 
 server.on('listening', () => {
-  const client = net.createConnection(common.PORT);
+  const client = net.createConnection(server.address().port);
   client.setEncoding('ascii');
   client.on('data', (d) => {
     console.log(d);
@@ -83,7 +83,7 @@ server.on('listening', () => {
     client.end();
   });
 });
-server.listen(common.PORT);
+server.listen(0);
 
 process.on('exit', () => {
   assert.strictEqual(recv.length, N);

--- a/test/pummel/test-net-throttle.js
+++ b/test/pummel/test-net-throttle.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
@@ -32,8 +32,6 @@ let npauses = 0;
 console.log('build big string');
 const body = 'C'.repeat(N);
 
-console.log(`start server on port ${common.PORT}`);
-
 const server = net.createServer((connection) => {
   connection.write(body.slice(0, part_N));
   connection.write(body.slice(part_N, 2 * part_N));
@@ -44,9 +42,11 @@ const server = net.createServer((connection) => {
   connection.end();
 });
 
-server.listen(common.PORT, () => {
+server.listen(0, () => {
+  const port = server.address().port;
+  console.log(`server started on port ${port}`);
   let paused = false;
-  const client = net.createConnection(common.PORT);
+  const client = net.createConnection(port);
   client.setEncoding('ascii');
   client.on('data', (d) => {
     chars_recved += d.length;

--- a/test/pummel/test-net-timeout.js
+++ b/test/pummel/test-net-timeout.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
@@ -54,10 +54,11 @@ const echo_server = net.createServer((socket) => {
   });
 });
 
-echo_server.listen(common.PORT, () => {
-  console.log(`server listening at ${common.PORT}`);
+echo_server.listen(0, () => {
+  const port = echo_server.address().port;
+  console.log(`server listening at ${port}`);
 
-  const client = net.createConnection(common.PORT);
+  const client = net.createConnection(port);
   client.setEncoding('UTF8');
   client.setTimeout(0); // Disable the timeout for client
   client.on('connect', () => {

--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -59,9 +59,9 @@ const server = tls.Server(options, common.mustCall(function(socket) {
   socket.pipe(mediator);
 }));
 
-server.listen(common.PORT, common.mustCall(function() {
+server.listen(0, common.mustCall(() => {
   const client1 = tls.connect({
-    port: common.PORT,
+    port: server.address().port,
     rejectUnauthorized: false
   }, common.mustCall(function() {
     client1.end(request);


### PR DESCRIPTION
Switch some pummel tests from common.PORT to a port assigned by the operating system.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
