### PR TITLE
test: run test-abort-aliased-buffer-overflow

### DIFF
--- a/test/abort/test_abort-aliased-buffer-overflow/binding.cc
+++ b/test/abort/test_abort-aliased-buffer-overflow/binding.cc
@@ -21,3 +21,5 @@ void init(v8::Local<v8::Object> exports) {
                   "allocateAndResizeBuffer",
                   AllocateAndResizeBuffer);
 }
+
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/abort/test_abort-aliased-buffer-overflow/test-abort-aliased-buffer-overflow.js
+++ b/test/abort/test_abort-aliased-buffer-overflow/test-abort-aliased-buffer-overflow.js
@@ -1,7 +1,8 @@
 'use strict';
-const common = require('../common');
+const common = require('../../common');
 const assert = require('assert');
 const cp = require('child_process');
+const debuglog = require('util').debuglog('test');
 
 // This test ensures that during resizing of an Aliased*Array the computation
 // of the new size does not overflow.
@@ -10,19 +11,22 @@ if (process.argv[2] === 'child') {
   // test
   const binding = require(`./build/${common.buildType}/binding`);
 
-  const bigValue = BigInt('0xE000 0000 E000 0000');
-  binding.AllocateAndResizeBuffer(bigValue);
+  const bigValue = BigInt('0xE0000000E0000000');
+  binding.allocateAndResizeBuffer(bigValue);
   assert.fail('this should be unreachable');
 } else {
   // observer
   const child = cp.spawn(`${process.execPath}`, [`${__filename}`, 'child']);
+  let stderr = '';
+  let stdout = '';
+  child.stderr.setEncoding('utf8');
+  child.stdout.setEncoding('utf8');
+  child.stderr.on('data', (data) => stderr += data);
+  child.stdout.on('data', (data) => stdout += data);
   child.on('exit', common.mustCall(function(code, signal) {
-    if (common.isWindows) {
-      assert.strictEqual(code, 134);
-      assert.strictEqual(signal, null);
-    } else {
-      assert.strictEqual(code, null);
-      assert.strictEqual(signal, 'SIGABRT');
-    }
+    debuglog(`exit with code ${code}, signal ${signal}`);
+    debuglog(stdout);
+    debuglog(stderr);
+    assert.ok(common.nodeProcessAborted(code, signal));
   }));
 }

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -144,6 +144,8 @@ class AddonTestConfiguration(SimpleTestConfiguration):
         for f in os.listdir(os.path.join(path, subpath)):
           if SelectTest(f):
             result.append([subpath, f[:-3]])
+      elif SelectTest(subpath):
+        result.append([subpath[:-3]])
     return result
 
   def ListTests(self, current_path, path, arch, mode):
@@ -156,7 +158,7 @@ class AddonTestConfiguration(SimpleTestConfiguration):
             SimpleTestCase(tst, file_path, arch, mode, self.context, self, self.additional_flags))
     return result
 
-class AbortTestConfiguration(SimpleTestConfiguration):
+class AbortTestConfiguration(AddonTestConfiguration):
   def __init__(self, context, root, section, additional=None):
     super(AbortTestConfiguration, self).__init__(context, root, section,
                                                  additional)

--- a/tools/test.py
+++ b/tools/test.py
@@ -1488,6 +1488,7 @@ def PrintCrashed(code):
 # default JavaScript test-run, e.g., internet/ requires a network connection,
 # addons/ requires compilation.
 IGNORED_SUITES = [
+  'abort',
   'addons',
   'benchmark',
   'doctool',

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -92,7 +92,7 @@ if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="ltcg"          set ltcg=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
 if /i "%1"=="test"          set test_args=%test_args% -J %common_test_suites%&set lint_cpp=1&set lint_js=1&set lint_md=1&goto arg-ok
-if /i "%1"=="test-ci-native" set test_args=%test_args% %test_ci_args% -J -p tap --logfile test.tap %CI_NATIVE_SUITES% %CI_DOC%&set build_addons=1&set build_js_native_api_tests=1&set build_node_api_tests=1&set cctest_args=%cctest_args% --gtest_output=xml:cctest.junit.xml&goto arg-ok
+if /i "%1"=="test-ci-native" set test_args=%test_args% %test_ci_args% -J -p tap --logfile test.tap %CI_NATIVE_SUITES% %CI_DOC%&set build_addons=1&set build_js_native_api_tests=1&set build_node_api_tests=1&set build_abort_tests=1&set cctest_args=%cctest_args% --gtest_output=xml:cctest.junit.xml&goto arg-ok
 if /i "%1"=="test-ci-js"    set test_args=%test_args% %test_ci_args% -J -p tap --logfile test.tap %CI_JS_SUITES%&set no_cctest=1&goto arg-ok
 if /i "%1"=="build-addons"   set build_addons=1&goto arg-ok
 if /i "%1"=="build-js-native-api-tests"   set build_js_native_api_tests=1&goto arg-ok


### PR DESCRIPTION
https://github.com/nodejs/node/pull/31740 added an addon-style test to
`test/abort` that was never run because `test/abort/testcfg.py` uses the
AbortTestConfiguration which inherits from SimpleTestConfiguration which
only finds tests in the root of `test/abort`.

Make AbortTestConfiguration inherit from AddonTestConfiguration and
change AddonTestConfiguration to find the tests in the root of the test
bucket in addition to the subfolders.

Fixup `test-abort-aliased-buffer-overflow` so that it works as intended.

Refs: https://github.com/nodejs/node/pull/31740

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
