### PR TITLE
repl: fixup error message

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1378,7 +1378,7 @@ REPLServer.prototype.defineCommand = function(keyword, cmd) {
   if (typeof cmd === 'function') {
     cmd = { action: cmd };
   } else if (typeof cmd.action !== 'function') {
-    throw new ERR_INVALID_ARG_TYPE('action', 'Function', cmd.action);
+    throw new ERR_INVALID_ARG_TYPE('cmd.action', 'Function', cmd.action);
   }
   this.commands[keyword] = cmd;
 };


### PR DESCRIPTION
Use "cmd.action" instead of just "action" for ERR_INVALID_ARG_TYPE

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
