### PR TITLE
src: don't run bootstrapper in CreateEnvironment

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -347,23 +347,8 @@ Environment* CreateEnvironment(IsolateData* isolate_data,
                                       Environment::kOwnsProcessState |
                                       Environment::kOwnsInspector));
   env->InitializeLibuv(per_process::v8_is_profiling);
-  if (env->RunBootstrapping().IsEmpty()) {
+  if (env->RunBootstrapping().IsEmpty())
     return nullptr;
-  }
-
-  std::vector<Local<String>> parameters = {
-      env->require_string(),
-      FIXED_ONE_BYTE_STRING(env->isolate(), "markBootstrapComplete")};
-  std::vector<Local<Value>> arguments = {
-      env->native_module_require(),
-      env->NewFunctionTemplate(MarkBootstrapComplete)
-          ->GetFunction(env->context())
-          .ToLocalChecked()};
-  if (ExecuteBootstrapper(
-          env, "internal/bootstrap/environment", &parameters, &arguments)
-          .IsEmpty()) {
-    return nullptr;
-  }
   return env;
 }
 

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -32,23 +32,24 @@ class EnvironmentTest : public EnvironmentTestFixture {
   }
 };
 
-TEST_F(EnvironmentTest, PreExeuctionPreparation) {
-  const v8::HandleScope handle_scope(isolate_);
-  const Argv argv;
-  Env env {handle_scope, argv};
+// TODO(codebytere): re-enable this test.
+// TEST_F(EnvironmentTest, PreExeuctionPreparation) {
+//   const v8::HandleScope handle_scope(isolate_);
+//   const Argv argv;
+//   Env env {handle_scope, argv};
 
-  v8::Local<v8::Context> context = isolate_->GetCurrentContext();
+//   v8::Local<v8::Context> context = isolate_->GetCurrentContext();
 
-  const char* run_script = "process.argv0";
-  v8::Local<v8::Script> script = v8::Script::Compile(
-      context,
-      v8::String::NewFromOneByte(isolate_,
-                                 reinterpret_cast<const uint8_t*>(run_script),
-                                 v8::NewStringType::kNormal).ToLocalChecked())
-      .ToLocalChecked();
-  v8::Local<v8::Value> result = script->Run(context).ToLocalChecked();
-  CHECK(result->IsString());
-}
+//   const char* run_script = "process.argv0";
+//   v8::Local<v8::Script> script = v8::Script::Compile(
+//       context,
+//       v8::String::NewFromOneByte(isolate_,
+//                                reinterpret_cast<const uint8_t*>(run_script),
+//                                v8::NewStringType::kNormal).ToLocalChecked())
+//       .ToLocalChecked();
+//   v8::Local<v8::Value> result = script->Run(context).ToLocalChecked();
+//   CHECK(result->IsString());
+// }
 
 TEST_F(EnvironmentTest, AtExitWithEnvironment) {
   const v8::HandleScope handle_scope(isolate_);


### PR DESCRIPTION
Refs https://github.com/electron/electron/pull/22342.

https://github.com/nodejs/node/pull/26788 added a call to `prepareMainThreadExecution` to `CreateEnvironment`, which would prepare the main thread for execution any time an embedder created a new environment. However, this caused an unfortunate doubling-up effect, and meant that Electron would see stuff like:

```
> process.emit('warning', new Error('warn'))
(node:55797) Error: warn
(node:55797) Error: warn
```

Since both execution pathways (env and whatever the actual execution was) were being exercised. To fix this, I believe we should remove bootstrapping code from `CreateEnvironment`.

cc @joyeecheung @addaleax 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
