### PR TITLE
lib: cache timestamps in util.log()

### DIFF
--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -10,6 +10,11 @@ const { PerformanceEntry, notify } = internalBinding('performance');
 let nowCache;
 let utcCache;
 
+function date() {
+  if (!nowCache) return cache();
+  return new Date(nowCache);
+}
+
 function nowDate() {
   if (!nowCache) cache();
   return nowCache;
@@ -25,6 +30,7 @@ function cache() {
   nowCache = d.valueOf();
   utcCache = d.toUTCString();
   setUnrefTimeout(resetCache, 1000 - d.getMilliseconds());
+  return d;
 }
 
 function resetCache() {
@@ -51,6 +57,7 @@ function emitStatistics(statistics) {
 module.exports = {
   kOutHeaders: Symbol('kOutHeaders'),
   kNeedDrain: Symbol('kNeedDrain'),
+  date,
   nowDate,
   utcDate,
   emitStatistics

--- a/lib/util.js
+++ b/lib/util.js
@@ -52,6 +52,7 @@ const {
 const { debuglog } = require('internal/util/debuglog');
 const { validateNumber } = require('internal/validators');
 const { TextDecoder, TextEncoder } = require('internal/encoding');
+const { date } = require('internal/http');
 const { isBuffer } = require('buffer').Buffer;
 const types = require('internal/util/types');
 
@@ -117,7 +118,7 @@ const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
 
 // 26 Feb 16:19:34
 function timestamp() {
-  const d = new Date();
+  const d = date();
   const time = [pad(d.getHours()),
                 pad(d.getMinutes()),
                 pad(d.getSeconds())].join(':');


### PR DESCRIPTION
`new Date()` isn't necessarily cheap - it makes a system call to obtain
the current time - and the infrastructure to cache timestamps already
exists so use that.