### PR TITLE
test: mark test-http2-reset-flood flaky on bsd

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -49,6 +49,8 @@ test-crypto-keygen: SKIP
 [$system==freebsd]
 # https://github.com/nodejs/node/issues/31727
 test-fs-stat-bigint: PASS,FLAKY
+# https://github.com/nodejs/node/issues/29802
+test-http2-reset-flood: PASS,FLAKY
 
 [$system==aix]
 


### PR DESCRIPTION
This test is somewhat regularly flaky on 12.x and it appears master as
well. There appears to be an issue tracking flakes for 6+ months. Seems
reasonable to mark this to keep us from having red CI.

Refs: https://github.com/nodejs/node/issues/29802
