### PR TITLE
build: add commit message linting to workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,23 @@ jobs:
         node-version: 10.x
     - name: Lint addon docs
       run: NODE=$(which node) make lint-addon-docs
+  lint-commit-message:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Lints message of the first commit in this pull request
+        continue-on-error: true
+        run: bash -x tools/lint-pr-commit-message.sh ${{ github.event.number }} || echo ::set-env name=needs_fixup::true
+      - name: Label on commit message lint failure
+        if: env.needs_fixup == 'true'
+        uses: actions/github@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: label "needs commit message fix"
   lint-cpp:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Run linting on the commit message of the first commit in a pull
request as part of our GitHub actions CI workflow. If linting fails
the pull request will be labelled as requiring a fix to the commit
message. The check itself will always pass so as to not concern
first time contributors.

This is a different approach to the commit message linting that
is currently run on Travis CI. The new label introduced by this
pull request (`needs commit message fix`) could also be added
manually for cases where the commit message needs updating
before landing for things not caught by `core-validate-commit`
(e.g. typos). We can also teach `node-core-utils` to check for the
label when landing pull requests (for those things not caught by
`core-validate-commit`).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
