### PR TITLE
test: always ignore vm-timeout-escape-queuemicrotask

### DIFF
--- a/test/known_issues/known_issues.status
+++ b/test/known_issues/known_issues.status
@@ -5,6 +5,11 @@ prefix known_issues
 # sample-test                        : SKIP
 
 [true] # This section applies to all platforms
+# This issue is unfixable with the current implementations of V8 and
+# Node.js. Changes to make this fixable are unlikely to happen in the
+# foreseeable future. The test itself is flaky and skipped.  It
+# serves as a demonstration of the issue only.
+test-vm-timeout-escape-queuemicrotask: SKIP
 
 [$system==win32]
 


### PR DESCRIPTION
Always skip the test as it is not expected to be fixed (probably ever).
Left in the known_issues as an example and 'note' that the issue is
there and won't be fixed.

Follow up https://github.com/nodejs/node/pull/31966.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
