### PR TITLE
http: fix incorrect headersTimeout measurement (alt)

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -727,7 +727,8 @@ function tickOnSocket(req, socket) {
                     new HTTPClientAsyncResource('HTTPINCOMINGMESSAGE', req),
                     req.maxHeaderSize || 0,
                     req.insecureHTTPParser === undefined ?
-                      isLenient() : req.insecureHTTPParser);
+                      isLenient() : req.insecureHTTPParser,
+                    0);
   parser.socket = socket;
   parser.outgoing = req;
   req.parser = parser;

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -47,6 +47,7 @@ const kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;
 const kOnBody = HTTPParser.kOnBody | 0;
 const kOnMessageComplete = HTTPParser.kOnMessageComplete | 0;
 const kOnExecute = HTTPParser.kOnExecute | 0;
+const kOnTimeout = HTTPParser.kOnTimeout | 0;
 
 const MAX_HEADER_PAIRS = 2000;
 
@@ -165,6 +166,7 @@ const parsers = new FreeList('parsers', 1000, function parsersCb() {
   parser[kOnHeadersComplete] = parserOnHeadersComplete;
   parser[kOnBody] = parserOnBody;
   parser[kOnMessageComplete] = parserOnMessageComplete;
+  parser[kOnTimeout] = null;
 
   return parser;
 });

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -142,6 +142,7 @@ const STATUS_CODES = {
 };
 
 const kOnExecute = HTTPParser.kOnExecute | 0;
+const kOnTimeout = HTTPParser.kOnTimeout | 0;
 
 class HTTPServerAsyncResource {
   constructor(type, socket) {
@@ -426,11 +427,9 @@ function connectionListenerInternal(server, socket) {
     server.maxHeaderSize || 0,
     server.insecureHTTPParser === undefined ?
       isLenient() : server.insecureHTTPParser,
+    server.headersTimeout,
   );
   parser.socket = socket;
-
-  // We are starting to wait for our headers.
-  parser.parsingHeadersStart = nowDate();
   socket.parser = parser;
 
   // Propagate headers limit from server instance to parser
@@ -481,6 +480,9 @@ function connectionListenerInternal(server, socket) {
   }
   parser[kOnExecute] =
     onParserExecute.bind(undefined, server, socket, parser, state);
+
+  parser[kOnTimeout] = 
+    onParserTimeout.bind(undefined, server, socket, parser, state);
 
   socket._paused = false;
 }
@@ -570,21 +572,15 @@ function socketOnData(server, socket, parser, state, d) {
 
 function onParserExecute(server, socket, parser, state, ret) {
   socket._unrefTimer();
-  const start = parser.parsingHeadersStart;
   debug('SERVER socketOnParserExecute %d', ret);
-
-  // If we have not parsed the headers, destroy the socket
-  // after server.headersTimeout to protect from DoS attacks.
-  // start === 0 means that we have parsed headers.
-  if (start !== 0 && nowDate() - start > server.headersTimeout) {
-    const serverTimeout = server.emit('timeout', socket);
-
-    if (!serverTimeout)
-      socket.destroy();
-    return;
-  }
-
   onParserExecuteCommon(server, socket, parser, state, ret, undefined);
+}
+
+function onParserTimeout(server, socket, parser, state, ret) {
+  const serverTimeout = server.emit('timeout', socket);
+
+  if (!serverTimeout)
+    socket.destroy();
 }
 
 const noop = () => {};
@@ -720,13 +716,6 @@ function emitCloseNT(self) {
 function parserOnIncoming(server, socket, state, req, keepAlive) {
   resetSocketTimeout(server, socket, state);
 
-  if (server.keepAliveTimeout > 0) {
-    req.on('end', resetHeadersTimeoutOnReqEnd);
-  }
-
-  // Set to zero to communicate that we have finished parsing.
-  socket.parser.parsingHeadersStart = 0;
-
   if (req.upgrade) {
     req.upgrade = req.method === 'CONNECT' ||
                   server.listenerCount('upgrade') > 0;
@@ -849,17 +838,6 @@ function generateSocketListenerWrapper(originalFnName) {
 
     return res;
   };
-}
-
-function resetHeadersTimeoutOnReqEnd() {
-  debug('resetHeadersTimeoutOnReqEnd');
-
-  const parser = this.socket.parser;
-  // Parser can be null if the socket was destroyed
-  // in that case, there is nothing to do.
-  if (parser) {
-    parser.parsingHeadersStart = nowDate();
-  }
 }
 
 module.exports = {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -49,7 +49,6 @@ const { OutgoingMessage } = require('_http_outgoing');
 const {
   kOutHeaders,
   kNeedDrain,
-  nowDate,
   emitStatistics
 } = require('internal/http');
 const {
@@ -427,7 +426,7 @@ function connectionListenerInternal(server, socket) {
     server.maxHeaderSize || 0,
     server.insecureHTTPParser === undefined ?
       isLenient() : server.insecureHTTPParser,
-    server.headersTimeout,
+    server.headersTimeout || 0,
   );
   parser.socket = socket;
   socket.parser = parser;
@@ -481,8 +480,8 @@ function connectionListenerInternal(server, socket) {
   parser[kOnExecute] =
     onParserExecute.bind(undefined, server, socket, parser, state);
 
-  parser[kOnTimeout] = 
-    onParserTimeout.bind(undefined, server, socket, parser, state);
+  parser[kOnTimeout] =
+    onParserTimeout.bind(undefined, server, socket);
 
   socket._paused = false;
 }
@@ -576,7 +575,7 @@ function onParserExecute(server, socket, parser, state, ret) {
   onParserExecuteCommon(server, socket, parser, state, ret, undefined);
 }
 
-function onParserTimeout(server, socket, parser, state, ret) {
+function onParserTimeout(server, socket) {
   const serverTimeout = server.emit('timeout', socket);
 
   if (!serverTimeout)

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -646,8 +646,8 @@ class Parser : public AsyncWrap, public StreamListener {
 
     // check header parsing time
     if (header_parsing_start_time_ != 0 && headers_timeout_ != 0) {
-      auto now = uv_hrtime();
-      auto parsing_time = (now - header_parsing_start_time_) / 1e6;
+      uint64_t now = uv_hrtime();
+      uint64_t parsing_time = (now - header_parsing_start_time_) / 1e6;
 
       if (parsing_time > headers_timeout_) {
         Local<Value> cb =

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -519,8 +519,10 @@ class Parser : public AsyncWrap, public StreamListener {
       max_http_header_size = env->options()->max_http_header_size;
     }
 
-    CHECK(args[4]->IsInt32());
-    headers_timeout = args[4].As<Number>()->Value();
+    if (args.Length() > 4) {
+      CHECK(args[4]->IsInt32());
+      headers_timeout = args[4].As<Number>()->Value();
+    }
 
     llhttp_type_t type =
         static_cast<llhttp_type_t>(args[0].As<Int32>()->Value());
@@ -803,7 +805,8 @@ class Parser : public AsyncWrap, public StreamListener {
   }
 
 
-  void Init(llhttp_type_t type, uint64_t max_http_header_size, bool lenient, uint64_t headers_timeout) {
+  void Init(llhttp_type_t type, uint64_t max_http_header_size,
+            bool lenient, uint64_t headers_timeout) {
     llhttp_init(&parser_, type, &settings);
     llhttp_set_lenient(&parser_, lenient);
     header_nread_ = 0;
@@ -857,7 +860,7 @@ class Parser : public AsyncWrap, public StreamListener {
   bool pending_pause_ = false;
   uint64_t header_nread_ = 0;
   uint64_t max_http_header_size_;
-  uint64_t headers_timeout_; 
+  uint64_t headers_timeout_;
   uint64_t header_parsing_start_time_ = 0;
 
   // These are helper functions for filling `http_parser_settings`, which turn

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -74,6 +74,7 @@ const uint32_t kOnHeadersComplete = 1;
 const uint32_t kOnBody = 2;
 const uint32_t kOnMessageComplete = 3;
 const uint32_t kOnExecute = 4;
+const uint32_t kOnTimeout = 5;
 // Any more fields than this will be flushed into JS
 const size_t kMaxHeaderFieldsCount = 32;
 
@@ -181,6 +182,7 @@ class Parser : public AsyncWrap, public StreamListener {
     num_fields_ = num_values_ = 0;
     url_.Reset();
     status_message_.Reset();
+    header_parsing_start_time_ = uv_hrtime();
     return 0;
   }
 
@@ -504,6 +506,7 @@ class Parser : public AsyncWrap, public StreamListener {
     bool lenient = args[3]->IsTrue();
 
     uint64_t max_http_header_size = 0;
+    uint64_t headers_timeout = 0;
 
     CHECK(args[0]->IsInt32());
     CHECK(args[1]->IsObject());
@@ -515,6 +518,9 @@ class Parser : public AsyncWrap, public StreamListener {
     if (max_http_header_size == 0) {
       max_http_header_size = env->options()->max_http_header_size;
     }
+
+    CHECK(args[4]->IsInt32());
+    headers_timeout = args[4].As<Number>()->Value();
 
     llhttp_type_t type =
         static_cast<llhttp_type_t>(args[0].As<Int32>()->Value());
@@ -532,7 +538,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
     parser->set_provider_type(provider);
     parser->AsyncReset(args[1].As<Object>());
-    parser->Init(type, max_http_header_size, lenient);
+    parser->Init(type, max_http_header_size, lenient, headers_timeout);
   }
 
   template <bool should_pause>
@@ -635,6 +641,24 @@ class Parser : public AsyncWrap, public StreamListener {
     // Exception
     if (ret.IsEmpty())
       return;
+
+    // check header parsing time
+    if (header_parsing_start_time_ != 0 && headers_timeout_ != 0) {
+      auto now = uv_hrtime();
+      auto parsing_time = (now - header_parsing_start_time_) / 1e6;
+
+      if (parsing_time > headers_timeout_) {
+        Local<Value> cb =
+            object()->Get(env()->context(), kOnTimeout).ToLocalChecked();
+
+        if (!cb->IsFunction())
+          return;
+
+        MakeCallback(cb.As<Function>(), 0, nullptr);
+
+        return;
+      }
+    }
 
     Local<Value> cb =
         object()->Get(env()->context(), kOnExecute).ToLocalChecked();
@@ -779,7 +803,7 @@ class Parser : public AsyncWrap, public StreamListener {
   }
 
 
-  void Init(llhttp_type_t type, uint64_t max_http_header_size, bool lenient) {
+  void Init(llhttp_type_t type, uint64_t max_http_header_size, bool lenient, uint64_t headers_timeout) {
     llhttp_init(&parser_, type, &settings);
     llhttp_set_lenient(&parser_, lenient);
     header_nread_ = 0;
@@ -790,6 +814,8 @@ class Parser : public AsyncWrap, public StreamListener {
     have_flushed_ = false;
     got_exception_ = false;
     max_http_header_size_ = max_http_header_size;
+    header_parsing_start_time_ = 0;
+    headers_timeout_ = headers_timeout;
   }
 
 
@@ -831,6 +857,8 @@ class Parser : public AsyncWrap, public StreamListener {
   bool pending_pause_ = false;
   uint64_t header_nread_ = 0;
   uint64_t max_http_header_size_;
+  uint64_t headers_timeout_; 
+  uint64_t header_parsing_start_time_ = 0;
 
   // These are helper functions for filling `http_parser_settings`, which turn
   // a member function of Parser into a C-style HTTP parser callback.
@@ -890,6 +918,8 @@ void InitializeHttpParser(Local<Object> target,
          Integer::NewFromUnsigned(env->isolate(), kOnMessageComplete));
   t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kOnExecute"),
          Integer::NewFromUnsigned(env->isolate(), kOnExecute));
+  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kOnTimeout"),
+         Integer::NewFromUnsigned(env->isolate(), kOnTimeout));
 
   Local<Array> methods = Array::New(env->isolate());
 #define V(num, name, string)                                                  \

--- a/test/async-hooks/test-graph.http.js
+++ b/test/async-hooks/test-graph.http.js
@@ -39,10 +39,12 @@ process.on('exit', () => {
         id: 'httpclientrequest:1',
         triggerAsyncId: 'tcpserver:1' },
       { type: 'TCPWRAP', id: 'tcp:2', triggerAsyncId: 'tcpserver:1' },
-      { type: 'Timeout', id: 'timeout:1', triggerAsyncId: 'tcp:2' },
       { type: 'HTTPINCOMINGMESSAGE',
         id: 'httpincomingmessage:1',
         triggerAsyncId: 'tcp:2' },
+      { type: 'Timeout',
+        id: 'timeout:1',
+        triggerAsyncId: 'httpincomingmessage:1' },
       { type: 'SHUTDOWNWRAP',
         id: 'shutdown:1',
         triggerAsyncId: 'tcp:2' } ]

--- a/test/parallel/test-http-slow-headers-keepalive-multiple-requests.js
+++ b/test/parallel/test-http-slow-headers-keepalive-multiple-requests.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+const net = require('net');
+const { finished } = require('stream');
+
+const headers =
+  'GET / HTTP/1.1\r\n' +
+  'Host: localhost\r\n' +
+  'Connection: keep-alive\r\n' +
+  'Agent: node\r\n';
+
+const baseTimeout = 1000;
+
+const server = http.createServer(common.mustCall((req, res) => {
+  req.resume();
+  res.writeHead(200);
+  res.end();
+}, 2));
+
+server.keepAliveTimeout = 10 * baseTimeout;
+server.headersTimeout = baseTimeout;
+
+server.once('timeout', common.mustNotCall((socket) => {
+  socket.destroy();
+}));
+
+server.listen(0, () => {
+  const client = net.connect(server.address().port);
+
+  // first request
+  client.write(headers);
+  client.write('\r\n');
+
+  setTimeout(() => {
+    // second request
+    client.write(headers);
+    // `headersTimeout` doesn't seem to fire if request
+    // is sent altogether.
+    setTimeout(() => {
+      client.write('\r\n');
+      client.end();
+    }, 10);
+  }, baseTimeout + 10);
+
+  client.resume();
+  finished(client, common.mustCall((err) => {
+    server.close();
+  }));
+});


### PR DESCRIPTION
For keep-alive connections, the headersTimeout may fire during
subsequent request because the measurement was reset after
a request and not before a request.

Fixes: https://github.com/nodejs/node/issues/27363

Alternative implementation for: https://github.com/nodejs/node/pull/30184

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
