### PR TITLE
deps: openssl: cherry-pick 4dcb150ea30f

### DIFF
--- a/deps/openssl/openssl/crypto/rand/rand_unix.c
+++ b/deps/openssl/openssl/crypto/rand/rand_unix.c
@@ -282,12 +282,58 @@ static ssize_t sysctl_random(char *buf, size_t buflen)
 #  if defined(OPENSSL_RAND_SEED_GETRANDOM)
 
 #   if defined(__linux) && !defined(__NR_getrandom)
-#    if defined(__arm__) && defined(__NR_SYSCALL_BASE)
+#    if defined(__arm__)
 #     define __NR_getrandom    (__NR_SYSCALL_BASE+384)
 #    elif defined(__i386__)
 #     define __NR_getrandom    355
-#    elif defined(__x86_64__) && !defined(__ILP32__)
-#     define __NR_getrandom    318
+#    elif defined(__x86_64__)
+#     if defined(__ILP32__)
+#      define __NR_getrandom   (__X32_SYSCALL_BIT + 318)
+#     else
+#      define __NR_getrandom   318
+#     endif
+#    elif defined(__xtensa__)
+#     define __NR_getrandom    338
+#    elif defined(__s390__) || defined(__s390x__)
+#     define __NR_getrandom    349
+#    elif defined(__bfin__)
+#     define __NR_getrandom    389
+#    elif defined(__powerpc__)
+#     define __NR_getrandom    359
+#    elif defined(__mips__) || defined(__mips64)
+#     if _MIPS_SIM == _MIPS_SIM_ABI32
+#      define __NR_getrandom   (__NR_Linux + 353)
+#     elif _MIPS_SIM == _MIPS_SIM_ABI64
+#      define __NR_getrandom   (__NR_Linux + 313)
+#     elif _MIPS_SIM == _MIPS_SIM_NABI32
+#      define __NR_getrandom   (__NR_Linux + 317)
+#     endif
+#    elif defined(__hppa__)
+#     define __NR_getrandom    (__NR_Linux + 339)
+#    elif defined(__sparc__)
+#     define __NR_getrandom    347
+#    elif defined(__ia64__)
+#     define __NR_getrandom    1339
+#    elif defined(__alpha__)
+#     define __NR_getrandom    511
+#    elif defined(__sh__)
+#     if defined(__SH5__)
+#      define __NR_getrandom   373
+#     else
+#      define __NR_getrandom   384
+#     endif
+#    elif defined(__avr32__)
+#     define __NR_getrandom    317
+#    elif defined(__microblaze__)
+#     define __NR_getrandom    385
+#    elif defined(__m68k__)
+#     define __NR_getrandom    352
+#    elif defined(__cris__)
+#     define __NR_getrandom    356
+#    elif defined(__aarch64__)
+#     define __NR_getrandom    278
+#    else /* generic */
+#     define __NR_getrandom    278
 #    endif
 #   endif
 


### PR DESCRIPTION
OpenSSL 1.1.1d does not ship with getrandom syscall being
predefined on all architectures. So when NodeJS is run with glibc
prior to 2.25, where getentropy is unavailable, and the getrandom
syscall is unknown, it will fail. PPC64LE or s390 are affected
by lack of this definition.

Original commit message.

    commit 4dcb150ea30f9bbfa7946e6b39c30a86aca5ed02
    Author: Kurt Roeckx <kurt@roeckx.be>
    Date:   Sat Sep 28 14:59:32 2019 +0200

      Add defines for __NR_getrandom for all Linux architectures

      Fixes: #10015

      Reviewed-by: Bernd Edlinger <bernd.edlinger@hotmail.de>
      GH: #10044

Fixes: https://github.com/nodejs/node/issues/31671

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
