### PR TITLE
http2: refactor counter in `mapToHeaders` inner loop

### DIFF
--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -442,13 +442,13 @@ function mapToHeaders(map,
   let count = 0;
   const keys = ObjectKeys(map);
   const singles = new Set();
-  let i;
+  let i, j;
   let isArray;
   let key;
   let value;
   let isSingleValueHeader;
   let err;
-  for (i = 0; i < keys.length; i++) {
+  for (i = 0; i < keys.length; ++i) {
     key = keys[i];
     value = map[key];
     if (value === undefined || key === '')
@@ -488,8 +488,8 @@ function mapToHeaders(map,
       throw new ERR_HTTP2_INVALID_CONNECTION_HEADERS(key);
     }
     if (isArray) {
-      for (var k = 0; k < value.length; k++) {
-        const val = String(value[k]);
+      for (j = 0; j < value.length; ++j) {
+        const val = String(value[j]);
         ret += `${key}\0${val}\0`;
       }
       count += value.length;


### PR DESCRIPTION
This cosmetic change is to prevent potential bugs - e.g., someone might
automatically use the variable `k`, instead of `key`, that is used in
vicinity of this loop. Got rid of old-style `var` declaration. It does
make sense to sometimes use `var` in `for` loops for optimization, but
not in this context. Also changed post-increment to pre-increment in
iteration steps. It is probably done by the optimizer anyway, 
otherwise it will save an opcode each iteration. And it is a good
practice.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)