### PR TITLE
stream: do not swallow errors with async iterators and pipeline

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -25,10 +25,10 @@ let EE;
 let PassThrough;
 let createReadableStreamAsyncIterator;
 
-function destroyer(stream, reading, writing, callback) {
+function destroyer(stream, reading, writing, final, callback) {
   const _destroy = once((err) => {
     const readable = stream.readable || isRequest(stream);
-    if (err || !readable) {
+    if (err || !final || !readable) {
       destroyImpl.destroyer(stream, err);
     }
     callback(err);
@@ -182,7 +182,7 @@ function pipeline(...streams) {
 
     if (isStream(stream)) {
       finishCount++;
-      destroys.push(destroyer(stream, reading, writing, finish));
+      destroys.push(destroyer(stream, reading, writing, !reading, finish));
     }
 
     if (i === 0) {
@@ -238,7 +238,7 @@ function pipeline(...streams) {
         ret = pt;
 
         finishCount++;
-        destroys.push(destroyer(ret, false, true, finish));
+        destroys.push(destroyer(ret, false, true, true, finish));
       }
     } else if (isStream(stream)) {
       if (isReadable(ret)) {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -25,10 +25,10 @@ let EE;
 let PassThrough;
 let createReadableStreamAsyncIterator;
 
-function destroyer(stream, reading, writing, final, callback) {
+function destroyer(stream, reading, writing, callback) {
   const _destroy = once((err) => {
     const readable = stream.readable || isRequest(stream);
-    if (err || !final || !readable) {
+    if (err || !readable) {
       destroyImpl.destroyer(stream, err);
     }
     callback(err);
@@ -123,6 +123,7 @@ async function pump(iterable, writable, finish) {
   if (!EE) {
     EE = require('events');
   }
+  let error;
   try {
     for await (const chunk of iterable) {
       if (!writable.write(chunk)) {
@@ -132,7 +133,9 @@ async function pump(iterable, writable, finish) {
     }
     writable.end();
   } catch (err) {
-    finish(err);
+    error = err;
+  } finally {
+    finish(error);
   }
 }
 
@@ -149,26 +152,26 @@ function pipeline(...streams) {
   let value;
   const destroys = [];
 
-  function finish(err, final) {
-    if (!error && err) {
+  let finishCount = 0;
+
+  function finish(err) {
+    const final = --finishCount === 0;
+
+    if (err && (!error || error.code === 'ERR_STREAM_PREMATURE_CLOSE')) {
       error = err;
     }
 
-    if (error || final) {
-      for (const destroy of destroys) {
-        destroy(error);
-      }
+    if (!error && !final) {
+      return;
+    }
+
+    while (destroys.length) {
+      destroys.shift()(error);
     }
 
     if (final) {
       callback(error, value);
     }
-  }
-
-  function wrap(stream, reading, writing, final) {
-    destroys.push(destroyer(stream, reading, writing, final, (err) => {
-      finish(err, final);
-    }));
   }
 
   let ret;
@@ -178,7 +181,8 @@ function pipeline(...streams) {
     const writing = i > 0;
 
     if (isStream(stream)) {
-      wrap(stream, reading, writing, !reading);
+      finishCount++;
+      destroys.push(destroyer(stream, reading, writing, finish));
     }
 
     if (i === 0) {
@@ -224,6 +228,7 @@ function pipeline(...streams) {
               pt.destroy(err);
             });
         } else if (isIterable(ret, true)) {
+          finishCount++;
           pump(ret, pt, finish);
         } else {
           throw new ERR_INVALID_RETURN_VALUE(
@@ -231,13 +236,17 @@ function pipeline(...streams) {
         }
 
         ret = pt;
-        wrap(ret, false, true, true);
+
+        finishCount++;
+        destroys.push(destroyer(ret, false, true, finish));
       }
     } else if (isStream(stream)) {
       if (isReadable(ret)) {
         ret.pipe(stream);
       } else {
         ret = makeAsyncIterable(ret);
+
+        finishCount++;
         pump(ret, stream, finish);
       }
       ret = stream;

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -984,3 +984,30 @@ const { promisify } = require('util');
   }));
   src.end();
 }
+
+{
+  let res = '';
+  const rs = new Readable({
+    read() {
+      setImmediate(() => {
+        rs.push('hello');
+      });
+    }
+  });
+  const ws = new Writable({
+    write: common.mustNotCall()
+  });
+  pipeline(rs, async function*(stream) {
+    /* eslint no-unused-vars: off */
+    for await (const chunk of stream) {
+      throw new Error('kaboom');
+    }
+  }, async function *(source) {
+    for await (const chunk of source) {
+      res += chunk;
+    }
+  }, ws, common.mustCall((err) => {
+    assert.strictEqual(err.message, 'kaboom');
+    assert.strictEqual(res, '');
+  }));
+}


### PR DESCRIPTION
Before this patch, pipeline() could swallow errors by pre-emptively
producing a ERR_STREAM_PREMATURE_CLOSE that was not really helpful
to the user.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
