### PR TITLE
test:  better error validations for event-capture

### DIFF
--- a/test/parallel/test-event-capture-rejections.js
+++ b/test/parallel/test-event-capture-rejections.js
@@ -278,14 +278,22 @@ function resetCaptureOnThrowInError() {
 function argValidation() {
 
   function testType(obj) {
+    const received = obj.constructor.name !== 'Number' ?
+      `an instance of ${obj.constructor.name}` :
+      `type number (${obj})`;
+
     assert.throws(() => new EventEmitter({ captureRejections: obj }), {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError'
+      name: 'TypeError',
+      message: 'The "options.captureRejections" property must be of type ' +
+               `boolean. Received ${received}`
     });
 
     assert.throws(() => EventEmitter.captureRejections = obj, {
       code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError'
+      name: 'TypeError',
+      message: 'The "EventEmitter.captureRejections" property must be of ' +
+               `type boolean. Received ${received}`
     });
   }
 


### PR DESCRIPTION
This PR improves the error validation including messages for `test-event-capture-rejections.js`

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)