### PR TITLE
build: output dots instead of tap in GitHub actions

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Build
         run: make build-ci -j2 V=1
       - name: Test
-        run: make run-ci -j2 V=1 TEST_CI_PROGRESS="-p dots"
+        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p dots"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Build
         run: make build-ci -j2 V=1
       - name: Test
-        run: make run-ci -j2 V=1
+        run: make run-ci -j2 V=1 TEST_CI_PROGRESS="-p dots"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Build
         run: make build-ci -j8 V=1
       - name: Test
-        run: make run-ci -j8 V=1
+        run: make run-ci -j8 V=1 TEST_CI_PROGRESS="-p dots"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Build
         run: make build-ci -j8 V=1
       - name: Test
-        run: make run-ci -j8 V=1 TEST_CI_PROGRESS="-p dots"
+        run: make run-ci -j8 V=1 TEST_CI_ARGS="-p dots"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ SIGN ?=
 PREFIX ?= /usr/local
 FLAKY_TESTS ?= run
 TEST_CI_ARGS ?=
-TEST_CI_PROGRESS ?= -p tap --logfile test.tap
 STAGINGSERVER ?= node-www
 LOGLEVEL ?= silent
 OSTYPE := $(shell uname -s | tr '[A-Z]' '[a-z]')
@@ -537,7 +536,7 @@ endif
 # Related CI job: node-test-commit-arm-fanned
 test-ci-native: LOGLEVEL := info
 test-ci-native: | test/addons/.buildstamp test/js-native-api/.buildstamp test/node-api/.buildstamp test/abort/.buildstamp
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) $(TEST_CI_PROGRESS) \
+	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_NATIVE_SUITES)
 
@@ -545,7 +544,7 @@ test-ci-native: | test/addons/.buildstamp test/js-native-api/.buildstamp test/no
 # This target should not use a native compiler at all
 # Related CI job: node-test-commit-arm-fanned
 test-ci-js: | clear-stalled
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) $(TEST_CI_PROGRESS) \
+	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES)
 	@echo "Clean up any leftover processes, error if found."
@@ -560,7 +559,7 @@ test-ci-js: | clear-stalled
 test-ci: LOGLEVEL := info
 test-ci: | clear-stalled build-addons build-abort-tests build-js-native-api-tests build-node-api-tests doc-only
 	out/Release/cctest --gtest_output=xml:out/junit/cctest.xml
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) $(TEST_CI_PROGRESS) \
+	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES) $(CI_NATIVE_SUITES) $(CI_DOC)
 	out/Release/embedtest 'require("./test/embedding/test-embedding.js")'

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SIGN ?=
 PREFIX ?= /usr/local
 FLAKY_TESTS ?= run
 TEST_CI_ARGS ?=
+TEST_CI_PROGRESS ?= -p tap --logfile test.tap
 STAGINGSERVER ?= node-www
 LOGLEVEL ?= silent
 OSTYPE := $(shell uname -s | tr '[A-Z]' '[a-z]')
@@ -536,7 +537,7 @@ endif
 # Related CI job: node-test-commit-arm-fanned
 test-ci-native: LOGLEVEL := info
 test-ci-native: | test/addons/.buildstamp test/js-native-api/.buildstamp test/node-api/.buildstamp test/abort/.buildstamp
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
+	$(PYTHON) tools/test.py $(PARALLEL_ARGS) $(TEST_CI_PROGRESS) \
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_NATIVE_SUITES)
 
@@ -544,7 +545,7 @@ test-ci-native: | test/addons/.buildstamp test/js-native-api/.buildstamp test/no
 # This target should not use a native compiler at all
 # Related CI job: node-test-commit-arm-fanned
 test-ci-js: | clear-stalled
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
+	$(PYTHON) tools/test.py $(PARALLEL_ARGS) $(TEST_CI_PROGRESS) \
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES)
 	@echo "Clean up any leftover processes, error if found."
@@ -559,7 +560,7 @@ test-ci-js: | clear-stalled
 test-ci: LOGLEVEL := info
 test-ci: | clear-stalled build-addons build-abort-tests build-js-native-api-tests build-node-api-tests doc-only
 	out/Release/cctest --gtest_output=xml:out/junit/cctest.xml
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
+	$(PYTHON) tools/test.py $(PARALLEL_ARGS) $(TEST_CI_PROGRESS) \
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES) $(CI_NATIVE_SUITES) $(CI_DOC)
 	out/Release/embedtest 'require("./test/embedding/test-embedding.js")'


### PR DESCRIPTION
This makes the output much smaller and lets us focus on errors if there
are any.

Otherwise, the UI becomes too slow and prevents navigating in the test output. The output is still too long IMO but this reduces it significantly
I'm open to alternative ways to pass that option to the test runner.