### PR TITLE
http,stream: make virtual methods throw an error

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -619,7 +619,7 @@ OutgoingMessage.prototype.removeHeader = function removeHeader(name) {
 
 
 OutgoingMessage.prototype._implicitHeader = function _implicitHeader() {
-  this.emit('error', new ERR_METHOD_NOT_IMPLEMENTED('_implicitHeader()'));
+  throw new ERR_METHOD_NOT_IMPLEMENTED('_implicitHeader()');
 };
 
 ObjectDefineProperty(OutgoingMessage.prototype, 'headersSent', {

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -628,7 +628,7 @@ function maybeReadMore_(stream, state) {
 // for virtual (non-string, non-buffer) streams, "length" is somewhat
 // arbitrary, and perhaps not very meaningful.
 Readable.prototype._read = function(n) {
-  errorOrDestroy(this, new ERR_METHOD_NOT_IMPLEMENTED('_read()'));
+  throw new ERR_METHOD_NOT_IMPLEMENTED('_read()');
 };
 
 Readable.prototype.pipe = function(dest, pipeOpts) {

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -163,7 +163,7 @@ Transform.prototype.push = function(chunk, encoding) {
 // an error, then that'll put the hurt on the whole operation.  If you
 // never call cb(), then you'll never get another chunk.
 Transform.prototype._transform = function(chunk, encoding, cb) {
-  cb(new ERR_METHOD_NOT_IMPLEMENTED('_transform()'));
+  throw new ERR_METHOD_NOT_IMPLEMENTED('_transform()');
 };
 
 Transform.prototype._write = function(chunk, encoding, cb) {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -560,7 +560,7 @@ Writable.prototype._write = function(chunk, encoding, cb) {
   if (this._writev) {
     this._writev([{ chunk, encoding }], cb);
   } else {
-    process.nextTick(cb, new ERR_METHOD_NOT_IMPLEMENTED('_write()'));
+    throw new ERR_METHOD_NOT_IMPLEMENTED('_write()');
   }
 };
 

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const http = require('http');
@@ -62,13 +62,16 @@ assert.throws(() => {
 {
   const outgoingMessage = new OutgoingMessage();
 
-  outgoingMessage.on('error', common.expectsError({
-    code: 'ERR_METHOD_NOT_IMPLEMENTED',
-    name: 'Error',
-    message: 'The _implicitHeader() method is not implemented'
-  }));
-
-  outgoingMessage.write('');
+  assert.throws(
+    () => {
+      outgoingMessage.write('');
+    },
+    {
+      code: 'ERR_METHOD_NOT_IMPLEMENTED',
+      name: 'Error',
+      message: 'The _implicitHeader() method is not implemented'
+    }
+  );
 }
 
 assert(OutgoingMessage.prototype.write.call({ _header: 'test' }));

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -14,7 +14,9 @@ async function tests() {
   {
     const AsyncIteratorPrototype = Object.getPrototypeOf(
       Object.getPrototypeOf(async function* () {}).prototype);
-    const rs = new Readable({});
+    const rs = new Readable({
+      read() {}
+    });
     assert.strictEqual(
       Object.getPrototypeOf(Object.getPrototypeOf(rs[Symbol.asyncIterator]())),
       AsyncIteratorPrototype);

--- a/test/parallel/test-stream-readable-with-unimplemented-_read.js
+++ b/test/parallel/test-stream-readable-with-unimplemented-_read.js
@@ -1,14 +1,18 @@
 'use strict';
-const common = require('../common');
+require('../common');
 
+const assert = require('assert');
 const { Readable } = require('stream');
 
 const readable = new Readable();
 
-readable.on('error', common.expectsError({
-  code: 'ERR_METHOD_NOT_IMPLEMENTED',
-  name: 'Error',
-  message: 'The _read() method is not implemented'
-}));
-
-readable.read();
+assert.throws(
+  () => {
+    readable.read();
+  },
+  {
+    code: 'ERR_METHOD_NOT_IMPLEMENTED',
+    name: 'Error',
+    message: 'The _read() method is not implemented'
+  }
+);

--- a/test/parallel/test-stream-transform-constructor-set-methods.js
+++ b/test/parallel/test-stream-transform-constructor-set-methods.js
@@ -1,18 +1,21 @@
 'use strict';
 const common = require('../common');
 
-const { strictEqual } = require('assert');
+const assert = require('assert');
 const { Transform } = require('stream');
 
 const t = new Transform();
 
-t.on('error', common.expectsError({
-  name: 'Error',
-  code: 'ERR_METHOD_NOT_IMPLEMENTED',
-  message: 'The _transform() method is not implemented'
-}));
-
-t.end(Buffer.from('blerg'));
+assert.throws(
+  () => {
+    t.end(Buffer.from('blerg'));
+  },
+  {
+    name: 'Error',
+    code: 'ERR_METHOD_NOT_IMPLEMENTED',
+    message: 'The _transform() method is not implemented'
+  }
+);
 
 const _transform = common.mustCall((chunk, _, next) => {
   next();
@@ -32,9 +35,9 @@ const t2 = new Transform({
   final: _final
 });
 
-strictEqual(t2._transform, _transform);
-strictEqual(t2._flush, _flush);
-strictEqual(t2._final, _final);
+assert.strictEqual(t2._transform, _transform);
+assert.strictEqual(t2._flush, _flush);
+assert.strictEqual(t2._final, _final);
 
 t2.end(Buffer.from('blerg'));
 t2.resume();

--- a/test/parallel/test-stream-writable-constructor-set-methods.js
+++ b/test/parallel/test-stream-writable-constructor-set-methods.js
@@ -1,34 +1,36 @@
 'use strict';
 const common = require('../common');
 
-const { strictEqual } = require('assert');
+const assert = require('assert');
 const { Writable } = require('stream');
 
+const bufferBlerg = Buffer.from('blerg');
 const w = new Writable();
 
-w.on('error', common.expectsError({
-  name: 'Error',
-  code: 'ERR_METHOD_NOT_IMPLEMENTED',
-  message: 'The _write() method is not implemented'
-}));
-
-const bufferBlerg = Buffer.from('blerg');
-
-w.end(bufferBlerg);
+assert.throws(
+  () => {
+    w.end(bufferBlerg);
+  },
+  {
+    name: 'Error',
+    code: 'ERR_METHOD_NOT_IMPLEMENTED',
+    message: 'The _write() method is not implemented'
+  }
+);
 
 const _write = common.mustCall((chunk, _, next) => {
   next();
 });
 
 const _writev = common.mustCall((chunks, next) => {
-  strictEqual(chunks.length, 2);
+  assert.strictEqual(chunks.length, 2);
   next();
 });
 
 const w2 = new Writable({ write: _write, writev: _writev });
 
-strictEqual(w2._write, _write);
-strictEqual(w2._writev, _writev);
+assert.strictEqual(w2._write, _write);
+assert.strictEqual(w2._writev, _writev);
 
 w2.write(bufferBlerg);
 

--- a/test/parallel/test-tls-socket-allow-half-open-option.js
+++ b/test/parallel/test-tls-socket-allow-half-open-option.js
@@ -21,7 +21,10 @@ const tls = require('tls');
 {
   // The option is ignored when the `socket` argument is a generic
   // `stream.Duplex`.
-  const duplex = new stream.Duplex({ allowHalfOpen: false });
+  const duplex = new stream.Duplex({
+    allowHalfOpen: false,
+    read() {}
+  });
   const socket = new tls.TLSSocket(duplex, { allowHalfOpen: true });
   assert.strictEqual(socket.allowHalfOpen, false);
 }


### PR DESCRIPTION
Make virtual methods throw an ERR_METHOD_NOT_IMPLEMENTED error instead
of emitting it.

The error is not recoverable and the only way to handle it is to
override the method.

Refs: https://github.com/nodejs/node/pull/31818#pullrequestreview-359403469

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
