### PR TITLE
test: increase timeout in vm-timeout-escape-queuemicrotask

### DIFF
--- a/test/known_issues/test-vm-timeout-escape-queuemicrotask.js
+++ b/test/known_issues/test-vm-timeout-escape-queuemicrotask.js
@@ -12,8 +12,8 @@ const NS_PER_MS = 1000000n;
 
 const hrtime = process.hrtime.bigint;
 
-const loopDuration = common.platformTimeout(100n);
-const timeout = common.platformTimeout(10);
+const loopDuration = common.platformTimeout(1000n);
+const timeout = common.platformTimeout(100);
 
 function loop() {
   const start = hrtime();


### PR DESCRIPTION
It looks like under high load the loop isn't even started and therefore
successfully finishes without 'escaping'. After increasing the timeout
during parallel run of the test failure rate decreased from 15/1000 to
0/1000.

This will not fix the issue but should at least decrease its failure rate. Though imo the test is inherently flaky and we probably won't be able to fix this completely.
Refs: https://github.com/nodejs/node/issues/25529

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
/cc @nodejs/testing 