### PR TITLE
doc: improve WHATWG url constructor code example

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -108,7 +108,7 @@ const myURL = new URL('/foo', 'https://example.org/');
 The URL constructor is accessible as a property on the global object.
 It can also be imported from the built-in url module:
 
-```
+```js
 console.log(URL === require('url').URL); // Prints 'true'.
 ```
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -53,7 +53,6 @@ WHATWG URL's `origin` property includes `protocol` and `host`, but not
 Parsing the URL string using the WHATWG API:
 
 ```js
-const URL = require('url').URL
 const myURL =
   new URL('https://user:pass@sub.example.com:8080/p/a/t/h?query=string#hash');
 ```
@@ -104,6 +103,13 @@ Creates a new `URL` object by parsing the `input` relative to the `base`. If
 ```js
 const myURL = new URL('/foo', 'https://example.org/');
 // https://example.org/foo
+```
+
+The URL constructor is accessible as a property on the global object.
+It can also be imported from the built-in url module:
+
+```
+console.log(URL === require('url').URL); // Prints 'true'.
 ```
 
 A `TypeError` will be thrown if the `input` or `base` are not valid URLs. Note

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -53,6 +53,7 @@ WHATWG URL's `origin` property includes `protocol` and `host`, but not
 Parsing the URL string using the WHATWG API:
 
 ```js
+const URL = require('url').URL
 const myURL =
   new URL('https://user:pass@sub.example.com:8080/p/a/t/h?query=string#hash');
 ```


### PR DESCRIPTION
## Why this PR ?
Currently, the URL docs for the WHATWG URL spec support are
somewhat lacking in their code example of how to access the
new URL constructor that lives inside the core url package.

## Suggested change
Improve the code example that shows how the new URL 
constructor should be accessed to begin with.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
