### PR TITLE
module: recover on statCache failure

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1091,6 +1091,22 @@ Module.prototype.require = function(id) {
   requireDepth++;
   try {
     return Module._load(id, this, /* isMain */ false);
+  } catch (e) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      // A module might be created synchronously in which case Node might
+      // errornously not find it - so try again without the statCache
+      const oldStatCache = statCache;
+      statCache = new Map();
+      try {
+        return Module._load(id, this, /* isMain */ false);
+      } catch (e) {
+        // If it failed, nothing was wrong with the statCache and this was
+        // just a conditional require so restore it
+        statCache = oldStatCache;
+        throw e;
+      }
+    }
+    throw e;
   } finally {
     requireDepth--;
   }

--- a/test/parallel/test-require-cache-clear-fail.js
+++ b/test/parallel/test-require-cache-clear-fail.js
@@ -1,0 +1,17 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const filename = path.join(tmpdir.path, 'nonExistingModule.js');
+assert.throws(() => {
+  require(filename);
+}, /Cannot find module/);
+
+fs.writeFileSync(filename, 'module.exports = \'Hello Node!\';');
+
+assert.strictEqual(require(filename), 'Hello Node!');


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Hey, this is an attempt to resolve the use cases in https://github.com/nodejs/node/issues/31803 and only pay the penalty on unsuccessful loads.

This means that conditional loads are slightly slower (since we attempt them again without the statCache) but all other loads should be as fast and the caching behaviour is less exposed to the user.

I think this is a reasonable tradeoff between not regressing the common pattern of conditional requires while still enabling synchronous resource creation.