### PR TITLE
deps: revert whitespace changes on V8

### DIFF
--- a/deps/v8/test/cctest/interpreter/bytecode_expectations/PrivateMethodAccess.golden
+++ b/deps/v8/test/cctest/interpreter/bytecode_expectations/PrivateMethodAccess.golden
@@ -111,7 +111,7 @@ snippet: "
     #d() { return 1; }
     constructor() { (() => this)().#d(); }
   }
-
+  
   var test = D;
   new test;
 "
@@ -147,3 +147,4 @@ constant pool: [
 ]
 handlers: [
 ]
+

--- a/deps/v8/test/inspector/debugger/class-private-methods-preview-expected.txt
+++ b/deps/v8/test/inspector/debugger/class-private-methods-preview-expected.txt
@@ -9,7 +9,7 @@ expression: new class { #method() { return 1; } get #accessor() { } set #accesso
     [0] : {
         name : #method
         type : function
-        value :
+        value : 
     }
     [1] : {
         name : #accessor
@@ -21,7 +21,7 @@ expression: new class extends class { #method() { return 1; } } { get #accessor(
     [0] : {
         name : #method
         type : function
-        value :
+        value : 
     }
     [1] : {
         name : #accessor

--- a/deps/v8/test/inspector/debugger/wasm-scope-info-liftoff-expected.txt
+++ b/deps/v8/test/inspector/debugger/wasm-scope-info-liftoff-expected.txt
@@ -17,7 +17,7 @@ at C (interpreted) (0:85):
    globals: "global#0": 0 (number)
  - scope (local):
    locals: "i32_arg": 42 (number), "i32_local": 0 (number)
-   stack:
+   stack: 
 at B (liftoff) (0:76):
  - scope (global):
    globals: "global#0": 0 (number)
@@ -29,7 +29,7 @@ at A (liftoff) (0:54):
    globals: "global#0": 0 (number)
  - scope (local):
    locals: "arg#0": 42 (number)
-   stack:
+   stack: 
 at (anonymous) (0:17):
  - scope (global):
    -- skipped globals
@@ -54,7 +54,7 @@ at A (liftoff) (0:54):
    globals: "global#0": 0 (number)
  - scope (local):
    locals: "arg#0": 42 (number)
-   stack:
+   stack: 
 at (anonymous) (0:17):
  - scope (global):
    -- skipped globals
@@ -67,7 +67,7 @@ at C (interpreted) (0:89):
    globals: "global#0": 42 (number)
  - scope (local):
    locals: "i32_arg": 42 (number), "i32_local": 0 (number)
-   stack:
+   stack: 
 at B (liftoff) (0:76):
  - scope (global):
    globals: "global#0": 42 (number)
@@ -79,7 +79,7 @@ at A (liftoff) (0:54):
    globals: "global#0": 42 (number)
  - scope (local):
    locals: "arg#0": 42 (number)
-   stack:
+   stack: 
 at (anonymous) (0:17):
  - scope (global):
    -- skipped globals
@@ -104,7 +104,7 @@ at A (liftoff) (0:54):
    globals: "global#0": 42 (number)
  - scope (local):
    locals: "arg#0": 42 (number)
-   stack:
+   stack: 
 at (anonymous) (0:17):
  - scope (global):
    -- skipped globals
@@ -117,7 +117,7 @@ at C (interpreted) (0:93):
    globals: "global#0": 42 (number)
  - scope (local):
    locals: "i32_arg": 42 (number), "i32_local": 47 (number)
-   stack:
+   stack: 
 at B (liftoff) (0:76):
  - scope (global):
    globals: "global#0": 42 (number)
@@ -129,7 +129,7 @@ at A (liftoff) (0:54):
    globals: "global#0": 42 (number)
  - scope (local):
    locals: "arg#0": 42 (number)
-   stack:
+   stack: 
 at (anonymous) (0:17):
  - scope (global):
    -- skipped globals

--- a/deps/v8/test/inspector/runtime/evaluate-repl-await-expected.txt
+++ b/deps/v8/test/inspector/runtime/evaluate-repl-await-expected.txt
@@ -14,10 +14,10 @@ Tests that top-level await in Runtime.evaluate REPL mode includes stack trace.
                 callFrames : [
                     [0] : {
                         columnNumber : 0
-                        functionName :
+                        functionName : 
                         lineNumber : 0
                         scriptId : <scriptId>
-                        url :
+                        url : 
                     }
                 ]
             }
@@ -50,21 +50,21 @@ Tests that top-level await in Runtime.evaluate REPL mode includes stack trace.
                         functionName : bar
                         lineNumber : 2
                         scriptId : <scriptId>
-                        url :
+                        url : 
                     }
                     [1] : {
                         columnNumber : 6
                         functionName : foo
                         lineNumber : 6
                         scriptId : <scriptId>
-                        url :
+                        url : 
                     }
                     [2] : {
                         columnNumber : 4
-                        functionName :
+                        functionName : 
                         lineNumber : 9
                         scriptId : <scriptId>
-                        url :
+                        url : 
                     }
                 ]
             }


### PR DESCRIPTION
While landing the upgrade to V8 8.1, something went wrong and git made
unecessary (and incorrect) whitespace changes to test fixtures, which
broke V8 tests. Revert those changes to fix our tests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
