### PR TITLE
lib: preventing id check if not required

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -391,13 +391,11 @@ function getTimerDuration(msecs, name) {
 
 function compareTimersLists(a, b) {
   const expiryDiff = a.expiry - b.expiry;
-  if (expiryDiff === 0) {
-    if (a.id < b.id)
-      return -1;
-    if (a.id > b.id)
-      return 1;
-  }
-  return expiryDiff;
+  if (expiryDiff !== 0)
+    return expiryDiff;
+  if (a.id < b.id)
+    return -1;
+  return 1;
 }
 
 function setPosition(node, pos) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

restructured comparator to give preference to the difference of delay, and if the delay doesn't exist then to the id, also removed an un-necessary check for id (id's were always incremented so no case for equal)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->