### PR TITLE
doc: revise --zero-fill-buffers text in buffer.md

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -123,15 +123,12 @@ added: v5.10.0
 -->
 
 Node.js can be started using the `--zero-fill-buffers` command line option to
-cause all newly allocated `Buffer` instances to be zero-filled upon creation by
-default. Before Node.js 8.0.0, this included buffers allocated by `new
-Buffer(size)`. Since Node.js 8.0.0, buffers allocated with `new` are always
-zero-filled, whether this option is used or not.
-[`Buffer.allocUnsafe()`][], [`Buffer.allocUnsafeSlow()`][], and `new
-SlowBuffer(size)`. Use of this flag can have a significant negative impact on
-performance. Use of the `--zero-fill-buffers` option is recommended only when
-necessary to enforce that newly allocated `Buffer` instances cannot contain old
-data that is potentially sensitive.
+cause all newly-allocated `Buffer` instances to be zero-filled upon creation by
+default. Without the option, buffers created with [`Buffer.allocUnsafe()`][],
+[`Buffer.allocUnsafeSlow()`][], and `new SlowBuffer(size)` are not zero-filled.
+Use of this flag can have a significant negative impact on performance. Use the
+`--zero-fill-buffers` option only when necessary to enforce that newly allocated
+`Buffer` instances cannot contain old data that is potentially sensitive.
 
 ```console
 $ node --zero-fill-buffers


### PR DESCRIPTION
There was an unclear sentence fragment that needed fixing, so I edited
the entire paragraph for clarity. I also removed irrelevant information
about behavior before Node.js 8.0.0. That version of Node.js is no
longer supported and these docs will never apply to 8.0.0. (At the time
of this writing, 10.x is the oldest supported line, and so changes to
the docs will never be backported farther than the 10.x docs.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
