### PR TITLE
async_hooks: introduce mandatory store argument in AsyncLocalStorage run methods

### DIFF
--- a/benchmark/async_hooks/async-resource-vs-destroy.js
+++ b/benchmark/async_hooks/async-resource-vs-destroy.js
@@ -106,7 +106,7 @@ function buildDestroy(getServe) {
 function buildAsyncLocalStorage(getServe) {
   const asyncLocalStorage = new AsyncLocalStorage();
   const server = createServer((req, res) => {
-    asyncLocalStorage.runSyncAndReturn(() => {
+    asyncLocalStorage.runSyncAndReturn({}, () => {
       getServe(getCLS, setCLS)(req, res);
     });
   });
@@ -118,12 +118,12 @@ function buildAsyncLocalStorage(getServe) {
 
   function getCLS() {
     const store = asyncLocalStorage.getStore();
-    return store.get('store');
+    return store.state;
   }
 
   function setCLS(state) {
     const store = asyncLocalStorage.getStore();
-    store.set('store', state);
+    store.state = state;
   }
 
   function close() {

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -1,11 +1,9 @@
 'use strict';
 
 const {
-  Map,
   NumberIsSafeInteger,
   ReflectApply,
   Symbol,
-
 } = primordials;
 
 const {
@@ -247,14 +245,14 @@ class AsyncLocalStorage {
     }
   }
 
-  _enter() {
+  _enter(store) {
     if (!this.enabled) {
       this.enabled = true;
       storageList.push(this);
       storageHook.enable();
     }
     const resource = executionAsyncResource();
-    resource[this.kResourceStore] = new Map();
+    resource[this.kResourceStore] = store;
   }
 
   _exit() {
@@ -264,8 +262,8 @@ class AsyncLocalStorage {
     }
   }
 
-  runSyncAndReturn(callback, ...args) {
-    this._enter();
+  runSyncAndReturn(store, callback, ...args) {
+    this._enter(store);
     try {
       return callback(...args);
     } finally {
@@ -289,8 +287,8 @@ class AsyncLocalStorage {
     }
   }
 
-  run(callback, ...args) {
-    this._enter();
+  run(store, callback, ...args) {
+    this._enter(store);
     process.nextTick(callback, ...args);
     this._exit();
   }

--- a/test/async-hooks/test-async-local-storage-args.js
+++ b/test/async-hooks/test-async-local-storage-args.js
@@ -5,14 +5,14 @@ const { AsyncLocalStorage } = require('async_hooks');
 
 const asyncLocalStorage = new AsyncLocalStorage();
 
-asyncLocalStorage.run((runArg) => {
+asyncLocalStorage.run({}, (runArg) => {
   assert.strictEqual(runArg, 1);
   asyncLocalStorage.exit((exitArg) => {
     assert.strictEqual(exitArg, 2);
   }, 2);
 }, 1);
 
-asyncLocalStorage.runSyncAndReturn((runArg) => {
+asyncLocalStorage.runSyncAndReturn({}, (runArg) => {
   assert.strictEqual(runArg, 'foo');
   asyncLocalStorage.exitSyncAndReturn((exitArg) => {
     assert.strictEqual(exitArg, 'bar');

--- a/test/async-hooks/test-async-local-storage-async-await.js
+++ b/test/async-hooks/test-async-local-storage-async-await.js
@@ -12,7 +12,7 @@ async function test() {
 }
 
 async function main() {
-  await asyncLocalStorage.runSyncAndReturn(test);
+  await asyncLocalStorage.runSyncAndReturn(new Map(), test);
   assert.strictEqual(asyncLocalStorage.getStore(), undefined);
 }
 

--- a/test/async-hooks/test-async-local-storage-async-functions.js
+++ b/test/async-hooks/test-async-local-storage-async-functions.js
@@ -19,7 +19,7 @@ async function testAwait() {
   await asyncLocalStorage.exitSyncAndReturn(testOut);
 }
 
-asyncLocalStorage.run(() => {
+asyncLocalStorage.run(new Map(), () => {
   const store = asyncLocalStorage.getStore();
   store.set('key', 'value');
   testAwait(); // should not reject

--- a/test/async-hooks/test-async-local-storage-enable-disable.js
+++ b/test/async-hooks/test-async-local-storage-enable-disable.js
@@ -5,7 +5,7 @@ const { AsyncLocalStorage } = require('async_hooks');
 
 const asyncLocalStorage = new AsyncLocalStorage();
 
-asyncLocalStorage.runSyncAndReturn(() => {
+asyncLocalStorage.runSyncAndReturn(new Map(), () => {
   asyncLocalStorage.getStore().set('foo', 'bar');
   process.nextTick(() => {
     assert.strictEqual(asyncLocalStorage.getStore().get('foo'), 'bar');
@@ -13,7 +13,7 @@ asyncLocalStorage.runSyncAndReturn(() => {
     assert.strictEqual(asyncLocalStorage.getStore(), undefined);
     process.nextTick(() => {
       assert.strictEqual(asyncLocalStorage.getStore(), undefined);
-      asyncLocalStorage.runSyncAndReturn(() => {
+      asyncLocalStorage.runSyncAndReturn(new Map(), () => {
         assert.notStrictEqual(asyncLocalStorage.getStore(), undefined);
       });
     });

--- a/test/async-hooks/test-async-local-storage-errors-async.js
+++ b/test/async-hooks/test-async-local-storage-errors-async.js
@@ -13,7 +13,7 @@ process.setUncaughtExceptionCaptureCallback((err) => {
   assert.strictEqual(asyncLocalStorage.getStore().get('hello'), 'node');
 });
 
-asyncLocalStorage.run(() => {
+asyncLocalStorage.run(new Map(), () => {
   const store = asyncLocalStorage.getStore();
   store.set('hello', 'node');
   setTimeout(() => {

--- a/test/async-hooks/test-async-local-storage-errors-sync-ret.js
+++ b/test/async-hooks/test-async-local-storage-errors-sync-ret.js
@@ -14,7 +14,7 @@ process.setUncaughtExceptionCaptureCallback((err) => {
 });
 
 try {
-  asyncLocalStorage.runSyncAndReturn(() => {
+  asyncLocalStorage.runSyncAndReturn(new Map(), () => {
     const store = asyncLocalStorage.getStore();
     store.set('hello', 'node');
     setTimeout(() => {

--- a/test/async-hooks/test-async-local-storage-http.js
+++ b/test/async-hooks/test-async-local-storage-http.js
@@ -10,7 +10,7 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(0, () => {
-  asyncLocalStorage.run(() => {
+  asyncLocalStorage.run(new Map(), () => {
     const store = asyncLocalStorage.getStore();
     store.set('hello', 'world');
     http.get({ host: 'localhost', port: server.address().port }, () => {

--- a/test/async-hooks/test-async-local-storage-misc-stores.js
+++ b/test/async-hooks/test-async-local-storage-misc-stores.js
@@ -1,0 +1,24 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { AsyncLocalStorage } = require('async_hooks');
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+asyncLocalStorage.run(42, () => {
+  assert.strictEqual(asyncLocalStorage.getStore(), 42);
+});
+
+const runStore = { foo: 'bar' };
+asyncLocalStorage.run(runStore, () => {
+  assert.strictEqual(asyncLocalStorage.getStore(), runStore);
+});
+
+asyncLocalStorage.runSyncAndReturn('hello node', () => {
+  assert.strictEqual(asyncLocalStorage.getStore(), 'hello node');
+});
+
+const runSyncStore = { hello: 'node' };
+asyncLocalStorage.runSyncAndReturn(runSyncStore, () => {
+  assert.strictEqual(asyncLocalStorage.getStore(), runSyncStore);
+});

--- a/test/async-hooks/test-async-local-storage-nested.js
+++ b/test/async-hooks/test-async-local-storage-nested.js
@@ -6,9 +6,9 @@ const { AsyncLocalStorage } = require('async_hooks');
 const asyncLocalStorage = new AsyncLocalStorage();
 
 setTimeout(() => {
-  asyncLocalStorage.run(() => {
+  asyncLocalStorage.run(new Map(), () => {
     const asyncLocalStorage2 = new AsyncLocalStorage();
-    asyncLocalStorage2.run(() => {
+    asyncLocalStorage2.run(new Map(), () => {
       const store = asyncLocalStorage.getStore();
       const store2 = asyncLocalStorage2.getStore();
       store.set('hello', 'world');

--- a/test/async-hooks/test-async-local-storage-no-mix-contexts.js
+++ b/test/async-hooks/test-async-local-storage-no-mix-contexts.js
@@ -7,8 +7,8 @@ const asyncLocalStorage = new AsyncLocalStorage();
 const asyncLocalStorage2 = new AsyncLocalStorage();
 
 setTimeout(() => {
-  asyncLocalStorage.run(() => {
-    asyncLocalStorage2.run(() => {
+  asyncLocalStorage.run(new Map(), () => {
+    asyncLocalStorage2.run(new Map(), () => {
       const store = asyncLocalStorage.getStore();
       const store2 = asyncLocalStorage2.getStore();
       store.set('hello', 'world');
@@ -28,7 +28,7 @@ setTimeout(() => {
 }, 100);
 
 setTimeout(() => {
-  asyncLocalStorage.run(() => {
+  asyncLocalStorage.run(new Map(), () => {
     const store = asyncLocalStorage.getStore();
     store.set('hello', 'earth');
     setTimeout(() => {

--- a/test/async-hooks/test-async-local-storage-promises.js
+++ b/test/async-hooks/test-async-local-storage-promises.js
@@ -12,7 +12,7 @@ async function main() {
       throw err;
     });
   await new Promise((resolve, reject) => {
-    asyncLocalStorage.run(() => {
+    asyncLocalStorage.run(new Map(), () => {
       const store = asyncLocalStorage.getStore();
       store.set('a', 1);
       next().then(resolve, reject);


### PR DESCRIPTION
This PR introduces `store` as the first argument in `AsyncLocalStorage`'s `.run*()` methods. The change is motivated by the following expectation: most users are going to use a custom object
as the store and an extra `Map` created by the old implementation is an overhead for their use case.

**Important note**. This is a backwards incompatible change. But as `AsyncLocalStorage` API has just landed into `master` (https://github.com/nodejs/node/commit/9c702922cdcf830cedb92d51e5dc9f956584c3ee), it should be OK.

This PR implements the most simple (and as I believe, the most convenient for users) option from this discussion thread: https://github.com/nodejs/node/pull/26540#discussion_r382896437

cc @vdeturckheim, @Qard, @Flarna 

#### API change

Both run methods now have `.run*(store, callback[, ..args])` signature instead of the old `.run*(callback[, ..args])`. For users who want to use a `Map` this change simply means
```js
asyncLocalStorage.run(new Map(), () => /* ... */)
```
call instead of 
```js
asyncLocalStorage.run(() => /* ... */)
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
