### PR TITLE
src: enable `StreamPipe` for generic `StreamBase`s

### DIFF
--- a/src/stream_pipe.h
+++ b/src/stream_pipe.h
@@ -17,6 +17,8 @@ class StreamPipe : public AsyncWrap {
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Unpipe(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void IsClosed(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void PendingWrites(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   SET_NO_MEMORY_INFO()
   SET_MEMORY_INFO_NAME(StreamPipe)
@@ -26,14 +28,13 @@ class StreamPipe : public AsyncWrap {
   inline StreamBase* source();
   inline StreamBase* sink();
 
-  inline void ShutdownWritable();
-
+  int pending_writes_ = 0;
   bool is_reading_ = false;
-  bool is_writing_ = false;
   bool is_eof_ = false;
   bool is_closed_ = true;
   bool sink_destroyed_ = false;
   bool source_destroyed_ = false;
+  bool uses_wants_write_ = false;
 
   // Set a default value so that when we’re coming from Start(), we know
   // that we don’t want to read just yet.


### PR DESCRIPTION
Authored by @addaleax and landed in the nodejs/quic repo and used there for efficient file sending. Separating this out from the main [QUIC PR](https://github.com/nodejs/node/pull/30943) to help reduce the size. There is no QUIC specific details in this, however.

Original review metadata:

```
  PR-URL: https://github.com/nodejs/quic/pull/150
  Reviewed-By: James M Snell <jasnell@gmail.com>
```

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

