### PR TITLE
doc: document `buffer.from` returns internal pool buffer

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -572,8 +572,8 @@ const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 A `TypeError` will be thrown if `array` is not an `Array` or other type
 appropriate for `Buffer.from()` variants.
 
-`Buffer.from(array)` may also use the internal `Buffer` pool like
- [`Buffer.allocUnsafe()`][] does.
+`Buffer.from(array)` and [`Buffer.from(string)`][] may also use the internal
+`Buffer` pool like [`Buffer.allocUnsafe()`][] does.
 
 ### Class Method: `Buffer.from(arrayBuffer[, byteOffset[, length]])`
 <!-- YAML

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -380,7 +380,7 @@ A `TypeError` will be thrown if `size` is not a number.
 The `Buffer` module pre-allocates an internal `Buffer` instance of
 size [`Buffer.poolSize`][] that is used as a pool for the fast allocation of new
 `Buffer` instances created using [`Buffer.allocUnsafe()`][],
-[`Buffer.from(array)`][] and the deprecated `new Buffer(size)` constructor only
+[`Buffer.from(array)`][], and the deprecated `new Buffer(size)` constructor only
 when `size` is less than or equal to `Buffer.poolSize >> 1` (floor of
 [`Buffer.poolSize`][] divided by two).
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -379,9 +379,10 @@ A `TypeError` will be thrown if `size` is not a number.
 
 The `Buffer` module pre-allocates an internal `Buffer` instance of
 size [`Buffer.poolSize`][] that is used as a pool for the fast allocation of new
-`Buffer` instances created using [`Buffer.allocUnsafe()`][] and the deprecated
-`new Buffer(size)` constructor only when `size` is less than or equal to
-`Buffer.poolSize >> 1` (floor of [`Buffer.poolSize`][] divided by two).
+`Buffer` instances created using [`Buffer.allocUnsafe()`][],
+[`Buffer.from(array)`][] and the deprecated `new Buffer(size)` constructor only
+when `size` is less than or equal to `Buffer.poolSize >> 1` (floor of
+[`Buffer.poolSize`][] divided by two).
 
 Use of this pre-allocated internal memory pool is a key difference between
 calling `Buffer.alloc(size, fill)` vs. `Buffer.allocUnsafe(size).fill(fill)`.
@@ -570,6 +571,9 @@ const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 
 A `TypeError` will be thrown if `array` is not an `Array` or other type
 appropriate for `Buffer.from()` variants.
+
+`Buffer.from(array)` may also use the internal `Buffer` pool like
+ [`Buffer.allocUnsafe()`][] does.
 
 ### Class Method: `Buffer.from(arrayBuffer[, byteOffset[, length]])`
 <!-- YAML
@@ -2726,10 +2730,11 @@ to one of these new APIs.*
   uninitialized, the allocated segment of memory might contain old data that is
   potentially sensitive.
 
-`Buffer` instances returned by [`Buffer.allocUnsafe()`][] *may* be allocated off
-a shared internal memory pool if `size` is less than or equal to half
-[`Buffer.poolSize`][]. Instances returned by [`Buffer.allocUnsafeSlow()`][]
-*never* use the shared internal memory pool.
+`Buffer` instances returned by [`Buffer.allocUnsafe()`][] and
+[`Buffer.from(array)`][] *may* be allocated off a shared internal memory pool
+if `size` is less than or equal to half [`Buffer.poolSize`][]. Instances
+returned by [`Buffer.allocUnsafeSlow()`][] *never* use the shared internal
+memory pool.
 
 ### The `--zero-fill-buffers` command line option
 <!-- YAML


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/22139

Co-authored-by: Mritunjay Goutam <mritunjaygoutam2204@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
