### PR TITLE
test: skip a wasi test on IBMi PASE

### DIFF
--- a/test/wasi/test-wasi.js
+++ b/test/wasi/test-wasi.js
@@ -57,12 +57,20 @@ if (process.argv[2] === 'wasi-child') {
   }
 
   runWASI({ test: 'cant_dotdot' });
-  runWASI({ test: 'clock_getres' });
+
+  // Tests that are currently unsupported on IBM i PASE.
+  if (!common.isIBMi) {
+    runWASI({ test: 'clock_getres' });
+  }
   runWASI({ test: 'exitcode', exitCode: 120 });
   runWASI({ test: 'fd_prestat_get_refresh' });
   runWASI({ test: 'freopen', stdout: `hello from input2.txt${EOL}` });
   runWASI({ test: 'getentropy' });
-  runWASI({ test: 'getrusage' });
+
+  // Tests that are currently unsupported on IBM i PASE.
+  if (!common.isIBMi) {
+    runWASI({ test: 'getrusage' });
+  }
   runWASI({ test: 'gettimeofday' });
   runWASI({ test: 'link' });
   runWASI({ test: 'main_args' });


### PR DESCRIPTION
The API clock_getres with attribute API CLOCK_THREAD_CPUTIME_ID
is not supported on IBM i PASE.

This is the same change as V8 --> https://github.com/nodejs/node/blob/master/deps/v8/src/base/platform/time.cc#L73