### PR TITLE
doc: change worker.takeHeapSnapshot to getHeapSnapshot

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -612,6 +612,21 @@ added: v10.5.0
 The `'online'` event is emitted when the worker thread has started executing
 JavaScript code.
 
+### `worker.getHeapSnapshot()`
+<!-- YAML
+added: v13.9.0
+-->
+
+* Returns: {Promise} A promise for a Readable Stream containing
+  a V8 heap snapshot
+
+Returns a readable stream for a V8 snapshot of the current state of the Worker.
+See [`v8.getHeapSnapshot()`][] for more details.
+
+If the Worker thread is no longer running, which may occur before the
+[`'exit'` event][] is emitted, the returned `Promise` will be rejected
+immediately with an [`ERR_WORKER_NOT_RUNNING`][] error.
+
 ### `worker.postMessage(value[, transferList])`
 <!-- YAML
 added: v10.5.0
@@ -684,21 +699,6 @@ This is a readable stream which contains data written to [`process.stdout`][]
 inside the worker thread. If `stdout: true` was not passed to the
 [`Worker`][] constructor, then data will be piped to the parent thread's
 [`process.stdout`][] stream.
-
-### `worker.getHeapSnapshot()`
-<!-- YAML
-added: v13.9.0
--->
-
-* Returns: {Promise} A promise for a Readable Stream containing
-  a V8 heap snapshot
-
-Returns a readable stream for a V8 snapshot of the current state of the Worker.
-See [`v8.getHeapSnapshot()`][] for more details.
-
-If the Worker thread is no longer running, which may occur before the
-[`'exit'` event][] is emitted, the returned `Promise` will be rejected
-immediately with an [`ERR_WORKER_NOT_RUNNING`][] error.
 
 ### `worker.terminate()`
 <!-- YAML

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -685,7 +685,7 @@ inside the worker thread. If `stdout: true` was not passed to the
 [`Worker`][] constructor, then data will be piped to the parent thread's
 [`process.stdout`][] stream.
 
-### `worker.takeHeapSnapshot()`
+### `worker.getHeapSnapshot()`
 <!-- YAML
 added: v13.9.0
 -->


### PR DESCRIPTION
Adapt doc to match implementation which exports getHeapSnapshot().

Refs: https://github.com/nodejs/node/pull/31569
Refs: https://github.com/nodejs/node/blob/987a67339518d0380177a2e589f2bbd274230d0e/lib/internal/worker.js#L323

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

