### PR TITLE
timers: captureRejections for timers

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -38,7 +38,7 @@ setTimeout(async () => {
   throw new Error('kaboom');
 }, 1000);
 
-process.on('error', (err, timer) => {
+process.on('error', (err) => {
   // Error handled!
   console.log(err);
 });

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -12,6 +12,41 @@ The timer functions within Node.js implement a similar API as the timers API
 provided by Web Browsers but use a different internal implementation that is
 built around the Node.js [Event Loop][].
 
+## Capture Rejections of Promises
+
+> Stability: 1 - captureRejections is experimental.
+
+Using `async` functions with timers is problematic because it can lead to
+unhandled rejection in case of a thrown exception:
+
+```js
+setTimeout(async () => {
+  throw new Error('kaboom');
+}, 1000);
+```
+
+The `captureRejections` property can be used to change this behavior,
+allowing a `then(undefined, handler)` handler on the `Promise`. This
+handler routes the exception asynchronously to the `process.on('error')`
+event handler.
+
+```js
+const timers = require('timers');
+timers.captureRejections = true;
+
+setTimeout(async () => {
+  throw new Error('kaboom');
+}, 1000);
+
+process.on('error', (err, timer) => {
+  // Error handled!
+  console.log(err);
+});
+```
+
+The `captureRejections`  property works for `setImmediate()`, `setTimeout()`,
+and `setInterval()`.
+
 ## Class: `Immediate`
 
 This object is created internally and is returned from [`setImmediate()`][]. It

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -125,6 +125,7 @@ const TIMEOUT_MAX = 2 ** 31 - 1;
 
 let timerListId = NumberMIN_SAFE_INTEGER;
 
+const kCapture = Symbol('kCapture');
 const kRefed = Symbol('refed');
 
 // Create a single linked list instance only once at startup
@@ -145,6 +146,25 @@ const timerListQueue = new PriorityQueue(compareTimersLists, setPosition);
 // - value = linked list
 const timerListMap = ObjectCreate(null);
 
+// Attaches a catch handler if captureRejections is enabled and the
+// thing is a thenable
+function addCatch(timer, promise) {
+  if (!timer[kCapture])
+    return;
+
+  try {
+    const then = promise.then;
+    if (typeof then === 'function') {
+      then.call(promise, undefined, (err) => {
+        clearTimeout(timer);  // eslint-disable-line no-undef
+        process.nextTick(() => process.emit('error', err));
+      });
+    }
+  } catch (err) {
+    process.emit('error', err);
+  }
+}
+
 function initAsyncResource(resource, type) {
   const asyncId = resource[async_id_symbol] = newAsyncId();
   const triggerAsyncId =
@@ -155,7 +175,8 @@ function initAsyncResource(resource, type) {
 
 // Timer constructor function.
 // The entire prototype is defined in lib/timers.js
-function Timeout(callback, after, args, isRepeat, isRefed) {
+function Timeout(callback, after, args, isRepeat, isRefed,
+                 captureRejections = false) {
   after *= 1; // Coalesce to number or NaN
   if (!(after >= 1 && after <= TIMEOUT_MAX)) {
     if (after > TIMEOUT_MAX) {
@@ -178,6 +199,7 @@ function Timeout(callback, after, args, isRepeat, isRefed) {
   this._timerArgs = args;
   this._repeat = isRepeat ? after : null;
   this._destroyed = false;
+  this[kCapture] = captureRejections;
 
   if (isRefed)
     incRefCount();
@@ -365,7 +387,7 @@ function setUnrefTimeout(callback, after) {
     throw new ERR_INVALID_CALLBACK(callback);
   }
 
-  const timer = new Timeout(callback, after, undefined, false, false);
+  const timer = new Timeout(callback, after, undefined, false, false, false);
   insert(timer, timer._idleTimeout);
 
   return timer;
@@ -545,10 +567,14 @@ function getTimerCallbacks(runNextTicks) {
 
       try {
         const args = timer._timerArgs;
+        let result;
         if (args === undefined)
-          timer._onTimeout();
+          result = timer._onTimeout();
         else
-          timer._onTimeout(...args);
+          result = timer._onTimeout(...args);
+
+        if (result !== undefined && result !== null)
+          addCatch(timer, result);
       } finally {
         if (timer._repeat && timer._idleTimeout !== -1) {
           timer._idleTimeout = timer._repeat;
@@ -595,6 +621,8 @@ module.exports = {
   trigger_async_id_symbol,
   Timeout,
   kRefed,
+  kCapture,
+  addCatch,
   initAsyncResource,
   setUnrefTimeout,
   getTimerDuration,

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -40,6 +40,8 @@ const {
     kRefCount
   },
   kRefed,
+  kCapture,
+  addCatch,
   initAsyncResource,
   getTimerDuration,
   timerListMap,
@@ -53,7 +55,10 @@ const {
   promisify: { custom: customPromisify },
   deprecate
 } = require('internal/util');
-const { ERR_INVALID_CALLBACK } = require('internal/errors').codes;
+const {
+  ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_CALLBACK,
+} = require('internal/errors').codes;
 const debug = require('internal/util/debuglog').debuglog('timer');
 
 const {
@@ -61,6 +66,8 @@ const {
   // The needed emit*() functions.
   emitDestroy
 } = require('internal/async_hooks');
+
+let captureRejections = false;
 
 // Remove a timer. Cancels the timeout and resets the relevant timer properties.
 function unenroll(item) {
@@ -143,7 +150,8 @@ function setTimeout(callback, after, arg1, arg2, arg3) {
       break;
   }
 
-  const timeout = new Timeout(callback, after, args, false, true);
+  const timeout = new Timeout(callback, after, args, false, true,
+                              captureRejections);
   insert(timeout, timeout._idleTimeout);
 
   return timeout;
@@ -152,7 +160,7 @@ function setTimeout(callback, after, arg1, arg2, arg3) {
 setTimeout[customPromisify] = function(after, value) {
   const args = value !== undefined ? [value] : value;
   return new Promise((resolve) => {
-    const timeout = new Timeout(resolve, after, args, false, true);
+    const timeout = new Timeout(resolve, after, args, false, true, true);
     insert(timeout, timeout._idleTimeout);
   });
 };
@@ -190,7 +198,8 @@ function setInterval(callback, repeat, arg1, arg2, arg3) {
       break;
   }
 
-  const timeout = new Timeout(callback, repeat, args, true, true);
+  const timeout = new Timeout(callback, repeat, args, true, true,
+                              captureRejections);
   insert(timeout, timeout._idleTimeout);
 
   return timeout;
@@ -209,13 +218,23 @@ Timeout.prototype.close = function() {
 };
 
 const Immediate = class Immediate {
-  constructor(callback, args) {
+  constructor(callback, args, captureRejections = false) {
     this._idleNext = null;
     this._idlePrev = null;
-    this._onImmediate = callback;
     this._argv = args;
     this._destroyed = false;
     this[kRefed] = false;
+    this[kCapture] = captureRejections;
+
+    if (!this[kCapture]) {
+      this._onImmediate = callback;
+    } else {
+      this._onImmediate = (...args) => {
+        const result = callback(...args);
+        if (result !== undefined && result !== null)
+          addCatch(this, result);
+      };
+    }
 
     initAsyncResource(this, 'Immediate');
 
@@ -273,11 +292,11 @@ function setImmediate(callback, arg1, arg2, arg3) {
       break;
   }
 
-  return new Immediate(callback, args);
+  return new Immediate(callback, args, captureRejections);
 }
 
 setImmediate[customPromisify] = function(value) {
-  return new Promise((resolve) => new Immediate(resolve, [value]));
+  return new Promise((resolve) => new Immediate(resolve, [value], true));
 };
 
 function clearImmediate(immediate) {
@@ -307,6 +326,18 @@ module.exports = {
   clearImmediate,
   setInterval,
   clearInterval,
+
+  get captureRejections() {
+    return captureRejections;
+  },
+
+  set captureRejections(value) {
+    if (typeof value !== 'boolean')
+      throw new ERR_INVALID_ARG_TYPE('timers.captureRejections',
+                                     'boolean', value);
+    captureRejections = true;
+  },
+
   _unrefActive: deprecate(
     unrefActive,
     'timers._unrefActive() is deprecated.' +

--- a/test/parallel/test-timers-capture-rejections.js
+++ b/test/parallel/test-timers-capture-rejections.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const timers = require('timers');
+
+// Capture rejections is false by default
+assert(!timers.captureRejections);
+
+[1, '', {}, [], null, undefined, 1n].forEach((i) => {
+  assert.throws(() => timers.captureRejections = i, {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
+common.disableCrashOnUnhandledRejection();
+
+// Unhandled rejection must called only three times.
+// If the captureRejection = true below is not working,
+// it will have been called 6 times;
+process.on('unhandledRejection', common.mustCall(3));
+
+setTimeout(async () => { throw new Error('foo'); },
+           common.platformTimeout(10));
+
+const i = setInterval(async () => {
+  // Be sure to clear the interval here or test will hang.
+  clearInterval(i);
+  throw new Error('foo');
+}, common.platformTimeout(10));
+
+setImmediate(async () => { throw new Error('foo'); });
+
+timers.captureRejections = true;
+
+setTimeout(async () => { throw new Error('foo'); },
+           common.platformTimeout(10));
+
+// The interval will be cleared automatically when it fails.
+setInterval(async () => { throw new Error('foo'); },
+            common.platformTimeout(10));
+
+setImmediate(async () => { throw new Error('foo'); });
+
+process.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'foo');
+}, 3));


### PR DESCRIPTION
The `setTimeout()`, `setInterval()`, and `setImmediate()` functions are
currently not implemented to handle async functions or thenable responses.

```js
setTimeout(async () => { throw new Error('boom'); }, 1000)
```

Will result in an unhandled rejection that will result in an unhandled
rejection warning.

Inspired by @mcollina's recent `captureRejections` extension for
`EventEmitter`, this implements a similar capability for timers.

```js
const timers = require('timers')
timers.captureRejections = true;

setTimeout(async () => { throw new Error('boom'); }, 1000)

process.on('error', (err) => /* handle here */)
```

Whether or not this is desirable behavior vs. crashing immediately
is a matter that can (and should) be debated.

An alternative approach here would be to make the timer objects into thenables (which I believe has been discussed before)... such that that thenable would reject when an error is thrown, and resolves when cleared.

```js
const i = setInterval(async () => { throw new Error('foo'); }, 1000);

// Only used when function returns a thenable...
i.then(
  () => { /** called when clearInterval(i) is called **/ },
  (err) => { /** called when throws **/ })
```

This approach has some API weirdness that would need to be figured out.

/cc @mcollina @BridgeAR 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
