### PR TITLE
doc: fix os.version() Windows API

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -399,7 +399,7 @@ added: v13.11.0
 Returns a string identifying the kernel version.
 
 On POSIX systems, the operating system release is determined by calling
-[uname(3)][]. On Windows, `pRtlGetVersion` is used, and if it is not available,
+[uname(3)][]. On Windows, `RtlGetVersion()` is used, and if it is not available,
 `GetVersionExW()` will be used. See
 https://en.wikipedia.org/wiki/Uname#Examples for more information.
 


### PR DESCRIPTION
`pRtlGetVersion` is not a thing. This text was likely a result of copying the variable name used in libuv. This commit updates the documentation to reference the correct Windows API call.

Refs: https://github.com/nodejs/node/pull/31732

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)