### PR TITLE
stream: fix finished typo

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -62,7 +62,7 @@ function eos(stream, opts, callback) {
   };
 
   let writableFinished = stream.writableFinished ||
-    (rState && rState.finished);
+    (wState && wState.finished);
   const onfinish = () => {
     writable = false;
     writableFinished = true;

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -312,7 +312,6 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   }));
 }
 
-
 {
   const r = new Readable({
     autoDestroy: false
@@ -331,4 +330,15 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   rs.on('end', common.mustCall(() => {
     finished(rs, common.mustCall());
   }));
+}
+
+{
+  const d = new EE();
+  d._writableState = {};
+  d._writableState.finished = true;
+  finished(d, { readable: false, writable: true }, common.mustCall((err) => {
+    assert.strictEqual(err, undefined);
+  }));
+  d._writableState.errored = true;
+  d.emit('close');
 }


### PR DESCRIPTION
https://github.com/nodejs/node/pull/31509 introduced a slight typo. Fortunately this typo does not have big impact due to `isWritableFinished()`.
    
Fixes: https://github.com/nodejs/node/pull/31509#discussion_r381809355

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
