### PR TITLE
module: remove experimental modules warning

### DIFF
--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -3,7 +3,6 @@
 const {
   ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING,
 } = require('internal/errors').codes;
-const assert = require('internal/assert');
 const { Loader } = require('internal/modules/esm/loader');
 const { pathToFileURL } = require('internal/url');
 const {
@@ -23,13 +22,6 @@ exports.initializeImportMetaObject = function(wrap, meta) {
 };
 
 exports.importModuleDynamicallyCallback = async function(wrap, specifier) {
-  assert(calledInitialize === true || !userLoader);
-  if (!calledInitialize) {
-    process.emitWarning(
-      'The ESM module loader is experimental.',
-      'ExperimentalWarning', undefined);
-    calledInitialize = true;
-  }
   const { callbackMap } = internalBinding('module_wrap');
   if (callbackMap.has(wrap)) {
     const { importModuleDynamically } = callbackMap.get(wrap);
@@ -44,14 +36,8 @@ exports.importModuleDynamicallyCallback = async function(wrap, specifier) {
 let ESMLoader = new Loader();
 exports.ESMLoader = ESMLoader;
 
-let calledInitialize = false;
 exports.initializeLoader = initializeLoader;
 async function initializeLoader() {
-  assert(calledInitialize === false);
-  process.emitWarning(
-    'The ESM module loader is experimental.',
-    'ExperimentalWarning', undefined);
-  calledInitialize = true;
   if (!userLoader)
     return;
   let cwd;

--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -42,9 +42,6 @@ function expectFsNamespace(result) {
 // For direct use of import expressions inside of CJS or ES modules, including
 // via eval, all kinds of specifiers should work without issue.
 (function testScriptOrModuleImport() {
-  common.expectWarning('ExperimentalWarning',
-                       'The ESM module loader is experimental.');
-
   // Importing another file, both direct & via eval
   // expectOkNamespace(import(relativePath));
   expectOkNamespace(eval(`import("${relativePath}")`));

--- a/test/es-module/test-esm-nowarn-exports.mjs
+++ b/test/es-module/test-esm-nowarn-exports.mjs
@@ -16,7 +16,7 @@ child.stderr.on('data', (data) => {
 child.on('close', (code, signal) => {
   strictEqual(code, 0);
   strictEqual(signal, null);
-  ok(stderr.toString().includes(
+  ok(!stderr.toString().includes(
     'ExperimentalWarning: The ESM module loader is experimental'
   ));
   ok(!stderr.toString().includes(

--- a/test/message/async_error_sync_esm.out
+++ b/test/message/async_error_sync_esm.out
@@ -1,5 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
-(Use `node --trace-warnings ...` to show where the warning was created)
 Error: test
     at one (*fixtures*async-error.js:4:9)
     at two (*fixtures*async-error.js:17:9)

--- a/test/message/esm_display_syntax_error.out
+++ b/test/message/esm_display_syntax_error.out
@@ -1,5 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
-(Use `node --trace-warnings ...` to show where the warning was created)
 file:///*/test/message/esm_display_syntax_error.mjs:2
 await async () => 0;
 ^^^^^

--- a/test/message/esm_display_syntax_error_import.out
+++ b/test/message/esm_display_syntax_error_import.out
@@ -1,5 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
-(Use `node --trace-warnings ...` to show where the warning was created)
 file:///*/test/message/esm_display_syntax_error_import.mjs:5
   notfound
   ^^^^^^^^

--- a/test/message/esm_display_syntax_error_import_module.out
+++ b/test/message/esm_display_syntax_error_import_module.out
@@ -1,5 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
-(Use `node --trace-warnings ...` to show where the warning was created)
 file:///*/test/fixtures/es-module-loaders/syntax-error-import.mjs:1
 import { foo, notfound } from './module-named-exports.mjs';
               ^^^^^^^^

--- a/test/message/esm_display_syntax_error_module.out
+++ b/test/message/esm_display_syntax_error_module.out
@@ -1,5 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
-(Use `node --trace-warnings ...` to show where the warning was created)
 file:///*/test/fixtures/es-module-loaders/syntax-error.mjs:2
 await async () => 0;
 ^^^^^

--- a/test/message/esm_loader_not_found.out
+++ b/test/message/esm_loader_not_found.out
@@ -1,6 +1,5 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
-(Use `node --trace-warnings ...` to show where the warning was created)
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
 internal/modules/run_main.js:*
     internalBinding('errors').triggerUncaughtException(
                               ^

--- a/test/message/esm_loader_syntax_error.out
+++ b/test/message/esm_loader_syntax_error.out
@@ -1,6 +1,5 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
-(Use `node --trace-warnings ...` to show where the warning was created)
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
 file://*/test/fixtures/es-module-loaders/syntax-error.mjs:2
 await async () => 0;
 ^^^^^


### PR DESCRIPTION
This PR removes the experimental modules warnings for Node.js.

The modules group currently does not have consensus to remove the experimental warning for using ES modules in Node.js, but these timelines are currently being discussed.

This PR was separated out from https://github.com/nodejs/node/pull/31845. I would like if we could keep this PR open while discussion is happening, with the goal to eventually merge it when the appropriate timeline is agreed and met.

@nodejs/modules-active-members 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
