### PR TITLE
src: avoid using elevated v8 namespaces in headers

### DIFF
--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -12,14 +12,10 @@
 
 namespace node {
 
-using v8::Local;
-using v8::Message;
-using v8::Value;
-
 enum ErrorHandlingMode { CONTEXTIFY_ERROR, FATAL_ERROR, MODULE_ERROR };
 void AppendExceptionLine(Environment* env,
-                         Local<Value> er,
-                         Local<Message> message,
+                         v8::Local<v8::Value> er,
+                         v8::Local<v8::Message> message,
                          enum ErrorHandlingMode mode);
 
 [[noreturn]] void FatalError(const char* location, const char* message);
@@ -193,8 +189,8 @@ class TryCatchScope : public v8::TryCatch {
 void TriggerUncaughtException(v8::Isolate* isolate,
                               const v8::TryCatch& try_catch);
 void TriggerUncaughtException(v8::Isolate* isolate,
-                              Local<Value> error,
-                              Local<Message> message,
+                              v8::Local<v8::Value> error,
+                              v8::Local<v8::Message> message,
                               bool from_promise = false);
 
 const char* errno_string(int errorno);

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -19,13 +19,6 @@ class Environment;
 
 namespace performance {
 
-using v8::FunctionCallbackInfo;
-using v8::GCType;
-using v8::GCCallbackFlags;
-using v8::Local;
-using v8::Object;
-using v8::Value;
-
 extern const uint64_t timeOrigin;
 
 static inline const char* GetPerformanceMilestoneName(
@@ -60,9 +53,9 @@ class PerformanceEntry {
  public:
   static void Notify(Environment* env,
                      PerformanceEntryType type,
-                     Local<Value> object);
+                     v8::Local<v8::Value> object);
 
-  static void New(const FunctionCallbackInfo<Value>& args);
+  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   PerformanceEntry(Environment* env,
                    const char* name,
@@ -76,7 +69,7 @@ class PerformanceEntry {
 
   virtual ~PerformanceEntry() = default;
 
-  virtual v8::MaybeLocal<Object> ToObject() const;
+  virtual v8::MaybeLocal<v8::Object> ToObject() const;
 
   Environment* env() const { return env_; }
 
@@ -105,27 +98,27 @@ class PerformanceEntry {
 };
 
 enum PerformanceGCKind {
-  NODE_PERFORMANCE_GC_MAJOR = GCType::kGCTypeMarkSweepCompact,
-  NODE_PERFORMANCE_GC_MINOR = GCType::kGCTypeScavenge,
-  NODE_PERFORMANCE_GC_INCREMENTAL = GCType::kGCTypeIncrementalMarking,
-  NODE_PERFORMANCE_GC_WEAKCB = GCType::kGCTypeProcessWeakCallbacks
+  NODE_PERFORMANCE_GC_MAJOR = v8::GCType::kGCTypeMarkSweepCompact,
+  NODE_PERFORMANCE_GC_MINOR = v8::GCType::kGCTypeScavenge,
+  NODE_PERFORMANCE_GC_INCREMENTAL = v8::GCType::kGCTypeIncrementalMarking,
+  NODE_PERFORMANCE_GC_WEAKCB = v8::GCType::kGCTypeProcessWeakCallbacks
 };
 
 enum PerformanceGCFlags {
   NODE_PERFORMANCE_GC_FLAGS_NO =
-    GCCallbackFlags::kNoGCCallbackFlags,
+    v8::GCCallbackFlags::kNoGCCallbackFlags,
   NODE_PERFORMANCE_GC_FLAGS_CONSTRUCT_RETAINED =
-    GCCallbackFlags::kGCCallbackFlagConstructRetainedObjectInfos,
+    v8::GCCallbackFlags::kGCCallbackFlagConstructRetainedObjectInfos,
   NODE_PERFORMANCE_GC_FLAGS_FORCED =
-    GCCallbackFlags::kGCCallbackFlagForced,
+    v8::GCCallbackFlags::kGCCallbackFlagForced,
   NODE_PERFORMANCE_GC_FLAGS_SYNCHRONOUS_PHANTOM_PROCESSING =
-    GCCallbackFlags::kGCCallbackFlagSynchronousPhantomCallbackProcessing,
+    v8::GCCallbackFlags::kGCCallbackFlagSynchronousPhantomCallbackProcessing,
   NODE_PERFORMANCE_GC_FLAGS_ALL_AVAILABLE_GARBAGE =
-    GCCallbackFlags::kGCCallbackFlagCollectAllAvailableGarbage,
+    v8::GCCallbackFlags::kGCCallbackFlagCollectAllAvailableGarbage,
   NODE_PERFORMANCE_GC_FLAGS_ALL_EXTERNAL_MEMORY =
-    GCCallbackFlags::kGCCallbackFlagCollectAllExternalMemory,
+    v8::GCCallbackFlags::kGCCallbackFlagCollectAllExternalMemory,
   NODE_PERFORMANCE_GC_FLAGS_SCHEDULE_IDLE =
-    GCCallbackFlags::kGCCallbackScheduleIdleGarbageCollection
+    v8::GCCallbackFlags::kGCCallbackScheduleIdleGarbageCollection
 };
 
 class GCPerformanceEntry : public PerformanceEntry {
@@ -150,7 +143,7 @@ class GCPerformanceEntry : public PerformanceEntry {
 class ELDHistogram : public HandleWrap, public Histogram {
  public:
   ELDHistogram(Environment* env,
-               Local<Object> wrap,
+               v8::Local<v8::Object> wrap,
                int32_t resolution);
 
   bool RecordDelta();


### PR DESCRIPTION
Just had a handful of `using v8:...` elevations in a couple of header files. This goes ahead and removes those.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

