### PR TITLE
docs: refine conditional exports documentation

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2550,7 +2550,7 @@ such as `process.stdout.on('data')`.
 [crypto digest algorithm]: crypto.html#crypto_crypto_gethashes
 [domains]: domain.html
 [event emitter-based]: events.html#events_class_eventemitter
-[exports]: esm.html#esm_package_exports
+[exports]: esm.html#package_entry_points
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
 [policy]: policy.html
 [stream-based]: stream.html

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2550,7 +2550,7 @@ such as `process.stdout.on('data')`.
 [crypto digest algorithm]: crypto.html#crypto_crypto_gethashes
 [domains]: domain.html
 [event emitter-based]: events.html#events_class_eventemitter
-[exports]: esm.html#package_entry_points
+[exports]: esm.html#esm_package_entry_points
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
 [policy]: policy.html
 [stream-based]: stream.html

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -187,7 +187,7 @@ any other entry points besides those defined in `"exports"`. If package entry
 points are defined in both `"main"` and `"exports"`, the latter takes precedence
 in versions of Node.js that support `"exports"`. [Conditional Exports][] can
 also be used within `"exports"` to define different package entry points per
-environment.
+environment, including whether the package is referenced via `require` or via `import`.
 
 If both `"exports"` and `"main"` are defined, the `"exports"` field takes
 precedence over `"main"`.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -415,7 +415,7 @@ use in Node.js but not the browser:
 Conditions continue to be matched in order as with flat conditions. If
 a nested conditional does not have any mapping it will continue checking
 the remaining conditions of the parent condition. In this way nested
-conditions behave fully analogously to nested `if` statements in JS.
+conditions behave analogously to nested JavaScript `if` statements.
 
 ### Dual CommonJS/ES Module Packages
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -175,7 +175,7 @@ unspecified.
 
 ## Packages
 
-### Package Exports
+### Package Entry Points
 
 In a package’s `package.json` file, two fields can define entry points for a
 package: `"main"` and `"exports"`. The `"main"` field is supported in all

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -379,7 +379,8 @@ etc. could be defined in other runtimes or tools. Further restrictions,
 definitions or guidance on condition names may be provided in future.
 
 Using the `"import"` and `"require"` conditions can lead to some hazards,
-which are explained further in [the dual mode packages section][].
+which are explained further in
+[the dual CommonJS/ES module packages section][].
 
 Conditional exports can also be extended to exports subpaths, for example:
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -218,7 +218,7 @@ subpaths of the package will no longer be available to importers under
 `require('pkg/subpath.js')`, and instead they will get a new error,
 `ERR_PACKAGE_PATH_NOT_EXPORTED`.
 
-This new encapsulation of exports provides new more reliable guarantees
+This encapsulation of exports provides more reliable guarantees
 about package interfaces for tools and when handling semver upgrades for a
 package. It is not a strong encapsulation since a direct require of any
 absolute subpath of the package such as

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -173,7 +173,7 @@ For completeness there is also `--input-type=commonjs`, for explicitly running
 string input as CommonJS. This is the default behavior if `--input-type` is
 unspecified.
 
-## Packages Entry Points
+## Packages
 
 ### Package Exports
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -256,7 +256,7 @@ import submodule from 'es-module-package/private-module.js';
 // Throws ERR_PACKAGE_PATH_NOT_EXPORTED
 ```
 
-Folders can also be mapped with package exports:
+Entire folders can also be mapped with package exports:
 
 <!-- eslint-skip -->
 ```js
@@ -268,16 +268,23 @@ Folders can also be mapped with package exports:
 }
 ```
 
+With the above, all modules within the `./src/features/` folder
+are exposed deeply to `import` and `require`:
+
 ```js
 import feature from 'es-module-package/features/x.js';
 // Loads ./node_modules/es-module-package/src/features/x.js
 ```
 
-Any invalid exports entries will be ignored. This includes exports not
-starting with `"./"` or a missing trailing `"/"` for directory exports.
+When using folder mappings, ensure that you do want to expose every
+module inside the subfolder. Any modules which are not public
+should be moved to another folder to retain the encapsulation
+benefits of exports.
 
-Array fallback support is provided for exports, similarly to import maps
-in order to be forwards-compatible with possible fallback workflows in future:
+#### Package Exports Fallbacks
+
+For possible new specifier support in future, array fallbacks are
+supported for all invalid specifiers:
 
 <!-- eslint-skip -->
 ```js
@@ -288,7 +295,7 @@ in order to be forwards-compatible with possible fallback workflows in future:
 }
 ```
 
-Since `"not:valid"` is not a supported target, `"./submodule.js"` is used
+Since `"not:valid"` is not a valid specifier, `"./submodule.js"` is used
 instead as the fallback, as if it were the only target.
 
 #### Exports Sugar

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -173,9 +173,9 @@ For completeness there is also `--input-type=commonjs`, for explicitly running
 string input as CommonJS. This is the default behavior if `--input-type` is
 unspecified.
 
-## Packages
+## Packages Entry Points
 
-### Package Entry Points
+### Package Exports
 
 There are two fields that can define entry points for a package: `"main"` and
 `"exports"`. The `"main"` field is supported in all versions of Node.js, but its

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -369,6 +369,7 @@ Node.js supports the following conditions:
 * `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
    module file.
 * `"require"` - matched when the package is loaded via `require()`.
+   As `require()` only supports CommonJS, the referenced file must be CommonJS.
 
 Condition matching is applied in object order from first to last within the
 `"exports"` object. _The general rule is that conditions should be used

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -226,7 +226,7 @@ package. It is not a strong encapsulation since a direct require of any
 absolute subpath of the package such as
 `require('/path/to/node_modules/pkg/subpath.js')` will still load `subpath.js`.
 
-#### Package Exports Subpaths
+#### Subpath Exports
 
 When using the `"exports"` field, custom subpaths can be defined along
 with the main entry point by treating the main entry point as the

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -177,9 +177,10 @@ unspecified.
 
 ### Package Exports
 
-In a package’s `package.json` file, two fields can define entry points for a package: `"main"` and
-`"exports"`. The `"main"` field is supported in all versions of Node.js, but its
-capabilities are limited: it only defines the main entry point of the package.
+In a package’s `package.json` file, two fields can define entry points for a
+package: `"main"` and `"exports"`. The `"main"` field is supported in all
+versions of Node.js, but its capabilities are limited: it only defines the main
+entry point of the package.
 
 The `"exports"` field provides an alternative to `"main"` where the package
 main entry point can be defined while also encapsulating the package, preventing
@@ -187,7 +188,8 @@ any other entry points besides those defined in `"exports"`. If package entry
 points are defined in both `"main"` and `"exports"`, the latter takes precedence
 in versions of Node.js that support `"exports"`. [Conditional Exports][] can
 also be used within `"exports"` to define different package entry points per
-environment, including whether the package is referenced via `require` or via `import`.
+environment, including whether the package is referenced via `require` or via
+`import`.
 
 If both `"exports"` and `"main"` are defined, the `"exports"` field takes
 precedence over `"main"`.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1640,7 +1640,7 @@ success!
 [dynamic instantiate hook]: #esm_code_dynamicinstantiate_code_hook
 [special scheme]: https://url.spec.whatwg.org/#special-scheme
 [the official standard format]: https://tc39.github.io/ecma262/#sec-modules
-[the dual mode packages section]: #esm_dual_commonjs_es_module_packages
+[the dual CommonJS/ES module packages section]: #esm_dual_commonjs_es_module_packages
 [transpiler loader example]: #esm_transpiler_loader
 [6.1.7 Array Index]: https://tc39.es/ecma262/#integer-index
 [Top-Level Await]: https://github.com/tc39/proposal-top-level-await

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -189,13 +189,16 @@ in versions of Node.js that support `"exports"`. [Conditional Exports][] can
 also be used within `"exports"` to define different package entry points per
 environment.
 
-When using both `import` and `require` the `"exports"` field will be resolved
-if it is set, otherwise the `"main"` field will be resolved.
+If both `"exports"` and `"main"` are defined, the `"exports"` field takes
+precedence over `"main"`.
 
-When setting any package entry points to ES modules, `require()` will not work
-in both modern and legacy Node.js versions, so it is important to carefully
-follow [the dual CommonJS/ES module packages section][] to properly handle
-these types of backwards-compatible ES module support.
+All package entry points apply to both `import` and `require`; `"exports"` and
+`"main"` are **not** specific to ES modules or CommonJS.
+
+This is important with regard to `require`, since `require` of ES module files
+throws an error in all versions of Node.js. To create a package that works both
+in modern Node.js via `import` and `require` and also legacy Node.js versions,
+see [the dual CommonJS/ES module packages section][].
 
 #### Package Exports Main
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -364,8 +364,8 @@ Node.js supports the following conditions:
 * `"default"` - the generic fallback that will always match. Can be a CommonJS
    or ES module file. _This condition should always come last._
 * `"import"` - matched when the package is loaded via `import` or
-   `import()`. Can be any module format, this field does not set the type
-   interpretation.
+   `import()`. Can reference either an ES module or CommonJS file, as both
+   `import` and `import()` can load either ES module or CommonJS sources.
 * `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
    module file.
 * `"require"` - matched when the package is loaded via `require()`.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -359,7 +359,7 @@ For example, a package that wants to provide different ES module exports for
 }
 ```
 
-The conditions supported in Node.js condition matching:
+Node.js supports the following conditions:
 
 * `"default"` - the generic fallback that will always match. Can be a CommonJS
    or ES module file. _This condition should always come last._

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -393,8 +393,7 @@ given third-party tool support for a `"browser"` condition.
 
 #### Nested conditions
 
-In addition to direct mappings, conditional exports also supports nested
-conditions with nested condition objects.
+In addition to direct mappings, Node.js also supports nested condition objects.
 
 For example, to define a package that only has dual mode entry points for
 use in Node.js but not the browser:

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -249,7 +249,7 @@ import submodule from 'es-module-package/submodule';
 // Loads ./node_modules/es-module-package/src/submodule.js
 ```
 
-While other subpaths will still error:
+While other subpaths will error:
 
 ```js
 import submodule from 'es-module-package/private-module.js';

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1620,7 +1620,6 @@ success!
 [ECMAScript-modules implementation]: https://github.com/nodejs/modules/blob/master/doc/plan-for-new-modules-implementation.md
 [ES Module Integration Proposal for Web Assembly]: https://github.com/webassembly/esm-integration
 [Node.js EP for ES Modules]: https://github.com/nodejs/node-eps/blob/master/002-es-modules.md
-[Package Exports]: #esm_package_exports
 [Terminology]: #esm_terminology
 [WHATWG JSON modules specification]: https://html.spec.whatwg.org/#creating-a-json-module-script
 [`"exports"` field]: #esm_package_exports

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -218,7 +218,7 @@ subpaths of the package will no longer be available to importers under
 This new encapsulation of exports provides new more reliable guarantees
 about package interfaces for tools and when handling semver upgrades for a
 package. It is not a strong encapsulation since
-`require('/path/to/pkg/subpath.js')` will still work correctly.
+a direct require of any absolute subpath of the package such as `require('/path/to/node_modules/pkg/subpath.js')` will still work correctly.
 
 #### Package Exports Subpaths
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -192,10 +192,10 @@ environment.
 When using both `import` and `require` the `"exports"` field will be resolved
 if it is set, otherwise the `"main"` field will be resolved.
 
-When setting any package entry points to ES modules, `require()` will not work in
-both modern and legacy Node.js versions, so it is important to carefully follow
-[the dual CommonJS/ES module packages section][] to properly handle these types
-of backwards-compatible ES module support.
+When setting any package entry points to ES modules, `require()` will not work
+in both modern and legacy Node.js versions, so it is important to carefully
+follow [the dual CommonJS/ES module packages section][] to properly handle
+these types of backwards-compatible ES module support.
 
 #### Package Exports Main
 
@@ -217,8 +217,9 @@ subpaths of the package will no longer be available to importers under
 
 This new encapsulation of exports provides new more reliable guarantees
 about package interfaces for tools and when handling semver upgrades for a
-package. It is not a strong encapsulation since
-a direct require of any absolute subpath of the package such as `require('/path/to/node_modules/pkg/subpath.js')` will still work correctly.
+package. It is not a strong encapsulation since a direct require of any
+absolute subpath of the package such as
+`require('/path/to/node_modules/pkg/subpath.js')` will still work correctly.
 
 #### Package Exports Subpaths
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1519,7 +1519,7 @@ The resolver can throw the following errors:
 
 **PACKAGE_EXPORTS_TARGET_RESOLVE**(_packageURL_, _target_, _subpath_, _env_)
 
-> 1.If _target_ is a String, then
+> 1. If _target_ is a String, then
 >    1. If _target_ does not start with _"./"_ or contains any _"node_modules"_
 >       segments including _"node_modules"_ percent-encoding, throw an
 >       _Invalid Package Target_ error.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -222,7 +222,7 @@ This encapsulation of exports provides more reliable guarantees
 about package interfaces for tools and when handling semver upgrades for a
 package. It is not a strong encapsulation since a direct require of any
 absolute subpath of the package such as
-`require('/path/to/node_modules/pkg/subpath.js')` will still work correctly.
+`require('/path/to/node_modules/pkg/subpath.js')` will still load `subpath.js`.
 
 #### Package Exports Subpaths
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -344,7 +344,7 @@ Conditional exports provide a way to map to different paths depending on
 certain conditions. They are supported for both CommonJS and ES module imports.
 
 For example, a package that wants to provide different ES module exports for
-require() and import can be written:
+`require()` and `import` can be written:
 
 <!-- eslint-skip -->
 ```js

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -177,7 +177,7 @@ unspecified.
 
 ### Package Exports
 
-There are two fields that can define entry points for a package: `"main"` and
+In a package’s `package.json` file, two fields can define entry points for a package: `"main"` and
 `"exports"`. The `"main"` field is supported in all versions of Node.js, but its
 capabilities are limited: it only defines the main entry point of the package.
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -375,8 +375,9 @@ Condition matching is applied in object order from first to last within the
 from most specific to least specific in object order._
 
 Other conditions such as `"browser"`, `"electron"`, `"deno"`, `"react-native"`,
-etc. could be defined in other runtimes or tools. Further restrictions,
-definitions or guidance on condition names may be provided in future.
+etc. are ignored by Node.js but may be used by other runtimes or tools.
+Further restrictions, definitions or guidance on condition names may be
+provided in the future.
 
 Using the `"import"` and `"require"` conditions can lead to some hazards,
 which are explained further in

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -202,7 +202,7 @@ throws an error in all versions of Node.js. To create a package that works both
 in modern Node.js via `import` and `require` and also legacy Node.js versions,
 see [the dual CommonJS/ES module packages section][].
 
-#### Package Exports Main
+#### Main Entry Point Export
 
 To set the main entry point for a package, it is advisable to define both
 `"exports"` and `"main"` in the package’s `package.json` file:

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1642,7 +1642,6 @@ success!
 [Node.js EP for ES Modules]: https://github.com/nodejs/node-eps/blob/master/002-es-modules.md
 [Terminology]: #esm_terminology
 [WHATWG JSON modules specification]: https://html.spec.whatwg.org/#creating-a-json-module-script
-[`"exports"` field]: #esm_package_exports
 [`data:` URLs]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
 [`esm`]: https://github.com/standard-things/esm#readme
 [`export`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -348,7 +348,7 @@ For example, a package that wants to provide different ES module exports for
 
 <!-- eslint-skip -->
 ```js
-// ./node_modules/pkg/package.json
+// package.json
 {
   "main": "./main-require.cjs",
   "exports": {

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -175,18 +175,19 @@ unspecified.
 
 ## Packages
 
-### Package Entry Points
+### Package Exports
 
 There are two fields that can define entry points for a package: `"main"` and
 `"exports"`. The `"main"` field is supported in all versions of Node.js, but its
 capabilities are limited: it only defines the main entry point of the package.
-The `"exports"` field, part of [Package Exports][], provides an alternative to
-`"main"` where the package main entry point can be defined while also
-encapsulating the package, preventing any other entry points besides those
-defined in `"exports"`. If package entry points are defined in both `"main"` and
-`"exports"`, the latter takes precedence in versions of Node.js that support
-`"exports"`. [Conditional Exports][] can also be used within `"exports"` to
-define different package entry points per environment.
+
+The `"exports"` field provides an alternative to `"main"` where the package
+main entry point can be defined while also encapsulating the package, preventing
+any other entry points besides those defined in `"exports"`. If package entry
+points are defined in both `"main"` and `"exports"`, the latter takes precedence
+in versions of Node.js that support `"exports"`. [Conditional Exports][] can
+also be used within `"exports"` to define different package entry points per
+environment.
 
 #### Package Exports Main
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -353,7 +353,7 @@ require() and import can be written:
   "main": "./main-require.cjs",
   "exports": {
     "import": "./main-module.js",
-    "default": "./main-require.cjs"
+    "require": "./main-require.cjs"
   },
   "type": "module"
 }
@@ -362,15 +362,13 @@ require() and import can be written:
 The conditions supported in Node.js condition matching:
 
 * `"default"` - the generic fallback that will always match. Can be a CommonJS
-   or ES module file. **This condition should always come last.**
+   or ES module file. _This condition should always come last._
 * `"import"` - matched when the package is loaded via `import` or
    `import()`. Can be any module format, this field does not set the type
    interpretation.
 * `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
    module file.
 * `"require"` - matched when the package is loaded via `require()`.
-  _Due to limited support in Node.js 13.x early versions it can be recommended
-  to avoid using this condition._
 
 Condition matching is applied in object order from first to last within the
 `"exports"` object. _The general rule is that conditions should be used
@@ -379,11 +377,6 @@ from most specific to least specific in object order._
 Other conditions such as `"browser"`, `"electron"`, `"deno"`, `"react-native"`,
 etc. could be defined in other runtimes or tools. Further restrictions,
 definitions or guidance on condition names may be provided in future.
-
-`"default"` is set to a CommonJS module in the example above since early
-versions of Node.js 13.x support `"default"` but not `"import"` or `"require"`
-conditions. If `"default"` did not resolve as CommonJS this would break the
-use of `require('pkg')` in these Node.js versions when it matches the default.
 
 Using the `"import"` and `"require"` conditions can lead to some hazards,
 which are explained further in [the dual mode packages section][].
@@ -494,7 +487,7 @@ CommonJS entry point for `require`.
   "main": "./index.cjs",
   "exports": {
     "import": "./wrapper.mjs",
-    "default": "./index.cjs"
+    "require": "./index.cjs"
   }
 }
 ```
@@ -574,7 +567,7 @@ CommonJS and ES module entry points directly:
   "main": "./index.cjs",
   "exports": {
     "import": "./index.mjs",
-    "default": "./index.cjs"
+    "require": "./index.cjs"
   }
 }
 ```

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -194,8 +194,8 @@ environment, including whether the package is referenced via `require` or via
 If both `"exports"` and `"main"` are defined, the `"exports"` field takes
 precedence over `"main"`.
 
-All package entry points apply to both `import` and `require`; `"exports"` and
-`"main"` are **not** specific to ES modules or CommonJS.
+Both `"main"` and `"exports"` entry points are not specific to ES modules or CommonJS;
+`"main"` will be overridden by `"exports"` in a `require` so it is not a CommonJS fallback.
 
 This is important with regard to `require`, since `require` of ES module files
 throws an error in all versions of Node.js. To create a package that works both

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -389,7 +389,7 @@ Conditional exports can also be extended to exports subpaths, for example:
 
 Defines a package where `require('pkg/feature')` and `import 'pkg/feature'`
 could provide different implementations between the browser and Node.js,
-given third-part tool support for a `"browser"` condition.
+given third-party tool support for a `"browser"` condition.
 
 #### Nested conditions
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -175,7 +175,7 @@ unspecified.
 
 ## Packages
 
-### Package Exports
+### Package Entry Points
 
 There are two fields that can define entry points for a package: `"main"` and
 `"exports"`. The `"main"` field is supported in all versions of Node.js, but its
@@ -188,6 +188,14 @@ points are defined in both `"main"` and `"exports"`, the latter takes precedence
 in versions of Node.js that support `"exports"`. [Conditional Exports][] can
 also be used within `"exports"` to define different package entry points per
 environment.
+
+When using both `import` and `require` the `"exports"` field will be resolved
+if it is set, otherwise the `"main"` field will be resolved.
+
+When setting any package entry points to ES modules, `require()` will not work in
+both modern and legacy Node.js versions, so it is important to carefully follow
+[the dual CommonJS/ES module packages section][] to properly handle these types
+of backwards-compatible ES module support.
 
 #### Package Exports Main
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -202,8 +202,8 @@ see [the dual CommonJS/ES module packages section][].
 
 #### Package Exports Main
 
-To set the main entry point for a package, it is advisable to use both
-`"exports"` and the `"main"`:
+To set the main entry point for a package, it is advisable to define both
+`"exports"` and `"main"` in the package’s `package.json` file:
 
 <!-- eslint-skip -->
 ```js

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -194,8 +194,9 @@ environment, including whether the package is referenced via `require` or via
 If both `"exports"` and `"main"` are defined, the `"exports"` field takes
 precedence over `"main"`.
 
-Both `"main"` and `"exports"` entry points are not specific to ES modules or CommonJS;
-`"main"` will be overridden by `"exports"` in a `require` so it is not a CommonJS fallback.
+Both `"main"` and `"exports"` entry points are not specific to ES modules or
+CommonJS; `"main"` will be overridden by `"exports"` in a `require` so it is
+not a CommonJS fallback.
 
 This is important with regard to `require`, since `require` of ES module files
 throws an error in all versions of Node.js. To create a package that works both
@@ -849,8 +850,8 @@ can either be an URL-style relative path like `'./file.mjs'` or a package name
 like `'fs'`.
 
 Like in CommonJS, files within packages can be accessed by appending a path to
-the package name; unless the package’s `package.json` contains an [`"exports"`
-field][], in which case files within packages need to be accessed via the path
+the package name; unless the package’s `package.json` contains an `"exports"`
+field, in which case files within packages need to be accessed via the path
 defined in `"exports"`.
 
 ```js


### PR DESCRIPTION
This began as a bigger change of guidance but has been pulled back to a simple docs refactoring.

* Moves exports sugar section up
* Makes conditional exports examples using main form directly
* Explains conditional exports sugar second
* Adds some extra guidance on conditions usage
* Cuts down on some unnecessary explanations to try aid readability
* Removes incorrect statement about export main falling back to package.json main

Resolves https://github.com/nodejs/node/issues/32107.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
