### PR TITLE
src: move InternalCallbackScope to StartExecution

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -397,6 +397,12 @@ MaybeLocal<Value> StartExecution(Environment* env, const char* main_script_id) {
           ->GetFunction(env->context())
           .ToLocalChecked()};
 
+  InternalCallbackScope callback_scope(
+    env,
+    Object::New(env->isolate()),
+    { 1, 0 },
+    InternalCallbackScope::kSkipAsyncHooks);
+
   return scope.EscapeMaybe(
       ExecuteBootstrapper(env, main_script_id, &parameters, &arguments));
 }

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -122,14 +122,7 @@ int NodeMainInstance::Run() {
   Context::Scope context_scope(env->context());
 
   if (exit_code == 0) {
-    {
-      InternalCallbackScope callback_scope(
-          env.get(),
-          Object::New(isolate_),
-          { 1, 0 },
-          InternalCallbackScope::kSkipAsyncHooks);
-      LoadEnvironment(env.get());
-    }
+    LoadEnvironment(env.get());
 
     env->set_trace_sync_io(env->options()->trace_sync_io);
 

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -341,11 +341,6 @@ void Worker::Run() {
         env_->InitializeInspector(std::move(inspector_parent_handle_));
 #endif
         HandleScope handle_scope(isolate_);
-        InternalCallbackScope callback_scope(
-            env_.get(),
-            Object::New(isolate_),
-            { 1, 0 },
-            InternalCallbackScope::kSkipAsyncHooks);
 
         if (!env_->RunBootstrapping().IsEmpty()) {
           CreateEnvMessagePort(env_.get());


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/30467.

As Electron embeds Node.js,  when running in `ELECTRON_RUN_AS_NODE` we need to mimic `NodeMainInstance::Run() ` as much as possible. However, the externally-facing CallbackScope does not allow for skipping async hooks. As such, in order to embed properly without async hook issues we need to expose `InternalCallbackScope` via patch, which we would rather not do.

This PR thus moves that callback scope into `StartExecution` so that we can decrease our patch surface and avoid having to handle something which should reasonably be handled upstream.

cc @addaleax 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
