### PR TITLE
events: fix not emit removeListener

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -31,7 +31,6 @@ const {
   ObjectDefineProperty,
   ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
-  ObjectKeys,
   Promise,
   PromiseReject,
   PromiseResolve,
@@ -531,7 +530,7 @@ EventEmitter.prototype.removeAllListeners =
 
       // Emit removeListener for all listeners on all events
       if (arguments.length === 0) {
-        for (const key of ObjectKeys(events)) {
+        for (const key of ReflectOwnKeys(events)) {
           if (key === 'removeListener') continue;
           this.removeAllListeners(key);
         }

--- a/test/parallel/test-event-emitter-remove-all-listeners.js
+++ b/test/parallel/test-event-emitter-remove-all-listeners.js
@@ -108,3 +108,16 @@ function expect(expected) {
   ee._events = undefined;
   assert.strictEqual(ee, ee.removeAllListeners());
 }
+
+{
+  const ee = new events.EventEmitter();
+  const symbol = Symbol('symbol');
+  const noop = common.mustNotCall();
+  ee.on(symbol, noop);
+
+  ee.on('removeListener', common.mustCall((...args) => {
+    assert.deepStrictEqual(args, [symbol, noop]);
+  }));
+
+  ee.removeAllListeners();
+}


### PR DESCRIPTION
Fix not emit removeListener when eventName type is 'symbol'.

```js
const EventEmitter = require('events');
const myEmitter = new EventEmitter();
const sym = Symbol('symbol');
const fn = () => { };
myEmitter.on(sym, fn);

myEmitter.on('removeListener', (...args) => {
  console.log('removeListener');
  console.log(args, args[0] === sym, args[1] === fn);
});

myEmitter.removeAllListeners()
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
