### PR TITLE
module: port source map sorting logic from chromium

### DIFF
--- a/lib/internal/source_map/source_map.js
+++ b/lib/internal/source_map/source_map.js
@@ -212,6 +212,7 @@ class SourceMap {
     let sourceIndex = 0;
     let sourceLineNumber = 0;
     let sourceColumnNumber = 0;
+    let hadNegativeColumnOffset = false;
 
     const sources = [];
     const originalToCanonicalURLMap = {};
@@ -241,7 +242,13 @@ class SourceMap {
           break;
       }
 
-      columnNumber += decodeVLQ(stringCharIterator);
+      // A negative columnOffset is valid, and if one is observed sorting is
+      // necessary, see: https://github.com/mozilla/source-map/pull/92
+      const columnOffset = decodeVLQ(stringCharIterator);
+      if (columnOffset < 0) {
+        hadNegativeColumnOffset = true;
+      }
+      columnNumber += columnOffset;
       if (isSeparator(stringCharIterator.peek())) {
         this.#mappings.push([lineNumber, columnNumber]);
         continue;
@@ -260,6 +267,9 @@ class SourceMap {
 
       this.#mappings.push([lineNumber, columnNumber, sourceURL,
                            sourceLineNumber, sourceColumnNumber]);
+    }
+    if (hadNegativeColumnOffset) {
+      this.#mappings.sort(compareSourceMapEntry);
     }
   };
 }
@@ -319,6 +329,21 @@ function cloneSourceMapV3(payload) {
     }
   }
   return payload;
+}
+
+/**
+ * @param {Array} entry1 source map entry [lineNumber, columnNumber, sourceURL,
+ *  sourceLineNumber, sourceColumnNumber]
+ * @param {Array} entry2 source map entry.
+ * @return {number}
+ */
+function compareSourceMapEntry(entry1, entry2) {
+  const [lineNumber1, columnNumber1] = entry1;
+  const [lineNumber2, columnNumber2] = entry2;
+  if (lineNumber1 !== lineNumber2) {
+    return lineNumber1 - lineNumber2;
+  }
+  return columnNumber1 - columnNumber2;
 }
 
 module.exports = {

--- a/lib/internal/source_map/source_map.js
+++ b/lib/internal/source_map/source_map.js
@@ -152,10 +152,12 @@ class SourceMap {
    * @param {SourceMapV3} mappingPayload
    */
   #parseMappingPayload = () => {
-    if (this.#payload.sections)
+    if (this.#payload.sections) {
       this.#parseSections(this.#payload.sections);
-    else
+    } else {
       this.#parseMap(this.#payload, 0, 0);
+    }
+    this.#mappings.sort(compareSourceMapEntry);
   }
 
   /**
@@ -212,7 +214,6 @@ class SourceMap {
     let sourceIndex = 0;
     let sourceLineNumber = 0;
     let sourceColumnNumber = 0;
-    let hadNegativeColumnOffset = false;
 
     const sources = [];
     const originalToCanonicalURLMap = {};
@@ -242,13 +243,7 @@ class SourceMap {
           break;
       }
 
-      // A negative columnOffset is valid, and if one is observed sorting is
-      // necessary, see: https://github.com/mozilla/source-map/pull/92
-      const columnOffset = decodeVLQ(stringCharIterator);
-      if (columnOffset < 0) {
-        hadNegativeColumnOffset = true;
-      }
-      columnNumber += columnOffset;
+      columnNumber += decodeVLQ(stringCharIterator);
       if (isSeparator(stringCharIterator.peek())) {
         this.#mappings.push([lineNumber, columnNumber]);
         continue;
@@ -267,9 +262,6 @@ class SourceMap {
 
       this.#mappings.push([lineNumber, columnNumber, sourceURL,
                            sourceLineNumber, sourceColumnNumber]);
-    }
-    if (hadNegativeColumnOffset) {
-      this.#mappings.sort(compareSourceMapEntry);
     }
   };
 }

--- a/test/parallel/test-source-map-api.js
+++ b/test/parallel/test-source-map-api.js
@@ -131,7 +131,7 @@ const { readFileSync } = require('fs');
   function makeMinimalMap(generatedColumns, originalColumns) {
     return {
       sources: ['test.js'],
-      // Mapping from the 0th line, 0th column of the output file to the 0th
+      // Mapping from the 0th line, ${g}th column of the output file to the 0th
       // source file, 0th line, ${column}th column.
       mappings: generatedColumns.map((g, i) => `${g}AA${originalColumns[i]}`)
         .join(',')

--- a/test/parallel/test-source-map-api.js
+++ b/test/parallel/test-source-map-api.js
@@ -124,3 +124,28 @@ const { readFileSync } = require('fs');
     assert.strictEqual(originalColumn, knownDecodings[column]);
   }
 }
+
+// Test that generated columns are sorted when a negative offset is
+// observed, see: https://github.com/mozilla/source-map/pull/92
+{
+  function makeMinimalMap(generatedColumns, originalColumns) {
+    return {
+      sources: ['test.js'],
+      // Mapping from the 0th line, 0th column of the output file to the 0th
+      // source file, 0th line, ${column}th column.
+      mappings: generatedColumns.map((g, i) => `${g}AA${originalColumns[i]}`)
+        .join(',')
+    };
+  }
+  // U = 10
+  // F = -2
+  // A = 0
+  // E = 2
+  const sourceMap = new SourceMap(makeMinimalMap(
+    ['U', 'F', 'F'],
+    ['A', 'E', 'E']
+  ));
+  assert.strictEqual(sourceMap.findEntry(0, 6).originalColumn, 4);
+  assert.strictEqual(sourceMap.findEntry(0, 8).originalColumn, 2);
+  assert.strictEqual(sourceMap.findEntry(0, 10).originalColumn, 0);
+}


### PR DESCRIPTION
Digging in to the delta between V8's source map library, and chromium's
the most significant difference that jumped out at me was that we were
failing to sort generated columns. Since negative offsets are not
restricted in the spec, this can lead to bugs.

fixes: #31286

---

Reading through the Chromium source map implementation, this was the most significant logic that jumped out at me as missing. Given the number of additional dependencies Chromium's implementation has, I think we'd do better to fix this bug, and stick with the source map class we have.

@jridgewell does this logic look correct to you, I used your tests as a starting point.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
