### PR TITLE
src: inform callback scopes about exceptions in HTTP parser

### DIFF
--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -330,6 +330,7 @@ class Parser : public AsyncWrap, public StreamListener {
           this, InternalCallbackScope::kSkipTaskQueues);
       head_response = cb.As<Function>()->Call(
           env()->context(), object(), arraysize(argv), argv);
+      if (head_response.IsEmpty()) callback_scope.MarkAsFailed();
     }
 
     int64_t val;
@@ -401,6 +402,7 @@ class Parser : public AsyncWrap, public StreamListener {
       InternalCallbackScope callback_scope(
           this, InternalCallbackScope::kSkipTaskQueues);
       r = cb.As<Function>()->Call(env()->context(), object(), 0, nullptr);
+      if (r.IsEmpty()) callback_scope.MarkAsFailed();
     }
 
     if (r.IsEmpty()) {

--- a/test/parallel/test-http-uncaught-from-request-callback.js
+++ b/test/parallel/test-http-uncaught-from-request-callback.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common');
+const asyncHooks = require('async_hooks');
+const http = require('http');
+
+// Regression test for https://github.com/nodejs/node/issues/31796
+
+asyncHooks.createHook({
+  after: () => {}
+}).enable();
+
+
+process.once('uncaughtException', common.mustCall(() => {
+  server.close();
+}));
+
+const server = http.createServer(common.mustCall((request, response) => {
+  response.writeHead(200, { 'Content-Type': 'text/plain' });
+  response.end();
+}));
+
+server.listen(0, common.mustCall(() => {
+  http.get({
+    host: 'localhost',
+    port: server.address().port
+  }, common.mustCall(() => {
+    throw new Error('whoah');
+  }));
+}));


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/commit/4aca277f16b8649b5fc21d41f340fad0a47c2e61
Refs: https://github.com/nodejs/node/pull/30236
Fixes: https://github.com/nodejs/node/issues/31796

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
