### PR TITLE
test: using fs.promises destructuring

### DIFF
--- a/test/parallel/test-filehandle-close.js
+++ b/test/parallel/test-filehandle-close.js
@@ -1,14 +1,14 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const fs = require('fs');
+const { closeSync, promises: { open } } = require('fs');
 
 // Test that using FileHandle.close to close an already-closed fd fails
 // with EBADF.
 
 (async function() {
-  const fh = await fs.promises.open(__filename);
-  fs.closeSync(fh.fd);
+  const fh = await open(__filename);
+  closeSync(fh.fd);
 
   assert.rejects(() => fh.close(), {
     code: 'EBADF',

--- a/test/parallel/test-fs-promises-file-handle-close.js
+++ b/test/parallel/test-fs-promises-file-handle-close.js
@@ -8,7 +8,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { promises: fs } = require('fs');
+const { promises: { open } } = require('fs');
 
 const warning =
   'Closing a FileHandle object on garbage collection is deprecated. ' +
@@ -17,7 +17,7 @@ const warning =
   'thrown if a file descriptor is closed during garbage collection.';
 
 async function doOpen() {
-  const fh = await fs.open(__filename);
+  const fh = await open(__filename);
 
   common.expectWarning({
     Warning: [[`Closing file descriptor ${fh.fd} on garbage collection`]],

--- a/test/parallel/test-fs-promises-readfile-empty.js
+++ b/test/parallel/test-fs-promises-readfile-empty.js
@@ -2,16 +2,16 @@
 require('../common');
 
 const assert = require('assert');
-const { promises: fs } = require('fs');
+const { promises: { readFile } } = require('fs');
 const fixtures = require('../common/fixtures');
 
 const fn = fixtures.path('empty.txt');
 
-fs.readFile(fn)
+readFile(fn)
   .then(assert.ok);
 
-fs.readFile(fn, 'utf8')
+readFile(fn, 'utf8')
   .then(assert.strictEqual.bind(this, ''));
 
-fs.readFile(fn, { encoding: 'utf8' })
+readFile(fn, { encoding: 'utf8' })
   .then(assert.strictEqual.bind(this, ''));


### PR DESCRIPTION
This PR uses fs.promises destructuring in few fs tests

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
