### PR TITLE
crypto: make update(buf, enc) ignore encoding

### DIFF
--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -151,12 +151,12 @@ Cipher.prototype.update = function update(data, inputEncoding, outputEncoding) {
   inputEncoding = inputEncoding || encoding;
   outputEncoding = outputEncoding || encoding;
 
-  if (typeof data !== 'string' && !isArrayBufferView(data)) {
+  if (typeof data === 'string') {
+    validateEncoding(data, inputEncoding);
+  } else if (!isArrayBufferView(data)) {
     throw new ERR_INVALID_ARG_TYPE(
       'data', ['string', 'Buffer', 'TypedArray', 'DataView'], data);
   }
-
-  validateEncoding(data, inputEncoding);
 
   const ret = this[kHandle].update(data, inputEncoding);
 

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -78,16 +78,12 @@ Hash.prototype.update = function update(data, encoding) {
   if (state[kFinalized])
     throw new ERR_CRYPTO_HASH_FINALIZED();
 
-  if (typeof data !== 'string' && !isArrayBufferView(data)) {
-    throw new ERR_INVALID_ARG_TYPE('data',
-                                   ['string',
-                                    'Buffer',
-                                    'TypedArray',
-                                    'DataView'],
-                                   data);
+  if (typeof data === 'string') {
+    validateEncoding(data, encoding);
+  } else if (!isArrayBufferView(data)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'data', ['string', 'Buffer', 'TypedArray', 'DataView'], data);
   }
-
-  validateEncoding(data, encoding);
 
   if (!this[kHandle].update(data, encoding))
     throw new ERR_CRYPTO_HASH_UPDATE_FAILED();

--- a/test/parallel/test-crypto-update-encoding.js
+++ b/test/parallel/test-crypto-update-encoding.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const crypto = require('crypto');
+
+const zeros = Buffer.alloc;
+const key = zeros(16);
+const iv = zeros(16);
+
+const cipher = () => crypto.createCipheriv('aes-128-cbc', key, iv);
+const decipher = () => crypto.createDecipheriv('aes-128-cbc', key, iv);
+const hash = () => crypto.createSign('sha256');
+const hmac = () => crypto.createHmac('sha256', key);
+const sign = () => crypto.createSign('sha256');
+const verify = () => crypto.createVerify('sha256');
+
+for (const f of [cipher, decipher, hash, hmac, sign, verify])
+  for (const n of [15, 16])
+    f().update(zeros(n), 'hex');  // Should ignore inputEncoding.


### PR DESCRIPTION
Make the cipher/decipher/hash/hmac update() methods ignore the input
encoding when the input is a buffer.

This is the documented behavior but some inputs were rejected, notably
when the specified encoding is 'hex' and the buffer has an odd length
(because a _string_ with an odd length is never a valid hex string.)

The sign/verify update() methods work okay because they use different
validation logic.

Fixes: https://github.com/nodejs/node/issues/31751