### PR TITLE
async_hooks: fix context loss after nested calls to AsyncLocalStorage

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -255,23 +255,21 @@ class AsyncLocalStorage {
     resource[this.kResourceStore] = store;
   }
 
-  _exit() {
-    const resource = executionAsyncResource();
-    if (resource) {
-      resource[this.kResourceStore] = undefined;
-    }
-  }
-
   runSyncAndReturn(store, callback, ...args) {
+    const resource = executionAsyncResource();
+    const outerStore = resource[this.kResourceStore];
     this._enter(store);
     try {
       return callback(...args);
     } finally {
-      this._exit();
+      resource[this.kResourceStore] = outerStore;
     }
   }
 
   exitSyncAndReturn(callback, ...args) {
+    if (!this.enabled) {
+      return callback(...args);
+    }
     this.enabled = false;
     try {
       return callback(...args);
@@ -288,12 +286,17 @@ class AsyncLocalStorage {
   }
 
   run(store, callback, ...args) {
+    const resource = executionAsyncResource();
+    const outerStore = resource[this.kResourceStore];
     this._enter(store);
     process.nextTick(callback, ...args);
-    this._exit();
+    resource[this.kResourceStore] = outerStore;
   }
 
   exit(callback, ...args) {
+    if (!this.enabled) {
+      return process.nextTick(callback, ...args);
+    }
     this.enabled = false;
     process.nextTick(callback, ...args);
     this.enabled = true;

--- a/test/async-hooks/test-async-local-storage-enable-disable.js
+++ b/test/async-hooks/test-async-local-storage-enable-disable.js
@@ -12,8 +12,16 @@ asyncLocalStorage.runSyncAndReturn(new Map(), () => {
     process.nextTick(() => {
       assert.strictEqual(asyncLocalStorage.getStore(), undefined);
     });
+
     asyncLocalStorage.disable();
     assert.strictEqual(asyncLocalStorage.getStore(), undefined);
+
+    // Calls to exit() should not mess with enabled status
+    asyncLocalStorage.exit(() => {
+      assert.strictEqual(asyncLocalStorage.getStore(), undefined);
+    });
+    assert.strictEqual(asyncLocalStorage.getStore(), undefined);
+
     process.nextTick(() => {
       assert.strictEqual(asyncLocalStorage.getStore(), undefined);
       asyncLocalStorage.runSyncAndReturn(new Map(), () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Fixes the following issues within `AsyncLocalStorage` API:
* Nested calls to `run*` were erasing the outer store, leading to context loss.
  - Note: `test-async-local-storage-nested.js` was updated to validate this fix, as its previous contents were a partial duplicate of `test-async-local-storage-no-mix-contexts.js`
* Calls to `exit*` were switching `enabled` field to `true` without checking current value. This leads to incorrect behavior of further `getStore` and `run*` calls.

These issues were discussed in #31950, but as that PR involves significant changes in implementation and will require some time to settle down.

cc @vdeturckheim @Qard @Flarna 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
