### PR TITLE
test: unflake async-hooks/test-statwatcher

### DIFF
--- a/test/async-hooks/async-hooks.status
+++ b/test/async-hooks/async-hooks.status
@@ -7,8 +7,6 @@ prefix async-hooks
 [true] # This section applies to all platforms
 
 [$system==win32]
-# https://github.com/nodejs/node/issues/29852
-test-statwatcher: PASS,FLAKY
 
 [$system==linux]
 

--- a/test/async-hooks/test-statwatcher.js
+++ b/test/async-hooks/test-statwatcher.js
@@ -64,8 +64,6 @@ w1.on('change', common.mustCallAtLeast((curr, prev) => {
   // Wait until we get the write above.
   if (prev.size !== 0 || curr.size !== 5)
     return;
-  // Remove listeners to make w1HookCount final
-  w1.removeAllListeners('change');
 
   setImmediate(() => {
     checkInvocations(statwatcher1,
@@ -81,8 +79,6 @@ w1.on('change', common.mustCallAtLeast((curr, prev) => {
       // Wait until we get the write above.
       if (prev.size !== 0 || curr.size !== 5)
         return;
-      // Remove listeners to make w2HookCount final
-      w2.removeAllListeners('change');
 
       setImmediate(() => {
         checkInvocations(statwatcher1,


### PR DESCRIPTION
On Windows 2016 under high load further change events can be emitted
after writing the 5 bytes is reported. Updating the mtime of the file
can be reported as a separate change. This will increase the "before"
count, but not the "w1HookCount" since we removed the listener.

This makes the test keep the listeners until the end of the test.

Fixes: https://github.com/nodejs/node/issues/21425

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
