### PR TITLE
build: enable NODE_DEBUG=test by default for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ GNUMAKEFLAGS += --no-print-directory
 GCOV ?= gcov
 PWD = $(CURDIR)
 BUILD_WITH ?= make
+CI_DEBUG_TEST ?= NODE_DEBUG=test,${NODE_DEBUG}
 
 ifdef JOBS
 	PARALLEL_ARGS = -j $(JOBS)
@@ -536,16 +537,20 @@ endif
 # Related CI job: node-test-commit-arm-fanned
 test-ci-native: LOGLEVEL := info
 test-ci-native: | test/addons/.buildstamp test/js-native-api/.buildstamp test/node-api/.buildstamp test/abort/.buildstamp
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
-		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
+	$(CI_DEBUG_TEST) $(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap \
+	        --logfile test.tap           \
+		--mode=$(BUILDTYPE_LOWER)    \
+		--flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_NATIVE_SUITES)
 
 .PHONY: test-ci-js
 # This target should not use a native compiler at all
 # Related CI job: node-test-commit-arm-fanned
 test-ci-js: | clear-stalled
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
-		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
+	$(CI_DEBUG_TEST) $(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap \
+	        --logfile test.tap           \
+		--mode=$(BUILDTYPE_LOWER)    \
+		--flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES)
 	@echo "Clean up any leftover processes, error if found."
 	ps awwx | grep Release/node | grep -v grep | cat
@@ -559,8 +564,10 @@ test-ci-js: | clear-stalled
 test-ci: LOGLEVEL := info
 test-ci: | clear-stalled build-addons build-abort-tests build-js-native-api-tests build-node-api-tests doc-only
 	out/Release/cctest --gtest_output=xml:out/junit/cctest.xml
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
-		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
+	$(CI_DEBUG_TEST) $(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap \
+	        --logfile test.tap           \
+		--mode=$(BUILDTYPE_LOWER)    \
+		--flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES) $(CI_NATIVE_SUITES) $(CI_DOC)
 	out/Release/embedtest 'require("./test/embedding/test-embedding.js")'
 	@echo "Clean up any leftover processes, error if found."

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -19,6 +19,7 @@ cd %~dp0
 set CI_NATIVE_SUITES=addons js-native-api node-api abort
 set CI_JS_SUITES=default
 set CI_DOC=doctool
+echo %CI_DEBUG_TEST%
 @rem Same as the test-ci target in Makefile
 set "common_test_suites=%CI_JS_SUITES% %CI_NATIVE_SUITES% %CI_DOC%&set build_addons=1&set build_js_native_api_tests=1&set build_node_api_tests=1&set build_aborts_tests=1"
 
@@ -63,6 +64,7 @@ set http2_debug=
 set nghttp2_debug=
 set link_module=
 set no_cctest=
+set no_debug_test=
 set cctest=
 set openssl_no_asm=
 set doc=
@@ -143,6 +145,7 @@ if /i "%1"=="no-NODE-OPTIONS"	set no_NODE_OPTIONS=1&goto arg-ok
 if /i "%1"=="debug-nghttp2" set debug_nghttp2=1&goto arg-ok
 if /i "%1"=="link-module"   set "link_module= --link-module=%2%link_module%"&goto arg-ok-2
 if /i "%1"=="no-cctest"     set no_cctest=1&goto arg-ok
+if /i "%i"=="no-debug-test" set no_debug_test=1&goto arg-ok
 if /i "%1"=="cctest"        set cctest=1&goto arg-ok
 if /i "%1"=="openssl-no-asm"   set openssl_no_asm=1&goto arg-ok
 if /i "%1"=="doc"           set doc=1&goto arg-ok
@@ -658,6 +661,7 @@ echo running 'cctest %cctest_args%'
 if %errorlevel% neq 0 set exit_code=%errorlevel%
 :run-test-py
 echo running 'python tools\test.py %test_args%'
+if no_debug_test neq 1 set NODE_DEBUG=test
 python tools\test.py %test_args%
 if %errorlevel% neq 0 set exit_code=%errorlevel%
 goto test-v8


### PR DESCRIPTION
By convention, `require('util').debuglog('test')` can be used
within tests to separate debug output from console.log/error
statements that are actually a part of the test. These should
be enabled by default in most cases in CI.

Running `make test-ci` or variants (e.g. `test-ci-js`) will set
the `NODE_DEBUG=test` option by default unless explicitly
overridden. `vcbuild` will set `NODE_DEBUG=test` automatically
unless the `no-debug-test` option is set.

Refs: https://github.com/nodejs/node/issues/32678

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
