### PR TITLE
readline: rename input field and remove excess params 

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -43,7 +43,8 @@ const {
 const {
   ERR_INVALID_CALLBACK,
   ERR_INVALID_CURSOR_POS,
-  ERR_INVALID_OPT_VALUE
+  ERR_INVALID_OPT_VALUE,
+  ERR_MISSING_OPTION
 } = require('internal/errors').codes;
 const {
   validateString,
@@ -146,6 +147,8 @@ function Interface(options) {
     }
     crlfDelay = options.crlfDelay;
     input = options.input;
+  } else {
+    throw new ERR_MISSING_OPTION('options.input');
   }
 
   if (completer !== undefined && typeof completer !== 'function') {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -91,14 +91,14 @@ const ESCAPE_DECODER = Symbol('escape-decoder');
 // GNU readline library - keyseq-timeout is 500ms (default)
 const ESCAPE_CODE_TIMEOUT = 500;
 
-function createInterface(input, output, completer, terminal) {
-  return new Interface(input, output, completer, terminal);
+function createInterface(options) {
+  return new Interface(options);
 }
 
 
-function Interface(input, output, completer, terminal) {
+function Interface(options) {
   if (!(this instanceof Interface)) {
-    return new Interface(input, output, completer, terminal);
+    return new Interface(options);
   }
 
   this._sawReturnAt = 0;
@@ -111,28 +111,32 @@ function Interface(input, output, completer, terminal) {
   this.tabSize = 8;
 
   EventEmitter.call(this);
+  let input;
+  let output;
+  let completer;
+  let terminal;
   let historySize;
   let removeHistoryDuplicates = false;
   let crlfDelay;
   let prompt = '> ';
 
-  if (input && input.input) {
+  if (options && options.input) {
     // An options object was given
-    output = input.output;
-    completer = input.completer;
-    terminal = input.terminal;
-    historySize = input.historySize;
-    if (input.tabSize !== undefined) {
-      validateUint32(input.tabSize, 'tabSize', true);
-      this.tabSize = input.tabSize;
+    output = options.output;
+    completer = options.completer;
+    terminal = options.terminal;
+    historySize = options.historySize;
+    if (options.tabSize !== undefined) {
+      validateUint32(options.tabSize, 'tabSize', true);
+      this.tabSize = options.tabSize;
     }
-    removeHistoryDuplicates = input.removeHistoryDuplicates;
-    if (input.prompt !== undefined) {
-      prompt = input.prompt;
+    removeHistoryDuplicates = options.removeHistoryDuplicates;
+    if (options.prompt !== undefined) {
+      prompt = options.prompt;
     }
-    if (input.escapeCodeTimeout !== undefined) {
-      if (NumberIsFinite(input.escapeCodeTimeout)) {
-        this.escapeCodeTimeout = input.escapeCodeTimeout;
+    if (options.escapeCodeTimeout !== undefined) {
+      if (NumberIsFinite(options.escapeCodeTimeout)) {
+        this.escapeCodeTimeout = options.escapeCodeTimeout;
       } else {
         throw new ERR_INVALID_OPT_VALUE(
           'escapeCodeTimeout',
@@ -140,8 +144,8 @@ function Interface(input, output, completer, terminal) {
         );
       }
     }
-    crlfDelay = input.crlfDelay;
-    input = input.input;
+    crlfDelay = options.crlfDelay;
+    input = options.input;
   }
 
   if (completer !== undefined && typeof completer !== 'function') {
@@ -229,28 +233,37 @@ function Interface(input, output, completer, terminal) {
 
   if (!this.terminal) {
     function onSelfCloseWithoutTerminal() {
-      input.removeListener('data', ondata);
-      input.removeListener('end', onend);
+      if (input !== null && input !== undefined) {
+        input.removeListener('data', ondata);
+        input.removeListener('end', onend);
+      }
     }
 
-    input.on('data', ondata);
-    input.on('end', onend);
+    if (input !== null && input !== undefined) {
+      input.on('data', ondata);
+      input.on('end', onend);
+    }
+
     self.once('close', onSelfCloseWithoutTerminal);
     this._decoder = new StringDecoder('utf8');
   } else {
     function onSelfCloseWithTerminal() {
-      input.removeListener('keypress', onkeypress);
-      input.removeListener('end', ontermend);
+      if (input !== null && input !== undefined) {
+        input.removeListener('keypress', onkeypress);
+        input.removeListener('end', ontermend);
+      }
+
       if (output !== null && output !== undefined) {
         output.removeListener('resize', onresize);
       }
     }
 
-    emitKeypressEvents(input, this);
-
-    // `input` usually refers to stdin
-    input.on('keypress', onkeypress);
-    input.on('end', ontermend);
+    if (input !== null && input !== undefined) {
+      emitKeypressEvents(input, this);
+      // `input` usually refers to stdin
+      input.on('keypress', onkeypress);
+      input.on('end', ontermend);
+    }
 
     // Current line
     this.line = '';
@@ -270,7 +283,9 @@ function Interface(input, output, completer, terminal) {
     self.once('close', onSelfCloseWithTerminal);
   }
 
-  input.resume();
+  if (input !== null && input !== undefined) {
+    input.resume();
+  }
 }
 
 ObjectSetPrototypeOf(Interface.prototype, EventEmitter.prototype);
@@ -292,9 +307,12 @@ Interface.prototype.setPrompt = function(prompt) {
 
 
 Interface.prototype._setRawMode = function(mode) {
-  const wasInRawMode = this.input.isRaw;
+  let wasInRawMode;
+  if (this.input) {
+    wasInRawMode = this.input.isRaw;
+  }
 
-  if (typeof this.input.setRawMode === 'function') {
+  if (this.input && typeof this.input.setRawMode === 'function') {
     this.input.setRawMode(mode);
   }
 
@@ -427,21 +445,23 @@ Interface.prototype.close = function() {
 
 Interface.prototype.pause = function() {
   if (this.paused) return;
-  this.input.pause();
-  this.paused = true;
-  this.emit('pause');
-  return this;
+  if (this.input !== null && this.input !== undefined) {
+    this.input.pause();
+    this.paused = true;
+    this.emit('pause');
+    return this;
+  }
 };
-
 
 Interface.prototype.resume = function() {
   if (!this.paused) return;
-  this.input.resume();
-  this.paused = false;
-  this.emit('resume');
-  return this;
+  if (this.input !== null && this.input !== undefined) {
+    this.input.resume();
+    this.paused = false;
+    this.emit('resume');
+    return this;
+  }
 };
-
 
 Interface.prototype.write = function(d, key) {
   if (this.paused) this.resume();

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -80,7 +80,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
   // Constructor throws if completer is not a function or undefined
   assert.throws(() => {
     readline.createInterface({
-      input,
+      input: input,
       completer: 'string is not valid'
     });
   }, {
@@ -90,7 +90,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
 
   assert.throws(() => {
     readline.createInterface({
-      input,
+      input: input,
       completer: ''
     });
   }, {
@@ -100,7 +100,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
 
   assert.throws(() => {
     readline.createInterface({
-      input,
+      input: input,
       completer: false
     });
   }, {
@@ -111,7 +111,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
   // Constructor throws if historySize is not a positive number
   assert.throws(() => {
     readline.createInterface({
-      input,
+      input: input,
       historySize: 'not a number'
     });
   }, {
@@ -121,7 +121,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
 
   assert.throws(() => {
     readline.createInterface({
-      input,
+      input: input,
       historySize: -1
     });
   }, {
@@ -131,7 +131,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
 
   assert.throws(() => {
     readline.createInterface({
-      input,
+      input: input,
       historySize: NaN
     });
   }, {
@@ -176,7 +176,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
 // Sending a single character with no newline
 {
   const fi = new FakeInput();
-  const rli = new readline.Interface(fi, {});
+  const rli = new readline.Interface({ input: fi });
   rli.on('line', common.mustNotCall());
   fi.emit('data', 'a');
   rli.close();
@@ -1027,8 +1027,8 @@ for (let i = 0; i < 12; i++) {
     }),
   });
   const rl = new readline.createInterface({
-    input,
-    output,
+    input: input,
+    output: output,
     terminal: true,
   });
   rl.line = `a${' '.repeat(1e6)}a`;

--- a/test/parallel/test-tty-stdin-pipe.js
+++ b/test/parallel/test-tty-stdin-pipe.js
@@ -28,7 +28,9 @@ require('../common');
 const assert = require('assert');
 const readline = require('readline');
 
-const rl = readline.createInterface(process.stdin, process.stdout);
+const rl = readline.createInterface(
+  { input: process.stdin, output: process.stdout }
+);
 rl.resume();
 
 let hasPaused = false;


### PR DESCRIPTION
Removed excess parameters from the createInterface method,
renamed input field to options, in accordance with the docs,
and made corresponding changes in tests.

Refs: https://github.com/nodejs/node/pull/31603#issuecomment-581053704

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)