### PR TITLE
doc: correct version metadata for Readable.from

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1670,7 +1670,9 @@ failure, this can cause event listener leaks and swallowed errors.
 
 ### `stream.Readable.from(iterable, [options])`
 <!-- YAML
-added: v12.3.0
+added:
+  - v12.3.0
+  - v10.17.0
 -->
 
 * `iterable` {Iterable} Object implementing the `Symbol.asyncIterator` or


### PR DESCRIPTION
Please also see the corresponding issue for more background: https://github.com/nodejs/node/issues/32638

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
