### PR TITLE
doc: expand fs.watch caveats

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3773,6 +3773,9 @@ The recursive option is only supported on macOS and Windows.
 An `ERR_FEATURE_UNAVAILABLE_ON_PLATFORM` exception will be thrown
 when the option is used on a platform that does not support it.
 
+On Windows no events will be emitted if the watched directory is moved or
+renamed. If the watched directory is deleted `EPERM` error will be reported.
+
 #### Availability
 
 <!--type=misc-->

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3773,8 +3773,8 @@ The recursive option is only supported on macOS and Windows.
 An `ERR_FEATURE_UNAVAILABLE_ON_PLATFORM` exception will be thrown
 when the option is used on a platform that does not support it.
 
-On Windows no events will be emitted if the watched directory is moved or
-renamed. If the watched directory is deleted `EPERM` error will be reported.
+On Windows, no events will be emitted if the watched directory is moved or
+renamed. An `EPERM` error is reported when the watched directory is deleted.
 
 #### Availability
 


### PR DESCRIPTION
Document Windows specific fs.watch caveats.

Fixes: https://github.com/nodejs/node/issues/31702

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
