### PR TITLE
stream: emit 'pause' on unpipe

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -819,7 +819,7 @@ Readable.prototype.unpipe = function(dest) {
     // remove all.
     var dests = state.pipes;
     state.pipes = [];
-    state.flowing = false;
+    this.pause();
 
     for (const dest of dests)
       dest.emit('unpipe', this, { hasUnpiped: false });
@@ -833,7 +833,7 @@ Readable.prototype.unpipe = function(dest) {
 
   state.pipes.splice(index, 1);
   if (state.pipes.length === 0)
-    state.flowing = false;
+    this.pause();
 
   dest.emit('unpipe', this, unpipeInfo);
 

--- a/test/parallel/test-stream-pipe-unpipe-streams.js
+++ b/test/parallel/test-stream-pipe-unpipe-streams.js
@@ -84,3 +84,13 @@ assert.strictEqual(source._readableState.pipes.length, 0);
   checkDestCleanup(dest2);
   source.unpipe();
 }
+
+{
+  const src = Readable({ read: () => {} });
+  const dst = Writable({ write: () => {} });
+  src.pipe(dst);
+  src.on('resume', common.mustCall(() => {
+    src.on('pause', common.mustCall());
+    src.unpipe(dst);
+  }));
+}


### PR DESCRIPTION
unpipe should use pause() instead of mutating
state.flowing directly so that pausing side
effects such as emitting 'pause' are properly
performed.

Fixes: https://github.com/nodejs/node/issues/32470

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
