### PR TITLE
embedding: provide hook for custom process.exit() behaviour

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -724,4 +724,17 @@ ThreadId AllocateEnvironmentThreadId() {
   return ThreadId { next_thread_id++ };
 }
 
+void DefaultProcessExitHandler(Environment* env, int exit_code) {
+  env->set_can_call_into_js(false);
+  env->stop_sub_worker_contexts();
+  DisposePlatform();
+  exit(exit_code);
+}
+
+
+void SetProcessExitHandler(Environment* env,
+                           std::function<void(Environment*, int)>&& handler) {
+  env->set_process_exit_handler(std::move(handler));
+}
+
 }  // namespace node

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -725,8 +725,7 @@ ThreadId AllocateEnvironmentThreadId() {
 }
 
 void DefaultProcessExitHandler(Environment* env, int exit_code) {
-  env->set_can_call_into_js(false);
-  env->stop_sub_worker_contexts();
+  Stop(env);
   DisposePlatform();
   exit(exit_code);
 }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -1279,6 +1279,11 @@ void Environment::set_main_utf16(std::unique_ptr<v8::String::Value> str) {
   main_utf16_ = std::move(str);
 }
 
+void Environment::set_process_exit_handler(
+    std::function<void(Environment*, int)>&& handler) {
+  process_exit_handler_ = std::move(handler);
+}
+
 #define VP(PropertyName, StringValue) V(v8::Private, PropertyName)
 #define VY(PropertyName, StringValue) V(v8::Symbol, PropertyName)
 #define VS(PropertyName, StringValue) V(v8::String, PropertyName)

--- a/src/env.cc
+++ b/src/env.cc
@@ -501,9 +501,10 @@ void Environment::InitializeLibuv(bool start_profiler_idle_notifier) {
   }
 }
 
-void Environment::ExitEnv() {
+void Environment::Stop() {
   set_can_call_into_js(false);
   set_stopping(true);
+  stop_sub_worker_contexts();
   isolate_->TerminateExecution();
   SetImmediateThreadsafe([](Environment* env) { uv_stop(env->event_loop()); });
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -984,14 +984,7 @@ void Environment::Exit(int exit_code) {
                     StackTrace::CurrentStackTrace(
                         isolate(), stack_trace_limit(), StackTrace::kDetailed));
   }
-  if (is_main_thread()) {
-    set_can_call_into_js(false);
-    stop_sub_worker_contexts();
-    DisposePlatform();
-    exit(exit_code);
-  } else {
-    worker_context()->Exit(exit_code);
-  }
+  process_exit_handler_(this, exit_code);
 }
 
 void Environment::stop_sub_worker_contexts() {

--- a/src/env.h
+++ b/src/env.h
@@ -1257,6 +1257,8 @@ class Environment : public MemoryRetainer {
 #endif  // HAVE_INSPECTOR
 
   inline void set_main_utf16(std::unique_ptr<v8::String::Value>);
+  inline void set_process_exit_handler(
+      std::function<void(Environment*, int)>&& handler);
 
  private:
   template <typename Fn>
@@ -1458,6 +1460,9 @@ class Environment : public MemoryRetainer {
 
   int64_t base_object_count_ = 0;
   std::atomic_bool is_stopping_ { false };
+
+  std::function<void(Environment*, int)> process_exit_handler_ {
+      DefaultProcessExitHandler };
 
   template <typename T>
   void ForEachBaseObject(T&& iterator);

--- a/src/env.h
+++ b/src/env.h
@@ -897,7 +897,7 @@ class Environment : public MemoryRetainer {
   void RegisterHandleCleanups();
   void CleanupHandles();
   void Exit(int code);
-  void ExitEnv();
+  void Stop();
 
   // Register clean-up cb to be called on environment destruction.
   inline void RegisterHandleCleanup(uv_handle_t* handle,

--- a/src/node.cc
+++ b/src/node.cc
@@ -1059,7 +1059,7 @@ int Start(int argc, char** argv) {
 }
 
 int Stop(Environment* env) {
-  env->ExitEnv();
+  env->Stop();
   return 0;
 }
 

--- a/src/node.h
+++ b/src/node.h
@@ -473,6 +473,18 @@ NODE_EXTERN v8::MaybeLocal<v8::Value> LoadEnvironment(
     std::unique_ptr<InspectorParentHandle> inspector_parent_handle = {});
 NODE_EXTERN void FreeEnvironment(Environment* env);
 
+// Set a callback that is called when process.exit() is called from JS,
+// overriding the default handler.
+// It receives the Environment* instance and the exit code as arguments.
+// This could e.g. call Stop(env); in order to terminate execution and stop
+// the event loop.
+// The default handler disposes of the global V8 platform instance, if one is
+// being used, and calls exit().
+NODE_EXTERN void SetProcessExitHandler(
+    Environment* env,
+    std::function<void(Environment*, int)>&& handler);
+NODE_EXTERN void DefaultProcessExitHandler(Environment* env, int exit_code);
+
 // This may return nullptr if context is not associated with a Node instance.
 NODE_EXTERN Environment* GetCurrentEnvironment(v8::Local<v8::Context> context);
 

--- a/src/node.h
+++ b/src/node.h
@@ -224,7 +224,8 @@ class Environment;
 NODE_EXTERN int Start(int argc, char* argv[]);
 
 // Tear down Node.js while it is running (there are active handles
-// in the loop and / or actively executing JavaScript code).
+// in the loop and / or actively executing JavaScript code). This also stops
+// all Workers that may have been started earlier.
 NODE_EXTERN int Stop(Environment* env);
 
 // TODO(addaleax): Officially deprecate this and replace it with something
@@ -478,8 +479,8 @@ NODE_EXTERN void FreeEnvironment(Environment* env);
 // It receives the Environment* instance and the exit code as arguments.
 // This could e.g. call Stop(env); in order to terminate execution and stop
 // the event loop.
-// The default handler disposes of the global V8 platform instance, if one is
-// being used, and calls exit().
+// The default handler calls Stop(), disposes of the global V8 platform
+// instance, if one is being used, and calls exit().
 NODE_EXTERN void SetProcessExitHandler(
     Environment* env,
     std::function<void(Environment*, int)>&& handler);


### PR DESCRIPTION
Embedders may not want to terminate the process when `process.exit()`
is called. This provides a hook for more flexible handling of that
situation.

Refs: https://github.com/nodejs/node/pull/30467#issuecomment-603689644 (/cc @linroid)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
