### PR TITLE
test: fix test-tls-env-extra-ca-file-load

### DIFF
--- a/test/parallel/test-tls-env-extra-ca-file-load.js
+++ b/test/parallel/test-tls-env-extra-ca-file-load.js
@@ -16,14 +16,7 @@ const { fork } = require('child_process');
 
 // This test ensures that extra certificates are loaded at startup.
 if (process.argv[2] !== 'child') {
-  if (process.env.CHILD_USE_EXTRA_CA_CERTS === 'yes') {
-    assert.strictEqual(binding.isExtraRootCertsFileLoaded(), true);
-  } else if (process.env.CHILD_USE_EXTRA_CA_CERTS === 'no') {
-    assert.strictEqual(binding.isExtraRootCertsFileLoaded(), false);
-    tls.createServer({});
-    assert.strictEqual(binding.isExtraRootCertsFileLoaded(), false);
-  }
-} else {
+  // Parent
   const NODE_EXTRA_CA_CERTS = fixtures.path('keys', 'ca1-cert.pem');
   const extendsEnv = (obj) => ({ ...process.env, ...obj });
 
@@ -37,4 +30,12 @@ if (process.argv[2] !== 'child') {
       assert.strictEqual(status, 0);
     }));
   });
+} else if (process.env.CHILD_USE_EXTRA_CA_CERTS === 'yes') {
+  // Child with extra certificates loaded at startup.
+  assert.strictEqual(binding.isExtraRootCertsFileLoaded(), true);
+} else {
+  // Child without extra certificates.
+  assert.strictEqual(binding.isExtraRootCertsFileLoaded(), false);
+  tls.createServer({});
+  assert.strictEqual(binding.isExtraRootCertsFileLoaded(), false);
 }


### PR DESCRIPTION
Fixes broken unit test for the NODE_EXTRA_CA_CERTS environment variable. Unit test was exiting without evaluating any assertions or running any tests. Code blocks for the parent and child (forked) process had been incorrectly swapped.

Fixes: https://github.com/nodejs/node/issues/32072

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
