### PR TITLE
src: improve KVStore API

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -605,11 +605,13 @@ class KVStore {
 
   virtual v8::MaybeLocal<v8::String> Get(v8::Isolate* isolate,
                                          v8::Local<v8::String> key) const = 0;
+  virtual v8::Maybe<std::string> Get(const char* key) const = 0;
   virtual void Set(v8::Isolate* isolate,
                    v8::Local<v8::String> key,
                    v8::Local<v8::String> value) = 0;
   virtual int32_t Query(v8::Isolate* isolate,
                         v8::Local<v8::String> key) const = 0;
+  virtual int32_t Query(const char* key) const = 0;
   virtual void Delete(v8::Isolate* isolate, v8::Local<v8::String> key) = 0;
   virtual v8::Local<v8::Array> Enumerate(v8::Isolate* isolate) const = 0;
 

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -30,8 +30,10 @@ using v8::Value;
 class RealEnvStore final : public KVStore {
  public:
   MaybeLocal<String> Get(Isolate* isolate, Local<String> key) const override;
+  Maybe<std::string> Get(const char* key) const override;
   void Set(Isolate* isolate, Local<String> key, Local<String> value) override;
   int32_t Query(Isolate* isolate, Local<String> key) const override;
+  int32_t Query(const char* key) const override;
   void Delete(Isolate* isolate, Local<String> key) override;
   Local<Array> Enumerate(Isolate* isolate) const override;
 };
@@ -39,8 +41,10 @@ class RealEnvStore final : public KVStore {
 class MapKVStore final : public KVStore {
  public:
   MaybeLocal<String> Get(Isolate* isolate, Local<String> key) const override;
+  Maybe<std::string> Get(const char* key) const override;
   void Set(Isolate* isolate, Local<String> key, Local<String> value) override;
   int32_t Query(Isolate* isolate, Local<String> key) const override;
+  int32_t Query(const char* key) const override;
   void Delete(Isolate* isolate, Local<String> key) override;
   Local<Array> Enumerate(Isolate* isolate) const override;
 
@@ -72,26 +76,36 @@ void DateTimeConfigurationChangeNotification(Isolate* isolate, const T& key) {
   }
 }
 
-MaybeLocal<String> RealEnvStore::Get(Isolate* isolate,
-                                     Local<String> property) const {
+Maybe<std::string> RealEnvStore::Get(const char* key) const {
   Mutex::ScopedLock lock(per_process::env_var_mutex);
 
-  node::Utf8Value key(isolate, property);
   size_t init_sz = 256;
   MaybeStackBuffer<char, 256> val;
-  int ret = uv_os_getenv(*key, *val, &init_sz);
+  int ret = uv_os_getenv(key, *val, &init_sz);
 
   if (ret == UV_ENOBUFS) {
     // Buffer is not large enough, reallocate to the updated init_sz
     // and fetch env value again.
     val.AllocateSufficientStorage(init_sz);
-    ret = uv_os_getenv(*key, *val, &init_sz);
+    ret = uv_os_getenv(key, *val, &init_sz);
   }
 
   if (ret >= 0) {  // Env key value fetch success.
-    MaybeLocal<String> value_string =
-        String::NewFromUtf8(isolate, *val, NewStringType::kNormal, init_sz);
-    return value_string;
+    return v8::Just(std::string(*val, init_sz));
+  }
+
+  return v8::Nothing<std::string>();
+}
+
+MaybeLocal<String> RealEnvStore::Get(Isolate* isolate,
+                                     Local<String> property) const {
+  node::Utf8Value key(isolate, property);
+  Maybe<std::string> value = Get(*key);
+
+  if (value.IsJust()) {
+    std::string val = value.FromJust();
+    return String::NewFromUtf8(
+        isolate, val.data(), NewStringType::kNormal, val.size());
   }
 
   return MaybeLocal<String>();
@@ -112,14 +126,12 @@ void RealEnvStore::Set(Isolate* isolate,
   DateTimeConfigurationChangeNotification(isolate, key);
 }
 
-int32_t RealEnvStore::Query(Isolate* isolate, Local<String> property) const {
+int32_t RealEnvStore::Query(const char* key) const {
   Mutex::ScopedLock lock(per_process::env_var_mutex);
-
-  node::Utf8Value key(isolate, property);
 
   char val[2];
   size_t init_sz = sizeof(val);
-  int ret = uv_os_getenv(*key, val, &init_sz);
+  int ret = uv_os_getenv(key, val, &init_sz);
 
   if (ret == UV_ENOENT) {
     return -1;
@@ -134,6 +146,11 @@ int32_t RealEnvStore::Query(Isolate* isolate, Local<String> property) const {
 #endif
 
   return 0;
+}
+
+int32_t RealEnvStore::Query(Isolate* isolate, Local<String> property) const {
+  node::Utf8Value key(isolate, property);
+  return Query(*key);
 }
 
 void RealEnvStore::Delete(Isolate* isolate, Local<String> property) {
@@ -190,13 +207,19 @@ std::shared_ptr<KVStore> KVStore::Clone(v8::Isolate* isolate) const {
   return copy;
 }
 
-MaybeLocal<String> MapKVStore::Get(Isolate* isolate, Local<String> key) const {
+Maybe<std::string> MapKVStore::Get(const char* key) const {
   Mutex::ScopedLock lock(mutex_);
+  auto it = map_.find(key);
+  return it == map_.end() ? v8::Nothing<std::string>() : v8::Just(it->second);
+}
+
+MaybeLocal<String> MapKVStore::Get(Isolate* isolate, Local<String> key) const {
   Utf8Value str(isolate, key);
-  auto it = map_.find(std::string(*str, str.length()));
-  if (it == map_.end()) return Local<String>();
-  return String::NewFromUtf8(isolate, it->second.data(),
-                             NewStringType::kNormal, it->second.size());
+  Maybe<std::string> value = Get(*str);
+  if (value.IsNothing()) return Local<String>();
+  std::string val = value.FromJust();
+  return String::NewFromUtf8(
+      isolate, val.data(), NewStringType::kNormal, val.size());
 }
 
 void MapKVStore::Set(Isolate* isolate, Local<String> key, Local<String> value) {
@@ -209,11 +232,14 @@ void MapKVStore::Set(Isolate* isolate, Local<String> key, Local<String> value) {
   }
 }
 
-int32_t MapKVStore::Query(Isolate* isolate, Local<String> key) const {
+int32_t MapKVStore::Query(const char* key) const {
   Mutex::ScopedLock lock(mutex_);
+  return map_.find(key) == map_.end() ? -1 : 0;
+}
+
+int32_t MapKVStore::Query(Isolate* isolate, Local<String> key) const {
   Utf8Value str(isolate, key);
-  auto it = map_.find(std::string(*str, str.length()));
-  return it == map_.end() ? -1 : 0;
+  return Query(*str);
 }
 
 void MapKVStore::Delete(Isolate* isolate, Local<String> key) {

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -31,6 +31,7 @@ using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::Locker;
+using v8::Maybe;
 using v8::MaybeLocal;
 using v8::Null;
 using v8::Number;
@@ -482,14 +483,9 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
   if (args[1]->IsObject() || args[2]->IsArray()) {
     per_isolate_opts.reset(new PerIsolateOptions());
 
-    HandleEnvOptions(
-        per_isolate_opts->per_env, [isolate, &env_vars](const char* name) {
-          MaybeLocal<String> value =
-              env_vars->Get(isolate, OneByteString(isolate, name));
-          return value.IsEmpty() ? std::string{}
-                                 : std::string(*String::Utf8Value(
-                                       isolate, value.ToLocalChecked()));
-        });
+    HandleEnvOptions(per_isolate_opts->per_env, [&env_vars](const char* name) {
+      return env_vars->Get(name).FromMaybe("");
+    });
 
 #ifndef NODE_WITHOUT_NODE_OPTIONS
     MaybeLocal<String> maybe_node_opts =


### PR DESCRIPTION
This adds `const char*` based APIs to KVStore to avoid multiple string
conversions (char -> Utf8 -> Local -> char etc.) when possible.

Unfortunately this only changes `Get` and `Query` methods as others have a hard dependency on `Isolate` in `RealEnvStore` as they need to call `DateTimeConfigurationChangeNotification`. Not sure how can we move forward with that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @addaleax
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
