### PR TITLE
Revert "test: mark empty udp tests flaky on OS X"

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -29,13 +29,6 @@ test-worker-message-port-transfer-terminate: PASS,FLAKY
 [$system==linux]
 
 [$system==macos]
-# https://github.com/nodejs/node/issues/30030
-test-dgram-connect-send-empty-buffer: PASS,FLAKY
-test-dgram-connect-send-empty-array: PASS,FLAKY
-test-dgram-connect-send-empty-packet: PASS,FLAKY
-test-dgram-send-empty-array: PASS,FLAKY
-test-dgram-send-empty-buffer: PASS,FLAKY
-test-dgram-send-empty-packet: PASS,FLAKY
 
 [$arch==arm || $arch==arm64]
 # https://github.com/nodejs/node/issues/26610


### PR DESCRIPTION
This reverts commit 24a4f76709bd9edc8d86e9f3fb4d5e3c7d4c3d69.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
