### PR TITLE
doc: make openssl commit messages be valid

### DIFF
--- a/doc/guides/maintaining-openssl.md
+++ b/doc/guides/maintaining-openssl.md
@@ -93,8 +93,8 @@ The commit message can be (with the openssl version set to the relevant value):
 ```text
  deps: update archs files for OpenSSL-1.1.0
 
- After an OpenSSL source update, all the config files need to be regenerated and
- committed by:
+ After an OpenSSL source update, all the config files need to be
+ regenerated and committed by:
     $ cd deps/openssl/config
     $ make
     $ git add deps/openssl/config/archs


### PR DESCRIPTION
The current commit message is wrapped at 80 columns, but commit message
descriptions should wrap at 72, so the maintainer has to fix the
message up instead of just copying it in. They might not notice that
requirement, in which case it has to be fixed during landing because
`git node land` notices. To prevent that, make the message template
wrap before 72 to keep the landing process as simple as possible.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
