### PR TITLE
util: only inspect error properties that are not visible otherwise

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -885,7 +885,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
         return ctx.stylize(base, 'date');
       }
     } else if (isError(value)) {
-      base = formatError(value, constructor, tag, ctx);
+      base = formatError(value, constructor, tag, ctx, keys);
       if (keys.length === 0 && protoProps === undefined)
         return base;
     } else if (isAnyArrayBuffer(value)) {
@@ -1078,10 +1078,22 @@ function getFunctionBase(value, constructor, tag) {
   return base;
 }
 
-function formatError(err, constructor, tag, ctx) {
+function formatError(err, constructor, tag, ctx, keys) {
   const name = err.name != null ? String(err.name) : 'Error';
   let len = name.length;
   let stack = err.stack ? String(err.stack) : ErrorPrototypeToString(err);
+
+  // Do not "duplicate" error properties that are already included in the output
+  // otherwise.
+  if (!ctx.showHidden && keys.length !== 0) {
+    for (const name of ['name', 'message', 'stack']) {
+      const index = keys.indexOf(name);
+      // Only hide the property in case it's part of the original stack
+      if (index !== -1 && stack.includes(err[name])) {
+        keys.splice(index, 1);
+      }
+    }
+  }
 
   // A stack trace may contain arbitrary data. Only manipulate the output
   // for "regular errors" (errors that "look normal") for now.

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -696,6 +696,28 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
   Error.stackTraceLimit = tmp;
 }
 
+// Prevent enumerable error properties from being printed.
+{
+  let err = new Error();
+  err.message = 'foobar';
+  let out = util.inspect(err).split('\n');
+  assert.strictEqual(out[0], 'Error: foobar');
+  assert(out[out.length - 1].startsWith('    at '));
+  // Reset the error, the stack is otherwise not recreated.
+  err = new Error();
+  err.message = 'foobar';
+  err.name = 'Unique';
+  Object.defineProperty(err, 'stack', { value: err.stack, enumerable: true });
+  out = util.inspect(err).split('\n');
+  assert.strictEqual(out[0], 'Unique: foobar');
+  assert(out[out.length - 1].startsWith('    at '));
+  err.name = 'Baz';
+  out = util.inspect(err).split('\n');
+  assert.strictEqual(out[0], 'Unique: foobar');
+  assert.strictEqual(out[out.length - 2], "  name: 'Baz'");
+  assert.strictEqual(out[out.length - 1], '}');
+}
+
 // Doesn't capture stack trace.
 {
   function BadCustomError(msg) {


### PR DESCRIPTION
Inspecting errors results in duplicated information in case an error
is created with enumerable `name`, `message` or `stack` properties.
In that case, check if the output already contains that information
and prevent listing that property.

This reduces the noise as receiver.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
