### PR TITLE
doc,crypto: re-document oaepLabel option

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2484,6 +2484,8 @@ changes:
 * `privateKey` {Object | string | Buffer | KeyObject}
   * `oaepHash` {string} The hash function to use for OAEP padding.
     **Default:** `'sha1'`
+  * `oaepLabel` {Buffer | TypedArray | DataView} The label to use for OAEP
+     padding. If not specified, no label is used.
   * `padding` {crypto.constants} An optional padding value defined in
     `crypto.constants`, which may be: `crypto.constants.RSA_NO_PADDING`,
     `crypto.constants.RSA_PKCS1_PADDING`, or
@@ -2572,6 +2574,8 @@ changes:
   * `key` {string | Buffer | KeyObject} A PEM encoded public or private key.
   * `oaepHash` {string} The hash function to use for OAEP padding.
     **Default:** `'sha1'`
+  * `oaepLabel` {Buffer | TypedArray | DataView} The label to use for OAEP
+     padding. If not specified, no label is used.
   * `passphrase` {string | Buffer} An optional passphrase for the private key.
   * `padding` {crypto.constants} An optional padding value defined in
     `crypto.constants`, which may be: `crypto.constants.RSA_NO_PADDING`,


### PR DESCRIPTION
Erroneously removed in https://github.com/nodejs/node/pull/29516.

Fixes: https://github.com/nodejs/node/issues/31810
Refs: https://github.com/nodejs/node/pull/29516