### PR TITLE
src,cli: support compact (one-line) JSON reports

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -592,6 +592,15 @@ file will be created if it does not exist, and will be appended to if it does.
 If an error occurs while attempting to write the warning to the file, the
 warning will be written to stderr instead.
 
+### `--report-compact`
+<!-- YAML
+added: REPLACEME
+-->
+
+Write reports in a compact format, single-line JSON, more easily consumable
+by log processing systems than the default multi-line format designed for
+human consumption.
+
 ### `--report-directory=directory`
 <!-- YAML
 added: v11.8.0
@@ -1136,6 +1145,7 @@ Node.js options that are allowed are:
 * `--preserve-symlinks`
 * `--prof-process`
 * `--redirect-warnings`
+* `--report-compact`
 * `--report-directory`
 * `--report-filename`
 * `--report-on-fatalerror`

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1795,6 +1795,21 @@ changes:
 reports for the current process. Additional documentation is available in the
 [report documentation][].
 
+### `process.report.compact`
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+Write reports in a compact format, single-line JSON, more easily consumable
+by log processing systems than the default multi-line format designed for
+human consumption.
+
+```js
+console.log(`Reports are compact? ${process.report.compact}`);
+```
+
 ### `process.report.directory`
 <!-- YAML
 added: v11.12.0

--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -419,6 +419,10 @@ that leads to termination of the application. Useful to inspect various
 diagnostic data elements such as heap, stack, event loop state, resource
 consumption etc. to reason about the fatal error.
 
+* `--report-compact` Write reports in a compact format, single-line JSON, more
+easily consumable by log processing systems than the default multi-line format
+designed for human consumption.
+
 * `--report-directory` Location at which the report will be
 generated.
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -281,6 +281,11 @@ Write process warnings to the given
 .Ar file
 instead of printing to stderr.
 .
+.It Fl -report-compact
+Write
+.Sy diagnostic reports
+in a compact format, single-line JSON.
+.
 .It Fl -report-directory
 Location at which the
 .Sy diagnostic report

--- a/lib/internal/process/report.js
+++ b/lib/internal/process/report.js
@@ -3,7 +3,11 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_SYNTHETIC
 } = require('internal/errors').codes;
-const { validateSignalName, validateString } = require('internal/validators');
+const {
+  validateSignalName,
+  validateString,
+  validateBoolean,
+} = require('internal/validators');
 const nr = internalBinding('report');
 const {
   JSONParse,
@@ -44,6 +48,13 @@ const report = {
   set filename(name) {
     validateString(name, 'filename');
     nr.setFilename(name);
+  },
+  get compact() {
+    return nr.getCompact();
+  },
+  set compact(b) {
+    validateBoolean(b, 'compact');
+    nr.setCompact(b);
   },
   get signal() {
     return nr.getSignal();

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -577,6 +577,10 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
             "generate diagnostic report on uncaught exceptions",
             &PerIsolateOptions::report_uncaught_exception,
             kAllowedInEnvironment);
+  AddOption("--report-compact",
+            "output compact single-line JSON",
+            &PerIsolateOptions::report_compact,
+            kAllowedInEnvironment);
   AddOption("--report-on-signal",
             "generate diagnostic report upon receiving signals",
             &PerIsolateOptions::report_on_signal,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -187,6 +187,7 @@ class PerIsolateOptions : public Options {
   bool report_uncaught_exception = false;
   bool report_on_signal = false;
   bool report_on_fatalerror = false;
+  bool report_compact = false;
   std::string report_signal = "SIGUSR2";
   std::string report_filename;
   std::string report_directory;

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -52,7 +52,8 @@ static void WriteNodeReport(Isolate* isolate,
                             const char* trigger,
                             const std::string& filename,
                             std::ostream& out,
-                            Local<String> stackstr);
+                            Local<String> stackstr,
+                            bool compact);
 static void PrintVersionInformation(JSONWriter* writer);
 static void PrintJavaScriptStack(JSONWriter* writer,
                                  Isolate* isolate,
@@ -126,8 +127,9 @@ std::string TriggerNodeReport(Isolate* isolate,
     std::cerr << "\nWriting Node.js report to file: " << filename;
   }
 
+  bool compact = env != nullptr ? options->report_compact : true;
   WriteNodeReport(isolate, env, message, trigger, filename, *outstream,
-                  stackstr);
+                  stackstr, compact);
 
   // Do not close stdout/stderr, only close files we opened.
   if (outfile.is_open()) {
@@ -145,7 +147,7 @@ void GetNodeReport(Isolate* isolate,
                    const char* trigger,
                    Local<String> stackstr,
                    std::ostream& out) {
-  WriteNodeReport(isolate, env, message, trigger, "", out, stackstr);
+  WriteNodeReport(isolate, env, message, trigger, "", out, stackstr, false);
 }
 
 // Internal function to coordinate and write the various
@@ -156,7 +158,8 @@ static void WriteNodeReport(Isolate* isolate,
                             const char* trigger,
                             const std::string& filename,
                             std::ostream& out,
-                            Local<String> stackstr) {
+                            Local<String> stackstr,
+                            bool compact) {
   // Obtain the current time and the pid.
   TIME_TYPE tm_struct;
   DiagnosticFilename::LocalTime(&tm_struct);
@@ -169,7 +172,7 @@ static void WriteNodeReport(Isolate* isolate,
   // File stream opened OK, now start printing the report content:
   // the title and header information (event, filename, timestamp and pid)
 
-  JSONWriter writer(out);
+  JSONWriter writer(out, compact);
   writer.json_start();
   writer.json_objectstart("header");
   writer.json_keyvalue("reportVersion", NODE_REPORT_VERSION);

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -68,6 +68,18 @@ void GetReport(const FunctionCallbackInfo<Value>& info) {
                                 .ToLocalChecked());
 }
 
+static void GetCompact(const FunctionCallbackInfo<Value>& info) {
+  Environment* env = Environment::GetCurrent(info);
+  info.GetReturnValue().Set(env->isolate_data()->options()->report_compact);
+}
+
+static void SetCompact(const FunctionCallbackInfo<Value>& info) {
+  Environment* env = Environment::GetCurrent(info);
+  Isolate* isolate = env->isolate();
+  bool compact = info[0]->ToBoolean(isolate)->Value();
+  env->isolate_data()->options()->report_compact = compact;
+}
+
 static void GetDirectory(const FunctionCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
   std::string directory = env->isolate_data()->options()->report_directory;
@@ -161,6 +173,8 @@ static void Initialize(Local<Object> exports,
 
   env->SetMethod(exports, "writeReport", WriteReport);
   env->SetMethod(exports, "getReport", GetReport);
+  env->SetMethod(exports, "getCompact", GetCompact);
+  env->SetMethod(exports, "setCompact", SetCompact);
   env->SetMethod(exports, "getDirectory", GetDirectory);
   env->SetMethod(exports, "setDirectory", SetDirectory);
   env->SetMethod(exports, "getFilename", GetFilename);

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -25,7 +25,12 @@ function findReports(pid, dir) {
 }
 
 function validate(filepath) {
-  validateContent(JSON.parse(fs.readFileSync(filepath, 'utf8')));
+  const report = fs.readFileSync(filepath, 'utf8');
+  if (process.report.compact) {
+    const end = report.indexOf('\n');
+    assert.strictEqual(end, report.length - 1);
+  }
+  validateContent(JSON.parse(report));
 }
 
 function validateContent(report) {

--- a/test/report/test-report-config.js
+++ b/test/report/test-report-config.js
@@ -1,4 +1,4 @@
-// Flags: --report-on-fatalerror --report-on-signal --report-uncaught-exception
+// Flags: --report-on-fatalerror --report-on-signal --report-uncaught-exception --report-compact
 'use strict';
 const common = require('../common');
 const assert = require('assert');
@@ -54,6 +54,17 @@ assert.throws(() => {
   process.report.reportOnSignal = {};
 }, { code: 'ERR_INVALID_ARG_TYPE' });
 assert.strictEqual(process.report.reportOnSignal, true);
+
+// Verify that process.report.reportCompact behaves properly.
+assert.strictEqual(process.report.compact, true);
+process.report.compact = false;
+assert.strictEqual(process.report.compact, false);
+process.report.compact = true;
+assert.strictEqual(process.report.compact, true);
+assert.throws(() => {
+  process.report.compact = {};
+}, { code: 'ERR_INVALID_ARG_TYPE' });
+assert.strictEqual(process.report.compact, true);
 
 if (!common.isWindows) {
   // Verify that process.report.signal behaves properly.

--- a/test/report/test-report-uncaught-exception-compat.js
+++ b/test/report/test-report-uncaught-exception-compat.js
@@ -1,0 +1,5 @@
+// Flags: --experimental-report --report-uncaught-exception --report-compact
+'use strict';
+// Test producing a compact report on uncaught exception.
+require('../common');
+require('./test-report-uncaught-exception.js');


### PR DESCRIPTION
Multi-line JSON is more human readable, but harder for log aggregators
to consume, they usually require a log message per line, particularly
for JSON. Compact output will be consumable by aggregators such as EFK
(Elastic Search-Fluentd-Kibana), LogDNA, DataDog, etc.

<details><summary>I'll address these in follow-up PRs</summary>
I've left this as draft, even though it passes test locally, has docs, etc., because in the process of doing this I've become convinced that JSON output should default to a compact single-line representation, easily consumable by tools, and should *also* default to stdout (or perhaps stderr) as the report destination. The _default_ is important, because reports have a problem in that under some conditions, the command line settings aren't reachable, and you get default behaviour whether you want it or not.

Now, that in itself is actually solvable, at the price of global variables, which we've avoided because _some_ uses Node.js can't access them, so we are trying to isolate all CLI configuration into v8 reachable values, which makes sense, except that the diagnostic report can't always access them, so is possibly not such a good candidate for that limitation.

If the report isn't going to be able to respect the command line flags, specifically, the (new) `--report-compact` and the pre-existing `--report-filename=stdout`, then its not possible to integrate into modern logging systems. Pretty much everyone (I couldn't find a counter-example, but probably one exists), has gone 12-factor app as a matter of principle, or is using docker and got forced into logging to stdout. As it is, its not possible to force the diagnostic report to go to stdout ***always***, so the file it forced to disk is going to just get discarded with the container.

The current defaults seem targetted at local development: human readable, written to the CWD. I'm not sure there are good deployment practices that suggest writing log files to the CWD, or even having a CWD that is writable by the user ID node is running.

Given the experimental nature of node reports, on the path to stabilizing them, maybe its time to remove some of the configurability wrt to output, and also provide a one-shot "hook everything" CLI/env option, a user running in deployment wants a diag report on _all_ the abnormal exit paths!

@mcollina (a known one-line json fan) @rmg @richardlau  @boneskull @nodejs/diagnostics, thoughts?


Note, humanizing single-line JSON is easy:
```
cat compact.json | npx pino-pretty
cat compact.json | jq .
```
</details>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
