### PR TITLE
[v13.x] deps: V8: cherry-pick dc3a90be6ca7

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.30',
+    'v8_embedder_string': '-node.31',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/builtins/builtins-function.cc
+++ b/deps/v8/src/builtins/builtins-function.cc
@@ -93,17 +93,6 @@ MaybeHandle<Object> CreateDynamicFunction(Isolate* isolate,
     function->shared().set_name_should_print_as_anonymous(true);
   }
 
-  // The spec says that we have to wrap code created via the function
-  // constructor in e.g. 'function anonymous(' as above, including with extra
-  // line breaks. Ths is confusing when reporting stack traces from the eval'd
-  // code as the line number of the error is always reported with 2 extra line
-  // breaks e.g. line 1 is reported as line 3. We fix this up here by setting
-  // line_offset which is read by stack trace code.
-  Handle<Script> script(Script::cast(function->shared().script()), isolate);
-  if (script->line_offset() == 0) {
-    script->set_line_offset(-2);
-  }
-
   // If new.target is equal to target then the function created
   // is already correctly setup and nothing else should be done
   // here. But if new.target is not equal to target then we are

--- a/deps/v8/test/cctest/test-api-stack-traces.cc
+++ b/deps/v8/test/cctest/test-api-stack-traces.cc
@@ -250,31 +250,31 @@ static void AnalyzeStackInNativeCode(
     v8::Local<v8::StackTrace> stackTrace = v8::StackTrace::CurrentStackTrace(
         args.GetIsolate(), 5, v8::StackTrace::kOverview);
     CHECK_EQ(3, stackTrace->GetFrameCount());
-    checkStackFrame(nullptr, "function.name", 1, 1, true, false,
+    checkStackFrame(nullptr, "function.name", 3, 1, true, false,
                     stackTrace->GetFrame(isolate, 0));
   } else if (testGroup == kDisplayName) {
     v8::Local<v8::StackTrace> stackTrace = v8::StackTrace::CurrentStackTrace(
         args.GetIsolate(), 5, v8::StackTrace::kOverview);
     CHECK_EQ(3, stackTrace->GetFrameCount());
-    checkStackFrame(nullptr, "function.displayName", 1, 1, true, false,
+    checkStackFrame(nullptr, "function.displayName", 3, 1, true, false,
                     stackTrace->GetFrame(isolate, 0));
   } else if (testGroup == kFunctionNameAndDisplayName) {
     v8::Local<v8::StackTrace> stackTrace = v8::StackTrace::CurrentStackTrace(
         args.GetIsolate(), 5, v8::StackTrace::kOverview);
     CHECK_EQ(3, stackTrace->GetFrameCount());
-    checkStackFrame(nullptr, "function.displayName", 1, 1, true, false,
+    checkStackFrame(nullptr, "function.displayName", 3, 1, true, false,
                     stackTrace->GetFrame(isolate, 0));
   } else if (testGroup == kDisplayNameIsNotString) {
     v8::Local<v8::StackTrace> stackTrace = v8::StackTrace::CurrentStackTrace(
         args.GetIsolate(), 5, v8::StackTrace::kOverview);
     CHECK_EQ(3, stackTrace->GetFrameCount());
-    checkStackFrame(nullptr, "function.name", 1, 1, true, false,
+    checkStackFrame(nullptr, "function.name", 3, 1, true, false,
                     stackTrace->GetFrame(isolate, 0));
   } else if (testGroup == kFunctionNameIsNotString) {
     v8::Local<v8::StackTrace> stackTrace = v8::StackTrace::CurrentStackTrace(
         args.GetIsolate(), 5, v8::StackTrace::kOverview);
     CHECK_EQ(3, stackTrace->GetFrameCount());
-    checkStackFrame(nullptr, "", 1, 1, true, false,
+    checkStackFrame(nullptr, "", 3, 1, true, false,
                     stackTrace->GetFrame(isolate, 0));
   }
 }

--- a/deps/v8/test/debugger/debugger.status
+++ b/deps/v8/test/debugger/debugger.status
@@ -11,9 +11,6 @@
   # not work, but we expect it to not crash.
   'debug/debug-step-turbofan': [PASS, FAIL],
 
-  # BUG (v8:9721)
-  'debug/es6/generators-relocation': [FAIL],
-
   # Issue 3641: The new 'then' semantics suppress some exceptions.
   # These tests may be changed or removed when 'chain' is deprecated.
   'debug/es6/debug-promises/reject-with-throw-in-reject': [FAIL],

--- a/deps/v8/test/inspector/runtime/evaluate-new-function-error-expected.txt
+++ b/deps/v8/test/inspector/runtime/evaluate-new-function-error-expected.txt
@@ -6,19 +6,19 @@ Tests that Runtime.evaluate has the correct error line number for 'new Function(
             columnNumber : 3
             exception : {
                 className : TypeError
-                description : TypeError: 0 is not a function     at eval (eval at <anonymous> (:1:1), <anonymous>:1:4)     at <anonymous>:1:22
+                description : TypeError: 0 is not a function     at eval (eval at <anonymous> (:1:1), <anonymous>:3:4)     at <anonymous>:1:22
                 objectId : <objectId>
                 subtype : error
                 type : object
             }
             exceptionId : <exceptionId>
-            lineNumber : 0
+            lineNumber : 2
             scriptId : <scriptId>
             text : Uncaught
         }
         result : {
             className : TypeError
-            description : TypeError: 0 is not a function     at eval (eval at <anonymous> (:1:1), <anonymous>:1:4)     at <anonymous>:1:22
+            description : TypeError: 0 is not a function     at eval (eval at <anonymous> (:1:1), <anonymous>:3:4)     at <anonymous>:1:22
             objectId : <objectId>
             subtype : error
             type : object

--- a/deps/v8/test/mjsunit/regress/regress-crbug-109362.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-109362.js
@@ -19,7 +19,7 @@ function test(expectation, f) {
 1 + reference_error //@ sourceURL=evaltest
 })
 */
-test("1:5", new Function(
+test("3:5", new Function(
     '1 + reference_error //@ sourceURL=evaltest'));
 /*
 (function(x
@@ -28,7 +28,7 @@ test("1:5", new Function(
  1 + reference_error //@ sourceURL=evaltest
 })
 */
-test("2:6", new Function(
+test("4:6", new Function(
     'x', '\n 1 + reference_error //@ sourceURL=evaltest'));
 /*
 (function(x
@@ -40,7 +40,7 @@ test("2:6", new Function(
  1 + reference_error //@ sourceURL=evaltest
 })
 */
-test("5:6", new Function(
+test("7:6", new Function(
     'x\n\n', "z//\n", "y", '\n 1 + reference_error //@ sourceURL=evaltest'));
 /*
 (function(x/\*,z//
@@ -49,7 +49,7 @@ test("5:6", new Function(
 1 + reference_error //@ sourceURL=evaltest
 })
 */
-test("2:5", new Function(
+test("4:5", new Function(
     'x/*', "z//\n", "y*/", '1 + reference_error //@ sourceURL=evaltest'));
 /*
 (function () {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -277,7 +277,7 @@ function getErrMessage(message, fn) {
   const call = err.stack[0];
 
   const filename = call.getFileName();
-  let line = call.getLineNumber() - 1;
+  const line = call.getLineNumber() - 1;
   let column = call.getColumnNumber() - 1;
   let identifier;
   let code;
@@ -297,9 +297,6 @@ function getErrMessage(message, fn) {
       return message;
     }
     code = String(fn);
-    // For functions created with the Function constructor, V8 does not count
-    // the lines containing the function header.
-    line += 2;
     identifier = `${code}${line}${column}`;
   }
 


### PR DESCRIPTION
Original commit message:

    [debug] Revert to old line number behavior for new Function()

    Reverting https://chromium-review.googlesource.com/c/v8/v8/+/1741660

    This fixed one bug but caused a lot of others and on balance I think
    reverting it is the lesser evil.

    This also fixed generator-relocation.js because
    (function*(){}).constructor is the function constructor and we try to
    set a breakpoint on line 3.

    Bug: chromium:109362, chromium:1028689
    Fixes: v8:9721
    Change-Id: I1bfe6ec57ce77ea7292df91266311f5c0194947e
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1940259
    Commit-Queue: Peter Marshall <petermarshall@chromium.org>
    Reviewed-by: Yang Guo <yangguo@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#65232}

Refs: https://github.com/v8/v8/commit/dc3a90be6ca7f7160e1865f289e76c7bc32f78c4

Revert "assert: fix line number calculation after V8 upgrade"

This reverts commit 5981fb7faa13de95550b01272ebfbd8a5220aadb.

Fixes: https://github.com/nodejs/node/issues/32688

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
