### PR TITLE
lib: removes unused params

### DIFF
--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -105,7 +105,7 @@ class Dir {
     );
   }
 
-  readSync(options) {
+  readSync() {
     if (this[kDirClosed] === true) {
       throw new ERR_DIR_CLOSED();
     }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -144,7 +144,7 @@ function validateFileHandle(handle) {
     throw new ERR_INVALID_ARG_TYPE('filehandle', 'FileHandle', handle);
 }
 
-async function writeFileHandle(filehandle, data, options) {
+async function writeFileHandle(filehandle, data) {
   let remaining = data.length;
   if (remaining === 0) return;
   do {
@@ -514,10 +514,10 @@ async function writeFile(path, data, options) {
   }
 
   if (path instanceof FileHandle)
-    return writeFileHandle(path, data, options);
+    return writeFileHandle(path, data);
 
   const fd = await open(path, flag, options.mode);
-  return writeFileHandle(fd, data, options).finally(fd.close);
+  return writeFileHandle(fd, data).finally(fd.close);
 }
 
 async function appendFile(path, data, options) {


### PR DESCRIPTION
This PR removes the `options` params from `readSync` and  `writeFileHandle ` functions as it's never used within them.

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)