### PR TITLE
http, async_hooks: remove unneeded reference to wrapping resource

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -50,18 +50,10 @@ const kOnKeylog = Symbol('onkeylog');
 // ClientRequest.onSocket(). The Agent is now *strictly*
 // concerned with managing a connection pool.
 
-const kReusedHandle = Symbol('kReusedHandle');
 class ReusedHandle {
   constructor(type, handle) {
     this.type = type;
     this.handle = handle;
-    // We need keep the resource object alive from this object, because
-    // domains rely on GC of the resource object for lifetime tracking.
-    // TODO(addaleax): This should really apply to all uses of
-    // AsyncWrap::AsyncReset() when the resource is not the AsyncWrap object
-    // itself. However, HTTPClientAsyncResource and HTTPServerAsyncResource
-    // hold on to other objects, inhibiting GC.
-    handle[kReusedHandle] = this;
   }
 }
 


### PR DESCRIPTION
Remove the reference from handle to unique resource `ReusedHandle` in `HttpAgent` as there is meanwhile a strong reference for all async resources in place via `AsyncWarp::resource_`.

Refs: https://github.com/nodejs/node/pull/30959
Refs: https://github.com/nodejs/node/pull/30196

fyi @addaleax 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
