### PR TITLE
src: ignore GCC -Wcast-function-type for v8.h

### DIFF
--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -26,7 +26,14 @@
 
 // Decodes a v8::Local<v8::String> or Buffer to a raw char*
 
+#if (__GNUC__ >= 8) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 #include "v8.h"
+#if (__GNUC__ >= 8) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 #include "env-inl.h"
 
 #include <string>

--- a/test/cctest/test_aliased_buffer.cc
+++ b/test/cctest/test_aliased_buffer.cc
@@ -1,4 +1,11 @@
+#if (__GNUC__ >= 8) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 #include "v8.h"
+#if (__GNUC__ >= 8) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 #include "aliased_buffer.h"
 #include "node_test_fixture.h"
 


### PR DESCRIPTION
Currently, the following warnings are emitted during compilation:
```console
In file included from ../src/string_bytes.h:29,
                 from ../src/string_bytes.cc:22:
../deps/v8/include/v8.h:
In instantiation of ‘void v8::PersistentBase<T>::SetWeak(
    P*,typename v8::WeakCallbackInfo<P>::Callback, v8::WeakCallbackType)
[with P = node::BaseObject;
T = v8::Object;
typename v8::WeakCallbackInfo<P>::Callback =
    void (*)(const v8::WeakCallbackInfo<node::BaseObject>&)]’:
../src/base_object-inl.h:135:42:   required from here
../deps/v8/include/v8.h:10732:16: warning:
cast between incompatible function types from
‘v8::WeakCallbackInfo<node::BaseObject>::Callback’ {aka
‘void (*)(const v8::WeakCallbackInfo<node::BaseObject>&)’} to
‘Callback’ {aka ‘void (*)(const v8::WeakCallbackInfo<void>&)’}
[-Wcast-function-type]
10732 |                reinterpret_cast<Callback>(callback), type);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
````
And the same from test/cctest/test_aliased_buffer.cc

We have an open pull request against v8 for this:
https://chromium-review.googlesource.com/c/v8/v8/+/2080361

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
