### PR TITLE
feat(fs): Make parameters optional for readSync

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3069,6 +3069,32 @@ Returns the number of `bytesRead`.
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.read()`][].
 
+## `fs.readSync(fd, buffer, [options])`
+<!-- YAML
+added: REPLACEME
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32460
+    description: Options object can be passed in
+                 to make offset, length and position optional
+-->
+
+* `fd` {integer}
+* `buffer` {Buffer|TypedArray|DataView}
+* `options` {Object}
+  * `offset` {integer} **Default:** `0`
+  * `length` {integer} **Default:** `buffer.length`
+  * `position` {integer} **Default:** `null`
+* Returns: {number}
+
+Returns the number of `bytesRead`.
+
+Similar to the above `fs.readSync` function, this version takes an optional `options` object.
+If no `options` object is specified, it will default with the above values.
+
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.read()`][].
+
 ## `fs.readv(fd, buffers[, position], callback)`
 <!-- YAML
 added: REPLACEME

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -544,9 +544,7 @@ function readSync(fd, buffer, offset, length, position) {
     // Assume fs.read(fd, buffer, options)
     const options = offset || {};
 
-    offset = options.offset || 0;
-    length = options.length || buffer.length;
-    position = options.position;
+    ({ offset = 0, length = buffer.length, position } = options);
   }
 
   validateBuffer(buffer);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -533,8 +533,22 @@ function read(fd, buffer, offset, length, position, callback) {
 ObjectDefineProperty(read, internalUtil.customPromisifyArgs,
                      { value: ['bytesRead', 'buffer'], enumerable: false });
 
+// usage:
+// fs.readSync(fd, buffer, offset, length, position);
+// OR
+// fs.readSync(fd, buffer, {}) or fs.readSync(fd, buffer)
 function readSync(fd, buffer, offset, length, position) {
   validateInt32(fd, 'fd', 0);
+
+  if (arguments.length <= 3) {
+    // Assume fs.read(fd, buffer, options)
+    const options = offset || {};
+
+    offset = options.offset || 0;
+    length = options.length || buffer.length;
+    position = options.position;
+  }
+
   validateBuffer(buffer);
 
   if (offset == null) {

--- a/test/parallel/test-fs-readSync-optional-params.js
+++ b/test/parallel/test-fs-readSync-optional-params.js
@@ -8,27 +8,20 @@ const filepath = fixtures.path('x.txt');
 const fd = fs.openSync(filepath, 'r');
 
 const expected = Buffer.from('xyz\n');
-const defaultBuffer1 = Buffer.allocUnsafe(expected.length);
-const defaultBuffer2 = Buffer.allocUnsafe(expected.length);
-const defaultBuffer3 = Buffer.allocUnsafe(expected.length);
+
+function runTest(defaultBuffer, options) {
+  const result = fs.readSync(fd, defaultBuffer, options);
+  assert.strictEqual(result, expected.length);
+  assert.deepStrictEqual(defaultBuffer, expected);
+}
 
 // Test passing in an empty options object
-const result1 = fs.readSync(fd, defaultBuffer1, { position: 0 });
-assert.strictEqual(result1, expected.length);
-assert.deepStrictEqual(defaultBuffer1, expected);
+runTest(Buffer.allocUnsafe(expected.length), { position: 0 });
 
 // Test not passing in any options object
-const result2 = fs.readSync(fd, defaultBuffer2);
-assert.strictEqual(result2, expected.length);
-assert.deepStrictEqual(defaultBuffer2, expected);
-
+runTest(Buffer.allocUnsafe(expected.length));
 
 // Test passing in options
-const result3 = fs.readSync(fd, defaultBuffer3, {
-  offset: 0,
-  length: defaultBuffer3.length,
-  position: 0
-});
-
-assert.strictEqual(result3, expected.length);
-assert.deepStrictEqual(defaultBuffer3, expected);
+runTest(Buffer.allocUnsafe(expected.length), { offset: 0,
+                                               length: expected.length,
+                                               position: 0 });

--- a/test/parallel/test-fs-readSync-optional-params.js
+++ b/test/parallel/test-fs-readSync-optional-params.js
@@ -26,7 +26,7 @@ assert.deepStrictEqual(defaultBuffer2, expected);
 // Test passing in options
 const result3 = fs.readSync(fd, defaultBuffer3, {
   offset: 0,
-  lenght: defaultBuffer3.length,
+  length: defaultBuffer3.length,
   position: 0
 });
 

--- a/test/parallel/test-fs-readSync-optional-params.js
+++ b/test/parallel/test-fs-readSync-optional-params.js
@@ -1,0 +1,34 @@
+'use strict';
+
+require('../common');
+const fixtures = require('../common/fixtures');
+const fs = require('fs');
+const assert = require('assert');
+const filepath = fixtures.path('x.txt');
+const fd = fs.openSync(filepath, 'r');
+
+const expected = Buffer.from('xyz\n');
+const defaultBuffer1 = Buffer.allocUnsafe(expected.length);
+const defaultBuffer2 = Buffer.allocUnsafe(expected.length);
+const defaultBuffer3 = Buffer.allocUnsafe(expected.length);
+
+// Test passing in an empty options object
+const result1 = fs.readSync(fd, defaultBuffer1, { position: 0 });
+assert.strictEqual(result1, expected.length);
+assert.deepStrictEqual(defaultBuffer1, expected);
+
+// Test not passing in any options object
+const result2 = fs.readSync(fd, defaultBuffer2);
+assert.strictEqual(result2, expected.length);
+assert.deepStrictEqual(defaultBuffer2, expected);
+
+
+// Test passing in options
+const result3 = fs.readSync(fd, defaultBuffer3, {
+  offset: 0,
+  lenght: defaultBuffer3.length,
+  position: 0
+});
+
+assert.strictEqual(result3, expected.length);
+assert.deepStrictEqual(defaultBuffer3, expected);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [x] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Similar to the recently merged #31402, which was for fs.read, this PR does something similar for fs.readSync

This adds the signature `fs.readSync(fd, buffer, options)`, where the options is an object that can contain optional values for offset, length and position.

The difference with this PR and the previous one for fs.read, is that here i'm making the buffer object not optional.  Since the function returns the amount of bytes read, the user needs to use the buffer they pass in to actually read value of what they are trying to read.

I still need to add docs for this,  but wanted to get any thoughts on if also making buffer optional and part of the options object which would then change  the new function signature to `fs.readSync(fd, {})`



<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
