### PR TITLE
util: mark classes while inspecting them

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -171,7 +171,7 @@ const numberRegExp = /^(0|[1-9][0-9]*)$/;
 const coreModuleRegExp = /^    at (?:[^/\\(]+ \(|)((?<![/\\]).+)\.js:\d+:\d+\)?$/;
 const nodeModulesRegExp = /[/\\]node_modules[/\\](.+?)(?=[/\\])/g;
 
-const classRegExp = /^(class\s+[^(]*?)\s*{/;
+const classRegExp = /^(\s+[^(]*?)\s*{/;
 // eslint-disable-next-line node-core/no-unescaped-regexp-dot
 const stripCommentsRegExp = /(\/\/.*?\n)|(\/\*(.|\n)*?\*\/)/g;
 
@@ -1065,47 +1065,37 @@ function getBoxedBase(value, ctx, keys, constructor, tag) {
   return ctx.stylize(base, type.toLowerCase());
 }
 
-function getClassBase(string, value, constructor, tag) {
-  const parts = string.split(/\s+/);
-  if (parts[1] === 'extends') {
-    parts[3] = parts[2];
-    parts[1] = '';
-  }
-  const [, name, , superClass] = parts;
+function getClassBase(value, constructor, tag) {
+  const hasName = ObjectPrototypeHasOwnProperty(value, 'name');
+  const name = (hasName && value.name) || '(anonymous)';
   let base = `class ${name}`;
-  if (name !== value.name) {
-    if (name === '') {
-      base += value.name;
-    } else if (value.name) {
-      base += ` [${value.name}]`;
-    }
-  } else if (name === '') {
-    base += '(anonymous)';
-  }
-  if (constructor !== 'Function') {
-    if (constructor === null) {
-      base += ' [null prototype]';
-    } else {
-      base += ` [${constructor}]`;
-    }
+  if (constructor !== 'Function' && constructor !== null) {
+    base += ` [${constructor}]`;
   }
   if (tag !== '' && constructor !== tag) {
     base += ` [${tag}]`;
   }
-  if (superClass !== undefined) {
-    base += ` extends ${superClass}`;
+  if (constructor !== null) {
+    const superName = ObjectGetPrototypeOf(value).name;
+    if (superName) {
+      base += ` extends ${superName}`;
+    }
+  } else {
+    base += ' extends [null prototype]';
   }
   return `[${base}]`;
 }
 
 function getFunctionBase(value, constructor, tag) {
   const stringified = FunctionPrototypeToString(value);
-  if (stringified.slice(0, 5) === 'class') {
-    const match = stringified
-      .replace(stripCommentsRegExp, ' ')
-      .match(classRegExp);
-    if (match !== null) {
-      return getClassBase(match[1], value, constructor, tag);
+  if (stringified.slice(0, 5) === 'class' && stringified.endsWith('}')) {
+    const slice = stringified.slice(5, -1);
+    const bracketIndex = slice.indexOf('{');
+    if (bracketIndex !== -1 &&
+        (!slice.slice(0, bracketIndex).includes('(') ||
+          // Slow path to guarantee that it's indeed a class.
+          classRegExp.test(slice.replace(stripCommentsRegExp)))) {
+      return getClassBase(value, constructor, tag);
     }
   }
   let type = 'Function';

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -12,6 +12,7 @@ const {
   DatePrototypeToString,
   ErrorPrototypeToString,
   Float32Array,
+  FunctionPrototypeToString,
   JSONStringify,
   Map,
   MapPrototype,
@@ -169,6 +170,10 @@ const numberRegExp = /^(0|[1-9][0-9]*)$/;
 
 const coreModuleRegExp = /^    at (?:[^/\\(]+ \(|)((?<![/\\]).+)\.js:\d+:\d+\)?$/;
 const nodeModulesRegExp = /[/\\]node_modules[/\\](.+?)(?=[/\\])/g;
+
+const classRegExp = /^(class\s+[^(]*?)\s*{/;
+// eslint-disable-next-line node-core/no-unescaped-regexp-dot
+const stripCommentsRegExp = /(\/\/.*?\n)|(\/\*(.|\n)*?\*\/)/g;
 
 const kMinLineLength = 16;
 
@@ -1060,7 +1065,49 @@ function getBoxedBase(value, ctx, keys, constructor, tag) {
   return ctx.stylize(base, type.toLowerCase());
 }
 
+function getClassBase(string, value, constructor, tag) {
+  const parts = string.split(/\s+/);
+  if (parts[1] === 'extends') {
+    parts[3] = parts[2];
+    parts[1] = '';
+  }
+  const [, name, , superClass] = parts;
+  let base = `class ${name}`;
+  if (name !== value.name) {
+    if (name === '') {
+      base += value.name;
+    } else if (value.name) {
+      base += ` [${value.name}]`;
+    }
+  } else if (name === '') {
+    base += '(anonymous)';
+  }
+  if (constructor !== 'Function') {
+    if (constructor === null) {
+      base += ' [null prototype]';
+    } else {
+      base += ` [${constructor}]`;
+    }
+  }
+  if (tag !== '' && constructor !== tag) {
+    base += ` [${tag}]`;
+  }
+  if (superClass !== undefined) {
+    base += ` extends ${superClass}`;
+  }
+  return `[${base}]`;
+}
+
 function getFunctionBase(value, constructor, tag) {
+  const stringified = FunctionPrototypeToString(value);
+  if (stringified.slice(0, 5) === 'class') {
+    const match = stringified
+      .replace(stripCommentsRegExp, ' ')
+      .match(classRegExp);
+    if (match !== null) {
+      return getClassBase(match[1], value, constructor, tag);
+    }
+  }
   let type = 'Function';
   if (isGeneratorFunction(value)) {
     type = `Generator${type}`;

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -116,7 +116,7 @@ async function ordinaryTests() {
     ['await 0; function foo() {}'],
     ['foo', '[Function: foo]'],
     ['class Foo {}; await 1;', '1'],
-    ['Foo', '[Function: Foo]'],
+    ['Foo', '[class Foo]'],
     ['if (await true) { function bar() {}; }'],
     ['bar', '[Function: bar]'],
     ['if (await true) { class Bar {}; }'],

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1973,6 +1973,89 @@ assert.strictEqual(util.inspect('"\'${a}'), "'\"\\'${a}'");
   );
 });
 
+// Verify that classes are properly inspected.
+[
+  /* eslint-disable spaced-comment, no-multi-spaces, brace-style */
+  // The whitespace is intentional.
+  [class   { }, '[class (anonymous)]'],
+  [class extends Error { log() {} }, '[class (anonymous) extends Error]'],
+  [class A { constructor(a) { this.a = a; } log() { return this.a; } },
+   '[class A]'],
+  [class
+  // Random { // comments /* */ are part of the toString() result
+  /* eslint-disable-next-line space-before-blocks */
+  äß/**/extends/*{*/TypeError{}, '[class äß extends TypeError]'],
+  /* The whitespace and new line is intended! */
+  // Foobar !!!
+  [class X   extends /****/ Error
+  // More comments
+  {}, '[class X extends Error]']
+  /* eslint-enable spaced-comment, no-multi-spaces, brace-style */
+].forEach(([clazz, string]) => {
+  const inspected = util.inspect(clazz);
+  assert.strictEqual(inspected, string);
+  Object.defineProperty(clazz, Symbol.toStringTag, {
+    value: 'Woohoo'
+  });
+  const parts = inspected.slice(0, -1).split(' ');
+  const [, name, ...rest] = parts;
+  rest.unshift('[Woohoo]');
+  if (rest.length) {
+    rest[rest.length - 1] += ']';
+  }
+  assert.strictEqual(
+    util.inspect(clazz),
+    ['[class', name, ...rest].join(' ')
+  );
+  Object.setPrototypeOf(clazz, null);
+  assert.strictEqual(
+    util.inspect(clazz),
+    ['[class', name, '[null prototype]', ...rest].join(' ')
+  );
+  Object.defineProperty(clazz, 'name', { value: 'Foo' });
+  const newName = name === '(anonymous)' ? 'Foo' : `${name} [Foo]`;
+  assert.strictEqual(
+    util.inspect(clazz),
+    ['[class', newName, '[null prototype]', ...rest].join(' ')
+  );
+  Object.setPrototypeOf(clazz, Number.prototype);
+  assert.strictEqual(
+    util.inspect(clazz),
+    ['[class', newName, '[Number]', ...rest].join(' ')
+  );
+  clazz.foo = true;
+  assert.strictEqual(
+    util.inspect(clazz),
+    ['[class', newName, '[Number]', ...rest, '{ foo: true }'].join(' ')
+  );
+});
+
+// "class" properties should not be detected as "class".
+{
+  // eslint-disable-next-line space-before-function-paren
+  let obj = { class () {} };
+  assert.strictEqual(
+    util.inspect(obj),
+    '{ class: [Function: class] }'
+  );
+  obj = { class: () => {} };
+  assert.strictEqual(
+    util.inspect(obj),
+    '{ class: [Function: class] }'
+  );
+  obj = { ['class Foo {}']() {} };
+  assert.strictEqual(
+    util.inspect(obj),
+    "{ 'class Foo {}': [Function: class Foo {}] }"
+  );
+  function Foo() {}
+  Object.defineProperty(Foo, 'toString', { value: () => 'class Foo {}' });
+  assert.strictEqual(
+    util.inspect(Foo),
+    '[Function: Foo]'
+  );
+}
+
 // Verify that throwing in valueOf and toString still produces nice results.
 [
   [new String(55), "[String: '55']"],

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2007,27 +2007,20 @@ assert.strictEqual(util.inspect('"\'${a}'), "'\"\\'${a}'");
     util.inspect(clazz),
     ['[class', name, ...rest].join(' ')
   );
+  if (rest.length) {
+    rest[rest.length - 1] = rest[rest.length - 1].slice(0, -1);
+    rest.length = 1;
+  }
   Object.setPrototypeOf(clazz, null);
   assert.strictEqual(
     util.inspect(clazz),
-    ['[class', name, '[null prototype]', ...rest].join(' ')
+    ['[class', name, ...rest, 'extends [null prototype]]'].join(' ')
   );
   Object.defineProperty(clazz, 'name', { value: 'Foo' });
-  const newName = name === '(anonymous)' ? 'Foo' : `${name} [Foo]`;
-  assert.strictEqual(
-    util.inspect(clazz),
-    ['[class', newName, '[null prototype]', ...rest].join(' ')
-  );
-  Object.setPrototypeOf(clazz, Number.prototype);
-  assert.strictEqual(
-    util.inspect(clazz),
-    ['[class', newName, '[Number]', ...rest].join(' ')
-  );
+  const res = ['[class', 'Foo', ...rest, 'extends [null prototype]]'].join(' ');
+  assert.strictEqual(util.inspect(clazz), res);
   clazz.foo = true;
-  assert.strictEqual(
-    util.inspect(clazz),
-    ['[class', newName, '[Number]', ...rest, '{ foo: true }'].join(' ')
-  );
+  assert.strictEqual(util.inspect(clazz), `${res} { foo: true }`);
 });
 
 // "class" properties should not be detected as "class".
@@ -2053,6 +2046,12 @@ assert.strictEqual(util.inspect('"\'${a}'), "'\"\\'${a}'");
   assert.strictEqual(
     util.inspect(Foo),
     '[Function: Foo]'
+  );
+  const fn = function() {};
+  Object.defineProperty(fn, 'name', { value: 'class Foo {}' });
+  assert.strictEqual(
+    util.inspect(fn),
+    '[Function: class Foo {}]'
   );
 }
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2047,7 +2047,7 @@ assert.strictEqual(util.inspect('"\'${a}'), "'\"\\'${a}'");
     util.inspect(Foo),
     '[Function: Foo]'
   );
-  const fn = function() {};
+  function fn() {}
   Object.defineProperty(fn, 'name', { value: 'class Foo {}' });
   assert.strictEqual(
     util.inspect(fn),


### PR DESCRIPTION
This outlines the basic class setup when inspecting a class.

The implementation is a bit tricky but it should cover all edge cases.

Fixes: #32270 

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
