### PR TITLE
http: align destroy w streams

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -375,9 +375,6 @@ function _destroy(req, socket, err) {
     socket.destroy(err);
   } else {
     socket.emit('free');
-    if (!req.aborted && !err) {
-      err = connResetException('socket hang up');
-    }
     if (err) {
       req.emit('error', err);
     }
@@ -427,7 +424,7 @@ function socketCloseListener() {
       res.emit('close');
     }
   } else {
-    if (!req.socket._hadError) {
+    if (!req.destroyed && !req.socket._hadError) {
       // This socket error fired before we started to
       // receive a response. The error needs to
       // fire on the request.

--- a/test/parallel/test-http-client-abort-destroy.js
+++ b/test/parallel/test-http-client-abort-destroy.js
@@ -58,8 +58,7 @@ const assert = require('assert');
   server.listen(0, common.mustCall(() => {
     const options = { port: server.address().port };
     const req = http.get(options, common.mustNotCall());
-    req.on('error', common.mustCall((err) => {
-      assert.strictEqual(err.code, 'ECONNRESET');
+    req.on('close', common.mustCall((err) => {
       server.close();
     }));
     assert.strictEqual(req.aborted, false);

--- a/test/parallel/test-http-client-abort-keep-alive-queued-tcp-socket.js
+++ b/test/parallel/test-http-client-abort-keep-alive-queued-tcp-socket.js
@@ -29,13 +29,7 @@ for (const destroyer of ['destroy', 'abort']) {
     const req = http.get({ agent, port }, common.mustNotCall());
     req[destroyer]();
 
-    if (destroyer === 'destroy') {
-      req.on('error', common.mustCall((err) => {
-        assert.strictEqual(err.code, 'ECONNRESET');
-      }));
-    } else {
-      req.on('error', common.mustNotCall());
-    }
+    req.on('error', common.mustNotCall());
 
     http.get({ agent, port }, common.mustCall((res) => {
       res.resume();

--- a/test/parallel/test-http-client-close-event.js
+++ b/test/parallel/test-http-client-close-event.js
@@ -5,24 +5,15 @@ const common = require('../common');
 // event when a request is made and the socket is closed before we started to
 // receive a response.
 
-const assert = require('assert');
 const http = require('http');
 
 const server = http.createServer(common.mustNotCall());
 
 server.listen(0, common.mustCall(() => {
   const req = http.get({ port: server.address().port }, common.mustNotCall());
-  let errorEmitted = false;
 
-  req.on('error', common.mustCall((err) => {
-    errorEmitted = true;
-    assert.strictEqual(err.constructor, Error);
-    assert.strictEqual(err.message, 'socket hang up');
-    assert.strictEqual(err.code, 'ECONNRESET');
-  }));
-
+  req.on('error', common.mustNotCall());
   req.on('close', common.mustCall(() => {
-    assert.strictEqual(errorEmitted, true);
     server.close();
   }));
 

--- a/test/parallel/test-http-client-set-timeout.js
+++ b/test/parallel/test-http-client-set-timeout.js
@@ -36,4 +36,9 @@ server.listen(0, mustCall(() => {
   req.on('close', mustCall(() => {
     server.close();
   }));
+
+  req.on('timeout', mustCall(() => {
+    strictEqual(req.socket.listenerCount('timeout'), 1);
+    req.destroy();
+  }));
 }));

--- a/test/parallel/test-http-client-set-timeout.js
+++ b/test/parallel/test-http-client-set-timeout.js
@@ -3,7 +3,7 @@
 // Test that the `'timeout'` event is emitted exactly once if the `timeout`
 // option and `request.setTimeout()` are used together.
 
-const { expectsError, mustCall } = require('../common');
+const { mustNotCall, mustCall } = require('../common');
 const { strictEqual } = require('assert');
 const { createServer, get } = require('http');
 
@@ -31,18 +31,9 @@ server.listen(0, mustCall(() => {
     }));
   }));
 
-  req.on('error', expectsError({
-    name: 'Error',
-    code: 'ECONNRESET',
-    message: 'socket hang up'
-  }));
+  req.on('error', mustNotCall());
 
   req.on('close', mustCall(() => {
     server.close();
-  }));
-
-  req.on('timeout', mustCall(() => {
-    strictEqual(req.socket.listenerCount('timeout'), 1);
-    req.destroy();
   }));
 }));

--- a/test/parallel/test-http-client-timeout-on-connect.js
+++ b/test/parallel/test-http-client-timeout-on-connect.js
@@ -23,8 +23,7 @@ server.listen(0, common.localhostIPv4, common.mustCall(() => {
     }));
   }));
   req.on('timeout', common.mustCall(() => req.abort()));
-  req.on('error', common.mustCall((err) => {
-    assert.strictEqual(err.message, 'socket hang up');
+  req.on('close', common.mustCall((err) => {
     server.close();
   }));
 }));

--- a/test/parallel/test-http-writable-true-after-close.js
+++ b/test/parallel/test-http-writable-true-after-close.js
@@ -34,7 +34,7 @@ const server = createServer(common.mustCall((req, res) => {
     }));
   }).listen(0, () => {
     external = get(`http://127.0.0.1:${server.address().port}`);
-    external.on('error', common.mustCall(() => {
+    external.on('close', common.mustCall(() => {
       server.close();
       internal.close();
     }));

--- a/test/parallel/test-https-timeout.js
+++ b/test/parallel/test-https-timeout.js
@@ -51,11 +51,7 @@ const server = https.createServer(options, function() {
     console.log('got response');
   });
 
-  req.on('error', common.expectsError({
-    message: 'socket hang up',
-    code: 'ECONNRESET',
-    name: 'Error'
-  }));
+  req.on('error', common.mustNotCall());
 
   req.on('timeout', common.mustCall(function() {
     console.log('timeout occurred outside');


### PR DESCRIPTION
This further aligns ClientRequest with streams

Streams that are prematurely destroyed without
error through .destroy() do usually not emit
an error.

Align ClientRequest with this behavior.

This changes the behavior to not error when:

- `abort()` from `req.socket` has been assigned until `req.res` has been assigned.
- `destroy()` until `req.res` has been assigned.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
