### PR TITLE
test: use portable EOL

### DIFF
--- a/test/parallel/test-child-process-pipe-dataflow.js
+++ b/test/parallel/test-child-process-pipe-dataflow.js
@@ -3,6 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const spawn = require('child_process').spawn;
 const tmpdir = require('../common/tmpdir');
 
@@ -19,14 +20,15 @@ const MB = KB * KB;
 {
   tmpdir.refresh();
   const file = path.resolve(tmpdir.path, 'data.txt');
-  const buf = Buffer.alloc(MB).fill('x');
+  let buf = Buffer.alloc(MB).fill('x');
 
   // Most OS commands that deal with data, attach special
   // meanings to new line - for example, line buffering.
   // So cut the buffer into lines at some points, forcing
   // data flow to be split in the stream.
+  const eol_len = os.EOL.length;
   for (let i = 0; i < KB; i++)
-    buf[i * KB] = 10;
+    buf = buf.fill(os.EOL, i * KB, (i * KB + eol_len));
   fs.writeFileSync(file, buf.toString());
 
   cat = spawn('cat', [file]);

--- a/test/parallel/test-child-process-pipe-dataflow.js
+++ b/test/parallel/test-child-process-pipe-dataflow.js
@@ -20,15 +20,14 @@ const MB = KB * KB;
 {
   tmpdir.refresh();
   const file = path.resolve(tmpdir.path, 'data.txt');
-  let buf = Buffer.alloc(MB).fill('x');
+  const buf = Buffer.alloc(MB).fill('x');
 
   // Most OS commands that deal with data, attach special
   // meanings to new line - for example, line buffering.
   // So cut the buffer into lines at some points, forcing
   // data flow to be split in the stream.
-  const eol_len = os.EOL.length;
   for (let i = 0; i < KB; i++)
-    buf = buf.fill(os.EOL, i * KB, (i * KB + eol_len));
+    buf.write(os.EOL, i * KB);
   fs.writeFileSync(file, buf.toString());
 
   cat = spawn('cat', [file]);

--- a/test/parallel/test-child-process-pipe-dataflow.js
+++ b/test/parallel/test-child-process-pipe-dataflow.js
@@ -63,6 +63,6 @@ const MB = KB * KB;
 
   wc.stdout.on('data', common.mustCall((data) => {
     // Grep always adds one extra byte at the end.
-    assert.strictEqual(data.toString().trim(), (MB+1).toString());
+    assert.strictEqual(data.toString().trim(), (MB + 1).toString());
   }));
 }

--- a/test/parallel/test-child-process-pipe-dataflow.js
+++ b/test/parallel/test-child-process-pipe-dataflow.js
@@ -26,7 +26,7 @@ const MB = KB * KB;
   // meanings to new line - for example, line buffering.
   // So cut the buffer into lines at some points, forcing
   // data flow to be split in the stream.
-  for (let i = 0; i < KB; i++)
+  for (let i = 1; i < KB; i++)
     buf.write(os.EOL, i * KB);
   fs.writeFileSync(file, buf.toString());
 
@@ -62,6 +62,7 @@ const MB = KB * KB;
   });
 
   wc.stdout.on('data', common.mustCall((data) => {
-    assert.strictEqual(data.toString().trim(), MB.toString());
+    // Grep always adds one extra byte at the end.
+    assert.strictEqual(data.toString().trim(), (MB+1).toString());
   }));
 }


### PR DESCRIPTION
The test wanted to cut huge string into 1KB strings,
for which a new line character was inserted at appropriate
places. The value is different in Windows (10, 13).
Make it portable, by making use of os.EOL semantics

Refs: https://github.com/nodejs/node/issues/25988

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
