### PR TITLE
lib: refactored cluster schedule_handlers

### DIFF
--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -297,12 +297,7 @@ function queryServer(worker, message) {
       constructor = SharedHandle;
     }
 
-    handle = new constructor(key,
-                             address,
-                             message.port,
-                             message.addressType,
-                             message.fd,
-                             message.flags);
+    handle = new constructor(key, address, message);
     handles.set(key, handle);
   }
 

--- a/lib/internal/cluster/round_robin_handle.js
+++ b/lib/internal/cluster/round_robin_handle.js
@@ -10,115 +10,104 @@ const net = require('net');
 const { sendHelper } = require('internal/cluster/utils');
 const { constants } = internalBinding('tcp_wrap');
 
-module.exports = RoundRobinHandle;
-
-function RoundRobinHandle(key, address, port, addressType, fd, flags) {
-  this.key = key;
-  this.all = new Map();
-  this.free = [];
-  this.handles = [];
-  this.handle = null;
-  this.server = net.createServer(assert.fail);
-
-  if (fd >= 0)
-    this.server.listen({ fd });
-  else if (port >= 0) {
-    this.server.listen({
-      port,
-      host: address,
-      // Currently, net module only supports `ipv6Only` option in `flags`.
-      ipv6Only: Boolean(flags & constants.UV_TCP_IPV6ONLY),
+class RoundRobinHandle {
+  constructor(key, address, { port, fd, flags }) {
+    this.key = key;
+    this.all = new Map();
+    this.free = new Map();
+    this.handles = [];
+    this.handle = null;
+    this.server = net.createServer(assert.fail);
+    this.attachListener(fd, port, address, flags); // UNIX socket path.
+    this.server.once('listening', () => {
+      this.handle = this.server._handle;
+      this.handle.onconnection = (err, handle) => this.distribute(err, handle);
+      this.server._handle = null;
+      this.server = null;
     });
-  } else
-    this.server.listen(address);  // UNIX socket path.
+  }
 
-  this.server.once('listening', () => {
-    this.handle = this.server._handle;
-    this.handle.onconnection = (err, handle) => this.distribute(err, handle);
-    this.server._handle = null;
-    this.server = null;
-  });
+  attachListener(fd, port, address, flags) {
+    if (fd >= 0)
+      this.server.listen({ fd });
+    else if (port >= 0) {
+      this.server.listen({
+        port,
+        host: address,
+        // Currently, net module only supports `ipv6Only` option in `flags`.
+        ipv6Only: Boolean(flags & constants.UV_TCP_IPV6ONLY),
+      });
+    } else
+      this.server.listen(address);
+  }
+
+  add(worker, send) {
+    assert(!this.all.has(worker.id));
+    this.all.set(worker.id, worker);
+    const done = () => {
+      if (this.handle.getsockname) {
+        const out = {};
+        this.handle.getsockname(out);
+        // TODO(bnoordhuis) Check err.
+        send(null, { sockname: out }, null);
+      } else {
+        send(null, null, null); // UNIX socket.
+      }
+      this.handoff(worker); // In case there are connections pending.
+    };
+    if (this.server === null)
+      return done();
+    // Still busy binding.
+    this.server.once('listening', done);
+    this.server.once('error', (err) => {
+      send(err.errno, null);
+    });
+  }
+
+  remove(worker) {
+    const existed = this.all.delete(worker.id);
+    if (!existed)
+      return false;
+    this.free.delete(worker.id);
+    if (this.all.size !== 0)
+      return false;
+    for (const handle of this.handles) {
+      handle.close();
+    }
+    this.handles = [];
+    this.handle.close();
+    this.handle = null;
+    return true;
+  }
+
+  distribute(err, handle) {
+    this.handles.push(handle);
+    const workerId = this.free.keys().next().value;
+    if (workerId) {
+      const worker = this.free.get(workerId);
+      this.free.delete(workerId);
+      this.handoff(worker);
+    }
+  }
+
+  handoff(worker) {
+    if (this.all.has(worker.id) === false) {
+      return; // Worker is closing (or has closed) the server.
+    }
+    const handle = this.handles.shift();
+    if (handle === undefined) {
+      this.free.set(worker.id, worker); // Add to ready queue again.
+      return;
+    }
+    const message = { act: 'newconn', key: this.key };
+    sendHelper(worker.process, message, handle, (reply) => {
+      if (reply.accepted)
+        handle.close();
+      else
+        this.distribute(0, handle); // Worker is shutting down. Send to another.
+      this.handoff(worker);
+    });
+  }
 }
 
-RoundRobinHandle.prototype.add = function(worker, send) {
-  assert(this.all.has(worker.id) === false);
-  this.all.set(worker.id, worker);
-
-  const done = () => {
-    if (this.handle.getsockname) {
-      const out = {};
-      this.handle.getsockname(out);
-      // TODO(bnoordhuis) Check err.
-      send(null, { sockname: out }, null);
-    } else {
-      send(null, null, null);  // UNIX socket.
-    }
-
-    this.handoff(worker);  // In case there are connections pending.
-  };
-
-  if (this.server === null)
-    return done();
-
-  // Still busy binding.
-  this.server.once('listening', done);
-  this.server.once('error', (err) => {
-    send(err.errno, null);
-  });
-};
-
-RoundRobinHandle.prototype.remove = function(worker) {
-  const existed = this.all.delete(worker.id);
-
-  if (!existed)
-    return false;
-
-  const index = this.free.indexOf(worker);
-
-  if (index !== -1)
-    this.free.splice(index, 1);
-
-  if (this.all.size !== 0)
-    return false;
-
-  for (const handle of this.handles) {
-    handle.close();
-  }
-  this.handles = [];
-
-  this.handle.close();
-  this.handle = null;
-  return true;
-};
-
-RoundRobinHandle.prototype.distribute = function(err, handle) {
-  this.handles.push(handle);
-  const worker = this.free.shift();
-
-  if (worker)
-    this.handoff(worker);
-};
-
-RoundRobinHandle.prototype.handoff = function(worker) {
-  if (this.all.has(worker.id) === false) {
-    return;  // Worker is closing (or has closed) the server.
-  }
-
-  const handle = this.handles.shift();
-
-  if (handle === undefined) {
-    this.free.push(worker);  // Add to ready queue again.
-    return;
-  }
-
-  const message = { act: 'newconn', key: this.key };
-
-  sendHelper(worker.process, message, handle, (reply) => {
-    if (reply.accepted)
-      handle.close();
-    else
-      this.distribute(0, handle);  // Worker is shutting down. Send to another.
-
-    this.handoff(worker);
-  });
-};
+module.exports = RoundRobinHandle;

--- a/lib/internal/cluster/shared_handle.js
+++ b/lib/internal/cluster/shared_handle.js
@@ -1,46 +1,49 @@
 'use strict';
+const { Map } = primordials;
 const assert = require('internal/assert');
 const dgram = require('internal/dgram');
 const net = require('net');
 
-module.exports = SharedHandle;
+class SharedHandle {
+  constructor(key, address, { port, addressType, fd, flags }) {
+    this.key = key;
+    this.workers = new Map();
+    this.handle = null;
+    this.errno = 0;
+    const rval = this.determineRval(addressType,
+                                    address,
+                                    port,
+                                    fd,
+                                    flags);
+    if (typeof rval === 'number')
+      this.errno = rval;
+    else
+      this.handle = rval;
+  }
 
-function SharedHandle(key, address, port, addressType, fd, flags) {
-  this.key = key;
-  this.workers = [];
-  this.handle = null;
-  this.errno = 0;
+  determineRval(addressType, address, port, fd, flags) {
+    if (addressType === 'udp4' || addressType === 'udp6')
+      return dgram._createSocketHandle(address, port, addressType, fd, flags);
+    else
+      return net._createServerHandle(address, port, addressType, fd, flags);
+  }
 
-  let rval;
-  if (addressType === 'udp4' || addressType === 'udp6')
-    rval = dgram._createSocketHandle(address, port, addressType, fd, flags);
-  else
-    rval = net._createServerHandle(address, port, addressType, fd, flags);
+  add(worker, send) {
+    assert(!this.workers.has(worker.id));
+    this.workers.set(worker.id, worker);
+    send(this.errno, null, this.handle);
+  }
 
-  if (typeof rval === 'number')
-    this.errno = rval;
-  else
-    this.handle = rval;
+  remove(worker) {
+    if (!this.workers.has(worker.id))
+      return false; // The worker wasn't sharing this handle.
+    this.workers.delete(worker.id);
+    if (this.workers.size !== 0)
+      return false;
+    this.handle.close();
+    this.handle = null;
+    return true;
+  }
 }
 
-SharedHandle.prototype.add = function(worker, send) {
-  assert(!this.workers.includes(worker));
-  this.workers.push(worker);
-  send(this.errno, null, this.handle);
-};
-
-SharedHandle.prototype.remove = function(worker) {
-  const index = this.workers.indexOf(worker);
-
-  if (index === -1)
-    return false; // The worker wasn't sharing this handle.
-
-  this.workers.splice(index, 1);
-
-  if (this.workers.length !== 0)
-    return false;
-
-  this.handle.close();
-  this.handle = null;
-  return true;
-};
+module.exports = SharedHandle;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Scheduler handler for cluster were implemented in function prototype
form, which can be converted to newer syntax of classes. Also seperated
concern for attaching listener to one of the internal methods of class
in round_robin_handle. Used `Map` instead of `Array` when there are
cases for continous finding element. Also prefered destructuring over
sending large number of parameters because one of the parameters
`addressType` can only be used in shared_handle implementation and not
round_robin.

Fixes: https://github.com/nodejs/node/issues/32480
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->