### PR TITLE
cli: allow --jitless V8 flag in NODE_OPTIONS

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -170,6 +170,14 @@ added: v12.9.0
 
 Enable experimental JSON support for the ES Module loader.
 
+### `--experimental-loader=module`
+<!-- YAML
+added: v9.0.0
+-->
+
+Specify the `module` of a custom [experimental ECMAScript Module loader][].
+`module` may be either a path to a file, or an ECMAScript Module name.
+
 ### `--experimental-modules`
 <!-- YAML
 added: v8.5.0
@@ -405,14 +413,6 @@ Specify ways of the inspector web socket url exposure.
 By default inspector websocket url is available in stderr and under `/json/list`
 endpoint on `http://host:port/json/list`.
 
-### `--experimental-loader=module`
-<!-- YAML
-added: v9.0.0
--->
-
-Specify the `module` of a custom [experimental ECMAScript Module loader][].
-`module` may be either a path to a file, or an ECMAScript Module name.
-
 ### `--insecure-http-parser`
 <!-- YAML
 added: v13.4.0
@@ -422,6 +422,15 @@ Use an insecure HTTP parser that accepts invalid HTTP headers. This may allow
 interoperability with non-conformant HTTP implementations. It may also allow
 request smuggling and other HTTP attacks that rely on invalid headers being
 accepted. Avoid using this option.
+
+### `--jitless`
+<!-- YAML
+added: v12.0.0
+-->
+
+Disable [runtime allocation of executable memory][jitless]. This may be
+required on some platforms for security reasons. It can also reduce attack
+surface on other platforms, but the performance impact may be severe.
 
 ### `--max-http-header-size=size`
 <!-- YAML
@@ -1156,6 +1165,7 @@ V8 options that are allowed are:
 * `--abort-on-uncaught-exception`
 * `--disallow-code-generation-from-strings`
 * `--interpreted-frames-native-stack`
+* `--jitless`
 * `--max-old-space-size`
 * `--perf-basic-prof-only-functions`
 * `--perf-basic-prof`
@@ -1391,5 +1401,6 @@ greater than `4` (its current default value). For more information, see the
 [debugging security implications]: https://nodejs.org/en/docs/guides/debugging-getting-started/#security-implications
 [emit_warning]: process.html#process_process_emitwarning_warning_type_code_ctor
 [experimental ECMAScript Module loader]: esm.html#esm_experimental_loaders
+[jitless]: https://v8.dev/blog/jitless
 [libuv threadpool documentation]: http://docs.libuv.org/en/latest/threadpool.html
 [remote code execution]: https://www.owasp.org/index.php/Code_Injection

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -432,6 +432,9 @@ Disable [runtime allocation of executable memory][jitless]. This may be
 required on some platforms for security reasons. It can also reduce attack
 surface on other platforms, but the performance impact may be severe.
 
+This flag is inherited from v8 and is subject to change upstream. It may
+disappear in a non-semver-major release.
+
 ### `--max-http-header-size=size`
 <!-- YAML
 added: v11.6.0

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -432,7 +432,7 @@ Disable [runtime allocation of executable memory][jitless]. This may be
 required on some platforms for security reasons. It can also reduce attack
 surface on other platforms, but the performance impact may be severe.
 
-This flag is inherited from v8 and is subject to change upstream. It may
+This flag is inherited from V8 and is subject to change upstream. It may
 disappear in a non-semver-major release.
 
 ### `--max-http-header-size=size`

--- a/doc/node.1
+++ b/doc/node.1
@@ -119,6 +119,11 @@ Enable experimental ES modules support for import.meta.resolve().
 .It Fl -experimental-json-modules
 Enable experimental JSON interop support for the ES Module loader.
 .
+.It Fl -experimental-loader Ns = Ns Ar module
+Specify the
+.Ar module
+to use as a custom module loader.
+.
 .It Fl -experimental-modules
 Enable experimental latest experimental modules features.
 .
@@ -220,16 +225,16 @@ Default is
 V8 Inspector integration allows attaching Chrome DevTools and IDEs to Node.js instances for debugging and profiling.
 It uses the Chrome DevTools Protocol.
 .
-.It Fl -experimental-loader Ns = Ns Ar module
-Specify the
-.Ar module
-to use as a custom module loader.
-.
 .It Fl -insecure-http-parser
 Use an insecure HTTP parser that accepts invalid HTTP headers. This may allow
 interoperability with non-conformant HTTP implementations. It may also allow
 request smuggling and other HTTP attacks that rely on invalid headers being
 accepted. Avoid using this option.
+.
+.It Fl -jitless
+Disable runtime allocation of executable memory. This may be required on
+some platforms for security reasons. It can also reduce attack surface on
+other platforms, but the performance impact may be severe.
 .
 .It Fl -max-http-header-size Ns = Ns Ar size
 Specify the maximum size of HTTP headers in bytes. Defaults to 8KB.

--- a/doc/node.1
+++ b/doc/node.1
@@ -237,7 +237,7 @@ some platforms for security reasons. It can also reduce attack surface on
 other platforms, but the performance impact may be severe.
 .
 .Pp
-This flag is inherited from v8 and is subject to change upstream. It may
+This flag is inherited from V8 and is subject to change upstream. It may
 disappear in a non-semver-major release.
 .
 .It Fl -max-http-header-size Ns = Ns Ar size

--- a/doc/node.1
+++ b/doc/node.1
@@ -236,6 +236,10 @@ Disable runtime allocation of executable memory. This may be required on
 some platforms for security reasons. It can also reduce attack surface on
 other platforms, but the performance impact may be severe.
 .
+.Pp
+This flag is inherited from v8 and is subject to change upstream. It may
+disappear in a non-semver-major release.
+.
 .It Fl -max-http-header-size Ns = Ns Ar size
 Specify the maximum size of HTTP headers in bytes. Defaults to 8KB.
 .

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -616,6 +616,10 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
             "disallow eval and friends",
             V8Option{},
             kAllowedInEnvironment);
+  AddOption("--jitless",
+             "disable runtime allocation of executable memory",
+             V8Option{},
+             kAllowedInEnvironment);
 
 #ifdef NODE_REPORT
   AddOption("--report-uncaught-exception",

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -67,6 +67,7 @@ if (common.hasCrypto) {
 // V8 options
 expect('--abort_on-uncaught_exception', 'B\n');
 expect('--disallow-code-generation-from-strings', 'B\n');
+expect('--jitless', 'B\n');
 expect('--max-old-space-size=0', 'B\n');
 expect('--stack-trace-limit=100',
        /(\s*at f \(\[(eval|worker eval)\]:1:\d*\)\r?\n)/,


### PR DESCRIPTION
This work is modeled on #30094 which allowed
`--disallow-code-generation-from-strings` in `NODE_OPTIONS`.

The `--jitless` v8 option has been supported since 12.0.0. As a v8 option,
node automatically picks it up, but there have been a few issues that were
resolved by simply telling users about the option: #26758, #28800.

This PR:
  - allows `--jitless` in `NODE_OPTIONS`
  - documents `--jitless`
  - moves `--experimental-loader=module` to locally restore alphabetical
    order in option documentation

Refs: https://github.com/nodejs/node/pull/30094
Refs: https://github.com/nodejs/node/issues/26758
Refs: https://github.com/nodejs/node/issues/28800

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
