### PR TITLE
[v12.x backport] util: use a global symbol for `util.promisify.custom`

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -992,10 +992,31 @@ throw an error.
 ### `util.promisify.custom`
 <!-- YAML
 added: v8.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/31672
+    description: This is now defined as a shared symbol.
 -->
 
 * {symbol} that can be used to declare custom promisified variants of functions,
 see [Custom promisified functions][].
+
+In addition to being accessible through `util.promisify.custom`, this
+symbol is [registered globally][global symbol registry] and can be
+accessed in any environment as `Symbol.for('nodejs.util.promisify.custom')`.
+
+For example, with a function that takes in
+`(foo, onSuccessCallback, onErrorCallback)`:
+
+```js
+const kCustomPromisifiedSymbol = Symbol.for('nodejs.util.promisify.custom');
+
+doSomething[kCustomPromisifiedSymbol] = (foo) => {
+  return new Promise((resolve, reject) => {
+    doSomething(foo, resolve, reject);
+  });
+};
+```
 
 ## Class: `util.TextDecoder`
 <!-- YAML

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -271,7 +271,7 @@ function getSystemErrorName(err) {
   return entry ? entry[0] : `Unknown system error ${err}`;
 }
 
-const kCustomPromisifiedSymbol = Symbol('util.promisify.custom');
+const kCustomPromisifiedSymbol = SymbolFor('nodejs.util.promisify.custom');
 const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
 
 function promisify(original) {

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -35,6 +35,21 @@ const stat = promisify(fs.stat);
 
 {
   function fn() {}
+
+  function promisifiedFn() {}
+
+  // util.promisify.custom is a shared symbol which can be accessed
+  // as `Symbol.for("nodejs.util.promisify.custom")`.
+  const kCustomPromisifiedSymbol = Symbol.for('nodejs.util.promisify.custom');
+  fn[kCustomPromisifiedSymbol] = promisifiedFn;
+
+  assert.strictEqual(kCustomPromisifiedSymbol, promisify.custom);
+  assert.strictEqual(promisify(fn), promisifiedFn);
+  assert.strictEqual(promisify(promisify(fn)), promisifiedFn);
+}
+
+{
+  function fn() {}
   fn[promisify.custom] = 42;
   common.expectsError(
     () => promisify(fn),


### PR DESCRIPTION
This backports <https://github.com/nodejs/node/pull/31672> to **Node v12**.

It has already been backported to **Node v13** as <https://github.com/nodejs/node/commit/975d6b01447e426847baf9011a1c4ce15342fd6c>.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
