### PR TITLE
[12.x] module: self resolve flag as experimental modules

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -432,6 +432,7 @@ function resolveBasePath(basePath, exts, isMain, trailingSlash, request) {
 }
 
 function trySelf(parentPath, isMain, request) {
+  if (!experimentalModules) return false;
   const { data: pkg, path: basePath } = readPackageScope(parentPath) || {};
   if (!pkg || pkg.exports === undefined) return false;
   if (typeof pkg.name !== 'string') return false;

--- a/test/es-module/test-esm-flagged-self.js
+++ b/test/es-module/test-esm-flagged-self.js
@@ -1,0 +1,16 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const path = require('path');
+const { createRequireFromPath } = require('module');
+
+const fixturesRequire =
+    createRequireFromPath(path.resolve(__dirname, '../fixtures/_'));
+
+try {
+  fixturesRequire('pkgexports/resolve-self');
+  assert(false);
+} catch (e) {
+  assert.strictEqual(e.code, 'MODULE_NOT_FOUND');
+}


### PR DESCRIPTION
Resolves https://github.com/nodejs/node/issues/31754.

Ensure package self resolution remains behind `--experimental-modules`.

//cc @nodejs/modules-active-members @MylesBorins 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
