### PR TITLE
[v12.x] deps: revert whitespace changes on V8

### DIFF
--- a/deps/v8/test/cctest/interpreter/bytecode_expectations/PrivateAccessorAccess.golden
+++ b/deps/v8/test/cctest/interpreter/bytecode_expectations/PrivateAccessorAccess.golden
@@ -12,7 +12,7 @@ snippet: "
   class A {
     get #a() { return 1; }
     set #a(val) { }
-
+  
     constructor() {
       this.#a++;
       this.#a = 1;
@@ -189,3 +189,4 @@ constant pool: [
 ]
 handlers: [
 ]
+

--- a/deps/v8/test/cctest/interpreter/bytecode_expectations/PrivateAccessorDeclaration.golden
+++ b/deps/v8/test/cctest/interpreter/bytecode_expectations/PrivateAccessorDeclaration.golden
@@ -165,7 +165,7 @@ snippet: "
       get #d() { return 1; }
       set #d(val) { }
     }
-
+  
     class E extends D {
       get #e() { return 2; }
       set #e(val) { }
@@ -395,3 +395,4 @@ constant pool: [
 ]
 handlers: [
 ]
+

--- a/deps/v8/test/cctest/interpreter/bytecode_expectations/PrivateMethodAccess.golden
+++ b/deps/v8/test/cctest/interpreter/bytecode_expectations/PrivateMethodAccess.golden
@@ -13,7 +13,7 @@ snippet: "
     #a() { return 1; }
     constructor() { return this.#a(); }
   }
-
+  
   var test = A;
   new A;
 "
@@ -44,7 +44,7 @@ snippet: "
     #b() { return 1; }
     constructor() { this.#b = 1; }
   }
-
+  
   var test = B;
   new test;
 "
@@ -76,7 +76,7 @@ snippet: "
     #c() { return 1; }
     constructor() { this.#c++; }
   }
-
+  
   var test = C;
   new test;
 "
@@ -101,3 +101,4 @@ constant pool: [
 ]
 handlers: [
 ]
+

--- a/deps/v8/test/cctest/interpreter/bytecode_expectations/PrivateMethodDeclaration.golden
+++ b/deps/v8/test/cctest/interpreter/bytecode_expectations/PrivateMethodDeclaration.golden
@@ -195,3 +195,4 @@ constant pool: [
 ]
 handlers: [
 ]
+


### PR DESCRIPTION
While landing some of the V8 upgrades on the v12 branch, something went
wrong and git made unecessary (and incorrect) whitespace changes to test
fixtures, which broke V8 tests. This was likely caused by the use of
`git node land` or a simiar tool. Revert those changes to fix our tests.
Since this only reverts unwanted changes on deps/v8, and it only affects
tests, don't bump v8_embedder_string.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
