### PR TITLE
build: use Actions to validate commit message

### DIFF
--- a/.github/workflows/commit-lint-problem-matcher.json
+++ b/.github/workflows/commit-lint-problem-matcher.json
@@ -1,0 +1,13 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "core-validate-commit",
+      "pattern": [
+        {
+          "regexp": "^not ok \\d+ (.*)$",
+          "message": 1
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,21 @@
+name: "Commit messages adheres to guidelines at https://goo.gl/p2fr5Q"
+
+on: [pull_request]
+
+jobs:
+  lint-commit-message:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Last 100 commits should be enough for a PR
+          fetch-depth: 100
+      - name: Use Node.js 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Validate commit messages
+        run: |
+          echo "::add-matcher::.github/workflows/commit-lint-problem-matcher.json"
+          git log --oneline ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -v -e fixup -e squash | awk '{ print $1 }' |  xargs npx -q core-validate-commit --no-validate-metadata --tap


### PR DESCRIPTION
Actions interface has a better integration with GitHub, and with
Annotations and Problem Matcher we can display all failed checks in a
single place, so that users don't have to go through the logs to figure
out what's wrong. Since the job on Travis was allowed to fail and is not
as easy to read, remove it from our Matrix.

The Action will check every commit in the Pull Request, skipping commits
with "fixup" or "squash".

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
