### PR TITLE
stream: don't emit 'finish' after 'error'

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -666,6 +666,10 @@ function finishMaybe(stream, state, sync) {
 
 function finish(stream, state) {
   state.pendingcb--;
+  if (state.errorEmitted) {
+    return;
+  }
+
   state.finished = true;
   stream.emit('finish');
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -666,9 +666,8 @@ function finishMaybe(stream, state, sync) {
 
 function finish(stream, state) {
   state.pendingcb--;
-  if (state.errorEmitted) {
+  if (state.errorEmitted)
     return;
-  }
 
   state.finished = true;
   stream.emit('finish');

--- a/test/parallel/test-stream-writable-write-writev-finish.js
+++ b/test/parallel/test-stream-writable-write-writev-finish.js
@@ -132,6 +132,7 @@ const stream = require('stream');
     process.nextTick(cb);
   };
   w.on('error', common.mustCall());
+  w.on('finish', common.mustNotCall());
   w.on('prefinish', () => {
     w.write("shouldn't write in prefinish listener");
   });


### PR DESCRIPTION
An edge case could emit `'finish'` after `'error'`.

Refs: https://github.com/nodejs/node/issues/28710

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
