### PR TITLE
src: fix StringSearch compiler warning

### DIFF
--- a/src/string_search.h
+++ b/src/string_search.h
@@ -55,6 +55,9 @@ class Vector {
 // independently of subject and pattern char size.
 class StringSearchBase {
  protected:
+   StringSearchBase() : bad_char_shift_table_(), good_suffix_shift_table_(),
+                        suffix_table_() {}
+
   // Cap on the maximal shift in the Boyer-Moore implementation. By setting a
   // limit, we can fix the size of tables. For a needle longer than this limit,
   // search will not be optimal, since we only build tables for a suffix


### PR DESCRIPTION
StringSearchBase has tables (int array members) that are used only for
some search strategies, but g++-9 (at least) doesn't understand when
they will or will not be used. Default-initialize them in the
constructor to avoid this warning:

	In file included from ../../src/node_buffer.cc:29:
	../../src/string_search.h: In function ‘size_t node::stringsearch::SearchString(node::stringsearch::Vector<const Char>, node::stringsearch::Vector<const Char>, size_t) [with Char = short unsigned int]’:
	../../src/string_search.h:113:30: warning: ‘search’ may be used uninitialized in this function [-Wmaybe-uninitialized]
		113 |     return (this->*strategy_)(subject, index);
				|            ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
	../../src/string_search.h: In function ‘size_t node::stringsearch::SearchString(node::stringsearch::Vector<const Char>, node::stringsearch::Vector<const Char>, size_t) [with Char = unsigned char]’:
	../../src/string_search.h:113:30: warning: ‘search’ may be used uninitialized in this function [-Wmaybe-uninitialized]
		113 |     return (this->*strategy_)(subject, index);
				|            ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
