### PR TITLE
src: make fs functions handle pre-epoch timestamps

### DIFF
--- a/deps/uv/test/test-fs.c
+++ b/deps/uv/test/test-fs.c
@@ -2493,6 +2493,33 @@ TEST_IMPL(fs_utime) {
 }
 
 
+TEST_IMPL(fs_utime_round) {
+  const char path[] = "test_file";
+  double atime;
+  double mtime;
+  uv_fs_t req;
+  int r;
+
+  loop = uv_default_loop();
+  unlink(path);
+  r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  uv_fs_req_cleanup(&req);
+  ASSERT(0 == uv_fs_close(loop, &req, r, NULL));
+
+  atime = mtime = -14245440.0;  /* 1969-07-20T02:56:00.00Z */
+  ASSERT(0 == uv_fs_utime(NULL, &req, path, atime, mtime, NULL));
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
+  check_utime(path, atime, mtime);
+  unlink(path);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+
 #ifdef _WIN32
 TEST_IMPL(fs_stat_root) {
   int r;

--- a/deps/uv/test/test-list.h
+++ b/deps/uv/test/test-list.h
@@ -352,6 +352,7 @@ TEST_DECLARE   (fs_open_flags)
 TEST_DECLARE   (fs_fd_hash)
 #endif
 TEST_DECLARE   (fs_utime)
+TEST_DECLARE   (fs_utime_round)
 TEST_DECLARE   (fs_futime)
 TEST_DECLARE   (fs_file_open_append)
 TEST_DECLARE   (fs_statfs)
@@ -968,6 +969,7 @@ TASK_LIST_START
 #endif
   TEST_ENTRY  (fs_chown)
   TEST_ENTRY  (fs_utime)
+  TEST_ENTRY  (fs_utime_round)
   TEST_ENTRY  (fs_futime)
   TEST_ENTRY  (fs_readlink)
   TEST_ENTRY  (fs_realpath)

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -362,16 +362,6 @@ function nsFromTimeSpecBigInt(sec, nsec) {
   return sec * kNsPerSecBigInt + nsec;
 }
 
-// The Date constructor performs Math.floor() to the timestamp.
-// https://www.ecma-international.org/ecma-262/#sec-timeclip
-// Since there may be a precision loss when the timestamp is
-// converted to a floating point number, we manually round
-// the timestamp here before passing it to Date().
-// Refs: https://github.com/nodejs/node/pull/12607
-function dateFromMs(ms) {
-  return new Date(Number(ms) + 0.5);
-}
-
 function BigIntStats(dev, mode, nlink, uid, gid, rdev, blksize,
                      ino, size, blocks,
                      atimeNs, mtimeNs, ctimeNs, birthtimeNs) {
@@ -386,10 +376,10 @@ function BigIntStats(dev, mode, nlink, uid, gid, rdev, blksize,
   this.mtimeNs = mtimeNs;
   this.ctimeNs = ctimeNs;
   this.birthtimeNs = birthtimeNs;
-  this.atime = dateFromMs(this.atimeMs);
-  this.mtime = dateFromMs(this.mtimeMs);
-  this.ctime = dateFromMs(this.ctimeMs);
-  this.birthtime = dateFromMs(this.birthtimeMs);
+  this.atime = new Date(Number(this.atimeMs));
+  this.mtime = new Date(Number(this.mtimeMs));
+  this.ctime = new Date(Number(this.ctimeMs));
+  this.birthtime = new Date(Number(this.birthtimeMs));
 }
 
 ObjectSetPrototypeOf(BigIntStats.prototype, StatsBase.prototype);
@@ -412,10 +402,10 @@ function Stats(dev, mode, nlink, uid, gid, rdev, blksize,
   this.mtimeMs = mtimeMs;
   this.ctimeMs = ctimeMs;
   this.birthtimeMs = birthtimeMs;
-  this.atime = dateFromMs(atimeMs);
-  this.mtime = dateFromMs(mtimeMs);
-  this.ctime = dateFromMs(ctimeMs);
-  this.birthtime = dateFromMs(birthtimeMs);
+  this.atime = new Date(atimeMs);
+  this.mtime = new Date(mtimeMs);
+  this.ctime = new Date(ctimeMs);
+  this.birthtime = new Date(birthtimeMs);
 }
 
 ObjectSetPrototypeOf(Stats.prototype, StatsBase.prototype);

--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -85,8 +85,7 @@ void FillStatsArray(AliasedBufferBase<NativeT, V8T>* fields,
                    static_cast<NativeT>(stat))
 
 #define SET_FIELD_WITH_TIME_STAT(stat_offset, stat)                          \
-  /* NOLINTNEXTLINE(runtime/int) */                                          \
-  SET_FIELD_WITH_STAT(stat_offset, static_cast<unsigned long>(stat))
+  SET_FIELD_WITH_STAT(stat_offset, static_cast<double>(stat))
 
   SET_FIELD_WITH_STAT(kDev, s->st_dev);
   SET_FIELD_WITH_STAT(kMode, s->st_mode);

--- a/test/parallel/test-fs-stat-before-unix-epoch.js
+++ b/test/parallel/test-fs-stat-before-unix-epoch.js
@@ -1,0 +1,20 @@
+// Check that file timestamps from before the UNIX epoch
+// are set and retrieved correctly.
+
+'use strict';
+
+require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const date = new Date('1969-07-20 02:56:00Z');
+const filename = path.join(tmpdir.path, '42.txt');
+
+tmpdir.refresh();
+fs.writeFileSync(filename, '42');
+fs.utimesSync(filename, date, date);
+const s = fs.statSync(filename);
+assert.deepStrictEqual(s.atime, date);
+assert.deepStrictEqual(s.mtime, date);


### PR DESCRIPTION
A wrong type cast prevented timestamps before 1970-01-01 from working
with functions like `fs.stat()`.

Fixes: #32369

The first commit is https://github.com/libuv/libuv/pull/2747. This PR can't land (at least, not without the test failing) until libuv is upgraded.