### PR TITLE
deps: V8: cherry-pick f9257802c1c0

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.30',
+    'v8_embedder_string': '-node.31',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/parsing/parser.cc
+++ b/deps/v8/src/parsing/parser.cc
@@ -503,7 +503,6 @@ FunctionLiteral* Parser::ParseProgram(Isolate* isolate, ParseInfo* info) {
                         Scope::DeserializationMode::kIncludingVariables);
 
   scanner_.Initialize();
-  scanner_.SkipHashBang();
   FunctionLiteral* result = DoParseProgram(isolate, info);
   MaybeResetCharacterStream(info, result);
   MaybeProcessSourceRanges(info, result, stack_limit_);

--- a/deps/v8/src/parsing/preparser.cc
+++ b/deps/v8/src/parsing/preparser.cc
@@ -74,10 +74,6 @@ PreParser::PreParseResult PreParser::PreParseProgram() {
   scope->set_is_being_lazily_parsed(true);
 #endif
 
-  // Note: We should only skip the hashbang in non-Eval scripts
-  // (currently, Eval is not handled by the PreParser).
-  scanner()->SkipHashBang();
-
   // ModuleDeclarationInstantiation for Source Text Module Records creates a
   // new Module Environment Record whose outer lexical environment record is
   // the global scope.

--- a/deps/v8/src/parsing/scanner-inl.h
+++ b/deps/v8/src/parsing/scanner-inl.h
@@ -505,6 +505,10 @@ V8_INLINE Token::Value Scanner::ScanSingleToken() {
           return ScanTemplateSpan();
 
         case Token::PRIVATE_NAME:
+          if (source_pos() == 0 && Peek() == '!') {
+            token = SkipSingleLineComment();
+            continue;
+          }
           return ScanPrivateName();
 
         case Token::WHITESPACE:

--- a/deps/v8/src/parsing/scanner.cc
+++ b/deps/v8/src/parsing/scanner.cc
@@ -314,13 +314,6 @@ Token::Value Scanner::SkipMultiLineComment() {
   return Token::ILLEGAL;
 }
 
-void Scanner::SkipHashBang() {
-  if (c0_ == '#' && Peek() == '!' && source_pos() == 0) {
-    SkipSingleLineComment();
-    Scan();
-  }
-}
-
 Token::Value Scanner::ScanHtmlComment() {
   // Check for <!-- comments.
   DCHECK_EQ(c0_, '!');

--- a/deps/v8/src/parsing/scanner.h
+++ b/deps/v8/src/parsing/scanner.h
@@ -421,9 +421,6 @@ class V8_EXPORT_PRIVATE Scanner {
 
   const Utf16CharacterStream* stream() const { return source_; }
 
-  // If the next characters in the stream are "#!", the line is skipped.
-  void SkipHashBang();
-
  private:
   // Scoped helper for saving & restoring scanner error state.
   // This is used for tagged template literals, in which normally forbidden

--- a/deps/v8/test/message/fail/hashbang-incomplete-string.js
+++ b/deps/v8/test/message/fail/hashbang-incomplete-string.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env d8
+// Copyright 2015 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+//
+
+const x = 'valid code';
+
+'incomplete string
+
+const y = 'even more valid code!';

--- a/deps/v8/test/message/fail/hashbang-incomplete-string.out
+++ b/deps/v8/test/message/fail/hashbang-incomplete-string.out
@@ -1,0 +1,5 @@
+*%(basename)s:10: SyntaxError: Invalid or unexpected token
+'incomplete string
+^^^^^^^^^^^^^^^^^^
+
+SyntaxError: Invalid or unexpected token


### PR DESCRIPTION
Original commit message:

    Fix scanner-level error reporting for hashbang

    When the file begins with a hashbang, the scanner is in a failed state
    when SkipHashbang() is called. This is usually not an issue but when
    the parser encounters an ILLEGAL token, it will reset the SyntaxError
    location because of it.

    Bug: v8:10110
    Change-Id: I1c7344bf5ad20079cff80130c991f3bff4d7e9a8
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1995312
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Commit-Queue: Toon Verwaest <verwaest@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#66038}

Refs: https://github.com/v8/v8/commit/f9257802c1c0a0663a1d05bacf662283f6bd9050
Fixes: https://github.com/nodejs/node/issues/31284
Signed-off-by: Matheus Marchini <mmarchini@netflix.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
