### PR TITLE
stream: fix pipeline with dest in objectMode

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -240,7 +240,9 @@ function pipeline(...streams) {
         // always returns a stream which can be further
         // composed through `.pipe(stream)`.
 
-        const pt = new PassThrough();
+        const pt = new PassThrough({
+          objectMode: true
+        });
         if (isPromise(ret)) {
           ret
             .then((val) => {

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1065,3 +1065,15 @@ const { promisify } = require('util');
   src.push('asd');
   dst.destroy();
 }
+
+{
+  pipeline(async function * () {
+    yield 'asd';
+  }, async function * (source) {
+    for await (const chunk of source) {
+      yield { chunk };
+    }
+  }, common.mustCall((err) => {
+    assert.ifError(err);
+  }));
+}


### PR DESCRIPTION
pipeline did not support destination which is generator that does not return strings or buffers.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
