### PR TITLE
src: fix compiler warnings in node_report_module

### DIFF
--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -129,13 +129,11 @@ static void SetSignal(const FunctionCallbackInfo<Value>& info) {
 }
 
 static void ShouldReportOnFatalError(const FunctionCallbackInfo<Value>& info) {
-  Environment* env = Environment::GetCurrent(info);
   info.GetReturnValue().Set(
       node::per_process::cli_options->report_on_fatalerror);
 }
 
 static void SetReportOnFatalError(const FunctionCallbackInfo<Value>& info) {
-  Environment* env = Environment::GetCurrent(info);
   CHECK(info[0]->IsBoolean());
   node::per_process::cli_options->report_on_fatalerror = info[0]->IsTrue();
 }


### PR DESCRIPTION
Currently, the following compiler warnings are generated:
```console
../src/node_report_module.cc:
In function ‘void report::ShouldReportOnFatalError(const v8::FunctionCallbackInfo<v8::Value>&)’:
../src/node_report_module.cc:132:16: warning: unused variable ‘env’ [-Wunused-variable]
  132 |   Environment* env = Environment::GetCurrent(info);
      |                ^~~
../src/node_report_module.cc:
In function ‘void report::SetReportOnFatalError(const v8::FunctionCallbackInfo<v8::Value>&)’:
../src/node_report_module.cc:138:16: warning: unused variable ‘env’ [-Wunused-variable]
  138 |   Environment* env = Environment::GetCurrent(info);
      |                ^~~
```
This commit removes the unused variables.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
