### PR TITLE
src: fix missing extra ca in secure contexts

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1029,7 +1029,7 @@ static X509_STORE* NewRootCertStore() {
 
 X509_STORE* CloneRootCertStore() {
   if (root_cert_store == nullptr) {
-    root_cert_store = NewRootCertStore();
+    return NewRootCertStore();
   }
 
   X509_STORE* store_clone = X509_STORE_new();

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1028,9 +1028,8 @@ static X509_STORE* NewRootCertStore() {
 
 
 X509_STORE* CloneRootCertStore() {
-  if (root_cert_store == nullptr) {
+  if (root_cert_store == nullptr)
     return NewRootCertStore();
-  }
 
   X509_STORE* store_clone = X509_STORE_new();
   X509_STORE_set1_param(store_clone, X509_STORE_get0_param(root_cert_store));

--- a/test/parallel/test-tls-env-extra-ca-with-ca.js
+++ b/test/parallel/test-tls-env-extra-ca-with-ca.js
@@ -1,0 +1,55 @@
+// Certs in NODE_EXTRA_CA_CERTS are used for TLS peer validation
+
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+
+const { fork } = require('child_process');
+
+if (process.env.CHILD) {
+  const copts = {
+    port: process.env.PORT,
+    checkServerIdentity: common.mustCall()
+  };
+
+  // New secure contexts have the well-known root CAs.
+  copts.secureContext = tls.createSecureContext();
+
+  // Explicit calls to addCACert() add to the root certificates,
+  // instead of replacing, so connection still succeeds.
+  copts.secureContext.context.addCACert(
+    fixtures.readKey('ca1-cert.pem')
+  );
+
+  const client = tls.connect(copts, common.mustCall(function() {
+    client.end('hi');
+  }));
+  return;
+}
+
+const options = {
+  key: fixtures.readKey('agent3-key.pem'),
+  cert: fixtures.readKey('agent3-cert.pem')
+};
+
+const server = tls.createServer(options, common.mustCall(function(s) {
+  s.end('bye');
+  server.close();
+})).listen(0, common.mustCall(function() {
+  const env = Object.assign({}, process.env, {
+    CHILD: 'yes',
+    PORT: this.address().port,
+    NODE_EXTRA_CA_CERTS: fixtures.path('keys', 'ca2-cert.pem')
+  });
+
+  fork(__filename, { env }).on('exit', common.mustCall(function(status) {
+    // Client did not succeed in connecting
+    assert.strictEqual(status, 0);
+  }));
+}));

--- a/test/parallel/test-tls-env-extra-ca-with-ca.js
+++ b/test/parallel/test-tls-env-extra-ca-with-ca.js
@@ -1,6 +1,5 @@
-// Certs in NODE_EXTRA_CA_CERTS are used for TLS peer validation
-
 'use strict';
+
 const common = require('../common');
 
 if (!common.hasCrypto)
@@ -27,9 +26,10 @@ if (process.env.CHILD) {
     fixtures.readKey('ca1-cert.pem')
   );
 
-  const client = tls.connect(copts, common.mustCall(function() {
+  const client = tls.connect(copts, common.mustCall(() => {
     client.end('hi');
   }));
+
   return;
 }
 
@@ -38,17 +38,17 @@ const options = {
   cert: fixtures.readKey('agent3-cert.pem')
 };
 
-const server = tls.createServer(options, common.mustCall(function(s) {
-  s.end('bye');
+const server = tls.createServer(options, common.mustCall((socket) => {
+  socket.end('bye');
   server.close();
-})).listen(0, common.mustCall(function() {
+})).listen(0, common.mustCall(() => {
   const env = Object.assign({}, process.env, {
     CHILD: 'yes',
-    PORT: this.address().port,
+    PORT: server.address().port,
     NODE_EXTRA_CA_CERTS: fixtures.path('keys', 'ca2-cert.pem')
   });
 
-  fork(__filename, { env }).on('exit', common.mustCall(function(status) {
+  fork(__filename, { env }).on('exit', common.mustCall((status) => {
     // Client did not succeed in connecting
     assert.strictEqual(status, 0);
   }));

--- a/test/parallel/test-tls-env-extra-ca-with-crl.js
+++ b/test/parallel/test-tls-env-extra-ca-with-crl.js
@@ -1,6 +1,5 @@
-// Certs in NODE_EXTRA_CA_CERTS are used for TLS peer validation
-
 'use strict';
+
 const common = require('../common');
 
 if (!common.hasCrypto)
@@ -18,9 +17,11 @@ if (process.env.CHILD) {
     checkServerIdentity: common.mustCall(),
     crl: fixtures.readKey('ca2-crl.pem')
   };
-  const client = tls.connect(copts, common.mustCall(function() {
+
+  const client = tls.connect(copts, common.mustCall(() => {
     client.end('hi');
   }));
+
   return;
 }
 
@@ -29,17 +30,17 @@ const options = {
   cert: fixtures.readKey('agent3-cert.pem')
 };
 
-const server = tls.createServer(options, common.mustCall(function(s) {
-  s.end('bye');
+const server = tls.createServer(options, common.mustCall((socket) => {
+  socket.end('bye');
   server.close();
-})).listen(0, common.mustCall(function() {
+})).listen(0, common.mustCall(() => {
   const env = Object.assign({}, process.env, {
     CHILD: 'yes',
-    PORT: this.address().port,
+    PORT: server.address().port,
     NODE_EXTRA_CA_CERTS: fixtures.path('keys', 'ca2-cert.pem')
   });
 
-  fork(__filename, { env }).on('exit', common.mustCall(function(status) {
+  fork(__filename, { env }).on('exit', common.mustCall((status) => {
     // Client did not succeed in connecting
     assert.strictEqual(status, 0);
   }));

--- a/test/parallel/test-tls-env-extra-ca-with-crl.js
+++ b/test/parallel/test-tls-env-extra-ca-with-crl.js
@@ -1,0 +1,46 @@
+// Certs in NODE_EXTRA_CA_CERTS are used for TLS peer validation
+
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+
+const { fork } = require('child_process');
+
+if (process.env.CHILD) {
+  const copts = {
+    port: process.env.PORT,
+    checkServerIdentity: common.mustCall(),
+    crl: fixtures.readKey('ca2-crl.pem')
+  };
+  const client = tls.connect(copts, common.mustCall(function() {
+    client.end('hi');
+  }));
+  return;
+}
+
+const options = {
+  key: fixtures.readKey('agent3-key.pem'),
+  cert: fixtures.readKey('agent3-cert.pem')
+};
+
+const server = tls.createServer(options, common.mustCall(function(s) {
+  s.end('bye');
+  server.close();
+})).listen(0, common.mustCall(function() {
+  const env = Object.assign({}, process.env, {
+    CHILD: 'yes',
+    PORT: this.address().port,
+    NODE_EXTRA_CA_CERTS: fixtures.path('keys', 'ca2-cert.pem')
+  });
+
+  fork(__filename, { env }).on('exit', common.mustCall(function(status) {
+    // Client did not succeed in connecting
+    assert.strictEqual(status, 0);
+  }));
+}));

--- a/test/parallel/test-tls-env-extra-ca-with-pfx.js
+++ b/test/parallel/test-tls-env-extra-ca-with-pfx.js
@@ -1,6 +1,5 @@
-// Certs in NODE_EXTRA_CA_CERTS are used for TLS peer validation
-
 'use strict';
+
 const common = require('../common');
 
 if (!common.hasCrypto)
@@ -19,9 +18,11 @@ if (process.env.CHILD) {
     pfx: fixtures.readKey('agent1.pfx'),
     passphrase: 'sample'
   };
-  const client = tls.connect(copts, common.mustCall(function() {
+
+  const client = tls.connect(copts, common.mustCall(() => {
     client.end('hi');
   }));
+
   return;
 }
 
@@ -30,17 +31,17 @@ const options = {
   cert: fixtures.readKey('agent3-cert.pem')
 };
 
-const server = tls.createServer(options, common.mustCall(function(s) {
-  s.end('bye');
+const server = tls.createServer(options, common.mustCall((socket) => {
+  socket.end('bye');
   server.close();
-})).listen(0, common.mustCall(function() {
+})).listen(0, common.mustCall(() => {
   const env = Object.assign({}, process.env, {
     CHILD: 'yes',
-    PORT: this.address().port,
+    PORT: server.address().port,
     NODE_EXTRA_CA_CERTS: fixtures.path('keys', 'ca2-cert.pem')
   });
 
-  fork(__filename, { env }).on('exit', common.mustCall(function(status) {
+  fork(__filename, { env }).on('exit', common.mustCall((status) => {
     // Client did not succeed in connecting
     assert.strictEqual(status, 0);
   }));

--- a/test/parallel/test-tls-env-extra-ca-with-pfx.js
+++ b/test/parallel/test-tls-env-extra-ca-with-pfx.js
@@ -1,0 +1,47 @@
+// Certs in NODE_EXTRA_CA_CERTS are used for TLS peer validation
+
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+
+const { fork } = require('child_process');
+
+if (process.env.CHILD) {
+  const copts = {
+    port: process.env.PORT,
+    checkServerIdentity: common.mustCall(),
+    pfx: fixtures.readKey('agent1.pfx'),
+    passphrase: 'sample'
+  };
+  const client = tls.connect(copts, common.mustCall(function() {
+    client.end('hi');
+  }));
+  return;
+}
+
+const options = {
+  key: fixtures.readKey('agent3-key.pem'),
+  cert: fixtures.readKey('agent3-cert.pem')
+};
+
+const server = tls.createServer(options, common.mustCall(function(s) {
+  s.end('bye');
+  server.close();
+})).listen(0, common.mustCall(function() {
+  const env = Object.assign({}, process.env, {
+    CHILD: 'yes',
+    PORT: this.address().port,
+    NODE_EXTRA_CA_CERTS: fixtures.path('keys', 'ca2-cert.pem')
+  });
+
+  fork(__filename, { env }).on('exit', common.mustCall(function(status) {
+    // Client did not succeed in connecting
+    assert.strictEqual(status, 0);
+  }));
+}));


### PR DESCRIPTION
Fixes SecureContext missing NODE_EXTRA_CA_CERTS when
SecureContext::AddCACert, SecureContext::AddCRL,
or SecureContext::LoadPKCS12 are called.

Fixes: https://github.com/nodejs/node/issues/32010

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
