### PR TITLE
stream: avoid destroying http1 objects

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -43,7 +43,7 @@ function isOutgoing(stream) {
 
 function destroyer(stream, reading, writing, final, callback) {
   const _destroy = once((err) => {
-    if (!err && ((isIncoming(stream) || isOutgoing(stream)))) {
+    if (!err && (isIncoming(stream) || isOutgoing(stream))) {
       // http/1 request objects have a coupling to their response and should
       // not be prematurely destroyed. Assume they will handle their own
       // lifecycle.

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -25,10 +25,32 @@ let EE;
 let PassThrough;
 let createReadableStreamAsyncIterator;
 
+function isIncoming(stream) {
+  return (
+    stream.socket &&
+    typeof stream._dump === 'function' &&
+    typeof stream._consuming === 'boolean' &&
+    ArrayIsArray(stream.rawHeaders)
+  );
+}
+
+function isOutgoing(stream) {
+  return (
+    stream.socket &&
+    typeof stream.setHeader === 'function'
+  );
+}
+
 function destroyer(stream, reading, writing, final, callback) {
   const _destroy = once((err) => {
-    const readable = stream.readable || isRequest(stream);
-    if (err || !final || !readable) {
+    if (!err && ((isIncoming(stream) || isOutgoing(stream)))) {
+      // http/1 request objects have a coupling to their response and should
+      // not be prematurely destroyed. Assume they will handle their own
+      // lifecycle.
+      return callback();
+    }
+
+    if (err || !final || !stream.readable) {
       destroyImpl.destroyer(stream, err);
     }
     callback(err);
@@ -69,10 +91,6 @@ function popCallback(streams) {
   if (typeof streams[streams.length - 1] !== 'function')
     throw new ERR_INVALID_CALLBACK(streams[streams.length - 1]);
   return streams.pop();
-}
-
-function isRequest(stream) {
-  return stream.setHeader && typeof stream.abort === 'function';
 }
 
 function isPromise(obj) {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -28,8 +28,8 @@ let createReadableStreamAsyncIterator;
 function isIncoming(stream) {
   return (
     stream.socket &&
-    typeof stream._dump === 'function' &&
-    typeof stream._consuming === 'boolean' &&
+    typeof stream.complete === 'boolean' &&
+    ArrayIsArray(stream.rawTrailers) &&
     ArrayIsArray(stream.rawHeaders)
   );
 }

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1011,3 +1011,24 @@ const { promisify } = require('util');
     assert.strictEqual(res, '');
   }));
 }
+
+{
+  const server = http.createServer((req, res) => {
+    req.socket.on('error', common.mustNotCall());
+    pipeline(req, new PassThrough(), (err) => {
+      assert(!err);
+      res.end();
+      server.close();
+    });
+  });
+
+  server.listen(0, () => {
+    const req = http.request({
+      method: 'PUT',
+      port: server.address().port
+    });
+    req.end('asd123');
+    req.on('response', common.mustCall());
+    req.on('error', common.mustNotCall());
+  });
+}

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1016,7 +1016,7 @@ const { promisify } = require('util');
   const server = http.createServer((req, res) => {
     req.socket.on('error', common.mustNotCall());
     pipeline(req, new PassThrough(), (err) => {
-      assert(!err);
+      assert.ifError(err);
       res.end();
       server.close();
     });


### PR DESCRIPTION
http1 objects are coupled with their corresponding
res/req and cannot be treated independently as
normal streams. Add a special exception for this
in the pipeline cleanup.

Fixes: https://github.com/nodejs/node/issues/32184

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
