### PR TITLE
Add type option to Worker constructor

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -588,7 +588,8 @@ changes:
 * `filename` {string|URL} The path to the Worker’s main script or module. Must
   be either an absolute path or a relative path (i.e. relative to the
   current working directory) starting with `./` or `../`, or a WHATWG `URL`
-  object using `file:` protocol.
+  object using `file:` or `data:` protocol.
+  When using a [`data:` URL][], you must set the `type` option to `"module"`.
   If `options.eval` is `true`, this is a string containing JavaScript code
   rather than a path.
 * `options` {Object}
@@ -601,12 +602,13 @@ changes:
     to specify that the parent thread and the child thread should share their
     environment variables; in that case, changes to one thread’s `process.env`
     object will affect the other thread as well. **Default:** `process.env`.
-  * `eval` {boolean} If `true`, interpret the first argument to the constructor
+  * `eval` {boolean} If `true`, interprets the first argument to the constructor
     as a script (or a module if `type` is set to `module`) that is executed once
     the worker is online.
-  * `type` {string} If `"module"` and `eval` is set to `true`, interpret the
-    first argument as an ECMAScript 2015 module instead of a script. The default
-    value is `"classic"`. Doesn't have any effect when `eval` is set to `false`.
+  * `type` {string} If `"module"`, interprets the first argument as an
+    ECMAScript 2015 module instead of a script. The default value is
+    `"classic"`. Doesn't have any effect when `filename` refers to a file, in
+    which case the type is inferred from the file extension.
   * `execArgv` {string[]} List of node CLI options passed to the worker.
     V8 options (such as `--max-old-space-size`) and options that affect the
     process (such as `--title`) are not supported. If set, this will be provided
@@ -869,3 +871,4 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [child processes]: child_process.html
 [contextified]: vm.html#vm_what_does_it_mean_to_contextify_an_object
 [v8.serdes]: v8.html#v8_serialization_api
+[`data:` URL]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -561,14 +561,15 @@ if (isMainThread) {
 <!-- YAML
 added: v10.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/31760
+    description: The `type` option was introduced.
   - version:
      - v13.13.0
      - v12.17.0
     pr-url: https://github.com/nodejs/node/pull/32278
     description: The `transferList` option was introduced.
-  - version:
-     - v13.12.0
-     - v12.17.0
+  - version: v13.12.0
     pr-url: https://github.com/nodejs/node/pull/31664
     description: The `filename` parameter can be a WHATWG `URL` object using
                  `file:` protocol.
@@ -600,9 +601,12 @@ changes:
     to specify that the parent thread and the child thread should share their
     environment variables; in that case, changes to one thread’s `process.env`
     object will affect the other thread as well. **Default:** `process.env`.
-  * `eval` {boolean} If `true` and the first argument is a `string`, interpret
-    the first argument to the constructor as a script that is executed once the
-    worker is online.
+  * `eval` {boolean} If `true`, interpret the first argument to the constructor
+    as a script (or a module if `type` is set to `module`) that is executed once
+    the worker is online.
+  * `type` {string} If `"module"` and `eval` is set to `true`, interpret the
+    first argument as an ECMAScript 2015 module instead of a script. The default
+    value is `"classic"`. Doesn't have any effect when `eval` is set to `false`.
   * `execArgv` {string[]} List of node CLI options passed to the worker.
     V8 options (such as `--max-old-space-size`) and options that affect the
     process (such as `--title`) are not supported. If set, this will be provided

--- a/lib/internal/main/eval_stdin.js
+++ b/lib/internal/main/eval_stdin.js
@@ -9,7 +9,7 @@ const {
 const { getOptionValue } = require('internal/options');
 
 const {
-  evalModule,
+  evalModuleOrCrash,
   evalScript,
   readStdin
 } = require('internal/process/execution');
@@ -24,7 +24,7 @@ readStdin((code) => {
 
   const print = getOptionValue('--print');
   if (getOptionValue('--input-type') === 'module')
-    evalModule(code, print);
+    evalModuleOrCrash(code, print);
   else
     evalScript('[stdin]',
                code,

--- a/lib/internal/main/eval_string.js
+++ b/lib/internal/main/eval_string.js
@@ -6,7 +6,7 @@
 const {
   prepareMainThreadExecution
 } = require('internal/bootstrap/pre_execution');
-const { evalModule, evalScript } = require('internal/process/execution');
+const { evalModuleOrCrash, evalScript } = require('internal/process/execution');
 const { addBuiltinLibsToObject } = require('internal/modules/cjs/helpers');
 
 const { getOptionValue } = require('internal/options');
@@ -18,7 +18,7 @@ markBootstrapComplete();
 const source = getOptionValue('--eval');
 const print = getOptionValue('--print');
 if (getOptionValue('--input-type') === 'module')
-  evalModule(source, print);
+  evalModuleOrCrash(source, print);
 else
   evalScript('[eval]',
              source,

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -4,6 +4,7 @@
 // message port.
 
 const {
+  ArrayPrototypeSplice,
   ObjectDefineProperty,
 } = primordials;
 
@@ -98,6 +99,7 @@ port.on('message', (message) => {
       cwdCounter,
       filename,
       doEval,
+      workerType,
       workerData,
       publicPort,
       manifestSrc,
@@ -148,17 +150,24 @@ port.on('message', (message) => {
           `(eval = ${eval}) at cwd = ${process.cwd()}`);
     port.postMessage({ type: UP_AND_RUNNING });
     if (doEval) {
-      const { evalScript } = require('internal/process/execution');
-      const name = '[worker eval]';
-      // This is necessary for CJS module compilation.
-      // TODO: pass this with something really internal.
-      ObjectDefineProperty(process, '_eval', {
-        configurable: true,
-        enumerable: true,
-        value: filename,
-      });
-      process.argv.splice(1, 0, name);
-      evalScript(name, filename);
+      if (workerType === 'module') {
+        const { evalModule } = require('internal/process/execution');
+        evalModule(filename).catch((e) => {
+          workerOnGlobalUncaughtException(e, true);
+        });
+      } else {
+        const { evalScript } = require('internal/process/execution');
+        const name = '[worker eval]';
+        // This is necessary for CJS module compilation.
+        // TODO: pass this with something really internal.
+        ObjectDefineProperty(process, '_eval', {
+          configurable: true,
+          enumerable: true,
+          value: filename,
+        });
+        ArrayPrototypeSplice(process.argv, 1, 0, name);
+        evalScript(name, filename);
+      }
     } else {
       // script filename
       // runMain here might be monkey-patched by users in --require.

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  FunctionPrototypeApply,
   JSONStringify,
   PromiseResolve,
 } = primordials;
@@ -43,16 +44,20 @@ function evalModule(source, print) {
   if (print) {
     throw new ERR_EVAL_ESM_CANNOT_PRINT();
   }
-  const { log, error } = require('internal/console/global');
-  const { decorateErrorStack } = require('internal/util');
+  const { log } = require('internal/console/global');
   const asyncESM = require('internal/process/esm_loader');
-  PromiseResolve(asyncESM.ESMLoader).then(async (loader) => {
+  return PromiseResolve(asyncESM.ESMLoader).then(async (loader) => {
     const { result } = await loader.eval(source);
     if (print) {
       log(result);
     }
-  })
-  .catch((e) => {
+  });
+}
+
+function evalModuleOrCrash() {
+  const { error } = require('internal/console/global');
+  const { decorateErrorStack } = require('internal/util');
+  FunctionPrototypeApply(evalModule, this, arguments).catch((e) => {
     decorateErrorStack(e);
     error(e);
     process.exit(1);
@@ -216,6 +221,7 @@ module.exports = {
   readStdin,
   tryGetCwd,
   evalModule,
+  evalModuleOrCrash,
   evalScript,
   onGlobalUncaughtException: createOnGlobalUncaughtException(),
   setUncaughtExceptionCaptureCallback,

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -44,6 +44,7 @@ const {
 } = workerIo;
 const { deserializeError } = require('internal/error-serdes');
 const { fileURLToPath, isURLInstance, pathToFileURL } = require('internal/url');
+const { validateString } = require('internal/validators');
 
 const {
   ownsProcessState,
@@ -130,6 +131,16 @@ class Worker extends EventEmitter {
         throw new ERR_WORKER_UNSUPPORTED_EXTENSION(ext);
       }
     }
+    if (options.type) {
+      validateString(options.type, 'options.type');
+      if (options.type !== 'module' && options.type !== 'classic') {
+        throw new ERR_INVALID_ARG_VALUE(
+          'options.type',
+          options.type,
+          'must be either "module" or "classic"'
+        );
+      }
+    }
 
     let env;
     if (typeof options.env === 'object' && options.env !== null) {
@@ -197,6 +208,7 @@ class Worker extends EventEmitter {
       type: messageTypes.LOAD_SCRIPT,
       filename,
       doEval: !!options.eval,
+      workerType: options.type,
       cwdCounter: cwdCounter || workerIo.sharedCwdCounter,
       workerData: options.workerData,
       publicPort: port2,

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -4,6 +4,7 @@
 
 const {
   ArrayIsArray,
+  JSONStringify,
   MathMax,
   ObjectCreate,
   ObjectEntries,
@@ -99,7 +100,7 @@ class Worker extends EventEmitter {
       argv = options.argv.map(String);
     }
 
-    let url;
+    let url, doEval;
     if (options.eval) {
       if (typeof filename !== 'string') {
         throw new ERR_INVALID_ARG_VALUE(
@@ -109,7 +110,20 @@ class Worker extends EventEmitter {
         );
       }
       url = null;
+      doEval = true;
+    } else if (filename?.protocol === 'data:') {
+      if (options.type !== 'module') {
+        throw new ERR_INVALID_ARG_VALUE(
+          'options.type',
+          options.type,
+          'must be set to "module" when filename is a data: URL'
+        );
+      }
+      url = null;
+      doEval = true;
+      filename = `import ${JSONStringify(filename)}`;
     } else {
+      doEval = false;
       if (isURLInstance(filename)) {
         url = filename;
         filename = fileURLToPath(filename);
@@ -207,7 +221,7 @@ class Worker extends EventEmitter {
       argv,
       type: messageTypes.LOAD_SCRIPT,
       filename,
-      doEval: !!options.eval,
+      doEval,
       workerType: options.type,
       cwdCounter: cwdCounter || workerIo.sharedCwdCounter,
       workerData: options.workerData,

--- a/test/parallel/test-worker-eval.js
+++ b/test/parallel/test-worker-eval.js
@@ -10,6 +10,8 @@ const cjsLoadingESMError = /Unexpected token 'export'/;
 const esmLoadingCJSError = /module is not defined/;
 const invalidValueError =
   /The argument 'options\.type' must be either "module" or "classic"/;
+const invalidValueError2 =
+  /The argument 'options\.type' must be set to "module" when filename is a data: URL/;
 
 function runInWorker(evalString, options) {
   return new Promise((resolve, reject) => {
@@ -19,20 +21,42 @@ function runInWorker(evalString, options) {
   });
 }
 
-let options;
+{
+  const options = { eval: true };
+  assert.rejects(runInWorker(moduleString, options), cjsLoadingESMError);
+  runInWorker(cjsString, options); // does not reject
+}
 
-options = { eval: true };
-assert.rejects(runInWorker(moduleString, options), cjsLoadingESMError);
-runInWorker(cjsString, options); // does not reject
+{
+  const options = { eval: true, type: 'classic' };
+  assert.rejects(runInWorker(moduleString, options), cjsLoadingESMError);
+  runInWorker(cjsString, options); // does not reject
+}
 
-options = { eval: true, type: 'classic' };
-assert.rejects(runInWorker(moduleString, options), cjsLoadingESMError);
-runInWorker(cjsString, options); // does not reject
+{
+  const options = { eval: true, type: 'module' };
+  runInWorker(moduleString, options); // does not reject
+  assert.rejects(runInWorker(cjsString, options), esmLoadingCJSError);
+}
 
-options = { eval: true, type: 'module' };
-runInWorker(moduleString, options); // does not reject
-assert.rejects(runInWorker(cjsString, options), esmLoadingCJSError);
+{
+  const options = { eval: false, type: 'module' };
+  runInWorker(new URL(`data:text/javascript,${moduleString}`),
+              options); // does not reject
+  assert.rejects(runInWorker(new URL(`data:text/javascript,${cjsString}`),
+                             options), esmLoadingCJSError);
+}
 
-options = { eval: true, type: 'wasm' };
-assert.rejects(runInWorker(moduleString, options), invalidValueError);
-assert.rejects(runInWorker(cjsString, options), invalidValueError);
+{
+  const options = { eval: true, type: 'wasm' };
+  assert.rejects(runInWorker(moduleString, options), invalidValueError);
+  assert.rejects(runInWorker(cjsString, options), invalidValueError);
+}
+
+{
+  const options = { type: 'classic' };
+  assert.rejects(runInWorker(new URL(`data:text/javascript,${moduleString}`),
+                             options), invalidValueError2);
+  assert.rejects(runInWorker(new URL(`data:text/javascript,${cjsString}`),
+                             options), invalidValueError2);
+}

--- a/test/parallel/test-worker-eval.js
+++ b/test/parallel/test-worker-eval.js
@@ -1,0 +1,38 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+const moduleString = 'export default import.meta.url;';
+const cjsString = 'module.exports=__filename;';
+
+const cjsLoadingESMError = /Unexpected token 'export'/;
+const esmLoadingCJSError = /module is not defined/;
+const invalidValueError =
+  /The argument 'options\.type' must be either "module" or "classic"/;
+
+function runInWorker(evalString, options) {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(evalString, options);
+    worker.on('error', reject);
+    worker.on('exit', resolve);
+  });
+}
+
+let options;
+
+options = { eval: true };
+assert.rejects(runInWorker(moduleString, options), cjsLoadingESMError);
+runInWorker(cjsString, options); // does not reject
+
+options = { eval: true, type: 'classic' };
+assert.rejects(runInWorker(moduleString, options), cjsLoadingESMError);
+runInWorker(cjsString, options); // does not reject
+
+options = { eval: true, type: 'module' };
+runInWorker(moduleString, options); // does not reject
+assert.rejects(runInWorker(cjsString, options), esmLoadingCJSError);
+
+options = { eval: true, type: 'wasm' };
+assert.rejects(runInWorker(moduleString, options), invalidValueError);
+assert.rejects(runInWorker(cjsString, options), invalidValueError);

--- a/test/parallel/test-worker-type-check.js
+++ b/test/parallel/test-worker-type-check.js
@@ -27,3 +27,22 @@ const { Worker } = require('worker_threads');
     );
   });
 }
+
+{
+  [
+    Symbol('test'),
+    {},
+    [],
+    () => {}
+  ].forEach((type) => {
+    assert.throws(
+      () => new Worker('', { type, eval: true }),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError',
+        message: 'The "options.type" property must be of type string.' +
+                 common.invalidArgTypeHelper(type)
+      }
+    );
+  });
+}

--- a/test/parallel/test-worker-unsupported-path.js
+++ b/test/parallel/test-worker-unsupported-path.js
@@ -47,6 +47,4 @@ const { Worker } = require('worker_threads');
   };
   assert.throws(() => { new Worker(new URL('https://www.url.com')); },
                 expectedErr);
-  assert.throws(() => { new Worker(new URL('data:application/javascript,')); },
-                expectedErr);
 }


### PR DESCRIPTION
This PR adds a `type` option to the `Worker` constructor, inspired from [WorkerType in HTML spec](https://html.spec.whatwg.org/multipage/workers.html#workertype), and support for `data:` URLs. 

* When `eval` is true OR `filename` is a `data:` URL object, the `type` option explicitly tells Node.js what kind of JS to expect (ESM or CJS).
* Otherwise, the option is ignored and the usual file extension rules is used.

```js
// use ESM loader to load the worker.js file
new Worker('./worker.js', { type: 'module' });

// eval ESM
new Worker('export default import.meta.url', { eval: true, type: 'module' });

// data: URL
new Worker(
  new URL('data:text/javascript,export default import.meta.url'),
  { type: 'module' }
);
```

~Note: `new Worker('./worker.cjs', {type: 'module'})` would load `worker.cjs` as ES module and `new Worker('./worker.mjs', {type: 'classic'})` would load `worker.mjs` as CJS. I don't expect anyone to have a use-case for this edge-case, but I wanted to clarify it's a possibility with this PR's implementation.~ _This has been reverted based on this PR's comments._

I had to tweak some internal functions, I have put those changes in separate commits to make reviewing them easier.

Fixes: #30682

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
