### PR TITLE
worker: do not emit 'exit' events during process.exit()

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -986,6 +986,7 @@ void Environment::Exit(int exit_code) {
                         isolate(), stack_trace_limit(), StackTrace::kDetailed));
   }
   if (is_main_thread()) {
+    set_can_call_into_js(false);
     stop_sub_worker_contexts();
     DisposePlatform();
     exit(exit_code);

--- a/test/parallel/test-worker-nested-on-process-exit.js
+++ b/test/parallel/test-worker-nested-on-process-exit.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker, workerData } = require('worker_threads');
+
+// Test that 'exit' events for nested Workers are not received when a Worker
+// terminates itself through process.exit().
+
+if (workerData === null) {
+  const nestedWorkerExitCounter = new Int32Array(new SharedArrayBuffer(4));
+  const w = new Worker(__filename, { workerData: nestedWorkerExitCounter });
+  w.on('exit', common.mustCall(() => {
+    assert.strictEqual(nestedWorkerExitCounter[0], 0);
+  }));
+} else {
+  const nestedWorker = new Worker('setInterval(() => {}, 100)', { eval: true });
+  // The counter should never be increased here.
+  nestedWorker.on('exit', () => workerData[0]++);
+  nestedWorker.on('online', () => process.exit());
+}

--- a/test/parallel/test-worker-on-process-exit.js
+++ b/test/parallel/test-worker-on-process-exit.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const { Worker } = require('worker_threads');
+
+// Test that 'exit' events for Workers are not received when the main thread
+// terminates itself through process.exit().
+
+if (process.argv[2] !== 'child') {
+  const {
+    stdout, stderr, status
+  } = spawnSync(process.execPath, [__filename, 'child'], { encoding: 'utf8' });
+  assert.strictEqual(stderr, '');
+  assert.strictEqual(stdout, '');
+  assert.strictEqual(status, 0);
+} else {
+  const nestedWorker = new Worker('setInterval(() => {}, 100)', { eval: true });
+  // This console.log() should never fire.
+  nestedWorker.on('exit', () => console.log('exit event received'));
+  nestedWorker.on('online', () => process.exit());
+}
+

--- a/test/parallel/test-worker-on-process-exit.js
+++ b/test/parallel/test-worker-on-process-exit.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const { spawnSync } = require('child_process');
 const { Worker } = require('worker_threads');
@@ -20,4 +20,3 @@ if (process.argv[2] !== 'child') {
   nestedWorker.on('exit', () => console.log('exit event received'));
   nestedWorker.on('online', () => process.exit());
 }
-


### PR DESCRIPTION
Do not emit `'exit'` events caused by recursively stopping all
running Workers from inside the `process.exit()` call.

(Split out from #32531 as this is semver-patch and should definitely be backported to LTS.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
