### PR TITLE
build: rework ASAN build on Actions

### DIFF
--- a/.github/workflows/ASAN.yml
+++ b/.github/workflows/ASAN.yml
@@ -3,23 +3,19 @@ name: node ASAN
 on: [push, pull_request]
 
 jobs:
-  ubuntu-build:
-      runs-on: ubuntu-latest
-      container: gengjiawen/node-build:2020-02-14
-      steps:
-        - uses: actions/checkout@v2
-        - name: Build
-          # TODO(mmarchini): With V8 8.1, GitHub Actions doesn't have enough
-          # memory to build with debug and ASAN. Allow this build to fail until
-          # we figure out a workaround, or until we update to 8.2 (where build
-          # is passing).
-          continue-on-error: true
-          run: |
-              npx envinfo
-              ./configure --debug --enable-asan --ninja && ninja -C out/Debug
-        - name: Test
-          env:
-            ASAN_OPTIONS: halt_on_error=0
-          continue-on-error: true
-          run: |
-            python3 tools/test.py -J --mode=debug
+  build-linux-asan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Environment Information
+        run: npx envinfo
+      - name: Build
+        run: ./configure --enable-asan && make -j2
+      # TODO(mmarchini): re-enable tests when we fix all issues pointed out
+      # by ASAN
+      # - name: Test
+      #   env:
+      #     ASAN_OPTIONS: halt_on_error=0
+      #   continue-on-error: true
+      #   run: |
+      #     python3 tools/test.py -J


### PR DESCRIPTION
Changed from Debug build to Release build to avoid out of memory issues
during the link step. This should also speed up the build.

Commented out the test runner for now, since there are too many ASAN
warnings there to be useful. We should re-enable the test runner once
our ASAN warnings are fixed.

Simplify the environment: instead of running on a container, runs
directly on the host. With this, ASAN build looks identical to other
builds in GitHub Actions, with the exception of the `--enable-asan`
flag.

Ref: https://github.com/nodejs/node/issues/32257
Ref: https://github.com/nodejs/node/pull/32324

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
