### PR TITLE
src: fix warnings on SPrintF

### DIFF
--- a/src/debug_utils-inl.h
+++ b/src/debug_utils-inl.h
@@ -30,16 +30,17 @@ struct ToStringHelper {
   template <unsigned BASE_BITS,
             typename T,
             typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
-  static std::string BaseConvert(T value) {
+  static std::string BaseConvert(const T& value) {
+    auto v = static_cast<uint64_t>(value);
     char ret[3 * sizeof(T)];
     char* ptr = ret + 3 * sizeof(T) - 1;
     *ptr = '\0';
     const char* digits = "0123456789abcdef";
     do {
-      unsigned digit = value & ((1 << BASE_BITS) - 1);
+      unsigned digit = v & ((1 << BASE_BITS) - 1);
       *--ptr =
           (BASE_BITS < 4 ? static_cast<char>('0' + digit) : digits[digit]);
-    } while ((value >>= BASE_BITS) != 0);
+    } while ((v >>= BASE_BITS) != 0);
     return ptr;
   }
   template <unsigned BASE_BITS,
@@ -56,8 +57,8 @@ std::string ToString(const T& value) {
 }
 
 template <unsigned BASE_BITS, typename T>
-std::string ToBaseString(T&& value) {
-  return ToStringHelper::BaseConvert<BASE_BITS>(std::forward<T>(value));
+std::string ToBaseString(const T& value) {
+  return ToStringHelper::BaseConvert<BASE_BITS>(value);
 }
 
 inline std::string SPrintFImpl(const char* format) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Refs: https://github.com/nodejs/node/pull/32551#discussion_r399830524 https://github.com/nodejs/node/pull/32385#pullrequestreview-378668359

Previous error message on Windows:

```bash
C:\Users\jasne\Projects\node\src\node_http2.cc(2738,13): warning C4244: 'initializing': conversion from 'T' to 'int', possible loss of data [C:\Users\jasne\Projects\node\libnode.vcxproj]
          with
          [
              T=int64_t
          ]
C:\Users\jasne\Projects\node\src\debug_utils-inl.h(39,1): warning C4806: '&': unsafe operation: no value of type 'T' promoted to type 'int' can equal the given constant [C:\Users\jasne\Projects\node\libnode.vcxproj]
          with
          [
              T=bool
          ]
C:\Users\jasne\Projects\node\src\debug_utils-inl.h(60): message : see reference to function template instantiation 'std::string node::ToStringHelper::BaseConvert<3,bool,0>(T)' being compiled [C:\Users\jasne\Projects\node\lib
node.vcxproj]
          with
          [
              T=bool
          ]
C:\Users\jasne\Projects\node\src\debug_utils-inl.h(97): message : see reference to function template instantiation 'std::string node::ToBaseString<3,bool&>(T)' being compiled [C:\Users\jasne\Projects\node\libnode.vcxproj]
          with
          [
              T=bool &
          ]
C:\Users\jasne\Projects\node\src\debug_utils-inl.h(117): message : see reference to function template instantiation 'std::string node::SPrintFImpl<bool&,>(const char *,Arg)' being compiled [C:\Users\jasne\Projects\node\libno
de.vcxproj]
          with
          [
              Arg=bool &
          ]
C:\Users\jasne\Projects\node\src\debug_utils-inl.h(117): message : see reference to function template instantiation 'std::string node::SPrintFImpl<int&,bool&>(const char *,Arg,bool &)' being compiled [C:\Users\jasne\Projects
\node\libnode.vcxproj]
          with
          [
              Arg=int &
          ]
C:\Users\jasne\Projects\node\src\debug_utils-inl.h(123): message : see reference to function template instantiation 'std::string node::SPrintFImpl<int&,int&,bool&>(const char *,Arg,int &,bool &)' being compiled [C:\Users\jas
ne\Projects\node\libnode.vcxproj]
          with
          [
              Arg=int &
          ]
C:\Users\jasne\Projects\node\src\debug_utils-inl.h(128): message : see reference to function template instantiation 'std::string node::SPrintF<int&,int&,bool&>(const char *,int &,int &,bool &)' being compiled [C:\Users\jasne
\Projects\node\libnode.vcxproj]
C:\Users\jasne\Projects\node\src\debug_utils-inl.h(137): message : see reference to function template instantiation 'void node::FPrintF<int&,int&,bool&>(FILE *,const char *,int &,int &,bool &)' being compiled [C:\Users\jasne
\Projects\node\libnode.vcxproj]
C:\Users\jasne\Projects\node\src\debug_utils-inl.h(150): message : see reference to function template instantiation 'void node::Debug<int32_t&,int32_t&,bool&>(node::EnabledDebugList *,node::DebugCategory,const char *,int32_t
 &,int32_t &,bool &)' being compiled [C:\Users\jasne\Projects\node\libnode.vcxproj]
C:\Users\jasne\Projects\node\src\node_http2.cc(354): message : see reference to function template instantiation 'void node::Debug<int32_t&,int32_t&,bool&>(node::Environment *,node::DebugCategory,const char *,int32_t &,int32_
t &,bool &)' being compiled [C:\Users\jasne\Projects\node\libnode.vcxproj]
C:\Users\jasne\Projects\node\src\debug_utils-inl.h(42,1): warning C4804: '>>=': unsafe use of type 'bool' in operation [C:\Users\jasne\Projects\node\libnode.vcxproj]
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
