### PR TITLE
http: fix socket re-use races

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -239,6 +239,9 @@ added: v0.11.4
 An object which contains arrays of sockets currently awaiting use by
 the agent when `keepAlive` is enabled. Do not modify.
 
+Sockets in the `freeSockets` list will be automatically destroyed and
+removed from the array on `'timeout'`.
+
 ### `agent.getName(options)`
 <!-- YAML
 added: v0.11.4

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -120,6 +120,12 @@ function Agent(options) {
           socket[async_id_symbol] = -1;
           socket._httpMessage = null;
           this.removeSocket(socket, options);
+
+          const agentTimeout = this.options.timeout || 0;
+          if (socket.timeout !== agentTimeout) {
+            socket.setTimeout(agentTimeout);
+          }
+
           freeSockets.push(socket);
         } else {
           // Implementation doesn't want to keep socket alive
@@ -202,12 +208,21 @@ Agent.prototype.addRequest = function addRequest(req, options, port/* legacy */,
     this.sockets[name] = [];
   }
 
-  const freeLen = this.freeSockets[name] ? this.freeSockets[name].length : 0;
+  const freeSockets = this.freeSockets[name];
+  let socket;
+  if (freeSockets) {
+    while (freeSockets.length && freeSockets[0].destroyed) {
+      freeSockets.shift();
+    }
+    socket = freeSockets.shift();
+    if (!freeSockets.length)
+      delete this.freeSockets[name];
+  }
+
+  const freeLen = freeSockets ? freeSockets.length : 0;
   const sockLen = freeLen + this.sockets[name].length;
 
-  if (freeLen) {
-    // We have a free socket, so use that.
-    const socket = this.freeSockets[name].shift();
+  if (socket) {
     // Guard against an uninitialized or user supplied Socket.
     const handle = socket._handle;
     if (handle && typeof handle.asyncReset === 'function') {
@@ -215,10 +230,6 @@ Agent.prototype.addRequest = function addRequest(req, options, port/* legacy */,
       handle.asyncReset(new ReusedHandle(handle.getProviderType(), handle));
       socket[async_id_symbol] = handle.getAsyncId();
     }
-
-    // don't leak
-    if (!this.freeSockets[name].length)
-      delete this.freeSockets[name];
 
     this.reuseSocket(socket, req);
     setRequestSocket(this, req, socket);
@@ -319,6 +330,20 @@ function installListeners(agent, s, options) {
   }
   s.on('close', onClose);
 
+  function onTimeout() {
+    debug('CLIENT socket onTimeout');
+
+    // Destroy if in free list.
+    // TODO(ronag): Always destroy, even if not in free list.
+    const sockets = agent.freeSockets;
+    for (const name of ObjectKeys(sockets)) {
+      if (sockets[name].includes(s)) {
+        return s.destroy();
+      }
+    }
+  }
+  s.on('timeout', onTimeout);
+
   function onRemove() {
     // We need this function for cases like HTTP 'upgrade'
     // (defined by WebSockets) where we need to remove a socket from the
@@ -327,6 +352,7 @@ function installListeners(agent, s, options) {
     agent.removeSocket(s, options);
     s.removeListener('close', onClose);
     s.removeListener('free', onFree);
+    s.removeListener('timeout', onTimeout);
     s.removeListener('agentRemove', onRemove);
   }
   s.on('agentRemove', onRemove);
@@ -409,14 +435,6 @@ function setRequestSocket(agent, req, socket) {
     return;
   }
   socket.setTimeout(req.timeout);
-  // Reset timeout after response end
-  req.once('response', (res) => {
-    res.once('end', () => {
-      if (socket.timeout !== agentTimeout) {
-        socket.setTimeout(agentTimeout);
-      }
-    });
-  });
 }
 
 function emitErrorNT(emitter, err) {

--- a/test/parallel/test-http-agent-timeout-option.js
+++ b/test/parallel/test-http-agent-timeout-option.js
@@ -18,6 +18,6 @@ request.on('socket', mustCall((socket) => {
 
   const listeners = socket.listeners('timeout');
 
-  strictEqual(listeners.length, 1);
-  strictEqual(listeners[0], request.timeoutCb);
+  strictEqual(listeners.length, 2);
+  strictEqual(listeners[1], request.timeoutCb);
 }));

--- a/test/parallel/test-http-agent-timeout.js
+++ b/test/parallel/test-http-agent-timeout.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+{
+  // Ensure reuse of successful sockets.
+
+  const agent = new http.Agent({ keepAlive: true });
+
+  const server = http.createServer((req, res) => {
+    res.end();
+  });
+
+  server.listen(0, common.mustCall(() => {
+    let socket;
+    http.get({ port: server.address().port, agent })
+      .on('response', common.mustCall((res) => {
+        socket = res.socket;
+        assert(socket);
+        res.resume();
+        socket.on('free', common.mustCall(() => {
+          http.get({ port: server.address().port, agent })
+            .on('response', common.mustCall((res) => {
+              assert.strictEqual(socket, res.socket);
+              assert(socket);
+              agent.destroy();
+              server.close();
+            }));
+        }));
+      }));
+  }));
+}
+
+{
+  // Ensure that timeouted sockets are not reused.
+
+  const agent = new http.Agent({ keepAlive: true, timeout: 50 });
+
+  const server = http.createServer((req, res) => {
+    res.end();
+  });
+
+  server.listen(0, common.mustCall(() => {
+    let socket;
+    http.get({ port: server.address().port, agent })
+      .on('response', common.mustCall((res) => {
+        socket = res.socket;
+        assert(socket);
+        res.resume();
+        socket.on('free', common.mustCall(() => {
+          socket.on('timeout', common.mustCall(() => {
+            http.get({ port: server.address().port, agent })
+              .on('response', common.mustCall((res) => {
+                assert.notStrictEqual(socket, res.socket);
+                assert.strictEqual(socket.destroyed, true);
+                assert(socket);
+                agent.destroy();
+                server.close();
+              }));
+          }));
+        }));
+      }));
+  }));
+}
+
+{
+  // Ensure that destroyed sockets are not reused.
+
+  const agent = new http.Agent({ keepAlive: true });
+
+  const server = http.createServer((req, res) => {
+    res.end();
+  });
+
+  server.listen(0, common.mustCall(() => {
+    let socket;
+    http.get({ port: server.address().port, agent })
+      .on('response', common.mustCall((res) => {
+        socket = res.socket;
+        assert(socket);
+        res.resume();
+        socket.on('free', common.mustCall(() => {
+          socket.destroy();
+          http.get({ port: server.address().port, agent })
+            .on('response', common.mustCall((res) => {
+              assert.notStrictEqual(socket, res.socket);
+              assert(socket);
+              agent.destroy();
+              server.close();
+            }));
+        }));
+      }));
+  }));
+}

--- a/test/parallel/test-http-agent-timeout.js
+++ b/test/parallel/test-http-agent-timeout.js
@@ -43,10 +43,9 @@ const http = require('http');
   });
 
   server.listen(0, common.mustCall(() => {
-    let socket;
     http.get({ port: server.address().port, agent })
       .on('response', common.mustCall((res) => {
-        socket = res.socket;
+        const socket = res.socket;
         assert(socket);
         res.resume();
         socket.on('free', common.mustCall(() => {
@@ -55,7 +54,6 @@ const http = require('http');
               .on('response', common.mustCall((res) => {
                 assert.notStrictEqual(socket, res.socket);
                 assert.strictEqual(socket.destroyed, true);
-                assert(socket);
                 agent.destroy();
                 server.close();
               }));

--- a/test/parallel/test-http-client-set-timeout-after-end.js
+++ b/test/parallel/test-http-client-set-timeout-after-end.js
@@ -20,7 +20,7 @@ server.listen(0, () => {
   const req = get({ agent, port }, (res) => {
     res.on('end', () => {
       strictEqual(req.setTimeout(0), req);
-      strictEqual(socket.listenerCount('timeout'), 0);
+      strictEqual(socket.listenerCount('timeout'), 1);
       agent.destroy();
       server.close();
     });

--- a/test/parallel/test-http-client-set-timeout.js
+++ b/test/parallel/test-http-client-set-timeout.js
@@ -42,7 +42,7 @@ server.listen(0, mustCall(() => {
   }));
 
   req.on('timeout', mustCall(() => {
-    strictEqual(req.socket.listenerCount('timeout'), 0);
+    strictEqual(req.socket.listenerCount('timeout'), 1);
     req.destroy();
   }));
 }));

--- a/test/parallel/test-http-client-timeout-option-listeners.js
+++ b/test/parallel/test-http-client-timeout-option-listeners.js
@@ -24,9 +24,9 @@ const options = {
 server.listen(0, options.host, common.mustCall(() => {
   options.port = server.address().port;
   doRequest(common.mustCall((numListeners) => {
-    assert.strictEqual(numListeners, 1);
+    assert.strictEqual(numListeners, 2);
     doRequest(common.mustCall((numListeners) => {
-      assert.strictEqual(numListeners, 1);
+      assert.strictEqual(numListeners, 2);
       server.close();
       agent.destroy();
     }));

--- a/test/parallel/test-http-client-timeout-option-with-agent.js
+++ b/test/parallel/test-http-client-timeout-option-with-agent.js
@@ -18,6 +18,6 @@ request.on('socket', mustCall((socket) => {
 
   const listeners = socket.listeners('timeout');
 
-  strictEqual(listeners.length, 1);
-  strictEqual(listeners[0], request.timeoutCb);
+  strictEqual(listeners.length, 2);
+  strictEqual(listeners[1], request.timeoutCb);
 }));


### PR DESCRIPTION
This fixes two race conditions related to socket re-use in keep alive agents. 

- sockets in the free list, that has emitted `'timeout'` should not be re-used
- sockets that has been `destroy()`:d but has not yet emitted `'close'` should not be re-used

Refs: https://github.com/nodejs/node/pull/31526#issuecomment-592397564

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
