### PR TITLE
src: include large pages source unconditionally

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -620,6 +620,8 @@
         'src/histogram.h',
         'src/histogram-inl.h',
         'src/js_stream.h',
+        'src/large_pages/node_large_page.cc',
+        'src/large_pages/node_large_page.h'
         'src/memory_tracker.h',
         'src/memory_tracker-inl.h',
         'src/module_wrap.h',
@@ -851,10 +853,6 @@
           'target_arch=="x64" and '
           'node_target_type=="executable"', {
           'defines': [ 'NODE_ENABLE_LARGE_CODE_PAGES=1' ],
-          'sources': [
-            'src/large_pages/node_large_page.cc',
-            'src/large_pages/node_large_page.h'
-          ],
         }],
         [ 'use_openssl_def==1', {
           # TODO(bnoordhuis) Make all platforms export the same list of symbols.

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -75,7 +75,9 @@ extern char __executable_start;
 }  // extern "C"
 #endif  // defined(__linux__)
 
+#endif  // defined(NODE_ENABLE_LARGE_CODE_PAGES) && NODE_ENABLE_LARGE_CODE_PAGES
 namespace node {
+#if defined(NODE_ENABLE_LARGE_CODE_PAGES) && NODE_ENABLE_LARGE_CODE_PAGES
 
 namespace {
 

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -21,6 +21,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "node_large_page.h"
+
+// Besides returning ENOTSUP at runtime we do nothing if this define is missing.
+#if defined(NODE_ENABLE_LARGE_CODE_PAGES) && NODE_ENABLE_LARGE_CODE_PAGES
 #include "util.h"
 #include "uv.h"
 
@@ -73,6 +76,8 @@ extern char __executable_start;
 
 namespace node {
 
+namespace {
+
 struct text_region {
   char* from;
   char* to;
@@ -103,7 +108,7 @@ inline uintptr_t hugepage_align_down(uintptr_t addr) {
 // 00400000-00452000 r-xp 00000000 08:02 173521      /usr/bin/dbus-daemon
 // This is also handling the case where the first line is not the binary.
 
-static struct text_region FindNodeTextRegion() {
+struct text_region FindNodeTextRegion() {
   struct text_region nregion;
   nregion.found_text_region = false;
 #if defined(__linux__)
@@ -263,7 +268,7 @@ static struct text_region FindNodeTextRegion() {
 }
 
 #if defined(__linux__)
-static bool IsTransparentHugePagesEnabled() {
+bool IsTransparentHugePagesEnabled() {
   std::ifstream ifs;
 
   ifs.open("/sys/kernel/mm/transparent_hugepage/enabled");
@@ -293,6 +298,8 @@ static bool IsSuperPagesEnabled() {
          super_pages >= 1;
 }
 #endif
+
+}  // End of anonymous namespace
 
 // Moving the text region to large pages. We need to be very careful.
 // 1: This function itself should not be moved.
@@ -408,14 +415,26 @@ MoveTextRegionToLargePages(const text_region& r) {
   if (-1 == munmap(nmem, size)) PrintSystemError(errno);
   return ret;
 }
+#endif  // defined(NODE_ENABLE_LARGE_CODE_PAGES) && NODE_ENABLE_LARGE_CODE_PAGES
 
 // This is the primary API called from main.
 int MapStaticCodeToLargePages() {
+#if defined(NODE_ENABLE_LARGE_CODE_PAGES) && NODE_ENABLE_LARGE_CODE_PAGES
+  bool have_thp = false;
+#if defined(__linux__)
+  have_thp = IsTransparentHugePagesEnabled();
+#elif defined(__FreeBSD__)
+  have_thp = IsSuperPagesEnabled();
+#elif defined(__APPLE__)
+  // pse-36 flag is present in recent mac x64 products.
+  have_thp = true;
+#endif
+  if (!have_thp)
+    return EACCES;
+
   struct text_region r = FindNodeTextRegion();
-  if (r.found_text_region == false) {
-    PrintWarning("failed to find text region");
-    return -1;
-  }
+  if (r.found_text_region == false)
+    return ENOENT;
 
 #if defined(__FreeBSD__)
   if (r.from < reinterpret_cast<void*>(&MoveTextRegionToLargePages))
@@ -423,17 +442,32 @@ int MapStaticCodeToLargePages() {
 #endif
 
   return MoveTextRegionToLargePages(r);
+#else
+  return ENOTSUP;
+#endif
 }
 
-bool IsLargePagesEnabled() {
-#if defined(__linux__)
-  return IsTransparentHugePagesEnabled();
-#elif defined(__FreeBSD__)
-  return IsSuperPagesEnabled();
-#elif defined(__APPLE__)
-  // pse-36 flag is present in recent mac x64 products.
-  return true;
-#endif
+const char* LargePagesError(int status) {
+  switch (status) {
+    case ENOTSUP:
+      return "Mapping to large pages is not supported.";
+
+    case EACCES:
+      return "Large pages are not enabled.";
+
+    case ENOENT:
+      return "failed to find text region";
+
+    case -1:
+      return "Mapping code to large pages failed. Reverting to default page "
+          "size.";
+
+    case 0:
+      return "OK";
+
+    default:
+      return "Unknown error";
+  }
 }
 
 }  // namespace node

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -22,6 +22,8 @@
 
 #include "node_large_page.h"
 
+#include <cerrno>   // NOLINT(build/include)
+
 // Besides returning ENOTSUP at runtime we do nothing if this define is missing.
 #if defined(NODE_ENABLE_LARGE_CODE_PAGES) && NODE_ENABLE_LARGE_CODE_PAGES
 #include "util.h"
@@ -38,7 +40,6 @@
 #endif
 #include <unistd.h>  // readlink
 
-#include <cerrno>   // NOLINT(build/include)
 #include <climits>  // PATH_MAX
 #include <clocale>
 #include <csignal>

--- a/src/large_pages/node_large_page.h
+++ b/src/large_pages/node_large_page.h
@@ -25,10 +25,9 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-
 namespace node {
-bool IsLargePagesEnabled();
 int MapStaticCodeToLargePages();
+const char* LargePagesError(int status);
 }  // namespace node
 
 #endif  // NODE_WANT_INTERNALS

--- a/src/node.cc
+++ b/src/node.cc
@@ -65,9 +65,7 @@
 #include "inspector/worker_inspector.h"  // ParentInspectorHandle
 #endif
 
-#ifdef NODE_ENABLE_LARGE_CODE_PAGES
 #include "large_pages/node_large_page.h"
-#endif
 
 #ifdef NODE_REPORT
 #include "node_report.h"
@@ -936,25 +934,13 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
     }
   }
 
-#if defined(NODE_ENABLE_LARGE_CODE_PAGES) && NODE_ENABLE_LARGE_CODE_PAGES
   if (per_process::cli_options->use_largepages == "on" ||
       per_process::cli_options->use_largepages == "silent") {
-    if (node::IsLargePagesEnabled()) {
-      if (node::MapStaticCodeToLargePages() != 0 &&
-          per_process::cli_options->use_largepages != "silent") {
-        fprintf(stderr,
-                "Mapping code to large pages failed. Reverting to default page "
-                "size.\n");
-      }
-    } else if (per_process::cli_options->use_largepages != "silent") {
-      fprintf(stderr, "Large pages are not enabled.\n");
+    int result = node::MapStaticCodeToLargePages();
+    if (per_process::cli_options->use_largepages == "on" && result != 0) {
+      fprintf(stderr, "%s\n", node::LargePagesError(result));
     }
   }
-#else
-  if (per_process::cli_options->use_largepages == "on") {
-    fprintf(stderr, "Mapping to large pages is not supported.\n");
-  }
-#endif  // NODE_ENABLE_LARGE_CODE_PAGES
 
   if (per_process::cli_options->print_version) {
     printf("%s\n", NODE_VERSION);


### PR DESCRIPTION
Restrict the usage of the C preprocessor directive enabling large
pages support to the large pages implementation. This cleans up the
code in src/node.cc.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
