### PR TITLE
http: don't emit 'finish' after 'error'

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -745,6 +745,7 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
 };
 
 function onFinish(outmsg) {
+  if (outmsg && outmsg.socket && outmsg.socket._hadError) return;
   outmsg.emit('finish');
 }
 

--- a/test/parallel/test-tls-set-secure-context.js
+++ b/test/parallel/test-tls-set-secure-context.js
@@ -82,6 +82,7 @@ function makeRequest(port, id) {
       headers: { id }
     };
 
+    let errored = false;
     https.get(`https://localhost:${port}`, options, (res) => {
       let response = '';
 
@@ -95,7 +96,10 @@ function makeRequest(port, id) {
         resolve(response);
       }));
     }).on('error', (err) => {
+      errored = true;
       reject(err);
+    }).on('finish', () => {
+      assert.strictEqual(errored, false);
     });
   });
 }


### PR DESCRIPTION
An edge case could emit `'finish'` after `'error'`.

Refs: https://github.com/nodejs/node/issues/28710

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
