### PR TITLE
stream: Duplex autoDestroy with disabled readable/writable

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -66,7 +66,6 @@ function Duplex(options) {
 
     if (options.allowHalfOpen === false) {
       this.allowHalfOpen = false;
-      this.once('end', onend);
     }
   }
 }
@@ -128,18 +127,3 @@ ObjectDefineProperties(Duplex.prototype, {
     }
   }
 });
-
-// The no-half-open enforcer
-function onend() {
-  // If the writable side ended, then we're ok.
-  if (this._writableState.ended)
-    return;
-
-  // No more data can be written.
-  // But allow more writes to happen in this tick.
-  process.nextTick(onEndNT, this);
-}
-
-function onEndNT(self) {
-  self.end();
-}

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1217,14 +1217,29 @@ function endReadableNT(state, stream) {
     state.endEmitted = true;
     stream.emit('end');
 
-    if (state.autoDestroy) {
+    if (stream.writable && stream.allowHalfOpen === false) {
+      process.nextTick(endWritableNT, state, stream);
+    } else if (state.autoDestroy) {
       // In case of duplex streams we need a way to detect
       // if the writable side is ready for autoDestroy as well
       const wState = stream._writableState;
-      if (!wState || (wState.autoDestroy && wState.finished)) {
+      const autoDestroy = !wState || (
+        wState.autoDestroy &&
+        // We don't expect the writable to ever 'finish'
+        // if writable is explicitly set to false.
+        (wState.finished || wState.writable === false)
+      );
+
+      if (autoDestroy) {
         stream.destroy();
       }
     }
+  }
+}
+
+function endWritableNT(state, stream) {
+  if (stream.writable) {
+    stream.end();
   }
 }
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1238,7 +1238,9 @@ function endReadableNT(state, stream) {
 }
 
 function endWritableNT(state, stream) {
-  if (stream.writable) {
+  const writable = stream.writable && !stream.writableEnded &&
+    !stream.destroyed;
+  if (writable) {
     stream.end();
   }
 }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -675,7 +675,13 @@ function finish(stream, state) {
     // In case of duplex streams we need a way to detect
     // if the readable side is ready for autoDestroy as well
     const rState = stream._readableState;
-    if (!rState || (rState.autoDestroy && rState.endEmitted)) {
+    const autoDestroy = !rState || (
+      rState.autoDestroy &&
+      // We don't expect the readable to ever 'end'
+      // if readable is explicitly set to false.
+      (rState.endEmitted || rState.readable === false)
+    );
+    if (autoDestroy) {
       stream.destroy();
     }
   }
@@ -748,7 +754,7 @@ ObjectDefineProperties(Writable.prototype, {
       // Compat. The user might manually disable writable side through
       // deprecated setter.
       return !!w && w.writable !== false && !w.destroyed && !w.errored &&
-        !w.ending;
+        !w.ending && !w.ended;
     },
     set(val) {
       // Backwards compatible.

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -235,6 +235,6 @@ const assert = require('assert');
     process.nextTick(() => {
       duplex.end = common.mustCall(orgEnd);
     });
-  })
+  });
   duplex.on('close', common.mustCall());
 }

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -194,3 +194,47 @@ const assert = require('assert');
 
   new MyDuplex();
 }
+
+{
+  const duplex = new Duplex({
+    writable: false,
+    autoDestroy: true,
+    write(chunk, enc, cb) { cb(); },
+    read() {},
+  });
+  duplex.push(null);
+  duplex.resume();
+  duplex.on('close', common.mustCall());
+}
+
+{
+  const duplex = new Duplex({
+    readable: false,
+    autoDestroy: true,
+    write(chunk, enc, cb) { cb(); },
+    read() {},
+  });
+  duplex.end();
+  duplex.on('close', common.mustCall());
+}
+
+{
+  const duplex = new Duplex({
+    allowHalfOpen: false,
+    autoDestroy: true,
+    write(chunk, enc, cb) { cb(); },
+    read() {},
+  });
+  duplex.push(null);
+  duplex.resume();
+  const orgEnd = duplex.end;
+  duplex.end = common.mustNotCall();
+  duplex.on('end', () => {
+    // Ensure end() is called in next tick to allow
+    // any pending writes to be invoked first.
+    process.nextTick(() => {
+      duplex.end = common.mustCall(orgEnd);
+    });
+  })
+  duplex.on('close', common.mustCall());
+}

--- a/test/parallel/test-stream-duplex-end.js
+++ b/test/parallel/test-stream-duplex-end.js
@@ -22,7 +22,7 @@ const Duplex = require('stream').Duplex;
   });
   assert.strictEqual(stream.allowHalfOpen, false);
   stream.on('finish', common.mustCall());
-  assert.strictEqual(stream.listenerCount('end'), 1);
+  assert.strictEqual(stream.listenerCount('end'), 0);
   stream.resume();
   stream.push(null);
 }
@@ -35,7 +35,7 @@ const Duplex = require('stream').Duplex;
   assert.strictEqual(stream.allowHalfOpen, false);
   stream._writableState.ended = true;
   stream.on('finish', common.mustNotCall());
-  assert.strictEqual(stream.listenerCount('end'), 1);
+  assert.strictEqual(stream.listenerCount('end'), 0);
   stream.resume();
   stream.push(null);
 }


### PR DESCRIPTION
stream.Duplex and net.Socket slightly differs in behavior.

Especially when it comes to the case where one side never
becomes readable or writable. This aligns Duplex with the
behavior of Socket.

The "trick" `net.Socket` does is to explicitly set `writable`/`readable` to `false` instead of calling `end()`/`push(null)` to avoid the `'finish'`/`'end'` events.

This PR extract the streams part of https://github.com/nodejs/node/pull/31806 for easier review.

---- EDIT UPDATED DESCRIPTION ----

Some streams are implemented as `Duplex` but don't know whether they are unidirectional or not until runtime. In the case that it is determined as unidirectional then one of the sides need to be disabled for e.g. `autoDestroy`, `stream.finished` to work properly. However, it doesn't make sense to call `end()/push(null)` since it never were `writable/readable` and emitting `'finish'/'close'` is weird/confusing.

They way e.g. `net.Socket` resolves it (and maybe quic and other implementors might want to resolve it? @jasnell) is to explicitly set `writable/readable` to `false` once/if it has determined the stream to be unidirectional. This works already, however it would break `autoDestroy` which (before this PR) waits for both sides to complete, when (in this case) only one is expected complete.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
