### PR TITLE
process: delay throwing an error using `throwDeprecation`

### DIFF
--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -118,8 +118,13 @@ function emitWarning(warning, type, code, ctor) {
   if (warning.name === 'DeprecationWarning') {
     if (process.noDeprecation)
       return;
-    if (process.throwDeprecation)
-      throw warning;
+    if (process.throwDeprecation) {
+      // Delay throwing the error to guarantee that all former warnings were
+      // properly logged.
+      return process.nextTick(() => {
+        throw warning;
+      });
+    }
   }
   process.nextTick(doEmitWarning(warning));
 }

--- a/test/parallel/test-process-warning.js
+++ b/test/parallel/test-process-warning.js
@@ -38,9 +38,14 @@ function test4() {
   // process.emitWarning will throw when process.throwDeprecation is true
   // and type is `DeprecationWarning`.
   process.throwDeprecation = true;
-  assert.throws(
-    () => process.emitWarning('test', 'DeprecationWarning'),
-    /^DeprecationWarning: test$/);
+  process.once('uncaughtException', (err) => {
+    assert.match(err.toString(), /^DeprecationWarning: test$/);
+  });
+  try {
+    process.emitWarning('test', 'DeprecationWarning');
+  } catch {
+    assert.fail('Unreachable');
+  }
   process.throwDeprecation = false;
   setImmediate(test5);
 }


### PR DESCRIPTION
This makes sure all warnings that were triggered before a deprecation
warning during the same tick are properly handled and logged.

It also guarantees that users can not catch the error anymore.

Fixes: #17871

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
