### PR TITLE
fs: add --fs-url-strings option

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -272,6 +272,13 @@ reference. Code may break under this flag.
 `--require` runs prior to freezing intrinsics in order to allow polyfills to
 be added.
 
+### `--fs-url-strings`
+<!-- YAML
+added: REPLACEME
+-->
+
+Enables use of `'file://'` URL strings in `fs` module APIs.
+
 ### `--heapsnapshot-signal=signal`
 <!-- YAML
 added: v12.0.0
@@ -1138,6 +1145,7 @@ Node.js options that are allowed are:
 * `--force-context-aware`
 * `--force-fips`
 * `--frozen-intrinsics`
+* `--fs-url-strings`
 * `--heapsnapshot-signal`
 * `--http-parser`
 * `--icu-data-dir`

--- a/doc/node.1
+++ b/doc/node.1
@@ -167,6 +167,9 @@ Same requirements as
 .It Fl -frozen-intrinsics
 Enable experimental frozen intrinsics support.
 .
+.It Fl -fs-url-strings
+Enables use of 'file://' URL strings in `fs` module APIs.
+.
 .It Fl -heapsnapshot-signal Ns = Ns Ar signal
 Generate heap snapshot on specified signal.
 .

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -87,6 +87,8 @@ const special = Symbol('special');
 const searchParams = Symbol('query');
 const kFormat = Symbol('format');
 
+let fsURLStrings = undefined;
+
 // https://tc39.github.io/ecma262/#sec-%iteratorprototype%-object
 const IteratorPrototype = ObjectGetPrototypeOf(
   ObjectGetPrototypeOf([][SymbolIterator]())
@@ -1401,8 +1403,16 @@ function isURLInstance(fileURLOrPath) {
 }
 
 function toPathIfFileURL(fileURLOrPath) {
-  if (!isURLInstance(fileURLOrPath))
+  if (!isURLInstance(fileURLOrPath)) {
+    if (fsURLStrings === undefined) {
+      const { getOptionValue } = require('internal/options');
+      fsURLStrings = !!getOptionValue('--fs-url-strings');
+    }
+
+    if (fsURLStrings && fileURLOrPath.startsWith('file://'))
+      return fileURLToPath(new URL(fileURLOrPath));
     return fileURLOrPath;
+  }
   return fileURLToPath(fileURLOrPath);
 }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -329,6 +329,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental frozen intrinsics support",
             &EnvironmentOptions::frozen_intrinsics,
             kAllowedInEnvironment);
+  AddOption("--fs-url-strings",
+            "enable file:// URL strings in the fs API",
+            &EnvironmentOptions::fs_url_strings,
+            kAllowedInEnvironment);
   AddOption("--heapsnapshot-signal",
             "Generate heap snapshot on specified signal",
             &EnvironmentOptions::heap_snapshot_signal,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -120,6 +120,7 @@ class EnvironmentOptions : public Options {
   bool no_deprecation = false;
   bool no_force_async_hooks_checks = false;
   bool no_warnings = false;
+  bool fs_url_strings = false;
   bool force_context_aware = false;
   bool pending_deprecation = false;
   bool preserve_symlinks = false;

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -29,6 +29,7 @@ expect('--trace-warnings', 'B\n');
 expect('--redirect-warnings=_', 'B\n');
 expect('--trace-deprecation', 'B\n');
 expect('--trace-sync-io', 'B\n');
+expect('--fs-url-strings', 'B\n');
 expectNoWorker('--trace-events-enabled', 'B\n');
 expect('--track-heap-objects', 'B\n');
 expect('--throw-deprecation',

--- a/test/parallel/test-fs-url-string.js
+++ b/test/parallel/test-fs-url-string.js
@@ -1,0 +1,14 @@
+// Flags: --fs-url-strings
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { pathToFileURL } = require('url');
+const { readFileSync } = require('fs');
+
+const url = pathToFileURL(__filename);
+
+const data1 = readFileSync(url.toString());
+const data2 = readFileSync(url);
+
+assert.deepStrictEqual(data1, data2);


### PR DESCRIPTION
The `--fs-url-strings` option allows the fs API to use
`file://` URL strings as paths. The reason it is a flag
is because supporting `file://` URL strings without the
flag would be semver-major. This gives us a semver-minor
option that can be opted into.

/cc @MylesBorins 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
