### PR TITLE
stream: fix _final and 'prefinish' timing

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -99,10 +99,10 @@ function Transform(options) {
       this._flush = options.flush;
   }
 
-  // TODO(ronag): Unfortunately _final is invoked asynchronously.
-  // Use `prefinish` hack. `prefinish` is emitted synchronously when
-  // and only when `_final` is not defined. Implementing `_final`
-  // to a Transform should be an error.
+  // When the writable side finishes, then flush out anything remaining.
+  // Backwards compat. Some Transform streams incorrectly implement _final
+  // instead of or in addition to _flush. By using 'prefinish' instead of
+  // implementing _final we continue supporting this unfortunate use case.
   this.on('prefinish', prefinish);
 }
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -642,7 +642,7 @@ function callFinal(stream, state) {
       state.prefinished = true;
       stream.emit('prefinish');
       // Backwards compat. Don't check state.sync here.
-      // Some stream assume 'finish' will be emitted
+      // Some streams assume 'finish' will be emitted
       // asynchronously relative to _final callback.
       state.pendingcb++;
       process.nextTick(finish, stream, state);

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -635,10 +635,7 @@ function callFinal(stream, state) {
     state.pendingcb--;
     if (err) {
       errorOrDestroy(stream, err, state.sync);
-    } else {
-      // Backwards compat. Don't check needFinish() here.
-      // Some streams assume 'finish' will be emitted
-      // even if stream has been destroyed.
+    } else if (needFinish(state)) {
       state.prefinished = true;
       stream.emit('prefinish');
       // Backwards compat. Don't check state.sync here.
@@ -681,6 +678,8 @@ function finish(stream, state) {
   state.pendingcb--;
   if (state.errorEmitted)
     return;
+
+  // TODO(ronag): This could occur after 'close' is emitted.
 
   state.finished = true;
   stream.emit('finish');

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -629,24 +629,33 @@ function needFinish(state) {
 }
 
 function callFinal(stream, state) {
+  state.sync = true;
+  state.pendingcb++;
   stream._final((err) => {
     state.pendingcb--;
     if (err) {
-      errorOrDestroy(stream, err);
+      errorOrDestroy(stream, err, state.sync);
     } else {
+      // Backwards compat. Don't check needFinish() here.
+      // Some streams assume 'finish' will be emitted
+      // even if stream has been destroyed.
       state.prefinished = true;
       stream.emit('prefinish');
-      finishMaybe(stream, state);
+      // Backwards compat. Don't check state.sync here.
+      // Some stream assume 'finish' will be emitted
+      // asynchronously relative to _final callback.
+      state.pendingcb++;
+      process.nextTick(finish, stream, state);
     }
   });
+  state.sync = false;
 }
 
 function prefinish(stream, state) {
   if (!state.prefinished && !state.finalCalled) {
     if (typeof stream._final === 'function' && !state.destroyed) {
-      state.pendingcb++;
       state.finalCalled = true;
-      process.nextTick(callFinal, stream, state);
+      callFinal(stream, state);
     } else {
       state.prefinished = true;
       stream.emit('prefinish');
@@ -655,10 +664,9 @@ function prefinish(stream, state) {
 }
 
 function finishMaybe(stream, state, sync) {
-  const need = needFinish(state);
-  if (need) {
+  if (needFinish(state)) {
     prefinish(stream, state);
-    if (state.pendingcb === 0) {
+    if (state.pendingcb === 0 && needFinish(state)) {
       state.pendingcb++;
       if (sync) {
         process.nextTick(finish, stream, state);
@@ -667,7 +675,6 @@ function finishMaybe(stream, state, sync) {
       }
     }
   }
-  return need;
 }
 
 function finish(stream, state) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1710,11 +1710,14 @@ function streamOnPause() {
 }
 
 function afterShutdown(status) {
+  const stream = this.handle[kOwner];
+  if (stream) {
+    stream.on('finish', () => {
+      stream[kMaybeDestroy]();
+    });
+  }
   // Currently this status value is unused
   this.callback();
-  const stream = this.handle[kOwner];
-  if (stream)
-    stream[kMaybeDestroy]();
 }
 
 function finishSendTrailers(stream, headersList) {

--- a/test/parallel/test-stream-transform-final-sync.js
+++ b/test/parallel/test-stream-transform-final-sync.js
@@ -82,7 +82,7 @@ const t = new stream.Transform({
     process.nextTick(function() {
       state++;
       // fluchCallback part 2
-      assert.strictEqual(state, 15);
+      assert.strictEqual(state, 13);
       done();
     });
   }, 1)
@@ -90,7 +90,7 @@ const t = new stream.Transform({
 t.on('finish', common.mustCall(function() {
   state++;
   // finishListener
-  assert.strictEqual(state, 13);
+  assert.strictEqual(state, 14);
 }, 1));
 t.on('end', common.mustCall(function() {
   state++;
@@ -106,5 +106,5 @@ t.write(4);
 t.end(7, common.mustCall(function() {
   state++;
   // endMethodCallback
-  assert.strictEqual(state, 14);
+  assert.strictEqual(state, 15);
 }, 1));

--- a/test/parallel/test-stream-transform-final.js
+++ b/test/parallel/test-stream-transform-final.js
@@ -84,7 +84,7 @@ const t = new stream.Transform({
     process.nextTick(function() {
       state++;
       // flushCallback part 2
-      assert.strictEqual(state, 15);
+      assert.strictEqual(state, 13);
       done();
     });
   }, 1)
@@ -92,7 +92,7 @@ const t = new stream.Transform({
 t.on('finish', common.mustCall(function() {
   state++;
   // finishListener
-  assert.strictEqual(state, 13);
+  assert.strictEqual(state, 14);
 }, 1));
 t.on('end', common.mustCall(function() {
   state++;
@@ -108,5 +108,5 @@ t.write(4);
 t.end(7, common.mustCall(function() {
   state++;
   // endMethodCallback
-  assert.strictEqual(state, 14);
+  assert.strictEqual(state, 15);
 }, 1));

--- a/test/parallel/test-stream-writable-finished.js
+++ b/test/parallel/test-stream-writable-finished.js
@@ -30,7 +30,7 @@ const assert = require('assert');
 }
 
 {
-  // Emit finish asynchronously
+  // Emit finish asynchronously.
 
   const w = new Writable({
     write(chunk, encoding, cb) {
@@ -43,7 +43,7 @@ const assert = require('assert');
 }
 
 {
-  // Emit prefinish synchronously
+  // Emit prefinish synchronously.
 
   const w = new Writable({
     write(chunk, encoding, cb) {
@@ -60,7 +60,7 @@ const assert = require('assert');
 }
 
 {
-  // Emit prefinish synchronously w/ final
+  // Emit prefinish synchronously w/ final.
 
   const w = new Writable({
     write(chunk, encoding, cb) {
@@ -81,7 +81,7 @@ const assert = require('assert');
 
 
 {
-  // Call _final synchronouslyl
+  // Call _final synchronously.
 
   let sync = true;
   const w = new Writable({

--- a/test/parallel/test-stream-writable-finished.js
+++ b/test/parallel/test-stream-writable-finished.js
@@ -41,3 +41,59 @@ const assert = require('assert');
   w.end();
   w.on('finish', common.mustCall());
 }
+
+{
+  // Emit prefinish synchronously
+
+  const w = new Writable({
+    write(chunk, encoding, cb) {
+      cb();
+    }
+  });
+
+  let sync = true;
+  w.on('prefinish', common.mustCall(() => {
+    assert.strictEqual(sync, true);
+  }));
+  w.end();
+  sync = false;
+}
+
+{
+  // Emit prefinish synchronously w/ final
+
+  const w = new Writable({
+    write(chunk, encoding, cb) {
+      cb();
+    },
+    final(cb) {
+      cb();
+    }
+  });
+
+  let sync = true;
+  w.on('prefinish', common.mustCall(() => {
+    assert.strictEqual(sync, true);
+  }));
+  w.end();
+  sync = false;
+}
+
+
+{
+  // Call _final synchronouslyl
+
+  let sync = true;
+  const w = new Writable({
+    write(chunk, encoding, cb) {
+      cb();
+    },
+    final: common.mustCall((cb) => {
+      assert.strictEqual(sync, true);
+      cb();
+    })
+  });
+
+  w.end();
+  sync = false;
+}


### PR DESCRIPTION
This PR fixes a few different things:

The timing of 'prefinish' depends on whether or not
_final is defined. In one case the event is emitted
synchronously with end() and otherwise asynchronously.

_final is currently unecessarily called asynchronously
which forces implementors to use 'prefinish' as a hack
to emulate synchronous behaviour. Furthermore, this hack
is subtly broken due to the above issue.

~~The stream should not finish if errored or destroyed
synchronously during the prefinish stage.~~

Refs: https://github.com/nodejs/node/issues/31401
Refs: https://github.com/nodejs/node/pull/32763#discussion_r407041983

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
