### PR TITLE
build: fix vcbuild error for missing Visual Studio

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -321,7 +321,7 @@ goto msbuild-found
 :msbuild-not-found
 echo Failed to find a suitable Visual Studio installation.
 echo Try to run in a "Developer Command Prompt" or consult
-echo https://github.com/nodejs/node/blob/master/BUILDING.md#windows-1
+echo https://github.com/nodejs/node/blob/master/BUILDING.md#windows
 goto exit
 
 :msbuild-found


### PR DESCRIPTION
The previous error was wrongly redirecting users to the ICU installation steps, which is unrelated to missing Visual Studio (because PR https://github.com/nodejs/node/pull/26714 reordered sections in building.md)

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)