### PR TITLE
repl: allow recovery for wrapped eval

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -69,8 +69,17 @@ const {
 } = require('internal/modules/cjs/helpers');
 const {
   isIdentifierStart,
-  isIdentifierChar
+  isIdentifierChar,
+  Parser
 } = require('internal/deps/acorn/acorn/dist/acorn');
+const privateMethods =
+  require('internal/deps/acorn-plugins/acorn-private-methods/index');
+const classFields =
+  require('internal/deps/acorn-plugins/acorn-class-fields/index');
+const numericSeparator =
+  require('internal/deps/acorn-plugins/acorn-numeric-separator/index');
+const staticClassFeatures =
+  require('internal/deps/acorn-plugins/acorn-static-class-features/index');
 const {
   decorateErrorStack,
   isError,
@@ -332,8 +341,23 @@ function REPLServer(prompt,
     // an expression.  Note that if the above condition changes,
     // lib/internal/repl/utils.js needs to be changed to match.
     if (/^\s*{/.test(code) && !/;\s*$/.test(code)) {
-      code = `(${code.trim()})\n`;
-      wrappedCmd = true;
+      const parser = Parser.extend(
+        privateMethods,
+        classFields,
+        numericSeparator,
+        staticClassFeatures
+      );
+
+      // Ensure that the wrapped expression is valid,
+      // otherwise proceed unwrapped.
+      try {
+        parser.parse(`(${code.trim()})\n`, {
+          ecmaVersion: 11,
+          allowAwaitOutsideFunction: true
+        });
+        code = `(${code.trim()})\n`;
+        wrappedCmd = true;
+      } catch {}
     }
 
     if (experimentalREPLAwait && code.includes('await')) {


### PR DESCRIPTION
Follow-up to https://github.com/nodejs/node/pull/31943.

In the PR above, repl eval was altered to eagerly try and wrap code with parens, but this could in some cases cause failures for code which is only valid JavaScript in an unwrapped state.

This PR makes that logic more robust by ensuring that the wrapped code is parsed to be valid JS before evaluation continues, and proceeds unwrapped if it is found to be invalid.

cc @devsnek @BridgeAR 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
