### PR TITLE
esm: add gotcha to documentation

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -803,14 +803,18 @@ property:
 
 ### Absolute file paths don't work on Windows
 
-Note that `import` accepts _absolute specifiers_. These are similar to _absolute paths_ on linux and MacOS, and therefore they are also accepted. But on Windows, importing an _absolute path_ to a file will not work. Therefore, to ensure cross platform compatibility, be sure to turn your file paths into urls, like so:
+`import` accepts _absolute specifiers_. These are similar to _absolute paths_
+on linux and MacOS, and therefore they are also accepted.
+But on Windows, importing an _absolute path_ to a file will not work.
+To ensure cross platform compatibility, file paths should be converted into
+URLs.
 
-```
+```js
 import { pathToFileURL } from 'url';
 
-const fileUrl = pathToFileURL(...your path here...).href;
+const fileUrl = pathToFileURL('c:\\path\\to\\file.js').href;
 
-await import(fileUrl)
+await import(fileUrl);
 ```
 
 ### Mandatory file extensions

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -801,6 +801,18 @@ property:
 
 ## Differences Between ES Modules and CommonJS
 
+### Absolute file paths don't work on Windows
+
+Note that `import` accepts _absolute specifiers_. These are similar to _absolute paths_ on linux and MacOS, and therefore they are also accepted. But on Windows, importing an _absolute path_ to a file will not work. Therefore, to ensure cross platform compatibility, be sure to turn your file paths into urls, like so:
+
+```
+import { pathToFileURL } from 'url';
+
+const fileUrl = pathToFileURL(...your path here...).href;
+
+await import(fileUrl)
+```
+
 ### Mandatory file extensions
 
 A file extension must be provided when using the `import` keyword. Directory


### PR DESCRIPTION
Update es module documentation in accordance to https://github.com/nodejs/node/issues/31710 by providing a gotcha for windows users

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
