### PR TITLE
build: annotate markdown lint failures in pull requests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,7 +64,9 @@ jobs:
       with:
         node-version: 10.x
     - name: Lint docs
-      run: NODE=$(which node) make lint-md
+      run: |
+        echo "::add-matcher::.github/workflows/remark-lint-problem-matcher.json"
+        NODE=$(which node) make lint-md
   lint-js:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/remark-lint-problem-matcher.json
+++ b/.github/workflows/remark-lint-problem-matcher.json
@@ -1,0 +1,23 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "remark-lint",
+      "pattern": [
+        {
+          // Filename may be decorated by ANSI escape sequences
+          "regexp": "^(?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)*$",
+          "file": 1
+        },
+        {
+          "regexp": "^\\s+(?:\\d+:\\d+-)?(\\d+):(\\d+)\\s+\\S*(error|warning|info)\\S*\\s+(.+)\\s+(\\S+)\\s+(?:\\S+)$",
+          "line": 1,
+          "column": 2,
+          "severity": 3,
+          "message": 4,
+          "code": 5,
+          "loop": true
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/remark-lint-problem-matcher.json
+++ b/.github/workflows/remark-lint-problem-matcher.json
@@ -4,7 +4,6 @@
       "owner": "remark-lint",
       "pattern": [
         {
-          // Filename may be decorated by ANSI escape sequences
           "regexp": "^(?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)*$",
           "file": 1
         },


### PR DESCRIPTION
Add a problem matcher for output from remark-lint to our lint-md GitHub
Actions CI workflow so that any markdown linter failures are annotated
in the pull request in the web UI.

Refs: https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md
Refs: https://github.com/actions/toolkit/blob/master/docs/commands.md#problem-matchers

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
