### PR TITLE
async_hooks: avoid resource reuse by FileHandle

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -587,7 +587,7 @@ AsyncWrap::AsyncWrap(Environment* env,
   provider_type_ = provider;
 
   // Use AsyncReset() call to execute the init() callbacks.
-  AsyncReset(execution_async_id, silent);
+  AsyncReset(object, execution_async_id, silent);
   init_hook_ran_ = true;
 }
 
@@ -651,10 +651,6 @@ void AsyncWrap::EmitDestroy(Environment* env, double async_id) {
   }
 
   env->destroy_async_id_list()->push_back(async_id);
-}
-
-void AsyncWrap::AsyncReset(double execution_async_id, bool silent) {
-  AsyncReset(object(), execution_async_id, silent);
 }
 
 // Generalized call for both the constructor and for handles that are pooled

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -170,9 +170,6 @@ class AsyncWrap : public BaseObject {
                   double execution_async_id = kInvalidAsyncId,
                   bool silent = false);
 
-  void AsyncReset(double execution_async_id = kInvalidAsyncId,
-                  bool silent = false);
-
   // Only call these within a valid HandleScope.
   v8::MaybeLocal<v8::Value> MakeCallback(const v8::Local<v8::Function> cb,
                                          int argc,

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -381,7 +381,12 @@ int FileHandle::ReadStart() {
     if (freelist.size() > 0) {
       read_wrap = std::move(freelist.back());
       freelist.pop_back();
-      read_wrap->AsyncReset();
+      // Use a fresh async resource.
+      // Lifetime is ensured via AsyncWrap::resource_.
+      Local<Object> resource = Object::New(env()->isolate());
+      resource->Set(
+          env()->context(), env()->handle_string(), read_wrap->object());
+      read_wrap->AsyncReset(resource);
       read_wrap->file_handle_ = this;
     } else {
       Local<Object> wrap_obj;

--- a/test/async-hooks/test-filehandle-no-reuse.js
+++ b/test/async-hooks/test-filehandle-no-reuse.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const common = require('../common');
+const initHooks = require('./init-hooks');
+const { checkInvocations } = require('./hook-checks');
+const fixtures = require('../common/fixtures');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+const assert = require('assert');
+const fs = require('fs');
+
+// Checks that the async resource is not reused by FileHandle.
+// Test is based on parallel\test-http2-respond-file-fd.js.
+
+const hooks = initHooks();
+hooks.enable();
+
+const {
+  HTTP2_HEADER_CONTENT_TYPE
+} = http2.constants;
+
+const fname = fixtures.path('elipses.txt');
+const fd = fs.openSync(fname, 'r');
+
+const server = http2.createServer();
+server.on('stream', (stream) => {
+  stream.respondWithFD(fd, {
+    [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain'
+  });
+});
+server.on('close', common.mustCall(() => fs.closeSync(fd)));
+server.listen(0, () => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
+
+  req.on('response', common.mustCall());
+  req.on('data', () => {});
+  req.on('end', common.mustCall(() => {
+    client.close();
+    server.close();
+  }));
+  req.end();
+});
+
+process.on('exit', onExit);
+
+function onExit() {
+  hooks.disable();
+  hooks.sanityCheck();
+  const activities = hooks.activities;
+
+  // Verify both invocations
+  const fsReqs = activities.filter((x) => x.type === 'FSREQCALLBACK');
+  assert.ok(fsReqs.length >= 2);
+
+  checkInvocations(fsReqs[0], { init: 1, destroy: 1 }, 'when process exits');
+  checkInvocations(fsReqs[1], { init: 1, destroy: 1 }, 'when process exits');
+
+  // Verify reuse handle has been wrapped
+  assert.ok(fsReqs[0].handle !== fsReqs[1].handle, 'Resource reused');
+  assert.ok(fsReqs[0].handle === fsReqs[1].handle.handle,
+            'Resource not wrapped correctly');
+}

--- a/test/async-hooks/test-filehandle-no-reuse.js
+++ b/test/async-hooks/test-filehandle-no-reuse.js
@@ -20,7 +20,8 @@ const {
   HTTP2_HEADER_CONTENT_TYPE
 } = http2.constants;
 
-const fname = fixtures.path('elipses.txt');
+// Use large fixture to get several file operations.
+const fname = fixtures.path('person-large.jpg');
 const fd = fs.openSync(fname, 'r');
 
 const server = http2.createServer();


### PR DESCRIPTION
Wrap reused read_wrap in a unique async resource to ensure that `executionAsyncResource()` is not ambiguous.

Refs: https://github.com/nodejs/node/pull/30959

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

