### PR TITLE
modules: deprecate module.parent

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2722,7 +2722,7 @@ if (require.main === module) {
 }
 ```
 
-When looking for the CJS modules that have required the current one,
+When looking for the CommonJS modules that have required the current one,
 `require.cache` and `module.children` can be used:
 
 ```js

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2719,22 +2719,11 @@ if (require.main === module) {
 ```
 
 When looking for the CJS modules that have required the current one,
-`module.children` can be used:
+`require.cache` and `module.children` can be used:
 
 ```js
-const moduleParents = [];
-function findCurrentModuleParents(moduleParent = require.main) {
-  if (moduleParent === undefined) {
-    // If the entry point is not CJS (E.G.: REPL or ESM), this function is no op
-    return;
-  }
-  const { children } = moduleParent;
-  if (children.includes(module)) {
-    moduleParents.push(moduleParent);
-  }
-  children.forEach(findCurrentModuleParents);
-}
-findCurrentModuleParents();
+const moduleParents = Object.values(require.cache)
+  .filter((m) => m.children.includes(module));
 ```
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2703,18 +2703,22 @@ native modules. It was incomplete so far and instead it's better to rely upon
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/32217
-    description: Runtime deprecation.
+    description: Documentation-only deprecation.
 -->
-A CJS module can access the first module that required it using `module.parent`.
-This feature does not work when a module is imported using ECMAScript modules
-specification, therefore it is deprecated.
+
+Type: Documentation-only (supports [`--pending-deprecation`][])
+
+A CommonJS module can access the first module that required it using
+`module.parent`. This feature is deprecated because it does not work
+consistently in the presence of ECMAScript modules and because it gives an
+inaccurate representation of the CommonJS module graph.
 
 Some modules use it to check if they are the entry point of the current process.
 Instead, it is recommended to compare `require.main` and `module`:
 
 ```js
 if (require.main === module) {
-  // CLI code runs here
+  // Code section that will run only if current file is the entry point.
 }
 ```
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -690,7 +690,6 @@ Module {
   id: '.',
   path: '/absolute/path/to',
   exports: {},
-  parent: null,
   filename: '/absolute/path/to/entry.js',
   loaded: false,
   children: [],
@@ -894,11 +893,17 @@ loading.
 ### `module.parent`
 <!-- YAML
 added: v0.1.16
+deprecated: REPLACEME
 -->
 
-* {module}
+> Stability: 0 - Deprecated: Please use [`require.main`][] and
+> [`module.children`][] instead.
 
-The module that first required this one.
+* {module | null | undefined}
+
+The module that first required this one, or `null` if the current module is the
+entry point of the current process, or `undefined` if the module was loaded by
+something that is not a CJS module (E.G.: REPL or `import`). Read only.
 
 ### `module.path`
 <!-- YAML
@@ -1122,6 +1127,7 @@ consists of the following keys:
 [`createRequire()`]: #modules_module_createrequire_filename
 [`module` object]: #modules_the_module_object
 [`module.id`]: #modules_module_id
+[`module.children`]: #modules_module_children
 [`path.dirname()`]: path.html#path_path_dirname_path
 [ECMAScript Modules]: esm.html
 [an error]: errors.html#errors_err_require_esm
@@ -1129,6 +1135,7 @@ consists of the following keys:
 [module resolution]: #modules_all_together
 [module wrapper]: #modules_the_module_wrapper
 [native addons]: addons.html
+[`require.main`]: #modules_require_main
 [source map include directives]: https://sourcemaps.info/spec.html#h.lmz475t4mvbx
 [`--enable-source-maps`]: cli.html#cli_enable_source_maps
 [`NODE_V8_COVERAGE=dir`]: cli.html#cli_node_v8_coverage_dir

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -903,7 +903,7 @@ deprecated: REPLACEME
 
 The module that first required this one, or `null` if the current module is the
 entry point of the current process, or `undefined` if the module was loaded by
-something that is not a CJS module (E.G.: REPL or `import`). Read only.
+something that is not a CommonJS module (E.G.: REPL or `import`). Read only.
 
 ### `module.path`
 <!-- YAML

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -238,11 +238,15 @@ let warned = false;
 ObjectDefineProperty(Module.prototype, 'parent', {
   get: function() {
     const parent = moduleParentCache.get(this);
-    if (!process.noDeprecation && !warned && parent == null) {
+    if (
+      !process.noDeprecation &&
+      !warned &&
+      (parent == null || pendingDeprecation)
+    ) {
       warned = true;
       process.emitWarning(
-        'module.parent is deprecated and may be removed in a later ' +
-          'version of Node.js.',
+        'module.parent is deprecated due to accuracy issues. Please use ' +
+          'require.main === module to check for CLI usage instead.',
         'DeprecationWarning',
         'DEP0143'
       );

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -234,15 +234,21 @@ ObjectDefineProperty(Module, 'wrapper', {
   }
 });
 
+let warned = false;
 ObjectDefineProperty(Module.prototype, 'parent', {
-  get: deprecate(
-    function() {
-      return moduleParentCache.get(this);
-    },
-    'Module.prototype.parent is deprecated and may be removed in a later ' +
-    'version of Node.js.',
-    'DEP0143'
-  )
+  get: function() {
+    const parent = moduleParentCache.get(this);
+    if (!process.noDeprecation && !warned && parent == null) {
+      warned = true;
+      process.emitWarning(
+        'module.parent is deprecated and may be removed in a later ' +
+          'version of Node.js.',
+        'DeprecationWarning',
+        'DEP0143'
+      );
+    }
+    return parent;
+  }
 });
 
 const debug = require('internal/util/debuglog').debuglog('module');

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -234,25 +234,16 @@ ObjectDefineProperty(Module, 'wrapper', {
   }
 });
 
-let warned = false;
+function getModuleParent() {
+  return moduleParentCache.get(this);
+}
 ObjectDefineProperty(Module.prototype, 'parent', {
-  get: function() {
-    const parent = moduleParentCache.get(this);
-    if (
-      !process.noDeprecation &&
-      !warned &&
-      (parent == null || pendingDeprecation)
-    ) {
-      warned = true;
-      process.emitWarning(
-        'module.parent is deprecated due to accuracy issues. Please use ' +
-          'require.main === module to check for CLI usage instead.',
-        'DeprecationWarning',
-        'DEP0143'
-      );
-    }
-    return parent;
-  }
+  get: pendingDeprecation ? deprecate(
+    getModuleParent,
+    'module.parent is deprecated due to accuracy issues. Please use ' +
+      'require.main to find program entry point instead.',
+    'DEP0143'
+  ) : getModuleParent
 });
 
 const debug = require('internal/util/debuglog').debuglog('module');

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -39,6 +39,7 @@ const {
   ReflectSet,
   RegExpPrototypeTest,
   SafeMap,
+  SafeWeakMap,
   String,
   StringPrototypeIndexOf,
   StringPrototypeMatch,
@@ -159,11 +160,12 @@ function updateChildren(parent, child, scan) {
     children.push(child);
 }
 
+const moduleParentCache = new SafeWeakMap();
 function Module(id = '', parent) {
   this.id = id;
   this.path = path.dirname(id);
   this.exports = {};
-  this.parent = parent;
+  moduleParentCache.set(this, parent);
   updateChildren(parent, this, false);
   this.filename = null;
   this.loaded = false;
@@ -230,6 +232,17 @@ ObjectDefineProperty(Module, 'wrapper', {
     patched = true;
     wrapperProxy = value;
   }
+});
+
+ObjectDefineProperty(Module.prototype, 'parent', {
+  get: deprecate(
+    function() {
+      return moduleParentCache.get(this);
+    },
+    'Module.prototype.parent is deprecated and may be removed in a later ' +
+    'version of Node.js.',
+    'DEP0143'
+  )
 });
 
 const debug = require('internal/util/debuglog').debuglog('module');
@@ -1018,7 +1031,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
   const requireStack = [];
   for (let cursor = parent;
     cursor;
-    cursor = cursor.parent) {
+    cursor = moduleParentCache.get(cursor)) {
     requireStack.push(cursor.filename || cursor.id);
   }
   let message = `Cannot find module '${request}'`;
@@ -1211,7 +1224,8 @@ Module._extensions['.js'] = function(module, filename) {
     const pkg = readPackageScope(filename);
     // Function require shouldn't be used in ES modules.
     if (pkg && pkg.data && pkg.data.type === 'module') {
-      const parentPath = module.parent && module.parent.filename;
+      const parent = moduleParentCache.get(module);
+      const parentPath = parent && parent.filename;
       const packageJsonPath = path.resolve(pkg.path, 'package.json');
       throw new ERR_REQUIRE_ESM(filename, parentPath, packageJsonPath);
     }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -59,12 +59,12 @@ if (process.argv.length === 2 &&
     !process.env.NODE_SKIP_FLAG_CHECK &&
     isMainThread &&
     hasCrypto &&
-    module.parent &&
+    require.main &&
     require('cluster').isMaster) {
   // The copyright notice is relatively big and the flags could come afterwards.
   const bytesToRead = 1500;
   const buffer = Buffer.allocUnsafe(bytesToRead);
-  const fd = fs.openSync(module.parent.filename, 'r');
+  const fd = fs.openSync(require.main.filename, 'r');
   const bytesRead = fs.readSync(fd, buffer, 0, bytesToRead);
   fs.closeSync(fd);
   const source = buffer.toString('utf8', 0, bytesRead);

--- a/test/common/require-as.js
+++ b/test/common/require-as.js
@@ -1,7 +1,7 @@
 /* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
-if (module.parent) {
+if (require.main !== module) {
   const { spawnSync } = require('child_process');
 
   function runModuleAs(filename, flags, spawnOptions, role) {

--- a/test/js-native-api/test_instance_data/test.js
+++ b/test/js-native-api/test_instance_data/test.js
@@ -4,7 +4,7 @@
 const common = require('../../common');
 const assert = require('assert');
 
-if (module.parent) {
+if (module !== require.main) {
   // When required as a module, run the tests.
   const test_instance_data =
     require(`./build/${common.buildType}/test_instance_data`);

--- a/test/node-api/test_instance_data/test.js
+++ b/test/node-api/test_instance_data/test.js
@@ -3,7 +3,7 @@
 
 const common = require('../../common');
 
-if (module.parent) {
+if (module !== require.main) {
   // When required as a module, run the tests.
   const test_instance_data =
     require(`./build/${common.buildType}/test_instance_data`);

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-if (module.parent) {
+if (module !== require.main) {
   // Signal we've been loaded as a module.
   // The following console.log() is part of the test.
   console.log('Loaded as a module, exiting with status code 42.');

--- a/test/parallel/test-module-parent-deprecation.js
+++ b/test/parallel/test-module-parent-deprecation.js
@@ -1,3 +1,5 @@
+// Flags: --pending-deprecation
+
 'use strict';
 const common = require('../common');
 const assert = require('assert');
@@ -5,7 +7,7 @@ const assert = require('assert');
 common.expectWarning(
   'DeprecationWarning',
   'module.parent is deprecated due to accuracy issues. Please use ' +
-          'require.main === module to check for CLI usage instead.',
+    'require.main to find program entry point instead.',
   'DEP0143'
 );
 

--- a/test/parallel/test-module-parent-deprecation.js
+++ b/test/parallel/test-module-parent-deprecation.js
@@ -4,8 +4,8 @@ const assert = require('assert');
 
 common.expectWarning(
   'DeprecationWarning',
-  'module.parent is deprecated and may be removed in a later ' +
-  'version of Node.js.',
+  'module.parent is deprecated due to accuracy issues. Please use ' +
+          'require.main === module to check for CLI usage instead.',
   'DEP0143'
 );
 

--- a/test/parallel/test-module-parent-deprecation.js
+++ b/test/parallel/test-module-parent-deprecation.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 common.expectWarning(
   'DeprecationWarning',
-  'Module.prototype.parent is deprecated and may be removed in a later ' +
+  'module.parent is deprecated and may be removed in a later ' +
   'version of Node.js.',
   'DEP0143'
 );

--- a/test/parallel/test-module-parent-deprecation.js
+++ b/test/parallel/test-module-parent-deprecation.js
@@ -1,0 +1,12 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+common.expectWarning(
+  'DeprecationWarning',
+  'Module.prototype.parent is deprecated and may be removed in a later ' +
+  'version of Node.js.',
+  'DEP0143'
+);
+
+assert.strictEqual(module.parent, null);


### PR DESCRIPTION
This feature does not work when a module is imported using ECMAScript modules
specification, therefore it is deprecated.

This has been discussed during [Node.js Modules Team Meeting 2020-03-11](https://docs.google.com/document/d/1KZBgLnJn3ZejOIitOqTylXwKdCBZ7Byka9T3fUch3wU/view); the main issue with this feature is that users are using it to check if the current module is the entry point, but that breaks when a CJS module is imported using ESM loader. Also its behaviour is kind of counterintuitive because of CJS cache.

This PR contains a breaking change: `Object.keys(module).includes('parent')` used to be `true`, and is now `false`. Hopefully this can get merged before v14 feature freeze.

Fixes: https://github.com/nodejs/modules/issues/469

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
