### PR TITLE
async_hooks: move to lazy destroy hook registration in AsyncResource

### DIFF
--- a/benchmark/async_hooks/gc-tracking.js
+++ b/benchmark/async_hooks/gc-tracking.js
@@ -1,11 +1,12 @@
 'use strict';
 const common = require('../common.js');
-const { AsyncResource } = require('async_hooks');
+const { createHook, AsyncResource } = require('async_hooks');
 
 const bench = common.createBenchmark(main, {
   n: [1e6],
   method: [
     'trackingEnabled',
+    'trackingEnabledWithDestroyHook',
     'trackingDisabled',
   ]
 }, {
@@ -24,6 +25,14 @@ function endAfterGC(n) {
 function main({ n, method }) {
   switch (method) {
     case 'trackingEnabled':
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        new AsyncResource('foobar');
+      }
+      endAfterGC(n);
+      break;
+    case 'trackingEnabledWithDestroyHook':
+      createHook({ destroy: () => {} }).enable();
       bench.start();
       for (let i = 0; i < n; i++) {
         new AsyncResource('foobar');

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -685,6 +685,8 @@ asyncResource.triggerAsyncId();
   when the object is garbage collected. This usually does not need to be set
   (even if `emitDestroy` is called manually), unless the resource's `asyncId`
   is retrieved and the sensitive API's `emitDestroy` is called with it.
+  When set to `false`, the `emitDestroy` call on garbage collection
+  will only take place if there is at least one active `destroy` hook.
   **Default:** `false`.
 
 Example usage:

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -36,6 +36,7 @@ const {
   emitDestroy,
   enabledHooksExist,
   initHooksExist,
+  destroyHooksExist,
 } = internal_async_hooks;
 
 // Get symbols
@@ -168,7 +169,7 @@ class AsyncResource {
       emitInit(asyncId, type, triggerAsyncId, this);
     }
 
-    if (!requireManualDestroy) {
+    if (!requireManualDestroy && destroyHooksExist()) {
       // This prop name (destroyed) has to be synchronized with C++
       const destroyed = { destroyed: false };
       this[destroyedSymbol] = destroyed;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Adds a check into `AsyncResource` constructor, so that `registerDestroyHook` only gets called when `requireManualDestroy` is `false` and there are no active `destroy` hooks (previously the check only included `requireManualDestroy` value). As below benchmark shows this eliminates a certain overhead related with additional tracking of these objects as a part of GC cycle.

This scenario is important considering `AsyncLocalStorage` API which only uses `init` hooks.

**Important note**. Obviously, this PR changes the behavior in the following edge case: previously when an `AsyncResource` was created (but not yet destroyed) before enabling the first `destroy` hook, the hook would be called for the resource. With this change it's not called.

Related discussion thread: https://github.com/petkaantonov/bluebird/pull/1472#issuecomment-352104689

cc @addaleax @vdeturckheim @Qard @Flarna (sorry for such long CC list, but I think all of you might be interested)

##### Benchmarks

Before this change:
```bash
$ ./node benchmark/async_hooks/gc-tracking.js 
async_hooks/gc-tracking.js method="trackingEnabled" n=1000000: 3,338,788.791796874
async_hooks/gc-tracking.js method="trackingDisabled" n=1000000: 79,598,226.36048095
```

After this change:
```bash
$ ./node benchmark/async_hooks/gc-tracking.js 
async_hooks/gc-tracking.js method="trackingEnabled" n=1000000: 73,493,075.92334495
async_hooks/gc-tracking.js method="trackingEnabledWithDestroyHook" n=1000000: 2,497,582.277915421
async_hooks/gc-tracking.js method="trackingDisabled" n=1000000: 79,170,025.7848857
```

Note: `trackingEnabledWithDestroyHook` scenario was added as a replacement for the old `trackingEnabled` scenario.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
