### PR TITLE
cli, report: move --report-on-fatalerror to stable

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -648,13 +648,14 @@ Name of the file to which the report will be written.
 <!-- YAML
 added: v11.8.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32496
+    description: This option is no longer considered experimental.
   - version: v12.0.0
     pr-url: https://github.com/nodejs/node/pull/27312
     description: changed from `--diagnostic-report-on-fatalerror` to
                  `--report-on-fatalerror`
 -->
-
-> Stability: 1 - Experimental
 
 Enables the report to be triggered on fatal errors (internal errors within
 the Node.js runtime such as out of memory) that lead to termination of the


### PR DESCRIPTION
This commit moves the last experimental feature of diagnostic reports to stable status.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)