### PR TITLE
test: check bundled binaries are signed on macOS

### DIFF
--- a/test/parallel/test-macos-signed-deps.js
+++ b/test/parallel/test-macos-signed-deps.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// Notarization on macOS requires all binaries to be signed.
+// We sign our own binaries but check here if any binaries from our dependencies
+// (e.g. npm) are signed.
+const common = require('../common');
+
+if (!common.isOSX) {
+  common.skip('macOS specific test');
+}
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const debuglog = require('util').debuglog('test');
+
+const binaries = [
+  'deps/npm/node_modules/term-size/vendor/macos/term-size',
+];
+
+for (const testbin of binaries) {
+  const bin = path.resolve(__dirname, '..', '..', testbin);
+  debuglog(`Checking ${bin}`);
+  const cp = spawnSync('codesign', [ '-vvvv', bin ], { encoding: 'utf8' });
+  debuglog(cp.stdout);
+  debuglog(cp.stderr);
+  assert.strictEqual(cp.signal, null);
+  assert.strictEqual(cp.status, 0, `${bin} does not appear to be signed.\n` +
+                     `${cp.stdout}\n${cp.stderr}`);
+}


### PR DESCRIPTION
For notarization on macOS all packaged binaries must be signed. Add a
regression test to check that known binaries from our dependencies
(at the time of this commit term-size via npm) are signed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
