### PR TITLE
buffer: add type check in bidirectionalIndexOf

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -899,6 +899,10 @@ Buffer.prototype.compare = function compare(target,
 // - encoding - an optional encoding, relevant if val is a string
 // - dir - true for indexOf, false for lastIndexOf
 function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new ERR_INVALID_ARG_TYPE('buffer', 'Buffer', buffer);
+  }
+
   if (typeof byteOffset === 'string') {
     encoding = byteOffset;
     byteOffset = undefined;

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -899,7 +899,7 @@ Buffer.prototype.compare = function compare(target,
 // - encoding - an optional encoding, relevant if val is a string
 // - dir - true for indexOf, false for lastIndexOf
 function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
-  if (!Buffer.isBuffer(buffer)) {
+  if (!isArrayBufferView(buffer)) {
     throw new ERR_INVALID_ARG_TYPE('buffer', 'Buffer', buffer);
   }
 
@@ -915,7 +915,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   byteOffset = +byteOffset;
   // If the offset is undefined, "foo", {}, coerces to NaN, search whole buffer.
   if (NumberIsNaN(byteOffset)) {
-    byteOffset = dir ? 0 : buffer.length;
+    byteOffset = dir ? 0 : (buffer.length || buffer.byteLength);
   }
   dir = !!dir;  // Cast to bool.
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -95,6 +95,7 @@ const {
   hideStackFrames
 } = require('internal/errors');
 const {
+  validateBuffer,
   validateInt32,
   validateString
 } = require('internal/validators');
@@ -899,9 +900,7 @@ Buffer.prototype.compare = function compare(target,
 // - encoding - an optional encoding, relevant if val is a string
 // - dir - true for indexOf, false for lastIndexOf
 function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
-  if (!isArrayBufferView(buffer)) {
-    throw new ERR_INVALID_ARG_TYPE('buffer', 'Buffer', buffer);
-  }
+  validateBuffer(buffer);
 
   if (typeof byteOffset === 'string') {
     encoding = byteOffset;

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -616,7 +616,8 @@ assert.strictEqual(reallyLong.lastIndexOf(pattern), 0);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "buffer" argument must be an instance of Buffer. ' +
+    message: 'The "buffer" argument must be an instance of Buffer, ' +
+             'TypedArray, or DataView. ' +
              'Received an instance of lastIndexOf'
   });
 }

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -606,3 +606,17 @@ assert.strictEqual(reallyLong.lastIndexOf(pattern), 0);
   assert.strictEqual(haystack.indexOf(needle), 2);
   assert.strictEqual(haystack.lastIndexOf(needle), haystack.length - 3);
 }
+
+// Avoid abort because of invalid usage
+// see https://github.com/nodejs/node/issues/32753
+{
+  assert.throws(() => {
+    const buffer = require('buffer');
+    new buffer.Buffer.prototype.lastIndexOf(1, 'str');
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "buffer" argument must be an instance of Buffer. ' +
+             'Received an instance of lastIndexOf'
+  });
+}


### PR DESCRIPTION
Add a type check in bidirectionalIndexOf to avoid using something else as Buffer. This may happen if e.g. lastIndexOf is called with invalid this.

fixes: https://github.com/nodejs/node/issues/32753
fixes: https://github.com/nodejs/node/issues/32747
