### PR TITLE
perf_hooks: allow omitted parameters in 'performance.measure'

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -17,9 +17,12 @@ const obs = new PerformanceObserver((items) => {
   performance.clearMarks();
 });
 obs.observe({ entryTypes: ['measure'] });
+performance.measure('Start to Now');
 
 performance.mark('A');
 doSomeLongRunningProcess(() => {
+  performance.measure('A to Now', 'A');
+
   performance.mark('B');
   performance.measure('A to B', 'A', 'B');
 });
@@ -53,14 +56,18 @@ Creates a new `PerformanceMark` entry in the Performance Timeline. A
 `performanceEntry.duration` is always `0`. Performance marks are used
 to mark specific significant moments in the Performance Timeline.
 
-### `performance.measure(name, startMark, endMark)`
+### `performance.measure(name[, startMark[, endMark]])`
 <!-- YAML
 added: v8.5.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32651
+    description: Make `startMark` and `endMark` parameters optional.
 -->
 
 * `name` {string}
-* `startMark` {string}
-* `endMark` {string}
+* `startMark` {string} Optional.
+* `endMark` {string} Optional.
 
 Creates a new `PerformanceMeasure` entry in the Performance Timeline. A
 `PerformanceMeasure` is a subclass of `PerformanceEntry` whose
@@ -73,9 +80,10 @@ Performance Timeline, or *may* identify any of the timestamp properties
 provided by the `PerformanceNodeTiming` class. If the named `startMark` does
 not exist, then `startMark` is set to [`timeOrigin`][] by default.
 
-The `endMark` argument must identify any *existing* `PerformanceMark` in the
-Performance Timeline or any of the timestamp properties provided by the
-`PerformanceNodeTiming` class. If the named `endMark` does not exist, an
+The optional `endMark` argument must identify any *existing* `PerformanceMark`
+in the Performance Timeline or any of the timestamp properties provided by the
+`PerformanceNodeTiming` class. `endMark` will be `performance.now()`
+if no parameter is passed, otherwise if the named `endMark` does not exist, an
 error will be thrown.
 
 ### `performance.nodeTiming`

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -395,12 +395,14 @@ class Performance {
 
   measure(name, startMark, endMark) {
     name = `${name}`;
-    endMark = `${endMark}`;
-    startMark = startMark !== undefined ? `${startMark}` : '';
     const marks = this[kIndex][kMarks];
-    if (!marks.has(endMark) && !(endMark in nodeTiming)) {
-      throw new ERR_INVALID_PERFORMANCE_MARK(endMark);
+    if (arguments.length >= 3) {
+      if (!marks.has(endMark) && !(endMark in nodeTiming))
+        throw new ERR_INVALID_PERFORMANCE_MARK(endMark);
+      else
+        endMark = `${endMark}`;
     }
+    startMark = startMark !== undefined ? `${startMark}` : '';
     _measure(name, startMark, endMark);
   }
 

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -172,7 +172,6 @@ void Measure(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(env->isolate());
   Utf8Value name(env->isolate(), args[0]);
   Utf8Value startMark(env->isolate(), args[1]);
-  Utf8Value endMark(env->isolate(), args[2]);
 
   AliasedFloat64Array& milestones = env->performance_state()->milestones;
 
@@ -186,11 +185,17 @@ void Measure(const FunctionCallbackInfo<Value>& args) {
       startTimestamp = milestones[milestone];
   }
 
-  uint64_t endTimestamp = GetPerformanceMark(env, *endMark);
-  if (endTimestamp == 0) {
-    PerformanceMilestone milestone = ToPerformanceMilestoneEnum(*endMark);
-    if (milestone != NODE_PERFORMANCE_MILESTONE_INVALID)
-      endTimestamp = milestones[milestone];
+  uint64_t endTimestamp = 0;
+  if (args[2]->IsUndefined()) {
+    endTimestamp = PERFORMANCE_NOW();
+  } else {
+    Utf8Value endMark(env->isolate(), args[2]);
+    endTimestamp = GetPerformanceMark(env, *endMark);
+    if (endTimestamp == 0) {
+      PerformanceMilestone milestone = ToPerformanceMilestoneEnum(*endMark);
+      if (milestone != NODE_PERFORMANCE_MILESTONE_INVALID)
+        endTimestamp = milestones[milestone];
+    }
   }
 
   if (endTimestamp < startTimestamp)

--- a/test/parallel/test-performance-measure.js
+++ b/test/parallel/test-performance-measure.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const { PerformanceObserver, performance } = require('perf_hooks');
+const DELAY = 1000;
+
+const expected = ['Start to Now', 'A to Now', 'A to B'];
+const obs = new PerformanceObserver(common.mustCall((items) => {
+  const entries = items.getEntries();
+  const { name, duration } = entries[0];
+  assert.ok(duration > DELAY);
+  assert.strictEqual(expected.shift(), name);
+}, 3));
+obs.observe({ entryTypes: ['measure'] });
+
+performance.mark('A');
+setTimeout(common.mustCall(() => {
+  performance.measure('Start to Now');
+  performance.measure('A to Now', 'A');
+
+  performance.mark('B');
+  performance.measure('A to B', 'A', 'B');
+}), DELAY);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
FIxes: #32647
Refs: https://www.w3.org/TR/user-timing-2/#measure-method

```js
const { PerformanceObserver, performance } = require('perf_hooks');

const obs = new PerformanceObserver((items) => {
  console.log(items.getEntries()[0].duration);
  performance.clearMarks();
});
obs.observe({ entryTypes: ['measure'] });
performance.measure('Start to Now');

performance.mark('A');
doSomeLongRunningProcess(() => {
  performance.measure('A to Now', 'A');

  performance.mark('B');
  performance.measure('A to B', 'A', 'B');
});
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
