### PR TITLE
src: pass resource object along with InternalMakeCallback

### DIFF
--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -139,6 +139,7 @@ void InternalCallbackScope::Close() {
 }
 
 MaybeLocal<Value> InternalMakeCallback(Environment* env,
+                                       Local<Object> resource,
                                        Local<Object> recv,
                                        const Local<Function> callback,
                                        int argc,
@@ -150,7 +151,7 @@ MaybeLocal<Value> InternalMakeCallback(Environment* env,
     CHECK(!argv[i].IsEmpty());
 #endif
 
-  InternalCallbackScope scope(env, recv, asyncContext);
+  InternalCallbackScope scope(env, resource, asyncContext);
   if (scope.Failed()) {
     return MaybeLocal<Value>();
   }
@@ -224,7 +225,7 @@ MaybeLocal<Value> MakeCallback(Isolate* isolate,
   CHECK_NOT_NULL(env);
   Context::Scope context_scope(env->context());
   MaybeLocal<Value> ret =
-      InternalMakeCallback(env, recv, callback, argc, argv, asyncContext);
+      InternalMakeCallback(env, recv, recv, callback, argc, argv, asyncContext);
   if (ret.IsEmpty() && env->async_callback_scope_depth() == 0) {
     // This is only for legacy compatibility and we may want to look into
     // removing/adjusting it.

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -749,7 +749,7 @@ MaybeLocal<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   ProviderType provider = provider_type();
   async_context context { get_async_id(), get_trigger_async_id() };
   MaybeLocal<Value> ret = InternalMakeCallback(
-      env(), object(), cb, argc, argv, context);
+      env(), GetResource(), object(), cb, argc, argv, context);
 
   // This is a static call with cached values because the `this` object may
   // no longer be alive at this point.

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -199,6 +199,7 @@ static v8::MaybeLocal<v8::Object> New(Environment* env,
 
 v8::MaybeLocal<v8::Value> InternalMakeCallback(
     Environment* env,
+    v8::Local<v8::Object> resource,
     v8::Local<v8::Object> recv,
     const v8::Local<v8::Function> callback,
     int argc,

--- a/test/async-hooks/test-async-exec-resource-http-32060.js
+++ b/test/async-hooks/test-async-exec-resource-http-32060.js
@@ -1,0 +1,37 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const {
+  executionAsyncResource,
+  executionAsyncId,
+  createHook,
+} = require('async_hooks');
+const http = require('http');
+
+const hooked = {};
+createHook({
+  init(asyncId, type, triggerAsyncId, resource) {
+    hooked[asyncId] = resource;
+  }
+}).enable();
+
+const server = http.createServer((req, res) => {
+  res.write('hello');
+  setTimeout(() => {
+    res.end(' world!');
+  }, 1000);
+});
+
+server.listen(0, () => {
+  assert.strictEqual(executionAsyncResource(), hooked[executionAsyncId()]);
+  http.get({ port: server.address().port }, (res) => {
+    assert.strictEqual(executionAsyncResource(), hooked[executionAsyncId()]);
+    res.on('data', () => {
+      assert.strictEqual(executionAsyncResource(), hooked[executionAsyncId()]);
+    });
+    res.on('end', () => {
+      assert.strictEqual(executionAsyncResource(), hooked[executionAsyncId()]);
+      server.close();
+    });
+  });
+});


### PR DESCRIPTION
This was an oversight in 9fdb6e6aaf45b2364bac89a.
Fixing this is necessary to make `executionAsyncResource()` work
as expected.

Refs: https://github.com/nodejs/node/pull/30959
Fixes: https://github.com/nodejs/node/issues/32060

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
