### PR TITLE
src: move BaseObject subclass dtors/ctors out of node_crypto.h

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -531,6 +531,24 @@ void SecureContext::Initialize(Environment* env, Local<Object> target) {
   env->set_secure_context_constructor_template(t);
 }
 
+SecureContext::SecureContext(Environment* env, v8::Local<v8::Object> wrap)
+    : BaseObject(env, wrap) {
+  MakeWeak();
+  env->isolate()->AdjustAmountOfExternalAllocatedMemory(kExternalSize);
+}
+
+inline void SecureContext::Reset() {
+  if (ctx_ != nullptr) {
+    env()->isolate()->AdjustAmountOfExternalAllocatedMemory(-kExternalSize);
+  }
+  ctx_.reset();
+  cert_.reset();
+  issuer_.reset();
+}
+
+SecureContext::~SecureContext() {
+  Reset();
+}
 
 void SecureContext::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -3814,6 +3832,15 @@ KeyType KeyObject::GetKeyType() const {
   return this->key_type_;
 }
 
+KeyObject::KeyObject(Environment* env,
+                     v8::Local<v8::Object> wrap,
+                     KeyType key_type)
+    : BaseObject(env, wrap),
+      key_type_(key_type),
+      symmetric_key_(nullptr, nullptr) {
+  MakeWeak();
+}
+
 void KeyObject::Init(const FunctionCallbackInfo<Value>& args) {
   KeyObject* key;
   ASSIGN_OR_RETURN_UNWRAP(&key, args.Holder());
@@ -3958,6 +3985,17 @@ MaybeLocal<Value> KeyObject::ExportPrivateKey(
   return WritePrivateKey(env(), asymmetric_key_.get(), config);
 }
 
+CipherBase::CipherBase(Environment* env,
+                       v8::Local<v8::Object> wrap,
+                       CipherKind kind)
+    : BaseObject(env, wrap),
+      ctx_(nullptr),
+      kind_(kind),
+      auth_tag_state_(kAuthTagUnknown),
+      auth_tag_len_(kNoAuthTagLength),
+      pending_auth_failed_(false) {
+  MakeWeak();
+}
 
 void CipherBase::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -4580,6 +4618,11 @@ void CipherBase::Final(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(out.ToBuffer().ToLocalChecked());
 }
 
+Hmac::Hmac(Environment* env, v8::Local<v8::Object> wrap)
+    : BaseObject(env, wrap),
+      ctx_(nullptr) {
+  MakeWeak();
+}
 
 void Hmac::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -4699,6 +4742,13 @@ void Hmac::HmacDigest(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(rc.ToLocalChecked());
 }
 
+Hash::Hash(Environment* env, v8::Local<v8::Object> wrap)
+    : BaseObject(env, wrap),
+      mdctx_(nullptr),
+      has_md_(false),
+      md_value_(nullptr) {
+  MakeWeak();
+}
 
 void Hash::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -4713,6 +4763,10 @@ void Hash::Initialize(Environment* env, Local<Object> target) {
               t->GetFunction(env->context()).ToLocalChecked()).Check();
 }
 
+Hash::~Hash() {
+  if (md_value_ != nullptr)
+    OPENSSL_clear_free(md_value_, md_len_);
+}
 
 void Hash::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -4937,6 +4991,10 @@ void CheckThrow(Environment* env, SignBase::Error error) {
   }
 }
 
+SignBase::SignBase(Environment* env, v8::Local<v8::Object> wrap)
+    : BaseObject(env, wrap) {
+}
+
 void SignBase::CheckThrow(SignBase::Error error) {
   node::crypto::CheckThrow(env(), error);
 }
@@ -4960,6 +5018,9 @@ static bool ApplyRSAOptions(const ManagedEVPPKey& pkey,
 }
 
 
+Sign::Sign(Environment* env, v8::Local<v8::Object> wrap) : SignBase(env, wrap) {
+  MakeWeak();
+}
 
 void Sign::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -5280,6 +5341,11 @@ void SignOneShot(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(signature.ToBuffer().ToLocalChecked());
 }
 
+Verify::Verify(Environment* env, v8::Local<v8::Object> wrap) :
+    SignBase(env, wrap) {
+  MakeWeak();
+}
+
 void Verify::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
 
@@ -5587,6 +5653,10 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(out.ToBuffer().ToLocalChecked());
 }
 
+DiffieHellman::DiffieHellman(Environment* env, v8::Local<v8::Object> wrap)
+    : BaseObject(env, wrap), verifyError_(0) {
+  MakeWeak();
+}
 
 void DiffieHellman::Initialize(Environment* env, Local<Object> target) {
   auto make = [&] (Local<String> name, FunctionCallback callback) {
@@ -5956,6 +6026,15 @@ void ECDH::Initialize(Environment* env, Local<Object> target) {
               t->GetFunction(env->context()).ToLocalChecked()).Check();
 }
 
+ECDH::ECDH(Environment* env, v8::Local<v8::Object> wrap, ECKeyPointer&& key)
+    : BaseObject(env, wrap),
+    key_(std::move(key)),
+    group_(EC_KEY_get0_group(key_.get())) {
+  MakeWeak();
+  CHECK_NOT_NULL(group_);
+}
+
+ECDH::~ECDH() {}
 
 void ECDH::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -84,11 +84,9 @@ extern void UseExtraCaCerts(const std::string& file);
 
 void InitCryptoOnce();
 
-class SecureContext : public BaseObject {
+class SecureContext final : public BaseObject {
  public:
-  ~SecureContext() override {
-    Reset();
-  }
+  ~SecureContext() override;
 
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
@@ -177,20 +175,8 @@ class SecureContext : public BaseObject {
                                          HMAC_CTX* hctx,
                                          int enc);
 
-  SecureContext(Environment* env, v8::Local<v8::Object> wrap)
-      : BaseObject(env, wrap) {
-    MakeWeak();
-    env->isolate()->AdjustAmountOfExternalAllocatedMemory(kExternalSize);
-  }
-
-  inline void Reset() {
-    if (ctx_ != nullptr) {
-      env()->isolate()->AdjustAmountOfExternalAllocatedMemory(-kExternalSize);
-    }
-    ctx_.reset();
-    cert_.reset();
-    issuer_.reset();
-  }
+  SecureContext(Environment* env, v8::Local<v8::Object> wrap);
+  void Reset();
 };
 
 // SSLWrap implicitly depends on the inheriting class' handle having an
@@ -461,14 +447,7 @@ class KeyObject : public BaseObject {
   v8::MaybeLocal<v8::Value> ExportPrivateKey(
       const PrivateKeyEncodingConfig& config) const;
 
-  KeyObject(Environment* env,
-            v8::Local<v8::Object> wrap,
-            KeyType key_type)
-      : BaseObject(env, wrap),
-        key_type_(key_type),
-        symmetric_key_(nullptr, nullptr) {
-    MakeWeak();
-  }
+  KeyObject(Environment* env, v8::Local<v8::Object> wrap, KeyType key_type);
 
  private:
   const KeyType key_type_;
@@ -542,17 +521,7 @@ class CipherBase : public BaseObject {
   static void SetAuthTag(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetAAD(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  CipherBase(Environment* env,
-             v8::Local<v8::Object> wrap,
-             CipherKind kind)
-      : BaseObject(env, wrap),
-        ctx_(nullptr),
-        kind_(kind),
-        auth_tag_state_(kAuthTagUnknown),
-        auth_tag_len_(kNoAuthTagLength),
-        pending_auth_failed_(false) {
-    MakeWeak();
-  }
+  CipherBase(Environment* env, v8::Local<v8::Object> wrap, CipherKind kind);
 
  private:
   DeleteFnPtr<EVP_CIPHER_CTX, EVP_CIPHER_CTX_free> ctx_;
@@ -582,18 +551,16 @@ class Hmac : public BaseObject {
   static void HmacUpdate(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void HmacDigest(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  Hmac(Environment* env, v8::Local<v8::Object> wrap)
-      : BaseObject(env, wrap),
-        ctx_(nullptr) {
-    MakeWeak();
-  }
+  Hmac(Environment* env, v8::Local<v8::Object> wrap);
 
  private:
   DeleteFnPtr<HMAC_CTX, HMAC_CTX_free> ctx_;
 };
 
-class Hash : public BaseObject {
+class Hash final : public BaseObject {
  public:
+  ~Hash() override;
+
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
   // TODO(joyeecheung): track the memory used by OpenSSL types
@@ -609,18 +576,7 @@ class Hash : public BaseObject {
   static void HashUpdate(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void HashDigest(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  Hash(Environment* env, v8::Local<v8::Object> wrap)
-      : BaseObject(env, wrap),
-        mdctx_(nullptr),
-        has_md_(false),
-        md_value_(nullptr) {
-    MakeWeak();
-  }
-
-  ~Hash() override {
-    if (md_value_ != nullptr)
-      OPENSSL_clear_free(md_value_, md_len_);
-  }
+  Hash(Environment* env, v8::Local<v8::Object> wrap);
 
  private:
   EVPMDPointer mdctx_;
@@ -642,9 +598,7 @@ class SignBase : public BaseObject {
     kSignMalformedSignature
   } Error;
 
-  SignBase(Environment* env, v8::Local<v8::Object> wrap)
-      : BaseObject(env, wrap) {
-  }
+  SignBase(Environment* env, v8::Local<v8::Object> wrap);
 
   Error Init(const char* sign_type);
   Error Update(const char* data, int len);
@@ -690,9 +644,7 @@ class Sign : public SignBase {
   static void SignUpdate(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SignFinal(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  Sign(Environment* env, v8::Local<v8::Object> wrap) : SignBase(env, wrap) {
-    MakeWeak();
-  }
+  Sign(Environment* env, v8::Local<v8::Object> wrap);
 };
 
 class Verify : public SignBase {
@@ -712,9 +664,7 @@ class Verify : public SignBase {
   static void VerifyUpdate(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void VerifyFinal(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  Verify(Environment* env, v8::Local<v8::Object> wrap) : SignBase(env, wrap) {
-    MakeWeak();
-  }
+  Verify(Environment* env, v8::Local<v8::Object> wrap);
 };
 
 class PublicKeyCipher {
@@ -771,11 +721,7 @@ class DiffieHellman : public BaseObject {
   static void VerifyErrorGetter(
       const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  DiffieHellman(Environment* env, v8::Local<v8::Object> wrap)
-      : BaseObject(env, wrap),
-        verifyError_(0) {
-    MakeWeak();
-  }
+  DiffieHellman(Environment* env, v8::Local<v8::Object> wrap);
 
   // TODO(joyeecheung): track the memory used by OpenSSL types
   SET_NO_MEMORY_INFO()
@@ -794,11 +740,9 @@ class DiffieHellman : public BaseObject {
   DHPointer dh_;
 };
 
-class ECDH : public BaseObject {
+class ECDH final : public BaseObject {
  public:
-  ~ECDH() override {
-    group_ = nullptr;
-  }
+  ~ECDH() override;
 
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
   static ECPointPointer BufferToPoint(Environment* env,
@@ -811,13 +755,7 @@ class ECDH : public BaseObject {
   SET_SELF_SIZE(ECDH)
 
  protected:
-  ECDH(Environment* env, v8::Local<v8::Object> wrap, ECKeyPointer&& key)
-      : BaseObject(env, wrap),
-        key_(std::move(key)),
-        group_(EC_KEY_get0_group(key_.get())) {
-    MakeWeak();
-    CHECK_NOT_NULL(group_);
-  }
+  ECDH(Environment* env, v8::Local<v8::Object> wrap, ECKeyPointer&& key);
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GenerateKeys(const v8::FunctionCallbackInfo<v8::Value>& args);


### PR DESCRIPTION
Originally landed in the QUIC repo. Separated from from the [QUIC PR](https://github.com/nodejs/node/pull/30943). There is nothing QUIC specific in this change.

Move constructor and destructors for subclasses of `BaseObject`
from node_crypto.h to node_crypto.cc. This removes the need to
include base_object-inl.h when using node_crypto.h in some cases.

Original review metadata:

```
  PR-URL: https://github.com/nodejs/quic/pull/220
  Reviewed-By: Anna Henningsen <anna@addaleax.net>
  Reviewed-By: James M Snell <jasnell@gmail.com>
```

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

