### PR TITLE
lib: use map for worker mapping in cluster

### DIFF
--- a/benchmark/cluster/echo.js
+++ b/benchmark/cluster/echo.js
@@ -50,12 +50,11 @@ if (cluster.isMaster) {
     function broadcast() {
       if (broadcasts++ === n) {
         bench.end(n);
-        for (const id in cluster.workers)
-          cluster.workers[id].disconnect();
+        for (const worker of cluster.workers.values())
+          worker.disconnect();
         return;
       }
-      for (const id in cluster.workers) {
-        const worker = cluster.workers[id];
+      for (const worker of cluster.workers.values()) {
         for (let i = 0; i < sendsPerBroadcast; ++i)
           worker.send(data);
       }

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -227,8 +227,8 @@ if (cluster.isMaster) {
     cluster.fork();
   }
 
-  for (const id in cluster.workers) {
-    cluster.workers[id].on('message', messageHandler);
+  for (const worker of cluster.workers.values()) {
+    worker.on('message', messageHandler);
   }
 
 } else {
@@ -836,13 +836,18 @@ if (cluster.isMaster) {
 ## `cluster.workers`
 <!-- YAML
 added: v0.7.0
+changes:
+  - version: TODO
+    pr-url: https://github.com/nodejs/node/pull/32584
+    description: Converted to map implementation for easier traversal and
+      size lookups
 -->
 
-* {Object}
+* {Map}
 
-A hash that stores the active worker objects, keyed by `id` field. Makes it
-easy to loop through all the workers. It is only available in the master
-process.
+A map that stores the active worker objects, keyed by `id` field. Makes it
+easy to loop through all the workers, either by `id` or by the `value`.
+It is only available in the master process.
 
 A worker is removed from `cluster.workers` after the worker has disconnected
 _and_ exited. The order between these two events cannot be determined in
@@ -852,8 +857,8 @@ list happens before last `'disconnect'` or `'exit'` event is emitted.
 ```js
 // Go through all workers
 function eachWorker(callback) {
-  for (const id in cluster.workers) {
-    callback(cluster.workers[id]);
+  for (const worker of cluster.workers.values()) {
+    callback(worker);
   }
 }
 eachWorker((worker) => {
@@ -865,7 +870,7 @@ Using the worker's unique id is the easiest way to locate the worker.
 
 ```js
 socket.on('data', (id) => {
-  const worker = cluster.workers[id];
+  const worker = cluster.workers.get(id);
 });
 ```
 

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -2,8 +2,7 @@
 
 const {
   Map,
-  ObjectKeys,
-  ObjectValues,
+  MapPrototypeValues,
 } = primordials;
 
 const assert = require('internal/assert');
@@ -27,7 +26,7 @@ const handles = new Map();
 cluster.isWorker = false;
 cluster.isMaster = true;
 cluster.Worker = Worker;
-cluster.workers = {};
+cluster.workers = new Map();
 cluster.settings = {};
 cluster.SCHED_NONE = SCHED_NONE;  // Leave it to the operating system.
 cluster.SCHED_RR = SCHED_RR;      // Master distributes connections.
@@ -85,7 +84,7 @@ cluster.setupMaster = function(options) {
     if (message.cmd !== 'NODE_DEBUG_ENABLED')
       return;
 
-    for (const worker of ObjectValues(cluster.workers)) {
+    for (const worker of MapPrototypeValues(cluster.workers)) {
       if (worker.state === 'online' || worker.state === 'listening') {
         process._debugProcess(worker.process.pid);
       } else {
@@ -143,9 +142,9 @@ function createWorkerProcess(id, env) {
 
 function removeWorker(worker) {
   assert(worker);
-  delete cluster.workers[worker.id];
+  cluster.workers.delete(worker.id);
 
-  if (ObjectKeys(cluster.workers).length === 0) {
+  if (cluster.workers.size === 0) {
     assert(handles.size === 0, 'Resource leak detected.');
     intercom.emit('disconnect');
   }
@@ -175,7 +174,7 @@ cluster.fork = function(env) {
 
   worker.process.once('exit', (exitCode, signalCode) => {
     /*
-     * Remove the worker from the workers list only
+     * Remove the worker from the workers map only
      * if it has disconnected, otherwise we might
      * still want to access it.
      */
@@ -199,7 +198,7 @@ cluster.fork = function(env) {
     removeHandlesForWorker(worker);
 
     /*
-     * Remove the worker from the workers list only
+     * Remove the worker from the workers map only
      * if its process has exited. Otherwise, we might
      * still want to access it.
      */
@@ -214,7 +213,7 @@ cluster.fork = function(env) {
 
   worker.process.on('internalMessage', internal(worker, onmessage));
   process.nextTick(emitForkNT, worker);
-  cluster.workers[worker.id] = worker;
+  cluster.workers.set(worker.id, worker);
   return worker;
 };
 
@@ -223,12 +222,10 @@ function emitForkNT(worker) {
 }
 
 cluster.disconnect = function(cb) {
-  const workers = ObjectKeys(cluster.workers);
-
-  if (workers.length === 0) {
+  if (cluster.workers.size === 0) {
     process.nextTick(() => intercom.emit('disconnect'));
   } else {
-    for (const worker of ObjectValues(cluster.workers)) {
+    for (const worker of MapPrototypeValues(cluster.workers)) {
       if (worker.isConnected()) {
         worker.disconnect();
       }

--- a/test/fixtures/clustered-server/app.js
+++ b/test/fixtures/clustered-server/app.js
@@ -21,8 +21,8 @@ if (cluster.isMaster) {
     if (msg.type === 'getpids') {
       const pids = [];
       pids.push(process.pid);
-      for (var key in cluster.workers)
-        pids.push(cluster.workers[key].process.pid);
+      for (const worker in cluster.workers.values())
+        pids.push(worker.process.pid);
       process.send({ type: 'pids', pids: pids });
     }
   });

--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -71,9 +71,8 @@ function master() {
 
   // Set up event handlers for every worker. Each worker sends a message when
   // it has received the expected number of packets. After that it disconnects.
-  for (const key in cluster.workers) {
-    if (cluster.workers.hasOwnProperty(key))
-      setupWorker(cluster.workers[key]);
+  for (const worker of cluster.workers.values()) {
+    setupWorker(worker);
   }
 
   function setupWorker(worker) {

--- a/test/parallel/test-cluster-dgram-bind-fd.js
+++ b/test/parallel/test-cluster-dgram-bind-fd.js
@@ -62,9 +62,8 @@ function master() {
 
   // Set up event handlers for every worker. Each worker sends a message when
   // it has received the expected number of packets. After that it disconnects.
-  for (const key in cluster.workers) {
-    if (cluster.workers.hasOwnProperty(key))
-      setupWorker(cluster.workers[key]);
+  for (const worker of cluster.workers.values()) {
+    setupWorker(worker);
   }
 
   function setupWorker(worker) {

--- a/test/parallel/test-cluster-disconnect-idle-worker.js
+++ b/test/parallel/test-cluster-disconnect-idle-worker.js
@@ -29,6 +29,6 @@ if (cluster.isMaster) {
   fork(); // It is intentionally called `fork` instead of
   fork(); // `cluster.fork` to test that `this` is not used
   cluster.disconnect(common.mustCall(() => {
-    assert.deepStrictEqual(Object.keys(cluster.workers), []);
+    assert.strictEqual(cluster.workers.size, 0);
   }));
 }

--- a/test/parallel/test-cluster-shared-leak.js
+++ b/test/parallel/test-cluster-shared-leak.js
@@ -32,7 +32,7 @@ if (cluster.isMaster) {
     assert(worker === worker1 || worker === worker2);
     assert.strictEqual(exitCode, 0);
     assert.strictEqual(signalCode, null);
-    if (Object.keys(cluster.workers).length === 0)
+    if (cluster.workers.size === 0)
       conn.destroy();
   });
 

--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -52,9 +52,8 @@ if (cluster.isMaster) {
       // not guaranteed on secureConnect (it depends on TLS1.2 vs TLS1.3), but
       // it is guaranteed to happen before the connection is closed.
       if (++reqCount === expectedReqCount) {
-        Object.keys(cluster.workers).forEach(function(id) {
-          cluster.workers[id].send('die');
-        });
+        for (const worker of cluster.workers.values())
+          worker.send('die');
       } else {
         shoot();
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

In cluster master, we were using Object for storing workerId and
iterating on values and deciding the logic based on the length etc. For
such use-cases, Map is a better fit than an Object. As we don't have to recompute the keys every time for length purposes and the same benefits of lookup and deletion in O(1) (average case basis).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->