### PR TITLE
http: align OutgoingMessage and ClientRequest destroy

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -368,10 +368,7 @@ ClientRequest.prototype.destroy = function destroy(err) {
 };
 
 function _destroy(req, socket, err) {
-  // TODO (ronag): Check if socket was used at all (e.g. headersSent) and
-  // re-use it in that case. `req.socket` just checks whether the socket was
-  // assigned to the request and *might* have been used.
-  if (!req.agent || req.socket) {
+  if (!req.agent || req.headersSent) {
     socket.destroy(err);
   } else {
     socket.emit('free');

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -449,7 +449,9 @@ function socketErrorListener(err) {
   const req = socket._httpMessage;
   debug('SOCKET ERROR:', err.message, err.stack);
 
-  if (req) {
+  // If writableFinished then the error came from the readable/response
+  // side and will be emitted there.
+  if (req && !req.writableFinished) {
     // For Safety. Some additional errors might fire later on
     // and we need to make sure we don't double-fire the error event.
     req.socket._hadError = true;

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -66,7 +66,7 @@ const {
 } = require('internal/dtrace');
 
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
-const kOnSocket = Symbol('kOnSocket');
+const kError = Symbol('kError');
 
 function validateHost(host, name) {
   if (host !== null && host !== undefined && typeof host !== 'string') {
@@ -358,27 +358,16 @@ ClientRequest.prototype.destroy = function destroy(err) {
     this.res._dump();
   }
 
-  if (!this.socket) {
-    this.once(kOnSocket, (socket) => {
-      if (this.agent) {
-        socket.emit('free');
-      } else {
-        socket.destroy();
-      }
-
-      if (!this.aborted && !err) {
-        err = connResetException('socket hang up');
-      }
-
-      if (err) {
-        this.emit('error', err);
-      }
-      this.emit('close');
-    });
-  } else {
+  // In the event that we don't have a socket, we will pop out of
+  // the request queue through handling in onSocket.
+  if (this.socket) {
+    // in-progress
     this.socket.destroy(err);
+  } else if (err) {
+    this[kError] = err;
   }
 };
+
 
 function emitAbortNT(req) {
   req.emit('abort');
@@ -710,12 +699,6 @@ function emitFreeNT(req) {
 }
 
 function tickOnSocket(req, socket) {
-  req.emit(kOnSocket, socket);
-
-  if (req.destroyed) {
-    return;
-  }
-
   const parser = parsers.alloc();
   req.socket = socket;
   parser.initialize(HTTPParser.RESPONSE,
@@ -776,8 +759,29 @@ function listenSocketTimeout(req) {
 }
 
 ClientRequest.prototype.onSocket = function onSocket(socket) {
-  process.nextTick(tickOnSocket, this, socket);
+  process.nextTick(onSocketNT, this, socket);
 };
+
+function onSocketNT(req, socket) {
+  if (req.destroyed) {
+    // If we were aborted while waiting for a socket, skip the whole thing.
+    if (!req.agent) {
+      socket.destroy(req[kError]);
+    } else {
+      socket.emit('free');
+      let err = req[kError];
+      if (!req.aborted && !err) {
+        err = connResetException('socket hang up');
+      }
+      if (err) {
+        req.emit('error', err);
+      }
+      req.emit('close');
+    }
+  } else {
+    tickOnSocket(req, socket);
+  }
+}
 
 ClientRequest.prototype._deferToConnect = _deferToConnect;
 function _deferToConnect(method, arguments_, cb) {

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -449,9 +449,7 @@ function socketErrorListener(err) {
   const req = socket._httpMessage;
   debug('SOCKET ERROR:', err.message, err.stack);
 
-  // If writableFinished then the error came from the readable/response
-  // side and will be emitted there.
-  if (req && !req.writableFinished) {
+  if (req) {
     // For Safety. Some additional errors might fire later on
     // and we need to make sure we don't double-fire the error event.
     req.socket._hadError = true;

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -361,13 +361,29 @@ ClientRequest.prototype.destroy = function destroy(err) {
   // In the event that we don't have a socket, we will pop out of
   // the request queue through handling in onSocket.
   if (this.socket) {
-    // in-progress
-    this.socket.destroy(err);
+    _destroy(this, this.socket, err);
   } else if (err) {
     this[kError] = err;
   }
 };
 
+function _destroy(req, socket, err) {
+  // TODO (ronag): Check if socket was used at all (e.g. headersSent) and
+  // re-use it in that case. `req.socket` just checks whether the socket was
+  // assigned to the request and *might* have been used.
+  if (!req.agent || req.socket) {
+    socket.destroy(err);
+  } else {
+    socket.emit('free');
+    if (!req.aborted && !err) {
+      err = connResetException('socket hang up');
+    }
+    if (err) {
+      req.emit('error', err);
+    }
+    req.emit('close');
+  }
+}
 
 function emitAbortNT(req) {
   req.emit('abort');
@@ -764,20 +780,7 @@ ClientRequest.prototype.onSocket = function onSocket(socket) {
 
 function onSocketNT(req, socket) {
   if (req.destroyed) {
-    // If we were aborted while waiting for a socket, skip the whole thing.
-    if (!req.agent) {
-      socket.destroy(req[kError]);
-    } else {
-      socket.emit('free');
-      let err = req[kError];
-      if (!req.aborted && !err) {
-        err = connResetException('socket hang up');
-      }
-      if (err) {
-        req.emit('error', err);
-      }
-      req.emit('close');
-    }
+    _destroy(req, socket, req[kError]);
   } else {
     tickOnSocket(req, socket);
   }

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -368,7 +368,10 @@ ClientRequest.prototype.destroy = function destroy(err) {
 };
 
 function _destroy(req, socket, err) {
-  if (!req.agent || req.headersSent) {
+  // TODO (ronag): Check if socket was used at all (e.g. headersSent) and
+  // re-use it in that case. `req.socket` just checks whether the socket was
+  // assigned to the request and *might* have been used.
+  if (!req.agent || req.socket) {
     socket.destroy(err);
   } else {
     socket.emit('free');

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -29,6 +29,7 @@ const {
   ObjectAssign,
   ObjectKeys,
   ObjectSetPrototypeOf,
+  Symbol
 } = primordials;
 
 const net = require('net');
@@ -65,6 +66,7 @@ const {
 } = require('internal/dtrace');
 
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
+const kOnSocket = Symbol('kOnSocket');
 
 function validateHost(host, name) {
   if (host !== null && host !== undefined && typeof host !== 'string') {
@@ -337,24 +339,46 @@ ClientRequest.prototype._implicitHeader = function _implicitHeader() {
 };
 
 ClientRequest.prototype.abort = function abort() {
-  if (!this.aborted) {
-    process.nextTick(emitAbortNT, this);
+  if (this.aborted) {
+    return;
   }
   this.aborted = true;
+  process.nextTick(emitAbortNT, this);
+  this.destroy();
+};
+
+ClientRequest.prototype.destroy = function destroy(err) {
+  if (this.destroyed) {
+    return;
+  }
+  this.destroyed = true;
 
   // If we're aborting, we don't care about any more response data.
   if (this.res) {
     this.res._dump();
   }
 
-  // In the event that we don't have a socket, we will pop out of
-  // the request queue through handling in onSocket.
-  if (this.socket) {
-    // in-progress
-    this.socket.destroy();
+  if (!this.socket) {
+    this.once(kOnSocket, (socket) => {
+      if (this.agent) {
+        socket.emit('free');
+      } else {
+        socket.destroy();
+      }
+
+      if (!this.aborted && !err) {
+        err = connResetException('socket hang up');
+      }
+
+      if (err) {
+        this.emit('error', err);
+      }
+      this.emit('close');
+    });
+  } else {
+    this.socket.destroy(err);
   }
 };
-
 
 function emitAbortNT(req) {
   req.emit('abort');
@@ -686,6 +710,12 @@ function emitFreeNT(req) {
 }
 
 function tickOnSocket(req, socket) {
+  req.emit(kOnSocket, socket);
+
+  if (req.destroyed) {
+    return;
+  }
+
   const parser = parsers.alloc();
   req.socket = socket;
   parser.initialize(HTTPParser.RESPONSE,
@@ -746,22 +776,8 @@ function listenSocketTimeout(req) {
 }
 
 ClientRequest.prototype.onSocket = function onSocket(socket) {
-  process.nextTick(onSocketNT, this, socket);
+  process.nextTick(tickOnSocket, this, socket);
 };
-
-function onSocketNT(req, socket) {
-  if (req.aborted) {
-    // If we were aborted while waiting for a socket, skip the whole thing.
-    if (!req.agent) {
-      socket.destroy();
-    } else {
-      req.emit('close');
-      socket.emit('free');
-    }
-  } else {
-    tickOnSocket(req, socket);
-  }
-}
 
 ClientRequest.prototype._deferToConnect = _deferToConnect;
 function _deferToConnect(method, arguments_, cb) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -93,6 +93,7 @@ function OutgoingMessage() {
   this.outputSize = 0;
 
   this.writable = true;
+  this.destroyed = false;
 
   this._last = false;
   this.chunkedEncoding = false;
@@ -277,6 +278,11 @@ OutgoingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
 // any messages, before ever calling this.  In that case, just skip
 // it, since something else is destroying this connection anyway.
 OutgoingMessage.prototype.destroy = function destroy(error) {
+  if (this.destroyed) {
+    return;
+  }
+  this.destroyed = true;
+
   if (this.socket) {
     this.socket.destroy(error);
   } else {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -335,10 +335,6 @@ function _writeRaw(data, encoding, callback) {
     return false;
   }
 
-  if (this.destroyed) {
-    return false;
-  }
-
   if (typeof encoding === 'function') {
     callback = encoding;
     encoding = null;

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -335,6 +335,10 @@ function _writeRaw(data, encoding, callback) {
     return false;
   }
 
+  if (this.destroyed) {
+    return false;
+  }
+
   if (typeof encoding === 'function') {
     callback = encoding;
     encoding = null;

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -163,9 +163,9 @@ function isRequest(stream) {
 
 // Normalize destroy for legacy.
 function destroyer(stream, err) {
-  if (typeof stream.destroy === 'function') return stream.destroy(err);
   if (isRequest(stream)) return stream.abort();
   if (isRequest(stream.req)) return stream.req.abort();
+  if (typeof stream.destroy === 'function') return stream.destroy(err);
   if (typeof stream.close === 'function') return stream.close();
 }
 

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -163,10 +163,9 @@ function isRequest(stream) {
 
 // Normalize destroy for legacy.
 function destroyer(stream, err) {
-  // request.destroy just do .end - .abort is what we want
+  if (typeof stream.destroy === 'function') return stream.destroy(err);
   if (isRequest(stream)) return stream.abort();
   if (isRequest(stream.req)) return stream.req.abort();
-  if (typeof stream.destroy === 'function') return stream.destroy(err);
   if (typeof stream.close === 'function') return stream.close();
 }
 

--- a/test/parallel/test-http-client-abort-destroy.js
+++ b/test/parallel/test-http-client-abort-destroy.js
@@ -1,0 +1,71 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+
+{
+  // abort
+
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.end('Hello');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const options = { port: server.address().port };
+    const req = http.get(options, common.mustCall((res) => {
+      res.on('data', (data) => {
+        req.abort();
+        assert.strictEqual(req.aborted, true);
+        assert.strictEqual(req.destroyed, true);
+        server.close();
+      });
+    }));
+    req.on('error', common.mustNotCall());
+    assert.strictEqual(req.aborted, false);
+    assert.strictEqual(req.destroyed, false);
+  }));
+}
+
+{
+  // destroy + res
+
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.end('Hello');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const options = { port: server.address().port };
+    const req = http.get(options, common.mustCall((res) => {
+      res.on('data', (data) => {
+        req.destroy();
+        assert.strictEqual(req.aborted, false);
+        assert.strictEqual(req.destroyed, true);
+        server.close();
+      });
+    }));
+    req.on('error', common.mustNotCall());
+    assert.strictEqual(req.aborted, false);
+    assert.strictEqual(req.destroyed, false);
+  }));
+}
+
+
+{
+  // destroy
+
+  const server = http.createServer(common.mustNotCall((req, res) => {
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const options = { port: server.address().port };
+    const req = http.get(options, common.mustNotCall());
+    req.on('error', common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ECONNRESET');
+    }));
+    assert.strictEqual(req.aborted, false);
+    assert.strictEqual(req.destroyed, false);
+    req.destroy();
+    assert.strictEqual(req.aborted, false);
+    assert.strictEqual(req.destroyed, true);
+  }));
+}

--- a/test/parallel/test-http-client-abort-destroy.js
+++ b/test/parallel/test-http-client-abort-destroy.js
@@ -49,7 +49,6 @@ const assert = require('assert');
   }));
 }
 
-
 {
   // destroy
 
@@ -61,6 +60,7 @@ const assert = require('assert');
     const req = http.get(options, common.mustNotCall());
     req.on('error', common.mustCall((err) => {
       assert.strictEqual(err.code, 'ECONNRESET');
+      server.close();
     }));
     assert.strictEqual(req.aborted, false);
     assert.strictEqual(req.destroyed, false);

--- a/test/parallel/test-http-client-abort-keep-alive-queued-tcp-socket.js
+++ b/test/parallel/test-http-client-abort-keep-alive-queued-tcp-socket.js
@@ -3,34 +3,45 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
-let socketsCreated = 0;
 
-class Agent extends http.Agent {
-  createConnection(options, oncreate) {
-    const socket = super.createConnection(options, oncreate);
-    socketsCreated++;
-    return socket;
+for (const destroyer of ['destroy', 'abort']) {
+  let socketsCreated = 0;
+
+  class Agent extends http.Agent {
+    createConnection(options, oncreate) {
+      const socket = super.createConnection(options, oncreate);
+      socketsCreated++;
+      return socket;
+    }
   }
-}
 
-const server = http.createServer((req, res) => res.end());
+  const server = http.createServer((req, res) => res.end());
 
-server.listen(0, common.mustCall(() => {
-  const port = server.address().port;
-  const agent = new Agent({
-    keepAlive: true,
-    maxSockets: 1
-  });
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    const agent = new Agent({
+      keepAlive: true,
+      maxSockets: 1
+    });
 
-  http.get({ agent, port }, (res) => res.resume());
+    http.get({ agent, port }, (res) => res.resume());
 
-  const req = http.get({ agent, port }, common.mustNotCall());
-  req.abort();
+    const req = http.get({ agent, port }, common.mustNotCall());
+    req[destroyer]();
 
-  http.get({ agent, port }, common.mustCall((res) => {
-    res.resume();
-    assert.strictEqual(socketsCreated, 1);
-    agent.destroy();
-    server.close();
+    if (destroyer === 'destroy') {
+      req.on('error', common.mustCall((err) => {
+        assert.strictEqual(err.code, 'ECONNRESET');
+      }));
+    } else {
+      req.on('error', common.mustNotCall());
+    }
+
+    http.get({ agent, port }, common.mustCall((res) => {
+      res.resume();
+      assert.strictEqual(socketsCreated, 1);
+      agent.destroy();
+      server.close();
+    }));
   }));
-}));
+}

--- a/test/parallel/test-http-client-close-event.js
+++ b/test/parallel/test-http-client-close-event.js
@@ -14,12 +14,12 @@ server.listen(0, common.mustCall(() => {
   const req = http.get({ port: server.address().port }, common.mustNotCall());
   let errorEmitted = false;
 
-  req.on('error', (err) => {
+  req.on('error', common.mustCall((err) => {
     errorEmitted = true;
     assert.strictEqual(err.constructor, Error);
     assert.strictEqual(err.message, 'socket hang up');
     assert.strictEqual(err.code, 'ECONNRESET');
-  });
+  }));
 
   req.on('close', common.mustCall(() => {
     assert.strictEqual(errorEmitted, true);

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -122,3 +122,10 @@ assert.throws(() => {
   name: 'TypeError',
   message: 'Invalid character in trailer content ["404"]'
 });
+
+{
+  const outgoingMessage = new OutgoingMessage();
+  assert.strictEqual(outgoingMessage.destroyed, false);
+  outgoingMessage.destroy();
+  assert.strictEqual(outgoingMessage.destroyed, true);
+}


### PR DESCRIPTION
Added .destroyed property to OutgoingMessage and ClientRequest
to align with streams.

Fixed ClientRequest.destroy to dump res and re-use socket in agent
pool aligning it with abort.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
