### PR TITLE
deps: update to uvwasi 0.0.6

### DIFF
--- a/deps/uvwasi/include/fd_table.h
+++ b/deps/uvwasi/include/fd_table.h
@@ -6,6 +6,7 @@
 #include "wasi_types.h"
 
 struct uvwasi_s;
+struct uvwasi_options_s;
 
 struct uvwasi_fd_wrap_t {
   uvwasi_fd_t id;
@@ -27,8 +28,7 @@ struct uvwasi_fd_table_t {
 };
 
 uvwasi_errno_t uvwasi_fd_table_init(struct uvwasi_s* uvwasi,
-                                    struct uvwasi_fd_table_t* table,
-                                    uint32_t init_size);
+                                    struct uvwasi_options_s* options);
 void uvwasi_fd_table_free(struct uvwasi_s* uvwasi,
                           struct uvwasi_fd_table_t* table);
 uvwasi_errno_t uvwasi_fd_table_insert(struct uvwasi_s* uvwasi,

--- a/deps/uvwasi/include/uvwasi.h
+++ b/deps/uvwasi/include/uvwasi.h
@@ -11,7 +11,7 @@ extern "C" {
 
 #define UVWASI_VERSION_MAJOR 0
 #define UVWASI_VERSION_MINOR 0
-#define UVWASI_VERSION_PATCH 5
+#define UVWASI_VERSION_PATCH 6
 #define UVWASI_VERSION_HEX ((UVWASI_VERSION_MAJOR << 16) | \
                             (UVWASI_VERSION_MINOR <<  8) | \
                             (UVWASI_VERSION_PATCH))
@@ -60,6 +60,9 @@ typedef struct uvwasi_options_s {
   size_t argc;
   char** argv;
   char** envp;
+  uvwasi_fd_t in;
+  uvwasi_fd_t out;
+  uvwasi_fd_t err;
   const uvwasi_mem_t* allocator;
 } uvwasi_options_t;
 

--- a/deps/uvwasi/src/clocks.c
+++ b/deps/uvwasi/src/clocks.c
@@ -6,6 +6,7 @@
 #endif /* _WIN32 */
 
 #include "uv.h"
+#include "clocks.h"
 #include "wasi_types.h"
 #include "uv_mapping.h"
 

--- a/deps/uvwasi/src/uvwasi.c
+++ b/deps/uvwasi/src/uvwasi.c
@@ -34,6 +34,11 @@
 # define PATH_MAX_BYTES (PATH_MAX)
 #endif
 
+/* IBMi PASE does not support posix_fadvise() */
+#ifdef __PASE__
+# undef POSIX_FADV_NORMAL
+#endif
+
 static void* default_malloc(size_t size, void* mem_user_data) {
   return malloc(size);
 }
@@ -569,7 +574,7 @@ uvwasi_errno_t uvwasi_init(uvwasi_t* uvwasi, uvwasi_options_t* options) {
     }
   }
 
-  err = uvwasi_fd_table_init(uvwasi, &uvwasi->fds, options->fd_table_size);
+  err = uvwasi_fd_table_init(uvwasi, options);
   if (err != UVWASI_ESUCCESS)
     goto exit;
 

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -170,6 +170,9 @@ void WASI::New(const FunctionCallbackInfo<Value>& args) {
   const uint32_t argc = argv->Length();
   uvwasi_options_t options;
 
+  options.in = 0;
+  options.out = 1;
+  options.err = 2;
   options.fd_table_size = 3;
   options.argc = argc;
   options.argv = argc == 0 ? nullptr : new char*[argc];


### PR DESCRIPTION
Notable changes (the first two list items have already been cherry-picked to Node.js):

- Better thread synchronization (https://github.com/cjihrig/uvwasi/pull/87, https://github.com/cjihrig/uvwasi/pull/90, https://github.com/cjihrig/uvwasi/pull/91).
- Windows can now detect TTY file descriptors (https://github.com/cjihrig/uvwasi/pull/92).
- Documentation now includes build instructions (https://github.com/cjihrig/uvwasi/pull/96).
- Better support for IBMi (https://github.com/cjihrig/uvwasi/pull/100).
- The stdio file descriptors must now be passed in the options to `uvwasi_init()` (https://github.com/cjihrig/uvwasi/pull/102).

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)