### PR TITLE
worker: fix type check in receiveMessageOnPort

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -865,7 +865,12 @@ void MessagePort::Drain(const FunctionCallbackInfo<Value>& args) {
 }
 
 void MessagePort::ReceiveMessage(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args[0]->IsObject());
+  Environment* env = Environment::GetCurrent(args);
+  if (!args[0]->IsObject() ||
+      !env->message_port_constructor_template()->HasInstance(args[0])) {
+    return THROW_ERR_INVALID_ARG_TYPE(env,
+        "First argument needs to be a MessagePort instance");
+  }
   MessagePort* port = Unwrap<MessagePort>(args[0].As<Object>());
   if (port == nullptr) {
     // Return 'no messages' for a closed port.

--- a/test/parallel/test-worker-message-port-receive-message.js
+++ b/test/parallel/test-worker-message-port-receive-message.js
@@ -23,3 +23,11 @@ port2.on('message', common.mustNotCall());
 port1.postMessage(message1);
 assert.deepStrictEqual(receiveMessageOnPort(port2), { message: message1 });
 port1.close();
+
+for (const value of [null, 0, -1, {}, []]) {
+  assert.throws(() => receiveMessageOnPort(value), {
+    name: 'TypeError',
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'First argument needs to be a MessagePort instance'
+  });
+}


### PR DESCRIPTION
Use the same type check we use in `MoveToContext()` in
`ReceiveMessage()`.

Fixes: https://github.com/nodejs/node/issues/32742

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
