### PR TITLE
async_hooks: executionAsyncResource matches in hooks

### DIFF
--- a/test/async-hooks/test-async-exec-resource-match.js
+++ b/test/async-hooks/test-async-exec-resource-match.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { readFile } = require('fs');
+const {
+  createHook,
+  executionAsyncResource,
+  AsyncResource
+} = require('async_hooks');
+
+// Ignore any asyncIds created before our hook is active.
+let firstSeenAsyncId = -1;
+const idResMap = new Map();
+const numExpectedCalls = 5;
+
+createHook({
+  init: common.mustCallAtLeast(
+    (asyncId, type, triggerId, resource) => {
+      if (firstSeenAsyncId === -1) {
+        firstSeenAsyncId = asyncId;
+      }
+      assert.ok(idResMap.get(asyncId) === undefined);
+      idResMap.set(asyncId, resource);
+    }, numExpectedCalls),
+  before(asyncId) {
+    if (asyncId >= firstSeenAsyncId) {
+      beforeHook(asyncId);
+    }
+  },
+  after(asyncId) {
+    if (asyncId >= firstSeenAsyncId) {
+      afterHook(asyncId);
+    }
+  }
+}).enable();
+
+const beforeHook = common.mustCallAtLeast(
+  (asyncId) => {
+    const res = idResMap.get(asyncId);
+    assert.ok(res !== undefined);
+    const execRes = executionAsyncResource();
+    assert.ok(execRes === res, 'resource mismatch in before');
+  }, numExpectedCalls);
+
+const afterHook = common.mustCallAtLeast(
+  (asyncId) => {
+    const res = idResMap.get(asyncId);
+    assert.ok(res !== undefined);
+    const execRes = executionAsyncResource();
+    assert.ok(execRes === res, 'resource mismatch in after');
+  }, numExpectedCalls);
+
+const res = new AsyncResource('TheResource');
+const initRes = idResMap.get(res.asyncId());
+assert.ok(initRes === res, 'resource mismatch in init');
+res.runInAsyncScope(common.mustCall(() => {
+  const execRes = executionAsyncResource();
+  assert.ok(execRes === res, 'resource mismatch in cb');
+}));
+
+readFile(__filename, common.mustCall());


### PR DESCRIPTION
Ensure that resource returned by `executionAsyncResource()` in before and after hook matches that resource causing this before/after calls.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Refs: #30959
fyi @Qard 