### PR TITLE
util: add `maxStringLength` option to `inspect` function

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -488,7 +488,7 @@ changes:
     negative to show no elements. **Default:** `100`.
   * `maxStringLength` {integer} Specifies the maximum number of characters to
     include when formatting. Set to `null` or `Infinity` to show all elements.
-    Set to `0` or negative to show no characters. **Default:** `10000`.
+    Set to `0` or negative to show no characters. **Default:** `Infinity`.
   * `breakLength` {integer} The length at which input values are split across
     multiple lines. Set to `Infinity` to format the input as a single line
     (in combination with `compact` set to `true` or any number >= `1`).

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -398,6 +398,9 @@ stream.write('With ES6');
 <!-- YAML
 added: v0.3.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32392
+    description: The `maxStringLength` option is supported now.
   - version: v13.5.0
     pr-url: https://github.com/nodejs/node/pull/30768
     description: User defined prototype properties are inspected in case
@@ -483,6 +486,9 @@ changes:
     [`TypedArray`][], [`WeakMap`][] and [`WeakSet`][] elements to include when
     formatting. Set to `null` or `Infinity` to show all elements. Set to `0` or
     negative to show no elements. **Default:** `100`.
+  * `maxStringLength` {integer} Specifies the maximum number of characters to
+    include when formatting. Set to `null` or `Infinity` to show all elements.
+    Set to `0` or negative to show no characters. **Default:** `10000`.
   * `breakLength` {integer} The length at which input values are split across
     multiple lines. Set to `Infinity` to format the input as a single line
     (in combination with `compact` set to `true` or any number >= `1`).

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -146,6 +146,7 @@ const inspectDefaultOptions = ObjectSeal({
   customInspect: true,
   showProxy: false,
   maxArrayLength: 100,
+  maxStringLength: 10000,
   breakLength: 80,
   compact: 3,
   sorted: false,
@@ -215,6 +216,7 @@ function getUserOptions(ctx) {
     customInspect: ctx.customInspect,
     showProxy: ctx.showProxy,
     maxArrayLength: ctx.maxArrayLength,
+    maxStringLength: ctx.maxStringLength,
     breakLength: ctx.breakLength,
     compact: ctx.compact,
     sorted: ctx.sorted,
@@ -245,6 +247,7 @@ function inspect(value, opts) {
     customInspect: inspectDefaultOptions.customInspect,
     showProxy: inspectDefaultOptions.showProxy,
     maxArrayLength: inspectDefaultOptions.maxArrayLength,
+    maxStringLength: inspectDefaultOptions.maxStringLength,
     breakLength: inspectDefaultOptions.breakLength,
     compact: inspectDefaultOptions.compact,
     sorted: inspectDefaultOptions.sorted,
@@ -282,6 +285,7 @@ function inspect(value, opts) {
   }
   if (ctx.colors) ctx.stylize = stylizeWithColor;
   if (ctx.maxArrayLength === null) ctx.maxArrayLength = Infinity;
+  if (ctx.maxStringLength === null) ctx.maxStringLength = Infinity;
   return formatValue(ctx, value, 0);
 }
 inspect.custom = customInspectSymbol;
@@ -1301,6 +1305,12 @@ function formatBigInt(fn, value) {
 
 function formatPrimitive(fn, value, ctx) {
   if (typeof value === 'string') {
+    let trailer = '';
+    if (value.length > ctx.maxStringLength) {
+      const remaining = value.length - ctx.maxStringLength;
+      value = value.slice(0, ctx.maxStringLength);
+      trailer = `... ${remaining} more character${remaining > 1 ? 's' : ''}`;
+    }
     if (ctx.compact !== true &&
         // TODO(BridgeAR): Add unicode support. Use the readline getStringWidth
         // function.
@@ -1309,9 +1319,9 @@ function formatPrimitive(fn, value, ctx) {
       return value
         .split(/(?<=\n)/)
         .map((line) => fn(strEscape(line), 'string'))
-        .join(` +\n${' '.repeat(ctx.indentationLvl + 2)}`);
+        .join(` +\n${' '.repeat(ctx.indentationLvl + 2)}`) + trailer;
     }
-    return fn(strEscape(value), 'string');
+    return fn(strEscape(value), 'string') + trailer;
   }
   if (typeof value === 'number')
     return formatNumber(fn, value);

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -146,7 +146,7 @@ const inspectDefaultOptions = ObjectSeal({
   customInspect: true,
   showProxy: false,
   maxArrayLength: 100,
-  maxStringLength: 10000,
+  maxStringLength: Infinity,
   breakLength: 80,
   compact: 3,
   sorted: false,

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2779,3 +2779,12 @@ assert.strictEqual(
   v8.setFlagsFromString('--no-allow-natives-syntax');
   assert.strictEqual(inspect(undetectable), '{}');
 }
+
+{
+  const x = 'a'.repeat(1e6);
+  assert(util.inspect(x).endsWith('... 990000 more characters'));
+  assert.strictEqual(
+    util.inspect(x, { maxStringLength: 4 }),
+    "'aaaa'... 999996 more characters"
+  );
+}

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2782,7 +2782,6 @@ assert.strictEqual(
 
 {
   const x = 'a'.repeat(1e6);
-  assert(util.inspect(x).endsWith('... 990000 more characters'));
   assert.strictEqual(
     util.inspect(x, { maxStringLength: 4 }),
     "'aaaa'... 999996 more characters"


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/25478

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
