### PR TITLE
lib: refactor ServerResponse.prototype.writeHead

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -237,8 +237,11 @@ ServerResponse.prototype._implicitHeader = function _implicitHeader() {
   this.writeHead(this.statusCode);
 };
 
-ServerResponse.prototype.writeHead = writeHead;
-function writeHead(statusCode, reason, obj) {
+ServerResponse.prototype.writeHead = function(
+  statusCode,
+  statusMessage,
+  headers
+) {
   const originalStatusCode = statusCode;
 
   statusCode |= 0;
@@ -246,39 +249,38 @@ function writeHead(statusCode, reason, obj) {
     throw new ERR_HTTP_INVALID_STATUS_CODE(originalStatusCode);
   }
 
-
-  if (typeof reason === 'string') {
-    // writeHead(statusCode, reasonPhrase[, headers])
-    this.statusMessage = reason;
-  } else {
+  if (headers === undefined && typeof statusMessage === 'object') {
     // writeHead(statusCode[, headers])
-    if (!this.statusMessage)
-      this.statusMessage = STATUS_CODES[statusCode] || 'unknown';
-    obj = reason;
+    headers = statusMessage;
+  } else if (typeof statusMessage === 'string') {
+    // writeHead(statusCode, reasonPhrase[, headers])
+    this.statusMessage = statusMessage;
   }
+  if (this.statusMessage == null)
+    this.statusMessage = STATUS_CODES[statusCode] || 'unknown';
   this.statusCode = statusCode;
 
-  let headers;
+  let _headers;
   if (this[kOutHeaders]) {
     // Slow-case: when progressive API and header fields are passed.
     let k;
-    if (obj) {
-      const keys = ObjectKeys(obj);
+    if (headers) {
+      const keys = ObjectKeys(headers);
       // Retain for(;;) loop for performance reasons
       // Refs: https://github.com/nodejs/node/pull/30958
       for (let i = 0; i < keys.length; i++) {
         k = keys[i];
-        if (k) this.setHeader(k, obj[k]);
+        if (k) this.setHeader(k, headers[k]);
       }
     }
     if (k === undefined && this._header) {
       throw new ERR_HTTP_HEADERS_SENT('render');
     }
     // Only progressive api is used
-    headers = this[kOutHeaders];
+    _headers = this[kOutHeaders];
   } else {
     // Only writeHead() called
-    headers = obj;
+    _headers = headers;
   }
 
   if (checkInvalidHeaderChar(this.statusMessage))
@@ -307,10 +309,10 @@ function writeHead(statusCode, reason, obj) {
     this.shouldKeepAlive = false;
   }
 
-  this._storeHeader(statusLine, headers);
+  this._storeHeader(statusLine, _headers);
 
   return this;
-}
+};
 
 // Docs-only deprecated: DEP0063
 ServerResponse.prototype.writeHeader = ServerResponse.prototype.writeHead;

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -150,7 +150,7 @@ const s = http.createServer(common.mustCall((req, res) => {
     case 'writeHead':
       res.statusCode = 404;
       res.setHeader('x-foo', 'keyboard cat');
-      res.writeHead(200, { 'x-foo': 'bar', 'x-bar': 'baz' });
+      res.writeHead(200, undefined, { 'x-foo': 'bar', 'x-bar': 'baz' });
       break;
 
     default:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
fix #32395

make `HTTP` and `HTTP2` the behavior the same. 

example, allow `response.writeHead(200, undefined, { ...headers })` when the second parameter is undefined passing

https://github.com/nodejs/node/blob/d129e0c782914df8720d1335c95bd7f635f2788e/lib/internal/http2/compat.js#L608-L620

btw, I renamed the name of parameters for better coding experience

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
