### PR TITLE
stream: cleanup pipeline destroyer

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -41,7 +41,7 @@ function isOutgoing(stream) {
   );
 }
 
-function destroyer(stream, reading, writing, final, callback) {
+function destroyer(stream, reading, writing, callback) {
   const _destroy = once((err) => {
     if (!err && (isIncoming(stream) || isOutgoing(stream))) {
       // http/1 request objects have a coupling to their response and should
@@ -54,9 +54,11 @@ function destroyer(stream, reading, writing, final, callback) {
       return callback();
     }
 
-    if (err || !final || !stream.readable) {
-      destroyImpl.destroyer(stream, err);
+    if (!err && !reading && writing && stream.readable) {
+      return callback();
     }
+
+    destroyImpl.destroyer(stream, err);
     callback(err);
   });
 
@@ -204,7 +206,7 @@ function pipeline(...streams) {
 
     if (isStream(stream)) {
       finishCount++;
-      destroys.push(destroyer(stream, reading, writing, !reading, finish));
+      destroys.push(destroyer(stream, reading, writing, finish));
     }
 
     if (i === 0) {
@@ -262,7 +264,7 @@ function pipeline(...streams) {
         ret = pt;
 
         finishCount++;
-        destroys.push(destroyer(ret, false, true, true, finish));
+        destroys.push(destroyer(ret, false, true, finish));
       }
     } else if (isStream(stream)) {
       if (isReadable(ret)) {


### PR DESCRIPTION
Slightly cleans up the destroyer logic. Make readable and writable use similar logic.

i.e.

```js
    if (!err && reading && !writing && stream.writable) {
      return callback();
    }

    if (!err && !reading && writing && stream.readable) {
      return callback();
    }
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
