### PR TITLE
[v12.x] cli: allow --jitless V8 flag in NODE_OPTIONS

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -163,6 +163,14 @@ added: v12.9.0
 
 Enable experimental JSON support for the ES Module loader.
 
+### `--experimental-loader=module`
+<!-- YAML
+added: v9.0.0
+-->
+
+Specify the `module` of a custom [experimental ECMAScript Module loader][].
+`module` may be either a path to a file, or an ECMAScript Module name.
+
 ### `--experimental-modules`
 <!-- YAML
 added: v8.5.0
@@ -421,14 +429,6 @@ Specify ways of the inspector web socket url exposure.
 By default inspector websocket url is available in stderr and under `/json/list`
 endpoint on `http://host:port/json/list`.
 
-### `--experimental-loader=module`
-<!-- YAML
-added: v9.0.0
--->
-
-Specify the `module` of a custom [experimental ECMAScript Module loader][].
-`module` may be either a path to a file, or an ECMAScript Module name.
-
 ### `--insecure-http-parser`
 <!-- YAML
 added: v12.15.0
@@ -438,6 +438,18 @@ Use an insecure HTTP parser that accepts invalid HTTP headers. This may allow
 interoperability with non-conformant HTTP implementations. It may also allow
 request smuggling and other HTTP attacks that rely on invalid headers being
 accepted. Avoid using this option.
+
+### `--jitless`
+<!-- YAML
+added: v12.0.0
+-->
+
+Disable [runtime allocation of executable memory][jitless]. This may be
+required on some platforms for security reasons. It can also reduce attack
+surface on other platforms, but the performance impact may be severe.
+
+This flag is inherited from V8 and is subject to change upstream. It may
+disappear in a non-semver-major release.
 
 ### `--max-http-header-size=size`
 <!-- YAML
@@ -1147,6 +1159,7 @@ V8 options that are allowed are:
 * `--abort-on-uncaught-exception`
 * `--disallow-code-generation-from-strings`
 * `--interpreted-frames-native-stack`
+* `--jitless`
 * `--max-old-space-size`
 * `--perf-basic-prof-only-functions`
 * `--perf-basic-prof`
@@ -1382,5 +1395,6 @@ greater than `4` (its current default value). For more information, see the
 [debugging security implications]: https://nodejs.org/en/docs/guides/debugging-getting-started/#security-implications
 [emit_warning]: process.html#process_process_emitwarning_warning_type_code_ctor
 [experimental ECMAScript Module loader]: esm.html#esm_experimental_loaders
+[jitless]: https://v8.dev/blog/jitless
 [libuv threadpool documentation]: http://docs.libuv.org/en/latest/threadpool.html
 [remote code execution]: https://www.owasp.org/index.php/Code_Injection

--- a/doc/node.1
+++ b/doc/node.1
@@ -116,6 +116,11 @@ Enable experimental Source Map V3 support for stack traces.
 .It Fl -experimental-json-modules
 Enable experimental JSON interop support for the ES Module loader.
 .
+.It Fl -experimental-loader Ns = Ns Ar module
+Specify the
+.Ar module
+to use as a custom module loader.
+.
 .It Fl -experimental-modules
 Enable experimental ES module support and caching modules.
 .
@@ -226,17 +231,20 @@ Default is
 V8 Inspector integration allows attaching Chrome DevTools and IDEs to Node.js instances for debugging and profiling.
 It uses the Chrome DevTools Protocol.
 .
-.It Fl -experimental-loader Ns = Ns Ar module
-Specify the
-.Ar module
-as a custom loader, to load
-.Fl -experimental-modules .
-.
 .It Fl -insecure-http-parser
 Use an insecure HTTP parser that accepts invalid HTTP headers. This may allow
 interoperability with non-conformant HTTP implementations. It may also allow
 request smuggling and other HTTP attacks that rely on invalid headers being
 accepted. Avoid using this option.
+.
+.It Fl -jitless
+Disable runtime allocation of executable memory. This may be required on
+some platforms for security reasons. It can also reduce attack surface on
+other platforms, but the performance impact may be severe.
+.
+.Pp
+This flag is inherited from V8 and is subject to change upstream. It may
+disappear in a non-semver-major release.
 .
 .It Fl -max-http-header-size Ns = Ns Ar size
 Specify the maximum size of HTTP headers in bytes. Defaults to 8KB.

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -643,6 +643,10 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
             "disallow eval and friends",
             V8Option{},
             kAllowedInEnvironment);
+  AddOption("--jitless",
+             "disable runtime allocation of executable memory",
+             V8Option{},
+             kAllowedInEnvironment);
 
 #ifdef NODE_REPORT
   AddOption("--report-uncaught-exception",

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -67,6 +67,7 @@ if (common.hasCrypto) {
 // V8 options
 expect('--abort_on-uncaught_exception', 'B\n');
 expect('--disallow-code-generation-from-strings', 'B\n');
+expect('--jitless', 'B\n');
 expect('--max-old-space-size=0', 'B\n');
 expect('--stack-trace-limit=100',
        /(\s*at f \(\[(eval|worker eval)\]:1:\d*\)\r?\n)/,

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -67,7 +67,8 @@ if (common.hasCrypto) {
 // V8 options
 expect('--abort_on-uncaught_exception', 'B\n');
 expect('--disallow-code-generation-from-strings', 'B\n');
-expect('--jitless', 'B\n');
+if (!common.isAIX)
+  expect('--jitless', 'B\n');
 expect('--max-old-space-size=0', 'B\n');
 expect('--stack-trace-limit=100',
        /(\s*at f \(\[(eval|worker eval)\]:1:\d*\)\r?\n)/,


### PR DESCRIPTION
This work is modeled on #30094 which allowed
`--disallow-code-generation-from-strings` in `NODE_OPTIONS`.

The `--jitless` v8 option has been supported since 12.0.0. As a v8
option, node automatically picks it up, but there have been a few issues
that were resolved by simply telling users about the option: #26758,

This PR:
  - allows `--jitless` in `NODE_OPTIONS`
  - documents `--jitless`
  - moves `--experimental-loader=module` to locally restore alphabetical
    order in option documentation

Refs: https://github.com/nodejs/node/pull/30094
Refs: https://github.com/nodejs/node/issues/26758
Refs: https://github.com/nodejs/node/issues/28800

PR-URL: https://github.com/nodejs/node/pull/32100
Reviewed-By: Richard Lau <riclau@uk.ibm.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Sam Roberts <vieuxtech@gmail.com>
Reviewed-By: Gus Caplan <me@gus.host>
Reviewed-By: Shelley Vohr <codebytere@gmail.com>
Reviewed-By: David Carlier <devnexen@gmail.com>
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Michael Dawson <michael_dawson@ca.ibm.com>
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>