### PR TITLE
test: workaround for V8 8.1 inspector pause issue

### DIFF
--- a/test/fixtures/inspector-global-function.js
+++ b/test/fixtures/inspector-global-function.js
@@ -10,4 +10,8 @@ global.sum = function() {
   console.log(invocations++, c);
 };
 
+// NOTE(mmarchini): Calls console.log two times to ensure we loaded every
+// internal module before pausing. See
+// https://bugs.chromium.org/p/v8/issues/detail?id=10287.
+console.log('Loading');
 console.log('Ready!');

--- a/test/parallel/test-inspector-multisession-ws.js
+++ b/test/parallel/test-inspector-multisession-ws.js
@@ -20,6 +20,7 @@ session.on('Debugger.paused', () => {
 session.connect();
 session.post('Debugger.enable');
 console.log('Ready');
+console.log('Ready');
 `;
 
 async function setupSession(node) {
@@ -46,6 +47,10 @@ async function testSuspend(sessionA, sessionB) {
   await sessionA.waitForNotification('Debugger.paused', 'Initial pause');
   sessionA.send({ 'method': 'Debugger.resume' });
 
+  await sessionA.waitForNotification('Runtime.consoleAPICalled',
+                                     'Console output');
+  // NOTE(mmarchini): Remove second console.log when
+  // https://bugs.chromium.org/p/v8/issues/detail?id=10287 is fixed.
   await sessionA.waitForNotification('Runtime.consoleAPICalled',
                                      'Console output');
   sessionA.send({ 'method': 'Debugger.pause' });


### PR DESCRIPTION
`test-inspector-multisession-ws` and `test-inspector-break-when-eval`
will be affected by an upstream bug when we upgrade V8 to 8.1. The bug
is caused when the Inspector sets a pause at the start of a function
compiled with `CompileFunctionInContext`, but that function hasn't been
executed yet.

On both tests, this issue is triggered by pausing while in C++ executing
LookupAndCompile, which is called by requiring internal modules while
running `console.log`. To eliminate this issue in both tests, we add an
extra `console.log` to ensure we only pause we required all internal
modules we need. On `test-inspector-break-when-eval`, we also need to
start the child process with `--inspect-brk` instead of `--inspect` to
ensure the test is predictable (this test would occasianlly fail on
slower machines, when console.log doesn't run fast enough to finish
after emitting `Runtime.consoleAPICalled` and before the parent process
sending `Runtime.evaluate` message.

Ref: https://bugs.chromium.org/p/v8/issues/detail?id=10287

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
