### PR TITLE
lib: removes unnecessary else statement

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -188,11 +188,8 @@ async function readFileHandle(filehandle, options) {
   } while (!endOfFile);
 
   const result = Buffer.concat(chunks);
-  if (options.encoding) {
-    return result.toString(options.encoding);
-  } else {
-    return result;
-  }
+
+  return options.encoding ? result.toString(options.encoding) : result;
 }
 
 // All of the functions are defined as async in order to ensure that errors


### PR DESCRIPTION
This PR removes the `else` statement inside the readFileHandle function since exists a `return` in the `if` statement which makes that the `else` statement unnecessary

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)