### PR TITLE
src: remove calls to deprecated ArrayBuffer methods

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -2720,9 +2720,6 @@ napi_status napi_create_external_arraybuffer(napi_env env,
                                        nullptr);
   v8::Local<v8::ArrayBuffer> buffer =
       v8::ArrayBuffer::New(isolate, std::move(backing));
-  // TODO(thangktran): drop this check when V8 is pumped to 8.0 .
-  if (!buffer->IsExternal())
-    buffer->Externalize(buffer->GetBackingStore());
   v8::Maybe<bool> marked = env->mark_arraybuffer_as_untransferable(buffer);
   CHECK_MAYBE_NOTHING(env, marked, napi_generic_failure);
 
@@ -3184,9 +3181,6 @@ napi_status napi_detach_arraybuffer(napi_env env, napi_value arraybuffer) {
       env, value->IsArrayBuffer(), napi_arraybuffer_expected);
 
   v8::Local<v8::ArrayBuffer> it = value.As<v8::ArrayBuffer>();
-  // TODO(addaleax): Remove the first condition once we have V8 8.0.
-  RETURN_STATUS_IF_FALSE(
-      env, it->IsExternal(), napi_detachable_arraybuffer_expected);
   RETURN_STATUS_IF_FALSE(
       env, it->IsDetachable(), napi_detachable_arraybuffer_expected);
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -417,9 +417,6 @@ MaybeLocal<Object> New(Environment* env,
                                    nullptr);
   Local<ArrayBuffer> ab = ArrayBuffer::New(env->isolate(),
                                            std::move(backing));
-  // TODO(thangktran): drop this check when V8 is pumped to 8.0 .
-  if (!ab->IsExternal())
-    ab->Externalize(ab->GetBackingStore());
   if (ab->SetPrivate(env->context(),
                      env->arraybuffer_untransferable_private_symbol(),
                      True(env->isolate())).IsNothing()) {
@@ -1212,9 +1209,6 @@ void Initialize(Local<Object> target,
                                    nullptr);
     Local<ArrayBuffer> array_buffer =
         ArrayBuffer::New(env->isolate(), std::move(backing));
-    // TODO(thangktran): drop this check when V8 is pumped to 8.0 .
-    if (!array_buffer->IsExternal())
-      array_buffer->Externalize(array_buffer->GetBackingStore());
     array_buffer->SetPrivate(
         env->context(),
         env->arraybuffer_untransferable_private_symbol(),

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -389,9 +389,6 @@ Maybe<bool> Message::Serialize(Environment* env,
   for (Local<ArrayBuffer> ab : array_buffers) {
     // If serialization succeeded, we render it inaccessible in this Isolate.
     std::shared_ptr<BackingStore> backing_store = ab->GetBackingStore();
-    // TODO(addaleax): This can/should be dropped once we have V8 8.0.
-    if (!ab->IsExternal())
-      ab->Externalize(backing_store);
     ab->Detach();
 
     array_buffers_.emplace_back(std::move(backing_store));

--- a/test/js-native-api/test_typedarray/test.js
+++ b/test/js-native-api/test_typedarray/test.js
@@ -78,7 +78,11 @@ nonByteArrayTypes.forEach((currentType) => {
 // Test detaching
 arrayTypes.forEach((currentType) => {
   const buffer = Reflect.construct(currentType, [8]);
-  assert.doesNotThrow(() => test_typedarray.Detach(buffer));
+  assert.strictEqual(buffer.length, 8);
+  assert.ok(!test_typedarray.IsDetached(buffer.buffer));
+  test_typedarray.Detach(buffer);
+  assert.ok(test_typedarray.IsDetached(buffer.buffer));
+  assert.strictEqual(buffer.length, 0);
 });
 {
   const buffer = test_typedarray.External();

--- a/test/js-native-api/test_typedarray/test.js
+++ b/test/js-native-api/test_typedarray/test.js
@@ -78,9 +78,7 @@ nonByteArrayTypes.forEach((currentType) => {
 // Test detaching
 arrayTypes.forEach((currentType) => {
   const buffer = Reflect.construct(currentType, [8]);
-  assert.throws(
-    () => test_typedarray.Detach(buffer),
-    /A detachable arraybuffer was expected/);
+  assert.doesNotThrow(() => test_typedarray.Detach(buffer));
 });
 {
   const buffer = test_typedarray.External();


### PR DESCRIPTION
v8::ArrayBuffer::IsExternal and v8::ArrayBuffer::Externalize are
no longer necessary.
