### PR TITLE
build: clean up arm build options

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -2,6 +2,7 @@
   'variables': {
     'configuring_node%': 0,
     'asan%': 0,
+    'arm_version%': 0,                # ARM architecture version (6 or 7)
     'werror': '',                     # Turn off -Werror in V8 build.
     'visibility%': 'hidden',          # V8's visibility setting
     'target_arch%': 'ia32',           # set v8's target architecture
@@ -268,6 +269,17 @@
     'msvs_cygwin_shell': 0, # prevent actions from trying to use cygwin
 
     'conditions': [
+      [ 'arm_version==7', {
+        'target_conditions': [
+          ['_toolset=="target"', {
+            # Any Cortex-A that can run V8 supports at least armv7-a+neon.
+            'cflags': [
+              '-march=armv7-a',
+              '-mfpu=neon',  # Implies VFPv3.
+              ],
+          }],
+        ],
+      }],
       [ 'configuring_node', {
         'msvs_configuration_attributes': {
           'OutputDirectory': '<(DEPTH)/out/$(Configuration)/',

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -118,8 +118,6 @@
                 'INFLATE_CHUNK_SIMD_NEON',
               ],
               'sources': [
-                'arm_features.c',
-                'arm_features.h',
                 'contrib/optimizations/slide_hash_neon.h',
                 'crc32_simd.c',
                 'crc32_simd.h',

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -112,7 +112,20 @@
             }, {
               'sources': [ 'simd_stub.c', ],
             }],
-            ['target_arch=="arm64" or arm_version==7', {
+            ['arm_version==7', {
+              'defines': [
+                'ADLER32_SIMD_NEON',
+                'INFLATE_CHUNK_SIMD_NEON',
+              ],
+              'sources': [
+                'arm_features.c',
+                'arm_features.h',
+                'contrib/optimizations/slide_hash_neon.h',
+                'crc32_simd.c',
+                'crc32_simd.h',
+              ],
+            }],
+            ['target_arch=="arm64"', {
               'defines': [
                 'ADLER32_SIMD_NEON',
                 'INFLATE_CHUNK_SIMD_NEON',

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -5,7 +5,6 @@
 {
   'variables': {
     'use_system_zlib%': 0,
-    'arm_fpu%': '',
     'llvm_version%': '0.0',
   },
   'conditions': [
@@ -64,7 +63,8 @@
                 'USE_FILE32API'
               ],
             }],
-            ['(target_arch in "ia32 x64 x32" and OS!="ios") or arm_fpu=="neon"', {
+            ['(target_arch in "arm64 ia32 x64 x32" and OS!="ios") or '
+             'arm_version==7', {
               'sources': [
                 'adler32_simd.c',
                 'adler32_simd.h',
@@ -112,7 +112,7 @@
             }, {
               'sources': [ 'simd_stub.c', ],
             }],
-            ['arm_fpu=="neon"', {
+            ['target_arch=="arm64" or arm_version==7', {
               'defines': [
                 'ADLER32_SIMD_NEON',
                 'INFLATE_CHUNK_SIMD_NEON',
@@ -136,7 +136,7 @@
                     ['OS=="linux"', {
                       'defines': [ 'ARMV8_OS_LINUX' ],
                     }],
-                    ['OS="win"', {
+                    ['OS=="win"', {
                       'defines': [ 'ARMV8_OS_WINDOWS' ],
                     }],
                     ['OS!="android" and OS!="win" and llvm_version=="0.0"', {

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -176,27 +176,13 @@
           'V8_TARGET_ARCH_ARM',
         ],
         'conditions': [
-          [ 'arm_version==7 or arm_version=="default"', {
+          # ARMv7 supports NEON+VFP3, ARMv6 only supports VFP2.
+          [ 'arm_version==7', {
             'defines': [
               'CAN_USE_ARMV7_INSTRUCTIONS',
-            ],
-          }],
-          [ 'arm_fpu=="vfpv3-d16" or arm_fpu=="default"', {
-            'defines': [
-              'CAN_USE_VFP3_INSTRUCTIONS',
-            ],
-          }],
-          [ 'arm_fpu=="vfpv3"', {
-            'defines': [
-              'CAN_USE_VFP3_INSTRUCTIONS',
-              'CAN_USE_VFP32DREGS',
-            ],
-          }],
-          [ 'arm_fpu=="neon"', {
-            'defines': [
-              'CAN_USE_VFP3_INSTRUCTIONS',
-              'CAN_USE_VFP32DREGS',
               'CAN_USE_NEON',
+              'CAN_USE_VFP32DREGS',
+              'CAN_USE_VFP3_INSTRUCTIONS',
             ],
           }],
           [ 'arm_test_noprobe=="on"', {
@@ -204,94 +190,6 @@
               'ARM_TEST_NO_FEATURE_PROBE',
             ],
           }],
-        ],
-        'target_conditions': [
-          ['_toolset=="host"', {
-            'conditions': [
-              ['v8_target_arch==host_arch', {
-                # Host built with an Arm CXX compiler.
-                'conditions': [
-                  [ 'arm_version==7', {
-                    'cflags': ['-march=armv7-a',],
-                  }],
-                  [ 'arm_version==7 or arm_version=="default"', {
-                    'conditions': [
-                      [ 'arm_fpu!="default"', {
-                        'cflags': ['-mfpu=<(arm_fpu)',],
-                      }],
-                    ],
-                  }],
-                  [ 'arm_float_abi!="default"', {
-                    'cflags': ['-mfloat-abi=<(arm_float_abi)',],
-                  }],
-                  [ 'arm_thumb==1', {
-                    'cflags': ['-mthumb',],
-                  }],
-                  [ 'arm_thumb==0', {
-                    'cflags': ['-marm',],
-                  }],
-                ],
-              }, {
-                # 'v8_target_arch!=host_arch'
-                # Host not built with an Arm CXX compiler (simulator build).
-                'conditions': [
-                  [ 'arm_float_abi=="hard"', {
-                    'defines': [
-                      'USE_EABI_HARDFLOAT=1',
-                    ],
-                  }],
-                  [ 'arm_float_abi=="softfp" or arm_float_abi=="default"', {
-                    'defines': [
-                      'USE_EABI_HARDFLOAT=0',
-                    ],
-                  }],
-                ],
-              }],
-            ],
-          }],  # _toolset=="host"
-          ['_toolset=="target"', {
-            'conditions': [
-              ['v8_target_arch==target_arch', {
-                # Target built with an Arm CXX compiler.
-                'conditions': [
-                  [ 'arm_version==7', {
-                    'cflags': ['-march=armv7-a',],
-                  }],
-                  [ 'arm_version==7 or arm_version=="default"', {
-                    'conditions': [
-                      [ 'arm_fpu!="default"', {
-                        'cflags': ['-mfpu=<(arm_fpu)',],
-                      }],
-                    ],
-                  }],
-                  [ 'arm_float_abi!="default"', {
-                    'cflags': ['-mfloat-abi=<(arm_float_abi)',],
-                  }],
-                  [ 'arm_thumb==1', {
-                    'cflags': ['-mthumb',],
-                  }],
-                  [ 'arm_thumb==0', {
-                    'cflags': ['-marm',],
-                  }],
-                ],
-              }, {
-                # 'v8_target_arch!=target_arch'
-                # Target not built with an Arm CXX compiler (simulator build).
-                'conditions': [
-                  [ 'arm_float_abi=="hard"', {
-                    'defines': [
-                      'USE_EABI_HARDFLOAT=1',
-                    ],
-                  }],
-                  [ 'arm_float_abi=="softfp" or arm_float_abi=="default"', {
-                    'defines': [
-                      'USE_EABI_HARDFLOAT=0',
-                    ],
-                  }],
-                ],
-              }],
-            ],
-          }],  # _toolset=="target"
         ],
       }],  # v8_target_arch=="arm"
       ['v8_target_arch=="arm64"', {


### PR DESCRIPTION
* default to `-march=armv7-a+neon-vfp3` when targeting armv7. Any
  Cortex-A capable of running V8 supports at least that.

* remove the `--arm-fpu=...` configure option. It was added to support
  Debian's armel port (armv5, for the purpose of this discussion) but
  V8 (and therefore Node.js) dropped support for armv5 in early 2016.

* remove the `--arm-float-abi=...` configure option. There should never
  be a reason to build in soft or softp mode; armv6 is the bare minimum
  and supports VFP.

Fixes: https://github.com/nodejs/node/issues/30786