### PR TITLE
test: refactoring and cleanup on child-process tests

### DIFF
--- a/test/fixtures/child-process-spawn-node.js
+++ b/test/fixtures/child-process-spawn-node.js
@@ -1,7 +1,8 @@
 const assert = require('assert');
+const debug = require('util').debuglog('test');
 
 function onmessage(m) {
-  console.log('CHILD got message:', m);
+  debug('CHILD got message:', m);
   assert.ok(m.hello);
   process.removeListener('message', onmessage);
 }

--- a/test/parallel/test-bash-completion.js
+++ b/test/parallel/test-bash-completion.js
@@ -2,14 +2,15 @@
 require('../common');
 const assert = require('assert');
 const child_process = require('child_process');
-const { inspect } = require('util');
+const { debuglog, inspect } = require('util');
+const debug = debuglog('test');
 
 const p = child_process.spawnSync(
   process.execPath, [ '--completion-bash' ]);
 assert.ifError(p.error);
 
 const output = p.stdout.toString().trim().replace(/\r/g, '');
-console.log(output);
+debug(output);
 
 const prefix = `_node_complete() {
   local cur_word options

--- a/test/parallel/test-child-process-default-options.js
+++ b/test/parallel/test-child-process-default-options.js
@@ -20,15 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+const { isWindows } = require('../common');
 const assert = require('assert');
 
 const spawn = require('child_process').spawn;
+const debug = require('util').debuglog('test');
 
 process.env.HELLO = 'WORLD';
 
 let child;
-if (common.isWindows) {
+if (isWindows) {
   child = spawn('cmd.exe', ['/c', 'set'], {});
 } else {
   child = spawn('/usr/bin/env', [], {});
@@ -39,7 +40,7 @@ let response = '';
 child.stdout.setEncoding('utf8');
 
 child.stdout.on('data', function(chunk) {
-  console.log(`stdout: ${chunk}`);
+  debug(`stdout: ${chunk}`);
   response += chunk;
 });
 

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -20,9 +20,14 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+const {
+  isWindows,
+  mustCall,
+  mustCallAtLeast,
+} = require('../common');
 const assert = require('assert');
 const os = require('os');
+const debug = require('util').debuglog('test');
 
 const spawn = require('child_process').spawn;
 
@@ -38,7 +43,7 @@ Object.setPrototypeOf(env, {
 });
 
 let child;
-if (common.isWindows) {
+if (isWindows) {
   child = spawn('cmd.exe', ['/c', 'set'], { env });
 } else {
   child = spawn('/usr/bin/env', [], { env });
@@ -49,15 +54,15 @@ let response = '';
 
 child.stdout.setEncoding('utf8');
 
-child.stdout.on('data', (chunk) => {
-  console.log(`stdout: ${chunk}`);
+child.stdout.on('data', mustCallAtLeast((chunk) => {
+  debug(`stdout: ${chunk}`);
   response += chunk;
-});
+}));
 
-process.on('exit', () => {
+child.stdout.on('end', mustCall(() => {
   assert.ok(response.includes('HELLO=WORLD'));
   assert.ok(response.includes('FOO=BAR'));
   assert.ok(!response.includes('UNDEFINED=undefined'));
   assert.ok(response.includes('NULL=null'));
   assert.ok(response.includes(`EMPTY=${os.EOL}`));
-});
+}));

--- a/test/parallel/test-child-process-exec-env.js
+++ b/test/parallel/test-child-process-exec-env.js
@@ -20,9 +20,11 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+const { isWindows } = require('../common');
 const assert = require('assert');
 const exec = require('child_process').exec;
+const debug = require('util').debuglog('test');
+
 let success_count = 0;
 let error_count = 0;
 let response = '';
@@ -31,9 +33,9 @@ let child;
 function after(err, stdout, stderr) {
   if (err) {
     error_count++;
-    console.log(`error!: ${err.code}`);
-    console.log(`stdout: ${JSON.stringify(stdout)}`);
-    console.log(`stderr: ${JSON.stringify(stderr)}`);
+    debug(`error!: ${err.code}`);
+    debug(`stdout: ${JSON.stringify(stdout)}`);
+    debug(`stderr: ${JSON.stringify(stderr)}`);
     assert.strictEqual(err.killed, false);
   } else {
     success_count++;
@@ -41,7 +43,7 @@ function after(err, stdout, stderr) {
   }
 }
 
-if (!common.isWindows) {
+if (!isWindows) {
   child = exec('/usr/bin/env', { env: { 'HELLO': 'WORLD' } }, after);
 } else {
   child = exec('set',
@@ -55,7 +57,7 @@ child.stdout.on('data', function(chunk) {
 });
 
 process.on('exit', function() {
-  console.log('response: ', response);
+  debug('response: ', response);
   assert.strictEqual(success_count, 1);
   assert.strictEqual(error_count, 0);
   assert.ok(response.includes('HELLO=WORLD'));

--- a/test/parallel/test-child-process-fork-net-server.js
+++ b/test/parallel/test-child-process-fork-net-server.js
@@ -24,56 +24,60 @@ const common = require('../common');
 const assert = require('assert');
 const fork = require('child_process').fork;
 const net = require('net');
+const debug = require('util').debuglog('test');
 
-function ProgressTracker(missing, callback) {
-  this.missing = missing;
-  this.callback = callback;
-}
-ProgressTracker.prototype.done = function() {
-  this.missing -= 1;
-  this.check();
-};
-ProgressTracker.prototype.check = function() {
-  if (this.missing === 0) this.callback();
-};
+const Countdown = require('../common/countdown');
 
 if (process.argv[2] === 'child') {
 
   let serverScope;
 
-  process.on('message', function onServer(msg, server) {
+  // TODO(@jasnell): The message event is not called consistently
+  // across platforms. Need to investigate if it can be made
+  // more consistent.
+  const onServer = (msg, server) => {
     if (msg.what !== 'server') return;
     process.removeListener('message', onServer);
 
     serverScope = server;
 
-    server.on('connection', function(socket) {
-      console.log('CHILD: got connection');
+    // TODO(@jasnell): This is apparently not called consistently
+    // across platforms. Need to investigate if it can be made
+    // more consistent.
+    server.on('connection', (socket) => {
+      debug('CHILD: got connection');
       process.send({ what: 'connection' });
       socket.destroy();
     });
 
     // Start making connection from parent.
-    console.log('CHILD: server listening');
+    debug('CHILD: server listening');
     process.send({ what: 'listening' });
-  });
+  };
 
-  process.on('message', function onClose(msg) {
+  process.on('message', onServer);
+
+  // TODO(@jasnell): The close event is not called consistently
+  // across platforms. Need to investigate if it can be made
+  // more consistent.
+  const onClose = (msg) => {
     if (msg.what !== 'close') return;
     process.removeListener('message', onClose);
 
-    serverScope.on('close', function() {
+    serverScope.on('close', common.mustCall(() => {
       process.send({ what: 'close' });
-    });
+    }));
     serverScope.close();
-  });
+  };
+
+  process.on('message', onClose);
 
   process.send({ what: 'ready' });
 } else {
 
   const child = fork(process.argv[1], ['child']);
 
-  child.on('exit', common.mustCall(function(code, signal) {
+  child.on('exit', common.mustCall((code, signal) => {
     const message = `CHILD: died with ${code}, ${signal}`;
     assert.strictEqual(code, 0, message);
   }));
@@ -82,64 +86,74 @@ if (process.argv[2] === 'child') {
   function testServer(callback) {
 
     // Destroy server execute callback when done.
-    const progress = new ProgressTracker(2, function() {
-      server.on('close', function() {
-        console.log('PARENT: server closed');
+    const countdown = new Countdown(2, () => {
+      server.on('close', common.mustCall(() => {
+        debug('PARENT: server closed');
         child.send({ what: 'close' });
-      });
+      }));
       server.close();
     });
 
     // We expect 4 connections and close events.
-    const connections = new ProgressTracker(4, progress.done.bind(progress));
-    const closed = new ProgressTracker(4, progress.done.bind(progress));
+    const connections = new Countdown(4, () => countdown.dec());
+    const closed = new Countdown(4, () => countdown.dec());
 
     // Create server and send it to child.
     const server = net.createServer();
-    server.on('connection', function(socket) {
-      console.log('PARENT: got connection');
+
+    // TODO(@jasnell): The specific number of times the connection
+    // event is emitted appears to be variable across platforms.
+    // Need to investigate why and whether it can be made
+    // more consistent.
+    server.on('connection', (socket) => {
+      debug('PARENT: got connection');
       socket.destroy();
-      connections.done();
+      connections.dec();
     });
-    server.on('listening', function() {
-      console.log('PARENT: server listening');
+
+    server.on('listening', common.mustCall(() => {
+      debug('PARENT: server listening');
       child.send({ what: 'server' }, server);
-    });
+    }));
     server.listen(0);
 
     // Handle client messages.
-    function messageHandlers(msg) {
-
+    // TODO(@jasnell): The specific number of times the message
+    // event is emitted appears to be variable across platforms.
+    // Need to investigate why and whether it can be made
+    // more consistent.
+    const messageHandlers = (msg) => {
       if (msg.what === 'listening') {
         // Make connections.
         let socket;
         for (let i = 0; i < 4; i++) {
-          socket = net.connect(server.address().port, function() {
-            console.log('CLIENT: connected');
-          });
-          socket.on('close', function() {
-            closed.done();
-            console.log('CLIENT: closed');
-          });
+          socket = net.connect(server.address().port, common.mustCall(() => {
+            debug('CLIENT: connected');
+          }));
+          socket.on('close', common.mustCall(() => {
+            closed.dec();
+            debug('CLIENT: closed');
+          }));
         }
 
       } else if (msg.what === 'connection') {
         // Child got connection
-        connections.done();
+        connections.dec();
       } else if (msg.what === 'close') {
         child.removeListener('message', messageHandlers);
         callback();
       }
-    }
+    };
 
     child.on('message', messageHandlers);
   }
 
-  // Create server and send it to child.
-  child.on('message', function onReady(msg) {
+  const onReady = common.mustCall((msg) => {
     if (msg.what !== 'ready') return;
     child.removeListener('message', onReady);
-
     testServer(common.mustCall());
   });
+
+  // Create server and send it to child.
+  child.on('message', onReady);
 }

--- a/test/parallel/test-child-process-fork-ref2.js
+++ b/test/parallel/test-child-process-fork-ref2.js
@@ -20,26 +20,31 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+const {
+  mustCall,
+  mustNotCall,
+  platformTimeout,
+} = require('../common');
 const fork = require('child_process').fork;
+const debug = require('util').debuglog('test');
 
 if (process.argv[2] === 'child') {
-  console.log('child -> call disconnect');
+  debug('child -> call disconnect');
   process.disconnect();
 
-  setTimeout(function() {
-    console.log('child -> will this keep it alive?');
-    process.on('message', common.mustNotCall());
-  }, 400);
+  setTimeout(() => {
+    debug('child -> will this keep it alive?');
+    process.on('message', mustNotCall());
+  }, platformTimeout(400));
 
 } else {
   const child = fork(__filename, ['child']);
 
-  child.on('disconnect', function() {
-    console.log('parent -> disconnect');
-  });
+  child.on('disconnect', mustCall(() => {
+    debug('parent -> disconnect');
+  }));
 
-  child.once('exit', function() {
-    console.log('parent -> exit');
-  });
+  child.once('exit', mustCall(() => {
+    debug('parent -> exit');
+  }));
 }

--- a/test/parallel/test-child-process-fork.js
+++ b/test/parallel/test-child-process-fork.js
@@ -18,13 +18,14 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+// Flags: --no-warnings
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const fork = require('child_process').fork;
+const { fork } = require('child_process');
 const args = ['foo', 'bar'];
 const fixtures = require('../common/fixtures');
+const debug = require('util').debuglog('test');
 
 const n = fork(fixtures.path('child-process-spawn-node.js'), args);
 
@@ -32,7 +33,7 @@ assert.strictEqual(n.channel, n._channel);
 assert.deepStrictEqual(args, ['foo', 'bar']);
 
 n.on('message', (m) => {
-  console.log('PARENT got message:', m);
+  debug('PARENT got message:', m);
   assert.ok(m.foo);
 });
 

--- a/test/parallel/test-child-process-ipc.js
+++ b/test/parallel/test-child-process-ipc.js
@@ -21,47 +21,43 @@
 
 'use strict';
 
-require('../common');
+const {
+  mustCall,
+  mustNotCall,
+} = require('../common');
 const assert = require('assert');
+const debug = require('util').debuglog('test');
 
 const { spawn } = require('child_process');
 const fixtures = require('../common/fixtures');
 
 const sub = fixtures.path('echo.js');
 
-let gotHelloWorld = false;
-let gotEcho = false;
-
 const child = spawn(process.argv[0], [sub]);
 
-child.stderr.on('data', function(data) {
-  console.log(`parent stderr: ${data}`);
-});
+child.stderr.on('data', mustNotCall());
 
 child.stdout.setEncoding('utf8');
 
-child.stdout.on('data', function(data) {
-  console.log(`child said: ${JSON.stringify(data)}`);
-  if (!gotHelloWorld) {
-    console.error('testing for hello world');
-    assert.strictEqual(data, 'hello world\r\n');
-    gotHelloWorld = true;
-    console.error('writing echo me');
-    child.stdin.write('echo me\r\n');
+const messages = [
+  'hello world\r\n',
+  'echo me\r\n',
+];
+
+child.stdout.on('data', mustCall((data) => {
+  debug(`child said: ${JSON.stringify(data)}`);
+  const test = messages.shift();
+  debug(`testing for '${test}'`);
+  assert.strictEqual(data, test);
+  if (messages.length) {
+    debug(`writing '${messages[0]}'`);
+    child.stdin.write(messages[0]);
   } else {
-    console.error('testing for echo me');
-    assert.strictEqual(data, 'echo me\r\n');
-    gotEcho = true;
+    assert.strictEqual(messages.length, 0);
     child.stdin.end();
   }
-});
+}, messages.length));
 
-child.stdout.on('end', function(data) {
-  console.log('child end');
-});
-
-
-process.on('exit', function() {
-  assert.ok(gotHelloWorld);
-  assert.ok(gotEcho);
-});
+child.stdout.on('end', mustCall((data) => {
+  debug('child end');
+}));

--- a/test/parallel/test-child-process-spawnsync-timeout.js
+++ b/test/parallel/test-child-process-spawnsync-timeout.js
@@ -24,15 +24,16 @@ const common = require('../common');
 const assert = require('assert');
 
 const spawnSync = require('child_process').spawnSync;
-const { getSystemErrorName } = require('util');
+const { debuglog, getSystemErrorName } = require('util');
+const debug = debuglog('test');
 
 const TIMER = 200;
 const SLEEP = common.platformTimeout(5000);
 
 switch (process.argv[2]) {
   case 'child':
-    setTimeout(function() {
-      console.log('child fired');
+    setTimeout(() => {
+      debug('child fired');
       process.exit(1);
     }, SLEEP);
     break;

--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -20,9 +20,13 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+const {
+  mustCall,
+  mustCallAtLeast,
+  mustNotCall,
+} = require('../common');
 const assert = require('assert');
-
+const debug = require('util').debuglog('test');
 const spawn = require('child_process').spawn;
 
 const cat = spawn('cat');
@@ -38,21 +42,21 @@ cat.stdin.end();
 let response = '';
 
 cat.stdout.setEncoding('utf8');
-cat.stdout.on('data', function(chunk) {
-  console.log(`stdout: ${chunk}`);
+cat.stdout.on('data', mustCallAtLeast((chunk) => {
+  debug(`stdout: ${chunk}`);
   response += chunk;
-});
+}));
 
-cat.stdout.on('end', common.mustCall());
+cat.stdout.on('end', mustCall());
 
-cat.stderr.on('data', common.mustNotCall());
+cat.stderr.on('data', mustNotCall());
 
-cat.stderr.on('end', common.mustCall());
+cat.stderr.on('end', mustCall());
 
-cat.on('exit', common.mustCall(function(status) {
+cat.on('exit', mustCall((status) => {
   assert.strictEqual(status, 0);
 }));
 
-cat.on('close', common.mustCall(function() {
+cat.on('close', mustCall(() => {
   assert.strictEqual(response, 'hello world');
 }));

--- a/test/parallel/test-child-process-stdio-big-write-end.js
+++ b/test/parallel/test-child-process-stdio-big-write-end.js
@@ -20,8 +20,13 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+const {
+  mustCall,
+  mustCallAtLeast,
+} = require('../common');
 const assert = require('assert');
+const debug = require('util').debuglog('test');
+
 let bufsize = 0;
 
 switch (process.argv[2]) {
@@ -40,12 +45,12 @@ function parent() {
 
   let n = '';
   child.stdout.setEncoding('ascii');
-  child.stdout.on('data', function(c) {
+  child.stdout.on('data', mustCallAtLeast((c) => {
     n += c;
-  });
-  child.stdout.on('end', common.mustCall(function() {
+  }));
+  child.stdout.on('end', mustCall(() => {
     assert.strictEqual(+n, sent);
-    console.log('ok');
+    debug('ok');
   }));
 
   // Write until the buffer fills up.
@@ -71,10 +76,11 @@ function parent() {
 
 function child() {
   let received = 0;
-  process.stdin.on('data', function(c) {
+  process.stdin.on('data', mustCallAtLeast((c) => {
     received += c.length;
-  });
-  process.stdin.on('end', function() {
+  }));
+  process.stdin.on('end', mustCall(() => {
+    // This console.log is part of the test.
     console.log(received);
-  });
+  }));
 }

--- a/test/parallel/test-child-process-stdout-flush-exit.js
+++ b/test/parallel/test-child-process-stdout-flush-exit.js
@@ -24,6 +24,7 @@ const common = require('../common');
 const assert = require('assert');
 
 // If child process output to console and exit
+// The console.log statements here are part of the test.
 if (process.argv[2] === 'child') {
   console.log('hello');
   for (let i = 0; i < 200; i++) {
@@ -40,18 +41,15 @@ if (process.argv[2] === 'child') {
 
   let stdout = '';
 
-  child.stderr.setEncoding('utf8');
-  child.stderr.on('data', function(data) {
-    assert.fail(`Unexpected parent stderr: ${data}`);
-  });
+  child.stderr.on('data', common.mustNotCall());
 
   // Check if we receive both 'hello' at start and 'goodbye' at end
   child.stdout.setEncoding('utf8');
-  child.stdout.on('data', function(data) {
+  child.stdout.on('data', common.mustCallAtLeast((data) => {
     stdout += data;
-  });
+  }));
 
-  child.on('close', common.mustCall(function() {
+  child.on('close', common.mustCall(() => {
     assert.strictEqual(stdout.slice(0, 6), 'hello\n');
     assert.strictEqual(stdout.slice(stdout.length - 8), 'goodbye\n');
   }));


### PR DESCRIPTION
~~Commit 1 in this scratches an itch I've had for a while: it adds a `common.debug()` to `test/common/index.js` that uses `util.debuglog()` as a way of avoiding use of `console.log()` statements in tests that are not part of the test itself.~~

~~To enable the debug output while running tests, set the environment variable `NODE_DEBUG=test`.~~

~~Commit 2~~ Makes a number of improvements to child process tests including use of the `debuglog()`, more must calls, and use of `../common/countdown` where appropriate.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

