### PR TITLE
test: verify that WASI errors are rethrown

### DIFF
--- a/test/wasi/test-return-on-exit.js
+++ b/test/wasi/test-return-on-exit.js
@@ -5,14 +5,27 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const { WASI } = require('wasi');
-const wasi = new WASI({ returnOnExit: true });
-const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 const wasmDir = path.join(__dirname, 'wasm');
 const modulePath = path.join(wasmDir, 'exitcode.wasm');
 const buffer = fs.readFileSync(modulePath);
 
 (async () => {
+  const wasi = new WASI({ returnOnExit: true });
+  const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
   const { instance } = await WebAssembly.instantiate(buffer, importObject);
 
   assert.strictEqual(wasi.start(instance), 120);
+})().then(common.mustCall());
+
+(async () => {
+  // Verify that if a WASI application throws an exception, Node rethrows it
+  // properly.
+  const wasi = new WASI({ returnOnExit: true });
+  wasi.wasiImport.proc_exit = () => { throw new Error('test error'); };
+  const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
+  const { instance } = await WebAssembly.instantiate(buffer, importObject);
+
+  assert.throws(() => {
+    wasi.start(instance);
+  }, /^Error: test error$/);
 })().then(common.mustCall());


### PR DESCRIPTION
This commit adds a test to verify that exceptions thrown from a WASI application are properly caught and rethrown. This also gets the code coverage in `lib/wasi.js` back to 100%.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
