### PR TITLE
zlib: align with streams

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -55,6 +55,7 @@ const {
 } = require('internal/util/types');
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');
+const finished = require('internal/streams/end-of-stream');
 const {
   Buffer,
   kMaxLength
@@ -62,6 +63,7 @@ const {
 const { owner_symbol } = require('internal/async_hooks').symbols;
 
 const kFlushFlag = Symbol('kFlushFlag');
+const kSyncError = Symbol('kSyncError');
 
 const constants = internalBinding('constants').zlib;
 const {
@@ -173,14 +175,15 @@ function zlibOnError(message, errno, code) {
   const self = this[owner_symbol];
   // There is no way to cleanly recover.
   // Continuing only obscures problems.
-  _close(self);
-  self._hadError = true;
 
   // eslint-disable-next-line no-restricted-syntax
   const error = new Error(message);
   error.errno = errno;
   error.code = code;
-  self.emit('error', error);
+  self.destroy(error);
+
+  // Hack for processChunkSync error.
+  self.emit(kSyncError, error);
 }
 
 // 1. Returns false for undefined and NaN
@@ -260,8 +263,7 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
     }
   }
 
-  Transform.call(this, { autoDestroy: false, ...opts });
-  this._hadError = false;
+  Transform.call(this, { autoDestroy: true, ...opts });
   this.bytesWritten = 0;
   this._handle = handle;
   handle[owner_symbol] = this;
@@ -274,7 +276,6 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
   this._defaultFlushFlag = flush;
   this._finishFlushFlag = finishFlush;
   this._defaultFullFlushFlag = fullFlush;
-  this.once('end', this.close);
   this._info = opts && opts.info;
 }
 ObjectSetPrototypeOf(ZlibBase.prototype, Transform.prototype);
@@ -368,7 +369,7 @@ ZlibBase.prototype.flush = function(kind, callback) {
 };
 
 ZlibBase.prototype.close = function(callback) {
-  _close(this, callback);
+  if (callback) finished(this, callback);
   this.destroy();
 };
 
@@ -418,7 +419,10 @@ function processChunkSync(self, chunk, flushFlag) {
   const chunkSize = self._chunkSize;
 
   let error;
-  self.on('error', function onError(er) {
+  self.on('error', () => {
+    // Block unhandled exception error.
+  });
+  self.on(kSyncError, function onError(er) {
     error = er;
   });
 
@@ -512,7 +516,7 @@ function processCallback() {
   const self = this[owner_symbol];
   const state = self._writeState;
 
-  if (self._hadError || self.destroyed) {
+  if (self.destroyed) {
     this.buffer = null;
     this.cb();
     return;
@@ -578,10 +582,7 @@ function processCallback() {
   this.cb();
 }
 
-function _close(engine, callback) {
-  if (callback)
-    process.nextTick(callback);
-
+function _close(engine) {
   // Caller may invoke .close after a zlib error (which will null _handle).
   if (!engine._handle)
     return;
@@ -678,7 +679,7 @@ ObjectSetPrototypeOf(Zlib, ZlibBase);
 function paramsAfterFlushCallback(level, strategy, callback) {
   assert(this._handle, 'zlib binding closed');
   this._handle.params(level, strategy);
-  if (!this._hadError) {
+  if (!this.destroyed) {
     this._level = level;
     this._strategy = strategy;
     if (callback) callback();

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -63,6 +63,7 @@ const {
 const { owner_symbol } = require('internal/async_hooks').symbols;
 
 const kFlushFlag = Symbol('kFlushFlag');
+const kError = Symbol('kError');
 
 const constants = internalBinding('constants').zlib;
 const {
@@ -180,7 +181,7 @@ function zlibOnError(message, errno, code) {
   error.errno = errno;
   error.code = code;
   self.destroy(error);
-  self._error = error;
+  self[kError] = error;
 }
 
 // 1. Returns false for undefined and NaN
@@ -261,7 +262,7 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
   }
 
   Transform.call(this, { autoDestroy: true, ...opts });
-  this._error = null;
+  this[kError] = null;
   this.bytesWritten = 0;
   this._handle = handle;
   handle[owner_symbol] = this;
@@ -431,8 +432,8 @@ function processChunkSync(self, chunk, flushFlag) {
                      availOutBefore); // out_len
     if (error)
       throw error;
-    else if (self._error)
-      throw self._error;
+    else if (self[kError])
+      throw self[kError];
 
     availOutAfter = state[0];
     availInAfter = state[1];

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -63,7 +63,6 @@ const {
 const { owner_symbol } = require('internal/async_hooks').symbols;
 
 const kFlushFlag = Symbol('kFlushFlag');
-const kSyncError = Symbol('kSyncError');
 
 const constants = internalBinding('constants').zlib;
 const {
@@ -181,9 +180,7 @@ function zlibOnError(message, errno, code) {
   error.errno = errno;
   error.code = code;
   self.destroy(error);
-
-  // Hack for processChunkSync error.
-  self.emit(kSyncError, error);
+  self._error = error;
 }
 
 // 1. Returns false for undefined and NaN
@@ -264,6 +261,7 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
   }
 
   Transform.call(this, { autoDestroy: true, ...opts });
+  this._error = null;
   this.bytesWritten = 0;
   this._handle = handle;
   handle[owner_symbol] = this;
@@ -419,10 +417,7 @@ function processChunkSync(self, chunk, flushFlag) {
   const chunkSize = self._chunkSize;
 
   let error;
-  self.on('error', () => {
-    // Block unhandled exception error.
-  });
-  self.on(kSyncError, function onError(er) {
+  self.on('error', function onError(er) {
     error = er;
   });
 
@@ -436,6 +431,8 @@ function processChunkSync(self, chunk, flushFlag) {
                      availOutBefore); // out_len
     if (error)
       throw error;
+    else if (self._error)
+      throw self._error;
 
     availOutAfter = state[0];
     availInAfter = state[1];

--- a/test/parallel/test-zlib-destroy.js
+++ b/test/parallel/test-zlib-destroy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 
 const assert = require('assert');
 const zlib = require('zlib');
@@ -8,6 +8,24 @@ const zlib = require('zlib');
 // Verify that the zlib transform does clean up
 // the handle when calling destroy.
 
-const ts = zlib.createGzip();
-ts.destroy();
-assert.strictEqual(ts._handle, null);
+{
+  const ts = zlib.createGzip();
+  ts.destroy();
+  assert.strictEqual(ts._handle, null);
+
+  ts.on('close', common.mustCall(() => {
+    ts.close(common.mustCall());
+  }));
+}
+
+{
+  // Ensure 'error' is only emitted once.
+  const decompress = zlib.createGunzip(15);
+
+  decompress.on('error', common.mustCall((err) => {
+    decompress.close();
+  }));
+
+  decompress.write('something invalid');
+  decompress.destroy(new Error('asd'));
+}


### PR DESCRIPTION
- Ensure automatic destruction only happens after both
'end' and 'finish' has been emitted through autoDestroy.
- Ensure close() callback is always invoked.
- Ensure 'error' is only emitted once.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
