### PR TITLE
test: skip the freemem test on IBMi PASE

### DIFF
--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -127,7 +127,10 @@ assert.ok(arch.length > 0);
 if (!common.isSunOS) {
   // not implemented yet
   assert.ok(os.loadavg().length > 0);
-  assert.ok(os.freemem() > 0);
+  // On IBMi PASE, the amount of memory in use includes storage used for
+  // memory and disks so it is possible to exceed the amount of main storage.
+  if (!common.isIBMi)
+    assert.ok(os.freemem() > 0);
   assert.ok(os.totalmem() > 0);
 }
 


### PR DESCRIPTION
On IBMi PASE, the amount of memory in use includes storage
used for memory and disks so it is possible to exceed the
amount of main storage.

So skip this test on IBMi PASE as libuv --> https://github.com/libuv/libuv/pull/2614/files#diff-564d321f5718b4ed067d21caf87d4b59
