### PR TITLE
lib: runtime-deprecate `natives` and `util` bindings

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -83,7 +83,6 @@ const internalBindingAllowList = new SafeSet([
   'icu',
   'inspector',
   'js_stream',
-  'natives',
   'os',
   'pipe_wrap',
   'process_wrap',
@@ -95,7 +94,6 @@ const internalBindingAllowList = new SafeSet([
   'tty_wrap',
   'udp_wrap',
   'url',
-  'util',
   'uv',
   'v8',
   'zlib'
@@ -104,6 +102,8 @@ const internalBindingAllowList = new SafeSet([
 // internalBindingDeprecateList contains the name of internalBinding modules
 // that lead to deprecation warnings when being loaded.
 const internalBindingDeprecateList = new SafeSet([
+  'natives',
+  'util',
 ]);
 
 // Set up process.binding() and process._linkedBinding().

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -64,11 +64,12 @@ ObjectDefineProperty(process, 'moduleLoadList', {
 });
 
 
-// internalBindingWhitelist contains the name of internalBinding modules
-// that are whitelisted for access via process.binding()... This is used
-// to provide a transition path for modules that are being moved over to
-// internalBinding.
-const internalBindingWhitelist = new SafeSet([
+// internalBindingAllowList contains the name of internalBinding modules
+// that can be access via process.binding() without a DeprecationWarnings.
+// (Unless --pending-deprecation is being used.) This is used to provide
+// backwards compatibility, as, unfortunately, these are being used in userland
+// to varying degrees.
+const internalBindingAllowList = new SafeSet([
   'async_wrap',
   'buffer',
   'cares_wrap',
@@ -100,15 +101,34 @@ const internalBindingWhitelist = new SafeSet([
   'zlib'
 ]);
 
+// internalBindingDeprecateList contains the name of internalBinding modules
+// that lead to deprecation warnings when being loaded.
+const internalBindingDeprecateList = new SafeSet([
+]);
+
 // Set up process.binding() and process._linkedBinding().
 {
   const bindingObj = ObjectCreate(null);
 
+  let deprecateWarned;
   process.binding = function binding(module) {
     module = String(module);
     // Deprecated specific process.binding() modules, but not all, allow
     // selective fallback to internalBinding for the deprecated ones.
-    if (internalBindingWhitelist.has(module)) {
+    if (internalBindingAllowList.has(module)) {
+      return internalBinding(module);
+    }
+    if (internalBindingDeprecateList.has(module)) {
+      // Keep track off whether a warning has already been emitted.
+      // This will duplicate the warning emitted from --pending-deprecation,
+      // if that is being used.
+      if (!deprecateWarned) {
+        deprecateWarned = true;
+        nativeModuleRequire('internal/util').deprecate(
+          () => {},
+          'process.binding() is deprecated. Please use public APIs instead.',
+          'DEP0111')();
+      }
       return internalBinding(module);
     }
     // eslint-disable-next-line no-restricted-syntax

--- a/test/parallel/test-process-binding-deprecation.js
+++ b/test/parallel/test-process-binding-deprecation.js
@@ -1,0 +1,7 @@
+'use strict';
+const common = require('../common');
+
+const warn = 'process.binding() is deprecated. Please use public APIs instead.';
+common.expectWarning('DeprecationWarning', warn, 'DEP0111');
+
+process.binding('util');


### PR DESCRIPTION
##### lib: allow fully runtime-deprecating process.binding() modules

Allow emitting full runtime deprecations (i.e. including
without `--pending-deprecation`) for internal `process.binding()`
calls.

##### lib: runtime-deprecate `natives` and `util` bindings

Pick two native bindings and move them to fully runtime deprecations.

This is motivated by the fact that `process.binding('util')` usage
is existing even in relatively recently written code in the wild.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
