### PR TITLE
net: close connection if no 'connection' listener

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -83,6 +83,11 @@ event is not emitted until all connections are ended.
 ### Event: `'connection'`
 <!-- YAML
 added: v0.1.90
+changes:
+ - version: REPLACEME
+   pr-url: XXX
+   description: New connections are now closed instead of silently leaking them
+                when there are no `'connection'` listeners.
 -->
 
 * {net.Socket} The connection object

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -85,7 +85,7 @@ event is not emitted until all connections are ended.
 added: v0.1.90
 changes:
  - version: REPLACEME
-   pr-url: XXX
+   pr-url: https://github.com/nodejs/node/pull/32516
    description: New connections are now closed instead of silently leaking them
                 when there are no `'connection'` listeners.
 -->

--- a/lib/net.js
+++ b/lib/net.js
@@ -1536,6 +1536,11 @@ function onconnection(err, clientHandle) {
     return;
   }
 
+  if (self.listenerCount('connection') === 0) {
+    clientHandle.close();
+    return;
+  }
+
   if (self.maxConnections && self._connections >= self.maxConnections) {
     clientHandle.close();
     return;

--- a/test/parallel/test-net-server-no-handler.js
+++ b/test/parallel/test-net-server-no-handler.js
@@ -2,10 +2,10 @@
 // incoming connections rather than accepting, then forgetting about them.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const net = require('net');
 
-net.createServer(/* no handler */).listen(function() {
+net.createServer(common.mustCall()).listen(function() {
   const server = this;
   const { address: host, port } = server.address();
   net.connect(port, host).once('end', () => server.close());

--- a/test/parallel/test-net-server-no-handler.js
+++ b/test/parallel/test-net-server-no-handler.js
@@ -1,0 +1,12 @@
+// Ensure that a net.Server without 'connection' event listeners closes
+// incoming connections rather than accepting, then forgetting about them.
+
+'use strict';
+require('../common');
+const net = require('net');
+
+net.createServer(/* no handler */).listen(function() {
+  const server = this;
+  const { address: host, port } = server.address();
+  net.connect(port, host).once('end', () => server.close());
+});

--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -67,7 +67,7 @@ for (let i = 0; i < invalidCallbacks.length; i++) {
   );
 }
 
-const server = net.Server();
+const server = net.Server((conn) => { /* do nothing */ });
 server.listen(0, common.mustCall(() => {
   const socket = net.createConnection(server.address().port);
   socket.setTimeout(1, common.mustCall(() => {


### PR DESCRIPTION
A `net.Server` without a `'connection'` event listener would accept
incoming connections but then proceeded to drop them into the void:
the connections stay around, using up resources, but can no longer
be reached by the program - i.e., they become resource leaks.

Avoid that by closing the connection when there is no listener.

It would be even better to not accept connections at all but libuv
does not currently support that because It's Complicated.