### PR TITLE
doc,crypto: clarify oaepHash option's impact

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2482,7 +2482,7 @@ changes:
 -->
 
 * `privateKey` {Object | string | Buffer | KeyObject}
-  * `oaepHash` {string} The hash function to use for OAEP padding.
+  * `oaepHash` {string} The hash function to use for OAEP padding and MGF1.
     **Default:** `'sha1'`
   * `oaepLabel` {Buffer | TypedArray | DataView} The label to use for OAEP
      padding. If not specified, no label is used.
@@ -2572,7 +2572,7 @@ changes:
 
 * `key` {Object | string | Buffer | KeyObject}
   * `key` {string | Buffer | KeyObject} A PEM encoded public or private key.
-  * `oaepHash` {string} The hash function to use for OAEP padding.
+  * `oaepHash` {string} The hash function to use for OAEP padding and MGF1.
     **Default:** `'sha1'`
   * `oaepLabel` {Buffer | TypedArray | DataView} The label to use for OAEP
      padding. If not specified, no label is used.


### PR DESCRIPTION
Introduced in #28335 this option also applies the hash function to MGF1, not just OAEP. This doc update makes that clear.