### PR TITLE
src: removes unused v8::Integer and v8::Array namespace

### DIFF
--- a/src/timers.cc
+++ b/src/timers.cc
@@ -7,11 +7,9 @@
 namespace node {
 namespace {
 
-using v8::Array;
 using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
-using v8::Integer;
 using v8::Local;
 using v8::Object;
 using v8::Value;


### PR DESCRIPTION
This PR removes unused v8::Integer and v8::Array namespace 

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)