### PR TITLE
test: fix tool path in test-doctool-versions.js

### DIFF
--- a/test/doctool/test-doctool-versions.js
+++ b/test/doctool/test-doctool-versions.js
@@ -9,7 +9,7 @@ const tmpdir = require('../common/tmpdir');
 const util = require('util');
 
 const debuglog = util.debuglog('test');
-const versionsTool = path.join('../../tools/doc/versions.js');
+const versionsTool = path.resolve(__dirname, '../../tools/doc/versions.js');
 
 // At the time of writing these are the minimum expected versions.
 // New versions of Node.js do not have to be explicitly added here.
@@ -29,7 +29,7 @@ const expected = [
 
 tmpdir.refresh();
 const versionsFile = path.join(tmpdir.path, 'versions.json');
-debuglog(versionsFile);
+debuglog(`${process.execPath} ${versionsTool} ${versionsFile}`);
 const opts = { cwd: tmpdir.path, encoding: 'utf8' };
 const cp = spawnSync(process.execPath, [ versionsTool, versionsFile ], opts);
 debuglog(cp.stderr);


### PR DESCRIPTION
Path to the versions tool tested by test-doctool-versions.js would
be incorrect if the test temporary directory was redirected (e.g.
via `NODE_TEST_DIR`) outside of `test/`.

Refs: https://github.com/nodejs/node/pull/32518

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
