### PR TITLE
test: elevate common http sequences to common

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -223,6 +223,15 @@ function createZeroFilledFile(filename) {
   fs.closeSync(fd);
 }
 
+function receive(req, cb) {
+  let buf = '';
+  req.on('data', (data) => {
+    buf += data;
+  });
+  req.on('end', () => {
+    cb(buf);
+  });
+}
 
 const pwdCommand = isWindows ?
   ['cmd.exe', ['/d', '/c', 'cd']] :
@@ -688,6 +697,7 @@ const common = {
   platformTimeout,
   printSkipMessage,
   pwdCommand,
+  receive,
   rootDir,
   runWithInvalidFD,
   skip,

--- a/test/parallel/test-http-response-no-headers.js
+++ b/test/parallel/test-http-response-no-headers.js
@@ -45,18 +45,13 @@ function test(httpVersion, callback) {
     };
 
     const req = http.get(options, common.mustCall(function(res) {
-      let body = '';
-
-      res.on('data', function(data) {
-        body += data;
-      });
-
       res.on('aborted', common.mustNotCall());
-      res.on('end', common.mustCall(function() {
-        assert.strictEqual(body, expected[httpVersion]);
+
+      common.receive(res, function(data) {
+        assert.strictEqual(data, expected[httpVersion]);
         server.close();
         if (callback) process.nextTick(callback);
-      }));
+      });
     }));
 
     req.on('error', function(err) {


### PR DESCRIPTION
There are several instances of data download  sequences in test
cases. Defined an abstraction for it in common module for easy
consumption.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
