### PR TITLE
stream: make finished try to wait for 'close'

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -63,15 +63,33 @@ function eos(stream, opts, callback) {
 
   const wState = stream._writableState;
   const rState = stream._readableState;
+  const state = wState || rState;
 
   const onlegacyfinish = () => {
     if (!stream.writable) onfinish();
   };
 
+  // TODO (ronag): Improve soft detection to include core modules and
+  // common ecosystem modules that do properly emit 'close' but fail
+  // this generic check.
+  const willEmitClose = (
+    state &&
+    state.autoDestroy &&
+    state.emitClose &&
+    state.closed === false
+  );
+
   let writableFinished = stream.writableFinished ||
     (wState && wState.finished);
   const onfinish = () => {
     writableFinished = true;
+    if (willEmitClose && (!stream.readable || readable)) {
+      // TODO(ronag): Duplex won't autoDestroy if `stream.readable` was
+      // explicitly set to false.
+      if (!rState || rState.readable !== false) {
+        return;
+      }
+    }
     if (!readable || readableEnded) callback.call(stream);
   };
 
@@ -79,6 +97,13 @@ function eos(stream, opts, callback) {
     (rState && rState.endEmitted);
   const onend = () => {
     readableEnded = true;
+    if (willEmitClose && (!stream.writable || writable)) {
+      // TODO(ronag): Duplex won't autoDestroy if `stream.writable` was
+      // explicitly set to false.
+      if (!wState || wState.writable !== false) {
+        return;
+      }
+    }
     if (!writable || writableFinished) callback.call(stream);
   };
 

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -83,13 +83,7 @@ function eos(stream, opts, callback) {
     (wState && wState.finished);
   const onfinish = () => {
     writableFinished = true;
-    if (willEmitClose && (!stream.readable || readable)) {
-      // TODO(ronag): Duplex won't autoDestroy if `stream.readable` was
-      // explicitly set to false.
-      if (!rState || rState.readable !== false) {
-        return;
-      }
-    }
+    if (willEmitClose && (!stream.readable || readable)) return;
     if (!readable || readableEnded) callback.call(stream);
   };
 
@@ -97,13 +91,7 @@ function eos(stream, opts, callback) {
     (rState && rState.endEmitted);
   const onend = () => {
     readableEnded = true;
-    if (willEmitClose && (!stream.writable || writable)) {
-      // TODO(ronag): Duplex won't autoDestroy if `stream.writable` was
-      // explicitly set to false.
-      if (!wState || wState.writable !== false) {
-        return;
-      }
-    }
+    if (willEmitClose && (!stream.writable || writable)) return;
     if (!writable || writableFinished) callback.call(stream);
   };
 

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -7,7 +7,8 @@ const {
   Readable,
   Transform,
   pipeline,
-  PassThrough
+  PassThrough,
+  Duplex
 } = require('stream');
 const assert = require('assert');
 const http = require('http');
@@ -1075,5 +1076,45 @@ const { promisify } = require('util');
     }
   }, common.mustCall((err) => {
     assert.ifError(err);
+  }));
+}
+
+{
+  let closed = false;
+  const src = new Readable({
+    read() {},
+    destroy(err, cb) {
+      process.nextTick(cb);
+    }
+  });
+  const dst = new Writable({
+    write(chunk, encoding, callback) {
+      callback();
+    }
+  });
+  src.on('close', () => {
+    closed = true;
+  });
+  src.push(null);
+  pipeline(src, dst, common.mustCall((err) => {
+    assert.strictEqual(closed, true);
+  }));
+}
+
+{
+  let closed = false;
+  const src = new Readable({
+    read() {},
+    destroy(err, cb) {
+      process.nextTick(cb);
+    }
+  });
+  const dst = new Duplex({});
+  src.on('close', common.mustCall(() => {
+    closed = true;
+  }));
+  src.push(null);
+  pipeline(src, dst, common.mustCall((err) => {
+    assert.strictEqual(closed, true);
   }));
 }


### PR DESCRIPTION
Pipeline uses eos which will invoke the callback
on 'finish' and 'end' before all streams have been
fully destroyed.

Fixes: https://github.com/nodejs/node/issues/32032

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
