### PR TITLE
console: adhere to environment variables enforcing colors

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -91,6 +91,10 @@ changes:
   - version: v11.7.0
     pr-url: https://github.com/nodejs/node/pull/24978
     description: The `inspectOptions` option is introduced.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32308
+    description: The `colorMode` default adheres to the environment variables
+                 enforcing or disabling colors.
 -->
 
 * `options` {Object}
@@ -99,12 +103,12 @@ changes:
   * `ignoreErrors` {boolean} Ignore errors when writing to the underlying
     streams. **Default:** `true`.
   * `colorMode` {boolean|string} Set color support for this `Console` instance.
-    Setting to `true` enables coloring while inspecting values. Setting to
-    `false` disables coloring while inspecting values. Setting to
-    `'auto'` makes color support depend on the value of the `isTTY` property
-    and the value returned by `getColorDepth()` on the respective stream. This
-    option can not be used, if `inspectOptions.colors` is set as well.
-    **Default:** `'auto'`.
+    Set to `true` to enable coloring while inspecting values and set to `false`
+    to disable coloring. Set to `'auto'` checks the `FORCE_COLOR`, `NO_COLOR`
+    and `NODE_DISABLE_COLORS` environment variables. If none is set, makes color
+    support depend on the value of the `isTTY` property and the value returned
+    by `hasColors()` on the respective stream. This option can not be used, if
+    `inspectOptions.colors` is set as well. **Default:** `'auto'`.
   * `inspectOptions` {Object} Specifies options that are passed along to
     [`util.inspect()`][].
 

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -39,6 +39,9 @@ const {
   formatWithOptions
 } = require('internal/util/inspect');
 const {
+  getEnforcedColorBits
+} = require('internal/tty');
+const {
   isTypedArray, isSet, isMap, isSetIterator, isMapIterator,
 } = require('internal/util/types');
 const kCounts = Symbol('counts');
@@ -266,9 +269,14 @@ const kNoColorInspectOptions = {};
 Console.prototype[kGetInspectOptions] = function(stream) {
   let color = this[kColorMode];
   if (color === 'auto') {
-    color = stream.isTTY && (
-      typeof stream.getColorDepth === 'function' ?
-        stream.getColorDepth() > 2 : true);
+    const colorBits = getEnforcedColorBits(process.env);
+    if (colorBits !== undefined) {
+      color = colorBits !== 1;
+    } else {
+      color = stream.isTTY && (
+        typeof stream.hasColors === 'function' ?
+          stream.hasColors() : true);
+    }
   }
 
   const options = optionsMap.get(this);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -679,9 +679,18 @@ const fatalExceptionStackEnhancers = {
         colors: defaultColors
       }
     } = lazyInternalUtilInspect();
-    const colors = (internalBinding('util').guessHandleType(2) === 'TTY' &&
-                   require('internal/tty').hasColors()) ||
-                   defaultColors;
+    const {
+      getEnforcedColorBits,
+      hasColors
+    } = require('internal/tty');
+    let colors = false;
+    const colorBits = getEnforcedColorBits(process.env);
+    if (colorBits !== undefined) {
+      colors = colorBits !== 1;
+    } else {
+      const handleType = internalBinding('util').guessHandleType(2);
+      colors = (handleType === 'TTY' && hasColors()) || defaultColors;
+    }
     try {
       return inspect(error, { colors });
     } catch {

--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -96,10 +96,7 @@ function warnOnDeactivatedColors(env) {
   }
 }
 
-// The `getColorDepth` API got inspired by multiple sources such as
-// https://github.com/chalk/supports-color,
-// https://github.com/isaacs/color-support.
-function getColorDepth(env = process.env) {
+function getEnforcedColorBits(env) {
   // Use level 0-3 to support the same levels as `chalk` does. This is done for
   // consistency throughout the ecosystem.
   if (env.FORCE_COLOR !== undefined) {
@@ -129,6 +126,15 @@ function getColorDepth(env = process.env) {
       env.TERM === 'dumb') {
     return COLORS_2;
   }
+}
+
+// The `getColorDepth` API got inspired by multiple sources such as
+// https://github.com/chalk/supports-color,
+// https://github.com/isaacs/color-support.
+function getColorDepth(env = process.env) {
+  const colorBits = getEnforcedColorBits(env);
+  if (colorBits !== undefined)
+    return colorBits;
 
   if (process.platform === 'win32') {
     // Lazy load for startup performance.
@@ -225,5 +231,6 @@ function hasColors(count, env) {
 
 module.exports = {
   getColorDepth,
+  getEnforcedColorBits,
   hasColors
 };


### PR DESCRIPTION
Make sure the console color `auto` mode checks the environment
variables if any enforces (de)activation of colors.

Fatal errors will also check for the environment variables from now on.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
