### PR TITLE
doc: updating Ninja guide

### DIFF
--- a/doc/guides/building-node-with-ninja.md
+++ b/doc/guides/building-node-with-ninja.md
@@ -4,13 +4,15 @@ The purpose of this guide is to show how to build Node.js using [Ninja][], as
 doing so can be significantly quicker than using `make`. Please see
 [Ninja's site][Ninja] for installation instructions (Unix only).
 
-To build Node.js with ninja, there are 3 steps that must be taken:
+[Ninja][] is supported in the Makefile. Run `./configure --ninja` to configure
+the project to run the regular `make` commands with Ninja.
 
-1. Configure the project's OS-based build rules via `./configure --ninja`.
-2. Run `ninja -C out/Release` to produce a compiled release binary.
-3. Lastly, make symlink to `./node` using `ln -fs out/Release/node node`.
+For example, `make` will execute `ninja -C out/Release` internally
+to produce a compiled release binary, It will also execute
+`ln -fs out/Release/node node`, so that you can execute `./node` at
+the project's root.
 
-When running `ninja -C out/Release` you will see output similar to the following
+When running `make`, you will see output similar to the following
 if the build has succeeded:
 
 ```txt
@@ -22,27 +24,20 @@ The bottom line will change while building, showing the progress as
 `[finished/total]` build steps. This is useful output that `make` does not
 produce and is one of the benefits of using Ninja. Also, Ninja will likely
 compile much faster than even `make -j4` (or
-`-j<number of processor threads on your machine>`).
+`-j<number of processor threads on your machine>`). You can still pass the
+number of processes to run for [Ninja][] using the environment variable `JOBS`.
+This will be the equivalent to the `-j` parameter in the regular `make`:
 
-## Considerations
-
-Ninja builds vary slightly from `make` builds. If you wish to run `make test`
-after, `make` will likely still need to rebuild some amount of Node.js.
-
-As such, if you wish to run the tests, it can be helpful to invoke the test
-runner directly, like so:
-`tools/test.py --mode=release message parallel sequential -J`
-
-## Alias
-
-`alias nnode='./configure --ninja && ninja -C out/Release && ln -fs
-out/Release/node node'`
+```bash
+$ JOBS=12 make
+```
 
 ## Producing a debug build
 
-The above alias can be modified slightly to produce a debug build, rather than a
-release build as shown below:
-`alias nnodedebug='./configure --ninja && ninja -C out/Debug && ln -fs
-out/Debug/node node_g'`
+To create a debug build rather than a release build:
+
+```bash
+$ ./configure --ninja --debug && make
+```
 
 [Ninja]: https://ninja-build.org/


### PR DESCRIPTION
This PR updates the guide to use Ninja, because the instructions were outdated after merging this [PR](https://github.com/nodejs/node/pull/27504/commits/46eb532a2a144ebd0fe1aa91a2b4a9e9372aa902)  

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master
