### PR TITLE
doc: prevent tables from shrinking page

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -251,12 +251,28 @@ table {
 th,
 td {
   border: 1px solid #aaa;
-  padding: .75rem 1rem;
+  padding: .5rem;
   vertical-align: top;
 }
 
 th {
   text-align: left;
+}
+
+td {
+  word-break: break-all; /* Fallback if break-word isn't supported */
+  word-break: break-word;
+}
+
+@media only screen and (min-width: 600px) {
+  th,
+  td {
+    padding: .75rem 1rem;
+  }
+
+  td:first-child {
+    word-break: normal;
+  }
 }
 
 ol,


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This change prevents tables from growing so wide that they shrink the page on mobile.

Problem (currently on https://nodejs.org/api/crypto.html):

![nodejs org_dist_latest-v13 x_docs_api_crypto html(iPhone 6_7_8)](https://user-images.githubusercontent.com/4443482/74785406-5c2f5c80-52fe-11ea-90d0-fb6cb4590269.png)

Now, on phones, table content will break if it has to, so the page loads the same width as all the other pages. The padding's a tiny bit less, too.

![nodejs org_dist_latest-v13 x_docs_api_crypto html(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/4443482/74785487-913baf00-52fe-11ea-9e58-95ea1d3a668e.png)

On larger screens, the first column is prevented from wrapping, since it often contains variables. Content in other columns will still wrap (note the URLs wrap, which they don't currently).

![nodejs org_dist_latest-v13 x_docs_api_crypto html(iPad)](https://user-images.githubusercontent.com/4443482/74785561-ae707d80-52fe-11ea-9f97-81439091ec87.png)


