### PR TITLE
deprecate process.umask() with no arguments

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2635,16 +2635,16 @@ modules is unsupported.
 It is deprecated in favor of [`require.main`][], because it serves the same
 purpose and is only available on CommonJS environment.
 
-<a id="DEP0XXX"></a>
-### DEP0XXX: `process.umask()` with no arguments
+<a id="DEP0139"></a>
+### DEP0139: `process.umask()` with no arguments
 <!-- YAML
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/32499
-    description: Documentation-only deprecation.
+    description: Runtime deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 Calling `process.umask()` with no arguments causes the process-wide umask to be
 written twice. This introduces a race condition between threads, and is a

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2635,6 +2635,22 @@ modules is unsupported.
 It is deprecated in favor of [`require.main`][], because it serves the same
 purpose and is only available on CommonJS environment.
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: `process.umask()` with no arguments
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32499
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+Calling `process.umask()` with no arguments causes the process-wide umask to be
+written twice. This introduces a race condition between threads, and is a
+potential security vulnerability. There is no safe, cross-platform alternative
+API.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2426,7 +2426,15 @@ flag's behavior.
 ## `process.umask([mask])`
 <!-- YAML
 added: v0.1.19
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32499
+    description: Calling `process.umask()` with no arguments is deprecated.
+
 -->
+
+> Stability: 0 - Deprecated. Calling `process.umask()` with no arguments is
+> deprecated. No alternative is provided.
 
 * `mask` {string|integer}
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -910,6 +910,14 @@ void Environment::set_filehandle_close_warning(bool on) {
   emit_filehandle_warning_ = on;
 }
 
+bool Environment::emit_insecure_umask_warning() const {
+  return emit_insecure_umask_warning_;
+}
+
+void Environment::set_emit_insecure_umask_warning(bool on) {
+  emit_insecure_umask_warning_ = on;
+}
+
 inline uint64_t Environment::thread_id() const {
   return thread_id_;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -1065,6 +1065,8 @@ class Environment : public MemoryRetainer {
 
   inline bool filehandle_close_warning() const;
   inline void set_filehandle_close_warning(bool on);
+  inline bool emit_insecure_umask_warning() const;
+  inline void set_emit_insecure_umask_warning(bool on);
 
   inline void ThrowError(const char* errmsg);
   inline void ThrowTypeError(const char* errmsg);
@@ -1285,6 +1287,7 @@ class Environment : public MemoryRetainer {
   bool emit_env_nonstring_warning_ = true;
   bool emit_err_name_warning_ = true;
   bool emit_filehandle_warning_ = true;
+  bool emit_insecure_umask_warning_ = true;
   size_t async_callback_scope_depth_ = 0;
   std::vector<double> destroy_async_id_list_;
 

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -245,6 +245,17 @@ static void Umask(const FunctionCallbackInfo<Value>& args) {
 
   uint32_t old;
   if (args[0]->IsUndefined()) {
+    if (env->emit_insecure_umask_warning()) {
+      env->set_emit_insecure_umask_warning(false);
+      if (ProcessEmitDeprecationWarning(
+              env,
+              "Calling process.umask() with no arguments is prone to race "
+              "conditions and is a potential security vulnerability.",
+              "DEP0139").IsNothing()) {
+        return;
+      }
+    }
+
     old = umask(0);
     umask(static_cast<mode_t>(old));
   } else {

--- a/test/parallel/test-process-umask.js
+++ b/test/parallel/test-process-umask.js
@@ -40,6 +40,13 @@ if (common.isWindows) {
   mask = '0664';
 }
 
+common.expectWarning(
+  'DeprecationWarning',
+  'Calling process.umask() with no arguments is prone to race conditions ' +
+  'and is a potential security vulnerability.',
+  'DEP0139'
+);
+
 const old = process.umask(mask);
 
 assert.strictEqual(process.umask(old), parseInt(mask, 8));


### PR DESCRIPTION
This commit introduces a documentation deprecation for calling `process.umask()` with no arguments.

Fixes: https://github.com/nodejs/node/issues/32321

(I have a runtime deprecation PR ready to go as well, in case we want to skip straight to that step, as this is a potential security issue.)

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)