### PR TITLE
doc: deprecate process.mainModule

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2617,6 +2617,22 @@ async function openAndClose() {
 }
 ```
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: `process.mainModule`
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+[`process.mainModule`][] is a CJS-only feature while `process` global object is
+shared with non-CJS environment.
+
+It's safe to use [`require.main`][] as a replacement.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
@@ -2674,8 +2690,10 @@ async function openAndClose() {
 [`os.networkInterfaces()`]: os.html#os_os_networkinterfaces
 [`os.tmpdir()`]: os.html#os_os_tmpdir
 [`process.env`]: process.html#process_process_env
+[`process.mainModule`]: process.html#process_process_mainmodule
 [`punycode`]: punycode.html
 [`require.extensions`]: modules.html#modules_require_extensions
+[`require.main`]: modules.html#modules_accessing_the_main_module
 [`request.socket`]: http.html#http_request_socket
 [`request.connection`]: http.html#http_request_connection
 [`response.socket`]: http.html#http_response_socket

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2622,7 +2622,7 @@ async function openAndClose() {
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32232
     description: Documentation-only deprecation.
 -->
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2628,9 +2628,9 @@ changes:
 
 Type: Documentation-only
 
-[`process.mainModule`][] is a CommonJS-only feature while `process` global object is
-shared with non-CommonJS environment. Its use within ECMAScript modules is
-unsupported.
+[`process.mainModule`][] is a CommonJS-only feature while `process` global
+object is shared with non-CommonJS environment. Its use within ECMAScript
+modules is unsupported.
 
 It is deprecated in favor of [`require.main`][], because it serves the same
 purpose and is only available on CommonJS environment.

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2628,10 +2628,12 @@ changes:
 
 Type: Documentation-only
 
-[`process.mainModule`][] is a CJS-only feature while `process` global object is
-shared with non-CJS environment.
+[`process.mainModule`][] is a CommonJS-only feature while `process` global object is
+shared with non-CommonJS environment. Its use within ECMAScript modules is
+unsupported.
 
-It's safe to use [`require.main`][] as a replacement.
+It is deprecated in favor of [`require.main`][], because it serves the same
+purpose and is only available on CommonJS environment.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1499,7 +1499,10 @@ debugger. See [Signal Events][].
 ## `process.mainModule`
 <!-- YAML
 added: v0.1.17
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated: Use [`require.main`][] instead.
 
 * {Object}
 


### PR DESCRIPTION
Soft deprecate `process.mainModule` in favor of `require.main`:

* both refers most of the time to the same `Module` instance.
* `Module` is a CJS-specific API, while `process` is available on non-CJS env.

IMHO deprecating it simplifies the Node.js API (there used to be 2 recommended ways to do the same thing, now there's only one), and it would make more sens to have a clear separation between CJS API and the rest of Node.js'.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
