### PR TITLE
esm: implement import.meta.main

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -784,8 +784,10 @@ import _ from 'data:application/json,"world!"';
 * {Object}
 
 The `import.meta` metaproperty is an `Object` that contains the following
-property:
+properties:
 
+* `main` {boolean} `true` when the current module is the entry point of
+  the current process.
 * `url` {string} The absolute `file:` URL of the module.
 
 ## Differences Between ES Modules and CommonJS
@@ -819,6 +821,8 @@ import { dirname } from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 ```
+
+Equivalent of `require.main === module` is [`import.meta.main`][].
 
 ### No `require.resolve`
 
@@ -1694,6 +1698,7 @@ success!
 [`getFormat` hook]: #esm_code_getformat_code_hook
 [`import()`]: #esm_import-expressions
 [`import.meta.url`]: #esm_import_meta
+[`import.meta.main`]: #esm_import_meta
 [`import`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 [`module.createRequire()`]: modules.html#modules_module_createrequire_filename
 [`module.syncBuiltinESMExports()`]: modules.html#modules_module_syncbuiltinesmexports

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -3,6 +3,8 @@
 /* global WebAssembly */
 
 const {
+  Boolean,
+  FunctionPrototypeBind,
   JSONParse,
   ObjectKeys,
   SafeMap,
@@ -66,11 +68,12 @@ function initializeImportMeta(meta, { url }) {
   // Alphabetical
   if (experimentalImportMetaResolve)
     meta.resolve = createImportMetaResolve(url);
+  meta.main = Boolean(this?.isMain);
   meta.url = url;
 }
 
 // Strategy for loading a standard JavaScript module
-translators.set('module', async function moduleStrategy(url) {
+translators.set('module', async function moduleStrategy(url, isMain) {
   let { source } = await this._getSource(
     url, { format: 'module' }, defaultGetSource);
   source = `${source}`;
@@ -80,7 +83,9 @@ translators.set('module', async function moduleStrategy(url) {
   debug(`Translating StandardModule ${url}`);
   const module = new ModuleWrap(url, undefined, source, 0, 0);
   moduleWrap.callbackMap.set(module, {
-    initializeImportMeta,
+    initializeImportMeta: isMain ?
+      FunctionPrototypeBind(initializeImportMeta, { isMain }) :
+      initializeImportMeta,
     importModuleDynamically,
   });
   return module;

--- a/test/es-module/test-esm-import-meta-main.mjs
+++ b/test/es-module/test-esm-import-meta-main.mjs
@@ -1,0 +1,11 @@
+import { mustCall } from '../common/index.mjs';
+import fixtures from '../common/fixtures.js';
+import assert from 'assert';
+
+assert.strictEqual(import.meta.main, true);
+
+import(fixtures.path('/es-modules/import-meta-main.mjs')).then(
+  mustCall(({ isMain }) => {
+    assert.strictEqual(isMain, false);
+  })
+);

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -3,7 +3,7 @@ import assert from 'assert';
 
 assert.strictEqual(Object.getPrototypeOf(import.meta), null);
 
-const keys = ['url'];
+const keys = ['main', 'url'];
 assert.deepStrictEqual(Reflect.ownKeys(import.meta), keys);
 
 const descriptors = Object.getOwnPropertyDescriptors(import.meta);

--- a/test/fixtures/es-modules/import-meta-main.mjs
+++ b/test/fixtures/es-modules/import-meta-main.mjs
@@ -1,0 +1,1 @@
+export const isMain = import.meta.main;


### PR DESCRIPTION
Boolean value to check if a module is run as entry point of the current
process.

ES module authors need a way to determine if their code is run as CLI or as a dependency. nodejs/node#49440 have some proposal, I am implementing `import.meta.main` because:

- it is arguably similar to the CJS pattern:
```diff
- if (module === require.main) {
+ if (import.meta.main) {
```
- Deno has already implemented it, if we don't differ that is certainly easier for users to write code that runs everywhere.
- It was suggested originally in the [`import.meta` proposal](https://github.com/tc39/proposal-import-meta#am-i-the-main-module).

Fixes: https://github.com/nodejs/node/issues/49440

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
