### PR TITLE
fs: fix writeFile[Sync] for non-seekable files

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1248,9 +1248,9 @@ function futimesSync(fd, atime, mtime) {
   handleErrorFromBinding(ctx);
 }
 
-function writeAll(fd, isUserFd, buffer, offset, length, position, callback) {
+function writeAll(fd, isUserFd, buffer, offset, length, callback) {
   // write(fd, buffer, offset, length, position, callback)
-  fs.write(fd, buffer, offset, length, position, (writeErr, written) => {
+  fs.write(fd, buffer, offset, length, null, (writeErr, written) => {
     if (writeErr) {
       if (isUserFd) {
         callback(writeErr);
@@ -1268,10 +1268,7 @@ function writeAll(fd, isUserFd, buffer, offset, length, position, callback) {
     } else {
       offset += written;
       length -= written;
-      if (position !== null) {
-        position += written;
-      }
-      writeAll(fd, isUserFd, buffer, offset, length, position, callback);
+      writeAll(fd, isUserFd, buffer, offset, length, callback);
     }
   });
 }
@@ -1288,7 +1285,7 @@ function writeFile(path, data, options, callback) {
 
   if (isFd(path)) {
     const isUserFd = true;
-    writeAll(path, isUserFd, data, 0, data.byteLength, null, callback);
+    writeAll(path, isUserFd, data, 0, data.byteLength, callback);
     return;
   }
 
@@ -1297,8 +1294,7 @@ function writeFile(path, data, options, callback) {
       callback(openErr);
     } else {
       const isUserFd = false;
-      const position = /a/.test(flag) ? null : 0;
-      writeAll(fd, isUserFd, data, 0, data.byteLength, position, callback);
+      writeAll(fd, isUserFd, data, 0, data.byteLength, callback);
     }
   });
 }
@@ -1318,15 +1314,11 @@ function writeFileSync(path, data, options) {
 
   let offset = 0;
   let length = data.byteLength;
-  let position = (/a/.test(flag) || isUserFd) ? null : 0;
   try {
     while (length > 0) {
-      const written = fs.writeSync(fd, data, offset, length, position);
+      const written = fs.writeSync(fd, data, offset, length);
       offset += written;
       length -= written;
-      if (position !== null) {
-        position += written;
-      }
     }
   } finally {
     if (!isUserFd) fs.closeSync(fd);


### PR DESCRIPTION
Currently `writeFile` and `writeFileSync` perform a positioned write at the beginning of the file, which prevents them from working with non-seekable files (#31926).

Positioned writes were first removed for `createWriteStream` (#19329) and for custom FDs (#23433, #23709) as well as for files opened in append mode... but they're still used for filenames in normal mode. This PR removes positioned writes completely, as they're not needed for this case either.

This also makes it consistent with `readFile` (which does work with non-seekable files).

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included ← I'd like to test for this, but I can't find an OS-independent way of doing it...
- [ ] documentation is changed or added ← should we mention this change?
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)