### PR TITLE
[v12.x backport] events: allow monitoring error events

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -155,6 +155,18 @@ myEmitter.emit('error', new Error('whoops!'));
 // Prints: whoops! there was an error
 ```
 
+It is possible to monitor `'error'` events without consuming the emitted error
+by installing a listener using the symbol `errorMonitor`.
+
+```js
+const myEmitter = new MyEmitter();
+myEmitter.on(EventEmitter.errorMonitor, (err) => {
+  MyMonitoringTool.log(err);
+});
+myEmitter.emit('error', new Error('whoops!'));
+// Still throws and crashes Node.js
+```
+
 ## Capture Rejections of Promises
 
 > Stability: 1 - captureRejections is experimental.
@@ -347,6 +359,19 @@ have the additional `emitter`, `type` and `count` properties, referring to
 the event emitter instance, the event’s name and the number of attached
 listeners, respectively.
 Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+### EventEmitter.errorMonitor
+<!-- YAML
+added: REPLACEME
+-->
+
+This symbol shall be used to install a listener for only monitoring `'error'`
+events. Listeners installed using this symbol are called before the regular
+`'error'` listeners are called.
+
+Installing a listener using this symbol does not change the behavior once an
+`'error'` event is emitted, therefore the process will still crash if no
+regular `'error'` listener is installed.
 
 ### `emitter.addListener(eventName, listener)`
 <!-- YAML

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -360,7 +360,7 @@ the event emitter instance, the event’s name and the number of attached
 listeners, respectively.
 Its `name` property is set to `'MaxListenersExceededWarning'`.
 
-### EventEmitter.errorMonitor
+### `EventEmitter.errorMonitor`
 <!-- YAML
 added: REPLACEME
 -->

--- a/lib/events.js
+++ b/lib/events.js
@@ -59,6 +59,7 @@ const {
 } = require('internal/util/inspect');
 
 const kCapture = Symbol('kCapture');
+const kErrorMonitor = Symbol('events.errorMonitor');
 
 function EventEmitter(opts) {
   EventEmitter.init.call(this, opts);
@@ -85,6 +86,13 @@ ObjectDefineProperty(EventEmitter, 'captureRejections', {
 
     EventEmitter.prototype[kCapture] = value;
   },
+  enumerable: true
+});
+
+ObjectDefineProperty(EventEmitter, 'errorMonitor', {
+  value: kErrorMonitor,
+  writable: false,
+  configurable: true,
   enumerable: true
 });
 
@@ -261,9 +269,11 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
   let doError = (type === 'error');
 
   const events = this._events;
-  if (events !== undefined)
+  if (events !== undefined) {
+    if (doError && events[kErrorMonitor] !== undefined)
+      this.emit(kErrorMonitor, ...args);
     doError = (doError && events.error === undefined);
-  else if (!doError)
+  } else if (!doError)
     return false;
 
   // If there is no 'error' event listener then throw.

--- a/lib/events.js
+++ b/lib/events.js
@@ -89,12 +89,7 @@ ObjectDefineProperty(EventEmitter, 'captureRejections', {
   enumerable: true
 });
 
-ObjectDefineProperty(EventEmitter, 'errorMonitor', {
-  value: kErrorMonitor,
-  writable: false,
-  configurable: true,
-  enumerable: true
-});
+EventEmitter.errorMonitor = kErrorMonitor;
 
 // The default for captureRejections is false
 ObjectDefineProperty(EventEmitter.prototype, kCapture, {

--- a/test/parallel/test-event-emitter-error-monitor.js
+++ b/test/parallel/test-event-emitter-error-monitor.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const EventEmitter = require('events');
+
+const EE = new EventEmitter();
+const theErr = new Error('MyError');
+
+EE.on(
+  EventEmitter.errorMonitor,
+  common.mustCall(function onErrorMonitor(e) {
+    assert.strictEqual(e, theErr);
+  }, 3)
+);
+
+// Verify with no error listener
+common.expectsError(
+  () => EE.emit('error', theErr), theErr
+);
+
+// Verify with error listener
+EE.once('error', common.mustCall((e) => assert.strictEqual(e, theErr)));
+EE.emit('error', theErr);
+
+
+// Verify it works with once
+process.nextTick(() => EE.emit('error', theErr));
+assert.rejects(EventEmitter.once(EE, 'notTriggered'), theErr);
+
+// Only error events trigger error monitor
+EE.on('aEvent', common.mustCall());
+EE.emit('aEvent');

--- a/test/parallel/test-event-emitter-error-monitor.js
+++ b/test/parallel/test-event-emitter-error-monitor.js
@@ -14,7 +14,7 @@ EE.on(
 );
 
 // Verify with no error listener
-common.expectsError(
+assert.throws(
   () => EE.emit('error', theErr), theErr
 );
 


### PR DESCRIPTION
Backport https://github.com/nodejs/node/pull/30932 to v12 as it was reverted in 12.16.1 (see https://github.com/nodejs/node/pull/30932#issuecomment-587233501).

To avoid the issue seen in 12.16.0 I added the changes from https://github.com/nodejs/node/pull/31848 on top.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

