### PR TITLE
cluster: fix error on worker disconnect/destroy

### DIFF
--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -228,16 +228,23 @@ function _disconnect(masterInitiated) {
 
 // Extend generic Worker with methods specific to worker processes.
 Worker.prototype.disconnect = function() {
-  _disconnect.call(this);
+  if (![ 'disconnecting', 'destroying' ].includes(this.state)) {
+    this.state = 'disconnecting';
+    _disconnect.call(this);
+  }
+
   return this;
 };
 
 Worker.prototype.destroy = function() {
-  this.exitedAfterDisconnect = true;
+  if (this.state === 'destroying')
+    return;
 
+  this.exitedAfterDisconnect = true;
   if (!this.isConnected()) {
     process.exit(0);
   } else {
+    this.state = 'destroying';
     send({ act: 'exitedAfterDisconnect' }, () => process.disconnect());
     process.once('disconnect', () => process.exit(0));
   }

--- a/test/parallel/test-cluster-concurrent-disconnect.js
+++ b/test/parallel/test-cluster-concurrent-disconnect.js
@@ -1,0 +1,48 @@
+'use strict';
+
+// Ref: https://github.com/nodejs/node/issues/32106
+
+const common = require('../common');
+
+const assert = require('assert');
+const cluster = require('cluster');
+const os = require('os');
+
+if (cluster.isMaster) {
+  const workers = [];
+  const numCPUs = os.cpus().length;
+  let waitOnline = numCPUs;
+  for (let i = 0; i < numCPUs; i++) {
+    const worker = cluster.fork();
+    workers[i] = worker;
+    worker.once('online', common.mustCall(() => {
+      if (--waitOnline === 0)
+        for (const worker of workers)
+          if (worker.isConnected())
+            worker.send(i % 2 ? 'disconnect' : 'destroy');
+    }));
+
+    // These errors can occur due to the nature of the test, we might be trying
+    // to send messages when the worker is disconnecting.
+    worker.on('error', (err) => {
+      assert.strictEqual(err.syscall, 'write');
+      assert.strictEqual(err.code, 'EPIPE');
+    });
+
+    worker.once('disconnect', common.mustCall(() => {
+      for (const worker of workers)
+        if (worker.isConnected())
+          worker.send('disconnect');
+    }));
+
+    worker.once('exit', common.mustCall((code, signal) => {
+      assert.strictEqual(code, 0);
+      assert.strictEqual(signal, null);
+    }));
+  }
+} else {
+  process.on('message', (msg) => {
+    if (cluster.worker.isConnected())
+      cluster.worker[msg]();
+  });
+}


### PR DESCRIPTION
Avoid sending multiple `exitedAfterDisconnect` messages when
concurrently calling `disconnect()` and/or `destroy()` from the worker
so `ERR_IPC_DISCONNECTED` errors are not generated.

Not completely sure if it's something that should be fixed in the module or in the user code, but just in case...

Fixes: https://github.com/nodejs/node/issues/32106

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
