### PR TITLE
net: wait for shutdown to complete before closing

### DIFF
--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -213,6 +213,16 @@ function onStreamRead(arrayBuffer) {
     if (stream[kMaybeDestroy])
       stream.on('end', stream[kMaybeDestroy]);
 
+    // TODO(ronag): Without this `readStop`, `onStreamRead`
+    // will be called once more (i.e. after Readable.ended)
+    // on Windows causing a ECONNRESET, failing the
+    // test-https-truncate test.
+    if (handle.readStop) {
+      const err = handle.readStop();
+      if (err)
+        return stream.destroy(errnoException(err, 'read'));
+    }
+
     // Push a null to signal the end of data.
     // Do it before `maybeDestroy` for correct order of events:
     // `end` -> `close`

--- a/lib/net.js
+++ b/lib/net.js
@@ -630,9 +630,9 @@ function onReadableStreamEnd() {
     this.write = writeAfterFIN;
     if (this.writable)
       this.end();
-  }
-
-  if (!this.destroyed && !this.writable && !this.writableLength)
+    else if (!this.writableLength)
+      this.destroy();
+  } else if (!this.destroyed && !this.writable && !this.writableLength)
     this.destroy();
 }
 

--- a/test/async-hooks/test-graph.tls-write.js
+++ b/test/async-hooks/test-graph.tls-write.js
@@ -65,9 +65,7 @@ function onexit() {
       { type: 'TCPCONNECTWRAP',
         id: 'tcpconnect:1', triggerAsyncId: 'tcp:1' },
       { type: 'TCPWRAP', id: 'tcp:2', triggerAsyncId: 'tcpserver:1' },
-      { type: 'TLSWRAP', id: 'tls:2', triggerAsyncId: 'tcpserver:1' },
-      { type: 'Immediate', id: 'immediate:1', triggerAsyncId: 'tcp:2' },
-      { type: 'Immediate', id: 'immediate:2', triggerAsyncId: 'tcp:1' },
+      { type: 'TLSWRAP', id: 'tls:2', triggerAsyncId: 'tcpserver:1' }
     ]
   );
 }

--- a/test/parallel/test-net-allow-half-open.js
+++ b/test/parallel/test-net-allow-half-open.js
@@ -8,7 +8,7 @@ const server = net.createServer(common.mustCall((socket) => {
   socket.end(Buffer.alloc(1024));
 })).listen(0, common.mustCall(() => {
   const socket = net.connect(server.address().port);
-  assert(socket.allowHalfOpen === false);
+  assert.strictEqual(socket.allowHalfOpen, false);
   socket.resume();
   socket.on('end', common.mustCall(() => {
     process.nextTick(() => {
@@ -16,7 +16,7 @@ const server = net.createServer(common.mustCall((socket) => {
       // without proper shutdown.
       assert(!socket.destroyed);
       server.close();
-    })
+    });
   }));
   socket.on('finish', common.mustCall(() => {
     assert(!socket.destroyed);

--- a/test/parallel/test-net-allow-half-open.js
+++ b/test/parallel/test-net-allow-half-open.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const server = net.createServer(common.mustCall((socket) => {
+  socket.end(Buffer.alloc(1024));
+})).listen(0, common.mustCall(() => {
+  const socket = net.connect(server.address().port);
+  assert(socket.allowHalfOpen === false);
+  socket.resume();
+  socket.on('end', common.mustCall(() => {
+    process.nextTick(() => {
+      assert(!socket.destroyed);
+      server.close();
+    })
+  }));
+  socket.on('close', common.mustCall());
+}));

--- a/test/parallel/test-net-allow-half-open.js
+++ b/test/parallel/test-net-allow-half-open.js
@@ -12,9 +12,14 @@ const server = net.createServer(common.mustCall((socket) => {
   socket.resume();
   socket.on('end', common.mustCall(() => {
     process.nextTick(() => {
+      // Ensure socket is not destroyed straight away
+      // without proper shutdown.
       assert(!socket.destroyed);
       server.close();
     })
+  }));
+  socket.on('finish', common.mustCall(() => {
+    assert(!socket.destroyed);
   }));
   socket.on('close', common.mustCall());
 }));


### PR DESCRIPTION
When not allowing half open, handle.close would be
invoked before shutdown has been called and
completed causing a potential data race.

Fixes: https://github.com/nodejs/node/issues/32486#issuecomment-604072559

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
