### PR TITLE
test: mark test-worker-prof flaky on linux

### DIFF
--- a/test/root.status
+++ b/test/root.status
@@ -153,6 +153,7 @@ sequential/test-inspector-port-cluster: SLOW
 sequential/test-net-bytes-per-incoming-chunk-overhead: SLOW
 sequential/test-pipe: SLOW
 sequential/test-util-debug: SLOW
+sequential/test-worker-prof: SLOW
 
 [$type==coverage]
 async-hooks/test-callback-error: PASS,FAIL,CRASH


### PR DESCRIPTION
Consistently failing on ubuntu1804_sharedlibs_debug_x64

Refs: https://github.com/nodejs/node/issues/26401
