### PR TITLE
src: handle bad callback in asyc_wrap

### DIFF
--- a/src/async_wrap-inl.h
+++ b/src/async_wrap-inl.h
@@ -26,7 +26,6 @@
 
 #include "async_wrap.h"
 #include "base_object-inl.h"
-#include "node_errors.h"
 #include "node_internals.h"
 
 namespace node {

--- a/src/async_wrap-inl.h
+++ b/src/async_wrap-inl.h
@@ -26,6 +26,7 @@
 
 #include "async_wrap.h"
 #include "base_object-inl.h"
+#include "node_errors.h"
 #include "node_internals.h"
 
 namespace node {
@@ -74,9 +75,8 @@ inline v8::MaybeLocal<v8::Value> AsyncWrap::MakeCallback(
   if (!object()->Get(env()->context(), symbol).ToLocal(&cb_v))
     return v8::MaybeLocal<v8::Value>();
   if (!cb_v->IsFunction()) {
-    // TODO(addaleax): We should throw an error here to fulfill the
-    // `MaybeLocal<>` API contract.
-    return v8::MaybeLocal<v8::Value>();
+    v8::Isolate* isolate = env()->isolate();
+    return Undefined(isolate);
   }
   return MakeCallback(cb_v.As<v8::Function>(), argc, argv);
 }


### PR DESCRIPTION
**src: handle bad callback in asyc_wrap**

Align with the MaybeLocal<> API contract
Refs: https://github.com/nodejs/node/blob/940325042bef787e84917a27f9435d423b3f7f6d/deps/v8/include/v8.h#L345-L349

addresses an @addaleax 's TODO

**src: elevate v8 namespaces**

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
