### PR TITLE
src: fix warn_unused_result compiler warning

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -383,8 +383,8 @@ int FileHandle::ReadStart() {
       // Use a fresh async resource.
       // Lifetime is ensured via AsyncWrap::resource_.
       Local<Object> resource = Object::New(env()->isolate());
-      resource->Set(
-          env()->context(), env()->handle_string(), read_wrap->object());
+      USE(resource->Set(
+          env()->context(), env()->handle_string(), read_wrap->object()));
       read_wrap->AsyncReset(resource);
       read_wrap->file_handle_ = this;
     } else {


### PR DESCRIPTION
```
../src/node_file.cc:386:7: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
```

Refs: https://github.com/nodejs/node/pull/31972

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)