### PR TITLE
crypto: simplify exportKeyingMaterial

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2800,7 +2800,7 @@ void SSLWrap<Base>::ExportKeyingMaterial(
                                  *label,
                                  label.length(),
                                  reinterpret_cast<const unsigned char*>(
-                                   context.get()),
+                                     context.get()),
                                  context.size(),
                                  use_context) != 1) {
     return ThrowCryptoError(env, ERR_get_error(), "SSL_export_keying_material");

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2789,14 +2789,10 @@ void SSLWrap<Base>::ExportKeyingMaterial(
 
   AllocatedBuffer out = env->AllocateManaged(olen);
 
-  ByteSource key;
-
-  int useContext = 0;
-  if (!args[2]->IsNull() && Buffer::HasInstance(args[2])) {
-    key = ByteSource::FromBuffer(args[2]);
-
-    useContext = 1;
-  }
+  ByteSource context;
+  bool use_context = !args[2]->IsUndefined();
+  if (use_context)
+    context = ByteSource::FromBuffer(args[2]);
 
   if (SSL_export_keying_material(w->ssl_.get(),
                                  reinterpret_cast<unsigned char*>(out.data()),
@@ -2804,9 +2800,9 @@ void SSLWrap<Base>::ExportKeyingMaterial(
                                  *label,
                                  label.length(),
                                  reinterpret_cast<const unsigned char*>(
-                                   key.get()),
-                                 key.size(),
-                                 useContext) != 1) {
+                                   context.get()),
+                                 context.size(),
+                                 use_context) != 1) {
     return ThrowCryptoError(env, ERR_get_error(), "SSL_export_keying_material");
   }
 


### PR DESCRIPTION
1. Use `bool` instead of `int`.
2. Don't call `Buffer::HasInstance`. We shouldn't silently ignore non-buffers, and `ByteSource::FromBuffer` will `CHECK` that the input is a `Buffer` anyway.
3. Rename `key` to `context`, because that's what it is.
4. Rename `useContext` to `use_context` for consistency with the rest of `node_crypto.cc`.
5. Use `IsUndefined` instead of `IsNull`, because the JavaScript layer will always either pass `undefined` or a `Buffer`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
