### PR TITLE
doc: clear up child_process command resolution

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -37,7 +37,7 @@ The command lookup will be performed using `options.env.PATH` environment
 variable if passed in `options` object, otherwise `process.env.PATH` will be
 used. To account for the fact that Windows environment variables are
 case-insensitive Node.js will lexicographically sort all `env` keys and choose
-the first one case-insensitivety matching `'PATH'` to perform command lookup.
+the first one case-insensitively matching `'PATH'` to perform command lookup.
 This may lead to issues on Windows when passing objects to `env` option that
 have multiple variants of `PATH` variable.
 

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -37,7 +37,7 @@ The command lookup will be performed using `options.env.PATH` environment
 variable if passed in `options` object, otherwise `process.env.PATH` will be
 used. To account for the fact that Windows environment variables are
 case-insensitive Node.js will lexicographically sort all `env` keys and choose
-the first one case-insensitively matching `'PATH'` to perform command lookup.
+the first one case-insensitively matching `PATH` to perform command lookup.
 This may lead to issues on Windows when passing objects to `env` option that
 have multiple variants of `PATH` variable.
 

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -33,6 +33,14 @@ process will block waiting for the pipe buffer to accept more data. This is
 identical to the behavior of pipes in the shell. Use the `{ stdio: 'ignore' }`
 option if the output will not be consumed.
 
+The command lookup will be performed using `options.env.PATH` environment
+variable if passed in `options` object, otherwise `process.env.PATH` will be
+used. To account for the fact that Windows environment variables are
+case-insensitive Node.js will lexicographically sort all `env` keys and choose
+the first one case-insensitivety matching `'PATH'` to perform command lookup.
+This may lead to issues on Windows when passing objects to `env` option that
+have multiple variants of `PATH` variable.
+
 The [`child_process.spawn()`][] method spawns the child process asynchronously,
 without blocking the Node.js event loop. The [`child_process.spawnSync()`][]
 function provides equivalent functionality in a synchronous manner that blocks


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/20605
Refs: https://github.com/libuv/libuv/pull/1837

/cc @richardlau @nodejs/platform-windows @nodejs/documentation @nodejs/child_process 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
