### PR TITLE
module: self referential modules in repl or `-r`

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -29,6 +29,7 @@ module.exports = {
 
 const {
   ArrayIsArray,
+  ArrayPrototypeJoin,
   Error,
   JSONParse,
   Map,
@@ -424,7 +425,23 @@ function findLongestRegisteredExtension(filename) {
   return '.js';
 }
 
+function trySelfParentPath(parent) {
+  if (!parent) return false;
+
+  if (parent.filename) {
+    return parent.filename;
+  } else if (parent.id === '<repl>' || parent.id === 'internal/preload') {
+    try {
+      return process.cwd() + path.sep;
+    } catch {
+      return false;
+    }
+  }
+}
+
 function trySelf(parentPath, request) {
+  if (!parentPath) return false;
+
   const { data: pkg, path: basePath } = readPackageScope(parentPath) || {};
   if (!pkg || pkg.exports === undefined) return false;
   if (typeof pkg.name !== 'string') return false;
@@ -1055,13 +1072,16 @@ Module._resolveFilename = function(request, parent, isMain, options) {
         }
       }
     }
-    const filename = trySelf(parent.filename, request);
-    if (filename) {
-      const cacheKey = request + '\x00' +
-          (paths.length === 1 ? paths[0] : paths.join('\x00'));
-      Module._pathCache[cacheKey] = filename;
-      return filename;
-    }
+  }
+
+  // Try module self resoultion first
+  const parentPath = trySelfParentPath(parent);
+  const selfResolved = trySelf(parentPath, request);
+  if (selfResolved) {
+    const cacheKey = request + '\x00' +
+         (paths.length === 1 ? paths[0] : ArrayPrototypeJoin(paths, '\x00'));
+    Module._pathCache[cacheKey] = selfResolved;
+    return selfResolved;
   }
 
   // Look up the filename first, since that's the cache key.

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// This is needed to avoid cycles in esm/resolve <-> cjs/loader
+require('internal/modules/cjs/loader');
+
 const {
   FunctionPrototypeBind,
   ObjectSetPrototypeOf,

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -32,7 +32,6 @@ const {
 } = require('fs');
 const { getOptionValue } = require('internal/options');
 const { sep, relative } = require('path');
-const { Module: CJSModule } = require('internal/modules/cjs/loader');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const typeFlag = getOptionValue('--input-type');
@@ -49,10 +48,12 @@ const {
   ERR_UNSUPPORTED_DIR_IMPORT,
   ERR_UNSUPPORTED_ESM_URL_SCHEME,
 } = require('internal/errors').codes;
+const { Module: CJSModule } = require('internal/modules/cjs/loader');
 
 const packageJsonReader = require('internal/modules/package_json_reader');
 const DEFAULT_CONDITIONS = ObjectFreeze(['node', 'import']);
 const DEFAULT_CONDITIONS_SET = new SafeSet(DEFAULT_CONDITIONS);
+
 
 function getConditionsSet(conditions) {
   if (conditions !== undefined && conditions !== DEFAULT_CONDITIONS) {

--- a/test/fixtures/self_ref_module/index.js
+++ b/test/fixtures/self_ref_module/index.js
@@ -1,0 +1,4 @@
+'use strict'
+
+module.exports = 'Self resolution working';
+

--- a/test/fixtures/self_ref_module/package.json
+++ b/test/fixtures/self_ref_module/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "self_ref",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "exports": "./index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/test/parallel/test-preload-self-referential.js
+++ b/test/parallel/test-preload-self-referential.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const { exec } = require('child_process');
+
+const nodeBinary = process.argv[0];
+
+if (!common.isMainThread)
+  common.skip('process.chdir is not available in Workers');
+
+const selfRefModule = fixtures.path('self_ref_module');
+const fixtureA = fixtures.path('printA.js');
+
+exec(`"${nodeBinary}" -r self_ref "${fixtureA}"`, { cwd: selfRefModule },
+     (err, stdout, stderr) => {
+       assert.ifError(err);
+       assert.strictEqual(stdout, 'A\n');
+     });

--- a/test/parallel/test-repl-require-self-referential.js
+++ b/test/parallel/test-repl-require-self-referential.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const { spawn } = require('child_process');
+
+if (!common.isMainThread)
+  common.skip('process.chdir is not available in Workers');
+
+const selfRefModule = fixtures.path('self_ref_module');
+const child = spawn(process.execPath,
+                    ['--interactive'],
+                    { cwd: selfRefModule }
+);
+let output = '';
+child.stdout.on('data', (chunk) => output += chunk);
+child.on('exit', common.mustCall(() => {
+  const results = output.replace(/^> /mg, '').split('\n').slice(2);
+  assert.deepStrictEqual(results, [ "'Self resolution working'", '' ]);
+}));
+
+child.stdin.write('require("self_ref");\n');
+child.stdin.write('.exit');
+child.stdin.end();


### PR DESCRIPTION
Load self-referential modules from the repl and using the preload flag `-r`.
In both cases, the base path used for resolution is the current  `process.cwd()`.

Fix #31595 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
