### PR TITLE
build: turn warnings into errors for node sources

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -26,6 +26,7 @@
     'uv_library%': 'static_library',
 
     'clang%': 0,
+    'error_on_warn%': '0',
 
     'openssl_fips%': '',
     'openssl_no_asm%': 0,
@@ -219,8 +220,9 @@
     # simply not feasible to squelch all warnings, never mind that the
     # libraries in deps/ are not under our control.
     'conditions': [
-      ['_target_name!="<(node_lib_target_name)" or '
-        '_target_name!="<(node_core_target_name)"', {
+      [ 'error_on_warn=="true" and '
+        '(_target_name!="<(node_lib_target_name)" or '
+          '_target_name!="<(node_core_target_name)")', {
         'cflags!': ['-Werror'],
       }],
     ],

--- a/common.gypi
+++ b/common.gypi
@@ -26,7 +26,7 @@
     'uv_library%': 'static_library',
 
     'clang%': 0,
-    'error_on_warn%': '0',
+    'error_on_warn%': 'false',
 
     'openssl_fips%': '',
     'openssl_no_asm%': 0,

--- a/common.gypi
+++ b/common.gypi
@@ -218,7 +218,12 @@
     # Forcibly disable -Werror.  We support a wide range of compilers, it's
     # simply not feasible to squelch all warnings, never mind that the
     # libraries in deps/ are not under our control.
-    'cflags!': ['-Werror'],
+    'conditions': [
+      ['_target_name!="<(node_lib_target_name)" or '
+        '_target_name!="<(node_core_target_name)"', {
+        'cflags!': ['-Werror'],
+      }],
+    ],
     'msvs_settings': {
       'VCCLCompilerTool': {
         'BufferSecurityCheck': 'true',

--- a/common.gypi
+++ b/common.gypi
@@ -220,8 +220,9 @@
     # simply not feasible to squelch all warnings, never mind that the
     # libraries in deps/ are not under our control.
     'conditions': [
-      [ 'error_on_warn=="true" and '
-        '(_target_name!="<(node_lib_target_name)" or '
+      [ 'error_on_warn=="false"', {
+        'cflags!': ['-Werror'],
+      }, '(_target_name!="<(node_lib_target_name)" or '
           '_target_name!="<(node_core_target_name)")', {
         'cflags!': ['-Werror'],
       }],

--- a/configure.py
+++ b/configure.py
@@ -117,6 +117,11 @@ parser.add_option('--dest-os',
     choices=valid_os,
     help='operating system to build for ({0})'.format(', '.join(valid_os)))
 
+parser.add_option('--error-on-warn',
+    action='store_true',
+    dest='error_on_warn',
+    help='Turn compiler warnings into errors for node core sources.')
+
 parser.add_option('--gdb',
     action='store_true',
     dest='gdb',
@@ -1018,6 +1023,7 @@ def configure_node(o):
   o['variables']['node_install_npm'] = b(not options.without_npm)
   o['variables']['debug_node'] = b(options.debug_node)
   o['default_configuration'] = 'Debug' if options.debug else 'Release'
+  o['variables']['error_on_warn'] = b(options.error_on_warn)
 
   host_arch = host_arch_win() if os.name == 'nt' else host_arch_cc()
   target_arch = options.dest_cpu or host_arch

--- a/node.gyp
+++ b/node.gyp
@@ -346,8 +346,6 @@
         'node.gypi'
       ],
 
-      'cflags': [ '-Werror', ],
-
       'include_dirs': [
         'src',
         'deps/v8/include'
@@ -377,6 +375,9 @@
       'msvs_disabled_warnings!': [4244],
 
       'conditions': [
+        [ 'error_on_warn=="true"', {
+          'cflags': ['-Werror'],
+        }],
         [ 'node_intermediate_lib_type=="static_library" and '
             'node_shared=="true" and OS=="aix"', {
           # For AIX, shared lib is linked by static lib and .exp. In the
@@ -529,8 +530,6 @@
       'includes': [
         'node.gypi',
       ],
-
-      'cflags': [ '-Werror', ],
 
       'include_dirs': [
         'src',
@@ -753,6 +752,9 @@
       'msvs_disabled_warnings!': [4244],
 
       'conditions': [
+        [ 'error_on_warn=="true"', {
+          'cflags': ['-Werror'],
+        }],
         [ 'node_builtin_modules_path!=""', {
           'defines': [ 'NODE_BUILTIN_MODULES_PATH="<(node_builtin_modules_path)"' ]
         }],

--- a/node.gyp
+++ b/node.gyp
@@ -346,6 +346,8 @@
         'node.gypi'
       ],
 
+      'cflags': [ '-Werror', ],
+
       'include_dirs': [
         'src',
         'deps/v8/include'
@@ -527,6 +529,8 @@
       'includes': [
         'node.gypi',
       ],
+
+      'cflags': [ '-Werror', ],
 
       'include_dirs': [
         'src',

--- a/tools/inspector_protocol/lib/Values_cpp.template
+++ b/tools/inspector_protocol/lib/Values_cpp.template
@@ -606,7 +606,7 @@ std::unique_ptr<Value> DictionaryValue::clone() const
         DCHECK(value != m_data.cend() && value->second);
         result->setValue(key, value->second->clone());
     }
-    return std::move(result);
+    return result;
 }
 
 DictionaryValue::DictionaryValue()
@@ -647,7 +647,7 @@ std::unique_ptr<Value> ListValue::clone() const
     std::unique_ptr<ListValue> result = ListValue::create();
     for (const std::unique_ptr<protocol::Value>& value : m_data)
         result->pushValue(value->clone());
-    return std::move(result);
+    return result;
 }
 
 ListValue::ListValue()


### PR DESCRIPTION
This pr attempts to turn compilation warnings into errors for node's source code.
    
The motivation for this is to enable these errors to be reported by CI runs on pull requests and be able to fix them before they land.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
