### PR TITLE
deps,doc: move openssl maintenance guide to doc

### DIFF
--- a/deps/openssl/README.md
+++ b/deps/openssl/README.md
@@ -76,4 +76,4 @@ Please refer [config/opensslconf_asm.h](config/opensslconf_asm.h) for details.
 
 ### Upgrading OpenSSL
 
-Please refer [config/README.md](config/README.md).
+Please refer to [maintaining-openssl](../../doc/guides/maintaining-openssl.md).

--- a/doc/guides/maintaining-openssl.md
+++ b/doc/guides/maintaining-openssl.md
@@ -1,44 +1,46 @@
-## Upgrading OpenSSL
+# Maintaining OpenSSL
 
-### Requirements
-- Linux environment (Only CentOS7.1 and Ubuntu16 are tested)
-- `perl` Only Perl version 5 is tested.
-- `nasm` (http://www.nasm.us/)  The version of 2.11 or higher is needed.
-- GNU `as` in binutils. The version of 2.26 or higher is needed.
+This document describes how to update `deps/openssl/`.
 
-### 0. Check Requirements
+## Requirements
+* Linux environment
+* `perl` Only Perl version 5 is tested.
+* `nasm` (http://www.nasm.us/)  The version of 2.11 or higher is needed.
+* GNU `as` in binutils. The version of 2.26 or higher is needed.
+
+## 0. Check Requirements
 
 ```sh
-$ perl -v
+% perl -v
 
 This is perl 5, version 22, subversion 1 (v5.22.1) built for
 x86_64-linux-gnu-thread-multi
 (with 60 registered patches, see perl -V for more detail)
 
-$ as --version
+% as --version
 GNU assembler (GNU Binutils for Ubuntu) 2.26.1
 Copyright (C) 2015 Free Software Foundation, Inc.
 ...
-$ nasm -v
+% nasm -v
 NASM version 2.11.08
 ```
 
-### 1. Obtain and extract new OpenSSL sources
+## 1. Obtain and extract new OpenSSL sources
 
 Get a new source from  https://www.openssl.org/source/ and extract
 all files into `deps/openssl/openssl`. Then add all files and commit
 them.
 ```sh
-$ cd deps/openssl/
-$ rm -rf openssl
-$ tar zxf ~/tmp/openssl-1.1.0h.tar.gz
-$ mv openssl-1.1.0h openssl
-$ git add --all openssl
-$ git commit openssl
+% cd deps/openssl/
+% rm -rf openssl
+% tar zxf ~/tmp/openssl-1.1.0h.tar.gz
+% mv openssl-1.1.0h openssl
+% git add --all openssl
+% git commit openssl
 ````
 
 The commit message can be (with the openssl version set to the relevant value):
-```
+```text
 deps: upgrade openssl sources to 1.1.0h
 
 This updates all sources in deps/openssl/openssl by:
@@ -50,22 +52,22 @@ This updates all sources in deps/openssl/openssl by:
     $ git commit openssl
 ```
 
-### 2. Execute `make` in `deps/openssl/config` directory
+## 2. Execute `make` in `deps/openssl/config` directory
 
 Use `make` to regenerate all platform dependent files in
 `deps/openssl/config/archs/`:
 ```sh
-$ cd deps/openssl/config; make
+% cd deps/openssl/config; make
 ```
 
-### 3. Check diffs
+## 3. Check diffs
 
 Check diffs if updates are right. Even if no updates in openssl
 sources, `buildinf.h` files will be updated for they have a timestamp
 data in them.
 ```sh
-$ cd deps/openssl/config
-$ git diff
+% cd deps/openssl/config
+% git diff
 ```
 
 *Note*: On Windows, OpenSSL Configure generates `makefile` that can be
@@ -75,20 +77,20 @@ created. When source files or build options are updated in Windows,
 it needs to change these two Makefiles by hand. If you are not sure,
 please ask @shigeki for details.
 
-### 4. Commit and make test
+## 4. Commit and make test
 
 Update all architecture dependent files. Do not forget to git add or remove
 files if they are changed before commit:
 ```sh
-$ git add deps/openssl/config/archs
-$ git add deps/openssl/openssl/crypto/include/internal/bn_conf.h
-$ git add deps/openssl/openssl/crypto/include/internal/dso_conf.h
-$ git add deps/openssl/openssl/include/openssl/opensslconf.h
-$ git commit
+% git add deps/openssl/config/archs
+% git add deps/openssl/openssl/crypto/include/internal/bn_conf.h
+% git add deps/openssl/openssl/crypto/include/internal/dso_conf.h
+% git add deps/openssl/openssl/include/openssl/opensslconf.h
+% git commit
 ```
 
 The commit message can be (with the openssl version set to the relevant value):
-```
+```text
  deps: update archs files for OpenSSL-1.1.0
 
  After an OpenSSL source update, all the config files need to be regenerated and
@@ -102,4 +104,4 @@ The commit message can be (with the openssl version set to the relevant value):
     $ git commit
 ```
 
-Finally, build Node and run tests.
+Finally, build Node.js and run tests.


### PR DESCRIPTION
The maintainenance guides are mostly in doc/guides-maintaining-*.md, so
move the OpenSSL one there, too.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
