### PR TITLE
http: detach socket from IncomingMessage on keep-alive

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -636,6 +636,12 @@ function responseKeepAlive(req) {
   // Mark this socket as available, AFTER user-added end
   // handlers have a chance to run.
   defaultTriggerAsyncIdScope(asyncId, process.nextTick, emitFreeNT, req);
+
+  if (req.res) {
+    // Detach socket from IncomingMessage to avoid destroying the freed
+    // socket in IncomingMessage.destroy().
+    req.res.socket = null;
+  }
 }
 
 function responseOnEnd() {

--- a/test/parallel/test-http-agent-destroyed-socket.js
+++ b/test/parallel/test-http-agent-destroyed-socket.js
@@ -48,7 +48,7 @@ const server = http.createServer(common.mustCall((req, res) => {
     response.on('end', common.mustCall(() => {
       request1.socket.destroy();
 
-      response.socket.once('close', common.mustCall(() => {
+      request1.socket.once('close', common.mustCall(() => {
         // Assert request2 was removed from the queue
         assert(!agent.requests[key]);
         process.nextTick(() => {

--- a/test/parallel/test-http-client-abort-keep-alive-destroy-res.js
+++ b/test/parallel/test-http-client-abort-keep-alive-destroy-res.js
@@ -1,0 +1,39 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+let socketsCreated = 0;
+
+class Agent extends http.Agent {
+  createConnection(options, oncreate) {
+    const socket = super.createConnection(options, oncreate);
+    socketsCreated++;
+    return socket;
+  }
+}
+
+const server = http.createServer((req, res) => res.end());
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const agent = new Agent({
+    keepAlive: true,
+    maxSockets: 1
+  });
+
+  const req = http.get({ agent, port }, common.mustCall((res) => {
+    res.resume();
+    res.on('end', () => {
+      res.destroy();
+
+      http.get({ agent, port }, common.mustCall((res) => {
+        res.resume();
+        assert.strictEqual(socketsCreated, 1);
+        agent.destroy();
+        server.close();
+      }));
+    });
+  }));
+  req.end();
+}));


### PR DESCRIPTION
If the socket is not detached then a future call to res.destroy
(through e.g. pipeline) would unecessarily kill the socket while
its in the agent free list.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
