### PR TITLE
test: mark test-timers-blocking-callback flaky on osx

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -15,6 +15,8 @@ test-worker-prof: PASS, FLAKY
 [$system==linux]
 
 [$system==macos]
+# https://github.com/nodejs/node/issues/21781
+test-timers-blocking-callback: PASS, FLAKY
 
 [$system==solaris] # Also applies to SmartOS
 


### PR DESCRIPTION
This is only for 10.15 but this test is periodically failing across
many CI runs. Would like to mark this as flaky so we can avoid lots
of red CI.

Refs: https://github.com/nodejs/node/issues/21781
