### PR TITLE
doc: fix some 404 links

### DIFF
--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -121,7 +121,7 @@ included in the API docs will also be checked when running `make lint` (or
 use `REPLACEME` for the version number in the documentation YAML.
 
 For contributing C++ code, you may want to look at the
-[C++ Style Guide](../../cpp-style-guide.md), as well as the
+[C++ Style Guide](../cpp-style-guide.md), as well as the
 [README of `src/`](../../../src/README.md) for an overview over Node.js
 C++ internals.
 
@@ -582,14 +582,14 @@ If you want to know more about the code review and the landing process, see the
 [Collaborator Guide][].
 
 [approved]: #getting-approvals-for-your-pull-request
-[benchmark results]: ../../../benchmark/writing-and-running-benchmarks.md
+[benchmark results]: ../writing-and-running-benchmarks.md
 [Building guide]: ../../../BUILDING.md
 [CI (Continuous Integration) test run]: #ci-testing
 [Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
-[Collaborator Guide]: ../../../COLLABORATOR_GUIDE.md
+[Collaborator Guide]: ../collaborator-guide.md
 [guide for writing tests in Node.js]: ../writing-tests.md
 [hiding-a-comment]: https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment
 [https://ci.nodejs.org/]: https://ci.nodejs.org/
 [IRC in the #node-dev channel]: https://webchat.freenode.net?channels=node-dev&uio=d4
-[Onboarding guide]: ../../onboarding.md
+[Onboarding guide]: ../../../onboarding.md
 [running tests]: ../../../BUILDING.md#running-tests

--- a/onboarding.md
+++ b/onboarding.md
@@ -239,13 +239,13 @@ needs to be pointed out separately during the onboarding.
   the [summit](https://github.com/nodejs/summit) repository for details.
 
 [Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
-[`author-ready`]: https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md#author-ready-pull-requests
+[`author-ready`]: doc/guides/collaborator-guide.md#author-ready-pull-requests
 [`core-validate-commit`]: https://github.com/nodejs/core-validate-commit
 [`git-node`]: https://github.com/nodejs/node-core-utils/blob/master/docs/git-node.md
 [`node-core-utils`]: https://github.com/nodejs/node-core-utils
-[Landing Pull Requests]: https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md#landing-pull-requests
+[Landing Pull Requests]: doc/guides/collaborator-guide.md#landing-pull-requests
 [Publicizing or hiding organization membership]: https://help.github.com/articles/publicizing-or-hiding-organization-membership/
 [set up the credentials]: https://github.com/nodejs/node-core-utils#setting-up-credentials
 [two-factor authentication]: https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/
 [using a TOTP mobile app]: https://help.github.com/articles/configuring-two-factor-authentication-via-a-totp-mobile-app/
-[who-to-cc]: ../COLLABORATOR_GUIDE.md#who-to-cc-in-the-issue-tracker
+[who-to-cc]: doc/guides/collaborator-guide.md#who-to-cc-in-the-issue-tracker


### PR DESCRIPTION
I didn't check all of the `doc/guides` markdown files and I'm sure there is more than these, but a 404 link checker that can just check a sub-section of GitHub page structure is apparently not that easy to find, so I'll stop here to fix what I found.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)