### PR TITLE
build: fix libuv build for Android API28+

### DIFF
--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -263,6 +263,7 @@
             'src/unix/random-getrandom.c',
             'src/unix/random-sysctl-linux.c',
             'src/unix/sysinfo-loadavg.c',
+            'src/unix/random-getentropy.c',
           ],
           'link_settings': {
             'libraries': [ '-ldl' ],


### PR DESCRIPTION
The commit https://github.com/libuv/libuv/commit/f261d04d0a36df7c8ab041a45399c1fcba0a3c04 ("android: enable getentropy on Android >= 28") didn't
add `random-getentropy.c` to the set of files to build on Android, the fixing PR https://github.com/libuv/libuv/pull/2704 only fixed the cmake build. libuv is removing gyp build support in https://github.com/libuv/libuv/pull/2682, so I create PR here instead of libuv.

To build node for Android:
 - `source ./android-configure $NDK_PATH $ARCH 29`
 - `make -j4`
##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines]
