### PR TITLE
win: block running on EOL Windows versions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -106,8 +106,9 @@ platforms. This is true regardless of entries in the table below.
 | GNU/Linux        | armv6            | kernel >= 4.14, glibc >= 2.24   | Experimental | Downgraded as of Node.js 12       |
 | GNU/Linux        | ppc64le >=power8 | kernel >= 3.10.0, glibc >= 2.17 | Tier 2       | e.g. Ubuntu 16.04 <sup>[1](#fn1)</sup>, EL 7  <sup>[2](#fn2)</sup> |
 | GNU/Linux        | s390x            | kernel >= 3.10.0, glibc >= 2.17 | Tier 2       | e.g. EL 7 <sup>[2](#fn2)</sup>    |
-| Windows          | x64, x86 (WoW64) | >= Windows 7/2008 R2/2012 R2    | Tier 1       | <sup>[4](#fn4),[5](#fn5)</sup>    |
-| Windows          | x86 (native)     | >= Windows 7/2008 R2/2012 R2    | Tier 1 (running) / Experimental (compiling) <sup>[6](#fn6)</sup> | |
+| Windows          | x64, x86 (WoW64) | >= Windows 8.1/2012 R2          | Tier 1       | <sup>[4](#fn4),[5](#fn5)</sup>    |
+| Windows          | x86 (native)     | >= Windows 8.1/2012 R2          | Tier 1 (running) / Experimental (compiling) <sup>[6](#fn6)</sup> | |
+| Windows          | x64, x86         | Windows Server 2012 (not R2)    | Experimental |                                   |
 | Windows          | arm64            | >= Windows 10                   | Experimental |                                   |
 | macOS            | x64              | >= 10.11                        | Tier 1       |                                   |
 | SmartOS          | x64              | >= 18                           | Tier 2       |                                   |
@@ -174,7 +175,7 @@ Binaries at <https://nodejs.org/download/release/> are produced on:
 | linux-s390x           | RHEL 7 with devtoolset-6 / GCC 6 <sup>[7](#fn7)</sup>                    |
 | linux-x64             | CentOS 7 with devtoolset-6 / GCC 6 <sup>[7](#fn7)</sup>                  |
 | sunos-x64             | SmartOS 18 with GCC 7                                                    |
-| win-x64 and win-x86   | Windows 2012 R2 (x64) with Visual Studio 2017                            |
+| win-x64 and win-x86   | Windows 2012 R2 (x64) with Visual Studio 2019                            |
 
 <em id="fn7">7</em>: The Enterprise Linux devtoolset-6 allows us to compile
 binaries with GCC 6 but linked to the glibc and libstdc++ versions of the host

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -28,9 +28,12 @@
 #include <WinError.h>
 
 int wmain(int argc, wchar_t* wargv[]) {
-  if (!IsWindows7OrGreater()) {
-    fprintf(stderr, "This application is only supported on Windows 7, "
-                    "Windows Server 2008 R2, or higher.");
+  // Windows Server 2012 (not R2) is supported until 10/10/2023, so we allow it
+  // to run in the experimental support tier.
+  if (!IsWindows8Point1OrGreater() &&
+      !(IsWindowsServer() && IsWindows8OrGreater())) {
+    fprintf(stderr, "This application is only supported on Windows 8.1, "
+                    "Windows Server 2012 R2, or higher.");
     exit(ERROR_EXE_MACHINE_TYPE_MISMATCH);
   }
 

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -23,8 +23,8 @@
              Compressed="yes"
              InstallScope="perMachine"/>
 
-    <Condition Message="This application is only supported on Windows 7, Windows Server 2008 R2, or higher.">
-      <![CDATA[Installed OR (VersionNT >= 601)]]>
+    <Condition Message="This application is only supported on Windows 8.1, Windows Server 2012 R2, or higher.">
+      <![CDATA[Installed OR (VersionNT >= 603) OR (VersionNT >= 602 AND MsiNTProductType <> 1)]]>
     </Condition>
 
     <Media Id="1" Cabinet="media1.cab" EmbedCab="yes"/>


### PR DESCRIPTION
Node.js v14 is being released after Windows 7/2008R2 reached EOL. This blocks Node from running in these OSs (and also Windows 8, long due) since changes are no longer tested there.

Using EOL Windows versions is discouraged, we offer no guarantees that Node.js works correctly. The last Node.js versions tested on Windows 7/2008R2 are 10.18.1, 12.14.1 and 13.6.0. This does not block major Node.js versions up to 13 from running on EOL Windows as it's probably better to use a later version, even if untested (since there are no breaking changes).

Refs: https://github.com/nodejs/build/issues/2168
Refs: https://github.com/nodejs/node/pull/5167

cc @nodejs/platform-windows @nodejs/build 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
