### PR TITLE
stream: don't destroy final readable stream in pipeline

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -25,9 +25,12 @@ let EE;
 let PassThrough;
 let createReadableStreamAsyncIterator;
 
-function destroyer(stream, reading, writing, callback) {
+function destroyer(stream, reading, writing, final, callback) {
   const _destroy = once((err) => {
-    destroyImpl.destroyer(stream, err);
+    const readable = stream.readable || isRequest(stream);
+    if (err || !final || !readable) {
+      destroyImpl.destroyer(stream, err);
+    }
     callback(err);
   });
 
@@ -66,6 +69,10 @@ function popCallback(streams) {
   if (typeof streams[streams.length - 1] !== 'function')
     throw new ERR_INVALID_CALLBACK(streams[streams.length - 1]);
   return streams.pop();
+}
+
+function isRequest(stream) {
+  return stream.setHeader && typeof stream.abort === 'function';
 }
 
 function isPromise(obj) {
@@ -159,7 +166,7 @@ function pipeline(...streams) {
   }
 
   function wrap(stream, reading, writing, final) {
-    destroys.push(destroyer(stream, reading, writing, (err) => {
+    destroys.push(destroyer(stream, reading, writing, final, (err) => {
       finish(err, final);
     }));
   }

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -916,7 +916,7 @@ const { promisify } = require('util');
   const dst = new PassThrough({ autoDestroy: false });
   pipeline(src, dst, common.mustCall(() => {
     assert.strictEqual(src.destroyed, true);
-    assert.strictEqual(dst.destroyed, true);
+    assert.strictEqual(dst.destroyed, false);
   }));
   src.end();
 }
@@ -937,4 +937,50 @@ const { promisify } = require('util');
   r.push('asd');
   r.push(null);
   r.emit('close');
+}
+
+{
+  const server = http.createServer((req, res) => {
+  });
+
+  server.listen(0, () => {
+    const req = http.request({
+      port: server.address().port
+    });
+
+    const body = new PassThrough();
+    pipeline(
+      body,
+      req,
+      common.mustCall((err) => {
+        assert(!err);
+        assert(!req.res);
+        assert(!req.aborted);
+        req.abort();
+        server.close();
+      })
+    );
+    body.end();
+  });
+}
+
+{
+  const src = new PassThrough();
+  const dst = new PassThrough();
+  pipeline(src, dst, common.mustCall((err) => {
+    assert(!err);
+    assert.strictEqual(dst.destroyed, false);
+  }));
+  src.end();
+}
+
+{
+  const src = new PassThrough();
+  const dst = new PassThrough();
+  dst.readable = false;
+  pipeline(src, dst, common.mustCall((err) => {
+    assert(!err);
+    assert.strictEqual(dst.destroyed, true);
+  }));
+  src.end();
 }


### PR DESCRIPTION
If the last stream in a pipeline is still usable/readable
don't destroy it to allow further composition.

Fixes: https://github.com/nodejs/node/issues/32105

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
