### PR TITLE
dns: Add dns.ALL hints flag constant

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -209,6 +209,8 @@ configured. Loopback addresses are not considered.
 * `dns.V4MAPPED`: If the IPv6 family was specified, but no IPv6 addresses were
 found, then return IPv4 mapped IPv6 addresses. It is not supported
 on some operating systems (e.g FreeBSD 10.1).
+* `dns.ALL`: If `dns.V4MAPPED` is specified, return resolved IPv6 addresses as
+well as IPv4 mapped IPv6 addresses.
 
 ## `dns.lookupService(address, port, callback)`
 <!-- YAML

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -290,6 +290,7 @@ module.exports = {
 
   // uv_getaddrinfo flags
   ADDRCONFIG: cares.AI_ADDRCONFIG,
+  ALL: cares.AI_ALL,
   V4MAPPED: cares.AI_V4MAPPED,
 
   // ERROR CODES

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -10,7 +10,8 @@ const {
   ChannelWrap,
   strerror,
   AI_ADDRCONFIG,
-  AI_V4MAPPED
+  AI_ALL,
+  AI_V4MAPPED,
 } = internalBinding('cares_wrap');
 const IANA_DNS_PORT = 53;
 const IPv6RE = /^\[([^[\]]*)\]/;
@@ -136,10 +137,7 @@ function bindDefaultResolver(target, source) {
 }
 
 function validateHints(hints) {
-  if (hints !== 0 &&
-      hints !== AI_ADDRCONFIG &&
-      hints !== AI_V4MAPPED &&
-      hints !== (AI_ADDRCONFIG | AI_V4MAPPED)) {
+  if ((hints & ~(AI_ADDRCONFIG | AI_ALL | AI_V4MAPPED)) !== 0) {
     throw new ERR_INVALID_OPT_VALUE('hints', hints);
   }
 }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2877,11 +2877,7 @@ function initializeOptions(options) {
 
 function initializeTLSOptions(options, servername) {
   options = initializeOptions(options);
-  if (options.ALPNProtocols) {
-    options.ALPNProtocols.push('h2');
-  } else {
-    options.ALPNProtocols = ['h2'];
-  }
+  options.ALPNProtocols = ['h2'];
   if (options.allowHTTP1 === true)
     options.ALPNProtocols.push('http/1.1');
   if (servername !== undefined && options.servername === undefined)

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2877,7 +2877,11 @@ function initializeOptions(options) {
 
 function initializeTLSOptions(options, servername) {
   options = initializeOptions(options);
-  options.ALPNProtocols = ['h2'];
+  if (options.ALPNProtocols) {
+    options.ALPNProtocols.push('h2');
+  } else {
+    options.ALPNProtocols = ['h2'];
+  }
   if (options.allowHTTP1 === true)
     options.ALPNProtocols.push('http/1.1');
   if (servername !== undefined && options.servername === undefined)

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2188,6 +2188,9 @@ void Initialize(Local<Object> target,
                                                     "AI_ADDRCONFIG"),
               Integer::New(env->isolate(), AI_ADDRCONFIG)).Check();
   target->Set(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(),
+                                                    "AI_ALL"),
+              Integer::New(env->isolate(), AI_ALL)).Check();
+  target->Set(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(),
                                                     "AI_V4MAPPED"),
               Integer::New(env->isolate(), AI_V4MAPPED)).Check();
 

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -209,14 +209,14 @@ assert.deepStrictEqual(dns.getServers(), []);
 {
   /*
   * Make sure that dns.lookup throws if hints does not represent a valid flag.
-  * (dns.V4MAPPED | dns.ADDRCONFIG) + 1 is invalid because:
-  * - it's different from dns.V4MAPPED and dns.ADDRCONFIG.
-  * - it's different from them bitwise ored.
+  * (dns.V4MAPPED | dns.ADDRCONFIG | dns.ALL) + 1 is invalid because:
+  * - it's different from dns.V4MAPPED and dns.ADDRCONFIG and dns.ALL.
+  * - it's different from any subset of them bitwise ored.
   * - it's different from 0.
   * - it's an odd number different than 1, and thus is invalid, because
   * flags are either === 1 or even.
   */
-  const hints = (dns.V4MAPPED | dns.ADDRCONFIG) + 1;
+  const hints = (dns.V4MAPPED | dns.ADDRCONFIG | dns.ALL) + 1;
   const err = {
     code: 'ERR_INVALID_OPT_VALUE',
     name: 'TypeError',
@@ -254,11 +254,28 @@ dns.lookup('', {
   hints: dns.ADDRCONFIG | dns.V4MAPPED
 }, common.mustCall());
 
+dns.lookup('', {
+  hints: dns.ALL
+}, common.mustCall());
+
+dns.lookup('', {
+  hints: dns.V4MAPPED | dns.ALL
+}, common.mustCall());
+
+dns.lookup('', {
+  hints: dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL
+}, common.mustCall());
+
 (async function() {
   await dnsPromises.lookup('', { family: 4, hints: 0 });
   await dnsPromises.lookup('', { family: 6, hints: dns.ADDRCONFIG });
   await dnsPromises.lookup('', { hints: dns.V4MAPPED });
   await dnsPromises.lookup('', { hints: dns.ADDRCONFIG | dns.V4MAPPED });
+  await dnsPromises.lookup('', { hints: dns.ALL });
+  await dnsPromises.lookup('', { hints: dns.V4MAPPED | dns.ALL });
+  await dnsPromises.lookup('', {
+    hints: dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL
+  });
 })();
 
 {

--- a/test/parallel/test-net-connect-options-port.js
+++ b/test/parallel/test-net-connect-options-port.js
@@ -59,7 +59,7 @@ const net = require('net');
 // Test invalid hints
 {
   // connect({hint}, cb) and connect({hint})
-  const hints = (dns.ADDRCONFIG | dns.V4MAPPED) + 42;
+  const hints = (dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL) + 42;
   const hintOptBlocks = doConnect([{ hints }],
                                   () => common.mustNotCall());
   for (const fn of hintOptBlocks) {

--- a/test/parallel/test-tls-connect-hints-option.js
+++ b/test/parallel/test-tls-connect-hints-option.js
@@ -15,7 +15,11 @@ const hints = 512;
 
 assert.notStrictEqual(hints, dns.ADDRCONFIG);
 assert.notStrictEqual(hints, dns.V4MAPPED);
+assert.notStrictEqual(hints, dns.ALL);
 assert.notStrictEqual(hints, dns.ADDRCONFIG | dns.V4MAPPED);
+assert.notStrictEqual(hints, dns.ADDRCONFIG | dns.ALL);
+assert.notStrictEqual(hints, dns.V4MAPPED | dns.ALL);
+assert.notStrictEqual(hints, dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL);
 
 tls.connect({
   lookup: common.mustCall((host, options) => {


### PR DESCRIPTION
This change adds the `dns.ALL` flag and allows it to be passed in the `dns.lookup` hints option. I changed the relevant tests that I could find and added some basic documentation.

The documentation I wrote for that flag is based on how it is documented in `man 3 getaddrinfo`. However, the reason for this change is that we recently discovered that `getaddrinfo` (and therefore `dns.lookup`) behaves differently on different operating systems. In particular, on Linux it behaves as documented, but on Mac, the default behavior of `getaddrinfo` is as though the `AI_ADDRCONFIG` flag is set, and `AI_ALL` makes it act as though that flag is unset (i.e. the default Linux behavior). Setting `AI_ALL` appears to be the only way to get that behavior on Mac, and that is why I would like it to be available.

I am not sure if it would be better to explicitly document that part of the OS-specific behavior in the `dns` module documentation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
