### PR TITLE
net: don't explicitly set readable/writable

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -285,8 +285,6 @@ function Socket(options) {
   else
     options = { ...options };
 
-  options.readable = options.readable || false;
-  options.writable = options.writable || false;
   const { allowHalfOpen } = options;
 
   // Prevent the "no-half-open enforcer" from being inherited from `Duplex`.
@@ -366,7 +364,7 @@ function Socket(options) {
 
   // If we have a handle, then start the flow of data into the
   // buffer.  if not, then this will happen when we connect
-  if (this._handle && options.readable !== false) {
+  if (this._handle) {
     if (options.pauseOnCreate) {
       // Stop the handle from reading and pause the stream
       this._handle.reading = false;
@@ -654,8 +652,6 @@ Socket.prototype._destroy = function(exception, cb) {
   debug('destroy');
 
   this.connecting = false;
-
-  this.readable = this.writable = false;
 
   for (let s = this; s !== null; s = s._parent) {
     clearTimeout(s[kTimeout]);
@@ -968,7 +964,6 @@ Socket.prototype.connect = function(...args) {
   this._unrefTimer();
 
   this.connecting = true;
-  this.writable = true;
 
   if (pipe) {
     validateString(path, 'options.path');
@@ -1120,9 +1115,13 @@ function afterConnect(status, handle, req, readable, writable) {
   self._sockname = null;
 
   if (status === 0) {
-    self.readable = readable;
-    if (!self._writableState.ended)
-      self.writable = writable;
+    if (!readable) {
+      self.push(null);
+      self.read();
+    }
+    if (!writable) {
+      self.end();
+    }
     self._unrefTimer();
 
     self.emit('connect');
@@ -1544,9 +1543,7 @@ function onconnection(err, clientHandle) {
   const socket = new Socket({
     handle: clientHandle,
     allowHalfOpen: self.allowHalfOpen,
-    pauseOnCreate: self.pauseOnConnect,
-    readable: true,
-    writable: true
+    pauseOnCreate: self.pauseOnConnect
   });
 
   self._connections++;

--- a/test/parallel/test-net-socket-constructor.js
+++ b/test/parallel/test-net-socket-constructor.js
@@ -27,12 +27,12 @@ function test(sock, readable, writable) {
 }
 
 if (cluster.isMaster) {
-  test(undefined, false, false);
+  test(undefined, true, true);
 
   const server = net.createServer(common.mustCall((socket) => {
     socket.unref();
     test(socket, true, true);
-    test({ handle: socket._handle }, false, false);
+    test({ handle: socket._handle }, true, true);
     test({ handle: socket._handle, readable: true, writable: true },
          true, true);
     server.close();
@@ -45,7 +45,7 @@ if (cluster.isMaster) {
       socket.end();
     }));
 
-    test(socket, false, true);
+    test(socket, true, true);
   }));
 
   cluster.setupMaster({
@@ -58,8 +58,8 @@ if (cluster.isMaster) {
     assert.strictEqual(signal, null);
   }));
 } else {
-  test(4, false, false);
-  test({ fd: 5 }, false, false);
+  test(4, true, true);
+  test({ fd: 5 }, true, true);
   test({ fd: 6, readable: true, writable: true }, true, true);
   process.disconnect();
 }

--- a/test/parallel/test-net-socket-setnodelay.js
+++ b/test/parallel/test-net-socket-setnodelay.js
@@ -13,28 +13,32 @@ const genSetNoDelay = (desiredArg) => (enable) => {
 // setNoDelay should default to true
 let socket = new net.Socket({
   handle: {
-    setNoDelay: common.mustCall(genSetNoDelay(true))
+    setNoDelay: common.mustCall(genSetNoDelay(true)),
+    readStart() {}
   }
 });
 socket.setNoDelay();
 
 socket = new net.Socket({
   handle: {
-    setNoDelay: common.mustCall(genSetNoDelay(true), 1)
+    setNoDelay: common.mustCall(genSetNoDelay(true), 1),
+    readStart() {}
   }
 });
 truthyValues.forEach((testVal) => socket.setNoDelay(testVal));
 
 socket = new net.Socket({
   handle: {
-    setNoDelay: common.mustNotCall()
+    setNoDelay: common.mustNotCall(),
+    readStart() {}
   }
 });
 falseyValues.forEach((testVal) => socket.setNoDelay(testVal));
 
 socket = new net.Socket({
   handle: {
-    setNoDelay: common.mustCall(() => {}, 3)
+    setNoDelay: common.mustCall(() => {}, 3),
+    readStart() {}
   }
 });
 truthyValues.concat(falseyValues).concat(truthyValues)
@@ -44,7 +48,8 @@ truthyValues.concat(falseyValues).concat(truthyValues)
 // In the case below, if it is called an exception will be thrown
 socket = new net.Socket({
   handle: {
-    setNoDelay: null
+    setNoDelay: null,
+    readStart() {}
   }
 });
 const returned = socket.setNoDelay(true);


### PR DESCRIPTION
`net.Socket` is slightly breaking stream invariants by having readable/writable going from `false` to `true`. Streams assume that readable/writable always starts out `true` and then goes to `false` through `push(null)`/`end()` after which it never goes back to `true`, e.g. once a stream is `writable == false` it is assumed it will never become `true`. 

This PR changes 2 things:

- `net.Socket` always starts as `readable`/`writable` `true`.
- `net.Socket` uses `push(null)`/`end()` to set `readable`/`writable` to `false`. Note that this would cause the socket to emit the `'end'`/`'finish'` events, which it did not do previously.

This makes `net` behave like regular streams and the way quic currently handles the corresponding functionality.

This is an alternative to https://github.com/nodejs/node/pull/32139

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
