### PR TITLE
test: `buffer.write` with longer string scenario

### DIFF
--- a/test/parallel/test-buffer-write.js
+++ b/test/parallel/test-buffer-write.js
@@ -92,6 +92,7 @@ assert.strictEqual(z.write('\u0001', 3, 'ucs2'), 0);
 assert.strictEqual(Buffer.compare(z, Buffer.alloc(4, 0)), 0);
 // Make sure longer strings are written up to the buffer end.
 assert.strictEqual(z.write('abcd', 2), 2);
+assert.deepStrictEqual([...z], [0, 0, 0x61, 0x62]);
 
 // Large overrun could corrupt the process
 assert.strictEqual(Buffer.alloc(4)

--- a/test/parallel/test-buffer-write.js
+++ b/test/parallel/test-buffer-write.js
@@ -90,6 +90,8 @@ for (let i = 1; i < 4; i++) {
 const z = Buffer.alloc(4, 0);
 assert.strictEqual(z.write('\u0001', 3, 'ucs2'), 0);
 assert.strictEqual(Buffer.compare(z, Buffer.alloc(4, 0)), 0);
+// Make sure longer strings are written up to the buffer end.
+assert.strictEqual(z.write('abcd', 2), 2);
 
 // Large overrun could corrupt the process
 assert.strictEqual(Buffer.alloc(4)


### PR DESCRIPTION
Make sure longer strings are written up to the buffer end

Refs: https://github.com/nodejs/node/pull/32119

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
