### PR TITLE
doc: fix return type of `crypto.getFips()`

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2309,7 +2309,8 @@ added: v10.0.0
 -->
 
 * Returns: {number} `1` if and only if a FIPS compliant crypto provider is
-  currently in use, `0` otherwise.
+  currently in use, `0` otherwise. A future semver-major release may change
+  the return type of this API to a {boolean}.
 
 ### `crypto.getHashes()`
 <!-- YAML

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2308,8 +2308,8 @@ console.log(aliceSecret === bobSecret);
 added: v10.0.0
 -->
 
-* Returns: {boolean} `true` if and only if a FIPS compliant crypto provider is
-  currently in use.
+* Returns: {number} `1` if and only if a FIPS compliant crypto provider is
+  currently in use, `0` otherwise.
 
 ### `crypto.getHashes()`
 <!-- YAML


### PR DESCRIPTION
`crypto.getFips()` returns a number, not a boolean.

cc @danbev @nodejs/crypto 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
