### PR TITLE
lib: fix fs.read when passing null value

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -484,10 +484,12 @@ function read(fd, buffer, offset, length, position, callback) {
       callback = offset;
     }
 
-    buffer = options.buffer || Buffer.alloc(16384);
-    offset = options.offset || 0;
-    length = options.length || buffer.length;
-    position = options.position;
+    ({
+      buffer = Buffer.alloc(16384),
+      offset = 0,
+      length = buffer.length,
+      position
+    } = options);
   }
 
   validateBuffer(buffer);

--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -80,6 +80,14 @@ assert.throws(
   }
 );
 
+['buffer', 'offset', 'length'].forEach((option) =>
+  assert.throws(
+    () => fs.read(fd, {
+      [option]: null
+    }),
+    `not throws when options.${option} is null`
+  ));
+
 assert.throws(
   () => fs.read(null, Buffer.alloc(1), 0, 1, 0),
   {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
it shouldn't use the default value when user passing `null` on `options`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
