### PR TITLE
src: use C++ style for struct with initializers

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -505,13 +505,13 @@ class Http2Stream::Provider::Stream : public Http2Stream::Provider {
                         void* user_data);
 };
 
-typedef struct {
+struct SessionJSFields {
   uint8_t bitfield;
   uint8_t priority_listener_count;
   uint8_t frame_error_listener_count;
   uint32_t max_invalid_frames = 1000;
   uint32_t max_rejected_streams = 100;
-} SessionJSFields;
+};
 
 // Indices for js_fields_, which serves as a way to communicate data with JS
 // land fast. In particular, we store information about the number/presence


### PR DESCRIPTION
Fixes warning on clang 11:
```
  In file included from ../../src/node_http2.cc:6:
  ../../src/node_http2.h:508:15: warning: anonymous non-C-compatible type given name for linkage purposes by typedef declaration; add a tag name here [-Wnon-c-typedef-for-linkage]
  typedef struct {
                ^
                 SessionJSFields
  ../../src/node_http2.h:512:33: note: type is not C-compatible due to this default member initializer
    uint32_t max_invalid_frames = 1000;
                                  ^~~~
  ../../src/node_http2.h:514:3: note: type is given name 'SessionJSFields' for linkage purposes by this typedef declaration
  } SessionJSFields;
    ^
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
