### PR TITLE
doc: clarify `length` param in `buffer.write`

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2010,7 +2010,7 @@ const buf = Buffer.alloc(256);
 const len = buf.write('\u00bd + \u00bc = \u00be', 0);
 
 console.log(`${len} bytes: ${buf.toString('utf8', 0, len)}`);
-// Prints: 12 bytes: ½ + ¼ =
+// Prints: 12 bytes: ½ + ¼ ¾
 
 const buffer = Buffer.alloc(10);
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1996,8 +1996,8 @@ added: v0.1.90
   **Default:** `0`.
 * `length` {integer} Maximum number of bytes to write (written bytes will not
   exceed `buf.length - offset`). **Default:** `buf.length - offset`.
-  If the buffer has sufficient space from the offset, the string is written upto
-  `length`. If the buffer is short in space, only `buf.length - offset`
+  If the buffer has sufficient space from the offset, the string is written
+  up to `length`. If the buffer is short in space, only `buf.length - offset`
   bytes are written.
 * `encoding` {string} The character encoding of `string`. **Default:** `'utf8'`.
 * Returns: {integer} Number of bytes written.

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1,4 +1,4 @@
-	# Buffer
+# Buffer
 
 <!--introduced_in=v0.1.90-->
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1996,9 +1996,6 @@ added: v0.1.90
   **Default:** `0`.
 * `length` {integer} Maximum number of bytes to write (written bytes will not
   exceed `buf.length - offset`). **Default:** `buf.length - offset`.
-  If the buffer has sufficient space from the offset, the string is written
-  up to `length`. If the buffer is short in space, only `buf.length - offset`
-  bytes are written.
 * `encoding` {string} The character encoding of `string`. **Default:** `'utf8'`.
 * Returns: {integer} Number of bytes written.
 
@@ -2013,7 +2010,14 @@ const buf = Buffer.alloc(256);
 const len = buf.write('\u00bd + \u00bc = \u00be', 0);
 
 console.log(`${len} bytes: ${buf.toString('utf8', 0, len)}`);
-// Prints: 12 bytes: ½ + ¼ = ¾
+// Prints: 12 bytes: ½ + ¼ =
+
+const buffer = Buffer.alloc(10);
+
+const length = buffer.write('abcd', 8);
+
+console.log(`${length} bytes: ${buffer.toString('utf8', 8, 10)}`);
+// Prints: 2 bytes : ab
 ```
 
 ### `buf.writeBigInt64BE(value[, offset])`

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2010,7 +2010,7 @@ const buf = Buffer.alloc(256);
 const len = buf.write('\u00bd + \u00bc = \u00be', 0);
 
 console.log(`${len} bytes: ${buf.toString('utf8', 0, len)}`);
-// Prints: 12 bytes: ½ + ¼ ¾
+// Prints: 12 bytes: ½ + ¼ = ¾
 
 const buffer = Buffer.alloc(10);
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1,4 +1,4 @@
-# Buffer
+	# Buffer
 
 <!--introduced_in=v0.1.90-->
 
@@ -1994,8 +1994,11 @@ added: v0.1.90
 * `string` {string} String to write to `buf`.
 * `offset` {integer} Number of bytes to skip before starting to write `string`.
   **Default:** `0`.
-* `length` {integer} Maximum number of bytes to write. **Default:**
-  `buf.length - offset`.
+* `length` {integer} Maximum number of bytes to write (written bytes will not
+  exceed `buf.length - offset`). **Default:** `buf.length - offset`.
+  If the buffer has sufficient space from the offset, the string is written upto
+  `length`. If the buffer is short in space, only `buf.length - offset`
+  bytes are written.
 * `encoding` {string} The character encoding of `string`. **Default:** `'utf8'`.
 * Returns: {integer} Number of bytes written.
 


### PR DESCRIPTION
`buffer.write` documentation has an incaccuracy w.r.t the `length` parameter: 
It says default number of bytes written is `buf.length - offset`. Change it to:
If the buffer has sufficient space from the offset, the string is written upto `length`.
If the buffer is short in space, only `buf.length - offset` bytes are written.

proof:
```js
#node
> let buf = Buffer.alloc(10)
undefined
> buf
<Buffer 00 00 00 00 00 00 00 00 00 00>
> buf.write(‘abcd’, 3)
4
> buf
<Buffer 00 00 00 61 62 63 64 00 00 00>
> buf = Buffer.alloc(10)
<Buffer 00 00 00 00 00 00 00 00 00 00>
> buf.write(‘abcd’, 9)
1
> buf
<Buffer 00 00 00 00 00 00 00 00 00 61>
>
```

Refs : https://github.com/nodejs/node/pull/32104#discussion_r388524733

Thanks to @addaleax for her suggestion in the above comment, that lead to this finding.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
