### PR TITLE
test: save test file in temporary directory

### DIFF
--- a/test/parallel/test-fs-readv-sync.js
+++ b/test/parallel/test-fs-readv-sync.js
@@ -3,6 +3,7 @@
 require('../common');
 const assert = require('assert');
 const fs = require('fs');
+const path = require('path');
 const tmpdir = require('../common/tmpdir');
 
 tmpdir.refresh();
@@ -12,7 +13,7 @@ const expected = 'ümlaut. Лорем 運務ホソモ指及 आपको कर�
 const exptectedBuff = Buffer.from(expected);
 const expectedLength = exptectedBuff.length;
 
-const filename = 'readv_sync.txt';
+const filename = path.join(tmpdir.path, 'readv_sync.txt');
 fs.writeFileSync(filename, exptectedBuff);
 
 const allocateEmptyBuffers = (combinedLength) => {


### PR DESCRIPTION
The readv_sync.txt test file is currenly saved in the root directory.
Save it in the dedicated temporary directory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
