### PR TITLE
src: split out per-binding state from Environment

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -430,8 +430,8 @@ void InitializeHttpParser(Local<Object> target,
                           void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Environment::BindingScope<BindingData> binding_scope(env);
+  if (!binding_scope) return;
   BindingData* binding_data = binding_scope.data;
-  if (binding_data == nullptr) return;
 
   // Created within the Environment::BindingScope
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);

--- a/src/README.md
+++ b/src/README.md
@@ -395,6 +395,50 @@ void Initialize(Local<Object> target,
 NODE_MODULE_CONTEXT_AWARE_INTERNAL(cares_wrap, Initialize)
 ```
 
+<a id="per-binding-state">
+#### Per-binding state
+
+Some internal bindings, such as the HTTP parser, maintain internal state that
+only affects that particular binding. In that case, one common way to store
+that state is through the use of `Environment::BindingScope`, which gives all
+new functions created within it access to an object for storing such state.
+That object is always a [`BaseObject`][].
+
+```c++
+// In the HTTP parser source code file:
+class BindingData : public BaseObject {
+ public:
+  BindingData(Environment* env, Local<Object> obj) : BaseObject(env, obj) {}
+
+  std::vector<char> parser_buffer;
+  bool parser_buffer_in_use = false;
+
+  // ...
+};
+
+// Available for binding functions, e.g. the HTTP Parser constructor:
+static void New(const FunctionCallbackInfo<Value>& args) {
+  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  new Parser(binding_data, args.This());
+}
+
+// ... because the initialization function told the Environment to use this
+// BindingData class for all functions created by it:
+void InitializeHttpParser(Local<Object> target,
+                          Local<Value> unused,
+                          Local<Context> context,
+                          void* priv) {
+  Environment* env = Environment::GetCurrent(context);
+  Environment::BindingScope<BindingData> binding_scope(env);
+  BindingData* binding_data = binding_scope.data;
+  if (binding_data == nullptr) return;
+
+  // Created within the Environment::BindingScope
+  Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);
+  ...
+}
+```
+
 <a id="exception-handling"></a>
 ### Exception handling
 

--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -100,15 +100,16 @@ Environment* BaseObject::env() const {
   return env_;
 }
 
-BaseObject* BaseObject::FromJSObject(v8::Local<v8::Object> obj) {
-  CHECK_GT(obj->InternalFieldCount(), 0);
+BaseObject* BaseObject::FromJSObject(v8::Local<v8::Value> value) {
+  v8::Local<v8::Object> obj = value.As<v8::Object>();
+  DCHECK_GE(obj->InternalFieldCount(), BaseObject::kSlot);
   return static_cast<BaseObject*>(
       obj->GetAlignedPointerFromInternalField(BaseObject::kSlot));
 }
 
 
 template <typename T>
-T* BaseObject::FromJSObject(v8::Local<v8::Object> object) {
+T* BaseObject::FromJSObject(v8::Local<v8::Value> object) {
   return static_cast<T*>(FromJSObject(object));
 }
 

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -61,9 +61,9 @@ class BaseObject : public MemoryRetainer {
   // was also passed to the `BaseObject()` constructor initially.
   // This may return `nullptr` if the C++ object has not been constructed yet,
   // e.g. when the JS object used `MakeLazilyInitializedJSTemplate`.
-  static inline BaseObject* FromJSObject(v8::Local<v8::Object> object);
+  static inline BaseObject* FromJSObject(v8::Local<v8::Value> object);
   template <typename T>
-  static inline T* FromJSObject(v8::Local<v8::Object> object);
+  static inline T* FromJSObject(v8::Local<v8::Value> object);
 
   // Make the `v8::Global` a weak reference and, `delete` this object once
   // the JS object has been garbage collected and there are no (strong)
@@ -152,7 +152,7 @@ class BaseObject : public MemoryRetainer {
 
 // Global alias for FromJSObject() to avoid churn.
 template <typename T>
-inline T* Unwrap(v8::Local<v8::Object> obj) {
+inline T* Unwrap(v8::Local<v8::Value> obj) {
   return BaseObject::FromJSObject<T>(obj);
 }
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -580,23 +580,6 @@ inline double Environment::get_default_trigger_async_id() {
   return default_trigger_async_id;
 }
 
-inline char* Environment::http_parser_buffer() const {
-  return http_parser_buffer_;
-}
-
-inline void Environment::set_http_parser_buffer(char* buffer) {
-  CHECK_NULL(http_parser_buffer_);  // Should be set only once.
-  http_parser_buffer_ = buffer;
-}
-
-inline bool Environment::http_parser_buffer_in_use() const {
-  return http_parser_buffer_in_use_;
-}
-
-inline void Environment::set_http_parser_buffer_in_use(bool in_use) {
-  http_parser_buffer_in_use_ = in_use;
-}
-
 inline AliasedFloat64Array* Environment::fs_stats_field_array() {
   return &fs_stats_field_array_;
 }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -580,39 +580,6 @@ inline double Environment::get_default_trigger_async_id() {
   return default_trigger_async_id;
 }
 
-inline double* Environment::heap_statistics_buffer() const {
-  CHECK_NOT_NULL(heap_statistics_buffer_);
-  return static_cast<double*>(heap_statistics_buffer_->Data());
-}
-
-inline void Environment::set_heap_statistics_buffer(
-    std::shared_ptr<v8::BackingStore> backing_store) {
-  CHECK(!heap_statistics_buffer_);  // Should be set only once.
-  heap_statistics_buffer_ = std::move(backing_store);
-}
-
-inline double* Environment::heap_space_statistics_buffer() const {
-  CHECK(heap_space_statistics_buffer_);
-  return static_cast<double*>(heap_space_statistics_buffer_->Data());
-}
-
-inline void Environment::set_heap_space_statistics_buffer(
-    std::shared_ptr<v8::BackingStore> backing_store) {
-  CHECK(!heap_space_statistics_buffer_);  // Should be set only once.
-  heap_space_statistics_buffer_ = std::move(backing_store);
-}
-
-inline double* Environment::heap_code_statistics_buffer() const {
-  CHECK(heap_code_statistics_buffer_);
-  return static_cast<double*>(heap_code_statistics_buffer_->Data());
-}
-
-inline void Environment::set_heap_code_statistics_buffer(
-    std::shared_ptr<v8::BackingStore> backing_store) {
-  CHECK(!heap_code_statistics_buffer_);  // Should be set only once.
-  heap_code_statistics_buffer_ = std::move(backing_store);
-}
-
 inline char* Environment::http_parser_buffer() const {
   return http_parser_buffer_;
 }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -630,16 +630,6 @@ inline void Environment::set_http_parser_buffer_in_use(bool in_use) {
   http_parser_buffer_in_use_ = in_use;
 }
 
-inline http2::Http2State* Environment::http2_state() const {
-  return http2_state_.get();
-}
-
-inline void Environment::set_http2_state(
-    std::unique_ptr<http2::Http2State> buffer) {
-  CHECK(!http2_state_);  // Should be set only once.
-  http2_state_ = std::move(buffer);
-}
-
 inline AliasedFloat64Array* Environment::fs_stats_field_array() {
   return &fs_stats_field_array_;
 }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -580,19 +580,6 @@ inline double Environment::get_default_trigger_async_id() {
   return default_trigger_async_id;
 }
 
-inline AliasedFloat64Array* Environment::fs_stats_field_array() {
-  return &fs_stats_field_array_;
-}
-
-inline AliasedBigUint64Array* Environment::fs_stats_field_bigint_array() {
-  return &fs_stats_field_bigint_array_;
-}
-
-inline std::vector<std::unique_ptr<fs::FileHandleReadWrap>>&
-Environment::file_handle_read_wrap_freelist() {
-  return file_handle_read_wrap_freelist_;
-}
-
 inline std::shared_ptr<EnvironmentOptions> Environment::options() {
   return options_;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -466,8 +466,6 @@ Environment::~Environment() {
       tracing_controller->RemoveTraceStateObserver(trace_state_observer_.get());
   }
 
-  delete[] http_parser_buffer_;
-
   TRACE_EVENT_NESTABLE_ASYNC_END0(
     TRACING_CATEGORY_NODE1(environment), "Environment", this);
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -1,18 +1,19 @@
 #include "env.h"
 
 #include "async_wrap.h"
+#include "base_object-inl.h"
 #include "debug_utils-inl.h"
 #include "memory_tracker-inl.h"
 #include "node_buffer.h"
 #include "node_context_data.h"
 #include "node_errors.h"
-#include "node_file.h"
 #include "node_internals.h"
 #include "node_options-inl.h"
 #include "node_process.h"
 #include "node_v8_platform-inl.h"
 #include "node_worker.h"
 #include "req_wrap-inl.h"
+#include "stream_base.h"
 #include "tracing/agent.h"
 #include "tracing/traced_value.h"
 #include "util-inl.h"
@@ -341,8 +342,6 @@ Environment::Environment(IsolateData* isolate_data,
       flags_(flags),
       thread_id_(thread_id.id == static_cast<uint64_t>(-1) ?
           AllocateEnvironmentThreadId().id : thread_id.id),
-      fs_stats_field_array_(isolate_, kFsStatsBufferLength),
-      fs_stats_field_bigint_array_(isolate_, kFsStatsBufferLength),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
   HandleScope handle_scope(isolate());
@@ -443,10 +442,6 @@ Environment::~Environment() {
 
   isolate()->GetHeapProfiler()->RemoveBuildEmbedderGraphCallback(
       BuildEmbedderGraph, this);
-
-  // Make sure there are no re-used libuv wrapper objects.
-  // CleanupHandles() should have removed all of them.
-  CHECK(file_handle_read_wrap_freelist_.empty());
 
   HandleScope handle_scope(isolate());
 
@@ -614,8 +609,6 @@ void Environment::CleanupHandles() {
          !handle_wrap_queue_.IsEmpty()) {
     uv_run(event_loop(), UV_RUN_ONCE);
   }
-
-  file_handle_read_wrap_freelist_.clear();
 }
 
 void Environment::StartProfilerIdleNotifier() {
@@ -1095,9 +1088,6 @@ void Environment::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("should_abort_on_uncaught_toggle",
                       should_abort_on_uncaught_toggle_);
   tracker->TrackField("stream_base_state", stream_base_state_);
-  tracker->TrackField("fs_stats_field_array", fs_stats_field_array_);
-  tracker->TrackField("fs_stats_field_bigint_array",
-                      fs_stats_field_bigint_array_);
   tracker->TrackField("cleanup_hooks", cleanup_hooks_);
   tracker->TrackField("async_hooks", async_hooks_);
   tracker->TrackField("immediate_info", immediate_info_);

--- a/src/env.h
+++ b/src/env.h
@@ -1004,18 +1004,6 @@ class Environment : public MemoryRetainer {
   inline uint32_t get_next_script_id();
   inline uint32_t get_next_function_id();
 
-  inline double* heap_statistics_buffer() const;
-  inline void set_heap_statistics_buffer(
-      std::shared_ptr<v8::BackingStore> backing_store);
-
-  inline double* heap_space_statistics_buffer() const;
-  inline void set_heap_space_statistics_buffer(
-      std::shared_ptr<v8::BackingStore> backing_store);
-
-  inline double* heap_code_statistics_buffer() const;
-  inline void set_heap_code_statistics_buffer(
-      std::shared_ptr<v8::BackingStore> backing_store);
-
   inline char* http_parser_buffer() const;
   inline void set_http_parser_buffer(char* buffer);
   inline bool http_parser_buffer_in_use() const;
@@ -1377,14 +1365,10 @@ class Environment : public MemoryRetainer {
   int handle_cleanup_waiting_ = 0;
   int request_waiting_ = 0;
 
-  std::shared_ptr<v8::BackingStore> heap_statistics_buffer_;
-  std::shared_ptr<v8::BackingStore> heap_space_statistics_buffer_;
-  std::shared_ptr<v8::BackingStore> heap_code_statistics_buffer_;
-
   char* http_parser_buffer_ = nullptr;
   bool http_parser_buffer_in_use_ = false;
-
   EnabledDebugList enabled_debug_list_;
+
   AliasedFloat64Array fs_stats_field_array_;
   AliasedBigUint64Array fs_stats_field_bigint_array_;
 

--- a/src/env.h
+++ b/src/env.h
@@ -876,6 +876,9 @@ class Environment : public MemoryRetainer {
 
     T* data = nullptr;
     Environment* env;
+
+    inline operator bool() const { return data != nullptr; }
+    inline bool operator !() const { return data == nullptr; }
   };
 
   template <typename T>

--- a/src/env.h
+++ b/src/env.h
@@ -56,10 +56,6 @@ class ContextifyScript;
 class CompiledFnEntry;
 }
 
-namespace fs {
-class FileHandleReadWrap;
-}
-
 namespace performance {
 class PerformanceState;
 }
@@ -1006,12 +1002,6 @@ class Environment : public MemoryRetainer {
 
   EnabledDebugList* enabled_debug_list() { return &enabled_debug_list_; }
 
-  inline AliasedFloat64Array* fs_stats_field_array();
-  inline AliasedBigUint64Array* fs_stats_field_bigint_array();
-
-  inline std::vector<std::unique_ptr<fs::FileHandleReadWrap>>&
-      file_handle_read_wrap_freelist();
-
   inline performance::PerformanceState* performance_state();
   inline std::unordered_map<std::string, uint64_t>* performance_marks();
 
@@ -1361,12 +1351,6 @@ class Environment : public MemoryRetainer {
   int request_waiting_ = 0;
 
   EnabledDebugList enabled_debug_list_;
-
-  AliasedFloat64Array fs_stats_field_array_;
-  AliasedBigUint64Array fs_stats_field_bigint_array_;
-
-  std::vector<std::unique_ptr<fs::FileHandleReadWrap>>
-      file_handle_read_wrap_freelist_;
 
   std::list<node_module> extra_linked_bindings_;
   Mutex extra_linked_bindings_mutex_;

--- a/src/env.h
+++ b/src/env.h
@@ -1004,11 +1004,6 @@ class Environment : public MemoryRetainer {
   inline uint32_t get_next_script_id();
   inline uint32_t get_next_function_id();
 
-  inline char* http_parser_buffer() const;
-  inline void set_http_parser_buffer(char* buffer);
-  inline bool http_parser_buffer_in_use() const;
-  inline void set_http_parser_buffer_in_use(bool in_use);
-
   EnabledDebugList* enabled_debug_list() { return &enabled_debug_list_; }
 
   inline AliasedFloat64Array* fs_stats_field_array();
@@ -1365,8 +1360,6 @@ class Environment : public MemoryRetainer {
   int handle_cleanup_waiting_ = 0;
   int request_waiting_ = 0;
 
-  char* http_parser_buffer_ = nullptr;
-  bool http_parser_buffer_in_use_ = false;
   EnabledDebugList enabled_debug_list_;
 
   AliasedFloat64Array fs_stats_field_array_;

--- a/src/env.h
+++ b/src/env.h
@@ -436,6 +436,7 @@ constexpr size_t kFsStatsBufferLength =
   V(async_hooks_promise_resolve_function, v8::Function)                        \
   V(buffer_prototype_object, v8::Object)                                       \
   V(crypto_key_object_constructor, v8::Function)                               \
+  V(current_callback_data, v8::Object)                                         \
   V(domain_callback, v8::Function)                                             \
   V(domexception_function, v8::Function)                                       \
   V(enhance_fatal_stack_after_inspector, v8::Function)                         \
@@ -870,6 +871,21 @@ class Environment : public MemoryRetainer {
       const v8::PropertyCallbackInfo<T>& info);
 
   static inline Environment* GetFromCallbackData(v8::Local<v8::Value> val);
+
+  // Methods created using SetMethod(), SetPrototypeMethod(), etc. inside
+  // this scope can access the created T* object using
+  // Unwrap<T>(args.Data()) later.
+  template <typename T>
+  struct BindingScope {
+    explicit inline BindingScope(Environment* env);
+    inline ~BindingScope();
+
+    T* data = nullptr;
+    Environment* env;
+  };
+
+  template <typename T>
+  inline v8::MaybeLocal<v8::Object> MakeBindingCallbackData();
 
   static uv_key_t thread_local_env;
   static inline Environment* GetThreadLocalEnv();
@@ -1461,6 +1477,7 @@ class Environment : public MemoryRetainer {
   bool started_cleanup_ = false;
 
   int64_t base_object_count_ = 0;
+  int64_t initial_base_object_count_ = 0;
   std::atomic_bool is_stopping_ { false };
 
   std::function<void(Environment*, int)> process_exit_handler_ {

--- a/src/env.h
+++ b/src/env.h
@@ -33,7 +33,6 @@
 #include "handle_wrap.h"
 #include "node.h"
 #include "node_binding.h"
-#include "node_http2_state.h"
 #include "node_main_instance.h"
 #include "node_options.h"
 #include "req_wrap.h"
@@ -49,8 +48,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-struct nghttp2_rcbuf;
 
 namespace node {
 
@@ -515,7 +512,8 @@ class IsolateData : public MemoryRetainer {
 #undef VP
   inline v8::Local<v8::String> async_wrap_provider(int index) const;
 
-  std::unordered_map<const char*, v8::Eternal<v8::String>> http_static_strs;
+  std::unordered_map<const char*, v8::Eternal<v8::String>> static_str_map;
+
   inline v8::Isolate* isolate() const;
   IsolateData(const IsolateData&) = delete;
   IsolateData& operator=(const IsolateData&) = delete;
@@ -1023,9 +1021,6 @@ class Environment : public MemoryRetainer {
   inline bool http_parser_buffer_in_use() const;
   inline void set_http_parser_buffer_in_use(bool in_use);
 
-  inline http2::Http2State* http2_state() const;
-  inline void set_http2_state(std::unique_ptr<http2::Http2State> state);
-
   EnabledDebugList* enabled_debug_list() { return &enabled_debug_list_; }
 
   inline AliasedFloat64Array* fs_stats_field_array();
@@ -1388,7 +1383,6 @@ class Environment : public MemoryRetainer {
 
   char* http_parser_buffer_ = nullptr;
   bool http_parser_buffer_in_use_ = false;
-  std::unique_ptr<http2::Http2State> http2_state_;
 
   EnabledDebugList enabled_debug_list_;
   AliasedFloat64Array fs_stats_field_array_;

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -108,7 +108,7 @@ void FSEventWrap::Initialize(Local<Object> target,
   Local<FunctionTemplate> get_initialized_templ =
       FunctionTemplate::New(env->isolate(),
                             GetInitialized,
-                            env->as_callback_data(),
+                            env->current_callback_data(),
                             Signature::New(env->isolate(), t));
 
   t->PrototypeTemplate()->SetAccessorProperty(

--- a/src/node.cc
+++ b/src/node.cc
@@ -331,7 +331,7 @@ MaybeLocal<Value> Environment::BootstrapNode() {
 
   Local<String> env_string = FIXED_ONE_BYTE_STRING(isolate_, "env");
   Local<Object> env_var_proxy;
-  if (!CreateEnvVarProxy(context(), isolate_, as_callback_data())
+  if (!CreateEnvVarProxy(context(), isolate_, current_callback_data())
            .ToLocal(&env_var_proxy) ||
       process_object()->Set(context(), env_string, env_var_proxy).IsNothing()) {
     return MaybeLocal<Value>();

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -505,7 +505,7 @@ void SecureContext::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> ctx_getter_templ =
       FunctionTemplate::New(env->isolate(),
                             CtxGetter,
-                            env->as_callback_data(),
+                            env->current_callback_data(),
                             Signature::New(env->isolate(), t));
 
 
@@ -5101,7 +5101,7 @@ void DiffieHellman::Initialize(Environment* env, Local<Object> target) {
     Local<FunctionTemplate> verify_error_getter_templ =
         FunctionTemplate::New(env->isolate(),
                               DiffieHellman::VerifyErrorGetter,
-                              env->as_callback_data(),
+                              env->current_callback_data(),
                               Signature::New(env->isolate(), t),
                               /* length */ 0,
                               ConstructorBehavior::kThrow,

--- a/src/node_dir.cc
+++ b/src/node_dir.cc
@@ -152,7 +152,7 @@ void DirHandle::Close(const FunctionCallbackInfo<Value>& args) {
   dir->closing_ = false;
   dir->closed_ = true;
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[0]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 0);
   if (req_wrap_async != nullptr) {  // close(req)
     AsyncCall(env, req_wrap_async, args, "closedir", UTF8, AfterClose,
               uv_fs_closedir, dir->dir());
@@ -252,7 +252,7 @@ void DirHandle::Read(const FunctionCallbackInfo<Value>& args) {
     dir->dir_->dirents = dir->dirents_.data();
   }
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {  // dir.read(encoding, bufferSize, req)
     AsyncCall(env, req_wrap_async, args, "readdir", encoding,
               AfterDirRead, uv_fs_readdir, dir->dir());
@@ -320,7 +320,7 @@ static void OpenDir(const FunctionCallbackInfo<Value>& args) {
 
   const enum encoding encoding = ParseEncoding(isolate, args[1], UTF8);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {  // openDir(path, encoding, req)
     AsyncCall(env, req_wrap_async, args, "opendir", encoding, AfterOpenDir,
               uv_fs_opendir, *path);

--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -39,11 +39,13 @@ void FSContinuationData::Done(int result) {
   done_cb_(req_);
 }
 
-FSReqBase::FSReqBase(Environment* env,
-          v8::Local<v8::Object> req,
-          AsyncWrap::ProviderType type,
-          bool use_bigint)
-  : ReqWrap(env, req, type), use_bigint_(use_bigint) {
+FSReqBase::FSReqBase(BindingData* binding_data,
+                     v8::Local<v8::Object> req,
+                     AsyncWrap::ProviderType type,
+                     bool use_bigint)
+  : ReqWrap(binding_data->env(), req, type),
+    use_bigint_(use_bigint),
+    binding_data_(binding_data) {
 }
 
 void FSReqBase::Init(const char* syscall,
@@ -72,9 +74,13 @@ FSReqBase::Init(const char* syscall, size_t len, enum encoding encoding) {
   return buffer_;
 }
 
-FSReqCallback::FSReqCallback(Environment* env,
-                             v8::Local<v8::Object> req, bool use_bigint)
-  : FSReqBase(env, req, AsyncWrap::PROVIDER_FSREQCALLBACK, use_bigint) {}
+FSReqCallback::FSReqCallback(BindingData* binding_data,
+                             v8::Local<v8::Object> req,
+                             bool use_bigint)
+  : FSReqBase(binding_data,
+              req,
+              AsyncWrap::PROVIDER_FSREQCALLBACK,
+              use_bigint) {}
 
 template <typename NativeT, typename V8T>
 void FillStatsArray(AliasedBufferBase<NativeT, V8T>* fields,
@@ -112,18 +118,18 @@ void FillStatsArray(AliasedBufferBase<NativeT, V8T>* fields,
 #undef SET_FIELD_WITH_STAT
 }
 
-v8::Local<v8::Value> FillGlobalStatsArray(Environment* env,
+v8::Local<v8::Value> FillGlobalStatsArray(BindingData* binding_data,
                                           const bool use_bigint,
                                           const uv_stat_t* s,
                                           const bool second) {
   const ptrdiff_t offset =
       second ? static_cast<ptrdiff_t>(FsStatsOffset::kFsStatsFieldsNumber) : 0;
   if (use_bigint) {
-    auto* const arr = env->fs_stats_field_bigint_array();
+    auto* const arr = &binding_data->stats_field_bigint_array;
     FillStatsArray(arr, s, offset);
     return arr->GetJSArray();
   } else {
-    auto* const arr = env->fs_stats_field_array();
+    auto* const arr = &binding_data->stats_field_array;
     FillStatsArray(arr, s, offset);
     return arr->GetJSArray();
   }
@@ -131,7 +137,9 @@ v8::Local<v8::Value> FillGlobalStatsArray(Environment* env,
 
 template <typename AliasedBufferT>
 FSReqPromise<AliasedBufferT>*
-FSReqPromise<AliasedBufferT>::New(Environment* env, bool use_bigint) {
+FSReqPromise<AliasedBufferT>::New(BindingData* binding_data,
+                                  bool use_bigint) {
+  Environment* env = binding_data->env();
   v8::Local<v8::Object> obj;
   if (!env->fsreqpromise_constructor_template()
            ->NewInstance(env->context())
@@ -143,7 +151,7 @@ FSReqPromise<AliasedBufferT>::New(Environment* env, bool use_bigint) {
       obj->Set(env->context(), env->promise_string(), resolver).IsNothing()) {
     return nullptr;
   }
-  return new FSReqPromise(env, obj, use_bigint);
+  return new FSReqPromise(binding_data, obj, use_bigint);
 }
 
 template <typename AliasedBufferT>
@@ -154,12 +162,15 @@ FSReqPromise<AliasedBufferT>::~FSReqPromise() {
 
 template <typename AliasedBufferT>
 FSReqPromise<AliasedBufferT>::FSReqPromise(
-    Environment* env,
+    BindingData* binding_data,
     v8::Local<v8::Object> obj,
     bool use_bigint)
-  : FSReqBase(env, obj, AsyncWrap::PROVIDER_FSREQPROMISE, use_bigint),
+  : FSReqBase(binding_data,
+              obj,
+              AsyncWrap::PROVIDER_FSREQPROMISE,
+              use_bigint),
     stats_field_array_(
-        env->isolate(),
+        env()->isolate(),
         static_cast<size_t>(FsStatsOffset::kFsStatsFieldsNumber)) {}
 
 template <typename AliasedBufferT>
@@ -208,15 +219,21 @@ void FSReqPromise<AliasedBufferT>::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("stats_field_array", stats_field_array_);
 }
 
-FSReqBase* GetReqWrap(Environment* env, v8::Local<v8::Value> value,
+FSReqBase* GetReqWrap(const v8::FunctionCallbackInfo<v8::Value>& args,
+                      int index,
                       bool use_bigint) {
+  v8::Local<v8::Value> value = args[index];
   if (value->IsObject()) {
     return Unwrap<FSReqBase>(value.As<v8::Object>());
-  } else if (value->StrictEquals(env->fs_use_promises_symbol())) {
+  }
+
+  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  Environment* env = binding_data->env();
+  if (value->StrictEquals(env->fs_use_promises_symbol())) {
     if (use_bigint) {
-      return FSReqPromise<AliasedBigUint64Array>::New(env, use_bigint);
+      return FSReqPromise<AliasedBigUint64Array>::New(binding_data, use_bigint);
     } else {
-      return FSReqPromise<AliasedFloat64Array>::New(env, use_bigint);
+      return FSReqPromise<AliasedFloat64Array>::New(binding_data, use_bigint);
     }
   }
   return nullptr;

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2296,8 +2296,8 @@ void Initialize(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   Environment::BindingScope<BindingData> binding_scope(env);
+  if (!binding_scope) return;
   BindingData* binding_data = binding_scope.data;
-  if (binding_data == nullptr) return;
 
   env->SetMethod(target, "access", Access);
   env->SetMethod(target, "close", Close);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2015,7 +2015,7 @@ static void ReadBuffers(const FunctionCallbackInfo<Value>& args) {
     iovs[i] = uv_buf_init(Buffer::Data(buffer), Buffer::Length(buffer));
   }
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // readBuffers(fd, buffers, pos, req)
     AsyncCall(env, req_wrap_async, args, "read", UTF8, AfterInteger,
               uv_fs_read, fd, *iovs, iovs.length(), pos);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -120,30 +120,35 @@ void FSReqBase::MemoryInfo(MemoryTracker* tracker) const {
 // The FileHandle object wraps a file descriptor and will close it on garbage
 // collection if necessary. If that happens, a process warning will be
 // emitted (or a fatal exception will occur if the fd cannot be closed.)
-FileHandle::FileHandle(Environment* env, Local<Object> obj, int fd)
-    : AsyncWrap(env, obj, AsyncWrap::PROVIDER_FILEHANDLE),
-      StreamBase(env),
-      fd_(fd) {
+FileHandle::FileHandle(BindingData* binding_data,
+                       Local<Object> obj, int fd)
+    : AsyncWrap(binding_data->env(), obj, AsyncWrap::PROVIDER_FILEHANDLE),
+      StreamBase(env()),
+      fd_(fd),
+      binding_data_(binding_data) {
   MakeWeak();
   StreamBase::AttachToObject(GetObject());
 }
 
-FileHandle* FileHandle::New(Environment* env, int fd, Local<Object> obj) {
+FileHandle* FileHandle::New(BindingData* binding_data,
+                            int fd, Local<Object> obj) {
+  Environment* env = binding_data->env();
   if (obj.IsEmpty() && !env->fd_constructor_template()
                             ->NewInstance(env->context())
                             .ToLocal(&obj)) {
     return nullptr;
   }
-  return new FileHandle(env, obj, fd);
+  return new FileHandle(binding_data, obj, fd);
 }
 
 void FileHandle::New(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  Environment* env = binding_data->env();
   CHECK(args.IsConstructCall());
   CHECK(args[0]->IsInt32());
 
   FileHandle* handle =
-      FileHandle::New(env, args[0].As<Int32>()->Value(), args.This());
+      FileHandle::New(binding_data, args[0].As<Int32>()->Value(), args.This());
   if (handle == nullptr) return;
   if (args[1]->IsNumber())
     handle->read_offset_ = args[1]->IntegerValue(env->context()).FromJust();
@@ -362,7 +367,7 @@ int FileHandle::ReadStart() {
   if (current_read_)
     return 0;
 
-  std::unique_ptr<FileHandleReadWrap> read_wrap;
+  BaseObjectPtr<FileHandleReadWrap> read_wrap;
 
   if (read_length_ == 0) {
     EmitRead(UV_EOF);
@@ -376,7 +381,7 @@ int FileHandle::ReadStart() {
     HandleScope handle_scope(env()->isolate());
     AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(this);
 
-    auto& freelist = env()->file_handle_read_wrap_freelist();
+    auto& freelist = binding_data_->file_handle_read_wrap_freelist;
     if (freelist.size() > 0) {
       read_wrap = std::move(freelist.back());
       freelist.pop_back();
@@ -395,7 +400,7 @@ int FileHandle::ReadStart() {
                .ToLocal(&wrap_obj)) {
         return UV_EBUSY;
       }
-      read_wrap = std::make_unique<FileHandleReadWrap>(this, wrap_obj);
+      read_wrap = MakeDetachedBaseObject<FileHandleReadWrap>(this, wrap_obj);
     }
   }
   int64_t recommended_read = 65536;
@@ -422,7 +427,7 @@ int FileHandle::ReadStart() {
     // ReadStart() checks whether current_read_ is set to determine whether
     // a read is in progress. Moving it into a local variable makes sure that
     // the ReadStart() call below doesn't think we're still actively reading.
-    std::unique_ptr<FileHandleReadWrap> read_wrap =
+    BaseObjectPtr<FileHandleReadWrap> read_wrap =
         std::move(handle->current_read_);
 
     int result = req->result;
@@ -433,7 +438,7 @@ int FileHandle::ReadStart() {
     // Push the read wrap back to the freelist, or let it be destroyed
     // once we’re exiting the current scope.
     constexpr size_t wanted_freelist_fill = 100;
-    auto& freelist = handle->env()->file_handle_read_wrap_freelist();
+    auto& freelist = handle->binding_data_->file_handle_read_wrap_freelist;
     if (freelist.size() < wanted_freelist_fill) {
       read_wrap->Reset();
       freelist.emplace_back(std::move(read_wrap));
@@ -503,7 +508,7 @@ void FSReqCallback::Reject(Local<Value> reject) {
 }
 
 void FSReqCallback::ResolveStat(const uv_stat_t* stat) {
-  Resolve(FillGlobalStatsArray(env(), use_bigint(), stat));
+  Resolve(FillGlobalStatsArray(binding_data(), use_bigint(), stat));
 }
 
 void FSReqCallback::Resolve(Local<Value> value) {
@@ -522,8 +527,8 @@ void FSReqCallback::SetReturnValue(const FunctionCallbackInfo<Value>& args) {
 
 void NewFSReqCallback(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
-  Environment* env = Environment::GetCurrent(args);
-  new FSReqCallback(env, args.This(), args[0]->IsTrue());
+  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  new FSReqCallback(binding_data, args.This(), args[0]->IsTrue());
 }
 
 FSReqAfterScope::FSReqAfterScope(FSReqBase* wrap, uv_fs_t* req)
@@ -595,7 +600,7 @@ void AfterOpenFileHandle(uv_fs_t* req) {
   FSReqAfterScope after(req_wrap, req);
 
   if (after.Proceed()) {
-    FileHandle* fd = FileHandle::New(req_wrap->env(), req->result);
+    FileHandle* fd = FileHandle::New(req_wrap->binding_data(), req->result);
     if (fd == nullptr) return;
     req_wrap->Resolve(fd->object());
   }
@@ -773,7 +778,7 @@ void Access(const FunctionCallbackInfo<Value>& args) {
   BufferValue path(isolate, args[0]);
   CHECK_NOT_NULL(*path);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {  // access(path, mode, req)
     AsyncCall(env, req_wrap_async, args, "access", UTF8, AfterNoArgs,
               uv_fs_access, *path, mode);
@@ -796,7 +801,7 @@ void Close(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsInt32());
   int fd = args[0].As<Int32>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 1);
   if (req_wrap_async != nullptr) {  // close(fd, req)
     AsyncCall(env, req_wrap_async, args, "close", UTF8, AfterNoArgs,
               uv_fs_close, fd);
@@ -929,7 +934,8 @@ static void InternalModuleStat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void Stat(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  Environment* env = binding_data->env();
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
@@ -938,7 +944,7 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
   CHECK_NOT_NULL(*path);
 
   bool use_bigint = args[1]->IsTrue();
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2], use_bigint);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2, use_bigint);
   if (req_wrap_async != nullptr) {  // stat(path, use_bigint, req)
     AsyncCall(env, req_wrap_async, args, "stat", UTF8, AfterStat,
               uv_fs_stat, *path);
@@ -952,14 +958,15 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
       return;  // error info is in ctx
     }
 
-    Local<Value> arr = FillGlobalStatsArray(env, use_bigint,
+    Local<Value> arr = FillGlobalStatsArray(binding_data, use_bigint,
         static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr));
     args.GetReturnValue().Set(arr);
   }
 }
 
 static void LStat(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  Environment* env = binding_data->env();
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -968,7 +975,7 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
   CHECK_NOT_NULL(*path);
 
   bool use_bigint = args[1]->IsTrue();
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2], use_bigint);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2, use_bigint);
   if (req_wrap_async != nullptr) {  // lstat(path, use_bigint, req)
     AsyncCall(env, req_wrap_async, args, "lstat", UTF8, AfterStat,
               uv_fs_lstat, *path);
@@ -983,14 +990,15 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
       return;  // error info is in ctx
     }
 
-    Local<Value> arr = FillGlobalStatsArray(env, use_bigint,
+    Local<Value> arr = FillGlobalStatsArray(binding_data, use_bigint,
         static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr));
     args.GetReturnValue().Set(arr);
   }
 }
 
 static void FStat(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  Environment* env = binding_data->env();
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
@@ -999,7 +1007,7 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
   int fd = args[0].As<Int32>()->Value();
 
   bool use_bigint = args[1]->IsTrue();
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2], use_bigint);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2, use_bigint);
   if (req_wrap_async != nullptr) {  // fstat(fd, use_bigint, req)
     AsyncCall(env, req_wrap_async, args, "fstat", UTF8, AfterStat,
               uv_fs_fstat, fd);
@@ -1013,7 +1021,7 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
       return;  // error info is in ctx
     }
 
-    Local<Value> arr = FillGlobalStatsArray(env, use_bigint,
+    Local<Value> arr = FillGlobalStatsArray(binding_data, use_bigint,
         static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr));
     args.GetReturnValue().Set(arr);
   }
@@ -1034,7 +1042,7 @@ static void Symlink(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsInt32());
   int flags = args[2].As<Int32>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // symlink(target, path, flags, req)
     AsyncDestCall(env, req_wrap_async, args, "symlink", *path, path.length(),
                   UTF8, AfterNoArgs, uv_fs_symlink, *target, *path, flags);
@@ -1061,7 +1069,7 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
   BufferValue dest(isolate, args[1]);
   CHECK_NOT_NULL(*dest);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {  // link(src, dest, req)
     AsyncDestCall(env, req_wrap_async, args, "link", *dest, dest.length(), UTF8,
                   AfterNoArgs, uv_fs_link, *src, *dest);
@@ -1087,7 +1095,7 @@ static void ReadLink(const FunctionCallbackInfo<Value>& args) {
 
   const enum encoding encoding = ParseEncoding(isolate, args[1], UTF8);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {  // readlink(path, encoding, req)
     AsyncCall(env, req_wrap_async, args, "readlink", encoding, AfterStringPtr,
               uv_fs_readlink, *path);
@@ -1130,7 +1138,7 @@ static void Rename(const FunctionCallbackInfo<Value>& args) {
   BufferValue new_path(isolate, args[1]);
   CHECK_NOT_NULL(*new_path);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {
     AsyncDestCall(env, req_wrap_async, args, "rename", *new_path,
                   new_path.length(), UTF8, AfterNoArgs, uv_fs_rename,
@@ -1157,7 +1165,7 @@ static void FTruncate(const FunctionCallbackInfo<Value>& args) {
   CHECK(IsSafeJsInt(args[1]));
   const int64_t len = args[1].As<Integer>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {
     AsyncCall(env, req_wrap_async, args, "ftruncate", UTF8, AfterNoArgs,
               uv_fs_ftruncate, fd, len);
@@ -1180,7 +1188,7 @@ static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsInt32());
   const int fd = args[0].As<Int32>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 1);
   if (req_wrap_async != nullptr) {
     AsyncCall(env, req_wrap_async, args, "fdatasync", UTF8, AfterNoArgs,
               uv_fs_fdatasync, fd);
@@ -1202,7 +1210,7 @@ static void Fsync(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsInt32());
   const int fd = args[0].As<Int32>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 1);
   if (req_wrap_async != nullptr) {
     AsyncCall(env, req_wrap_async, args, "fsync", UTF8, AfterNoArgs,
               uv_fs_fsync, fd);
@@ -1224,7 +1232,7 @@ static void Unlink(const FunctionCallbackInfo<Value>& args) {
   BufferValue path(env->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 1);
   if (req_wrap_async != nullptr) {
     AsyncCall(env, req_wrap_async, args, "unlink", UTF8, AfterNoArgs,
               uv_fs_unlink, *path);
@@ -1246,7 +1254,7 @@ static void RMDir(const FunctionCallbackInfo<Value>& args) {
   BufferValue path(env->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);  // rmdir(path, req)
+  FSReqBase* req_wrap_async = GetReqWrap(args, 1);  // rmdir(path, req)
   if (req_wrap_async != nullptr) {
     AsyncCall(env, req_wrap_async, args, "rmdir", UTF8, AfterNoArgs,
               uv_fs_rmdir, *path);
@@ -1456,7 +1464,7 @@ static void MKDir(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsBoolean());
   bool mkdirp = args[2]->IsTrue();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // mkdir(path, mode, req)
     AsyncCall(env, req_wrap_async, args, "mkdir", UTF8,
               mkdirp ? AfterMkdirp : AfterNoArgs,
@@ -1502,7 +1510,7 @@ static void RealPath(const FunctionCallbackInfo<Value>& args) {
 
   const enum encoding encoding = ParseEncoding(isolate, args[1], UTF8);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {  // realpath(path, encoding, req)
     AsyncCall(env, req_wrap_async, args, "realpath", encoding, AfterStringPtr,
               uv_fs_realpath, *path);
@@ -1548,7 +1556,7 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
 
   bool with_types = args[2]->IsTrue();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // readdir(path, encoding, withTypes, req)
     if (with_types) {
       AsyncCall(env, req_wrap_async, args, "scandir", encoding,
@@ -1636,7 +1644,7 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsInt32());
   const int mode = args[2].As<Int32>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // open(path, flags, mode, req)
     AsyncCall(env, req_wrap_async, args, "open", UTF8, AfterInteger,
               uv_fs_open, *path, flags, mode);
@@ -1652,7 +1660,8 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  Environment* env = binding_data->env();
   Isolate* isolate = env->isolate();
 
   const int argc = args.Length();
@@ -1667,7 +1676,7 @@ static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsInt32());
   const int mode = args[2].As<Int32>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // openFileHandle(path, flags, mode, req)
     AsyncCall(env, req_wrap_async, args, "open", UTF8, AfterOpenFileHandle,
               uv_fs_open, *path, flags, mode);
@@ -1681,7 +1690,7 @@ static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
     if (result < 0) {
       return;  // syscall failed, no need to continue, error info is in ctx
     }
-    FileHandle* fd = FileHandle::New(env, result);
+    FileHandle* fd = FileHandle::New(binding_data, result);
     if (fd == nullptr) return;
     args.GetReturnValue().Set(fd->object());
   }
@@ -1703,7 +1712,7 @@ static void CopyFile(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsInt32());
   const int flags = args[2].As<Int32>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // copyFile(src, dest, flags, req)
     AsyncDestCall(env, req_wrap_async, args, "copyfile",
                   *dest, dest.length(), UTF8, AfterNoArgs,
@@ -1759,7 +1768,7 @@ static void WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   char* buf = buffer_data + off;
   uv_buf_t uvbuf = uv_buf_init(buf, len);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[5]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 5);
   if (req_wrap_async != nullptr) {  // write(fd, buffer, off, len, pos, req)
     AsyncCall(env, req_wrap_async, args, "write", UTF8, AfterInteger,
               uv_fs_write, fd, &uvbuf, 1, pos);
@@ -1804,7 +1813,7 @@ static void WriteBuffers(const FunctionCallbackInfo<Value>& args) {
     iovs[i] = uv_buf_init(Buffer::Data(chunk), Buffer::Length(chunk));
   }
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // writeBuffers(fd, chunks, pos, req)
     AsyncCall(env, req_wrap_async, args, "write", UTF8, AfterInteger,
               uv_fs_write, fd, *iovs, iovs.length(), pos);
@@ -1846,7 +1855,7 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
   char* buf = nullptr;
   size_t len;
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[4]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 4);
   const bool is_async = req_wrap_async != nullptr;
 
   // Avoid copying the string when it is externalized but only when:
@@ -1960,7 +1969,7 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
   char* buf = buffer_data + off;
   uv_buf_t uvbuf = uv_buf_init(buf, len);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[5]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 5);
   if (req_wrap_async != nullptr) {  // read(fd, buffer, offset, len, pos, req)
     AsyncCall(env, req_wrap_async, args, "read", UTF8, AfterInteger,
               uv_fs_read, fd, &uvbuf, 1, pos);
@@ -2037,7 +2046,7 @@ static void Chmod(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsInt32());
   int mode = args[1].As<Int32>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {  // chmod(path, mode, req)
     AsyncCall(env, req_wrap_async, args, "chmod", UTF8, AfterNoArgs,
               uv_fs_chmod, *path, mode);
@@ -2067,7 +2076,7 @@ static void FChmod(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsInt32());
   const int mode = args[1].As<Int32>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {  // fchmod(fd, mode, req)
     AsyncCall(env, req_wrap_async, args, "fchmod", UTF8, AfterNoArgs,
               uv_fs_fchmod, fd, mode);
@@ -2100,7 +2109,7 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsUint32());
   const uv_gid_t gid = static_cast<uv_gid_t>(args[2].As<Uint32>()->Value());
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // chown(path, uid, gid, req)
     AsyncCall(env, req_wrap_async, args, "chown", UTF8, AfterNoArgs,
               uv_fs_chown, *path, uid, gid);
@@ -2133,7 +2142,7 @@ static void FChown(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsUint32());
   const uv_gid_t gid = static_cast<uv_gid_t>(args[2].As<Uint32>()->Value());
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // fchown(fd, uid, gid, req)
     AsyncCall(env, req_wrap_async, args, "fchown", UTF8, AfterNoArgs,
               uv_fs_fchown, fd, uid, gid);
@@ -2163,7 +2172,7 @@ static void LChown(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsUint32());
   const uv_gid_t gid = static_cast<uv_gid_t>(args[2].As<Uint32>()->Value());
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // lchown(path, uid, gid, req)
     AsyncCall(env, req_wrap_async, args, "lchown", UTF8, AfterNoArgs,
               uv_fs_lchown, *path, uid, gid);
@@ -2193,7 +2202,7 @@ static void UTimes(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsNumber());
   const double mtime = args[2].As<Number>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // utimes(path, atime, mtime, req)
     AsyncCall(env, req_wrap_async, args, "utime", UTF8, AfterNoArgs,
               uv_fs_utime, *path, atime, mtime);
@@ -2222,7 +2231,7 @@ static void FUTimes(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsNumber());
   const double mtime = args[2].As<Number>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
   if (req_wrap_async != nullptr) {  // futimes(fd, atime, mtime, req)
     AsyncCall(env, req_wrap_async, args, "futime", UTF8, AfterNoArgs,
               uv_fs_futime, fd, atime, mtime);
@@ -2248,7 +2257,7 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
 
   const enum encoding encoding = ParseEncoding(isolate, args[1], UTF8);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {  // mkdtemp(tmpl, encoding, req)
     AsyncCall(env, req_wrap_async, args, "mkdtemp", encoding, AfterStringPath,
               uv_fs_mkdtemp, *tmpl);
@@ -2273,12 +2282,22 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+void BindingData::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackField("stats_field_array", stats_field_array);
+  tracker->TrackField("stats_field_bigint_array", stats_field_bigint_array);
+  tracker->TrackField("file_handle_read_wrap_freelist",
+                      file_handle_read_wrap_freelist);
+}
+
 void Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,
                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
+  Environment::BindingScope<BindingData> binding_scope(env);
+  BindingData* binding_data = binding_scope.data;
+  if (binding_data == nullptr) return;
 
   env->SetMethod(target, "access", Access);
   env->SetMethod(target, "close", Close);
@@ -2331,11 +2350,11 @@ void Initialize(Local<Object> target,
 
   target->Set(context,
               FIXED_ONE_BYTE_STRING(isolate, "statValues"),
-              env->fs_stats_field_array()->GetJSArray()).Check();
+              binding_data->stats_field_array.GetJSArray()).Check();
 
   target->Set(context,
               FIXED_ONE_BYTE_STRING(isolate, "bigintStatValues"),
-              env->fs_stats_field_bigint_array()->GetJSArray()).Check();
+              binding_data->stats_field_bigint_array.GetJSArray()).Check();
 
   StatWatcher::Initialize(env, target);
 

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -4,7 +4,6 @@
 #include "node.h"
 #include "node_buffer.h"
 #include "node_http2.h"
-#include "node_http2_state.h"
 #include "node_http_common-inl.h"
 #include "node_mem-inl.h"
 #include "node_perf.h"
@@ -113,7 +112,7 @@ Http2Scope::~Http2Scope() {
 // instances to configure an appropriate nghttp2_options struct. The class
 // uses a single TypedArray instance that is shared with the JavaScript side
 // to more efficiently pass values back and forth.
-Http2Options::Http2Options(Environment* env, nghttp2_session_type type) {
+Http2Options::Http2Options(Http2State* http2_state, nghttp2_session_type type) {
   nghttp2_option* option;
   CHECK_EQ(nghttp2_option_new(&option), 0);
   CHECK_NOT_NULL(option);
@@ -138,7 +137,7 @@ Http2Options::Http2Options(Environment* env, nghttp2_session_type type) {
     nghttp2_option_set_builtin_recv_extension_type(option, NGHTTP2_ORIGIN);
   }
 
-  AliasedUint32Array& buffer = env->http2_state()->options_buffer;
+  AliasedUint32Array& buffer = http2_state->options_buffer;
   uint32_t flags = buffer[IDX_OPTIONS_FLAGS];
 
   if (flags & (1 << IDX_OPTIONS_MAX_DEFLATE_DYNAMIC_TABLE_SIZE)) {
@@ -213,8 +212,8 @@ Http2Options::Http2Options(Environment* env, nghttp2_session_type type) {
     SetMaxSessionMemory(buffer[IDX_OPTIONS_MAX_SESSION_MEMORY] * 1000000);
 }
 
-void Http2Session::Http2Settings::Init() {
-  AliasedUint32Array& buffer = env()->http2_state()->settings_buffer;
+void Http2Session::Http2Settings::Init(Http2State* http2_state) {
+  AliasedUint32Array& buffer = http2_state->settings_buffer;
   uint32_t flags = buffer[IDX_SETTINGS_COUNT];
 
   size_t n = 0;
@@ -244,14 +243,14 @@ void Http2Session::Http2Settings::Init() {
 // The Http2Settings class is used to configure a SETTINGS frame that is
 // to be sent to the connected peer. The settings are set using a TypedArray
 // that is shared with the JavaScript side.
-Http2Session::Http2Settings::Http2Settings(Environment* env,
+Http2Session::Http2Settings::Http2Settings(Http2State* http2_state,
                                            Http2Session* session,
                                            Local<Object> obj,
                                            uint64_t start_time)
-    : AsyncWrap(env, obj, PROVIDER_HTTP2SETTINGS),
+    : AsyncWrap(http2_state->env(), obj, PROVIDER_HTTP2SETTINGS),
       session_(session),
       startTime_(start_time) {
-  Init();
+  Init(http2_state);
 }
 
 // Generates a Buffer that contains the serialized payload of a SETTINGS
@@ -272,10 +271,9 @@ Local<Value> Http2Session::Http2Settings::Pack() {
 
 // Updates the shared TypedArray with the current remote or local settings for
 // the session.
-void Http2Session::Http2Settings::Update(Environment* env,
-                                         Http2Session* session,
+void Http2Session::Http2Settings::Update(Http2Session* session,
                                          get_setting fn) {
-  AliasedUint32Array& buffer = env->http2_state()->settings_buffer;
+  AliasedUint32Array& buffer = session->http2_state()->settings_buffer;
   buffer[IDX_SETTINGS_HEADER_TABLE_SIZE] =
       fn(**session, NGHTTP2_SETTINGS_HEADER_TABLE_SIZE);
   buffer[IDX_SETTINGS_MAX_CONCURRENT_STREAMS] =
@@ -293,8 +291,8 @@ void Http2Session::Http2Settings::Update(Environment* env,
 }
 
 // Initializes the shared TypedArray with the default settings values.
-void Http2Session::Http2Settings::RefreshDefaults(Environment* env) {
-  AliasedUint32Array& buffer = env->http2_state()->settings_buffer;
+void Http2Session::Http2Settings::RefreshDefaults(Http2State* http2_state) {
+  AliasedUint32Array& buffer = http2_state->settings_buffer;
 
   buffer[IDX_SETTINGS_HEADER_TABLE_SIZE] =
       DEFAULT_SETTINGS_HEADER_TABLE_SIZE;
@@ -469,16 +467,17 @@ void Http2Session::DecreaseAllocatedSize(size_t size) {
   current_nghttp2_memory_ -= size;
 }
 
-Http2Session::Http2Session(Environment* env,
+Http2Session::Http2Session(Http2State* http2_state,
                            Local<Object> wrap,
                            nghttp2_session_type type)
-    : AsyncWrap(env, wrap, AsyncWrap::PROVIDER_HTTP2SESSION),
-      session_type_(type) {
+    : AsyncWrap(http2_state->env(), wrap, AsyncWrap::PROVIDER_HTTP2SESSION),
+      session_type_(type),
+      http2_state_(http2_state) {
   MakeWeak();
   statistics_.start_time = uv_hrtime();
 
   // Capture the configuration options for this session
-  Http2Options opts(env, type);
+  Http2Options opts(http2_state, type);
 
   max_session_memory_ = opts.GetMaxSessionMemory();
 
@@ -521,13 +520,13 @@ Http2Session::Http2Session(Environment* env,
 
   // Make the js_fields_ property accessible to JS land.
   js_fields_store_ =
-      ArrayBuffer::NewBackingStore(env->isolate(), sizeof(SessionJSFields));
+      ArrayBuffer::NewBackingStore(env()->isolate(), sizeof(SessionJSFields));
   js_fields_ = new(js_fields_store_->Data()) SessionJSFields;
 
-  Local<ArrayBuffer> ab = ArrayBuffer::New(env->isolate(), js_fields_store_);
+  Local<ArrayBuffer> ab = ArrayBuffer::New(env()->isolate(), js_fields_store_);
   Local<Uint8Array> uint8_arr =
       Uint8Array::New(ab, 0, kSessionUint8FieldCount);
-  USE(wrap->Set(env->context(), env->fields_string(), uint8_arr));
+  USE(wrap->Set(env()->context(), env()->fields_string(), uint8_arr));
 }
 
 Http2Session::~Http2Session() {
@@ -551,15 +550,17 @@ inline bool HasHttp2Observer(Environment* env) {
 }
 
 void Http2Stream::EmitStatistics() {
+  CHECK_NOT_NULL(session());
   if (!HasHttp2Observer(env()))
     return;
   auto entry =
-      std::make_unique<Http2StreamPerformanceEntry>(env(), id_, statistics_);
+      std::make_unique<Http2StreamPerformanceEntry>(
+          session()->http2_state(), id_, statistics_);
   env()->SetImmediate([entry = move(entry)](Environment* env) {
     if (!HasHttp2Observer(env))
       return;
     HandleScope handle_scope(env->isolate());
-    AliasedFloat64Array& buffer = env->http2_state()->stream_stats_buffer;
+    AliasedFloat64Array& buffer = entry->http2_state()->stream_stats_buffer;
     buffer[IDX_STREAM_STATS_ID] = entry->id();
     if (entry->first_byte() != 0) {
       buffer[IDX_STREAM_STATS_TIMETOFIRSTBYTE] =
@@ -592,12 +593,12 @@ void Http2Session::EmitStatistics() {
   if (!HasHttp2Observer(env()))
     return;
   auto entry = std::make_unique<Http2SessionPerformanceEntry>(
-      env(), statistics_, session_type_);
+      http2_state(), statistics_, session_type_);
   env()->SetImmediate([entry = std::move(entry)](Environment* env) {
     if (!HasHttp2Observer(env))
       return;
     HandleScope handle_scope(env->isolate());
-    AliasedFloat64Array& buffer = env->http2_state()->session_stats_buffer;
+    AliasedFloat64Array& buffer = entry->http2_state()->session_stats_buffer;
     buffer[IDX_SESSION_STATS_TYPE] = entry->type();
     buffer[IDX_SESSION_STATS_PINGRTT] = entry->ping_rtt() / 1e6;
     buffer[IDX_SESSION_STATS_FRAMESRECEIVED] = entry->frame_count();
@@ -2334,7 +2335,8 @@ void HttpErrorString(const FunctionCallbackInfo<Value>& args) {
 // would be suitable, for instance, for creating the Base64
 // output for an HTTP2-Settings header field.
 void PackSettings(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  Http2State* state = Unwrap<Http2State>(args.Data());
+  Environment* env = state->env();
   // TODO(addaleax): We should not be creating a full AsyncWrap for this.
   Local<Object> obj;
   if (!env->http2settings_constructor_template()
@@ -2342,7 +2344,7 @@ void PackSettings(const FunctionCallbackInfo<Value>& args) {
            .ToLocal(&obj)) {
     return;
   }
-  Http2Session::Http2Settings settings(env, nullptr, obj);
+  Http2Session::Http2Settings settings(state, nullptr, obj);
   args.GetReturnValue().Set(settings.Pack());
 }
 
@@ -2350,8 +2352,8 @@ void PackSettings(const FunctionCallbackInfo<Value>& args) {
 // default SETTINGS. RefreshDefaultSettings updates that TypedArray with the
 // default values.
 void RefreshDefaultSettings(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Http2Session::Http2Settings::RefreshDefaults(env);
+  Http2State* state = Unwrap<Http2State>(args.Data());
+  Http2Session::Http2Settings::RefreshDefaults(state);
 }
 
 // Sets the next stream ID the Http2Session. If successful, returns true.
@@ -2373,10 +2375,9 @@ void Http2Session::SetNextStreamID(const FunctionCallbackInfo<Value>& args) {
 // values established for each of the settings so those can be read in JS land.
 template <get_setting fn>
 void Http2Session::RefreshSettings(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
-  Http2Settings::Update(env, session, fn);
+  Http2Settings::Update(session, fn);
   Debug(session, "settings refreshed for session");
 }
 
@@ -2384,12 +2385,11 @@ void Http2Session::RefreshSettings(const FunctionCallbackInfo<Value>& args) {
 // information of the current Http2Session. This updates the values in the
 // TypedArray so those can be read in JS land.
 void Http2Session::RefreshState(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
   Debug(session, "refreshing state");
 
-  AliasedFloat64Array& buffer = env->http2_state()->session_state_buffer;
+  AliasedFloat64Array& buffer = session->http2_state()->session_state_buffer;
 
   nghttp2_session* s = **session;
 
@@ -2416,11 +2416,12 @@ void Http2Session::RefreshState(const FunctionCallbackInfo<Value>& args) {
 
 // Constructor for new Http2Session instances.
 void Http2Session::New(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  Http2State* state = Unwrap<Http2State>(args.Data());
+  Environment* env = state->env();
   CHECK(args.IsConstructCall());
   int32_t val = args[0]->Int32Value(env->context()).ToChecked();
   nghttp2_session_type type = static_cast<nghttp2_session_type>(val);
-  Http2Session* session = new Http2Session(env, args.This(), type);
+  Http2Session* session = new Http2Session(state, args.This(), type);
   session->get_async_id();  // avoid compiler warning
   Debug(session, "session created");
 }
@@ -2645,13 +2646,14 @@ void Http2Stream::Priority(const FunctionCallbackInfo<Value>& args) {
 // information about the Http2Stream. This updates the values in that
 // TypedArray so that the state can be read by JS.
 void Http2Stream::RefreshState(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
 
   Debug(stream, "refreshing state");
 
-  AliasedFloat64Array& buffer = env->http2_state()->stream_state_buffer;
+  CHECK_NOT_NULL(stream->session());
+  AliasedFloat64Array& buffer =
+      stream->session()->http2_state()->stream_state_buffer;
 
   nghttp2_stream* str = **stream;
   nghttp2_session* s = **(stream->session());
@@ -2797,7 +2799,8 @@ void Http2Session::Settings(const FunctionCallbackInfo<Value>& args) {
     return;
 
   Http2Settings* settings = session->AddSettings(
-      MakeDetachedBaseObject<Http2Settings>(session->env(), session, obj, 0));
+      MakeDetachedBaseObject<Http2Settings>(
+          session->http2_state(), session, obj, 0));
   if (settings == nullptr) return args.GetReturnValue().Set(false);
 
   settings->Send();
@@ -2921,6 +2924,10 @@ void SetCallbackFunctions(const FunctionCallbackInfo<Value>& args) {
 #undef SET_FUNCTION
 }
 
+void Http2State::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackField("root_buffer", root_buffer);
+}
+
 // Set up the process.binding('http2') binding.
 void Initialize(Local<Object> target,
                 Local<Value> unused,
@@ -2928,9 +2935,11 @@ void Initialize(Local<Object> target,
                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
-  HandleScope scope(isolate);
+  HandleScope handle_scope(isolate);
 
-  std::unique_ptr<Http2State> state(new Http2State(isolate));
+  Environment::BindingScope<Http2State> binding_scope(env);
+  Http2State* state = binding_scope.data;
+  if (state == nullptr) return;
 
 #define SET_STATE_TYPEDARRAY(name, field)             \
   target->Set(context,                                \
@@ -2952,8 +2961,6 @@ void Initialize(Local<Object> target,
   SET_STATE_TYPEDARRAY(
     "sessionStats", state->session_stats_buffer.GetJSArray());
 #undef SET_STATE_TYPEDARRAY
-
-  env->set_http2_state(std::move(state));
 
   NODE_DEFINE_CONSTANT(target, kBitfield);
   NODE_DEFINE_CONSTANT(target, kSessionPriorityListenerCount);

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2938,8 +2938,8 @@ void Initialize(Local<Object> target,
   HandleScope handle_scope(isolate);
 
   Environment::BindingScope<Http2State> binding_scope(env);
+  if (!binding_scope) return;
   Http2State* state = binding_scope.data;
-  if (state == nullptr) return;
 
 #define SET_STATE_TYPEDARRAY(name, field)             \
   target->Set(context,                                \

--- a/src/node_http2_state.h
+++ b/src/node_http2_state.h
@@ -5,6 +5,8 @@
 
 #include "aliased_buffer.h"
 
+struct nghttp2_rcbuf;
+
 namespace node {
 namespace http2 {
 
@@ -78,42 +80,43 @@ namespace http2 {
     IDX_SESSION_STATS_COUNT
   };
 
-class Http2State {
+class Http2State : public BaseObject {
  public:
-  explicit Http2State(v8::Isolate* isolate) :
-    root_buffer(
-      isolate,
-      sizeof(http2_state_internal)),
-    session_state_buffer(
-      isolate,
-      offsetof(http2_state_internal, session_state_buffer),
-      IDX_SESSION_STATE_COUNT,
-      root_buffer),
-    stream_state_buffer(
-      isolate,
-      offsetof(http2_state_internal, stream_state_buffer),
-      IDX_STREAM_STATE_COUNT,
-      root_buffer),
-    stream_stats_buffer(
-      isolate,
-      offsetof(http2_state_internal, stream_stats_buffer),
-      IDX_STREAM_STATS_COUNT,
-      root_buffer),
-    session_stats_buffer(
-      isolate,
-      offsetof(http2_state_internal, session_stats_buffer),
-      IDX_SESSION_STATS_COUNT,
-      root_buffer),
-    options_buffer(
-      isolate,
-      offsetof(http2_state_internal, options_buffer),
-      IDX_OPTIONS_FLAGS + 1,
-      root_buffer),
-    settings_buffer(
-      isolate,
-      offsetof(http2_state_internal, settings_buffer),
-      IDX_SETTINGS_COUNT + 1,
-      root_buffer) {
+  Http2State(Environment* env, v8::Local<v8::Object> obj)
+    : BaseObject(env, obj),
+      root_buffer(
+        env->isolate(),
+        sizeof(http2_state_internal)),
+      session_state_buffer(
+        env->isolate(),
+        offsetof(http2_state_internal, session_state_buffer),
+        IDX_SESSION_STATE_COUNT,
+        root_buffer),
+      stream_state_buffer(
+        env->isolate(),
+        offsetof(http2_state_internal, stream_state_buffer),
+        IDX_STREAM_STATE_COUNT,
+        root_buffer),
+      stream_stats_buffer(
+        env->isolate(),
+        offsetof(http2_state_internal, stream_stats_buffer),
+        IDX_STREAM_STATS_COUNT,
+        root_buffer),
+      session_stats_buffer(
+        env->isolate(),
+        offsetof(http2_state_internal, session_stats_buffer),
+        IDX_SESSION_STATS_COUNT,
+        root_buffer),
+      options_buffer(
+        env->isolate(),
+        offsetof(http2_state_internal, options_buffer),
+        IDX_OPTIONS_FLAGS + 1,
+        root_buffer),
+      settings_buffer(
+        env->isolate(),
+        offsetof(http2_state_internal, settings_buffer),
+        IDX_SETTINGS_COUNT + 1,
+        root_buffer) {
   }
 
   AliasedUint8Array root_buffer;
@@ -123,6 +126,10 @@ class Http2State {
   AliasedFloat64Array session_stats_buffer;
   AliasedUint32Array options_buffer;
   AliasedUint32Array settings_buffer;
+
+  void MemoryInfo(MemoryTracker* tracker) const override;
+  SET_SELF_SIZE(Http2State)
+  SET_MEMORY_INFO_NAME(Http2State)
 
  private:
   struct http2_state_internal {

--- a/src/node_http_common-inl.h
+++ b/src/node_http_common-inl.h
@@ -143,7 +143,7 @@ v8::MaybeLocal<v8::String> NgHeader<T>::GetName(
   // If header_name is not nullptr, then it is a known header with
   // a statically defined name. We can safely internalize it here.
   if (header_name != nullptr) {
-    auto& static_str_map = env_->isolate_data()->http_static_strs;
+    auto& static_str_map = env_->isolate_data()->static_str_map;
     v8::Eternal<v8::String> eternal = static_str_map[header_name];
     if (eternal.IsEmpty()) {
       v8::Local<v8::String> str = OneByteString(env_->isolate(), header_name);

--- a/src/node_http_common.h
+++ b/src/node_http_common.h
@@ -409,7 +409,7 @@ class NgRcBufPointer : public MemoryRetainer {
         NgRcBufPointer<T> ptr) {
       Environment* env = allocator->env();
       if (ptr.IsStatic()) {
-        auto& static_str_map = env->isolate_data()->http_static_strs;
+        auto& static_str_map = env->isolate_data()->static_str_map;
         const char* header_name = reinterpret_cast<const char*>(ptr.data());
         v8::Eternal<v8::String>& eternal = static_str_map[header_name];
         if (eternal.IsEmpty()) {

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -921,8 +921,8 @@ void InitializeHttpParser(Local<Object> target,
                           void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Environment::BindingScope<BindingData> binding_scope(env);
+  if (!binding_scope) return;
   BindingData* binding_data = binding_scope.data;
-  if (binding_data == nullptr) return;
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);
   t->InstanceTemplate()->SetInternalFieldCount(Parser::kInternalFieldCount);

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -922,7 +922,6 @@ void InitializeHttpParser(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
   Environment::BindingScope<BindingData> binding_scope(env);
   if (!binding_scope) return;
-  BindingData* binding_data = binding_scope.data;
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);
   t->InstanceTemplate()->SetInternalFieldCount(Parser::kInternalFieldCount);

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -82,6 +82,20 @@ inline bool IsOWS(char c) {
   return c == ' ' || c == '\t';
 }
 
+class BindingData : public BaseObject {
+ public:
+  BindingData(Environment* env, Local<Object> obj) : BaseObject(env, obj) {}
+
+  std::vector<char> parser_buffer;
+  bool parser_buffer_in_use = false;
+
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackField("parser_buffer", parser_buffer);
+  }
+  SET_SELF_SIZE(BindingData)
+  SET_MEMORY_INFO_NAME(BindingData)
+};
+
 // helper class for the Parser
 struct StringPtr {
   StringPtr() {
@@ -164,10 +178,11 @@ struct StringPtr {
 
 class Parser : public AsyncWrap, public StreamListener {
  public:
-  Parser(Environment* env, Local<Object> wrap)
-      : AsyncWrap(env, wrap),
+  Parser(BindingData* binding_data, Local<Object> wrap)
+      : AsyncWrap(binding_data->env(), wrap),
         current_buffer_len_(0),
-        current_buffer_data_(nullptr) {
+        current_buffer_data_(nullptr),
+        binding_data_(binding_data) {
   }
 
 
@@ -429,8 +444,8 @@ class Parser : public AsyncWrap, public StreamListener {
   }
 
   static void New(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args);
-    new Parser(env, args.This());
+    BindingData* binding_data = Unwrap<BindingData>(args.Data());
+    new Parser(binding_data, args.This());
   }
 
 
@@ -605,14 +620,14 @@ class Parser : public AsyncWrap, public StreamListener {
     // For most types of streams, OnStreamRead will be immediately after
     // OnStreamAlloc, and will consume all data, so using a static buffer for
     // reading is more efficient. For other streams, just use Malloc() directly.
-    if (env()->http_parser_buffer_in_use())
+    if (binding_data_->parser_buffer_in_use)
       return uv_buf_init(Malloc(suggested_size), suggested_size);
-    env()->set_http_parser_buffer_in_use(true);
+    binding_data_->parser_buffer_in_use = true;
 
-    if (env()->http_parser_buffer() == nullptr)
-      env()->set_http_parser_buffer(new char[kAllocBufferSize]);
+    if (binding_data_->parser_buffer.empty())
+      binding_data_->parser_buffer.resize(kAllocBufferSize);
 
-    return uv_buf_init(env()->http_parser_buffer(), kAllocBufferSize);
+    return uv_buf_init(binding_data_->parser_buffer.data(), kAllocBufferSize);
   }
 
 
@@ -622,8 +637,8 @@ class Parser : public AsyncWrap, public StreamListener {
     // is free for re-use, or free() the data if it didn’t come from there
     // in the first place.
     auto on_scope_leave = OnScopeLeave([&]() {
-      if (buf.base == env()->http_parser_buffer())
-        env()->set_http_parser_buffer_in_use(false);
+      if (buf.base == binding_data_->parser_buffer.data())
+        binding_data_->parser_buffer_in_use = false;
       else
         free(buf.base);
     });
@@ -863,6 +878,8 @@ class Parser : public AsyncWrap, public StreamListener {
   uint64_t headers_timeout_;
   uint64_t header_parsing_start_time_ = 0;
 
+  BaseObjectPtr<BindingData> binding_data_;
+
   // These are helper functions for filling `http_parser_settings`, which turn
   // a member function of Parser into a C-style HTTP parser callback.
   template <typename Parser, Parser> struct Proxy;
@@ -903,6 +920,10 @@ void InitializeHttpParser(Local<Object> target,
                           Local<Context> context,
                           void* priv) {
   Environment* env = Environment::GetCurrent(context);
+  Environment::BindingScope<BindingData> binding_scope(env);
+  BindingData* binding_data = binding_scope.data;
+  if (binding_data == nullptr) return;
+
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);
   t->InstanceTemplate()->SetInternalFieldCount(Parser::kInternalFieldCount);
   t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "HTTPParser"));

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -147,7 +147,7 @@ void PatchProcessObject(const FunctionCallbackInfo<Value>& args) {
                 FIXED_ONE_BYTE_STRING(isolate, "title"),
                 ProcessTitleGetter,
                 env->owns_process_state() ? ProcessTitleSetter : nullptr,
-                env->as_callback_data(),
+                env->current_callback_data(),
                 DEFAULT,
                 None,
                 SideEffectType::kHasNoSideEffect)
@@ -198,7 +198,7 @@ void PatchProcessObject(const FunctionCallbackInfo<Value>& args) {
                           FIXED_ONE_BYTE_STRING(isolate, "debugPort"),
                           DebugPortGetter,
                           env->owns_process_state() ? DebugPortSetter : nullptr,
-                          env->as_callback_data())
+                          env->current_callback_data())
             .FromJust());
 }
 

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -61,15 +61,16 @@ void StatWatcher::Initialize(Environment* env, Local<Object> target) {
 }
 
 
-StatWatcher::StatWatcher(Environment* env,
+StatWatcher::StatWatcher(fs::BindingData* binding_data,
                          Local<Object> wrap,
                          bool use_bigint)
-    : HandleWrap(env,
+    : HandleWrap(binding_data->env(),
                  wrap,
                  reinterpret_cast<uv_handle_t*>(&watcher_),
                  AsyncWrap::PROVIDER_STATWATCHER),
-      use_bigint_(use_bigint) {
-  CHECK_EQ(0, uv_fs_poll_init(env->event_loop(), &watcher_));
+      use_bigint_(use_bigint),
+      binding_data_(binding_data) {
+  CHECK_EQ(0, uv_fs_poll_init(env()->event_loop(), &watcher_));
 }
 
 
@@ -82,8 +83,10 @@ void StatWatcher::Callback(uv_fs_poll_t* handle,
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
 
-  Local<Value> arr = fs::FillGlobalStatsArray(env, wrap->use_bigint_, curr);
-  USE(fs::FillGlobalStatsArray(env, wrap->use_bigint_, prev, true));
+  Local<Value> arr = fs::FillGlobalStatsArray(
+      wrap->binding_data_.get(), wrap->use_bigint_, curr);
+  USE(fs::FillGlobalStatsArray(
+      wrap->binding_data_.get(), wrap->use_bigint_, prev, true));
 
   Local<Value> argv[2] = { Integer::New(env->isolate(), status), arr };
   wrap->MakeCallback(env->onchange_string(), arraysize(argv), argv);
@@ -92,8 +95,8 @@ void StatWatcher::Callback(uv_fs_poll_t* handle,
 
 void StatWatcher::New(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
-  Environment* env = Environment::GetCurrent(args);
-  new StatWatcher(env, args.This(), args[0]->IsTrue());
+  fs::BindingData* binding_data = Unwrap<fs::BindingData>(args.Data());
+  new StatWatcher(binding_data, args.This(), args[0]->IsTrue());
 }
 
 // wrap.start(filename, interval)

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -30,6 +30,9 @@
 #include "v8.h"
 
 namespace node {
+namespace fs {
+struct BindingData;
+}
 
 class Environment;
 
@@ -38,7 +41,7 @@ class StatWatcher : public HandleWrap {
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
  protected:
-  StatWatcher(Environment* env,
+  StatWatcher(fs::BindingData* binding_data,
               v8::Local<v8::Object> wrap,
               bool use_bigint);
 
@@ -57,6 +60,7 @@ class StatWatcher : public HandleWrap {
 
   uv_fs_poll_t watcher_;
   const bool use_bigint_;
+  BaseObjectPtr<fs::BindingData> binding_data_;
 };
 
 }  // namespace node

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -20,7 +20,9 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "node.h"
+#include "base_object-inl.h"
 #include "env-inl.h"
+#include "memory_tracker-inl.h"
 #include "util-inl.h"
 #include "v8.h"
 
@@ -59,7 +61,7 @@ using v8::Value;
   V(10, number_of_detached_contexts, kNumberOfDetachedContextsIndex)
 
 #define V(a, b, c) +1
-static const size_t kHeapStatisticsPropertiesCount =
+static constexpr size_t kHeapStatisticsPropertiesCount =
     HEAP_STATISTICS_PROPERTIES(V);
 #undef V
 
@@ -71,10 +73,28 @@ static const size_t kHeapStatisticsPropertiesCount =
   V(3, physical_space_size, kPhysicalSpaceSizeIndex)
 
 #define V(a, b, c) +1
-static const size_t kHeapSpaceStatisticsPropertiesCount =
+static constexpr size_t kHeapSpaceStatisticsPropertiesCount =
     HEAP_SPACE_STATISTICS_PROPERTIES(V);
 #undef V
 
+class BindingData : public BaseObject {
+ public:
+  BindingData(Environment* env, Local<Object> obj) : BaseObject(env, obj) {}
+
+  std::shared_ptr<BackingStore> heap_statistics_buffer;
+  std::shared_ptr<BackingStore> heap_space_statistics_buffer;
+  std::shared_ptr<BackingStore> heap_code_statistics_buffer;
+
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackField("heap_statistics_buffer", heap_statistics_buffer);
+    tracker->TrackField("heap_space_statistics_buffer",
+                        heap_space_statistics_buffer);
+    tracker->TrackField("heap_code_statistics_buffer",
+                        heap_code_statistics_buffer);
+  }
+  SET_SELF_SIZE(BindingData)
+  SET_MEMORY_INFO_NAME(BindingData)
+};
 
 #define HEAP_CODE_STATISTICS_PROPERTIES(V)                                    \
   V(0, code_and_metadata_size, kCodeAndMetadataSizeIndex)                    \
@@ -96,10 +116,11 @@ void CachedDataVersionTag(const FunctionCallbackInfo<Value>& args) {
 
 
 void UpdateHeapStatisticsArrayBuffer(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  BindingData* data = Unwrap<BindingData>(args.Data());
   HeapStatistics s;
-  env->isolate()->GetHeapStatistics(&s);
-  double* const buffer = env->heap_statistics_buffer();
+  args.GetIsolate()->GetHeapStatistics(&s);
+  double* const buffer =
+      static_cast<double*>(data->heap_statistics_buffer->Data());
 #define V(index, name, _) buffer[index] = static_cast<double>(s.name());
   HEAP_STATISTICS_PROPERTIES(V)
 #undef V
@@ -107,18 +128,20 @@ void UpdateHeapStatisticsArrayBuffer(const FunctionCallbackInfo<Value>& args) {
 
 
 void UpdateHeapSpaceStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  BindingData* data = Unwrap<BindingData>(args.Data());
   HeapSpaceStatistics s;
-  Isolate* const isolate = env->isolate();
-  double* buffer = env->heap_space_statistics_buffer();
-  size_t number_of_heap_spaces = env->isolate()->NumberOfHeapSpaces();
+  Isolate* const isolate = args.GetIsolate();
+  size_t number_of_heap_spaces = isolate->NumberOfHeapSpaces();
+
+  double* const buffer =
+      static_cast<double*>(data->heap_space_statistics_buffer->Data());
 
   for (size_t i = 0; i < number_of_heap_spaces; i++) {
     isolate->GetHeapSpaceStatistics(&s, i);
     size_t const property_offset = i * kHeapSpaceStatisticsPropertiesCount;
-#define V(index, name, _) buffer[property_offset + index] = \
-                              static_cast<double>(s.name());
-      HEAP_SPACE_STATISTICS_PROPERTIES(V)
+#define V(index, name, _)                                            \
+      buffer[property_offset + index] = static_cast<double>(s.name());
+    HEAP_SPACE_STATISTICS_PROPERTIES(V)
 #undef V
   }
 }
@@ -126,10 +149,11 @@ void UpdateHeapSpaceStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
 
 void UpdateHeapCodeStatisticsArrayBuffer(
     const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  BindingData* data = Unwrap<BindingData>(args.Data());
   HeapCodeStatistics s;
-  env->isolate()->GetHeapCodeAndMetadataStatistics(&s);
-  double* const buffer = env->heap_code_statistics_buffer();
+  args.GetIsolate()->GetHeapCodeAndMetadataStatistics(&s);
+  double* const buffer =
+      static_cast<double*>(data->heap_code_statistics_buffer->Data());
 #define V(index, name, _) buffer[index] = static_cast<double>(s.name());
   HEAP_CODE_STATISTICS_PROPERTIES(V)
 #undef V
@@ -148,6 +172,9 @@ void Initialize(Local<Object> target,
                 Local<Context> context,
                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
+  Environment::BindingScope<BindingData> binding_scope(env);
+  BindingData* binding_data = binding_scope.data;
+  if (binding_data == nullptr) return;
 
   env->SetMethodNoSideEffect(target, "cachedDataVersionTag",
                              CachedDataVersionTag);
@@ -158,11 +185,11 @@ void Initialize(Local<Object> target,
                  UpdateHeapStatisticsArrayBuffer);
 
   const size_t heap_statistics_buffer_byte_length =
-      sizeof(*env->heap_statistics_buffer()) * kHeapStatisticsPropertiesCount;
+      sizeof(double) * kHeapStatisticsPropertiesCount;
 
   Local<ArrayBuffer> heap_statistics_ab =
       ArrayBuffer::New(env->isolate(), heap_statistics_buffer_byte_length);
-  env->set_heap_statistics_buffer(heap_statistics_ab->GetBackingStore());
+  binding_data->heap_statistics_buffer = heap_statistics_ab->GetBackingStore();
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(),
                                     "heapStatisticsArrayBuffer"),
@@ -182,19 +209,17 @@ void Initialize(Local<Object> target,
                  UpdateHeapCodeStatisticsArrayBuffer);
 
   const size_t heap_code_statistics_buffer_byte_length =
-      sizeof(*env->heap_code_statistics_buffer())
-      * kHeapCodeStatisticsPropertiesCount;
+      sizeof(double) * kHeapCodeStatisticsPropertiesCount;
 
   Local<ArrayBuffer> heap_code_statistics_ab =
       ArrayBuffer::New(env->isolate(),
                        heap_code_statistics_buffer_byte_length);
-  env->set_heap_code_statistics_buffer(
-      heap_code_statistics_ab->GetBackingStore());
+  binding_data->heap_code_statistics_buffer =
+      heap_code_statistics_ab->GetBackingStore();
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(),
                                     "heapCodeStatisticsArrayBuffer"),
-              heap_code_statistics_ab)
-  .Check();
+              heap_code_statistics_ab).Check();
 
 #define V(i, _, name)                                                         \
   target->Set(env->context(),                                                 \
@@ -236,20 +261,20 @@ void Initialize(Local<Object> target,
                  UpdateHeapSpaceStatisticsBuffer);
 
   const size_t heap_space_statistics_buffer_byte_length =
-      sizeof(*env->heap_space_statistics_buffer()) *
+      sizeof(double) *
       kHeapSpaceStatisticsPropertiesCount *
       number_of_heap_spaces;
 
   Local<ArrayBuffer> heap_space_statistics_ab =
       ArrayBuffer::New(env->isolate(),
                        heap_space_statistics_buffer_byte_length);
-  env->set_heap_space_statistics_buffer(
-      heap_space_statistics_ab->GetBackingStore());
+  binding_data->heap_space_statistics_buffer =
+      heap_space_statistics_ab->GetBackingStore();
+
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(),
                                     "heapSpaceStatisticsArrayBuffer"),
-              heap_space_statistics_ab)
-              .Check();
+              heap_space_statistics_ab).Check();
 
 #define V(i, _, name)                                                         \
   target->Set(env->context(),                                                 \

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -30,6 +30,7 @@ namespace node {
 
 using v8::Array;
 using v8::ArrayBuffer;
+using v8::BackingStore;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::HeapCodeStatistics;

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -173,8 +173,8 @@ void Initialize(Local<Object> target,
                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Environment::BindingScope<BindingData> binding_scope(env);
+  if (!binding_scope) return;
   BindingData* binding_data = binding_scope.data;
-  if (binding_data == nullptr) return;
 
   env->SetMethodNoSideEffect(target, "cachedDataVersionTag",
                              CachedDataVersionTag);

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -142,7 +142,7 @@ Local<FunctionTemplate> LibuvStreamWrap::GetConstructorTemplate(
     Local<FunctionTemplate> get_write_queue_size =
         FunctionTemplate::New(env->isolate(),
                               GetWriteQueueSize,
-                              env->as_callback_data(),
+                              env->current_callback_data(),
                               Signature::New(env->isolate(), tmpl));
     tmpl->PrototypeTemplate()->SetAccessorProperty(
         env->write_queue_size_string(),

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -1276,7 +1276,7 @@ void TLSWrap::Initialize(Local<Object> target,
   Local<FunctionTemplate> get_write_queue_size =
       FunctionTemplate::New(env->isolate(),
                             GetWriteQueueSize,
-                            env->as_callback_data(),
+                            env->current_callback_data(),
                             Signature::New(env->isolate(), t));
   t->PrototypeTemplate()->SetAccessorProperty(
       env->write_queue_size_string(),

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -145,7 +145,7 @@ void UDPWrap::Initialize(Local<Object> target,
   Local<FunctionTemplate> get_fd_templ =
       FunctionTemplate::New(env->isolate(),
                             UDPWrap::GetFD,
-                            env->as_callback_data(),
+                            env->current_callback_data(),
                             signature);
 
   t->PrototypeTemplate()->SetAccessorProperty(env->fd_string(),


### PR DESCRIPTION
##### src: make creating per-binding data structures easier

Enable the state associated with the individual bindings, e.g. fs or
http2, to be moved out of the Environment class, in order for these
to be more modular and for Environment to be come less of a collection
of random data fields.

Do this by using a BaseObject as the data for callbacks, which can hold
the per-binding state. By default, no per-binding state is available,
although that can be configured when setting up the binding.

##### src: move HTTP/2 state out of Environment

Moves state that is specific to HTTP/2 into the HTTP/2 implementation
as a cleanup.

##### src: move v8 stats buffers out of Environment

Moves state that is specific to the `v8` binding into the
`v8` binding implementation as a cleanup.

##### src: move http parser state out of Environment

Moves state that is specific to HTTP/1 into the HTTP/1 implementation
as a cleanup.

##### src: move fs state out of Environment

Moves state that is specific to the `fs` binding into the
`fs` binding implementation as a cleanup.

##### src,doc: add documentation for per-binding state pattern

---

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
