### PR TITLE
lib: remove unnecesary else block

### DIFF
--- a/lib/internal/child_process/serialization.js
+++ b/lib/internal/child_process/serialization.js
@@ -25,10 +25,9 @@ class ChildProcessSerializer extends v8.DefaultSerializer {
     if (isArrayBufferView(object)) {
       this.writeUint32(kArrayBufferViewTag);
       return super._writeHostObject(object);
-    } else {
-      this.writeUint32(kNotArrayBufferViewTag);
-      this.writeValue({ ...object });
     }
+    this.writeUint32(kNotArrayBufferViewTag);
+    this.writeValue({ ...object });
   }
 }
 


### PR DESCRIPTION
The if statement inside the _writeHostObject function returns an expression which makes the else block unnecessary


##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)