### PR TITLE
doc: add note about ssh key to releases

### DIFF
--- a/doc/releases.md
+++ b/doc/releases.md
@@ -553,8 +553,30 @@ formatting passes the lint rules on `master`.
 to promote the builds as the `SHASUMS256.txt` file needs to be signed with the
 same GPG key!**
 
-Use `tools/release.sh` to promote and sign the build. When run, it will perform
-the following actions:
+Use `tools/release.sh` to promote and sign the build. Before doing this, you'll
+need to ensure you've loaded the correct ssh key, or you'll see the following:
+
+```sh
+# Checking for releases ...
+Enter passphrase for key '/Users/<user>/.ssh/id_rsa':
+dist@direct.nodejs.org's password:
+```
+
+The key can be loaded either with `ssh-add`:
+
+```sh
+# Substitute node_id_rsa with whatever you've named the key
+$ ssh-add ~/.ssh/node_id_rsa
+```
+
+or at runtime with:
+
+```sh
+# Substitute node_id_rsa with whatever you've named the key
+$ ./tools/release.sh -i ~/.ssh/node_id_rsa
+```
+
+`tools/release.sh` will perform the following actions when run:
 
 **a.** Select a GPG key from your private keys. It will use a command similar
 to: `gpg --list-secret-keys` to list your keys. If you don't have any keys, it


### PR DESCRIPTION
This PR adds a note to the final promotion stage discussing the need to ensure that your ssh key for Node.js has been properly loaded.

cc @nodejs/releasers 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
