### PR TITLE
events: remove unnecessary array clone

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -328,9 +328,8 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
     }
   } else {
     const len = handler.length;
-    const listeners = arrayClone(handler, len);
     for (let i = 0; i < len; ++i) {
-      const result = ReflectApply(listeners[i], this, args);
+      const result = ReflectApply(handler[i], this, args);
 
       // We check if result is undefined first because that
       // is the most common case so we do not pay any perf


### PR DESCRIPTION
In the `emit` method the handlers were shallowly cloned before looping through to run each handler. This clone served no obvious purpose. It was referenced once within the loop to obtain each handler, but because it was a _shallow_ clone, this was equivalent to referencing the original array.

These changes have been benchmarked using the `ee-emit` benchmark. Some single-listener cases show a slight decrease in performance (~2.5%), but the 5 and 10 listener cases are between 4-25% faster.

Full Benchmark results:
```
                                                  confidence improvement accuracy (*)   (**)  (***)
 events/ee-emit.js listeners=1 argc=0 n=2000000          ***     -2.72 %       ±1.35% ±1.78% ±2.29%
 events/ee-emit.js listeners=1 argc=10 n=2000000                  0.90 %       ±1.70% ±2.24% ±2.88%
 events/ee-emit.js listeners=1 argc=2 n=2000000          ***     -2.35 %       ±1.29% ±1.70% ±2.19%
 events/ee-emit.js listeners=1 argc=4 n=2000000                  -0.34 %       ±1.28% ±1.69% ±2.17%
 events/ee-emit.js listeners=10 argc=0 n=2000000         ***     25.33 %       ±1.88% ±2.48% ±3.19%
 events/ee-emit.js listeners=10 argc=10 n=2000000        ***     15.48 %       ±1.10% ±1.46% ±1.87%
 events/ee-emit.js listeners=10 argc=2 n=2000000         ***      6.64 %       ±1.10% ±1.46% ±1.87%
 events/ee-emit.js listeners=10 argc=4 n=2000000         ***      8.28 %       ±1.23% ±1.63% ±2.09%
 events/ee-emit.js listeners=5 argc=0 n=2000000          ***     25.75 %       ±1.87% ±2.47% ±3.18%
 events/ee-emit.js listeners=5 argc=10 n=2000000         ***     12.42 %       ±1.67% ±2.20% ±2.83%
 events/ee-emit.js listeners=5 argc=2 n=2000000          ***      4.10 %       ±1.64% ±2.16% ±2.78%
 events/ee-emit.js listeners=5 argc=4 n=2000000          ***      5.02 %       ±1.39% ±1.83% ±2.35%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)