### PR TITLE
src: fix -Wmaybe-uninitialized compiler warning

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -32,7 +32,6 @@
 #include "req_wrap-inl.h"
 #include "stream_base-inl.h"
 #include "string_bytes.h"
-#include "string_search.h"
 
 #include <fcntl.h>
 #include <sys/types.h>

--- a/src/string_search.h
+++ b/src/string_search.h
@@ -100,17 +100,29 @@ class StringSearch : private StringSearchBase {
     CHECK_GT(pattern_length, 0);
     if (pattern_length < kBMMinPatternLength) {
       if (pattern_length == 1) {
-        strategy_ = &StringSearch::SingleCharSearch;
+        strategy_ = SearchStrategy::kSingleChar;
         return;
       }
-      strategy_ = &StringSearch::LinearSearch;
+      strategy_ = SearchStrategy::kLinear;
       return;
     }
-    strategy_ = &StringSearch::InitialSearch;
+    strategy_ = SearchStrategy::kInitial;
   }
 
   size_t Search(Vector subject, size_t index) {
-    return (this->*strategy_)(subject, index);
+    switch (strategy_) {
+      case kBoyerMooreHorspool:
+        return BoyerMooreHorspoolSearch(subject, index);
+      case kBoyerMoore:
+        return BoyerMooreSearch(subject, index);
+      case kInitial:
+        return InitialSearch(subject, index);
+      case kLinear:
+        return LinearSearch(subject, index);
+      case kSingleChar:
+        return SingleCharSearch(subject, index);
+    }
+    UNREACHABLE();
   }
 
   static inline int AlphabetSize() {
@@ -149,10 +161,17 @@ class StringSearch : private StringSearchBase {
     return bad_char_occurrence[equiv_class];
   }
 
+  enum SearchStrategy {
+    kBoyerMooreHorspool,
+    kBoyerMoore,
+    kInitial,
+    kLinear,
+    kSingleChar,
+  };
+
   // The pattern to search for.
   Vector pattern_;
-  // Pointer to implementation of the search.
-  SearchFunction strategy_;
+  SearchStrategy strategy_;
   // Cache value of Max(0, pattern_length() - kBMMaxShift)
   size_t start_;
 };
@@ -476,7 +495,7 @@ size_t StringSearch<Char>::BoyerMooreHorspoolSearch(
     badness += (pattern_length - j) - last_char_shift;
     if (badness > 0) {
       PopulateBoyerMooreTable();
-      strategy_ = &StringSearch::BoyerMooreSearch;
+      strategy_ = SearchStrategy::kBoyerMoore;
       return BoyerMooreSearch(subject, index);
     }
   }
@@ -548,7 +567,7 @@ size_t StringSearch<Char>::InitialSearch(
       badness += j;
     } else {
       PopulateBoyerMooreHorspoolTable();
-      strategy_ = &StringSearch::BoyerMooreHorspoolSearch;
+      strategy_ = SearchStrategy::kBoyerMooreHorspool;
       return BoyerMooreHorspoolSearch(subject, i);
     }
   }


### PR DESCRIPTION
Turn the `strategy_` method pointer into an enum-based static dispatch.

It's both safer and more secure (no chance of method pointer corruption)
and it helps GCC see that the shift and suffix tables it's complaining
about are unused in single char search mode.

Fixes the following warning:

    ../src/string_search.h:113:30: warning:
    ‘search’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         return (this->*strategy_)(subject, index);

Fixes: #26733
Fixes: #31532
Fixes: #31798