### PR TITLE
tools: extend timeout for doc build version fetch

### DIFF
--- a/tools/doc/versions.js
+++ b/tools/doc/versions.js
@@ -15,7 +15,7 @@ const isRelease = () => {
 const getUrl = (url) => {
   return new Promise((resolve, reject) => {
     const https = require('https');
-    const request = https.get(url, { timeout: 5000 }, (response) => {
+    const request = https.get(url, { timeout: 30000 }, (response) => {
       if (response.statusCode !== 200) {
         reject(new Error(
           `Failed to get ${url}, status code ${response.statusCode}`));


### PR DESCRIPTION
5s is too short, one of our CI CentOS 7 machines fails on this, @MylesBorins noted that it regularly happens when he's doing releases. I don't know why this machine has problems (I'm updating it and restarting it atm) with a 5s timeout but it does.

<img width="936" alt="Screenshot 2020-03-27 09 27 23" src="https://user-images.githubusercontent.com/495647/77704366-08a4e280-7011-11ea-93f0-022becebc100.png">

Confirmed on that machine that extending the timeout gets it through `doc-only`.

Is 30s too much? The timeout is there to handle the no-internet case.