### PR TITLE
test: uv_tty_init returns EBADF on IBM i

### DIFF
--- a/test/parallel/test-ttywrap-invalid-fd.js
+++ b/test/parallel/test-ttywrap-invalid-fd.js
@@ -21,13 +21,14 @@ assert.throws(
 
 {
   const info = {
-    code: common.isWindows ? 'EBADF' : 'EINVAL',
-    message: common.isWindows ? 'bad file descriptor' : 'invalid argument',
-    errno: common.isWindows ? UV_EBADF : UV_EINVAL,
+    code: common.isWindows || common.isIBMi ? 'EBADF' : 'EINVAL',
+    message: common.isWindows ||
+      common.isIBMi ? 'bad file descriptor' : 'invalid argument',
+    errno: common.isWindows || common.isIBMi ? UV_EBADF : UV_EINVAL,
     syscall: 'uv_tty_init'
   };
 
-  const suffix = common.isWindows ?
+  const suffix = common.isWindows || common.isIBMi ?
     'EBADF (bad file descriptor)' : 'EINVAL (invalid argument)';
   const message = `TTY initialization failed: uv_tty_init returned ${suffix}`;
 


### PR DESCRIPTION
When TTY initialization failed, uv_tty_init returned EBADF on IBM i
PASE, rather than EINVAL

It resolves the `test-ttywrap-invalid-fd` test failure on IBM i --
```
python3 tools/test.py -J --mode=release -v test/parallel/test-ttywrap-invalid-fd.js 
# out/Release/node -p process.arch
# out/Release/node -p process.versions.openssl
# out/Release/node -p process.features.inspector
# out/Release/node -p process.versions.openssl
[00:00|%   0|+   0|-   0]: release test-ttywrap-invalid-fd# out/Release/node --expose-internals /git/node/test/parallel/test-ttywrap-invalid-fd.js
[00:01|% 100|+   1|-   0]: Done  
```