### PR TITLE
build: fail Travis if commit message check fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,4 +85,3 @@ jobs:
         - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   allow_failures:  # TODO (cclauss): remove this when dependencies are clean
     - name: "Find syntax errors in our Python dependencies"
-    - name: "First commit message adheres to guidelines at <a href=\"https://goo.gl/p2fr5Q\">https://goo.gl/p2fr5Q</a>"


### PR DESCRIPTION
"Allowed to fail" tests are easy to miss. With the failure on Travis,
new contributors can learn our commit guidelines. Collaborators are
still allowed (per our current policy) to land PRs where this check
fails, as long as the warnings are fixed before pushing to master.

Signed-off-by: Matheus Marchini <mmarchini@netflix.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
