### PR TITLE
http: don't emit 'readable' after 'close'

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -687,6 +687,8 @@ function resOnFinish(req, res, socket, state, server) {
     req._dump();
 
   res.detachSocket(socket);
+  // TODO(ronag): streamify IncomingMessage.destroy()
+  req._readableState.destroyed = true;
   req.emit('close');
   process.nextTick(emitCloseNT, res);
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -665,9 +665,12 @@ function clearIncoming(req) {
   if (parser && parser.incoming === req) {
     if (req.readableEnded) {
       parser.incoming = null;
+      req.emit('close');
     } else {
       req.on('end', clearIncoming);
     }
+  } else {
+    req.emit('close');
   }
 }
 
@@ -678,7 +681,6 @@ function resOnFinish(req, res, socket, state, server) {
   assert(state.incoming.length === 0 || state.incoming[0] === req);
 
   state.incoming.shift();
-  clearIncoming(req);
 
   // If the user never called req.read(), and didn't pipe() or
   // .resume() or .on('data'), then we call req._dump() so that the
@@ -687,9 +689,7 @@ function resOnFinish(req, res, socket, state, server) {
     req._dump();
 
   res.detachSocket(socket);
-  // TODO(ronag): streamify IncomingMessage.destroy()
-  req._readableState.destroyed = true;
-  req.emit('close');
+  clearIncoming(req);
   process.nextTick(emitCloseNT, res);
 
   if (res._last) {

--- a/test/parallel/test-async-hooks-http-parser-destroy.js
+++ b/test/parallel/test-async-hooks-http-parser-destroy.js
@@ -45,6 +45,13 @@ async_hooks.createHook({
 }).enable();
 
 const server = http.createServer((req, res) => {
+  let closed = false;
+  req.on('close', () => {
+    closed = true;
+  });
+  req.on('readable', () => {
+    assert.strictEqual(closed, false);
+  });
   res.end('Hello');
 });
 

--- a/test/parallel/test-async-hooks-http-parser-destroy.js
+++ b/test/parallel/test-async-hooks-http-parser-destroy.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');
 const http = require('http');
@@ -45,13 +45,9 @@ async_hooks.createHook({
 }).enable();
 
 const server = http.createServer((req, res) => {
-  let closed = false;
-  req.on('close', () => {
-    closed = true;
-  });
-  req.on('readable', () => {
-    assert.strictEqual(closed, false);
-  });
+  req.on('close', common.mustCall(() => {
+    req.on('readable', common.mustNotCall());
+  }));
   res.end('Hello');
 });
 

--- a/test/parallel/test-http-no-read-no-dump.js
+++ b/test/parallel/test-http-no-read-no-dump.js
@@ -1,6 +1,7 @@
 'use strict';
 const common = require('../common');
 const http = require('http');
+const assert = require('assert');
 
 let onPause = null;
 
@@ -10,6 +11,14 @@ const server = http.createServer((req, res) => {
 
   res.writeHead(200);
   res.flushHeaders();
+
+  let closed = false;
+  req.on('close', common.mustCall(() => {
+    closed = true;
+  }));
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(closed, false);
+  }));
 
   req.connection.on('pause', () => {
     res.end();

--- a/test/parallel/test-http-no-read-no-dump.js
+++ b/test/parallel/test-http-no-read-no-dump.js
@@ -1,7 +1,6 @@
 'use strict';
 const common = require('../common');
 const http = require('http');
-const assert = require('assert');
 
 let onPause = null;
 
@@ -12,12 +11,8 @@ const server = http.createServer((req, res) => {
   res.writeHead(200);
   res.flushHeaders();
 
-  let closed = false;
   req.on('close', common.mustCall(() => {
-    closed = true;
-  }));
-  req.on('end', common.mustCall(() => {
-    assert.strictEqual(closed, false);
+    req.on('end', common.mustNotCall());
   }));
 
   req.connection.on('pause', () => {


### PR DESCRIPTION
An edge case could emit 'readable' after 'close' and 'close' before 'end'.

Refs: #28710

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->