### PR TITLE
benchmark: remove deprecated tls.createSecurePair

### DIFF
--- a/benchmark/tls/secure-pair.js
+++ b/benchmark/tls/secure-pair.js
@@ -2,7 +2,7 @@
 const common = require('../common.js');
 const bench = common.createBenchmark(main, {
   dur: [5],
-  securing: ['SecurePair', 'TLSSocket', 'clear'],
+  securing: ['TLSSocket', 'clear'],
   size: [2, 100, 1024, 1024 * 1024]
 });
 
@@ -64,9 +64,6 @@ function main({ dur, size, securing }) {
   function onProxyConnection(conn) {
     const client = net.connect(REDIRECT_PORT, () => {
       switch (securing) {
-        case 'SecurePair':
-          securePair(conn, client);
-          break;
         case 'TLSSocket':
           secureTLSSocket(conn, client);
           break;
@@ -77,17 +74,6 @@ function main({ dur, size, securing }) {
           throw new Error('Invalid securing method');
       }
     });
-  }
-
-  function securePair(conn, client) {
-    const serverCtx = tls.createSecureContext(options);
-    const serverPair = tls.createSecurePair(serverCtx, true, true, false);
-    conn.pipe(serverPair.encrypted);
-    serverPair.encrypted.pipe(conn);
-    serverPair.on('error', (error) => {
-      throw new Error(`Pair error: ${error}`);
-    });
-    serverPair.cleartext.pipe(client);
   }
 
   function secureTLSSocket(conn, client) {

--- a/test/benchmark/test-benchmark-tls.js
+++ b/test/benchmark/test-benchmark-tls.js
@@ -20,7 +20,7 @@ runBenchmark('tls',
                'dur=0.1',
                'n=1',
                'size=2',
-               'securing=SecurePair',
+               'securing=clear',
                'type=asc'
              ],
              {


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
