### PR TITLE
stream: complete pipeline with stdio

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -164,6 +164,8 @@ async function pump(iterable, writable, finish) {
       const errorPromise = new Promise((resolve, reject) => {
         writable.on('error', reject);
       });
+      // Don't propagate to unhandledRejection
+      errorPromise.catch(() => {});
       for await (const chunk of iterable) {
         await Promise.race([
           errorPromise,

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -114,6 +114,10 @@ function isStream(obj) {
   return isReadable(obj) || isWritable(obj);
 }
 
+function isStdio(obj) {
+  return obj === process.stdout || obj === process.stderr;
+}
+
 function isIterable(obj, isAsync) {
   if (!obj) return false;
   if (isAsync === true) return typeof obj[SymbolAsyncIterator] === 'function';
@@ -148,7 +152,7 @@ async function pump(iterable, writable, finish) {
   }
   let error;
   try {
-    if (writable !== process.stdout && writable !== process.stderr) {
+    if (!isStdio(writable)) {
       for await (const chunk of iterable) {
         if (!writable.write(chunk)) {
           if (writable.destroyed) return;
@@ -157,12 +161,18 @@ async function pump(iterable, writable, finish) {
       }
       writable.end();
     } else {
+      const errorPromise = new Promise((resolve, reject) => {
+        writable.on('error', reject);
+      });
       for await (const chunk of iterable) {
-        await new Promise((resolve, reject) => {
-          writable.write(chunk, null, (err) => {
-            err ? reject(err) : resolve();
-          });
-        });
+        await Promise.race([
+          errorPromise,
+          await new Promise((resolve, reject) => {
+            writable.write(chunk, null, (err) => {
+              err ? reject(err) : resolve();
+            });
+          })
+        ]);
       }
     }
   } catch (err) {
@@ -213,9 +223,7 @@ function pipeline(...streams) {
     const reading = i < streams.length - 1;
     const writing = i > 0;
 
-    if (stream === process.stdout || stream === process.stderr) {
-      // `pipe()` doesn't .end() stdout and stderr.
-    } else if (isStream(stream)) {
+    if (isStream(stream) && !isStdio(stream)) {
       finishCount++;
       destroys.push(destroyer(stream, reading, writing, !reading, finish));
     }
@@ -276,10 +284,7 @@ function pipeline(...streams) {
         destroys.push(destroyer(ret, false, true, true, finish));
       }
     } else if (isStream(stream)) {
-      if (isReadable(ret) &&
-          stream !== process.stdout &&
-          stream !== process.stderr
-      ) {
+      if (isReadable(ret) && !isStdio(stream)) {
         ret.pipe(stream);
       } else {
         ret = makeAsyncIterable(ret);

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -146,37 +146,43 @@ async function* fromReadable(val) {
   yield* createReadableStreamAsyncIterator(val);
 }
 
+function pumpStdio(iterable, writable, finish) {
+  let iterator;
+  if (iterable[SymbolAsyncIterator])
+    iterator = iterable[SymbolAsyncIterator]();
+  else if (iterable[SymbolIterator])
+    iterator = iterable[SymbolIterator]();
+
+  async function _next(err) {
+    if (err) {
+      return finish(err);
+    }
+    try {
+      const { value, done } = await iterator.next();
+      if (done) {
+        return finish();
+      }
+      writable.write(value, _next);
+    } catch (err) {
+      finish(err);
+    }
+  }
+  _next();
+}
+
 async function pump(iterable, writable, finish) {
   if (!EE) {
     EE = require('events');
   }
   let error;
   try {
-    if (!isStdio(writable)) {
-      for await (const chunk of iterable) {
-        if (!writable.write(chunk)) {
-          if (writable.destroyed) return;
-          await EE.once(writable, 'drain');
-        }
-      }
-      writable.end();
-    } else {
-      const errorPromise = new Promise((resolve, reject) => {
-        writable.on('error', reject);
-      });
-      // Don't propagate to unhandledRejection
-      errorPromise.catch(() => {});
-      for await (const chunk of iterable) {
-        await Promise.race([
-          errorPromise,
-          new Promise((resolve, reject) => {
-            writable.write(chunk, null, (err) => {
-              err ? reject(err) : resolve();
-            });
-          })
-        ]);
+    for await (const chunk of iterable) {
+      if (!writable.write(chunk)) {
+        if (writable.destroyed) return;
+        await EE.once(writable, 'drain');
       }
     }
+    writable.end();
   } catch (err) {
     error = err;
   } finally {
@@ -292,7 +298,11 @@ function pipeline(...streams) {
         ret = makeAsyncIterable(ret);
 
         finishCount++;
-        pump(ret, stream, finish);
+        if (isStdio(stream)) {
+          pumpStdio(ret, stream, finish);
+        } else {
+          pump(ret, stream, finish);
+        }
       }
       ret = stream;
     } else {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -6,8 +6,7 @@
 const {
   ArrayIsArray,
   SymbolAsyncIterator,
-  SymbolIterator,
-  Promise
+  SymbolIterator
 } = primordials;
 
 let eos;
@@ -114,10 +113,6 @@ function isStream(obj) {
   return isReadable(obj) || isWritable(obj);
 }
 
-function isStdio(obj) {
-  return obj === process.stdout || obj === process.stderr;
-}
-
 function isIterable(obj, isAsync) {
   if (!obj) return false;
   if (isAsync === true) return typeof obj[SymbolAsyncIterator] === 'function';
@@ -151,32 +146,14 @@ async function pump(iterable, writable, finish) {
     EE = require('events');
   }
   let error;
-  writable.on('error', (err) => {
-    error = err;
-  });
   try {
-    let prev;
-    for await (const next of iterable) {
-      if (prev != null) {
-        if (!writable.write(prev)) {
-          if (writable.destroyed) return;
-          await EE.once(writable, 'drain');
-        }
+    for await (const chunk of iterable) {
+      if (!writable.write(chunk)) {
+        if (writable.destroyed) return;
+        await EE.once(writable, 'drain');
       }
-      prev = next;
     }
-
-    if (prev != null) {
-      await new Promise((resolve, reject) => {
-        writable.write(prev, (err) => {
-          err ? reject(err) : resolve();
-        });
-      });
-    }
-
-    if (!isStdio(writable)) {
-      writable.end();
-    }
+    writable.end();
   } catch (err) {
     error = err;
   } finally {
@@ -225,7 +202,7 @@ function pipeline(...streams) {
     const reading = i < streams.length - 1;
     const writing = i > 0;
 
-    if (isStream(stream) && !isStdio(stream)) {
+    if (isStream(stream)) {
       finishCount++;
       destroys.push(destroyer(stream, reading, writing, !reading, finish));
     }
@@ -286,8 +263,15 @@ function pipeline(...streams) {
         destroys.push(destroyer(ret, false, true, true, finish));
       }
     } else if (isStream(stream)) {
-      if (isReadable(ret) && !isStdio(stream)) {
+      if (isReadable(ret)) {
         ret.pipe(stream);
+
+        // Compat. Before node v10.12.0 stdio used to throw an error so
+        // pipe() did/does not end() stdio destinations.
+        // Now they allow it but "secretly" don't close the underlying fd.
+        if (stream === process.stdout || stream === process.stderr) {
+          ret.on('end', () => stream.end());
+        }
       } else {
         ret = makeAsyncIterable(ret);
 

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -6,7 +6,8 @@
 const {
   ArrayIsArray,
   SymbolAsyncIterator,
-  SymbolIterator
+  SymbolIterator,
+  Promise
 } = primordials;
 
 let eos;
@@ -147,13 +148,23 @@ async function pump(iterable, writable, finish) {
   }
   let error;
   try {
-    for await (const chunk of iterable) {
-      if (!writable.write(chunk)) {
-        if (writable.destroyed) return;
-        await EE.once(writable, 'drain');
+    if (writable !== process.stdout && writable !== process.stderr) {
+      for await (const chunk of iterable) {
+        if (!writable.write(chunk)) {
+          if (writable.destroyed) return;
+          await EE.once(writable, 'drain');
+        }
+      }
+      writable.end();
+    } else {
+      for await (const chunk of iterable) {
+        await new Promise((resolve, reject) => {
+          writable.write(chunk, null, (err) => {
+            err ? reject(err) : resolve();
+          });
+        });
       }
     }
-    writable.end();
   } catch (err) {
     error = err;
   } finally {
@@ -202,7 +213,9 @@ function pipeline(...streams) {
     const reading = i < streams.length - 1;
     const writing = i > 0;
 
-    if (isStream(stream)) {
+    if (stream === process.stdout || stream === process.stderr) {
+      // `pipe()` doesn't .end() stdout and stderr.
+    } else if (isStream(stream)) {
       finishCount++;
       destroys.push(destroyer(stream, reading, writing, !reading, finish));
     }
@@ -263,7 +276,10 @@ function pipeline(...streams) {
         destroys.push(destroyer(ret, false, true, true, finish));
       }
     } else if (isStream(stream)) {
-      if (isReadable(ret)) {
+      if (isReadable(ret) &&
+          stream !== process.stdout &&
+          stream !== process.stderr
+      ) {
         ret.pipe(stream);
       } else {
         ret = makeAsyncIterable(ret);

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -167,7 +167,7 @@ async function pump(iterable, writable, finish) {
       for await (const chunk of iterable) {
         await Promise.race([
           errorPromise,
-          await new Promise((resolve, reject) => {
+          new Promise((resolve, reject) => {
             writable.write(chunk, null, (err) => {
               err ? reject(err) : resolve();
             });

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -146,43 +146,37 @@ async function* fromReadable(val) {
   yield* createReadableStreamAsyncIterator(val);
 }
 
-function pumpStdio(iterable, writable, finish) {
-  let iterator;
-  if (iterable[SymbolAsyncIterator])
-    iterator = iterable[SymbolAsyncIterator]();
-  else if (iterable[SymbolIterator])
-    iterator = iterable[SymbolIterator]();
-
-  async function _next(err) {
-    if (err) {
-      return finish(err);
-    }
-    try {
-      const { value, done } = await iterator.next();
-      if (done) {
-        return finish();
-      }
-      writable.write(value, _next);
-    } catch (err) {
-      finish(err);
-    }
-  }
-  _next();
-}
-
 async function pump(iterable, writable, finish) {
   if (!EE) {
     EE = require('events');
   }
   let error;
+  writable.on('error', (err) => {
+    error = err;
+  });
   try {
-    for await (const chunk of iterable) {
-      if (!writable.write(chunk)) {
-        if (writable.destroyed) return;
-        await EE.once(writable, 'drain');
+    let prev;
+    for await (const next of iterable) {
+      if (prev != null) {
+        if (!writable.write(prev)) {
+          if (writable.destroyed) return;
+          await EE.once(writable, 'drain');
+        }
       }
+      prev = next;
     }
-    writable.end();
+
+    if (prev != null) {
+      await new Promise((resolve, reject) => {
+        writable.write(prev, (err) => {
+          err ? reject(err) : resolve();
+        });
+      });
+    }
+
+    if (!isStdio(writable)) {
+      writable.end();
+    }
   } catch (err) {
     error = err;
   } finally {
@@ -298,11 +292,7 @@ function pipeline(...streams) {
         ret = makeAsyncIterable(ret);
 
         finishCount++;
-        if (isStdio(stream)) {
-          pumpStdio(ret, stream, finish);
-        } else {
-          pump(ret, stream, finish);
-        }
+        pump(ret, stream, finish);
       }
       ret = stream;
     } else {

--- a/test/parallel/test-stream-pipeline-process.js
+++ b/test/parallel/test-stream-pipeline-process.js
@@ -2,6 +2,7 @@
 
 const common = require('../common');
 const assert = require('assert');
+const os = require('os')
 
 if (process.argv[2] === 'child') {
   const { pipeline } = require('stream');
@@ -23,6 +24,6 @@ if (process.argv[2] === 'child') {
     'child'
   ].join(' '), common.mustCall((err, stdout) => {
     assert.ifError(err);
-    assert.strictEqual(stdout, 'hello');
+    assert.strictEqual(stdout.split(os.EOL).shift(), 'hello');
   }));
 }

--- a/test/parallel/test-stream-pipeline-process.js
+++ b/test/parallel/test-stream-pipeline-process.js
@@ -24,6 +24,6 @@ if (process.argv[2] === 'child') {
     'child'
   ].join(' '), common.mustCall((err, stdout) => {
     assert.ifError(err);
-    assert.strictEqual(stdout.split(os.EOL).shift(), 'hello');
+    assert.strictEqual(stdout.split(os.EOL).shift().trim(), 'hello');
   }));
 }

--- a/test/parallel/test-stream-pipeline-process.js
+++ b/test/parallel/test-stream-pipeline-process.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+if (process.argv[2] === 'child') {
+  const { pipeline } = require('stream');
+  pipeline(
+    process.stdin,
+    process.stdout,
+    common.mustCall()
+  );
+} else {
+  const cp = require('child_process');
+  cp.exec([
+    'echo',
+    '"hello"',
+    '|',
+    `"${process.execPath}"`,
+    `"${__filename}"`,
+    'child'
+  ].join(' '), common.mustCall((err) => {
+    assert.ifError(err);
+  }));
+}

--- a/test/parallel/test-stream-pipeline-process.js
+++ b/test/parallel/test-stream-pipeline-process.js
@@ -16,13 +16,13 @@ if (process.argv[2] === 'child') {
   const cp = require('child_process');
   cp.exec([
     'echo',
-    '"hello"',
+    'hello',
     '|',
     `"${process.execPath}"`,
     `"${__filename}"`,
     'child'
   ].join(' '), common.mustCall((err, stdout) => {
     assert.ifError(err);
-    assert.strictEqual(stdout, 'hello\n');
+    assert.strictEqual(stdout, 'hello');
   }));
 }

--- a/test/parallel/test-stream-pipeline-process.js
+++ b/test/parallel/test-stream-pipeline-process.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const os = require('os')
+const os = require('os');
 
 if (process.argv[2] === 'child') {
   const { pipeline } = require('stream');

--- a/test/parallel/test-stream-pipeline-process.js
+++ b/test/parallel/test-stream-pipeline-process.js
@@ -8,7 +8,9 @@ if (process.argv[2] === 'child') {
   pipeline(
     process.stdin,
     process.stdout,
-    common.mustCall()
+    common.mustCall((err) => {
+      assert.ifError(err);
+    })
   );
 } else {
   const cp = require('child_process');

--- a/test/parallel/test-stream-pipeline-process.js
+++ b/test/parallel/test-stream-pipeline-process.js
@@ -23,6 +23,6 @@ if (process.argv[2] === 'child') {
     'child'
   ].join(' '), common.mustCall((err, stdout) => {
     assert.ifError(err);
-    assert.strictEqual(stdout, 'hello');
+    assert.strictEqual(stdout, 'hello\n');
   }));
 }

--- a/test/parallel/test-stream-pipeline-process.js
+++ b/test/parallel/test-stream-pipeline-process.js
@@ -21,7 +21,8 @@ if (process.argv[2] === 'child') {
     `"${process.execPath}"`,
     `"${__filename}"`,
     'child'
-  ].join(' '), common.mustCall((err) => {
+  ].join(' '), common.mustCall((err, stdout) => {
     assert.ifError(err);
+    assert.strictEqual(stdout, 'hello');
   }));
 }


### PR DESCRIPTION
stdio (stderr & stdout) should for compatibility
reasons not be closed/end():ed. However, this
causes pipeline with a stdio destination to
never finish. This commit fixes this issue at
a performance cost.

Refs: https://github.com/nodejs/node/issues/7606

Fixes: https://github.com/nodejs/node/issues/32363

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
