### PR TITLE
build: add missing comma in node.gyp

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -621,7 +621,7 @@
         'src/histogram-inl.h',
         'src/js_stream.h',
         'src/large_pages/node_large_page.cc',
-        'src/large_pages/node_large_page.h'
+        'src/large_pages/node_large_page.h',
         'src/memory_tracker.h',
         'src/memory_tracker-inl.h',
         'src/module_wrap.h',


### PR DESCRIPTION
This commit adds a missing comma for consistency with the surrounding lines.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)