### PR TITLE
benchmark: fix error on server close in AsyncLocalStorage benchmark

### DIFF
--- a/benchmark/async_hooks/async-resource-vs-destroy.js
+++ b/benchmark/async_hooks/async-resource-vs-destroy.js
@@ -35,7 +35,7 @@ function buildCurrentResource(getServe) {
 
   function getCLS() {
     const resource = executionAsyncResource();
-    if (resource === null || !resource[cls]) {
+    if (!resource[cls]) {
       return null;
     }
     return resource[cls].state;
@@ -43,9 +43,6 @@ function buildCurrentResource(getServe) {
 
   function setCLS(state) {
     const resource = executionAsyncResource();
-    if (resource === null) {
-      return;
-    }
     if (!resource[cls]) {
       resource[cls] = { state };
     } else {
@@ -116,11 +113,17 @@ function buildAsyncLocalStorage(getServe) {
 
   function getCLS() {
     const store = asyncLocalStorage.getStore();
+    if (store === undefined) {
+      return null;
+    }
     return store.state;
   }
 
   function setCLS(state) {
     const store = asyncLocalStorage.getStore();
+    if (store === undefined) {
+      return;
+    }
     store.state = state;
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

* Closes #32501

Fixes `AsyncLocalStorage` type from `benchmark/async_hooks/async-resource-vs-destroy.js` by adding `undefined` check for the store (CLS context). Before this fix it could fail when the server is closed (and ALS instance is disabled), which may lead to calls to `getCLS()` method of the benchmark in the following part of the request handling code:

```js
   setTimeout(() => {
      // the server may be already closed when this (and the next one) callback is run
      readFile(__filename, () => {
        res.setHeader('content-type', 'application/json');
        res.end(JSON.stringify({ cls: getCLS() }));
      });
    }, 10);
```

Other types within the benchmark already had similar checks, so that's why they weren't failing.

* Also removes redundant checks from `executionAsyncResource` type. Reason: the final implementation of `executionAsyncResource()` never returns `null`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
