### PR TITLE
perf_hooks: precise mode for monitorEventLoopDelay

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -432,21 +432,34 @@ is equal to `type`.
 ## `perf_hooks.monitorEventLoopDelay([options])`
 <!-- YAML
 added: v11.10.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32018
+    description: Introduce precise mode (`resolution` equal to `0`). Change
+      the default `resolution` to `0`.
 -->
 
 * `options` {Object}
-  * `resolution` {number} The sampling rate in milliseconds. Must be greater
-    than zero. **Default:** `10`.
+  * `resolution` {number} Optional sampling rate in milliseconds. Must be
+    greater or equal to zero. **Default:** `0`.
 * Returns: {Histogram}
 
 Creates a `Histogram` object that samples and reports the event loop delay
 over time. The delays will be reported in nanoseconds.
 
-Using a timer to detect approximate event loop delay works because the
-execution of timers is tied specifically to the lifecycle of the libuv
-event loop. That is, a delay in the loop will cause a delay in the execution
-of the timer, and those delays are specifically what this API is intended to
-detect.
+When `resolution` is zero a precise time difference between IO poll end and IO
+poll start is entered into the histogram on every event-loop iteration. During
+standby (i.e., no event-loop activity) - no data is added to the histogram, as
+would be expected.
+
+When `resolution` is non-zero a timer is used to detect approximate event loop
+delay. This works because the execution of timers is tied specifically to the
+lifecycle of the libuv event loop. That is, a delay in the loop will cause a
+delay in the execution of the timer, and those delays are specifically what this
+API is intended to detect. Timer-based monitoring happens continuously and adds
+delay statistics to the histogram even during standby when the Node.js would not
+otherwise be consuming CPU. Since this approach just checks the loop state
+periodically, it can easily miss loops that had excessive delays.
 
 ```js
 const { monitorEventLoopDelay } = require('perf_hooks');

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -604,12 +604,12 @@ function monitorEventLoopDelay(options = {}) {
   if (typeof options !== 'object' || options === null) {
     throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
   }
-  const { resolution = 10 } = options;
+  const { resolution = 0 } = options;
   if (typeof resolution !== 'number') {
     throw new ERR_INVALID_ARG_TYPE('options.resolution',
                                    'number', resolution);
   }
-  if (resolution <= 0 || !NumberIsSafeInteger(resolution)) {
+  if (resolution < 0 || !NumberIsSafeInteger(resolution)) {
     throw new ERR_INVALID_OPT_VALUE.RangeError('resolution', resolution);
   }
   return new ELDHistogram(new _ELDHistogram(resolution));

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -153,7 +153,8 @@ class ELDHistogram : public HandleWrap, public Histogram {
                Local<Object> wrap,
                int32_t resolution);
 
-  bool RecordDelta();
+  void RecordDelta();
+  void TraceHistogram();
   bool Enable();
   bool Disable();
   void ResetState() {
@@ -162,6 +163,8 @@ class ELDHistogram : public HandleWrap, public Histogram {
     prev_ = 0;
   }
   int64_t Exceeds() { return exceeds_; }
+
+  void Close(Local<Value> close_callback = Local<Value>()) override;
 
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackFieldWithSize("histogram", GetMemorySize());
@@ -172,12 +175,18 @@ class ELDHistogram : public HandleWrap, public Histogram {
 
  private:
   static void DelayIntervalCallback(uv_timer_t* req);
+  static void PrepareCallback(uv_prepare_t* handle);
+
+  inline bool is_precise() const {
+    return resolution_ == 0;
+  }
 
   bool enabled_ = false;
   int32_t resolution_ = 0;
   int64_t exceeds_ = 0;
   uint64_t prev_ = 0;
   uv_timer_t timer_;
+  uv_prepare_t prepare_;
 };
 
 }  // namespace performance

--- a/test/sequential/test-performance-eventloopdelay-reporting.js
+++ b/test/sequential/test-performance-eventloopdelay-reporting.js
@@ -1,0 +1,64 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const {
+  monitorEventLoopDelay
+} = require('perf_hooks');
+const { sleep } = require('internal/util');
+
+const ASYNC_SCHEDULERS = [
+  (cb) => setTimeout(cb, common.platformTimeout(10)),
+  (cb) => {
+    const server = net.createServer((s) => {
+      s.destroy();
+      server.close();
+
+      cb();
+    });
+    server.listen(0, () => {
+      const { port, address: host } = server.address();
+      net.connect(port, host, () => {
+      });
+    });
+  },
+];
+
+async function testSingle(resolution, callback) {
+  const histogram = monitorEventLoopDelay({ resolution });
+  histogram.enable();
+
+  for (const schedule of ASYNC_SCHEDULERS) {
+    histogram.reset();
+
+    const msSleep = common.platformTimeout(100);
+
+    await new Promise((resolve, reject) => {
+      schedule(() => {
+        sleep(msSleep);
+        resolve();
+      });
+    });
+
+    // Let the new event loop tick start
+    await new Promise((resolve, reject) => setTimeout(resolve, 10));
+
+    // Convert sleep time to nanoseconds
+    const nsSleep = msSleep * 1e6;
+
+    // We are generous
+    assert(histogram.max >= 0.75 * nsSleep,
+      `${histogram.max} must be greater or equal to ${0.75 * nsSleep}`);
+  }
+
+  histogram.disable();
+}
+
+async function test() {
+  await testSingle(0);
+  await testSingle(1);
+}
+
+test();

--- a/test/sequential/test-performance-eventloopdelay-reporting.js
+++ b/test/sequential/test-performance-eventloopdelay-reporting.js
@@ -12,16 +12,15 @@ const { sleep } = require('internal/util');
 const ASYNC_SCHEDULERS = [
   (cb) => setTimeout(cb, common.platformTimeout(10)),
   (cb) => {
-    const server = net.createServer((s) => {
+    const server = net.createServer(common.mustCall((s) => {
       s.destroy();
       server.close();
 
       cb();
-    });
+    }));
     server.listen(0, () => {
-      const { port, address: host } = server.address();
-      net.connect(port, host, () => {
-      });
+      const { port } = server.address();
+      net.connect(port, common.mustCall(() => {}));
     });
   },
 ];

--- a/test/sequential/test-performance-eventloopdelay-reporting.js
+++ b/test/sequential/test-performance-eventloopdelay-reporting.js
@@ -50,7 +50,7 @@ async function testSingle(resolution, callback) {
 
     // We are generous
     assert(histogram.max >= 0.75 * nsSleep,
-      `${histogram.max} must be greater or equal to ${0.75 * nsSleep}`);
+           `${histogram.max} must be greater or equal to ${0.75 * nsSleep}`);
   }
 
   histogram.disable();

--- a/test/sequential/test-performance-eventloopdelay.js
+++ b/test/sequential/test-performance-eventloopdelay.js
@@ -39,7 +39,7 @@ const { sleep } = require('internal/util');
     );
   });
 
-  [-1, 0, Infinity].forEach((i) => {
+  [-1, Infinity].forEach((i) => {
     assert.throws(
       () => monitorEventLoopDelay({ resolution: i }),
       {
@@ -50,8 +50,8 @@ const { sleep } = require('internal/util');
   });
 }
 
-{
-  const histogram = monitorEventLoopDelay({ resolution: 1 });
+for (const resolution of [ 0, 1 ]) {
+  const histogram = monitorEventLoopDelay({ resolution });
   histogram.enable();
   let m = 5;
   function spinAWhile() {


### PR DESCRIPTION
Introduce precise mode of `monitorEventLoopDelay` by using
`uv_prepare_t` to calculate time difference between two
`uv_prepare_t` callbacks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

cc @nodejs/performance 

---

NOTE: Moved from https://github.com/nodejs/node/pull/32018 since github didn't let me reopen the PR after force push... 😢 