### PR TITLE
[v13.x] zlib: emits 'close' event after readable 'end'

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -274,7 +274,7 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
   this._defaultFlushFlag = flush;
   this._finishFlushFlag = finishFlush;
   this._defaultFullFlushFlag = fullFlush;
-  this.once('end', _close.bind(null, this));
+  this.once('end', this.close);
   this._info = opts && opts.info;
 }
 ObjectSetPrototypeOf(ZlibBase.prototype, Transform.prototype);

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -171,7 +171,8 @@ zlib.createDeflateRaw({ windowBits: 8 });
       .pipe(zlib.createInflateRaw({ windowBits: 8 }))
       .on('data', (chunk) => reinflated.push(chunk))
       .on('end', common.mustCall(
-        () => assert(Buffer.concat(raw).equals(Buffer.concat(reinflated)))));
+        () => assert(Buffer.concat(raw).equals(Buffer.concat(reinflated)))))
+      .on('close', common.mustCall(1));
 }
 
 // For each of the files, make sure that compressing and


### PR DESCRIPTION
Call the close method after readable 'end' so that 'close' will be
emitted afterwards.

Fixes: https://github.com/nodejs/node/issues/32023

PR-URL: https://github.com/nodejs/node/pull/32050
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>