### PR TITLE
doc: adjust paths in openssl maintenance guide

### DIFF
--- a/doc/guides/maintaining-openssl.md
+++ b/doc/guides/maintaining-openssl.md
@@ -83,8 +83,8 @@ Update all architecture dependent files. Do not forget to git add or remove
 files if they are changed before commit:
 ```sh
 % git add deps/openssl/config/archs
-% git add deps/openssl/openssl/crypto/include/internal/bn_conf.h
-% git add deps/openssl/openssl/crypto/include/internal/dso_conf.h
+% git add deps/openssl/openssl/include/crypto/bn_conf.h
+% git add deps/openssl/openssl/include/crypto/dso_conf.h
 % git add deps/openssl/openssl/include/openssl/opensslconf.h
 % git commit
 ```
@@ -98,8 +98,8 @@ The commit message can be (with the openssl version set to the relevant value):
     $ cd deps/openssl/config
     $ make
     $ git add deps/openssl/config/archs
-    $ git add deps/openssl/openssl/crypto/include/internal/bn_conf.h
-    $ git add deps/openssl/openssl/crypto/include/internal/dso_conf.h
+    $ git add deps/openssl/openssl/include/crypto/bn_conf.h
+    $ git add deps/openssl/openssl/include/crypto/dso_conf.h
     $ git add deps/openssl/openssl/include/openssl/opensslconf.h
     $ git commit
 ```


### PR DESCRIPTION
The path for the crypto files in the `deps/openssl/openssl/`
after running `cd deps/openssl/config && make` has been changed.
The original path `deps/openssl/openssl/crypto/includes/internal/`
now maps to `deps/openssl/openssl/includes/crypto`for the files that
need to be added for the commit.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
