### PR TITLE
n-api: define release 6

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -374,6 +374,7 @@ tied to the life cycle of the Agent.
 ### napi_set_instance_data
 <!-- YAML
 added: v12.8.0
+napiVersion: 6
 -->
 
 ```C
@@ -401,6 +402,7 @@ by the previous call, it will not be called.
 ### napi_get_instance_data
 <!-- YAML
 added: v12.8.0
+napiVersion: 6
 -->
 
 ```C
@@ -1663,9 +1665,8 @@ the `napi_value` in question is of the JavaScript type expected by the API.
 #### napi_key_collection_mode
 <!-- YAML
 added: v13.7.0
+napiVersion: 6
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 typedef enum {
@@ -1685,9 +1686,8 @@ of the objects's prototype chain as well.
 #### napi_key_filter
 <!-- YAML
 added: v13.7.0
+napiVersion: 6
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 typedef enum {
@@ -1705,9 +1705,8 @@ Property filter bits. They can be or'ed to build a composite filter.
 #### napi_key_conversion
 <!-- YAML
 added: v13.7.0
+napiVersion: 6
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 typedef enum {
@@ -2262,9 +2261,8 @@ The JavaScript `Number` type is described in
 #### napi_create_bigint_int64
 <!-- YAML
 added: v10.7.0
+napiVersion: 6
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 napi_status napi_create_bigint_int64(napi_env env,
@@ -2283,9 +2281,8 @@ This API converts the C `int64_t` type to the JavaScript `BigInt` type.
 #### napi_create_bigint_uint64
 <!-- YAML
 added: v10.7.0
+napiVersion: 6
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 napi_status napi_create_bigint_uint64(napi_env env,
@@ -2304,9 +2301,8 @@ This API converts the C `uint64_t` type to the JavaScript `BigInt` type.
 #### napi_create_bigint_words
 <!-- YAML
 added: v10.7.0
+napiVersion: 6
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 napi_status napi_create_bigint_words(napi_env env,
@@ -2653,9 +2649,8 @@ This API returns the C double primitive equivalent of the given JavaScript
 #### napi_get_value_bigint_int64
 <!-- YAML
 added: v10.7.0
+napiVersion: 6
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 napi_status napi_get_value_bigint_int64(napi_env env,
@@ -2680,9 +2675,8 @@ This API returns the C `int64_t` primitive equivalent of the given JavaScript
 #### napi_get_value_bigint_uint64
 <!-- YAML
 added: v10.7.0
+napiVersion: 6
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 napi_status napi_get_value_bigint_uint64(napi_env env,
@@ -2707,9 +2701,8 @@ This API returns the C `uint64_t` primitive equivalent of the given JavaScript
 #### napi_get_value_bigint_words
 <!-- YAML
 added: v10.7.0
+napiVersion: 6
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 napi_status napi_get_value_bigint_words(napi_env env,
@@ -3595,9 +3588,8 @@ included.
 #### napi_get_all_property_names
 <!-- YAML
 added: v13.7.0
+napiVersion: 6
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 napi_get_all_property_names(napi_env env,

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -4,7 +4,6 @@
 // This file needs to be compatible with C compilers.
 #include <stddef.h>   // NOLINT(modernize-deprecated-headers)
 #include <stdbool.h>  // NOLINT(modernize-deprecated-headers)
-#include "js_native_api_types.h"
 
 // Use INT_MAX, this should only be consumed by the pre-processor anyway.
 #define NAPI_VERSION_EXPERIMENTAL 2147483647
@@ -18,9 +17,11 @@
 // functions available in a new version of N-API that is not yet ported in all
 // LTS versions, they can set NAPI_VERSION knowing that they have specifically
 // depended on that version.
-#define NAPI_VERSION 5
+#define NAPI_VERSION 6
 #endif
 #endif
+
+#include "js_native_api_types.h"
 
 // If you need __declspec(dllimport), either include <node_api.h> instead, or
 // define NAPI_EXTERN as __declspec(dllimport) on the compiler's command line.
@@ -478,7 +479,7 @@ NAPI_EXTERN napi_status napi_add_finalizer(napi_env env,
 
 #endif  // NAPI_VERSION >= 5
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 6
 
 // BigInt
 NAPI_EXTERN napi_status napi_create_bigint_int64(napi_env env,
@@ -523,7 +524,9 @@ NAPI_EXTERN napi_status napi_set_instance_data(napi_env env,
 
 NAPI_EXTERN napi_status napi_get_instance_data(napi_env env,
                                                void** data);
+#endif  // NAPI_VERSION >= 6
 
+#ifdef NAPI_EXPERIMENTAL
 // ArrayBuffer detaching
 NAPI_EXTERN napi_status napi_detach_arraybuffer(napi_env env,
                                                 napi_value arraybuffer);

--- a/src/js_native_api_types.h
+++ b/src/js_native_api_types.h
@@ -115,7 +115,7 @@ typedef struct {
   napi_status error_code;
 } napi_extended_error_info;
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 6
 typedef enum {
   napi_key_include_prototypes,
   napi_key_own_only
@@ -134,6 +134,6 @@ typedef enum {
   napi_key_keep_numbers,
   napi_key_numbers_to_strings
 } napi_key_conversion;
-#endif
+#endif  // NAPI_VERSION >= 6
 
 #endif  // SRC_JS_NATIVE_API_TYPES_H_

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -93,6 +93,6 @@
 
 // The NAPI_VERSION provided by this version of the runtime. This is the version
 // which the Node binary being built supports.
-#define NAPI_VERSION  5
+#define NAPI_VERSION  6
 
 #endif  // SRC_NODE_VERSION_H_

--- a/test/js-native-api/test_bigint/test_bigint.c
+++ b/test/js-native-api/test_bigint/test_bigint.c
@@ -1,5 +1,3 @@
-#define NAPI_EXPERIMENTAL
-
 #include <inttypes.h>
 #include <stdio.h>
 #include <js_native_api.h>

--- a/test/js-native-api/test_general/test.js
+++ b/test/js-native-api/test_general/test.js
@@ -33,7 +33,7 @@ assert.notStrictEqual(test_general.testGetPrototype(baseObject),
                       test_general.testGetPrototype(extendedObject));
 
 // Test version management functions. The expected version is currently 4.
-assert.strictEqual(test_general.testGetVersion(), 5);
+assert.strictEqual(test_general.testGetVersion(), 6);
 
 [
   123,

--- a/test/js-native-api/test_instance_data/test_instance_data.c
+++ b/test/js-native-api/test_instance_data/test_instance_data.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#define NAPI_EXPERIMENTAL
 #include <js_native_api.h>
 #include "../common.h"
 

--- a/test/js-native-api/test_object/test_null.c
+++ b/test/js-native-api/test_object/test_null.c
@@ -1,4 +1,3 @@
-#define NAPI_EXPERIMENTAL
 #include <js_native_api.h>
 
 #include "../common.h"

--- a/test/js-native-api/test_object/test_object.c
+++ b/test/js-native-api/test_object/test_object.c
@@ -1,5 +1,3 @@
-#define NAPI_EXPERIMENTAL
-
 #include <js_native_api.h>
 #include "../common.h"
 #include <string.h>

--- a/test/node-api/test_general/test_general.c
+++ b/test/node-api/test_general/test_general.c
@@ -1,4 +1,3 @@
-#define NAPI_EXPERIMENTAL
 #include <node_api.h>
 #include <stdlib.h>
 #include "../../js-native-api/common.h"

--- a/test/node-api/test_instance_data/addon.c
+++ b/test/node-api/test_instance_data/addon.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#define NAPI_EXPERIMENTAL
 #include <node_api.h>
 
 static void addon_free(napi_env env, void* data, void* hint) {

--- a/test/node-api/test_instance_data/test_instance_data.c
+++ b/test/node-api/test_instance_data/test_instance_data.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include <uv.h>
-#define NAPI_EXPERIMENTAL
 #include <node_api.h>
 #include "../../js-native-api/common.h"
 

--- a/test/node-api/test_instance_data/test_ref_then_set.c
+++ b/test/node-api/test_instance_data/test_ref_then_set.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#define NAPI_EXPERIMENTAL
 #include <node_api.h>
 
 napi_value addon_new(napi_env env, napi_value exports, bool ref_first);

--- a/test/node-api/test_instance_data/test_set_then_ref.c
+++ b/test/node-api/test_instance_data/test_set_then_ref.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#define NAPI_EXPERIMENTAL
 #include <node_api.h>
 
 napi_value addon_new(napi_env env, napi_value exports, bool ref_first);


### PR DESCRIPTION
Mark all N-APIs that have been added since version 5 as stable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
