### PR TITLE
src: use single ObjectTemplate for TextDecoder

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -411,6 +411,7 @@ constexpr size_t kFsStatsBufferLength =
   V(http2settings_constructor_template, v8::ObjectTemplate)                    \
   V(http2stream_constructor_template, v8::ObjectTemplate)                      \
   V(http2ping_constructor_template, v8::ObjectTemplate)                        \
+  V(i18n_converter_template, v8::ObjectTemplate)                               \
   V(libuv_stream_wrap_ctor_template, v8::FunctionTemplate)                     \
   V(message_port_constructor_template, v8::FunctionTemplate)                   \
   V(pipe_constructor_template, v8::FunctionTemplate)                           \

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -86,6 +86,7 @@ namespace node {
 
 using v8::Context;
 using v8::FunctionCallbackInfo;
+using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Int32;
 using v8::Isolate;
@@ -171,8 +172,7 @@ class ConverterObject : public BaseObject, Converter {
     Environment* env = Environment::GetCurrent(args);
     HandleScope scope(env->isolate());
 
-    Local<ObjectTemplate> t = ObjectTemplate::New(env->isolate());
-    t->SetInternalFieldCount(ConverterObject::kInternalFieldCount);
+    Local<ObjectTemplate> t = env->i18n_converter_template();
     Local<Object> obj;
     if (!t->NewInstance(env->context()).ToLocal(&obj)) return;
 
@@ -821,6 +821,16 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "transcode", Transcode);
 
   // ConverterObject
+  {
+    Local<FunctionTemplate> t = FunctionTemplate::New(env->isolate());
+    t->InstanceTemplate()->SetInternalFieldCount(
+        ConverterObject::kInternalFieldCount);
+    Local<String> converter_string =
+        FIXED_ONE_BYTE_STRING(env->isolate(), "Converter");
+    t->SetClassName(converter_string);
+    env->set_i18n_converter_template(t->InstanceTemplate());
+  }
+
   env->SetMethod(target, "getConverter", ConverterObject::Create);
   env->SetMethod(target, "decode", ConverterObject::Decode);
   env->SetMethod(target, "hasConverter", ConverterObject::Has);

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -107,8 +107,13 @@ if (common.hasIntl) {
   if (common.hasIntl) {
     assert.strictEqual(
       util.inspect(dec, { showHidden: true }),
-      'TextDecoder {\n  encoding: \'utf-8\',\n  fatal: false,\n  ' +
-      'ignoreBOM: true,\n  [Symbol(flags)]: 4,\n  [Symbol(handle)]: {}\n}'
+      'TextDecoder {\n' +
+      '  encoding: \'utf-8\',\n' +
+      '  fatal: false,\n' +
+      '  ignoreBOM: true,\n' +
+      '  [Symbol(flags)]: 4,\n' +
+      '  [Symbol(handle)]: Converter {}\n' +
+      '}'
     );
   } else {
     assert.strictEqual(


### PR DESCRIPTION
`ObjectTemplate`s are not garbage-collected like regular objects
(for some reason). It is sufficient to create a single template
anyway, so do that to address the memory leak.

Fixes: https://github.com/nodejs/node/issues/32424

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
