### PR TITLE
doc: add note re term-size commit on top of npm

### DIFF
--- a/doc/guides/maintaining-npm.md
+++ b/doc/guides/maintaining-npm.md
@@ -74,7 +74,24 @@ Note: please ensure you are only making the updates that are changed by npm.
 $ git rebase --whitespace=fix master
 ```
 
-## Step 7: Test the build
+## Step 7: Apply signed term-size commit
+
+The `term-size` package in npm's dependency tree contains an unsigned macOS
+binary in versions < 2.2.0. Until npm updates to a newer version of
+`update-notifier`, Node.js macOS package files can't be notarized and will fail
+to install on macOS Catalina and above.
+
+Where an `npm ls` shows a `term-size` package version < 2.2.0, cherry-pick
+commit `d2f08a1bdb` on to of the new npm.
+
+```console
+$ git cherry-pick d2f08a1bdb
+```
+
+Where `npm ls` shows a `term-size` package version >= 2.2.0, edit this file to
+remove this step.
+
+## Step 8: Test the build
 
 ```console
 $ make test-npm

--- a/doc/guides/maintaining-npm.md
+++ b/doc/guides/maintaining-npm.md
@@ -81,8 +81,8 @@ binary in versions < 2.2.0. Until npm updates to a newer version of
 `update-notifier`, Node.js macOS package files can't be notarized and will fail
 to install on macOS Catalina and above.
 
-Where an `npm ls` shows a `term-size` package version < 2.2.0, cherry-pick
-commit `d2f08a1bdb` on to of the new npm.
+When `npm ls` shows a `term-size` package version < 2.2.0, cherry-pick
+commit `d2f08a1bdb` on top of the upgraded npm.
 
 ```console
 $ git cherry-pick d2f08a1bdb

--- a/doc/guides/maintaining-npm.md
+++ b/doc/guides/maintaining-npm.md
@@ -88,7 +88,7 @@ commit `d2f08a1bdb` on top of the upgraded npm.
 $ git cherry-pick d2f08a1bdb
 ```
 
-Where `npm ls` shows a `term-size` package version >= 2.2.0, edit this file to
+When `npm ls` shows a `term-size` package version >= 2.2.0, edit this file to
 remove this step.
 
 ## Step 8: Test the build


### PR DESCRIPTION
Until npm updates update-notifier to a newer version, the dependency
tree will contain a version of term-size that has an unsigned macOS
binary. This will fail .pkg notarization and will result in failed
release builds. We built and signed a term-size and contributed it back
to the project for this purpose, but the dependency chain is long enough
that it's not likely to be included in a new npm very quickly.
Until it is, we need to cherry-pick commit d2f08a1bdb ontop of any npm
updates to master and any other release branch that includes
notarization.

The dependency chain is update-notifier -> boxen -> term-size. npm is on update-notifier@^2.5.0 but the latest is 4.1.0 and I can imagine it's a bit intimidating to just jump through those versions without grokking what's changed.

I've done this just now for `master` after the update to npm@6.14.3 in 4a3ccd893.

You can see what a failure looks like in the latest master nightly if you have access to ci-release: https://ci-release.nodejs.org/job/iojs+release/5763/nodes=osx1015-release-pkg/

```
17:54:06 3 errors occurred:
17:54:06 	* error for path "node-v14.0.0-nightly20200320f7771fffd0.pkg/npm-v6.14.3.pkg Contents/Payload/usr/local/lib/node_modules/npm/node_modules/term-size/vendor/macos/term-size": The binary is not signed.
17:54:06 	* error for path "node-v14.0.0-nightly20200320f7771fffd0.pkg/npm-v6.14.3.pkg Contents/Payload/usr/local/lib/node_modules/npm/node_modules/term-size/vendor/macos/term-size": The signature does not include a secure timestamp.
17:54:06 	* error for path "node-v14.0.0-nightly20200320f7771fffd0.pkg/npm-v6.14.3.pkg Contents/Payload/usr/local/lib/node_modules/npm/node_modules/term-size/vendor/macos/term-size": The executable does not have the hardened runtime enabled.
```

.pkg is missing from https://nodejs.org/download/nightly/v14.0.0-nightly20200320f7771fffd0/

@nodejs/build @nodejs/npm