### PR TITLE
stream: fix sync callback leak

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -131,7 +131,7 @@ function WritableState(options, stream, isDuplex) {
   // or on a later tick.  We set this to true at first, because any
   // actions that shouldn't happen until "later" should generally also
   // not happen before the first write call.
-  this.sync = true;
+  this.tick = process.tickId;
 
   // A flag to know if we're processing previously buffered items, which
   // may call the _write() callback in the same tick, so that we don't
@@ -198,6 +198,14 @@ WritableState.prototype.getBuffer = function getBuffer() {
   }
   return out;
 };
+
+ObjectDefineProperties(WritableState.prototype, {
+  sync: {
+    get() {
+      return this.tick === process.tickId;
+    }
+  },
+});
 
 // Test _writableState for inheritance to account for Duplex streams,
 // whose prototype chain only points to Readable.
@@ -377,14 +385,13 @@ function doWrite(stream, state, writev, len, chunk, encoding, cb) {
   state.writelen = len;
   state.writecb = cb;
   state.writing = true;
-  state.sync = true;
+  state.tick = process.tickId;
   if (state.destroyed)
     state.onwrite(new ERR_STREAM_DESTROYED('write'));
   else if (writev)
     stream._writev(chunk, state.onwrite);
   else
     stream._write(chunk, encoding, state.onwrite);
-  state.sync = false;
 }
 
 function onwriteError(stream, state, er, cb) {

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -228,8 +228,9 @@ process.emitWarning = emitWarning;
 // bootstrap to make sure that any operation done before this are synchronous.
 // If any ticks or timers are scheduled before this they are unlikely to work.
 {
-  const { nextTick, runNextTicks } = setupTaskQueue();
+  const { nextTick, runNextTicks, tickId } = setupTaskQueue();
   process.nextTick = nextTick;
+  process.tickId = tickId;
   // Used to emulate a tick manually in the JS land.
   // A better name for this function would be `runNextTicks` but
   // it has been exposed to the process object so we keep this legacy name

--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -55,6 +55,7 @@ function setHasTickScheduled(value) {
 }
 
 const queue = new FixedQueue();
+let tickId = newAsyncId();
 
 // Should be in sync with RunNextTicksNative in node_task_queue.cc
 function runNextTicks() {
@@ -70,7 +71,7 @@ function processTicksAndRejections() {
   let tock;
   do {
     while (tock = queue.shift()) {
-      const asyncId = tock[async_id_symbol];
+      const asyncId = tickId = tock[async_id_symbol];
       emitBefore(asyncId, tock[trigger_async_id_symbol], tock);
 
       try {
@@ -179,6 +180,7 @@ module.exports = {
     // Sets the callback to be run in every tick.
     setTickCallback(processTicksAndRejections);
     return {
+      tickId,
       nextTick,
       runNextTicks
     };

--- a/test/parallel/test-stream-writable-sync-error.js
+++ b/test/parallel/test-stream-writable-sync-error.js
@@ -1,0 +1,44 @@
+'use strict';
+const common = require('../common');
+
+// Tests for the regression in _stream_writable fixed in
+// https://github.com/nodejs/node/pull/31756
+
+// Specifically, when a write callback is invoked synchronously
+// with an error, and autoDestroy is not being used, the error
+// should still be emitted on nextTick.
+
+const { Writable } = require('stream');
+
+class MyStream extends Writable {
+  #cb = undefined;
+
+  constructor() {
+    super({ autoDestroy: false });
+  }
+
+  _write(_, __, cb) {
+    this.#cb = cb;
+  }
+
+  close() {
+    // Synchronously invoke the callback with an error.
+    this.#cb(new Error('foo'));
+  }
+}
+
+const stream = new MyStream();
+
+const mustError = common.mustCall(2);
+
+stream.write('test', () => {});
+
+// Both error callbacks should be invoked.
+
+stream.on('error', mustError);
+
+stream.close();
+
+// Without the fix in #31756, the error handler
+// added after the call to close will not be invoked.
+stream.on('error', mustError);


### PR DESCRIPTION
This PR currently is mostly a suggestion to discuss related to https://github.com/nodejs/node/pull/31756. It's not properly cleaned up and is mostly to illustrate the problem and possible solution.

Today when working with callbacks and events we need to keep in mind ordering and whether or not a callback is invoked synchronously or asynchronously.

The current pattern for this is something like:

```js
Stream.write = function (chunk) {
  state.sync = true;
  this._write(chunk, this._onWriteComplete);
  state.sync = false;
}
```

Which mostly works fine. However, as in https://github.com/nodejs/node/pull/31756, if the callback is leaked outside it can still be invoked in the same tick breaking the assumption that when `state.sync === false` a tick has elapsed.

i.e.

```js

const s = new Stream();
let cb;
s._write = (chunk, callback) => {
  cb = callback();
};
s.write('asd');
cb(); // uhoh! sync but the `Stream` thinks it's async.
s.on('someevent', common.mustCall()); // not called
```

This PR tries to resolve this by keeping track of which tick we are currently in and making sure that `state.sync === false` always is a different tick.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
