### PR TITLE
console: fixup error message

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -110,11 +110,14 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
     if (inspectOptions.colors !== undefined &&
         options.colorMode !== undefined) {
       throw new ERR_INCOMPATIBLE_OPTION_PAIR(
-        'inspectOptions.color', 'colorMode');
+        'options.inspectOptions.color', 'colorMode');
     }
     optionsMap.set(this, inspectOptions);
   } else if (inspectOptions !== undefined) {
-    throw new ERR_INVALID_ARG_TYPE('inspectOptions', 'object', inspectOptions);
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.inspectOptions',
+      'object',
+      inspectOptions);
   }
 
   // Bind the prototype functions to this Console instance

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -140,7 +140,7 @@ out.write = err.write = (d) => {};
       });
     },
     {
-      message: 'The "inspectOptions" argument must be of type object.' +
+      message: 'The "options.inspectOptions" property must be of type object.' +
                common.invalidArgTypeHelper(inspectOptions),
       code: 'ERR_INVALID_ARG_TYPE'
     }

--- a/test/parallel/test-console-tty-colors.js
+++ b/test/parallel/test-console-tty-colors.js
@@ -86,7 +86,7 @@ check(false, false, false);
         });
       },
       {
-        message: 'Option "inspectOptions.color" cannot be used in ' +
+        message: 'Option "options.inspectOptions.color" cannot be used in ' +
                  'combination with option "colorMode"',
         code: 'ERR_INCOMPATIBLE_OPTION_PAIR'
       }


### PR DESCRIPTION
Use "options.inspectOptions" instead of just "inspectOptions"

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
