### PR TITLE
[10.x] test: Mark test-http2-client-upload as flaky on 10.x

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -11,6 +11,8 @@ test-net-connect-options-port: PASS,FLAKY
 test-trace-events-api-worker-disabled: PASS,FLAKY
 
 [$system==win32]
+# https://github.com/nodejs/node/issues/20750
+test-http2-client-upload: PASS,FLAKY
 test-http2-pipe: PASS,FLAKY
 test-worker-syntax-error: PASS,FLAKY
 test-worker-syntax-error-file: PASS,FLAKY

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -13,6 +13,12 @@ test-trace-events-api-worker-disabled: PASS,FLAKY
 [$system==win32]
 # https://github.com/nodejs/node/issues/20750
 test-http2-client-upload: PASS,FLAKY
+# https://github.com/nodejs/node/issues/20750
+test-http2-client-upload-reject: PASS,FLAKY
+# https://github.com/nodejs/node/issues/30847
+test-http2-compat-client-upload-reject: PASS,FLAKY
+# https://github.com/nodejs/node/issues/30845
+test-http2-multistream-destroy-on-read-tls: PASS,FLAKY
 test-http2-pipe: PASS,FLAKY
 test-worker-syntax-error: PASS,FLAKY
 test-worker-syntax-error-file: PASS,FLAKY


### PR DESCRIPTION
This test is failing ci a lot and is already marked as flaky on master and 12.x