### PR TITLE
crypto: fix ieee-p1363 for createVerify

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -700,8 +700,7 @@ class Verify : public SignBase {
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
   Error VerifyFinal(const ManagedEVPPKey& key,
-                    const char* sig,
-                    int siglen,
+                    const ByteSource& sig,
                     int padding,
                     const v8::Maybe<int>& saltlen,
                     bool* verify_result);

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -527,6 +527,9 @@ assert.throws(
     // Unlike DER signatures, IEEE P1363 signatures have a predictable length.
     assert.strictEqual(sig.length, length);
     assert.strictEqual(crypto.verify('sha1', data, opts, sig), true);
+    assert.strictEqual(crypto.createVerify('sha1')
+                             .update(data)
+                             .verify(opts, sig), true);
 
     // Test invalid signature lengths.
     for (const i of [-2, -1, 1, 2, 4, 8]) {
@@ -546,6 +549,14 @@ assert.throws(
   for (const ok of [true, false]) {
     assert.strictEqual(
       crypto.verify('sha256', data, {
+        key: fixtures.readKey('ec-key.pem'),
+        dsaEncoding: 'ieee-p1363'
+      }, extSig),
+      ok
+    );
+
+    assert.strictEqual(
+      crypto.createVerify('sha256').update(data).verify({
         key: fixtures.readKey('ec-key.pem'),
         dsaEncoding: 'ieee-p1363'
       }, extSig),


### PR DESCRIPTION
Even though `createVerify` was correctly converting ieee-p1363 signatures to DER, it then passed a pointer to the ieee-p1363 signature to OpenSSL, instead of a pointer to the result of the conversion. My mistake, sorry.

Fixes: https://github.com/nodejs/node/issues/31866

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
