### PR TITLE
src: start the .text section with an asm symbol

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -314,6 +314,19 @@
 
   'targets': [
     {
+      'target_name': 'node_text_start',
+      'type': 'none',
+      'conditions': [
+        [ 'OS=="linux" and '
+          'target_arch=="x64"', {
+          'type': 'static_library',
+          'sources': [
+            'src/large_pages/node_text_start.S'
+          ]
+        }],
+      ]
+    },
+    {
       'target_name': '<(node_core_target_name)',
       'type': 'executable',
 
@@ -497,6 +510,13 @@
           'sources': [
             'src/node_snapshot_stub.cc'
           ],
+        }],
+        [ 'OS=="linux" and '
+          'target_arch=="x64"', {
+          'dependencies': [ 'node_text_start' ],
+          'ldflags+': [
+            '<(PRODUCT_DIR)/obj.target/node_text_start/src/large_pages/node_text_start.o'
+          ]
         }],
       ],
     }, # node_core_target_name

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -71,7 +71,11 @@
 
 #if defined(__linux__)
 extern "C" {
-extern char __executable_start;
+// This symbol must be declared weak because this file becomes part of all
+// Node.js targets (like node_mksnapshot, node_mkcodecache, and cctest) and
+// those files do not supply the symbol.
+extern char __attribute__((weak)) __node_text_start;
+extern char __start_lpstub;
 }  // extern "C"
 #endif  // defined(__linux__)
 
@@ -121,6 +125,8 @@ struct text_region FindNodeTextRegion() {
   std::string dev;
   char dash;
   uintptr_t start, end, offset, inode;
+  uintptr_t node_text_start = reinterpret_cast<uintptr_t>(&__node_text_start);
+  uintptr_t lpstub_start = reinterpret_cast<uintptr_t>(&__start_lpstub);
 
   ifs.open("/proc/self/maps");
   if (!ifs) {
@@ -144,21 +150,16 @@ struct text_region FindNodeTextRegion() {
     std::string pathname;
     iss >> pathname;
 
-    if (start != reinterpret_cast<uintptr_t>(&__executable_start))
+    if (permission != "r-xp")
       continue;
 
-    // The next line is our .text section.
-    if (!std::getline(ifs, map_line))
-      break;
+    if (node_text_start < start || node_text_start >= end)
+      continue;
 
-    iss = std::istringstream(map_line);
-    iss >> std::hex >> start;
-    iss >> dash;
-    iss >> std::hex >> end;
-    iss >> permission;
-
-    if (permission != "r-xp")
-      break;
+    start = node_text_start;
+    if (lpstub_start > start && lpstub_start <= end) {
+      end = lpstub_start;
+    }
 
     char* from = reinterpret_cast<char*>(hugepage_align_up(start));
     char* to = reinterpret_cast<char*>(hugepage_align_down(end));
@@ -318,7 +319,7 @@ static bool IsSuperPagesEnabled() {
 // d. If successful copy the code there and unmap the original region
 int
 #if !defined(__APPLE__)
-__attribute__((__section__(".lpstub")))
+__attribute__((__section__("lpstub")))
 #else
 __attribute__((__section__("__TEXT,__lpstub")))
 #endif

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -157,9 +157,8 @@ struct text_region FindNodeTextRegion() {
       continue;
 
     start = node_text_start;
-    if (lpstub_start > start && lpstub_start <= end) {
+    if (lpstub_start > start && lpstub_start <= end)
       end = lpstub_start;
-    }
 
     char* from = reinterpret_cast<char*>(hugepage_align_up(start));
     char* to = reinterpret_cast<char*>(hugepage_align_down(end));

--- a/src/large_pages/node_text_start.S
+++ b/src/large_pages/node_text_start.S
@@ -1,0 +1,5 @@
+.text
+.align 0x2000
+.global __node_text_start
+.hidden __node_text_start
+__node_text_start:


### PR DESCRIPTION
We create an object file in assembly which introduces the symbol
`__node_text_start` into the .text section and place the resulting
object file as the first file the linker encounters. We do this to
ensure that we can recognize the boundaries of the .text section when
attempting to establish the address range to map to large pages.

Additionally, we rename the section containing the remapping code from
`.lpstub` to `lpstub` so as to take advantage of the linker's feature
whereby it inserts the symbol `__start_lpstub` when the section's name
can be rendered as a valid C variable. We need this symbol in order to
avoid self-mapping the remapping code to large pages, because doing so
would cause the process to crash.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
This is an alternative to https://github.com/nodejs/node/pull/31947.