### PR TITLE
esm: allow configuring default package type

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -641,6 +641,12 @@ parser.add_option('--node-builtin-modules-path',
     default=False,
     help='node will load builtin modules from disk instead of from binary')
 
+parser.add_option('--default-package-type',
+    action='store',
+    dest='node_default_package_type',
+    default=False,
+    help='node will treat files outside of package boundaries as this type')
+
 # Create compile_commands.json in out/Debug and out/Release.
 parser.add_option('-C',
     action='store_true',
@@ -1184,6 +1190,11 @@ def configure_node(o):
   if options.node_builtin_modules_path:
     print('Warning! Loading builtin modules from disk is for development')
     o['variables']['node_builtin_modules_path'] = options.node_builtin_modules_path
+
+  if options.node_default_package_type:
+    if not ( options.node_default_package_type in ['module', 'commonjs'] ):
+      raise Exception('--default-package-type must be either "module" or "commonjs"');
+    o['variables']['node_default_package_type'] = options.node_default_package_type
 
 def configure_napi(output):
   version = getnapibuildversion.get_napi_version()

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -10,6 +10,7 @@ const experimentalWasmModules = getOptionValue('--experimental-wasm-modules');
 const { getPackageType } = require('internal/modules/esm/resolve');
 const { URL, fileURLToPath } = require('internal/url');
 const { ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
+const { defaultPackageType } = internalBinding('config');
 
 const extensionFormatMap = {
   '__proto__': null,
@@ -51,7 +52,8 @@ function defaultGetFormat(url, context, defaultGetFormatUnused) {
     const ext = extname(parsed.pathname);
     let format;
     if (ext === '.js') {
-      format = getPackageType(parsed.href) === 'module' ? 'module' : 'commonjs';
+      const type = getPackageType(parsed.href);
+      format = type !== 'none' ? type : defaultPackageType;
     } else {
       format = extensionFormatMap[ext];
     }

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -4,6 +4,7 @@ const CJSLoader = require('internal/modules/cjs/loader');
 const { Module, toRealPath, readPackageScope } = CJSLoader;
 const { getOptionValue } = require('internal/options');
 const path = require('path');
+const { defaultPackageType } = internalBinding('config');
 
 function resolveMainPath(main) {
   // Note extension resolution for the main entry point can be deprecated in a
@@ -33,8 +34,11 @@ function shouldUseESMLoader(mainPath) {
     return true;
   if (!mainPath || mainPath.endsWith('.cjs'))
     return false;
-  const pkg = readPackageScope(mainPath);
-  return pkg && pkg.data.type === 'module';
+  const pkgType = readPackageScope(mainPath)?.data?.type ?? 'none';
+  return pkgType === 'module' || (
+    pkgType === 'none' &&
+    defaultPackageType === 'module'
+  );
 }
 
 function runMainESM(mainPath) {

--- a/node.gyp
+++ b/node.gyp
@@ -26,6 +26,7 @@
     'node_lib_target_name%': 'libnode',
     'node_intermediate_lib_type%': 'static_library',
     'node_builtin_modules_path%': '',
+    'node_default_package_type%': '',
     'library_files': [
       'lib/internal/bootstrap/environment.js',
       'lib/internal/bootstrap/loaders.js',
@@ -747,6 +748,9 @@
       'conditions': [
         [ 'node_builtin_modules_path!=""', {
           'defines': [ 'NODE_BUILTIN_MODULES_PATH="<(node_builtin_modules_path)"' ]
+        }],
+        [ 'node_default_package_type!=""', {
+          'defines': [ 'NODE_DEFAULT_PACKAGE_TYPE="<(node_default_package_type)"' ]
         }],
         [ 'node_shared=="true"', {
           'sources': [

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -89,10 +89,7 @@ static void Initialize(Local<Object> target,
 #if defined NODE_DEFAULT_PACKAGE_TYPE
   READONLY_PROPERTY(target,
                     "defaultPackageType",
-                    String::NewFromOneByte(isolate,
-                      reinterpret_cast<const unsigned char *>(
-                        NODE_DEFAULT_PACKAGE_TYPE))
-                      .ToLocalChecked());
+                    FIXED_ONE_BYTE_STRING(isolate, NODE_DEFAULT_PACKAGE_TYPE));
 #else
   READONLY_PROPERTY(target,
                     "defaultPackageType",

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -13,7 +13,6 @@ using v8::Isolate;
 using v8::Local;
 using v8::Number;
 using v8::Object;
-using v8::String;
 using v8::Value;
 
 // The config binding is used to provide an internal view of compile time

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -13,6 +13,7 @@ using v8::Isolate;
 using v8::Local;
 using v8::Number;
 using v8::Object;
+using v8::String;
 using v8::Value;
 
 // The config binding is used to provide an internal view of compile time
@@ -83,6 +84,21 @@ static void Initialize(Local<Object> target,
 
 #if defined HAVE_DTRACE || defined HAVE_ETW
   READONLY_TRUE_PROPERTY(target, "hasDtrace");
+#endif
+
+#if defined NODE_DEFAULT_PACKAGE_TYPE
+  READONLY_PROPERTY(target,
+                    "defaultPackageType",
+                    String::NewFromOneByte(isolate,
+                      reinterpret_cast<const unsigned char *>(
+                        NODE_DEFAULT_PACKAGE_TYPE))
+                      .ToLocalChecked());
+#else
+  READONLY_PROPERTY(target,
+                    "defaultPackageType",
+                    String::NewFromOneByte(isolate,
+                      reinterpret_cast<const unsigned char *>("commonjs"))
+                    .ToLocalChecked());
 #endif
 
   READONLY_PROPERTY(target, "hasCachedBuiltins",

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -93,9 +93,7 @@ static void Initialize(Local<Object> target,
 #else
   READONLY_PROPERTY(target,
                     "defaultPackageType",
-                    String::NewFromOneByte(isolate,
-                      reinterpret_cast<const unsigned char *>("commonjs"))
-                    .ToLocalChecked());
+                    FIXED_ONE_BYTE_STRING(isolate, "commonjs"));
 #endif
 
   READONLY_PROPERTY(target, "hasCachedBuiltins",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This is purely to allow people make builds that play around with the idea of changing the default package type, per comments in https://github.com/nodejs/node/issues/32316 . This breaks many expectations and likely should not be done as a runtime flag for now (e.g. the test suite for node cannot run if this this is set to `module`).