### PR TITLE
stream: fix broken pipeline error propagation

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -198,12 +198,11 @@ function pipeline(...streams) {
         const pt = new PassThrough();
         if (isPromise(ret)) {
           ret
-            .catch((err) => {
-              pt.destroy(err);
-            })
             .then((val) => {
               value = val;
               pt.end(val);
+            }, (err) => {
+              pt.destroy(err);
             });
         } else if (isIterable(ret, true)) {
           pump(ret, pt, finish);

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -132,9 +132,10 @@ function pipeline(...streams) {
   }
 
   let error;
+  let value;
   const destroys = [];
 
-  function finish(err, val, final) {
+  function finish(err, final) {
     if (!error && err) {
       error = err;
     }
@@ -146,13 +147,13 @@ function pipeline(...streams) {
     }
 
     if (final) {
-      callback(error, val);
+      callback(error, value);
     }
   }
 
   function wrap(stream, reading, writing, final) {
     destroys.push(destroyer(stream, reading, writing, (err) => {
-      finish(err, null, final);
+      finish(err, final);
     }));
   }
 
@@ -197,12 +198,12 @@ function pipeline(...streams) {
         const pt = new PassThrough();
         if (isPromise(ret)) {
           ret
-            .then((val) => {
-              pt.end(val);
-              finish(null, val, true);
-            })
             .catch((err) => {
-              finish(err, null, true);
+              pt.destroy(err);
+            })
+            .then((val) => {
+              value = val;
+              pt.end(val);
             });
         } else if (isIterable(ret, true)) {
           pump(ret, pt, finish);
@@ -212,7 +213,7 @@ function pipeline(...streams) {
         }
 
         ret = pt;
-        wrap(ret, true, false, true);
+        wrap(ret, false, true, true);
       }
     } else if (isStream(stream)) {
       if (isReadable(ret)) {

--- a/test/parallel/test-stream-pipeline-uncaught.js
+++ b/test/parallel/test-stream-pipeline-uncaught.js
@@ -8,18 +8,18 @@ const {
 const assert = require('assert');
 
 process.on('uncaughtException', common.mustCall((err) => {
-  assert.strictEqual(err.message, 'asd');
+  assert.strictEqual(err.message, 'error');
 }));
 
 // Ensure that pipeline that ends with Promise
 // still propagates error to uncaughtException.
 const s = new PassThrough();
-s.end('asd');
+s.end('data');
 pipeline(s, async function(source) {
   for await (const chunk of source) {
     chunk;
   }
 }, common.mustCall((err) => {
   assert.ifError(err);
-  throw new Error('asd');
+  throw new Error('error');
 }));

--- a/test/parallel/test-stream-pipeline-uncaught.js
+++ b/test/parallel/test-stream-pipeline-uncaught.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+const {
+  pipeline,
+  PassThrough
+} = require('stream');
+const assert = require('assert');
+
+process.on('uncaughtException', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'asd');
+}));
+
+// Ensure that pipeline that ends with Promise
+// still propagates error to uncaughtException.
+const s = new PassThrough();
+s.end('asd');
+pipeline(s, async function(source) {
+  for await (const chunk of source) {
+    chunk;
+  }
+}, common.mustCall((err) => {
+  assert.ok(!err);
+  throw new Error('asd');
+}));

--- a/test/parallel/test-stream-pipeline-uncaught.js
+++ b/test/parallel/test-stream-pipeline-uncaught.js
@@ -20,6 +20,6 @@ pipeline(s, async function(source) {
     chunk;
   }
 }, common.mustCall((err) => {
-  assert.ok(!err);
+  assert.ifError(err);
   throw new Error('asd');
 }));

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -613,11 +613,9 @@ const { promisify } = require('util');
     yield 'hello';
     yield 'world';
   }, async function*(source) {
-    const ret = [];
     for await (const chunk of source) {
-      ret.push(chunk.toUpperCase());
+      yield chunk.toUpperCase();
     }
-    yield ret;
   }, async function(source) {
     let ret = '';
     for await (const chunk of source) {
@@ -754,7 +752,6 @@ const { promisify } = require('util');
   }, common.mustCall((err) => {
     assert.strictEqual(err, undefined);
     assert.strictEqual(ret, 'asd');
-    assert.strictEqual(s.destroyed, true);
   }));
 }
 
@@ -775,7 +772,6 @@ const { promisify } = require('util');
   }, common.mustCall((err) => {
     assert.strictEqual(err, undefined);
     assert.strictEqual(ret, 'asd');
-    assert.strictEqual(s.destroyed, true);
   }));
 }
 


### PR DESCRIPTION
If the destination was an async function any error thrown from that function would be swallowed.

EDITED

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
