### PR TITLE
src: delete BaseObjectWeakPtr data when pointee is gone

### DIFF
--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -234,13 +234,13 @@ BaseObject* BaseObjectPtrImpl<T, kIsWeak>::get_base_object() const {
 
 template <typename T, bool kIsWeak>
 BaseObjectPtrImpl<T, kIsWeak>::~BaseObjectPtrImpl() {
-  if (get() == nullptr) return;
   if (kIsWeak) {
-    if (--pointer_data()->weak_ptr_count == 0 &&
+    if (pointer_data() != nullptr &&
+        --pointer_data()->weak_ptr_count == 0 &&
         pointer_data()->self == nullptr) {
       delete pointer_data();
     }
-  } else {
+  } else if (get() != nullptr) {
     get()->decrease_refcount();
   }
 }


### PR DESCRIPTION
Fix the condition for deleting the underlying data pointed to by
a `BaseObjectWeakPtr`, which erroneously skipped that deletion
when `ptr->get()` was `nullptr`. This fixes a memory leak reported
by some of the tests.

Refs: https://github.com/nodejs/node/pull/30374#issuecomment-601848973

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
