### PR TITLE
net: don't discard elapsed stale time

### DIFF
--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -3,6 +3,7 @@
 const {
   Array,
   Symbol,
+  MathMax
 } = primordials;
 
 const { Buffer } = require('buffer');
@@ -26,7 +27,8 @@ const { owner_symbol } = require('internal/async_hooks').symbols;
 const {
   kTimeout,
   setUnrefTimeout,
-  getTimerDuration
+  getTimerDuration,
+  getLibuvNow
 } = require('internal/timers');
 const { isUint8Array } = require('internal/util/types');
 const { clearTimeout } = require('timers');
@@ -230,6 +232,12 @@ function setStreamTimeout(msecs, callback) {
   // Type checking identical to timers.enroll()
   msecs = getTimerDuration(msecs, 'msecs');
 
+  let after = msecs;
+  if (msecs && this[kTimeout]) {
+    const deadline = this[kTimeout]._idleStart + msecs;
+    after = MathMax(1, deadline - getLibuvNow());
+  }
+
   // Attempt to clear an existing timer in both cases -
   //  even if it will be rescheduled we don't want to leak an existing timer.
   clearTimeout(this[kTimeout]);
@@ -241,7 +249,11 @@ function setStreamTimeout(msecs, callback) {
       this.removeListener('timeout', callback);
     }
   } else {
-    this[kTimeout] = setUnrefTimeout(this._onTimeout.bind(this), msecs);
+    this[kTimeout] = setUnrefTimeout(this._onTimeout.bind(this), after);
+    // Update timeout time after timer has been scheduled so that a refresh
+    // gets the period duration.
+    this[kTimeout]._idleTimeout = msecs;
+
     if (this[kSession]) this[kSession][kUpdateTimer]();
 
     if (callback !== undefined) {

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -611,5 +611,6 @@ module.exports = {
   timerListMap,
   timerListQueue,
   decRefCount,
-  incRefCount
+  incRefCount,
+  getLibuvNow
 };

--- a/test/parallel/test-net-settimeout2.js
+++ b/test/parallel/test-net-settimeout2.js
@@ -25,9 +25,11 @@ const { performance } = require('perf_hooks');
       socket.setTimeout(1000);
     }, 500);
 
-    socket.on('timeout', () => {
+    socket.on('timeout', common.mustCall(() => {
       const elapsed = performance.now() - start;
       assert(elapsed < 1100);
-    });
+      server.close();
+      socket.destroy();
+    }));
   });
 }

--- a/test/parallel/test-net-settimeout2.js
+++ b/test/parallel/test-net-settimeout2.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../common');
+const net = require('net');
+const assert = require('assert');
+const { performance } = require('perf_hooks');
+
+{
+  // Updating timeout should not discard current stale time.
+  // This can be important if using http keep-alive and we know
+  // the server will kill connections after e.g. 2 min of inactivivity.
+  // If the user changes the socket timeout we could lose elapsed
+  // inativity time which increases the likelyhood of unexpected
+  // ECONNRESET from the server.
+  const server = net.createServer(common.mustCall((c) => {
+    c.write('hello');
+  }));
+
+  server.listen(0, function() {
+    const socket = net.createConnection(this.address().port, 'localhost');
+    socket.resume();
+    const start = performance.now();
+    socket.setTimeout(1000);
+    setTimeout(() => {
+      socket.setTimeout(1000);
+    }, 500);
+
+    socket.on('timeout', () => {
+      const elapsed = performance.now() - start;
+      assert(elapsed < 1100);
+    });
+  });
+}


### PR DESCRIPTION
  // Updating timeout should not discard current stale time.
  // This can be important if using http keep-alive and we know
  // the server will kill connections after e.g. 2 min of inactivivity.
  // If the user changes the socket timeout we could lose elapsed
  // inativity time which increases the likelyhood of unexpected
  // ECONNRESET from the server.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
