### PR TITLE
http: avoid using destroySoon

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -684,14 +684,8 @@ function responseOnEnd() {
 
   if (!req.shouldKeepAlive) {
     const socket = req.socket;
-    if (socket.writable) {
-      debug('AGENT socket.destroySoon()');
-      if (typeof socket.destroySoon === 'function')
-        socket.destroySoon();
-      else
-        socket.end();
-    }
-    assert(!socket.writable);
+    if (socket.writable)
+      socket.end();
   } else if (req.finished && !this.aborted) {
     // We can assume `req.finished` means all data has been written since:
     // - `'responseOnEnd'` means we have been assigned a socket.

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -691,11 +691,8 @@ function resOnFinish(req, res, socket, state, server) {
   process.nextTick(emitCloseNT, res);
 
   if (res._last) {
-    if (typeof socket.destroySoon === 'function') {
-      socket.destroySoon();
-    } else {
+    if (socket.writable)
       socket.end();
-    }
   } else if (state.outgoing.length === 0) {
     if (server.keepAliveTimeout && typeof socket.setTimeout === 'function') {
       socket.setTimeout(server.keepAliveTimeout);


### PR DESCRIPTION
destroySoon is an undocumented legacy method which should
no longer ber required. Calling end() should be enough to
clean up the socket. One step towards deprecation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
