### PR TITLE
test: elevate magic numbers to common

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -38,6 +38,8 @@ const bits = ['arm64', 'mips', 'mipsel', 'ppc64', 's390x', 'x64']
   .includes(process.arch) ? 64 : 32;
 const hasIntl = !!process.config.variables.v8_enable_i18n_support;
 
+const KB = 1024;
+const MB = 1024 * 1024;
 // Some tests assume a umask of 0o022 so set that up front. Tests that need a
 // different umask will set it themselves.
 //
@@ -673,6 +675,8 @@ function invalidArgTypeHelper(input) {
 }
 
 const common = {
+  KB,
+  MB,
   allowGlobals,
   buildType,
   canCreateSymLink,

--- a/test/parallel/test-memory-usage.js
+++ b/test/parallel/test-memory-usage.js
@@ -34,7 +34,7 @@ assert.ok(r.external > 0);
 
 assert.strictEqual(typeof r.arrayBuffers, 'number');
 if (r.arrayBuffers > 0) {
-  const size = 10 * 1024 * 1024;
+  const size = 10 * common.MB;
   // eslint-disable-next-line no-unused-vars
   const ab = new ArrayBuffer(size);
 


### PR DESCRIPTION
There are several instances of 1024 and 1024 * 1024 in test cases.
Defined constants in common module for easy consumption.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
