### PR TITLE
Revert "embedding: make Stop() stop Workers"

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -725,7 +725,8 @@ ThreadId AllocateEnvironmentThreadId() {
 }
 
 void DefaultProcessExitHandler(Environment* env, int exit_code) {
-  Stop(env);
+  env->set_can_call_into_js(false);
+  env->stop_sub_worker_contexts();
   DisposePlatform();
   exit(exit_code);
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -1014,6 +1014,8 @@ void Environment::Exit(int exit_code) {
 }
 
 void Environment::stop_sub_worker_contexts() {
+  DCHECK_EQ(Isolate::GetCurrent(), isolate());
+
   while (!sub_worker_contexts_.empty()) {
     Worker* w = *sub_worker_contexts_.begin();
     remove_sub_worker_context(w);

--- a/src/env.cc
+++ b/src/env.cc
@@ -528,10 +528,9 @@ void Environment::InitializeLibuv(bool start_profiler_idle_notifier) {
   }
 }
 
-void Environment::Stop() {
+void Environment::ExitEnv() {
   set_can_call_into_js(false);
   set_stopping(true);
-  stop_sub_worker_contexts();
   isolate_->TerminateExecution();
   SetImmediateThreadsafe([](Environment* env) { uv_stop(env->event_loop()); });
 }

--- a/src/env.h
+++ b/src/env.h
@@ -899,7 +899,7 @@ class Environment : public MemoryRetainer {
   void RegisterHandleCleanups();
   void CleanupHandles();
   void Exit(int code);
-  void Stop();
+  void ExitEnv();
 
   // Register clean-up cb to be called on environment destruction.
   inline void RegisterHandleCleanup(uv_handle_t* handle,

--- a/src/node.cc
+++ b/src/node.cc
@@ -1059,7 +1059,7 @@ int Start(int argc, char** argv) {
 }
 
 int Stop(Environment* env) {
-  env->Stop();
+  env->ExitEnv();
   return 0;
 }
 

--- a/src/node.h
+++ b/src/node.h
@@ -224,8 +224,7 @@ class Environment;
 NODE_EXTERN int Start(int argc, char* argv[]);
 
 // Tear down Node.js while it is running (there are active handles
-// in the loop and / or actively executing JavaScript code). This also stops
-// all Workers that may have been started earlier.
+// in the loop and / or actively executing JavaScript code).
 NODE_EXTERN int Stop(Environment* env);
 
 // TODO(addaleax): Officially deprecate this and replace it with something
@@ -479,8 +478,8 @@ NODE_EXTERN void FreeEnvironment(Environment* env);
 // It receives the Environment* instance and the exit code as arguments.
 // This could e.g. call Stop(env); in order to terminate execution and stop
 // the event loop.
-// The default handler calls Stop(), disposes of the global V8 platform
-// instance, if one is being used, and calls exit().
+// The default handler disposes of the global V8 platform instance, if one is
+// being used, and calls exit().
 NODE_EXTERN void SetProcessExitHandler(
     Environment* env,
     std::function<void(Environment*, int)>&& handler);

--- a/test/parallel/test-worker-terminate-nested.js
+++ b/test/parallel/test-worker-terminate-nested.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+const { Worker } = require('worker_threads');
+
+// Check that a Worker that's running another Worker can be terminated.
+
+const worker = new Worker(`
+const { Worker, parentPort } = require('worker_threads');
+const worker = new Worker('setInterval(() => {}, 10);', { eval: true });
+worker.on('online', () => {
+  parentPort.postMessage({});
+});
+`, { eval: true });
+
+worker.on('message', common.mustCall(() => worker.terminate()));


### PR DESCRIPTION
##### Revert "embedding: make Stop() stop Workers"

This reverts commit 037ac99ed5aa763b7a3567da2cc81f9d7b97bdf9.

As flaky CI failures have revealed, this feature was implemented
incorrectly. `stop_sub_worker_contexts()` needs to be called on the
thread on which the `Environment` is currently running, it’s not
thread-safe. The current API requires `Stop()` to be thread-safe,
though.

We could add a new API for this, but unless there’s demand, that’s
probably not necessary as `FreeEnvironment()` will also stop Workers,
which is commonly the next action on an `Environment` instance after
having `Stop()` called on it.

Refs: https://github.com/nodejs/node/pull/32531

##### src,test: add regression test for nested Worker termination

This adds a regression test for terminating a Worker inside which
another Worker is running.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
