### PR TITLE
src: use hex not decimal in IsArrayIndex

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -951,7 +951,7 @@ bool IsArrayIndex(Environment* env, Local<Value> p) {
   if (!n->ToInteger(context).ToLocal(&cmp_integer)) {
     return false;
   }
-  return n_dbl > 0 && n_dbl < (2 ^ 32) - 1;
+  return n_dbl > 0 && n_dbl < (1LL << 32) - 1;
 }
 
 Maybe<URL> ResolveExportsTarget(Environment* env,


### PR DESCRIPTION
In Electron, clang enforces `-Wxor-used-as-pow`, so the previous line would cause the following error:

```cpp
../../third_party/electron_node/src/module_wrap.cc:926:34: error: result of '2 ^ 32' is 34; did you mean '1LL << 32'? [-Werror,-Wxor-used-as-pow]
  return n_dbl > 0 && n_dbl < (2 ^ 32) - 1;
                               ~~^~~~
```

The simplest solution i see is to just use hex to clarify intent for the compiler, and so this PR does so.

cc @guybedford 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
