### PR TITLE
doc: tests local links in markdown documents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -599,6 +599,7 @@ test-doc: doc-only lint ## Builds, lints, and verifies the docs.
 	else \
 		$(PYTHON) tools/test.py $(PARALLEL_ARGS) doctool; \
 	fi
+	$(NODE) tools/doc/checkLinks.js .
 
 test-known-issues: all
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) known_issues

--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -37,8 +37,8 @@
 
 This document explains how Collaborators manage the Node.js project.
 Collaborators should understand the
-[guidelines for new contributors](CONTRIBUTING.md) and the
-[project governance model](GOVERNANCE.md).
+[guidelines for new contributors](../../CONTRIBUTING.md) and the
+[project governance model](../../GOVERNANCE.md).
 
 ## Issues and Pull Requests
 
@@ -50,7 +50,7 @@ request. See [Who to CC in the issue tracker](#who-to-cc-in-the-issue-tracker).
 
 Always show courtesy to individuals submitting issues and pull requests. Be
 welcoming to first-time contributors, identified by the GitHub
-![First-time contributor](./doc/first_timer_badge.png) badge.
+![First-time contributor](../first_timer_badge.png) badge.
 
 For first-time contributors, check if the commit author is the same as the pull
 request author. This way, once their pull request lands, GitHub will show them
@@ -481,7 +481,7 @@ $ git checkout master
 ```
 
 Update the tree (assumes your repo is set up as detailed in
-[CONTRIBUTING.md](./doc/guides/contributing/pull-requests.md#step-1-fork)):
+[CONTRIBUTING.md](./contributing/pull-requests.md#step-1-fork)):
 
 ```text
 $ git fetch upstream

--- a/doc/guides/cpp-style-guide.md
+++ b/doc/guides/cpp-style-guide.md
@@ -1,7 +1,7 @@
 # C++ Style Guide
 
-See also the [C++ codebase README](src/README.md) for C++ idioms in the Node.js
-codebase not related to stylistic issues.
+See also the [C++ codebase README](../../src/README.md) for C++ idioms in the
+Node.js codebase not related to stylistic issues.
 
 ## Table of Contents
 

--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -322,8 +322,8 @@ accordingly by removing the bold styling from the previous release.
 If this release includes new APIs then it is necessary to document that they
 were first added in this version. The relevant commits should already include
 `REPLACEME` tags as per the example in the
-[docs README](../tools/doc/README.md). Check for these tags with `grep REPLACEME
-doc/api/*.md`, and substitute this node version with `sed -i
+[docs README](../../tools/doc/README.md). Check for these tags with `grep
+REPLACEME doc/api/*.md`, and substitute this node version with `sed -i
 "s/REPLACEME/$VERSION/g" doc/api/*.md` or `perl -pi -e "s/REPLACEME/$VERSION/g"
 doc/api/*.md`.
 

--- a/onboarding.md
+++ b/onboarding.md
@@ -83,7 +83,7 @@ onboarding session.
   * Be nice about closing issues! Let people know why, and that issues and PRs
     can be reopened if necessary
 
-* [**See "Labels"**](./onboarding-extras.md#labels)
+* [**See "Labels"**](./doc/guides/onboarding-extras.md#labels)
   * There is [a bot](https://github.com/nodejs-github-bot/github-bot) that
     applies subsystem labels (for example, `doc`, `test`, `assert`, or `buffer`)
     so that we know what parts of the code base the pull request modifies. It is

--- a/tools/doc/checkLinks.js
+++ b/tools/doc/checkLinks.js
@@ -43,7 +43,7 @@ if (isMainThread) {
 
   function errorHandler(error) {
     console.error(error);
-    process.exitCode = -1;
+    process.exitCode = 1;
   }
 
   setImmediate(async () => {

--- a/tools/doc/checkLinks.js
+++ b/tools/doc/checkLinks.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const fs = require('fs');
+const { Worker, isMainThread, workerData: path } = require('worker_threads');
+
+function* getLinksRecursively(node) {
+  if (
+    (node.type === 'link' && !node.url.startsWith('#')) ||
+    node.type === 'image'
+  ) {
+    yield node;
+  }
+  for (const child of node.children || []) {
+    yield* getLinksRecursively(child);
+  }
+}
+
+if (isMainThread) {
+  const { extname, join, resolve } = require('path');
+  const DIR = resolve(process.argv[2]);
+
+  console.log('Running Markdown link checker...');
+
+  async function* findMarkdownFilesRecursively(dirPath) {
+    const fileNames = await fs.promises.readdir(dirPath);
+
+    for (const fileName of fileNames) {
+      const path = join(dirPath, fileName);
+
+      const stats = await fs.promises.stat(path);
+      if (
+        stats.isDirectory() &&
+        fileName !== 'api' &&
+        fileName !== 'deps' &&
+        fileName !== 'node_modules'
+      ) {
+        yield* findMarkdownFilesRecursively(path);
+      } else if (extname(fileName) === '.md') {
+        yield path;
+      }
+    }
+  }
+
+  function errorHandler(error) {
+    console.error(error);
+    process.exitCode = -1;
+  }
+
+  setImmediate(async () => {
+    for await (const path of findMarkdownFilesRecursively(DIR)) {
+      new Worker(__filename, { workerData: path }).on('error', errorHandler);
+    }
+  });
+} else {
+  const unified = require('unified');
+  const { pathToFileURL } = require('url');
+
+  const tree = unified()
+    .use(require('remark-parse'))
+    .parse(fs.readFileSync(path));
+
+  const base = pathToFileURL(path);
+  for (const node of getLinksRecursively(tree)) {
+    const targetURL = new URL(node.url, base);
+    if (targetURL.protocol === 'file:' && !fs.existsSync(targetURL)) {
+      const error = new Error('Broken link in a Markdown document.');
+      const { start } = node.position;
+      error.stack =
+        error.stack.substring(0, error.stack.indexOf('\n') + 5) +
+        `at ${node.type} (${path}:${start.line}:${start.column})`;
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
Sometimes MD files are moved around in the repo and it creates broken links. Unless I'm missing something, only `doc/api` files are checked currently, this PR adds a test script for all other MD files to check image URLs and link targets.

I have made an attempt to check HTTP links, but that was just taking too long so I have restricted to local links only.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
