### PR TITLE
zlib: emits 'close' event after readble 'end'

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -274,7 +274,7 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
   this._defaultFlushFlag = flush;
   this._finishFlushFlag = finishFlush;
   this._defaultFullFlushFlag = fullFlush;
-  this.once('end', _close.bind(null, this));
+  this.once('end', this.close);
   this._info = opts && opts.info;
 }
 ObjectSetPrototypeOf(ZlibBase.prototype, Transform.prototype);

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -171,7 +171,8 @@ zlib.createDeflateRaw({ windowBits: 8 });
       .pipe(zlib.createInflateRaw({ windowBits: 8 }))
       .on('data', (chunk) => reinflated.push(chunk))
       .on('end', common.mustCall(
-        () => assert(Buffer.concat(raw).equals(Buffer.concat(reinflated)))));
+        () => assert(Buffer.concat(raw).equals(Buffer.concat(reinflated)))))
+      .on('close', common.mustCall(1));
 }
 
 // For each of the files, make sure that compressing and


### PR DESCRIPTION
Hey there,
as far as I understand [this PR](https://github.com/nodejs/node/pull/31082) breaks behaviour when `zlib` streams emit `close` event in case of successful end.

Since emitting `close` is the part of `Readable.destroy` implementation - `.destroy` must be called on `ZlibBase` instance. In this case (case of successful finish) `this.on('end')` should be sufficient.

- [x] `make -j4 test` (UNIX)
- [x] tests are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Fixes: #32023 

\cc @addaleax 