### PR TITLE
test: harden the tick sampling logic

### DIFF
--- a/test/sequential/test-worker-prof.js
+++ b/test/sequential/test-worker-prof.js
@@ -26,7 +26,7 @@ if (process.argv[2] === 'child') {
     if (counter++ === 10)
       process.exit(0);
      parentPort.postMessage(
-       fs.readFileSync(m.toString()).toString());
+       fs.readFileSync(m.toString()).slice(0, 1024 * 1024));
   });
   `;
 

--- a/test/sequential/test-worker-prof.js
+++ b/test/sequential/test-worker-prof.js
@@ -36,11 +36,6 @@ if (process.argv[2] === 'child') {
     w.postMessage(process.execPath);
   });
 
-  w.on('error', (e) => {
-    console.error(`worker exited with error: ${e}`);
-    process.exit(1);
-  });
-
   w.on('exit', common.mustCall(() => {
     files = fs.readdirSync(tmpdir.path);
     const wlog = files.filter((name) => /\.log$/.test(name) && name !== plog)[0];

--- a/test/sequential/test-worker-prof.js
+++ b/test/sequential/test-worker-prof.js
@@ -11,6 +11,7 @@ const { spawnSync } = require('child_process');
 // Refs: https://github.com/nodejs/node/issues/24016
 
 if (process.argv[2] === 'child') {
+  const fs = require('fs');
   let files = fs.readdirSync(tmpdir.path);
   const plog = files.filter((name) => /\.log$/.test(name))[0];
   if (plog === undefined) {
@@ -19,20 +20,25 @@ if (process.argv[2] === 'child') {
   }
   const pingpong = `
   let counter = 0;
+  const fs = require('fs');
   const { Worker, parentPort  } = require('worker_threads');
   parentPort.on('message', (m) => {
-    if (counter++ === 1024)
+    if (counter++ === 10)
       process.exit(0);
      parentPort.postMessage(
-       m.toString().split('').reverse().toString().replace(/,/g, ''));
+       fs.readFileSync(m.toString()).toString());
   });
   `;
 
   const { Worker } = require('worker_threads');
-  const data = 'x'.repeat(1024);
   const w = new Worker(pingpong, { eval: true });
   w.on('message', (m) => {
-    w.postMessage(m.toString().split('').reverse().toString().replace(/,/g, ''));
+    w.postMessage(process.execPath);
+  });
+
+  w.on('error', (e) => {
+    console.error(`worker exited with error: ${e}`);
+    process.exit(1);
   });
 
   w.on('exit', common.mustCall(() => {
@@ -45,7 +51,7 @@ if (process.argv[2] === 'child') {
     }
     process.exit(0);
   }));
-  w.postMessage(data);
+  w.postMessage(process.execPath);
 } else {
   tmpdir.refresh();
   const spawnResult = spawnSync(


### PR DESCRIPTION
Under peculiar system load conditions, the profiler thread
does not get enough CPU slices to perform the sampling.
Improve the interaction between worker and parent thread
by performing a large disc read, which is a better blend of
CPU and I/O bound work, than earlier versions.
This produces x10 more samples than the existing one,
in 10 iterations, as opposed to 1024.

Also capture worker error situations to improve debugging

Refs: https://github.com/nodejs/node/issues/26401#issuecomment-597438516

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
