### PR TITLE
fs: prevent getter from making writev crash

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -629,7 +629,7 @@ function writev(fd, buffers, position, callback) {
   }
 
   validateInt32(fd, 'fd', 0);
-  validateBufferArray(buffers);
+  const validatedBuffers = validateBufferArray(buffers);
 
   const req = new FSReqCallback();
   req.oncomplete = wrapper;
@@ -639,7 +639,7 @@ function writev(fd, buffers, position, callback) {
   if (typeof position !== 'number')
     position = null;
 
-  return binding.writeBuffers(fd, buffers, position, req);
+  return binding.writeBuffers(fd, validatedBuffers, position, req);
 }
 
 ObjectDefineProperty(writev, internalUtil.customPromisifyArgs, {
@@ -649,14 +649,15 @@ ObjectDefineProperty(writev, internalUtil.customPromisifyArgs, {
 
 function writevSync(fd, buffers, position) {
   validateInt32(fd, 'fd', 0);
-  validateBufferArray(buffers);
+  const validatedBuffers = validateBufferArray(buffers);
 
   const ctx = {};
 
   if (typeof position !== 'number')
     position = null;
 
-  const result = binding.writeBuffers(fd, buffers, position, undefined, ctx);
+  const result =
+    binding.writeBuffers(fd, validatedBuffers, position, undefined, ctx);
 
   handleErrorFromBinding(ctx);
   return result;

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -587,7 +587,7 @@ const validateBufferArray = hideStackFrames((buffers, propName = 'buffers') => {
   const copy = [];
   for (let i = 0; i < buffers.length; i++) {
     const arr = buffers[i];
-    if (!isArrayBufferView(buffers[i]))
+    if (!isArrayBufferView(arr))
       throw new ERR_INVALID_ARG_TYPE(propName, 'ArrayBufferView[]', buffers);
     copy.push(arr);
   }

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -584,12 +584,15 @@ const validateBufferArray = hideStackFrames((buffers, propName = 'buffers') => {
   if (!ArrayIsArray(buffers))
     throw new ERR_INVALID_ARG_TYPE(propName, 'ArrayBufferView[]', buffers);
 
+  const copy = [];
   for (let i = 0; i < buffers.length; i++) {
+    const arr = buffers[i];
     if (!isArrayBufferView(buffers[i]))
       throw new ERR_INVALID_ARG_TYPE(propName, 'ArrayBufferView[]', buffers);
+    copy.push(arr);
   }
 
-  return buffers;
+  return copy;
 });
 
 let nonPortableTemplateWarn = true;

--- a/test/parallel/test-fs-writev-sync.js
+++ b/test/parallel/test-fs-writev-sync.js
@@ -87,7 +87,7 @@ const getFileName = (i) => path.join(tmpdir.path, `writev_sync_${i}.txt`);
 });
 
 /**
- * Testing with milicious getter
+ * Testing with malicious getter
  */
 {
   const filename = getFileName(4);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Hey !

With the help of @targos i made a change that fixes the `writev` function.
Indeed, function could make the process crash because of checks which can be bypassed by getters.

This change has been made Javascript side because the first case can be handle in C++ but not the second (no exception exist and so no one can be returned to Javascript).

Thank you for explanation @targos ! :)
Regards,

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
