### PR TITLE
events: convert errorMonitor to normal property

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -90,12 +90,7 @@ ObjectDefineProperty(EventEmitter, 'captureRejections', {
   enumerable: true
 });
 
-ObjectDefineProperty(EventEmitter, 'errorMonitor', {
-  value: kErrorMonitor,
-  writable: false,
-  configurable: true,
-  enumerable: true
-});
+EventEmitter.errorMonitor = kErrorMonitor;
 
 // The default for captureRejections is false
 ObjectDefineProperty(EventEmitter.prototype, kCapture, {


### PR DESCRIPTION
Convert property errorMonitor to a normal property as non-writable caused unwanted side effects.

Refs: https://github.com/nodejs/node/pull/30932#discussion_r379679982

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

