### PR TITLE
build: fix LINT_MD_NEWER assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1233,9 +1233,9 @@ lint-md-build:
 	$(warning "Deprecated no-op target 'lint-md-build'")
 
 ifeq ("$(wildcard tools/.mdlintstamp)","")
-	LINT_MD_NEWER =
+LINT_MD_NEWER =
 else
-	LINT_MD_NEWER = -newer tools/.mdlintstamp
+LINT_MD_NEWER = -newer tools/.mdlintstamp
 endif
 
 LINT_MD_TARGETS = doc src lib benchmark test tools/doc tools/icu $(wildcard *.md)


### PR DESCRIPTION
Indentation with a tab breaks the functionality, resulting in linting
all .md files when any one is changed. For consistency with the rest of
the Makefile and to restore functionality, remove indentation.

Refs: https://github.com/nodejs/node/pull/32614#issuecomment-610670779

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
