### PR TITLE
test: replace flag expose_internals to expose-internals

### DIFF
--- a/test/parallel/test-child-process-bad-stdio.js
+++ b/test/parallel/test-child-process-bad-stdio.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose_internals
+// Flags: --expose-internals
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');

--- a/test/parallel/test-child-process-exec-kill-throws.js
+++ b/test/parallel/test-child-process-exec-kill-throws.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose_internals
+// Flags: --expose-internals
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');

--- a/test/parallel/test-child-process-http-socket-leak.js
+++ b/test/parallel/test-child-process-http-socket-leak.js
@@ -1,4 +1,4 @@
-// Flags: --expose_internals
+// Flags: --expose-internals
 
 'use strict';
 

--- a/test/parallel/test-child-process-spawnsync-kill-signal.js
+++ b/test/parallel/test-child-process-spawnsync-kill-signal.js
@@ -1,4 +1,4 @@
-// Flags: --expose_internals
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -1,4 +1,4 @@
-// Flags: --expose_internals
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-child-process-validate-stdio.js
+++ b/test/parallel/test-child-process-validate-stdio.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose_internals
+// Flags: --expose-internals
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-child-process-windows-hide.js
+++ b/test/parallel/test-child-process-windows-hide.js
@@ -1,4 +1,4 @@
-// Flags: --expose_internals
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-constants.js
+++ b/test/parallel/test-constants.js
@@ -1,4 +1,4 @@
-// Flags: --expose_internals
+// Flags: --expose-internals
 'use strict';
 
 require('../common');

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// Flags: --expose_internals
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 

--- a/test/parallel/test-http2-compat-socket.js
+++ b/test/parallel/test-http2-compat-socket.js
@@ -1,4 +1,4 @@
-// Flags: --expose_internals
+// Flags: --expose-internals
 
 'use strict';
 

--- a/test/parallel/test-http2-socket-proxy.js
+++ b/test/parallel/test-http2-socket-proxy.js
@@ -1,4 +1,4 @@
-// Flags: --expose_internals
+// Flags: --expose-internals
 
 'use strict';
 

--- a/test/parallel/test-icu-stringwidth.js
+++ b/test/parallel/test-icu-stringwidth.js
@@ -1,4 +1,4 @@
-// Flags: --expose_internals
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 

--- a/test/parallel/test-internal-util-decorate-error-stack.js
+++ b/test/parallel/test-internal-util-decorate-error-stack.js
@@ -1,4 +1,4 @@
-// Flags: --expose_internals
+// Flags: --expose-internals
 'use strict';
 require('../common');
 const fixtures = require('../common/fixtures');

--- a/test/parallel/test-os-checked-function.js
+++ b/test/parallel/test-os-checked-function.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose_internals
+// Flags: --expose-internals
 
 require('../common');
 const { internalBinding } = require('internal/test/binding');

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// Flags: --expose_internals
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 

--- a/test/parallel/test-readline-tab-complete.js
+++ b/test/parallel/test-readline-tab-complete.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Flags: --expose_internals
+// Flags: --expose-internals
 
 const common = require('../common');
 const readline = require('readline');

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -2,7 +2,7 @@
 
 // Verifies that the REPL history file is created with mode 0600
 
-// Flags: --expose_internals
+// Flags: --expose-internals
 
 const common = require('../common');
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -560,7 +560,7 @@ const errorTests = [
     expect: '... ... ... undefined'
   },
   // REPL should get a normal require() function, not one that allows
-  // access to internal modules without the --expose_internals flag.
+  // access to internal modules without the --expose-internals flag.
   {
     send: 'require("internal/repl")',
     expect: [

--- a/test/parallel/test-safe-get-env.js
+++ b/test/parallel/test-safe-get-env.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose_internals
+// Flags: --expose-internals
 
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-stream-buffer-list.js
+++ b/test/parallel/test-stream-buffer-list.js
@@ -1,4 +1,4 @@
-// Flags: --expose_internals
+// Flags: --expose-internals
 'use strict';
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-stream2-readable-from-list.js
+++ b/test/parallel/test-stream2-readable-from-list.js
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// Flags: --expose_internals
+// Flags: --expose-internals
 'use strict';
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-tls-parse-cert-string.js
+++ b/test/parallel/test-tls-parse-cert-string.js
@@ -10,7 +10,7 @@ const {
   restoreStderr
 } = require('../common/hijackstdio');
 const assert = require('assert');
-// Flags: --expose_internals
+// Flags: --expose-internals
 const internalTLS = require('internal/tls');
 const tls = require('tls');
 

--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -1,4 +1,4 @@
-// Flags: --expose_internals
+// Flags: --expose-internals
 
 'use strict';
 const common = require('../common');

--- a/test/parallel/test-util-internal.js
+++ b/test/parallel/test-util-internal.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose_internals
+// Flags: --expose-internals
 
 require('../common');
 const assert = require('assert');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

They are the same, but `--expose-internals` seems to be the standard, actually, the written on `src/node_options.h` file, and by the way, `--expose_internals` flag is not documented anywhere.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
