### PR TITLE
doc, tools: added caching support for `CHANGELOG.md` in `tools/doc/versions.js`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ _UpgradeReport_Files/
 # === Global Rules ===
 # Keep last to avoid being excluded
 *.pyc
+.master-CHANGELOG.md
 __pycache__
 .DS_Store
 *~

--- a/tools/doc/versions.js
+++ b/tools/doc/versions.js
@@ -31,13 +31,6 @@ const getUrl = (url) => {
   });
 };
 
-const createMaster = (masterPath, file) => {
-  writeFileSync(
-    masterPath,
-    file, { encoding: 'utf8' }
-  );
-};
-
 const kNoInternet = !!process.env.NODE_TEST_NO_INTERNET;
 
 module.exports = {
@@ -60,7 +53,8 @@ module.exports = {
     } else {
       try {
         changelog = await getUrl(url);
-        createMaster(masterChangelog, changelog);
+        // Create the .master-CHANGLELOG.md file
+        writeFileSync(masterChangelog, changelog);
       } catch (e) {
         // Fail if this is a release build, otherwise fallback to local files.
         if (isRelease()) {

--- a/tools/doc/versions.js
+++ b/tools/doc/versions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { readFileSync } = require('fs');
+const { readFileSync, existsSync, writeFileSync } = require('fs');
 const path = require('path');
 const srcRoot = path.join(__dirname, '..', '..');
 
@@ -31,6 +31,13 @@ const getUrl = (url) => {
   });
 };
 
+const createMaster = (masterPath, file) => {
+  writeFileSync(
+    masterPath,
+    file, { encoding: 'utf8' }
+  );
+};
+
 const kNoInternet = !!process.env.NODE_TEST_NO_INTERNET;
 
 module.exports = {
@@ -45,11 +52,15 @@ module.exports = {
       'https://raw.githubusercontent.com/nodejs/node/master/CHANGELOG.md';
     let changelog;
     const file = path.join(srcRoot, 'CHANGELOG.md');
+    const masterChangelog = path.join(srcRoot, '.master-CHANGELOG.md');
     if (kNoInternet) {
       changelog = readFileSync(file, { encoding: 'utf8' });
+    } else if (existsSync(masterChangelog)) {
+      changelog = readFileSync(masterChangelog, { encoding: 'utf8' });
     } else {
       try {
         changelog = await getUrl(url);
+        createMaster(masterChangelog, changelog);
       } catch (e) {
         // Fail if this is a release build, otherwise fallback to local files.
         if (isRelease()) {


### PR DESCRIPTION
When running `make doc` the CHANGELOG.md file is pulled everytime for each
of the doc file that requires the versions list. This commit introduces a
new file called `.master-CHANGELOG.md` which will be created once so that
subsequent calls for the version are pulled locally instead of from the repo.
Since this file is not part of the codebase proper, it is appended in the
.gitignore file.

Closes #32512

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
