### PR TITLE
test: adds underscore to usused variables on async hook promise test

### DIFF
--- a/test/addons/async-hooks-promise/test.js
+++ b/test/addons/async-hooks-promise/test.js
@@ -26,7 +26,7 @@ hook0.disable();
 
 let pwrap = null;
 const hook1 = async_hooks.createHook({
-  init(id, type, tid, resource) {
+  init(_, __, ___, resource) {
     pwrap = resource;
   }
 }).enable();


### PR DESCRIPTION
This commit adds underscore to the id, type and tid arguments from createHook on init

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)