### PR TITLE
lib: changed functional logic in cluster schedulers

### DIFF
--- a/lib/internal/cluster/round_robin_handle.js
+++ b/lib/internal/cluster/round_robin_handle.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  ArrayIsArray,
   Boolean,
   Map,
 } = primordials;
@@ -15,7 +16,7 @@ module.exports = RoundRobinHandle;
 function RoundRobinHandle(key, address, port, addressType, fd, flags) {
   this.key = key;
   this.all = new Map();
-  this.free = [];
+  this.free = new Map();
   this.handles = [];
   this.handle = null;
   this.server = net.createServer(assert.fail);
@@ -73,10 +74,7 @@ RoundRobinHandle.prototype.remove = function(worker) {
   if (!existed)
     return false;
 
-  const index = this.free.indexOf(worker);
-
-  if (index !== -1)
-    this.free.splice(index, 1);
+  this.free.delete(worker.id);
 
   if (this.all.size !== 0)
     return false;
@@ -93,21 +91,24 @@ RoundRobinHandle.prototype.remove = function(worker) {
 
 RoundRobinHandle.prototype.distribute = function(err, handle) {
   this.handles.push(handle);
-  const worker = this.free.shift();
+  const [ workerEntry ] = this.free;
 
-  if (worker)
+  if (ArrayIsArray(workerEntry)) {
+    const [ workerId, worker ] = workerEntry;
+    this.free.delete(workerId);
     this.handoff(worker);
+  }
 };
 
 RoundRobinHandle.prototype.handoff = function(worker) {
-  if (this.all.has(worker.id) === false) {
+  if (!this.all.has(worker.id)) {
     return;  // Worker is closing (or has closed) the server.
   }
 
   const handle = this.handles.shift();
 
   if (handle === undefined) {
-    this.free.push(worker);  // Add to ready queue again.
+    this.free.set(worker.id, worker);  // Add to ready queue again.
     return;
   }
 

--- a/lib/internal/cluster/shared_handle.js
+++ b/lib/internal/cluster/shared_handle.js
@@ -1,4 +1,5 @@
 'use strict';
+const { Map } = primordials;
 const assert = require('internal/assert');
 const dgram = require('internal/dgram');
 const net = require('net');
@@ -7,7 +8,7 @@ module.exports = SharedHandle;
 
 function SharedHandle(key, address, port, addressType, fd, flags) {
   this.key = key;
-  this.workers = [];
+  this.workers = new Map();
   this.handle = null;
   this.errno = 0;
 
@@ -24,20 +25,18 @@ function SharedHandle(key, address, port, addressType, fd, flags) {
 }
 
 SharedHandle.prototype.add = function(worker, send) {
-  assert(!this.workers.includes(worker));
-  this.workers.push(worker);
+  assert(!this.workers.has(worker.id));
+  this.workers.set(worker.id, worker);
   send(this.errno, null, this.handle);
 };
 
 SharedHandle.prototype.remove = function(worker) {
-  const index = this.workers.indexOf(worker);
+  if (!this.workers.has(worker.id))
+    return false;
 
-  if (index === -1)
-    return false; // The worker wasn't sharing this handle.
+  this.workers.delete(worker.id);
 
-  this.workers.splice(index, 1);
-
-  if (this.workers.length !== 0)
+  if (this.workers.size !== 0)
     return false;
 
   this.handle.close();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Free pool in round_robin scheduler is implemented as an array. There
were constant lookups being for distributing load on other workers in
free pool. Reimplementing in Map will create will be more performant as
compared to Array implementation. This was done for all in past but free
wasn't implemented at that time.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->