### PR TITLE
cli: --perf-prof only works on Linux

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1164,6 +1164,9 @@ V8 options that are allowed are:
 * `--stack-trace-limit`
 <!-- node-options-v8 end -->
 
+`--perf-basic-prof-only-functions`, `--perf-basic-prof`,
+`--perf-prof-unwinding-info`, and `--perf-prof` are only available on Linux.
+
 ### `NODE_PATH=path[:…]`
 <!-- YAML
 added: v0.1.32

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -48,15 +48,14 @@ expectNoWorker('--trace-event-file-pattern {pid}-${rotation}.trace_events ' +
        '--trace-event-categories node.async_hooks', 'B\n');
 expect('--unhandled-rejections=none', 'B\n');
 
-if (!common.isWindows) {
+if (common.isLinux) {
   expect('--perf-basic-prof', 'B\n');
   expect('--perf-basic-prof-only-functions', 'B\n');
-}
 
-if (common.isLinux && ['arm', 'x64'].includes(process.arch)) {
-  // PerfJitLogger is only implemented in Linux.
-  expect('--perf-prof', 'B\n');
-  expect('--perf-prof-unwinding-info', 'B\n');
+  if (['arm', 'x64'].includes(process.arch)) {
+    expect('--perf-prof', 'B\n');
+    expect('--perf-prof-unwinding-info', 'B\n');
+  }
 }
 
 if (common.hasCrypto) {


### PR DESCRIPTION
`--perf-prof`-related flags have been removed in V8 on non-linux devices, and so we should note that in testing here as well as in docs.

See:
* https://chromium-review.googlesource.com/c/v8/v8/+/1993969
* https://chromium-review.googlesource.com/c/v8/v8/+/1993978

This broke in Electron, which is how i discovered it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
