### PR TITLE
test: revise test-net-reconnect-error

### DIFF
--- a/test/sequential/test-net-reconnect-error.js
+++ b/test/sequential/test-net-reconnect-error.js
@@ -24,24 +24,24 @@ const common = require('../common');
 const net = require('net');
 const assert = require('assert');
 const N = 20;
-let client_error_count = 0;
-let disconnect_count = 0;
+let clientErrorCount = 0;
+let disconnectCount = 0;
 
 const c = net.createConnection(common.PORT);
 
 c.on('connect', common.mustNotCall('client should not have connected'));
 
 c.on('error', common.mustCall((e) => {
-  client_error_count++;
+  clientErrorCount++;
   assert.strictEqual(e.code, 'ECONNREFUSED');
 }, N + 1));
 
 c.on('close', common.mustCall(() => {
-  if (disconnect_count++ < N)
+  if (disconnectCount++ < N)
     c.connect(common.PORT); // reconnect
 }, N + 1));
 
 process.on('exit', function() {
-  assert.strictEqual(disconnect_count, N + 1);
-  assert.strictEqual(client_error_count, N + 1);
+  assert.strictEqual(disconnectCount, N + 1);
+  assert.strictEqual(clientErrorCount, N + 1);
 });

--- a/test/sequential/test-net-reconnect-error.js
+++ b/test/sequential/test-net-reconnect-error.js
@@ -24,7 +24,6 @@ const common = require('../common');
 const net = require('net');
 const assert = require('assert');
 const N = 20;
-let clientErrorCount = 0;
 let disconnectCount = 0;
 
 const c = net.createConnection(common.PORT);
@@ -32,7 +31,6 @@ const c = net.createConnection(common.PORT);
 c.on('connect', common.mustNotCall('client should not have connected'));
 
 c.on('error', common.mustCall((e) => {
-  clientErrorCount++;
   assert.strictEqual(e.code, 'ECONNREFUSED');
 }, N + 1));
 
@@ -40,8 +38,3 @@ c.on('close', common.mustCall(() => {
   if (disconnectCount++ < N)
     c.connect(common.PORT); // reconnect
 }, N + 1));
-
-process.on('exit', function() {
-  assert.strictEqual(disconnectCount, N + 1);
-  assert.strictEqual(clientErrorCount, N + 1);
-});


### PR DESCRIPTION
Use camelCase instead of snake_case.

Remove superfluous `'exit'` event checks that duplicate checks already performed by `common.mustCall()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
