### PR TITLE
src: implement per-process native Debug() printer and use it in mkcodecache

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -1225,6 +1225,16 @@
       ],
 
       'conditions': [
+        [ 'node_use_openssl=="true"', {
+          'defines': [
+            'HAVE_OPENSSL=1',
+          ],
+        }],
+        ['v8_enable_inspector==1', {
+          'defines': [
+            'HAVE_INSPECTOR=1',
+          ],
+        }],
         ['OS=="win"', {
           'libraries': [
             'dbghelp.lib',
@@ -1269,6 +1279,16 @@
       ],
 
       'conditions': [
+        [ 'node_use_openssl=="true"', {
+          'defines': [
+            'HAVE_OPENSSL=1',
+          ],
+        }],
+        ['v8_enable_inspector==1', {
+          'defines': [
+            'HAVE_INSPECTOR=1',
+          ],
+        }],
         ['OS=="win"', {
           'libraries': [
             'Dbghelp.lib',

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -4,7 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include <cinttypes>
-#include "util.h"
+#include "util-inl.h"
 #include "v8.h"
 
 namespace node {

--- a/src/debug_utils-inl.h
+++ b/src/debug_utils-inl.h
@@ -164,6 +164,20 @@ inline void FORCE_INLINE Debug(AsyncWrap* async_wrap,
   Debug(async_wrap, format.c_str(), std::forward<Args>(args)...);
 }
 
+namespace per_process {
+
+template <typename... Args>
+inline void FORCE_INLINE Debug(DebugCategory cat,
+                               const char* format,
+                               Args&&... args) {
+  Debug(&enabled_debug_list, cat, format, std::forward<Args>(args)...);
+}
+
+inline void FORCE_INLINE Debug(DebugCategory cat, const char* message) {
+  Debug(&enabled_debug_list, cat, message);
+}
+
+}  // namespace per_process
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -54,6 +54,9 @@
 #endif  // _WIN32
 
 namespace node {
+namespace per_process {
+EnabledDebugList enabled_debug_list;
+}
 
 void EnabledDebugList::Parse(Environment* env) {
   std::string cats;

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -55,7 +55,7 @@
 
 namespace node {
 
-EnabledDebugList::EnabledDebugList(Environment* env) {
+void EnabledDebugList::Parse(Environment* env) {
   std::string cats;
   credentials::SafeGetenv("NODE_DEBUG_NATIVE", &cats, env);
   Parse(cats, true);

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -1,5 +1,6 @@
 #include "debug_utils-inl.h"  // NOLINT(build/include)
 #include "env-inl.h"
+#include "node_internals.h"
 
 #ifdef __POSIX__
 #if defined(__linux__)
@@ -53,6 +54,34 @@
 #endif  // _WIN32
 
 namespace node {
+
+EnabledDebugList::EnabledDebugList(Environment* env) {
+  std::string cats;
+  credentials::SafeGetenv("NODE_DEBUG_NATIVE", &cats, env);
+  Parse(cats, true);
+}
+
+void EnabledDebugList::Parse(const std::string& cats, bool enabled) {
+  std::string debug_categories = cats;
+  while (!debug_categories.empty()) {
+    std::string::size_type comma_pos = debug_categories.find(',');
+    std::string wanted = ToLower(debug_categories.substr(0, comma_pos));
+
+#define V(name)                                                                \
+  {                                                                            \
+    static const std::string available_category = ToLower(#name);              \
+    if (available_category.find(wanted) != std::string::npos)                  \
+      set_enabled(DebugCategory::name, enabled);                               \
+  }
+
+    DEBUG_CATEGORY_NAMES(V)
+#undef V
+
+    if (comma_pos == std::string::npos) break;
+    // Use everything after the `,` as the list for the next iteration.
+    debug_categories = debug_categories.substr(comma_pos + 1);
+  }
+}
 
 #ifdef __POSIX__
 #if HAVE_EXECINFO_H

--- a/src/debug_utils.h
+++ b/src/debug_utils.h
@@ -163,18 +163,14 @@ void CheckedUvLoopClose(uv_loop_t* loop);
 void PrintLibuvHandleInformation(uv_loop_t* loop, FILE* stream);
 
 namespace per_process {
-extern std::shared_ptr<EnabledDebugList> enabled_debug_list;
+extern EnabledDebugList enabled_debug_list;
 
 template <typename... Args>
 inline void FORCE_INLINE Debug(DebugCategory cat,
                                const char* format,
-                               Args&&... args) {
-  Debug(enabled_debug_list.get(), cat, format, std::forward<Args>(args)...);
-}
+                               Args&&... args);
 
-inline void FORCE_INLINE Debug(DebugCategory cat, const char* message) {
-  Debug(enabled_debug_list.get(), cat, message);
-}
+inline void FORCE_INLINE Debug(DebugCategory cat, const char* message);
 }  // namespace per_process
 }  // namespace node
 

--- a/src/debug_utils.h
+++ b/src/debug_utils.h
@@ -189,7 +189,20 @@ class NativeSymbolDebuggingContext {
 void CheckedUvLoopClose(uv_loop_t* loop);
 void PrintLibuvHandleInformation(uv_loop_t* loop, FILE* stream);
 
-}  // namespace node
+namespace per_process {
+extern std::shared_ptr<EnabledDebugList> enabled_debug_list;
+
+template <typename... Args>
+inline void FORCE_INLINE Debug(DebugCategory cat,
+                               const char* format,
+                               Args&&... args) {
+  Debug(enabled_debug_list.get(), cat, format, std::forward<Args>(args)...);
+}
+
+inline void FORCE_INLINE Debug(DebugCategory cat, const char* message) {
+  Debug(enabled_debug_list.get(), cat, message);
+}
+}  // namespace per_process
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 

--- a/src/debug_utils.h
+++ b/src/debug_utils.h
@@ -42,6 +42,7 @@ void FWrite(FILE* file, const std::string& str);
   NODE_ASYNC_PROVIDER_TYPES(V)                                                 \
   V(INSPECTOR_SERVER)                                                          \
   V(INSPECTOR_PROFILER)                                                        \
+  V(CODE_CACHE)                                                                \
   V(WASI)
 
 enum class DebugCategory {
@@ -203,6 +204,7 @@ inline void FORCE_INLINE Debug(DebugCategory cat, const char* message) {
   Debug(enabled_debug_list.get(), cat, message);
 }
 }  // namespace per_process
+}  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -609,20 +609,6 @@ inline void Environment::set_http2_state(
   http2_state_ = std::move(buffer);
 }
 
-bool Environment::debug_enabled(DebugCategory category) const {
-  DCHECK_GE(static_cast<int>(category), 0);
-  DCHECK_LT(static_cast<int>(category),
-           static_cast<int>(DebugCategory::CATEGORY_COUNT));
-  return debug_enabled_[static_cast<int>(category)];
-}
-
-void Environment::set_debug_enabled(DebugCategory category, bool enabled) {
-  DCHECK_GE(static_cast<int>(category), 0);
-  DCHECK_LT(static_cast<int>(category),
-           static_cast<int>(DebugCategory::CATEGORY_COUNT));
-  debug_enabled_[static_cast<int>(category)] = enabled;
-}
-
 inline AliasedFloat64Array* Environment::fs_stats_field_array() {
   return &fs_stats_field_array_;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -1,6 +1,7 @@
 #include "env.h"
 
 #include "async_wrap.h"
+#include "debug_utils-inl.h"
 #include "memory_tracker-inl.h"
 #include "node_buffer.h"
 #include "node_context_data.h"
@@ -315,6 +316,7 @@ Environment::Environment(IsolateData* isolate_data,
   Context::Scope context_scope(context);
 
   set_env_vars(per_process::system_environment);
+  enabled_debug_list_ = std::make_unique<EnabledDebugList>(this);
 
   // We create new copies of the per-Environment option sets, so that it is
   // easier to modify them after Environment creation. The defaults are
@@ -374,10 +376,6 @@ Environment::Environment(IsolateData* isolate_data,
 
   // By default, always abort when --abort-on-uncaught-exception was passed.
   should_abort_on_uncaught_toggle_[0] = 1;
-
-  std::string debug_cats;
-  credentials::SafeGetenv("NODE_DEBUG_NATIVE", &debug_cats, this);
-  set_debug_categories(debug_cats, true);
 
   if (options_->no_force_async_hooks_checks) {
     async_hooks_.no_force_checks();
@@ -862,29 +860,6 @@ Local<Value> Environment::GetNow() {
     return Integer::NewFromUnsigned(isolate(), static_cast<uint32_t>(now));
   else
     return Number::New(isolate(), static_cast<double>(now));
-}
-
-void Environment::set_debug_categories(const std::string& cats, bool enabled) {
-  std::string debug_categories = cats;
-  while (!debug_categories.empty()) {
-    std::string::size_type comma_pos = debug_categories.find(',');
-    std::string wanted = ToLower(debug_categories.substr(0, comma_pos));
-
-#define V(name)                                                          \
-    {                                                                    \
-      static const std::string available_category = ToLower(#name);      \
-      if (available_category.find(wanted) != std::string::npos)          \
-        set_debug_enabled(DebugCategory::name, enabled);                 \
-    }
-
-    DEBUG_CATEGORY_NAMES(V)
-#undef V
-
-    if (comma_pos == std::string::npos)
-      break;
-    // Use everything after the `,` as the list for the next iteration.
-    debug_categories = debug_categories.substr(comma_pos + 1);
-  }
 }
 
 void CollectExceptionInfo(Environment* env,

--- a/src/env.cc
+++ b/src/env.cc
@@ -316,7 +316,7 @@ Environment::Environment(IsolateData* isolate_data,
   Context::Scope context_scope(context);
 
   set_env_vars(per_process::system_environment);
-  enabled_debug_list_ = std::make_unique<EnabledDebugList>(this);
+  enabled_debug_list_.Parse(this);
 
   // We create new copies of the per-Environment option sets, so that it is
   // easier to modify them after Environment creation. The defaults are

--- a/src/env.h
+++ b/src/env.h
@@ -547,20 +547,7 @@ struct ContextInfo {
   bool is_default = false;
 };
 
-// Listing the AsyncWrap provider types first enables us to cast directly
-// from a provider type to a debug category.
-#define DEBUG_CATEGORY_NAMES(V)                                                \
-  NODE_ASYNC_PROVIDER_TYPES(V)                                                 \
-  V(INSPECTOR_SERVER)                                                          \
-  V(INSPECTOR_PROFILER)                                                        \
-  V(WASI)
-
-enum class DebugCategory {
-#define V(name) name,
-  DEBUG_CATEGORY_NAMES(V)
-#undef V
-  CATEGORY_COUNT
-};
+class EnabledDebugList;
 
 // A unique-pointer-ish object that is compatible with the JS engine's
 // ArrayBuffer::Allocator.
@@ -1022,9 +1009,9 @@ class Environment : public MemoryRetainer {
   inline http2::Http2State* http2_state() const;
   inline void set_http2_state(std::unique_ptr<http2::Http2State> state);
 
-  inline bool debug_enabled(DebugCategory category) const;
-  inline void set_debug_enabled(DebugCategory category, bool enabled);
-  void set_debug_categories(const std::string& cats, bool enabled);
+  EnabledDebugList* enabled_debug_list() const {
+    return enabled_debug_list_.get();
+  }
 
   inline AliasedFloat64Array* fs_stats_field_array();
   inline AliasedBigUint64Array* fs_stats_field_bigint_array();
@@ -1384,9 +1371,7 @@ class Environment : public MemoryRetainer {
   bool http_parser_buffer_in_use_ = false;
   std::unique_ptr<http2::Http2State> http2_state_;
 
-  bool debug_enabled_[static_cast<int>(DebugCategory::CATEGORY_COUNT)] = {
-      false};
-
+  std::unique_ptr<EnabledDebugList> enabled_debug_list_;
   AliasedFloat64Array fs_stats_field_array_;
   AliasedBigUint64Array fs_stats_field_bigint_array_;
 

--- a/src/env.h
+++ b/src/env.h
@@ -29,6 +29,7 @@
 #include "inspector_agent.h"
 #include "inspector_profiler.h"
 #endif
+#include "debug_utils.h"
 #include "handle_wrap.h"
 #include "node.h"
 #include "node_binding.h"
@@ -1009,9 +1010,7 @@ class Environment : public MemoryRetainer {
   inline http2::Http2State* http2_state() const;
   inline void set_http2_state(std::unique_ptr<http2::Http2State> state);
 
-  EnabledDebugList* enabled_debug_list() const {
-    return enabled_debug_list_.get();
-  }
+  EnabledDebugList* enabled_debug_list() { return &enabled_debug_list_; }
 
   inline AliasedFloat64Array* fs_stats_field_array();
   inline AliasedBigUint64Array* fs_stats_field_bigint_array();
@@ -1371,7 +1370,7 @@ class Environment : public MemoryRetainer {
   bool http_parser_buffer_in_use_ = false;
   std::unique_ptr<http2::Http2State> http2_state_;
 
-  std::unique_ptr<EnabledDebugList> enabled_debug_list_;
+  EnabledDebugList enabled_debug_list_;
   AliasedFloat64Array fs_stats_field_array_;
   AliasedBigUint64Array fs_stats_field_bigint_array_;
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -912,6 +912,10 @@ void Init(int* argc,
 }
 
 InitializationResult InitializeOncePerProcess(int argc, char** argv) {
+  // Initialized the enabled list for Debug() calls with system
+  // environment variables.
+  per_process::enabled_debug_list.Parse(nullptr);
+
   atexit(ResetStdio);
   PlatformInit();
 

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -1,3 +1,4 @@
+#include "debug_utils-inl.h"
 #include "env-inl.h"
 #include "node_errors.h"
 #include "node_process.h"

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -58,6 +58,8 @@ class MapKVStore final : public KVStore {
 namespace per_process {
 Mutex env_var_mutex;
 std::shared_ptr<KVStore> system_environment = std::make_shared<RealEnvStore>();
+std::shared_ptr<EnabledDebugList> enabled_debug_list =
+    std::make_shared<EnabledDebugList>(nullptr);
 }  // namespace per_process
 
 template <typename T>

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -58,8 +58,6 @@ class MapKVStore final : public KVStore {
 namespace per_process {
 Mutex env_var_mutex;
 std::shared_ptr<KVStore> system_environment = std::make_shared<RealEnvStore>();
-std::shared_ptr<EnabledDebugList> enabled_debug_list =
-    std::make_shared<EnabledDebugList>(nullptr);
 }  // namespace per_process
 
 template <typename T>

--- a/tools/code_cache/cache_builder.cc
+++ b/tools/code_cache/cache_builder.cc
@@ -1,4 +1,5 @@
 #include "cache_builder.h"
+#include "debug_utils-inl.h"
 #include "node_native_module.h"
 #include "util.h"
 
@@ -67,8 +68,7 @@ static void GetInitializer(const std::string& id, std::stringstream& ss) {
 }
 
 static std::string GenerateCodeCache(
-    const std::map<std::string, ScriptCompiler::CachedData*>& data,
-    bool log_progress) {
+    const std::map<std::string, ScriptCompiler::CachedData*>& data) {
   std::stringstream ss;
   ss << R"(#include <cinttypes>
 #include "node_native_module_env.h"
@@ -89,11 +89,13 @@ const bool has_code_cache = true;
     total += cached_data->length;
     std::string def = GetDefinition(id, cached_data->length, cached_data->data);
     ss << def << "\n\n";
-    if (log_progress) {
-      std::cout << "Generated cache for " << id
-                << ", size = " << FormatSize(cached_data->length)
-                << ", total = " << FormatSize(total) << "\n";
-    }
+    std::string size_str = FormatSize(cached_data->length);
+    std::string total_str = FormatSize(total);
+    per_process::Debug(DebugCategory::CODE_CACHE,
+                       "Generated cache for %s, size = %s, total = %s",
+                       id.c_str(),
+                       size_str.c_str(),
+                       total_str.c_str());
   }
 
   ss << R"(void NativeModuleEnv::InitializeCodeCache() {
@@ -142,14 +144,7 @@ std::string CodeCacheBuilder::Generate(Local<Context> context) {
     }
   }
 
-  char env_buf[32];
-  size_t env_size = sizeof(env_buf);
-  int ret = uv_os_getenv("NODE_DEBUG", env_buf, &env_size);
-  bool log_progress = false;
-  if (ret == 0 && strcmp(env_buf, "mkcodecache") == 0) {
-    log_progress = true;
-  }
-  return GenerateCodeCache(data, log_progress);
+  return GenerateCodeCache(data);
 }
 
 }  // namespace native_module

--- a/tools/code_cache/cache_builder.cc
+++ b/tools/code_cache/cache_builder.cc
@@ -92,7 +92,7 @@ const bool has_code_cache = true;
     std::string size_str = FormatSize(cached_data->length);
     std::string total_str = FormatSize(total);
     per_process::Debug(DebugCategory::CODE_CACHE,
-                       "Generated cache for %s, size = %s, total = %s",
+                       "Generated cache for %s, size = %s, total = %s\n",
                        id.c_str(),
                        size_str.c_str(),
                        total_str.c_str());

--- a/tools/code_cache/mkcodecache.cc
+++ b/tools/code_cache/mkcodecache.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "cache_builder.h"
+#include "debug_utils-inl.h"
 #include "libplatform/libplatform.h"
 #include "v8.h"
 
@@ -39,6 +40,8 @@ int main(int argc, char* argv[]) {
     std::cerr << "Cannot open " << argv[1] << "\n";
     return 1;
   }
+
+  node::per_process::enabled_debug_list.Parse(nullptr);
 
   std::unique_ptr<v8::Platform> platform = v8::platform::NewDefaultPlatform();
   v8::V8::InitializePlatform(platform.get());


### PR DESCRIPTION
#### src: make aliased_buffer.h self-contained

aliased_buffer.h uses MultiplyWithOverflowCheck() implemented
in util-inl.h

#### src: refactor debug category parsing

Move the debug category parsing into a new EnabledDebugList class,
so that it can be reused outside of Environment.

#### src: implement per-process native Debug() printer

This patch adds a per-process native Debug() printer that can be
called when an Environment is not available.

#### tools: use per-process native Debug() printer in mkcodecache

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
