### PR TITLE
test: replace console.error() with debuglog calls

### DIFF
--- a/test/parallel/test-http-information-processing.js
+++ b/test/parallel/test-http-information-processing.js
@@ -2,16 +2,17 @@
 require('../common');
 const assert = require('assert');
 const http = require('http');
+const debug = require('util').debuglog('test');
 
 const testResBody = 'other stuff!\n';
 const kMessageCount = 2;
 
 const server = http.createServer((req, res) => {
   for (let i = 0; i < kMessageCount; i++) {
-    console.error(`Server sending informational message #${i}...`);
+    debug(`Server sending informational message #${i}...`);
     res.writeProcessing();
   }
-  console.error('Server sending full response...');
+  debug('Server sending full response...');
   res.writeHead(200, {
     'Content-Type': 'text/plain',
     'ABCD': '1'
@@ -25,7 +26,7 @@ server.listen(0, function() {
     path: '/world'
   });
   req.end();
-  console.error('Client sending request...');
+  debug('Client sending request...');
 
   let body = '';
   let infoCount = 0;
@@ -40,7 +41,7 @@ server.listen(0, function() {
     res.setEncoding('utf8');
     res.on('data', function(chunk) { body += chunk; });
     res.on('end', function() {
-      console.error('Got full response.');
+      debug('Got full response.');
       assert.strictEqual(body, testResBody);
       assert.ok('abcd' in res.headers);
       server.close();


### PR DESCRIPTION
Somehow thought I did this in 8905be2ceea9abead85a5018c09645a3650d7495
but clearly did not.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
