### PR TITLE
net: autoDestroy Socket

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -285,19 +285,14 @@ function Socket(options) {
   else
     options = { ...options };
 
-  const { allowHalfOpen } = options;
-
-  // Prevent the "no-half-open enforcer" from being inherited from `Duplex`.
-  options.allowHalfOpen = true;
+  // Default to *not* allowing half open sockets.
+  options.allowHalfOpen = Boolean(options.allowHalfOpen);
   // For backwards compat do not emit close on destroy.
   options.emitClose = false;
-  options.autoDestroy = false;
+  options.autoDestroy = true;
   // Handle strings directly.
   options.decodeStrings = false;
   stream.Duplex.call(this, options);
-
-  // Default to *not* allowing half open sockets.
-  this.allowHalfOpen = Boolean(allowHalfOpen);
 
   if (options.handle) {
     this._handle = options.handle; // private
@@ -416,28 +411,18 @@ Socket.prototype._final = function(cb) {
   const err = this._handle.shutdown(req);
 
   if (err === 1 || err === UV_ENOTCONN)  // synchronous finish
-    return afterShutdown.call(req, 0);
+    return cb();
   else if (err !== 0)
-    return this.destroy(errnoException(err, 'shutdown'));
+    return cb(errnoException(err, 'shutdown'));
 };
 
-
-function afterShutdown(status) {
+function afterShutdown() {
   const self = this.handle[owner_symbol];
 
   debug('afterShutdown destroyed=%j', self.destroyed,
         self._readableState);
 
   this.callback();
-
-  // Callback may come after call to destroy.
-  if (self.destroyed)
-    return;
-
-  if (!self.readable || self.readableEnded) {
-    debug('readableState ended, destroying');
-    self.destroy();
-  }
 }
 
 // Provide a better error message when we call end() as a result
@@ -452,10 +437,10 @@ function writeAfterFIN(chunk, encoding, cb) {
   // eslint-disable-next-line no-restricted-syntax
   const er = new Error('This socket has been ended by the other party');
   er.code = 'EPIPE';
-  process.nextTick(emitErrorNT, this, er);
   if (typeof cb === 'function') {
     defaultTriggerAsyncIdScope(this[async_id_symbol], process.nextTick, cb, er);
   }
+  this.destroy(er);
 
   return false;
 }
@@ -628,12 +613,7 @@ Socket.prototype.read = function(n) {
 function onReadableStreamEnd() {
   if (!this.allowHalfOpen) {
     this.write = writeAfterFIN;
-    if (this.writable)
-      this.end();
-    else if (!this.writableLength)
-      this.destroy();
-  } else if (!this.destroyed && !this.writable && !this.writableLength)
-    this.destroy();
+  }
 }
 
 

--- a/test/parallel/test-http2-max-invalid-frames.js
+++ b/test/parallel/test-http2-max-invalid-frames.js
@@ -23,7 +23,10 @@ server.on('stream', (stream) => {
 
 server.listen(0, () => {
   const h2header = Buffer.alloc(9);
-  const conn = net.connect(server.address().port);
+  const conn = net.connect({
+    port: server.address().port,
+    allowHalfOpen: true
+  });
 
   conn.write('PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n');
 

--- a/test/parallel/test-net-write-after-close.js
+++ b/test/parallel/test-net-write-after-close.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const assert = require('assert');
 
 const net = require('net');
 
@@ -31,10 +32,7 @@ const server = net.createServer(common.mustCall(function(socket) {
 
   socket.resume();
 
-  socket.on('error', common.mustCall(function(error) {
-    console.error('received error as expected, closing server', error);
-    server.close();
-  }));
+  socket.on('error', common.mustNotCall());
 }));
 
 server.listen(0, function() {
@@ -44,7 +42,10 @@ server.listen(0, function() {
     // Then 'end' will be emitted when it receives a FIN packet from
     // the other side.
     client.on('end', common.mustCall(() => {
-      serverSocket.write('test', common.mustCall());
+      serverSocket.write('test', common.mustCall((err) => {
+        assert(err);
+        server.close();
+      }));
     }));
     client.end();
   });

--- a/test/parallel/test-tls-getprotocol.js
+++ b/test/parallel/test-tls-getprotocol.js
@@ -34,7 +34,8 @@ const server = tls.createServer(serverConfig, common.mustCall(function() {
       secureProtocol: v.secureProtocol
     }, common.mustCall(function() {
       assert.strictEqual(this.getProtocol(), v.version);
-      this.on('end', common.mustCall(function() {
+      this.on('end', common.mustCall());
+      this.on('close', common.mustCall(function() {
         assert.strictEqual(this.getProtocol(), null);
       })).end();
       if (++connected === clientConfigs.length)

--- a/test/parallel/test-tls-streamwrap-buffersize.js
+++ b/test/parallel/test-tls-streamwrap-buffersize.js
@@ -59,9 +59,8 @@ const net = require('net');
           assert.strictEqual(client.bufferSize, i + 1);
         }
 
-        // It seems that tlsSockets created from sockets of `Duplex` emit no
-        // "finish" events. We use "end" event instead.
-        client.on('end', common.mustCall(() => {
+        client.on('end', common.mustCall());
+        client.on('close', common.mustCall(() => {
           assert.strictEqual(client.bufferSize, undefined);
         }));
 


### PR DESCRIPTION
Refactors net.Socket into using autoDestroy functionality of streams. 

~During this refactoring due to slightly different timing of things other bugs got activated and needed to be resolved.~

~Also, the behaviour of `net.Socket` and `stream.Duplex` needed to be consolidated to have the same generic behaviour in terms of `allowHalfOpen`.~

~Also fixes a close vs shutdown race https://github.com/nodejs/node/issues/32486#issuecomment-604072559~

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
