### PR TITLE
test: remove unused variables on async hook test

### DIFF
--- a/test/parallel/test-async-hooks-enable-recursive.js
+++ b/test/parallel/test-async-hooks-enable-recursive.js
@@ -9,7 +9,7 @@ const nestedHook = async_hooks.createHook({
 });
 
 async_hooks.createHook({
-  init: common.mustCall((id, type) => {
+  init: common.mustCall(() => {
     nestedHook.enable();
   }, 2)
 }).enable();


### PR DESCRIPTION
This commit removes the `id` and `type` arguments from the mustCall
function on init.

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
