### PR TITLE
http: return this from IncomingMessage#destroy()

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1847,9 +1847,15 @@ const req = http.request({
 ### `message.destroy([error])`
 <!-- YAML
 added: v0.3.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32789
+    description: The function returns `this` for consistency with other Readable
+                 streams.
 -->
 
 * `error` {Error}
+* Returns: {this}
 
 Calls `destroy()` on the socket that received the `IncomingMessage`. If `error`
 is provided, an `'error'` event is emitted on the socket and `error` is passed

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -631,6 +631,11 @@ is finished.
 ### `request.destroy([error])`
 <!-- YAML
 added: v0.3.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32789
+    description: The function returns `this` for consistency with other Readable
+                 streams.
 -->
 
 * `error` {Error} Optional, an error to emit with `'error'` event.

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -349,7 +349,7 @@ ClientRequest.prototype.abort = function abort() {
 
 ClientRequest.prototype.destroy = function destroy(err) {
   if (this.destroyed) {
-    return;
+    return this;
   }
   this.destroyed = true;
 
@@ -365,6 +365,8 @@ ClientRequest.prototype.destroy = function destroy(err) {
   } else if (err) {
     this[kError] = err;
   }
+
+  return this;
 };
 
 function _destroy(req, socket, err) {

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -123,6 +123,7 @@ IncomingMessage.prototype.destroy = function destroy(error) {
   this.destroyed = true;
   if (this.socket)
     this.socket.destroy(error);
+  return this;
 };
 
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -283,7 +283,7 @@ OutgoingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
 // it, since something else is destroying this connection anyway.
 OutgoingMessage.prototype.destroy = function destroy(error) {
   if (this.destroyed) {
-    return;
+    return this;
   }
   this.destroyed = true;
 
@@ -294,6 +294,8 @@ OutgoingMessage.prototype.destroy = function destroy(error) {
       socket.destroy(error);
     });
   }
+
+  return this;
 };
 
 

--- a/test/parallel/test-client-request-destroy.js
+++ b/test/parallel/test-client-request-destroy.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// Test that http.ClientRequest,prototype.destroy() returns `this`.
+require('../common');
+
+const assert = require('assert');
+const http = require('http');
+const clientRequest = new http.ClientRequest({ createConnection: () => {} });
+
+assert.strictEqual(clientRequest.destroyed, false);
+assert.strictEqual(clientRequest.destroy(), clientRequest);
+assert.strictEqual(clientRequest.destroyed, true);
+assert.strictEqual(clientRequest.destroy(), clientRequest);

--- a/test/parallel/test-http-incoming-message-destroy.js
+++ b/test/parallel/test-http-incoming-message-destroy.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// Test that http.IncomingMessage,prototype.destroy() returns `this`.
+require('../common');
+
+const assert = require('assert');
+const http = require('http');
+const incomingMessage = new http.IncomingMessage();
+
+assert.strictEqual(incomingMessage.destroy(), incomingMessage);

--- a/test/parallel/test-outgoing-message-destroy.js
+++ b/test/parallel/test-outgoing-message-destroy.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// Test that http.OutgoingMessage,prototype.destroy() returns `this`.
+require('../common');
+
+const assert = require('assert');
+const http = require('http');
+const outgoingMessage = new http.OutgoingMessage();
+
+assert.strictEqual(outgoingMessage.destroyed, false);
+assert.strictEqual(outgoingMessage.destroy(), outgoingMessage);
+assert.strictEqual(outgoingMessage.destroyed, true);
+assert.strictEqual(outgoingMessage.destroy(), outgoingMessage);


### PR DESCRIPTION
This commit updates `IncomingMessage#destroy()` to return `this` for consistency with other readable streams.

Fixes: https://github.com/nodejs/node/issues/32772

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)