### PR TITLE
deps: V8: backport f7771e5b0cc4

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.29',
+    'v8_embedder_string': '-node.30',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/objects/dictionary-inl.h
+++ b/deps/v8/src/objects/dictionary-inl.h
@@ -61,13 +61,13 @@ BaseNameDictionary<Derived, Shape>::BaseNameDictionary(Address ptr)
     : Dictionary<Derived, Shape>(ptr) {}
 
 template <typename Derived, typename Shape>
-void BaseNameDictionary<Derived, Shape>::SetNextEnumerationIndex(int index) {
-  DCHECK_NE(0, index);
+void BaseNameDictionary<Derived, Shape>::set_next_enumeration_index(int index) {
+  DCHECK_LT(0, index);
   this->set(kNextEnumerationIndexIndex, Smi::FromInt(index));
 }
 
 template <typename Derived, typename Shape>
-int BaseNameDictionary<Derived, Shape>::NextEnumerationIndex() {
+int BaseNameDictionary<Derived, Shape>::next_enumeration_index() {
   return Smi::ToInt(this->get(kNextEnumerationIndexIndex));
 }
 

--- a/deps/v8/src/objects/dictionary.h
+++ b/deps/v8/src/objects/dictionary.h
@@ -120,10 +120,6 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) BaseNameDictionary
   static const int kObjectHashIndex = kNextEnumerationIndexIndex + 1;
   static const int kEntryValueIndex = 1;
 
-  // Accessors for next enumeration index.
-  inline void SetNextEnumerationIndex(int index);
-  inline int NextEnumerationIndex();
-
   inline void SetHash(int hash);
   inline int Hash() const;
 
@@ -138,6 +134,13 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) BaseNameDictionary
   V8_WARN_UNUSED_RESULT static ExceptionStatus CollectKeysTo(
       Handle<Derived> dictionary, KeyAccumulator* keys);
 
+  // Allocate the next enumeration index. Possibly updates all enumeration
+  // indices in the table.
+  static int NextEnumerationIndex(Isolate* isolate, Handle<Derived> dictionary);
+  // Accessors for next enumeration index.
+  inline int next_enumeration_index();
+  inline void set_next_enumeration_index(int index);
+
   // Return the key indices sorted by its enumeration index.
   static Handle<FixedArray> IterationIndices(Isolate* isolate,
                                              Handle<Derived> dictionary);
@@ -148,10 +151,6 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) BaseNameDictionary
   static void CopyEnumKeysTo(Isolate* isolate, Handle<Derived> dictionary,
                              Handle<FixedArray> storage, KeyCollectionMode mode,
                              KeyAccumulator* accumulator);
-
-  // Ensure enough space for n additional elements.
-  static Handle<Derived> EnsureCapacity(Isolate* isolate,
-                                        Handle<Derived> dictionary, int n);
 
   V8_WARN_UNUSED_RESULT static Handle<Derived> AddNoUpdateNextEnumerationIndex(
       Isolate* isolate, Handle<Derived> dictionary, Key key,

--- a/deps/v8/src/objects/hash-table.h
+++ b/deps/v8/src/objects/hash-table.h
@@ -201,7 +201,7 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) HashTable
 
   // Ensure enough space for n additional elements.
   V8_WARN_UNUSED_RESULT static Handle<Derived> EnsureCapacity(
-      Isolate* isolate, Handle<Derived> table, int n,
+      Isolate* isolate, Handle<Derived> table, int n = 1,
       AllocationType allocation = AllocationType::kYoung);
 
   // Returns true if this table has sufficient capacity for adding n elements.

--- a/deps/v8/src/objects/js-objects.cc
+++ b/deps/v8/src/objects/js-objects.cc
@@ -2908,7 +2908,7 @@ void MigrateFastToSlow(Isolate* isolate, Handle<JSObject> object,
   }
 
   // Copy the next enumeration index from instance descriptor.
-  dictionary->SetNextEnumerationIndex(real_size + 1);
+  dictionary->set_next_enumeration_index(real_size + 1);
 
   // From here on we cannot fail and we shouldn't GC anymore.
   DisallowHeapAllocation no_allocation;

--- a/deps/v8/src/objects/literal-objects.cc
+++ b/deps/v8/src/objects/literal-objects.cc
@@ -363,7 +363,7 @@ class ObjectDescriptor {
 
   void Finalize(Isolate* isolate) {
     if (HasDictionaryProperties()) {
-      properties_dictionary_template_->SetNextEnumerationIndex(
+      properties_dictionary_template_->set_next_enumeration_index(
           next_enumeration_index_);
       computed_properties_ = FixedArray::ShrinkOrEmpty(
           isolate, computed_properties_, current_computed_index_);

--- a/deps/v8/src/objects/lookup.cc
+++ b/deps/v8/src/objects/lookup.cc
@@ -634,8 +634,8 @@ void LookupIterator::PrepareTransitionToDataProperty(
       transition_ = cell;
       // Assign an enumeration index to the property and update
       // SetNextEnumerationIndex.
-      int index = dictionary->NextEnumerationIndex();
-      dictionary->SetNextEnumerationIndex(index + 1);
+      int index = GlobalDictionary::NextEnumerationIndex(isolate_, dictionary);
+      dictionary->set_next_enumeration_index(index + 1);
       property_details_ = PropertyDetails(
           kData, attributes, PropertyCellType::kUninitialized, index);
       PropertyCellType new_type =


### PR DESCRIPTION
This fixes a performance regression on V8 where frequent delete/reinsertions on a POJO object can lead to a bit overflow, causing subsequent property insertions to take exponentially more time.

We should try to backport this to v12, since the regression started there (yes, I'm volunteering to backport if it doesn't land cleanly).

---

Original commit message:

    [runtime] Recompute enumeration indices of dictionaries upon bitfield overflow

    Otherwise we'll get weird semantics when enumerating objects after many
    deletes/reinserts.

    Bug: chromium:1033771
    Change-Id: If0a459169c3794a30d9632d09e80da3cfcd4302c
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1993966
    Commit-Queue: Toon Verwaest <verwaest@chromium.org>
    Reviewed-by: Jakob Kummerow <jkummerow@chromium.org>
    Reviewed-by: Victor Gomes <victorgomes@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#65690}

Refs: https://github.com/v8/v8/commit/f7771e5b0cc46ab75fe5291482a727b3f115dcba

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
