### PR TITLE
test: fix typo preventing test from running

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -68,6 +68,13 @@ sure no unexpected rejections occur, because currently they result in silent
 failures. However, it is useful in some rare cases to disable it, for example if
 the `unhandledRejection` hook is directly used by the test.
 
+### `enoughTestCpu`
+
+* [&lt;boolean>][]
+
+Indicates if there is more than 1 CPU or that the single CPU has a speed of at
+least 1 GHz.
+
 ### `enoughTestMem`
 
 * [&lt;boolean>][]

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -717,7 +717,7 @@ module.exports = {
   skipIfReportDisabled,
   skipIfWorker,
 
-  get enoughTestCPU() {
+  get enoughTestCpu() {
     const cpus = require('os').cpus();
     return Array.isArray(cpus) && (cpus.length > 1 || cpus[0].speed > 999);
   },


### PR DESCRIPTION
test-fs-watch-system-limit is always being skipped because of a typo.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
