### PR TITLE
test: skip some binding tests on IBMi PASE 

### DIFF
--- a/test/addons/addon.status
+++ b/test/addons/addon.status
@@ -9,3 +9,7 @@ prefix addons
 [$arch==arm]
 # https://github.com/nodejs/node/issues/30786
 openssl-binding/test: PASS,FLAKY
+
+[$system==ibmi]
+openssl-binding/test: SKIP
+zlib-binding/test: SKIP

--- a/test/addons/openssl-binding/binding.gyp
+++ b/test/addons/openssl-binding/binding.gyp
@@ -3,8 +3,13 @@
     {
       'target_name': 'binding',
       'includes': ['../common.gypi'],
+      'variables': {
+        # Skip this building on IBM i.
+        'aix_variant_name': '<!(uname -s)',
+      },
       'conditions': [
-        ['node_use_openssl=="true"', {
+        ['node_use_openssl=="true" and '
+         '"<(aix_variant_name)"!="OS400"', {
           'sources': ['binding.cc'],
           'include_dirs': ['../../../deps/openssl/openssl/include'],
         }],

--- a/test/addons/zlib-binding/binding.gyp
+++ b/test/addons/zlib-binding/binding.gyp
@@ -2,8 +2,16 @@
   'targets': [
     {
       'target_name': 'binding',
-      'sources': ['binding.cc'],
-      'include_dirs': ['../../../deps/zlib'],
+      'variables': {
+        # Skip this building on IBM i.
+        'aix_variant_name': '<!(uname -s)',
+      },
+      'conditions': [
+        [ '"<(aix_variant_name)"!="OS400"', {
+          'sources': ['binding.cc'],
+          'include_dirs': ['../../../deps/zlib'],
+        }],
+      ],
       'includes': ['../common.gypi'],
     },
   ]


### PR DESCRIPTION
Ldflags "-lcrypto", "-lssl" and "-lz" are needed on
IBMi PASE to build the test suite