### PR TITLE
crypto: add crypto.createMac()

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -91,7 +91,8 @@ const {
 } = require('internal/crypto/sig');
 const {
   Hash,
-  Hmac
+  Hmac,
+  Mac,
 } = require('internal/crypto/hash');
 const {
   getCiphers,
@@ -142,6 +143,10 @@ function createHmac(hmac, key, options) {
   return new Hmac(hmac, key, options);
 }
 
+function createMac(mac, key, options) {
+  return new Mac(mac, key, options);
+}
+
 function createSign(algorithm, options) {
   return new Sign(algorithm, options);
 }
@@ -159,6 +164,7 @@ module.exports = {
   createECDH,
   createHash,
   createHmac,
+  createMac,
   createPrivateKey,
   createPublicKey,
   createSecretKey,
@@ -203,6 +209,7 @@ module.exports = {
   Hash,
   Hmac,
   KeyObject,
+  Mac,
   Sign,
   Verify
 };

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -6,8 +6,13 @@ const {
 } = primordials;
 
 const {
+  EVP_PKEY_CMAC,
+  EVP_PKEY_HMAC,
+  EVP_PKEY_POLY1305,
+  EVP_PKEY_SIPHASH,
   Hash: _Hash,
-  Hmac: _Hmac
+  Hmac: _Hmac,
+  Mac: _Mac,
 } = internalBinding('crypto');
 
 const {
@@ -25,7 +30,8 @@ const { Buffer } = require('buffer');
 const {
   ERR_CRYPTO_HASH_FINALIZED,
   ERR_CRYPTO_HASH_UPDATE_FAILED,
-  ERR_INVALID_ARG_TYPE
+  ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_OPT_VALUE,
 } = require('internal/errors').codes;
 const { validateEncoding, validateString, validateUint32 } =
   require('internal/validators');
@@ -140,7 +146,73 @@ Hmac.prototype.digest = function digest(outputEncoding) {
 Hmac.prototype._flush = Hash.prototype._flush;
 Hmac.prototype._transform = Hash.prototype._transform;
 
+class Mac extends LazyTransform {
+  constructor(mac, key, options) {
+    validateString(mac, 'mac');
+
+    let alg, nid;
+    switch (mac) {
+      case 'cmac':
+        alg = options && options.cipher;
+        nid = EVP_PKEY_CMAC;
+        validateString(alg, 'options.cipher');
+        break;
+
+      case 'hmac':
+        alg = options && options.digest;
+        nid = EVP_PKEY_HMAC;
+        validateString(alg, 'options.digest');
+        break;
+
+      case 'poly1305':
+        nid = EVP_PKEY_POLY1305;
+        break;
+
+      case 'siphash':
+        nid = EVP_PKEY_SIPHASH;
+        break;
+
+      default:
+        throw new ERR_INVALID_OPT_VALUE('mac', mac);
+    }
+
+    key = prepareSecretKey(key);
+    super(options);
+
+    this[kHandle] = new _Mac(nid, toBuf(key), alg);
+  }
+
+  _transform(chunk, encoding, callback) {
+    this[kHandle].update(chunk, encoding);
+    callback();
+  }
+
+  _flush(callback) {
+    this.push(this[kHandle].final());
+    callback();
+  }
+
+  update(data, encoding) {
+    encoding = encoding || getDefaultEncoding();
+
+    if (typeof data === 'string') {
+      validateEncoding(data, encoding);
+    } else if (!isArrayBufferView(data)) {
+      throw new ERR_INVALID_ARG_TYPE(
+        'data', ['string', 'Buffer', 'TypedArray', 'DataView'], data);
+    }
+
+    this[kHandle].update(data, encoding);
+    return this;
+  }
+
+  final(outputEncoding) {
+    return this[kHandle].final(outputEncoding || getDefaultEncoding());
+  }
+}
+
 module.exports = {
   Hash,
-  Hmac
+  Hmac,
+  Mac,
 };

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -589,6 +589,26 @@ class Hash final : public BaseObject {
   unsigned char* md_value_;
 };
 
+class Mac : public BaseObject {
+ public:
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
+
+  // TODO(joyeecheung): track the memory used by OpenSSL types
+  SET_NO_MEMORY_INFO()
+  SET_MEMORY_INFO_NAME(Mac)
+  SET_SELF_SIZE(Mac)
+
+ protected:
+  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Update(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Final(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  Mac(Environment* env, v8::Local<v8::Object> wrap, EVPMDPointer&& mdctx);
+
+ private:
+  EVPMDPointer mdctx_;
+};
+
 class SignBase : public BaseObject {
  public:
   typedef enum {

--- a/test/parallel/test-crypto-mac.js
+++ b/test/parallel/test-crypto-mac.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto) common.skip('missing crypto');
+
+const { EventEmitter } = require('events');
+const assert = require('assert');
+const crypto = require('crypto');
+
+assert.throws(() => crypto.createMac('boom', 'secret'),
+              /The value "boom" is invalid for option "mac"/);
+
+assert.throws(() => crypto.createMac('cmac', 'secret'),
+              /"options[.]cipher" property must be of type string/);
+
+assert.throws(() => crypto.createMac('hmac', 'secret'),
+              /"options[.]digest" property must be of type string/);
+
+assert.throws(() => crypto.createMac('cmac', 'secret', { cipher: 'boom' }),
+              /Unknown cipher/);
+
+assert.throws(() => crypto.createMac('hmac', 'secret', { digest: 'boom' }),
+              /Unknown message digest/);
+
+// cmac
+{
+  const key = Buffer.from('77a77faf290c1fa30c683df16ba7a77b', 'hex');
+  const data =
+    Buffer.from(
+      '020683e1f0392f4cac54318b6029259e9c553dbc4b6ad998e64d58e4e7dc2e13',
+      'hex');
+  const expected = Buffer.from('fbfea41bf9740cb501f1292c21cebb40', 'hex');
+  const mac = crypto.createMac('cmac', key, { cipher: 'aes-128-cbc' });
+  mac.update(data);
+  assert.deepStrictEqual(mac.final(), expected);
+  assert.deepStrictEqual(mac.final(), expected);  // Idempotent.
+}
+
+// hmac
+{
+  const expected =
+    Buffer.from('1b2c16b75bd2a870c114153ccda5bcfc' +
+                'a63314bc722fa160d690de133ccbb9db', 'hex');
+  const mac = crypto.createMac('hmac', 'secret', { digest: 'sha256' });
+  mac.update('data');
+  assert.deepStrictEqual(mac.final(), expected);
+  assert.deepStrictEqual(mac.final(), expected);  // Idempotent.
+}
+
+// poly1305
+{
+  const key =
+    Buffer.from(
+      '1c9240a5eb55d38af333888604f6b5f0473917c1402b80099dca5cbc207075c0',
+      'hex');
+  const data =
+    Buffer.from(
+      '2754776173206272696c6c69672c20616e642074686520736c6974687920' +
+      '746f7665730a446964206779726520616e642067696d626c6520696e2074' +
+      '686520776162653a0a416c6c206d696d737920776572652074686520626f' +
+      '726f676f7665732c0a416e6420746865206d6f6d65207261746873206f75' +
+      '7467726162652e',
+      'hex');
+  const expected = Buffer.from('4541669a7eaaee61e708dc7cbcc5eb62', 'hex');
+  const mac = crypto.createMac('poly1305', key).update(data);
+  assert.deepStrictEqual(mac.final(), expected);
+  assert.deepStrictEqual(mac.final(), expected);  // Idempotent.
+}
+
+// siphash
+{
+  const key = Buffer.from('000102030405060708090A0B0C0D0E0F', 'hex');
+  const data = Buffer.from('000102030405', 'hex');
+  const expected = Buffer.from('14eeca338b208613485ea0308fd7a15e', 'hex');
+  const mac = crypto.createMac('siphash', key).update(data);
+  assert.deepStrictEqual(mac.final(), expected);
+  assert.deepStrictEqual(mac.final(), expected);  // Idempotent.
+}
+
+// streaming mac
+{
+  const key =
+    Buffer.from(
+      '1c9240a5eb55d38af333888604f6b5f0473917c1402b80099dca5cbc207075c0',
+      'hex');
+  const data =
+    Buffer.from(
+      '2754776173206272696c6c69672c20616e642074686520736c6974687920' +
+      '746f7665730a446964206779726520616e642067696d626c6520696e2074' +
+      '686520776162653a0a416c6c206d696d737920776572652074686520626f' +
+      '726f676f7665732c0a416e6420746865206d6f6d65207261746873206f75' +
+      '7467726162652e',
+      'hex');
+  const expected = Buffer.from('4541669a7eaaee61e708dc7cbcc5eb62', 'hex');
+  const mac = crypto.createMac('poly1305', key);
+
+  const chunks = [];
+  // eslint-disable-next-line new-parens
+  mac.pipe(new class extends EventEmitter {
+    write(chunk) { chunks.push(chunk); }
+    end() {}
+  });
+
+  mac.write(data.slice(0, 1));
+  for (let i = 1; i < data.length; i += i) mac.write(data.slice(i, i + i));
+  mac.end();
+
+  assert.deepStrictEqual(chunks, [expected]);
+}


### PR DESCRIPTION
Per https://github.com/nodejs/node/pull/32448#issuecomment-603561335.

cc @mscdex @tniessen - this doesn't implement the one-shot API yet but, on the flip side, it supports CMACs.