### PR TITLE
src: check for empty maybe local

### DIFF
--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -516,9 +516,8 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
 
   // construct uv_buf_t array
   for (size_t i = 0; i < count; i++) {
-    MaybeLocal<Value> maybe_chunk = chunks->Get(env->context(), i);
-    if (maybe_chunk.IsEmpty()) return;
-    Local<Value> chunk = maybe_chunk.ToLocalChecked();
+    Local<Value> chunk;
+    if (!chunks->Get(env->context(), i).ToLocal(&chunk)) return;
 
     size_t length = Buffer::Length(chunk);
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -516,7 +516,9 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
 
   // construct uv_buf_t array
   for (size_t i = 0; i < count; i++) {
-    Local<Value> chunk = chunks->Get(env->context(), i).ToLocalChecked();
+    MaybeLocal<Value> maybe_chunk = chunks->Get(env->context(), i);
+    if (maybe_chunk.IsEmpty()) return;
+    Local<Value> chunk = maybe_chunk.ToLocalChecked();
 
     size_t length = Buffer::Length(chunk);
 


### PR DESCRIPTION
Using ToLocalChecked on MaybeLocal without verify it's empty can lead to unattempted crash.

Before the change: [this code](https://gist.github.com/Xstoudi/6ac8265aea1fea04799c1650a0cc94aa) leads Node.js to crash with C++ fatal error.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
