### PR TITLE
fs,test: throw rather than assert if condition is possible

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1966,6 +1966,12 @@ from another module.
 
 A string that contained unescaped characters was received.
 
+<a id="ERR_UNEXPECTED_INSTANCE"></a>
+### `ERR_UNEXPECTED_INSTANCE`
+
+A value's prototype chain lacks an expected constructor. This could be a result
+of monkey-patching gone awry or prototype poisoning.
+
 <a id="ERR_UNHANDLED_ERROR"></a>
 ### `ERR_UNHANDLED_ERROR`
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1348,6 +1348,9 @@ E('ERR_UNCAUGHT_EXCEPTION_CAPTURE_ALREADY_SET',
     'callback was already active',
   Error);
 E('ERR_UNESCAPED_CHARACTERS', '%s contains unescaped characters', TypeError);
+E('ERR_UNEXPECTED_INSTANCE',
+  '%s must have %s in its prototype chain',
+  TypeError);
 E('ERR_UNHANDLED_ERROR',
   // Using a default argument here is important so the argument is not counted
   // towards `Function#length`.

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -24,7 +24,6 @@ const {
 } = require('internal/async_hooks');
 const { toNamespacedPath } = require('path');
 const { validateUint32 } = require('internal/validators');
-const assert = require('internal/assert');
 
 const kOldStatus = Symbol('kOldStatus');
 const kUseBigint = Symbol('kUseBigint');
@@ -163,7 +162,9 @@ FSWatcher.prototype[kFSWatchStart] = function(filename,
   if (this._handle === null) {  // closed
     return;
   }
-  assert(this._handle instanceof FSEvent, 'handle must be a FSEvent');
+  if (!(this._handle instanceof FSEvent)) {
+    throw new errors.codes.ERR_UNEXPECTED_INSTANCE('handle', 'FSEvent');
+  }
   if (this._handle.initialized) {  // already started
     return;
   }
@@ -199,7 +200,9 @@ FSWatcher.prototype.close = function() {
   if (this._handle === null) {  // closed
     return;
   }
-  assert(this._handle instanceof FSEvent, 'handle must be a FSEvent');
+  if (!(this._handle instanceof FSEvent)) {
+    throw new errors.codes.ERR_UNEXPECTED_INSTANCE('handle', 'FSEvent');
+  }
   if (!this._handle.initialized) {  // not started
     return;
   }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -547,19 +547,6 @@ function expectsError(validator, exact) {
   }, exact);
 }
 
-const suffix = 'This is caused by either a bug in Node.js ' +
-  'or incorrect usage of Node.js internals.\n' +
-  'Please open an issue with this stack trace at ' +
-  'https://github.com/nodejs/node/issues\n';
-
-function expectsInternalAssertion(fn, message) {
-  assert.throws(fn, {
-    message: `${message}\n${suffix}`,
-    name: 'Error',
-    code: 'ERR_INTERNAL_ASSERTION'
-  });
-}
-
 function skipIfInspectorDisabled() {
   if (!process.features.inspector) {
     skip('V8 inspector is disabled');
@@ -680,7 +667,6 @@ const common = {
   createZeroFilledFile,
   disableCrashOnUnhandledRejection,
   expectsError,
-  expectsInternalAssertion,
   expectWarning,
   getArrayBufferViews,
   getBufferSources,

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -1,6 +1,6 @@
 // Flags: --expose-internals
 'use strict';
-const common = require('../common');
+require('../common');
 const {
   hijackStdout,
   restoreStdout,
@@ -50,10 +50,13 @@ errors.E('TEST_ERROR_2', (a, b) => `${a} ${b}`, Error);
 }
 
 {
-  common.expectsInternalAssertion(
+  assert.throws(
     () => new errors.codes.TEST_ERROR_1(),
-    'Code: TEST_ERROR_1; The provided arguments ' +
-    'length (0) does not match the required ones (1).'
+    {
+      message: /^Code: TEST_ERROR_1; The provided arguments length \(0\) does not match the required ones \(1\)\./,
+      name: 'Error',
+      code: 'ERR_INTERNAL_ASSERTION'
+    }
   );
 }
 

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -132,3 +132,25 @@ tmpdir.refresh();
   );
   oldhandle.close(); // clean up
 }
+
+{
+  let oldhandle;
+  assert.throws(
+    () => {
+      const w = fs.watch(__filename, common.mustNotCall());
+      oldhandle = w._handle;
+      const protoSymbols =
+        Object.getOwnPropertySymbols(Object.getPrototypeOf(w));
+      const kFSWatchStart =
+        protoSymbols.find((val) => val.toString() === 'Symbol(kFSWatchStart)');
+      w._handle = {};
+      w[kFSWatchStart]();
+    },
+    {
+      name: 'TypeError',
+      code: 'ERR_UNEXPECTED_INSTANCE',
+      message: 'handle must have FSEvent in its prototype chain',
+    }
+  );
+  oldhandle.close(); // clean up
+}

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -117,14 +117,18 @@ tmpdir.refresh();
 // https://github.com/joyent/node/issues/6690
 {
   let oldhandle;
-  common.expectsInternalAssertion(
+  assert.throws(
     () => {
       const w = fs.watch(__filename, common.mustNotCall());
       oldhandle = w._handle;
       w._handle = { close: w._handle.close };
       w.close();
     },
-    'handle must be a FSEvent'
+    {
+      name: 'TypeError',
+      code: 'ERR_UNEXPECTED_INSTANCE',
+      message: 'handle must have FSEvent in its prototype chain',
+    }
   );
   oldhandle.close(); // clean up
 }


### PR DESCRIPTION
Three commits:

    fs: throw rather than assert on errant monkey-patching
    
    It is possible to make `.close()` assert on an FSWatcher if the
    `_handle` property is monkey-patched. Assertions should be reserved for
    things that are believed to be logically impossible. Since we know end
    users can cause the assertion, change it to a throw.

---

    test: remove common.expectsInternal Assertion
    
    Remove convenience function for internal assertions. It is only used
    once.

---

    test: add coverage for FSWatcher exception
    
    Cover an previously uncovered exception possible in the internal start
    function for FSWatcher.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
