### PR TITLE
crypto: turn impossible DH errors into assertions

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5868,11 +5868,7 @@ void DiffieHellman::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
 
   ClearErrorOnReturn clear_error_on_return;
 
-  if (args.Length() == 0) {
-    return THROW_ERR_MISSING_ARGS(
-        env, "Other party's public key argument is mandatory");
-  }
-
+  CHECK_EQ(args.Length(), 1);
   THROW_AND_RETURN_IF_NOT_BUFFER(env, args[0], "Other party's public key");
   ArrayBufferViewContents<unsigned char> key_buf(args[0].As<ArrayBufferView>());
   BignumPointer key(BN_bin2bn(key_buf.data(), key_buf.length(), nullptr));
@@ -5923,11 +5919,7 @@ void DiffieHellman::SetKey(const FunctionCallbackInfo<Value>& args,
 
   char errmsg[64];
 
-  if (args.Length() == 0) {
-    snprintf(errmsg, sizeof(errmsg), "%s argument is mandatory", what);
-    return THROW_ERR_MISSING_ARGS(env, errmsg);
-  }
-
+  CHECK_EQ(args.Length(), 1);
   if (!Buffer::HasInstance(args[0])) {
     snprintf(errmsg, sizeof(errmsg), "%s must be a buffer", what);
     return THROW_ERR_INVALID_ARG_TYPE(env, errmsg);


### PR DESCRIPTION
These functions are always called with exactly one argument of the form `toBuf(...)`. Even if that call returns `undefined`, JavaScript still counts it as an argument.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
