### PR TITLE
test: refactor events  tests for invalid listeners

### DIFF
--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -84,14 +84,3 @@ const EventEmitter = require('events');
   // listeners were added.
   assert.deepStrictEqual(ee.listeners('hello'), [listen2, listen1]);
 }
-
-// Verify that the listener must be a function
-assert.throws(() => {
-  const ee = new EventEmitter();
-  ee.on('foo', null);
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  name: 'TypeError',
-  message: 'The "listener" argument must be of type function. ' +
-           'Received null'
-});

--- a/test/parallel/test-event-emitter-invalid-listener.js
+++ b/test/parallel/test-event-emitter-invalid-listener.js
@@ -1,0 +1,20 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const EventEmitter = require('events');
+
+const eventsMethods = ['on', 'once', 'removeListener', 'prependOnceListener'];
+
+// Verify that the listener must be a function for events methods
+for (const method of eventsMethods) {
+  assert.throws(() => {
+    const ee = new EventEmitter();
+    ee[method]('foo', null);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "listener" argument must be of type function. ' +
+             'Received null'
+  }, `event.${method}('foo', null) should throw the proper error`);
+}

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -49,17 +49,6 @@ e.once('e', common.mustCall());
 
 e.emit('e');
 
-// Verify that the listener must be a function
-assert.throws(() => {
-  const ee = new EventEmitter();
-  ee.once('foo', null);
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  name: 'TypeError',
-  message: 'The "listener" argument must be of type function. ' +
-           'Received null'
-});
-
 {
   // once() has different code paths based on the number of arguments being
   // emitted. Verify that all of the cases are covered.

--- a/test/parallel/test-event-emitter-prepend.js
+++ b/test/parallel/test-event-emitter-prepend.js
@@ -18,17 +18,6 @@ myEE.prependOnceListener('foo',
 
 myEE.emit('foo');
 
-// Verify that the listener must be a function
-assert.throws(() => {
-  const ee = new EventEmitter();
-  ee.prependOnceListener('foo', null);
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  name: 'TypeError',
-  message: 'The "listener" argument must be of type function. ' +
-           'Received null'
-});
-
 // Test fallback if prependListener is undefined.
 const stream = require('stream');
 

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -144,17 +144,6 @@ function listener2() {}
   assert.deepStrictEqual(ee, ee.removeListener('foo', () => {}));
 }
 
-// Verify that the removed listener must be a function
-assert.throws(() => {
-  const ee = new EventEmitter();
-  ee.removeListener('foo', null);
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  name: 'TypeError',
-  message: 'The "listener" argument must be of type function. ' +
-           'Received null'
-});
-
 {
   const ee = new EventEmitter();
   const listener = () => {};


### PR DESCRIPTION
This PR refactor some duplicated assertions in different event-emitter tests to a single one 

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
