### PR TITLE
module: improve error for invalid package targets

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1111,7 +1111,7 @@ E('ERR_INVALID_PACKAGE_TARGET',
       if (subpath !== '') {
         return `Invalid "exports" target ${JSONStringify(target)} defined ` +
         `for '${subpath}' in the package config ${pkgPath} imported from ` +
-        `${base}.${relError ? ' - targets must start with "./"' : ''}`;
+        `${base}.${relError ? '; targets must start with "./"' : ''}`;
       } else {
         return `Invalid "exports" main target ${target} defined in the ` +
           `package config ${pkgPath} imported from ${base}${relError ?

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -20,6 +20,7 @@ const {
   ObjectDefineProperty,
   ObjectKeys,
   StringPrototypeSlice,
+  StringPrototypeStartsWith,
   Symbol,
   SymbolFor,
   WeakMap,
@@ -1105,7 +1106,7 @@ E('ERR_INVALID_PACKAGE_CONFIG', (path, message, hasMessage = true) => {
 E('ERR_INVALID_PACKAGE_TARGET',
   (pkgPath, key, subpath, target, base = undefined) => {
     const relError = typeof target === 'string' &&
-      target.length && !target.startsWith('./');
+      target.length && !StringPrototypeStartsWith(target, './');
     if (key === null) {
       if (subpath !== '') {
         return `Invalid "exports" target ${JSONStringify(target)} defined ` +
@@ -1121,7 +1122,7 @@ E('ERR_INVALID_PACKAGE_TARGET',
       `in the package config ${pkgPath}${sep}package.json${relError ?
         ' - targets must start with "./"' : ''}`;
     } else if (typeof target === 'string' && target !== '' &&
-      !target.startsWith('./')) {
+      !StringPrototypeStartsWith(target, './')) {
       return `Invalid "exports" target ${JSONStringify(target)} defined for '${
         StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +
         `package config ${pkgPath}${sep}package.json. ` +

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1114,7 +1114,7 @@ E('ERR_INVALID_PACKAGE_TARGET',
         `${base}.${relError ? ' - targets must start with "./"' : ''}`;
       } else {
         return `Invalid "exports" main target ${target} defined in the ` +
-          `package config ${pkgPath} imported from ${base}.${relError ?
+          `package config ${pkgPath} imported from ${base}${relError ?
             ' - targets must start with "./"' : ''}`;
       }
     } else if (key === '.') {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1104,8 +1104,8 @@ E('ERR_INVALID_PACKAGE_CONFIG', (path, message, hasMessage = true) => {
 }, Error);
 E('ERR_INVALID_PACKAGE_TARGET',
   (pkgPath, key, subpath, target, base = undefined) => {
-    const relError = typeof target === 'string'
-      && target.length && !target.startsWith('./');
+    const relError = typeof target === 'string' &&
+      target.length && !target.startsWith('./');
     if (key === null) {
       if (subpath !== '') {
         return `Invalid "exports" target ${JSONStringify(target)} defined ` +
@@ -1114,18 +1114,18 @@ E('ERR_INVALID_PACKAGE_TARGET',
       } else {
         return `Invalid "exports" main target ${target} defined in the ` +
           `package config ${pkgPath} imported from ${base}.${relError ?
-          ' - targets must start with "./"' : ''}`;
+            ' - targets must start with "./"' : ''}`;
       }
     } else if (key === '.') {
       return `Invalid "exports" main target ${JSONStringify(target)} defined ` +
       `in the package config ${pkgPath}${sep}package.json${relError ?
-            ' - targets must start with "./"' : ''}`;
+        ' - targets must start with "./"' : ''}`;
     } else if (typeof target === 'string' && target !== '' &&
       !target.startsWith('./')) {
-        return `Invalid "exports" target ${JSONStringify(target)} defined for '${
-          StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +
-          `package config ${pkgPath}${sep}package.json. ` +
-          '- targets must start with `./`';
+      return `Invalid "exports" target ${JSONStringify(target)} defined for '${
+        StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +
+        `package config ${pkgPath}${sep}package.json. ` +
+        '- targets must start with `./`';
     } else {
       return `Invalid "exports" target ${JSONStringify(target)} defined for '${
         StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1125,8 +1125,8 @@ E('ERR_INVALID_PACKAGE_TARGET',
       !StringPrototypeStartsWith(target, './')) {
       return `Invalid "exports" target ${JSONStringify(target)} defined for '${
         StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +
-        `package config ${pkgPath}${sep}package.json. ` +
-        '- targets must start with "./"';
+        `package config ${pkgPath}${sep}package.json; ` +
+        'targets must start with "./"';
     } else {
       return `Invalid "exports" target ${JSONStringify(target)} defined for '${
         StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1126,7 +1126,7 @@ E('ERR_INVALID_PACKAGE_TARGET',
       return `Invalid "exports" target ${JSONStringify(target)} defined for '${
         StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +
         `package config ${pkgPath}${sep}package.json. ` +
-        '- targets must start with `./`';
+        '- targets must start with "./"';
     } else {
       return `Invalid "exports" target ${JSONStringify(target)} defined for '${
         StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1115,7 +1115,7 @@ E('ERR_INVALID_PACKAGE_TARGET',
       } else {
         return `Invalid "exports" main target ${target} defined in the ` +
           `package config ${pkgPath} imported from ${base}${relError ?
-            ' - targets must start with "./"' : ''}`;
+            '; targets must start with "./"' : ''}`;
       }
     } else if (key === '.') {
       return `Invalid "exports" main target ${JSONStringify(target)} defined ` +

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1120,7 +1120,7 @@ E('ERR_INVALID_PACKAGE_TARGET',
     } else if (key === '.') {
       return `Invalid "exports" main target ${JSONStringify(target)} defined ` +
       `in the package config ${pkgPath}${sep}package.json${relError ?
-        ' - targets must start with "./"' : ''}`;
+        '; targets must start with "./"' : ''}`;
     } else if (typeof target === 'string' && target !== '' &&
       !StringPrototypeStartsWith(target, './')) {
       return `Invalid "exports" target ${JSONStringify(target)} defined for '${

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1104,18 +1104,28 @@ E('ERR_INVALID_PACKAGE_CONFIG', (path, message, hasMessage = true) => {
 }, Error);
 E('ERR_INVALID_PACKAGE_TARGET',
   (pkgPath, key, subpath, target, base = undefined) => {
+    const relError = typeof target === 'string'
+      && target.length && !target.startsWith('./');
     if (key === null) {
       if (subpath !== '') {
         return `Invalid "exports" target ${JSONStringify(target)} defined ` +
         `for '${subpath}' in the package config ${pkgPath} imported from ` +
-        base;
+        `${base}.${relError ? ' - targets must start with "./"' : ''}`;
       } else {
         return `Invalid "exports" main target ${target} defined in the ` +
-          `package config ${pkgPath} imported from ${base}.`;
+          `package config ${pkgPath} imported from ${base}.${relError ?
+          ' - targets must start with "./"' : ''}`;
       }
     } else if (key === '.') {
       return `Invalid "exports" main target ${JSONStringify(target)} defined ` +
-      `in the package config ${pkgPath}${sep}package.json`;
+      `in the package config ${pkgPath}${sep}package.json${relError ?
+            ' - targets must start with "./"' : ''}`;
+    } else if (typeof target === 'string' && target !== '' &&
+      !target.startsWith('./')) {
+        return `Invalid "exports" target ${JSONStringify(target)} defined for '${
+          StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +
+          `package config ${pkgPath}${sep}package.json. ` +
+          '- targets must start with `./`';
     } else {
       return `Invalid "exports" target ${JSONStringify(target)} defined for '${
         StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -78,6 +78,7 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     ['pkgexports/null', './null'],
     ['pkgexports/invalid2', './invalid2'],
     ['pkgexports/invalid3', './invalid3'],
+    ['pkgexports/invalid5', 'invalid5'],
     // Missing / invalid fallbacks
     ['pkgexports/nofallback1', './nofallback1'],
     ['pkgexports/nofallback2', './nofallback2'],
@@ -106,6 +107,9 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
       strictEqual(err.code, 'ERR_INVALID_PACKAGE_TARGET');
       assertStartsWith(err.message, 'Invalid "exports"');
       assertIncludes(err.message, subpath);
+      if (!subpath.startsWith('./')) {
+        assertIncludes(err.message, 'targets must start with');
+      }
     }));
   }
 

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -13,6 +13,7 @@
     "./invalid2": 1234,
     "./invalid3": "",
     "./invalid4": {},
+    "./invalid5": "invalid5.js",
     "./fallbackdir/": [[], null, {}, "builtin:x/", "./fallbackfile", "./"],
     "./fallbackfile": [[], null, {}, "builtin:x", "./asdf.js"],
     "./nofallback1": [],


### PR DESCRIPTION
For targets that are strings that do not start with `./` or `/` the
error will now have additional information about what the programming
error is.

Closes: https://github.com/nodejs/node/issues/32034

PTAL @nodejs/modules