### PR TITLE
doc: fix more broken links

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -7,7 +7,7 @@
 * [Technical Steering Committee](#technical-steering-committee)
   * [TSC Meetings](#tsc-meetings)
 * [Collaborator Nominations](#collaborator-nominations)
-  * [Onboarding](#./onboarding)
+  * [Onboarding](#onboarding)
 * [Consensus Seeking Process](#consensus-seeking-process)
 
 <!-- /TOC -->

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ For information about the governance of the Node.js project, see
 **Matteo Collina** &lt;matteo.collina@gmail.com&gt; (he/him)
 * [mhdawson](https://github.com/mhdawson) -
 **Michael Dawson** &lt;michael_dawson@ca.ibm.com&gt; (he/him)
-* [mildsunrise](https://github.com/mildsunrise)
+* [mildsunrise](https://github.com/mildsunrise) -
 **Alba Mendez** &lt;me@alba.sh&gt; (she/her)
 * [misterdjules](https://github.com/misterdjules) -
 **Julien Gilli** &lt;jgilli@nodejs.org&gt;

--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -752,13 +752,13 @@ If you cannot find who to cc for a file, `git shortlog -n -s <file>` may help.
 
 ["Merge Pull Request"]: https://help.github.com/articles/merging-a-pull-request/#merging-a-pull-request-on-github
 [Deprecation]: https://en.wikipedia.org/wiki/Deprecation
-[Stability Index]: doc/api/documentation.md#stability-index
+[Stability Index]: ../api/documentation.md#stability-index
 [TSC]: https://github.com/nodejs/TSC
-[`--pending-deprecation`]: doc/api/cli.md#--pending-deprecation
-[`--throw-deprecation`]: doc/api/cli.md#--throw-deprecation
+[`--pending-deprecation`]: ../api/cli.md#--pending-deprecation
+[`--throw-deprecation`]: ../api/cli.md#--throw-deprecation
 [`node-core-utils`]: https://github.com/nodejs/node-core-utils
-[backporting guide]: doc/guides/backporting-to-release-lines.md
-[commit message guidelines]: ./doc/guides/contributing/pull-requests.md#commit-message-guidelines
+[backporting guide]: backporting-to-release-lines.md
+[commit message guidelines]: contributing/pull-requests.md#commit-message-guidelines
 [commit-example]: https://github.com/nodejs/node/commit/b636ba8186
 [git-node]: https://github.com/nodejs/node-core-utils/blob/master/docs/git-node.md
 [git-node-metadata]: https://github.com/nodejs/node-core-utils/blob/master/docs/git-node.md#git-node-metadata

--- a/doc/guides/doc-style-guide.md
+++ b/doc/guides/doc-style-guide.md
@@ -68,4 +68,4 @@ See also API documentation structure overview in [doctools README][].
 [Javascript type]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Data_structures_and_types
 [serial commas]: https://en.wikipedia.org/wiki/Serial_comma
 [plugin]: https://editorconfig.org/#download
-[doctools README]: ../tools/doc/README.md
+[doctools README]: ../../tools/doc/README.md

--- a/onboarding.md
+++ b/onboarding.md
@@ -110,7 +110,7 @@ onboarding session.
     organization (not just Collaborators on Node.js core) have access. Its
     contents should not be shared externally.
   * You can find the full moderation policy
-    [here](https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md).
+    [here](https://github.com/nodejs/admin/blob/master/Moderation-Policy.md).
 
 ## Reviewing PRs
 

--- a/tools/doc/checkLinks.js
+++ b/tools/doc/checkLinks.js
@@ -27,6 +27,8 @@ function findMarkdownFilesRecursively(dirPath) {
     if (
       entry.isDirectory() &&
       entry.name !== 'api' &&
+      entry.name !== 'fixtures' &&
+      entry.name !== 'changelogs' &&
       entry.name !== 'deps' &&
       entry.name !== 'node_modules'
     ) {

--- a/tools/doc/checkLinks.js
+++ b/tools/doc/checkLinks.js
@@ -1,13 +1,16 @@
 'use strict';
 
 const fs = require('fs');
-const { Worker, isMainThread, workerData: path } = require('worker_threads');
+const { extname, join, resolve } = require('path');
+const unified = require('unified');
+const { pathToFileURL } = require('url');
+const DIR = resolve(process.argv[2]);
+
+console.log('Running Markdown link checker...');
+findMarkdownFilesRecursively(DIR);
 
 function* getLinksRecursively(node) {
-  if (
-    (node.type === 'link' && !node.url.startsWith('#')) ||
-    node.type === 'image'
-  ) {
+  if (node.url && !node.url.startsWith('#')) {
     yield node;
   }
   for (const child of node.children || []) {
@@ -15,46 +18,26 @@ function* getLinksRecursively(node) {
   }
 }
 
-if (isMainThread) {
-  const { extname, join, resolve } = require('path');
-  const DIR = resolve(process.argv[2]);
+function findMarkdownFilesRecursively(dirPath) {
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
 
-  console.log('Running Markdown link checker...');
+  for (const entry of entries) {
+    const path = join(dirPath, entry.name);
 
-  async function* findMarkdownFilesRecursively(dirPath) {
-    const fileNames = await fs.promises.readdir(dirPath);
-
-    for (const fileName of fileNames) {
-      const path = join(dirPath, fileName);
-
-      const stats = await fs.promises.stat(path);
-      if (
-        stats.isDirectory() &&
-        fileName !== 'api' &&
-        fileName !== 'deps' &&
-        fileName !== 'node_modules'
-      ) {
-        yield* findMarkdownFilesRecursively(path);
-      } else if (extname(fileName) === '.md') {
-        yield path;
-      }
+    if (
+      entry.isDirectory() &&
+      entry.name !== 'api' &&
+      entry.name !== 'deps' &&
+      entry.name !== 'node_modules'
+    ) {
+      findMarkdownFilesRecursively(path);
+    } else if (entry.isFile() && extname(entry.name) === '.md') {
+      checkFile(path);
     }
   }
+}
 
-  function errorHandler(error) {
-    console.error(error);
-    process.exitCode = 1;
-  }
-
-  setImmediate(async () => {
-    for await (const path of findMarkdownFilesRecursively(DIR)) {
-      new Worker(__filename, { workerData: path }).on('error', errorHandler);
-    }
-  });
-} else {
-  const unified = require('unified');
-  const { pathToFileURL } = require('url');
-
+function checkFile(path) {
   const tree = unified()
     .use(require('remark-parse'))
     .parse(fs.readFileSync(path));
@@ -63,12 +46,9 @@ if (isMainThread) {
   for (const node of getLinksRecursively(tree)) {
     const targetURL = new URL(node.url, base);
     if (targetURL.protocol === 'file:' && !fs.existsSync(targetURL)) {
-      const error = new Error('Broken link in a Markdown document.');
-      const { start } = node.position;
-      error.stack =
-        error.stack.substring(0, error.stack.indexOf('\n') + 5) +
-        `at ${node.type} (${path}:${start.line}:${start.column})`;
-      throw error;
+      const { line, column } = node.position.start;
+      console.error(`Broken link at ${path}:${line}:${column} (${node.url})`);
+      process.exitCode = 1;
     }
   }
 }


### PR DESCRIPTION
This proposes some improvements to the Markdown link checker from #32359:

- Check link definitions too
- Report all broken links in a file, not just the first one
- Avoid use of workers & other simplifications (launching ~90 workers has substantial overhead; in my 4-core machine this makes it 25% faster)
- Exclude `doc/changelogs` because they're huge files which take very long to parse, and (IIRC) are auto-generated anyway (this cuts out 90% of the time)

Then fix the broken links, and exclude `test/fixtures` as there's some invalid links there.

Pinging @aduh95 as he wrote the tool :) Feel free to review, and if there's some detail I've missed from your code, tell me and I'll fix it.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)