### PR TITLE
test: test-net-dns-error.js fails on SunOS

### DIFF
--- a/test/parallel/test-net-dns-error.js
+++ b/test/parallel/test-net-dns-error.js
@@ -27,15 +27,15 @@ const net = require('net');
 
 const host = '*'.repeat(64);
 // Resolving hostname > 63 characters may return EAI_FAIL (permanent failure).
-const errCode = common.isOpenBSD || common.isSunOS ? 'EAI_FAIL' : 'ENOTFOUND';
+const errCodes = ['ENOTFOUND', 'EAI_FAIL'];
 
 const socket = net.connect(42, host, common.mustNotCall());
 socket.on('error', common.mustCall(function(err) {
-  assert.strictEqual(err.code, errCode);
+  assert(errCodes.includes(err.code), err);
 }));
 socket.on('lookup', common.mustCall(function(err, ip, type) {
   assert(err instanceof Error);
-  assert.strictEqual(err.code, errCode);
+  assert(errCodes.includes(err.code), err);
   assert.strictEqual(ip, undefined);
   assert.strictEqual(type, undefined);
 }));

--- a/test/parallel/test-net-dns-error.js
+++ b/test/parallel/test-net-dns-error.js
@@ -26,7 +26,8 @@ const assert = require('assert');
 const net = require('net');
 
 const host = '*'.repeat(64);
-const errCode = common.isOpenBSD ? 'EAI_FAIL' : 'ENOTFOUND';
+// Resolving hostname > 63 characters may return EAI_FAIL (permanent failure).
+const errCode = common.isOpenBSD || common.isSunOS ? 'EAI_FAIL' : 'ENOTFOUND';
 
 const socket = net.connect(42, host, common.mustNotCall());
 socket.on('error', common.mustCall(function(err) {


### PR DESCRIPTION
Test test-net-dns-error.js causes assertion failure on SunOS,
test expects ENOTFOUND, but OS returns EAI_FAIL.

Maximum length of a host name is 63 characters. Test test-net-dns-error.js
makes a connection attempt to invalid host name (longer than maximum by 1).
Such connection attempt on SunOS returns permanent failure (EAI_FAIL)
as invalid hostname won't be ever resolved.

##### Checklist
- [x] `make -j4 test` (UNIX)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
