### PR TITLE
build: disable -Wattributes warnings on aix

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -401,6 +401,15 @@
               '-Wl,-brtl',
             ],
           }, {                                             # else it's `AIX`
+            # Disable the following compiler warning:
+            #
+            #   warning: visibility attribute not supported in this
+            #   configuration; ignored [-Wattributes]
+            #
+            # This is gcc complaining about __attribute((visibility("default"))
+            # in static library builds. Legitimate but harmless and it drowns
+            # out more relevant warnings.
+            'cflags': [ '-Wno-attributes' ],
             'ldflags': [
               '-Wl,-blibpath:/usr/lib:/lib:/opt/freeware/lib/pthread/ppc64',
             ],


### PR DESCRIPTION
Disable the following compiler warning:

    warning: visibility attribute not supported in this
    configuration; ignored [-Wattributes]

This is gcc complaining about `__attribute((visibility("default"))`
in static library builds. Legitimate but harmless (and uninteresting)
and it drowns out more relevant warnings.