### PR TITLE
setTimeout method of net.Socket should return this

### DIFF
--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -238,7 +238,7 @@ function onStreamRead(arrayBuffer) {
 
 function setStreamTimeout(msecs, callback) {
   if (this.destroyed)
-    return;
+    return this;
 
   this.timeout = msecs;
 

--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -70,8 +70,12 @@ for (let i = 0; i < invalidCallbacks.length; i++) {
 const server = net.Server();
 server.listen(0, common.mustCall(() => {
   const socket = net.createConnection(server.address().port);
-  socket.setTimeout(1, common.mustCall(() => {
-    socket.destroy();
-    server.close();
-  }));
+  assert.strictEqual(
+    socket.setTimeout(1, common.mustCall(() => {
+      socket.destroy();
+      assert.strictEqual(socket.setTimeout(1, common.mustNotCall()), socket);
+      server.close();
+    })),
+    socket
+  );
 }));


### PR DESCRIPTION

setTimeout method of net.Socket should return this, not undefined, as doc said.

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
