### PR TITLE
benchmark: remove problematic tls params

### DIFF
--- a/benchmark/tls/secure-pair.js
+++ b/benchmark/tls/secure-pair.js
@@ -3,7 +3,7 @@ const common = require('../common.js');
 const bench = common.createBenchmark(main, {
   dur: [5],
   securing: ['SecurePair', 'TLSSocket', 'clear'],
-  size: [2, 100, 1024, 1024 * 1024]
+  size: [100, 1024, 1024 * 1024]
 });
 
 const fixtures = require('../../test/common/fixtures');

--- a/benchmark/tls/throughput.js
+++ b/benchmark/tls/throughput.js
@@ -3,7 +3,7 @@ const common = require('../common.js');
 const bench = common.createBenchmark(main, {
   dur: [5],
   type: ['buf', 'asc', 'utf'],
-  size: [2, 1024, 1024 * 1024, 4 * 1024 * 1024, 16 * 1024 * 1024]
+  size: [100, 1024, 1024 * 1024, 4 * 1024 * 1024, 16 * 1024 * 1024]
 });
 
 const fixtures = require('../../test/common/fixtures');

--- a/test/benchmark/test-benchmark-tls.js
+++ b/test/benchmark/test-benchmark-tls.js
@@ -19,9 +19,9 @@ runBenchmark('tls',
                'concurrency=1',
                'dur=0.1',
                'n=1',
-               'size=2',
+               'size=1024',
                'securing=SecurePair',
-               'type=asc'
+               'type=buf'
              ],
              {
                NODEJS_BENCHMARK_ZERO_ALLOWED: 1,


### PR DESCRIPTION
These very small values can cause crashes/exceptions to occur on some systems because most time is spent in V8 GC or in parts of node core that are not being tested (e.g. streams).

Specifically, I was seeing `size=1`/`size=2` for tls/secure-pair.js causing `bench.end(0)` occasionally (although it seems to have only started recently, but that could have been chance?).

While looking into that I also found that similarly small `size` values can cause crashing due to GC-related issues for tls/throughput.js.

I've also adjusted the `tls` benchmark test to use parameters that are faster.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
