### PR TITLE
tls: provide default cipher list from command line

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -25,6 +25,7 @@
 'use strict';
 
 const {
+  ObjectDefineProperty,
   ObjectDefineProperties,
 } = primordials;
 
@@ -223,6 +224,10 @@ function getFipsDisabled() {
 function getFipsForced() {
   return 1;
 }
+
+ObjectDefineProperty(constants, 'defaultCipherList', {
+  value: getOptionValue('--tls-cipher-list')
+});
 
 ObjectDefineProperties(module.exports, {
   createCipher: {

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -56,8 +56,7 @@ const _tls_wrap = require('_tls_wrap');
 exports.CLIENT_RENEG_LIMIT = 3;
 exports.CLIENT_RENEG_WINDOW = 600;
 
-exports.DEFAULT_CIPHERS =
-    internalBinding('constants').crypto.defaultCipherList;
+exports.DEFAULT_CIPHERS = getOptionValue('--tls-cipher-list');
 
 exports.DEFAULT_ECDH_CURVE = 'auto';
 

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1072,12 +1072,6 @@ void DefineCryptoConstants(Local<Object> target) {
   NODE_DEFINE_CONSTANT(target, POINT_CONVERSION_UNCOMPRESSED);
 
   NODE_DEFINE_CONSTANT(target, POINT_CONVERSION_HYBRID);
-
-  NODE_DEFINE_STRING_CONSTANT(
-      target,
-      "defaultCipherList",
-      per_process::cli_options->tls_cipher_list.c_str());
-
 #endif
 }
 

--- a/test/parallel/test-tls-cipher-list.js
+++ b/test/parallel/test-tls-cipher-list.js
@@ -8,11 +8,11 @@ const assert = require('assert');
 const spawn = require('child_process').spawn;
 const defaultCoreList = require('crypto').constants.defaultCoreCipherList;
 
-function doCheck(arg, check) {
+function doCheck(arg, expression, check) {
   let out = '';
   arg = arg.concat([
     '-pe',
-    'require("crypto").constants.defaultCipherList'
+    expression
   ]);
   spawn(process.execPath, arg, {})
     .on('error', common.mustNotCall())
@@ -24,7 +24,9 @@ function doCheck(arg, check) {
 }
 
 // Test the default unmodified version
-doCheck([], defaultCoreList);
+doCheck([], 'crypto.constants.defaultCipherList', defaultCoreList);
+doCheck([], 'tls.DEFAULT_CIPHERS', defaultCoreList);
 
 // Test the command line switch by itself
-doCheck(['--tls-cipher-list=ABC'], 'ABC');
+doCheck(['--tls-cipher-list=ABC'], 'crypto.constants.defaultCipherList', 'ABC');
+doCheck(['--tls-cipher-list=ABC'], 'tls.DEFAULT_CIPHERS', 'ABC');


### PR DESCRIPTION
Avoid storing data that depends on command line options on internal
bindings. This is generally a cleaner way of accessing CLI options.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
