### PR TITLE
src: refactoring and cleanup of node_i18n

### DIFF
--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -24,11 +24,16 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#if defined(NODE_HAVE_I18N_SUPPORT)
+
+#include "base_object.h"
+#include "env.h"
 #include "util.h"
+#include "v8.h"
+
+#include <unicode/ucnv.h>
 
 #include <string>
-
-#if defined(NODE_HAVE_I18N_SUPPORT)
 
 namespace node {
 
@@ -59,6 +64,75 @@ int32_t ToASCII(MaybeStackBuffer<char>* buf,
 int32_t ToUnicode(MaybeStackBuffer<char>* buf,
                   const char* input,
                   size_t length);
+
+struct ConverterDeleter {
+  void operator()(UConverter* pointer) const { ucnv_close(pointer); }
+};
+using ConverterPointer = std::unique_ptr<UConverter, ConverterDeleter>;
+
+class Converter {
+ public:
+  explicit Converter(const char* name, const char* sub = nullptr);
+  explicit Converter(UConverter* converter, const char* sub = nullptr);
+
+  UConverter* conv() const { return conv_.get(); }
+
+  size_t max_char_size() const;
+  size_t min_char_size() const;
+  void reset();
+  void set_subst_chars(const char* sub = nullptr);
+
+ private:
+  ConverterPointer conv_;
+};
+
+class ConverterObject : public BaseObject, Converter {
+ public:
+  enum ConverterFlags {
+    CONVERTER_FLAGS_FLUSH      = 0x1,
+    CONVERTER_FLAGS_FATAL      = 0x2,
+    CONVERTER_FLAGS_IGNORE_BOM = 0x4,
+    CONVERTER_FLAGS_UNICODE    = 0x8,
+    CONVERTER_FLAGS_BOM_SEEN   = 0x10,
+  };
+
+  static void Create(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Decode(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Has(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  SET_NO_MEMORY_INFO()
+  SET_MEMORY_INFO_NAME(ConverterObject)
+  SET_SELF_SIZE(ConverterObject)
+
+ protected:
+  ConverterObject(Environment* env,
+                  v8::Local<v8::Object> wrap,
+                  UConverter* converter,
+                  int flags,
+                  const char* sub = nullptr);
+
+  void set_bom_seen(bool seen) {
+    if (seen)
+      flags_ |= CONVERTER_FLAGS_BOM_SEEN;
+    else
+      flags_ &= ~CONVERTER_FLAGS_BOM_SEEN;
+  }
+
+  bool bom_seen() const {
+    return (flags_ & CONVERTER_FLAGS_BOM_SEEN) == CONVERTER_FLAGS_BOM_SEEN;
+  }
+
+  bool unicode() const {
+    return (flags_ & CONVERTER_FLAGS_UNICODE) == CONVERTER_FLAGS_UNICODE;
+  }
+
+  bool ignore_bom() const {
+    return (flags_ & CONVERTER_FLAGS_IGNORE_BOM) == CONVERTER_FLAGS_IGNORE_BOM;
+  }
+
+ private:
+  int flags_ = 0;
+};
 
 }  // namespace i18n
 }  // namespace node


### PR DESCRIPTION
Starting some cleanup/refactoring of node_i18n

* Refactor Converter and ConverterObject definitions
  * Move definitions to node_i18n.h
  * Introduce a new utility functions for better encapsulation
  * Adhere closer to c++ style guide
  * Simplify some state tracking
  * Use std::unique_ptr for cleanup

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
