### PR TITLE
errors: drop pronouns from ERR_WORKER_PATH message

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1425,8 +1425,7 @@ E('ERR_WORKER_PATH', (filename) =>
   'The worker script or module filename must be an absolute path or a ' +
   'relative path starting with \'./\' or \'../\'.' +
   (filename.startsWith('file://') ?
-    ' If you want to pass a file:// URL, you must wrap it around `new URL`.' :
-    ''
+    ' Wrap file:// URLs with `new URL`.' : ''
   ) +
   ` Received "${filename}"`,
   TypeError);

--- a/test/parallel/test-worker-unsupported-path.js
+++ b/test/parallel/test-worker-unsupported-path.js
@@ -31,12 +31,12 @@ const { Worker } = require('worker_threads');
 {
   assert.throws(
     () => { new Worker('file:///file_url'); },
-    /If you want to pass a file:\/\/ URL, you must wrap it around `new URL`/
+    /Wrap file:\/\/ URLs with `new URL`/
   );
   assert.throws(
     () => { new Worker('relative_no_dot'); },
     // eslint-disable-next-line node-core/no-unescaped-regexp-dot
-    /^((?!If you want to pass a file:\/\/ URL, you must wrap it around `new URL`).)*$/s
+    /^((?!Wrap file:\/\/ URLs with `new URL`).)*$/s
   );
 }
 


### PR DESCRIPTION
This commit drops pronouns from the `ERR_WORKER_PATH` message, and also shortens the text a bit.

Refs: https://github.com/nodejs/node/pull/31664

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)