### PR TITLE
net: fix crash if POLLHUP is received

### DIFF
--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -517,12 +517,20 @@ uv_buf_t CustomBufferJSListener::OnStreamAlloc(size_t suggested_size) {
 
 void CustomBufferJSListener::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
   CHECK_NOT_NULL(stream_);
-  CHECK_EQ(buf.base, buffer_.base);
 
   StreamBase* stream = static_cast<StreamBase*>(stream_);
   Environment* env = stream->stream_env();
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
+
+  // To deal with the case where POLLHUP is received and UV_EOF is returned, as
+  // libuv returns an empty buffer. (On unices only)
+  if (nread == UV_EOF && buf.base == nullptr) {
+    stream->CallJSOnreadMethod(nread, Local<ArrayBuffer>());
+    return;
+  }
+
+  CHECK_EQ(buf.base, buffer_.base);
 
   MaybeLocal<Value> ret = stream->CallJSOnreadMethod(nread,
                              Local<ArrayBuffer>(),

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -524,7 +524,7 @@ void CustomBufferJSListener::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
   Context::Scope context_scope(env->context());
 
   // To deal with the case where POLLHUP is received and UV_EOF is returned, as
-  // libuv returns an empty buffer. (On unices only)
+  // libuv returns an empty buffer (on unices only).
   if (nread == UV_EOF && buf.base == nullptr) {
     stream->CallJSOnreadMethod(nread, Local<ArrayBuffer>());
     return;


### PR DESCRIPTION
If the `onread` socket option is used and a `POLLHUP` event is received,
libuv returns `UV_EOF` along with a `NULL` buffer in the read callback,
causing the crash. Deal with this case.
See: https://github.com/nodejs/node/blob/master/deps/uv/src/unix/stream.c#L1317-L1323

Fixes: https://github.com/nodejs/node/issues/31823
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
