### PR TITLE
buffer: mark pool ArrayBuffer as untransferable

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -59,11 +59,13 @@ const {
   zeroFill: bindingZeroFill
 } = internalBinding('buffer');
 const {
+  arraybuffer_untransferable_private_symbol,
   getOwnNonIndexProperties,
   propertyFilter: {
     ALL_PROPERTIES,
     ONLY_ENUMERABLE
-  }
+  },
+  setHiddenValue,
 } = internalBinding('util');
 const {
   customInspectSymbol,
@@ -153,6 +155,7 @@ function createUnsafeBuffer(size) {
 function createPool() {
   poolSize = Buffer.poolSize;
   allocPool = createUnsafeBuffer(poolSize).buffer;
+  setHiddenValue(allocPool, arraybuffer_untransferable_private_symbol, true);
   poolOffset = 0;
 }
 createPool();

--- a/test/parallel/test-buffer-pool-untransferable.js
+++ b/test/parallel/test-buffer-pool-untransferable.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { MessageChannel } = require('worker_threads');
+
+// Make sure that the pools used by the Buffer implementation are not
+// transferable.
+// Refs: https://github.com/nodejs/node/issues/32752
+
+const a = Buffer.from('hello world');
+const b = Buffer.from('hello world');
+assert.strictEqual(a.buffer, b.buffer);
+const length = a.length;
+
+const { port1, port2 } = new MessageChannel();
+port1.postMessage(a, [ a.buffer ]);
+
+// Verify that the pool ArrayBuffer has not actually been transfered:
+assert.strictEqual(a.buffer, b.buffer);
+assert.strictEqual(a.length, length);

--- a/test/parallel/test-buffer-pool-untransferable.js
+++ b/test/parallel/test-buffer-pool-untransferable.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const { MessageChannel } = require('worker_threads');
 
@@ -12,7 +12,7 @@ const b = Buffer.from('hello world');
 assert.strictEqual(a.buffer, b.buffer);
 const length = a.length;
 
-const { port1, port2 } = new MessageChannel();
+const { port1 } = new MessageChannel();
 port1.postMessage(a, [ a.buffer ]);
 
 // Verify that the pool ArrayBuffer has not actually been transfered:


### PR DESCRIPTION
This removes a footgun in which users could attempt to transfer the
pooled ArrayBuffer underlying a regular `Buffer`, which would lead to
all `Buffer`s that share the same pool being rendered unusable as well,
and potentially break creation of new pooled `Buffer`s.

This disables this kind of transfer.

Refs: https://github.com/nodejs/node/issues/32752

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
