### PR TITLE
tools: only fetch previous versions when necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -784,15 +784,22 @@ out/doc/api/assets/%: doc/api_assets/% out/doc/api/assets
 run-npm-ci = $(PWD)/$(NPM) ci
 
 LINK_DATA = out/doc/apilinks.json
+VERSIONS_DATA = out/doc/previous-versions.json
 gen-api = tools/doc/generate.js --node-version=$(FULLVERSION) \
-		--apilinks=$(LINK_DATA) $< --output-directory=out/doc/api
+		--apilinks=$(LINK_DATA) $< --output-directory=out/doc/api \
+		--versions-file=$(VERSIONS_DATA)
 gen-apilink = tools/doc/apilinks.js $(LINK_DATA) $(wildcard lib/*.js)
 
 $(LINK_DATA): $(wildcard lib/*.js) tools/doc/apilinks.js
 	$(call available-node, $(gen-apilink))
 
+# Regenerate previous versions data if the current version changes
+$(VERSIONS_DATA): CHANGELOG.md src/node_version.h tools/doc/versions.js
+	$(call available-node, tools/doc/versions.js $@)
+
 out/doc/api/%.json out/doc/api/%.html: doc/api/%.md tools/doc/generate.js \
-	tools/doc/markdown.js tools/doc/html.js tools/doc/json.js tools/doc/apilinks.js | $(LINK_DATA)
+	tools/doc/markdown.js tools/doc/html.js tools/doc/json.js \
+	tools/doc/apilinks.js $(VERSIONS_DATA) | $(LINK_DATA)
 	$(call available-node, $(gen-api))
 
 out/doc/api/all.html: $(apidocs_html) tools/doc/allhtml.js \

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -36,7 +36,7 @@ const testLinksMapper = {
   }
 };
 
-async function toHTML({ input, filename, nodeVersion }) {
+function toHTML({ input, filename, nodeVersion, versions }) {
   const content = unified()
     .use(replaceLinks, { filename, linksMapper: testLinksMapper })
     .use(markdown)
@@ -49,7 +49,7 @@ async function toHTML({ input, filename, nodeVersion }) {
     .use(htmlStringify)
     .processSync(input);
 
-  return html.toHTML({ input, content, filename, nodeVersion });
+  return html.toHTML({ input, content, filename, nodeVersion, versions });
 }
 
 // Test data is a list of objects with two properties.
@@ -129,6 +129,16 @@ const testData = [
 ];
 
 const spaces = /\s/g;
+const versions = [
+  { num: '10.x', lts: true },
+  { num: '9.x' },
+  { num: '8.x' },
+  { num: '7.x' },
+  { num: '6.x' },
+  { num: '5.x' },
+  { num: '4.x' },
+  { num: '0.12.x' },
+  { num: '0.10.x' }];
 
 testData.forEach(({ file, html }) => {
   // Normalize expected data by stripping whitespace.
@@ -136,9 +146,10 @@ testData.forEach(({ file, html }) => {
 
   readFile(file, 'utf8', common.mustCall(async (err, input) => {
     assert.ifError(err);
-    const output = await toHTML({ input: input,
-                                  filename: 'foo',
-                                  nodeVersion: process.version });
+    const output = toHTML({ input: input,
+                            filename: 'foo',
+                            nodeVersion: process.version,
+                            versions: versions });
 
     const actual = output.replace(spaces, '');
     // Assert that the input stripped of all whitespace contains the

--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -42,6 +42,7 @@ let filename = null;
 let nodeVersion = null;
 let outputDir = null;
 let apilinks = {};
+let versions = {};
 
 async function main() {
   for (const arg of args) {
@@ -58,6 +59,13 @@ async function main() {
         throw new Error(`${linkFile} is empty`);
       }
       apilinks = JSON.parse(data);
+    } else if (arg.startsWith('--versions-file=')) {
+      const versionsFile = arg.replace(/^--versions-file=/, '');
+      const data = await fs.readFile(versionsFile, 'utf8');
+      if (!data.trim()) {
+        throw new Error(`${versionsFile} is empty`);
+      }
+      versions = JSON.parse(data);
     }
   }
 
@@ -84,7 +92,8 @@ async function main() {
     .use(htmlStringify)
     .process(input);
 
-  const myHtml = await html.toHTML({ input, content, filename, nodeVersion });
+  const myHtml = await html.toHTML({ input, content, filename, nodeVersion,
+                                     versions });
   const basename = path.basename(filename, '.md');
   const htmlTarget = path.join(outputDir, `${basename}.html`);
   const jsonTarget = path.join(outputDir, `${basename}.json`);

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -23,7 +23,6 @@
 
 const common = require('./common.js');
 const fs = require('fs');
-const getVersions = require('./versions.js');
 const unified = require('unified');
 const find = require('unist-util-find');
 const visit = require('unist-util-visit');
@@ -63,7 +62,7 @@ const gtocHTML = unified()
 const templatePath = path.join(docPath, 'template.html');
 const template = fs.readFileSync(templatePath, 'utf8');
 
-async function toHTML({ input, content, filename, nodeVersion }) {
+function toHTML({ input, content, filename, nodeVersion, versions }) {
   filename = path.basename(filename, '.md');
 
   const id = filename.replace(/\W+/g, '-');
@@ -81,7 +80,7 @@ async function toHTML({ input, content, filename, nodeVersion }) {
   const docCreated = input.match(
     /<!--\s*introduced_in\s*=\s*v([0-9]+)\.([0-9]+)\.[0-9]+\s*-->/);
   if (docCreated) {
-    HTML = HTML.replace('__ALTDOCS__', await altDocs(filename, docCreated));
+    HTML = HTML.replace('__ALTDOCS__', altDocs(filename, docCreated, versions));
   } else {
     console.error(`Failed to add alternative version links to ${filename}`);
     HTML = HTML.replace('__ALTDOCS__', '');
@@ -391,10 +390,9 @@ function getId(text, idCounters) {
   return text;
 }
 
-async function altDocs(filename, docCreated) {
+function altDocs(filename, docCreated, versions) {
   const [, docCreatedMajor, docCreatedMinor] = docCreated.map(Number);
   const host = 'https://nodejs.org';
-  const versions = await getVersions.versions();
 
   const getHref = (versionNum) =>
     `${host}/docs/latest-v${versionNum}/api/${filename}.html`;

--- a/tools/doc/versions.js
+++ b/tools/doc/versions.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const { readFileSync } = require('fs');
+const { readFileSync, writeFileSync } = require('fs');
 const path = require('path');
 const srcRoot = path.join(__dirname, '..', '..');
-
-let _versions;
 
 const isRelease = () => {
   const re = /#define NODE_VERSION_IS_RELEASE 0/;
@@ -15,7 +13,7 @@ const isRelease = () => {
 const getUrl = (url) => {
   return new Promise((resolve, reject) => {
     const https = require('https');
-    const request = https.get(url, { timeout: 5000 }, (response) => {
+    const request = https.get(url, { timeout: 30000 }, (response) => {
       if (response.statusCode !== 200) {
         reject(new Error(
           `Failed to get ${url}, status code ${response.statusCode}`));
@@ -32,45 +30,51 @@ const getUrl = (url) => {
 };
 
 const kNoInternet = !!process.env.NODE_TEST_NO_INTERNET;
+const outFile = (process.argv.length > 2 ? process.argv[2] : undefined);
 
-module.exports = {
-  async versions() {
-    if (_versions) {
-      return _versions;
-    }
-
-    // The CHANGELOG.md on release branches may not reference newer semver
-    // majors of Node.js so fetch and parse the version from the master branch.
-    const url =
-      'https://raw.githubusercontent.com/nodejs/node/master/CHANGELOG.md';
-    let changelog;
-    const file = path.join(srcRoot, 'CHANGELOG.md');
-    if (kNoInternet) {
-      changelog = readFileSync(file, { encoding: 'utf8' });
-    } else {
-      try {
-        changelog = await getUrl(url);
-      } catch (e) {
-        // Fail if this is a release build, otherwise fallback to local files.
-        if (isRelease()) {
-          throw e;
-        } else {
-          console.warn(`Unable to retrieve ${url}. Falling back to ${file}.`);
-          changelog = readFileSync(file, { encoding: 'utf8' });
-        }
+async function versions() {
+  // The CHANGELOG.md on release branches may not reference newer semver
+  // majors of Node.js so fetch and parse the version from the master branch.
+  const url =
+    'https://raw.githubusercontent.com/nodejs/node/master/CHANGELOG.md';
+  let changelog;
+  const file = path.join(srcRoot, 'CHANGELOG.md');
+  if (kNoInternet) {
+    changelog = readFileSync(file, { encoding: 'utf8' });
+  } else {
+    try {
+      changelog = await getUrl(url);
+    } catch (e) {
+      // Fail if this is a release build, otherwise fallback to local files.
+      if (isRelease()) {
+        throw e;
+      } else {
+        console.warn(`Unable to retrieve ${url}. Falling back to ${file}.`);
+        changelog = readFileSync(file, { encoding: 'utf8' });
       }
     }
-    const ltsRE = /Long Term Support/i;
-    const versionRE = /\* \[Node\.js ([0-9.]+)\]\S+ (.*)\r?\n/g;
-    _versions = [];
-    let match;
-    while ((match = versionRE.exec(changelog)) != null) {
-      const entry = { num: `${match[1]}.x` };
-      if (ltsRE.test(match[2])) {
-        entry.lts = true;
-      }
-      _versions.push(entry);
-    }
-    return _versions;
   }
-};
+  const ltsRE = /Long Term Support/i;
+  const versionRE = /\* \[Node\.js ([0-9.]+)\]\S+ (.*)\r?\n/g;
+  const _versions = [];
+  let match;
+  while ((match = versionRE.exec(changelog)) != null) {
+    const entry = { num: `${match[1]}.x` };
+    if (ltsRE.test(match[2])) {
+      entry.lts = true;
+    }
+    _versions.push(entry);
+  }
+  return _versions;
+}
+
+versions().then((v) => {
+  if (outFile) {
+    writeFileSync(outFile, JSON.stringify(v));
+  } else {
+    console.log(JSON.stringify(v));
+  }
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Refactor the logic for working out the previous versions of Node.js for
the API documentation so that the parsing (including the potential https
get) happens at most once per build (as opposed to the current once per
generated API doc).

Fixes: https://github.com/nodejs/node/issues/32512

cc @joyeecheung @rvagg 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
