### PR TITLE
doc: add esm alternative for require.main

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -928,6 +928,26 @@ hooks can provide this workflow in the future.
 
 `require.cache` is not used by `import`. It has a separate cache.
 
+### No `require.main`
+
+To detect when an ES module is run directly with Node.js, it is possible to
+compare the [`import.meta.url`][] value to the command line arguments. For
+example:
+
+```js
+import { fileURLToPath } from 'url';
+import process from 'process';
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  // The script was run directly.
+}
+```
+
+The above approach does not cover the case where the script is run without the
+`.js` extension (e.g. `node script` instead of `node script.js`). These cases
+could be normalized by trimming any extension from the `import.meta.url` and
+`process.argv[1]` values.
+
 ### URL-based paths
 
 ES modules are resolved and cached based upon

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -78,6 +78,9 @@ Because `module` provides a `filename` property (normally equivalent to
 `__filename`), the entry point of the current application can be obtained
 by checking `require.main.filename`.
 
+When running [ECMAScript Modules][], `require.main` is not available. See the
+ECMAScript Modules documentation for a possible [`require.main` alternative][].
+
 ## Addenda: Package manager tips
 
 <!-- type=misc -->
@@ -1148,3 +1151,4 @@ consists of the following keys:
 [`Error.prepareStackTrace(error, trace)`]: https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 [`SourceMap`]: modules.html#modules_class_module_sourcemap
 [Source map v3 format]: https://sourcemaps.info/spec.html#h.mofvlxcwqzej
+[`require.main` alternative]: esm.html#esm_no_require_main


### PR DESCRIPTION
This adds the absence of `require.main` to the list of [differences between ES Modules and CommonJS](https://nodejs.org/api/esm.html#esm_differences_between_es_modules_and_commonjs).

Comparing `import.meta.url` to `process.argv[1]` is documented as an alternative to `require.main === module`.

See nodejs/modules#274.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] `mkdir out/Release`
- [x] ``ln -s `which node` out/Release/node``
- [x] `make test-doc`
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
