### PR TITLE
meta: add requirement for signed-off-by statements

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -591,6 +591,10 @@ for that commit. This is an opportunity to fix commit messages.
     reviewed the change.
     * Useful for @mentions / contact list if something goes wrong in the PR.
     * Protects against the assumption that GitHub will be around forever.
+  * Required: A `Signed-off-by: Name <email>` line for each individual who
+    contributed to the commit. Commit authors should add these lines themselves.
+    Collaborators may add them while landing if the author agrees in the PR
+    discussion.
 
 Other changes may have landed on master since the successful CI run. As a
 precaution, run tests (`make -j4 test` or `vcbuild test`).

--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -12,6 +12,7 @@ so that you can make the actual changes. This is where we will start.
 * [The Process of Making Changes](#the-process-of-making-changes)
   * [Step 3: Code](#step-3-code)
   * [Step 4: Commit](#step-4-commit)
+    * [Signing off on commits](#signing-off-on-commits)
     * [Commit message guidelines](#commit-message-guidelines)
   * [Step 5: Rebase](#step-5-rebase)
   * [Step 6: Test](#step-6-test)
@@ -134,11 +135,31 @@ to review changes that are split across multiple commits.
 
 ```text
 $ git add my/changed/files
-$ git commit
+$ git commit -s
 ```
 
 Multiple commits often get squashed when they are landed. See the
 notes about [commit squashing](#commit-squashing).
+
+#### Signing off on commits
+
+All commits landed must contain one `Signed-off-by` metadata statement for
+each author. The value of this statement must
+match the name and email address configured in [Step 1][].
+
+```text
+Signed-off-by: J. Random User <j.random.user@example.com>
+```
+
+To add the `Signed-off-by` statement with `git`, use the `-s` (or `--signoff`)
+option:
+
+```text
+$ git commit -s
+```
+
+Sign-off indicates that the commit complies with
+[Developer's Certificate of Origin 1.1][].
 
 #### Commit message guidelines
 
@@ -587,9 +608,11 @@ If you want to know more about the code review and the landing process, see the
 [CI (Continuous Integration) test run]: #ci-testing
 [Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
 [Collaborator Guide]: ../../../COLLABORATOR_GUIDE.md
+[Developer's Certificate of Origin 1.1]: ../../../CONTRIBUTING.md#developers-certificate-of-origin
 [guide for writing tests in Node.js]: ../writing-tests.md
 [hiding-a-comment]: https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment
 [https://ci.nodejs.org/]: https://ci.nodejs.org/
 [IRC in the #node-dev channel]: https://webchat.freenode.net?channels=node-dev&uio=d4
 [Onboarding guide]: ../../onboarding.md
 [running tests]: ../../../BUILDING.md#running-tests
+[Step 1]: #step-1-fork


### PR DESCRIPTION
To improve handling of DCO compliance, the TSC is considering
the need to make inclusion of `Signed-off-by` statements in
every commit mandatory. The TSC is still working through the
process changes necessary to make this as painless as possible
but drafting the basic requirement is step one.

The Signed-off-by statement is an attestation that the commit
is contributed in accordance to the DCO.

This is a draft PR for now while the @nodejs/tsc deliberates further.

/cc @nodejs/tsc

/cc @nodejs/automation ... If this moves forward, then node-core-utils will need to be updated to check for, and possibly automatically apply, the `Signed-off-by` statements when preparing PRs to land.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

