### PR TITLE
workers: implement --max-worker-threads command line option

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1159,6 +1159,7 @@ Node.js options that are allowed are:
 * `--inspect-publish-uid`
 * `--inspect`
 * `--max-http-header-size`
+* `--max-worker-threads`
 * `--napi-modules`
 * `--no-deprecation`
 * `--no-force-async-hooks-checks`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -448,6 +448,17 @@ changes:
 
 Specify the maximum size, in bytes, of HTTP headers. Defaults to 16KB.
 
+### `--max-worker-threads=n`
+<!-- YAML
+added: REPLACEME
+-->
+
+Specify the maximum number of worker threads that should be created for
+this Node.js process. If the limit is exceeded, additional Worker threads
+may be created but a process warning will be emitted. When set to any negative
+value, the limit is set to four times the number of CPUs available. When set
+to 0, the check is disabled. Defaults to 0.
+
 ### `--napi-modules`
 <!-- YAML
 added: v7.10.0

--- a/doc/node.1
+++ b/doc/node.1
@@ -246,6 +246,13 @@ disappear in a non-semver-major release.
 .It Fl -max-http-header-size Ns = Ns Ar size
 Specify the maximum size of HTTP headers in bytes. Defaults to 16KB.
 .
+.It FL -max-worker-threads Ns = Ns Ar Size
+Specify the maximum number of worker threads that should be created for
+this Node.js process. If the limit is exceeded, additional Worker threads
+may be created but a process warning will be emitted. When set to any negative
+value, the limit is set to four times the number of CPUs available. When set to
+0, the check is disabled. Defaults to 0.
+.
 .It Fl -napi-modules
 This option is a no-op.
 It is kept for compatibility.

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -13,6 +13,8 @@
 
 namespace node {
 
+constexpr uint64_t kMaxWorkerThreadMultiplier = 4;
+
 class HostPort {
  public:
   HostPort(const std::string& host_name, int port)
@@ -199,6 +201,7 @@ class PerProcessOptions : public Options {
   std::string trace_event_categories;
   std::string trace_event_file_pattern = "node_trace.${rotation}.log";
   int64_t v8_thread_pool_size = 4;
+  int64_t max_worker_thread_count = 0;
   bool zero_fill_all_buffers = false;
   bool debug_arraybuffer_allocations = false;
   std::string disable_proto;

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -30,6 +30,7 @@ constexpr double SEC_PER_MICROS = 1e-6;
 namespace report {
 using node::arraysize;
 using node::ConditionVariable;
+using node::CPUInfo;
 using node::DiagnosticFilename;
 using node::Environment;
 using node::JSONWriter;
@@ -387,11 +388,10 @@ static void PrintVersionInformation(JSONWriter* writer) {
 
 // Report CPU info
 static void PrintCpuInfo(JSONWriter* writer) {
-  uv_cpu_info_t* cpu_info;
-  int count;
-  if (uv_cpu_info(&cpu_info, &count) == 0) {
+  CPUInfo cpu_info;
+  if (cpu_info) {
     writer->json_arraystart("cpus");
-    for (int i = 0; i < count; i++) {
+    for (int i = 0; i < cpu_info.count(); i++) {
       writer->json_start();
       writer->json_keyvalue("model", cpu_info[i].model);
       writer->json_keyvalue("speed", cpu_info[i].speed);
@@ -403,7 +403,6 @@ static void PrintCpuInfo(JSONWriter* writer) {
       writer->json_end();
     }
     writer->json_arrayend();
-    uv_free_cpu_info(cpu_info, count);
   }
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -33,6 +33,8 @@
 #pragma GCC diagnostic pop
 #endif
 
+#include "uv.h"
+
 #include <cassert>
 #include <climits>  // PATH_MAX
 #include <csignal>
@@ -762,6 +764,31 @@ class PersistentToLocal {
       const v8::PersistentBase<TypeName>& persistent) {
     return v8::Local<TypeName>::New(isolate, persistent);
   }
+};
+
+class CPUInfo {
+ public:
+  CPUInfo() {
+    if (uv_cpu_info(&info_, &count_) != 0) {
+      info_ = nullptr;
+      count_ = 0;
+    }
+  }
+  ~CPUInfo() {
+    if (info_ != nullptr)
+      uv_free_cpu_info(info_, count_);
+  }
+  int count() const { return count_; }
+  operator bool() const {
+    return info_ != nullptr;
+  }
+  const uv_cpu_info_t& operator[](int idx) const {
+    return info_[idx];
+  }
+
+ private:
+  uv_cpu_info_t* info_ = nullptr;
+  int count_ = 0;
 };
 
 }  // namespace node

--- a/test/parallel/test-cli-bad-options.js
+++ b/test/parallel/test-cli-bad-options.js
@@ -13,6 +13,7 @@ if (process.features.inspector) {
   requiresArgument('--debug-port=');
 }
 requiresArgument('--eval');
+requiresArgument('--max-worker-threads');
 
 function requiresArgument(option) {
   const r = spawn(process.execPath, [option], { encoding: 'utf8' });

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -28,6 +28,7 @@ expect('--no_warnings', 'B\n');
 expect('--trace-warnings', 'B\n');
 expect('--redirect-warnings=_', 'B\n');
 expect('--trace-deprecation', 'B\n');
+expectNoWorker('--max-worker-threads=1', 'B\n');
 expect('--trace-sync-io', 'B\n');
 expectNoWorker('--trace-events-enabled', 'B\n');
 expect('--track-heap-objects', 'B\n');

--- a/test/parallel/test-worker-max-count-auto.js
+++ b/test/parallel/test-worker-max-count-auto.js
@@ -1,0 +1,19 @@
+// Flags: --expose-internals --max-worker-threads=-1
+'use strict';
+
+// Check that when --max-worker-threads is negative,
+// the option value is auto-calculated based on the
+// number of CPUs
+
+require('../common');
+const { getOptionValue } = require('internal/options');
+const { cpus } = require('os');
+const assert = require('assert');
+
+// Make sure the flag is actually set
+assert(process.execArgv.indexOf('--max-worker-threads=-1') > -1);
+
+const kWorkerThreadsMultiplier = 4;
+const maxWorkerThreads = getOptionValue('--max-worker-threads');
+
+assert.strictEqual(cpus().length * kWorkerThreadsMultiplier, maxWorkerThreads);

--- a/test/parallel/test-worker-max-count-disabled.js
+++ b/test/parallel/test-worker-max-count-disabled.js
@@ -1,0 +1,33 @@
+// Flags: --max-worker-threads=0
+'use strict';
+const common = require('../common');
+const { Worker } = require('worker_threads');
+const { cpus } = require('os');
+
+const cpu_count = cpus().length;
+
+// This may need to be updated in the future if there are
+// any other warnings expected. For now, no warnings are
+// emitted with this code.
+process.on('warning', common.mustNotCall());
+
+const expr = 'setInterval(() => {}, 10);';
+
+function makeWorker(workers) {
+  return new Promise((res) => {
+    const worker = new Worker(expr, { eval: true });
+    worker.on('online', res);
+    workers.push(worker);
+  });
+}
+
+async function doTest() {
+  const workers = [];
+  const list = [];
+  for (let n = 0; n < cpu_count; n++)
+    list.push(makeWorker(workers));
+  await Promise.all(list);
+  workers.forEach((i) => i.terminate());
+}
+
+doTest().then(common.mustCall());

--- a/test/parallel/test-worker-max-count-nested.js
+++ b/test/parallel/test-worker-max-count-nested.js
@@ -34,7 +34,5 @@ if (process.argv[2] === 'child') {
     process.execPath,
     ['--max-worker-threads=1', __filename, 'child'],
     { stdio: 'inherit' });
-  child.on('close', common.mustCall((code) => {
-    assert.strictEqual(code, 0);
-  }));
+  child.on('close', common.mustCall((code) => assert(!code)));
 }

--- a/test/parallel/test-worker-max-count-nested.js
+++ b/test/parallel/test-worker-max-count-nested.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { spawn } = require('child_process');
+const { Worker } = require('worker_threads');
+
+if (process.argv[2] === 'child') {
+
+  // Checks that warning is emitted in the main thread,
+  // even tho the offending Worker is created from within
+  // another worker.
+  common.expectWarning({
+    Warning: [
+      'Too many active worker threads (2). Performance may be degraded. ' +
+      '(--max-worker-threads=1)'
+    ] });
+
+  const expr = `
+    setInterval(() => {}, 10);
+    const { Worker, parentPort } = require('worker_threads');
+    const expr = 'setInterval(() => {}, 10);';
+    const worker = new Worker(expr, { eval: true });
+    worker.on('online', () => {
+      worker.terminate();
+      parentPort.postMessage({});
+    });
+  `;
+
+  const worker = new Worker(expr, { eval: true });
+  worker.on('message', () => worker.terminate());
+
+} else {
+  const child = spawn(
+    process.execPath,
+    ['--max-worker-threads=1', __filename, 'child'],
+    { stdio: 'inherit' });
+  child.on('close', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+  }));
+}

--- a/test/parallel/test-worker-max-count.js
+++ b/test/parallel/test-worker-max-count.js
@@ -1,0 +1,46 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { spawn } = require('child_process');
+const { Worker } = require('worker_threads');
+const { cpus } = require('os');
+
+if (process.argv[2] === 'child') {
+  const cpu_count = cpus().length;
+
+  common.expectWarning({
+    Warning: [
+      'Too many active worker threads (2). Performance may be degraded. ' +
+      '(--max-worker-threads=1)'
+    ] });
+
+  const expr = 'setInterval(() => {}, 10);';
+
+  function makeWorker(workers) {
+    return new Promise((res) => {
+      const worker = new Worker(expr, { eval: true });
+      worker.on('online', res);
+      workers.push(worker);
+    });
+  }
+
+  async function doTest() {
+    const workers = [];
+    const list = [];
+    for (let n = 0; n < cpu_count; n++)
+      list.push(makeWorker(workers));
+    await Promise.all(list);
+    workers.forEach((i) => i.terminate());
+  }
+
+  doTest().then(doTest).then(common.mustCall());
+
+} else {
+  const child = spawn(
+    process.execPath,
+    ['--max-worker-threads=1', __filename, 'child'],
+    { stdio: 'inherit' });
+  child.on('close', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+  }));
+}


### PR DESCRIPTION
There are two commits here:

1. Adds a simple CPUInfo utility to make using uv_cpu_info just a tad easier
2. Implements the `--max-worker-threads` command line flag..

From the second commit message:

```
    Creating too many active worker threads at one time can
    lead to significant performance degradation of the entire
    Node.js process. This adds a worker thread counter that
    will cause a warning to be emitted if exceeded. Workers
    can still be created beyond the limit, however. The warning
    is similar in spirit to the too many event handlers warning
    emitted by EventEmitter.

    By default, the limit is one less than four times the total
    number of CPUs available calculated at system start. The
    `--max-worker-threads` command-line option can be set to
    set a non-default value. The option is permitted in
    `NODE_OPTIONS` and must be positive number greater than
    zero.

    The counter and the option are per-process in order to
    account for Workers that create their own Workers.

    The warning will be emitted once each time the limit
    is exceeded, so may be emitted more than once per process.
    That is, if the limit is 2, and 5 workers are created, only
    a single warning will be emitted. If the number of active
    workers falls back below 2 and is subsequently exceeded
    again, the warning will be emitted again.
```

/cc @addaleax 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
