### PR TITLE
src: discard tasks posted to platform TaskRunner during shutdown

### DIFF
--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -102,12 +102,8 @@ NodeMainInstance::~NodeMainInstance() {
   if (!owns_isolate_) {
     return;
   }
-  // TODO(addaleax): Reverse the order of these calls. The fact that we first
-  // dispose the Isolate is a temporary workaround for
-  // https://github.com/nodejs/node/issues/31752 -- V8 should not be posting
-  // platform tasks during Dispose(), but it does in some WASM edge cases.
-  isolate_->Dispose();
   platform_->UnregisterIsolate(isolate_);
+  isolate_->Dispose();
 }
 
 int NodeMainInstance::Run() {

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -244,14 +244,22 @@ void PerIsolatePlatformData::PostIdleTask(std::unique_ptr<v8::IdleTask> task) {
 }
 
 void PerIsolatePlatformData::PostTask(std::unique_ptr<Task> task) {
-  CHECK_NOT_NULL(flush_tasks_);
+  if (flush_tasks_ == nullptr) {
+    // V8 may post tasks during Isolate disposal. In that case, the only
+    // sensible path forward is to discard the task.
+    return;
+  }
   foreground_tasks_.Push(std::move(task));
   uv_async_send(flush_tasks_);
 }
 
 void PerIsolatePlatformData::PostDelayedTask(
     std::unique_ptr<Task> task, double delay_in_seconds) {
-  CHECK_NOT_NULL(flush_tasks_);
+  if (flush_tasks_ == nullptr) {
+    // V8 may post tasks during Isolate disposal. In that case, the only
+    // sensible path forward is to discard the task.
+    return;
+  }
   std::unique_ptr<DelayedTask> delayed(new DelayedTask());
   delayed->task = std::move(task);
   delayed->platform_data = shared_from_this();


### PR DESCRIPTION
Following the discussion in https://chromium-review.googlesource.com/c/v8/v8/+/2061548:

##### src: discard tasks posted to platform TaskRunner during shutdown

Discard tasks silently that are posted when the Isolate is being
disposed.

It is not possible to avoid a race condition window between
unregistering the Isolate with the platform and disposing it
in which background tasks and the Isolate deinit steps themselves
may lead to new tasks being posted. The only sensible action
in that case is discarding the tasks.

Fixes: https://github.com/nodejs/node/issues/31752
Fixes: https://bugs.chromium.org/p/v8/issues/detail?id=10104
Refs: https://chromium-review.googlesource.com/c/v8/v8/+/2061548
Refs: https://github.com/nodejs/node/pull/31795
Refs: https://github.com/nodejs/node/pull/30909

##### Revert "src: keep main-thread Isolate attached to platform during Dispose"

This reverts commit e460f8cf43863a5a8d73273ce311135ad3245699.

It is no longer necessary after the previous commit, and restores
consistency of the call order between the main thread code,
the other call sites, and the documentation.

Refs: https://github.com/nodejs/node/pull/31795


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
