### PR TITLE
doc: amend related to execFile explanation

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -171,11 +171,15 @@ changes:
   * `stderr` {string|Buffer}
 * Returns: {ChildProcess}
 
-Spawns a shell then executes the `command` within that shell, buffering any
+If the `shell` option is not passed as `false`, then a shell is spawned
+that executes the `command` within that shell, buffering any
 generated output. The `command` string passed to the exec function is processed
 directly by the shell and special characters (vary based on
 [shell](https://en.wikipedia.org/wiki/List_of_command-line_interpreters))
 need to be dealt with accordingly:
+
+If the `shell` option is passed as `false`, then certain shell behaviours such
+as I/O redirection and file globbing are not supported.
 
 ```js
 exec('"/path/to/test file/test.sh" arg1 arg2');
@@ -279,11 +283,11 @@ changes:
 * Returns: {ChildProcess}
 
 The `child_process.execFile()` function is similar to [`child_process.exec()`][]
-except that it does not spawn a shell by default. Rather, the specified
-executable `file` is spawned directly as a new process making it slightly more
-efficient than [`child_process.exec()`][].
+except that it does not spawn a shell by default. Also, `child_process.execFile()`
+takes an array of strings as an argument whereas `child_process.exec()`
+takes a single command string.
 
-The same options as [`child_process.exec()`][] are supported. Since a shell is
+The same options as [`child_process.exec()`][] are supported. If a shell is
 not spawned, behaviors such as I/O redirection and file globbing are not
 supported.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Both `execFile` and `exec` share the same source and thus difference
only lies in the default arguments and sanity of how arguments are
passed. Some statements that are placed in `execFile` also holds true
for `exec`.

See: https://github.com/nodejs/node/issues/32524


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->