### PR TITLE
report: handle on-fatalerror better

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -406,7 +406,7 @@ void OnFatalError(const char* location, const char* message) {
 
   Isolate* isolate = Isolate::GetCurrent();
   Environment* env = Environment::GetCurrent(isolate);
-  if (env == nullptr || env->isolate_data()->options()->report_on_fatalerror) {
+  if (per_process::cli_options->report_on_fatalerror) {
     report::TriggerNodeReport(
         isolate, env, message, "FatalError", "", Local<String>());
   }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -590,10 +590,6 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
             "generate diagnostic report upon receiving signals",
             &PerIsolateOptions::report_on_signal,
             kAllowedInEnvironment);
-  AddOption("--report-on-fatalerror",
-            "generate diagnostic report on fatal (internal) errors",
-            &PerIsolateOptions::report_on_fatalerror,
-            kAllowedInEnvironment);
   AddOption("--report-signal",
             "causes diagnostic report to be produced on provided signal,"
             " unsupported in Windows. (default: SIGUSR2)",
@@ -667,6 +663,10 @@ PerProcessOptionsParser::PerProcessOptionsParser(
   AddOption("--v8-options",
             "print V8 command line options",
             &PerProcessOptions::print_v8_help);
+  AddOption("--report-on-fatalerror",
+              "generate diagnostic report on fatal (internal) errors",
+              &PerProcessOptions::report_on_fatalerror,
+              kAllowedInEnvironment);
 
 #ifdef NODE_HAVE_I18N_SUPPORT
   AddOption("--icu-data-dir",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -186,7 +186,6 @@ class PerIsolateOptions : public Options {
   bool no_node_snapshot = false;
   bool report_uncaught_exception = false;
   bool report_on_signal = false;
-  bool report_on_fatalerror = false;
   bool report_compact = false;
   std::string report_signal = "SIGUSR2";
   std::string report_filename;
@@ -236,6 +235,7 @@ class PerProcessOptions : public Options {
   std::string use_largepages = "off";
   bool trace_sigint = false;
   std::vector<std::string> cmdline;
+  bool report_on_fatalerror = false;
 
   inline PerIsolateOptions* get_per_isolate_options();
   void CheckOptions(std::vector<std::string>* errors) override;

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -131,13 +131,13 @@ static void SetSignal(const FunctionCallbackInfo<Value>& info) {
 static void ShouldReportOnFatalError(const FunctionCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
   info.GetReturnValue().Set(
-      env->isolate_data()->options()->report_on_fatalerror);
+      node::per_process::cli_options->report_on_fatalerror);
 }
 
 static void SetReportOnFatalError(const FunctionCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
   CHECK(info[0]->IsBoolean());
-  env->isolate_data()->options()->report_on_fatalerror = info[0]->IsTrue();
+  node::per_process::cli_options->report_on_fatalerror = info[0]->IsTrue();
 }
 
 static void ShouldReportOnSignal(const FunctionCallbackInfo<Value>& info) {

--- a/test/report/test-report-fatal-error.js
+++ b/test/report/test-report-fatal-error.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 // Testcase to produce report on fatal error (javascript heap OOM)
 if (process.argv[2] === 'child') {

--- a/test/report/test-report-fatal-error.js
+++ b/test/report/test-report-fatal-error.js
@@ -20,17 +20,26 @@ if (process.argv[2] === 'child') {
   const helper = require('../common/report.js');
   const tmpdir = require('../common/tmpdir');
   tmpdir.refresh();
-  const spawn = require('child_process').spawn;
-  const args = ['--report-on-fatalerror',
-                '--max-old-space-size=20',
-                __filename,
-                'child'];
-  const child = spawn(process.execPath, args, { cwd: tmpdir.path });
-  child.on('exit', common.mustCall((code) => {
-    assert.notStrictEqual(code, 0, 'Process exited unexpectedly');
-    const reports = helper.findReports(child.pid, tmpdir.path);
-    assert.strictEqual(reports.length, 1);
-    const report = reports[0];
-    helper.validate(report);
-  }));
+  const spawnSync = require('child_process').spawnSync;
+  let args = ['--report-on-fatalerror',
+              '--max-old-space-size=20',
+              __filename,
+              'child'];
+
+  let child = spawnSync(process.execPath, args, { cwd: tmpdir.path });
+
+  assert.notStrictEqual(child.status, 0, 'Process exited unexpectedly');
+  let reports = helper.findReports(child.pid, tmpdir.path);
+  assert.strictEqual(reports.length, 1);
+  const report = reports[0];
+  helper.validate(report);
+
+  args = ['--max-old-space-size=20',
+          __filename,
+          'child'];
+
+  child = spawnSync(process.execPath, args, { cwd: tmpdir.path });
+  assert.notStrictEqual(child.status, 0, 'Process exited unexpectedly');
+  reports = helper.findReports(child.pid, tmpdir.path);
+  assert.strictEqual(reports.length, 0);
 }

--- a/test/report/test-report-fatal-error.js
+++ b/test/report/test-report-fatal-error.js
@@ -33,7 +33,6 @@ if (process.argv[2] === 'child') {
   assert.strictEqual(reports.length, 1);
   const report = reports[0];
   helper.validate(report);
- 
   // Verify that reports are not created on fatal error by default.
   args = ['--max-old-space-size=20',
           __filename,

--- a/test/report/test-report-fatal-error.js
+++ b/test/report/test-report-fatal-error.js
@@ -33,7 +33,8 @@ if (process.argv[2] === 'child') {
   assert.strictEqual(reports.length, 1);
   const report = reports[0];
   helper.validate(report);
-
+ 
+  // Verify that reports are not created on fatal error by default.
   args = ['--max-old-space-size=20',
           __filename,
           'child'];


### PR DESCRIPTION
--report-on-fatalerror was not honored properly, as there was no
way to check the value which was stored in the Environment pointer
which can be inaccessible under certain fatal error situations.

Move the flag out of Environment pointer so that this is doable.

Co-authored-by: Shobhit Chittora <schittora@paypal.com>

Fixes: https://github.com/nodejs/node/issues/31576
Refs: https://github.com/nodejs/node/pull/29881

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
