### PR TITLE
src: keep main-thread Isolate attached to platform during Dispose

### DIFF
--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -102,8 +102,12 @@ NodeMainInstance::~NodeMainInstance() {
   if (!owns_isolate_) {
     return;
   }
-  platform_->UnregisterIsolate(isolate_);
+  // TODO(addaleax): Reverse the order of these calls. The fact that we first
+  // dispose the Isolate is a temporary workaround for
+  // https://github.com/nodejs/node/issues/31752 -- V8 should not be posting
+  // platform tasks during Dispose(), but it does in some WASM edge cases.
   isolate_->Dispose();
+  platform_->UnregisterIsolate(isolate_);
 }
 
 int NodeMainInstance::Run() {


### PR DESCRIPTION
This works around a situation in which the V8 WASM code calls
into the platform while the Isolate is being disposed.

This goes against the V8 API constract for `v8::Platform`.
In lieu of a proper fix, it should be okay to keep the Isolate
registered; the race condition fixed by 25447d82d cannot
occur for the `NodeMainInstance`’s Isolate, as it is the last
one to exit in any given Node.js process.

This partially reverts 25447d82d.

Refs: https://github.com/nodejs/node/pull/30909
Refs: https://github.com/nodejs/node/issues/31752

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
