### PR TITLE
process: suggest --trace-warnings when printing warning

### DIFF
--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -58,6 +58,7 @@ function doEmitWarning(warning) {
   return () => process.emit('warning', warning);
 }
 
+let traceWarningHelperShown = false;
 function onWarning(warning) {
   if (!(warning instanceof Error)) return;
   const isDeprecation = warning.name === 'DeprecationWarning';
@@ -77,6 +78,12 @@ function onWarning(warning) {
   }
   if (typeof warning.detail === 'string') {
     msg += `\n${warning.detail}`;
+  }
+  if (!trace && !traceWarningHelperShown) {
+    const flag = isDeprecation ? '--trace-deprecation' : '--trace-warnings';
+    msg += `\n(Use \`node ${flag} ...\` to show where the warning ` +
+           'was created)';
+    traceWarningHelperShown = true;
   }
   const warningFile = lazyOption();
   if (warningFile) {

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -81,7 +81,7 @@ function onWarning(warning) {
   }
   if (!trace && !traceWarningHelperShown) {
     const flag = isDeprecation ? '--trace-deprecation' : '--trace-warnings';
-    const argv0 = require('path').basename(process.argv0 || 'node');
+    const argv0 = require('path').basename(process.argv0 || 'node', '.exe');
     msg += `\n(Use \`${argv0} ${flag} ...\` to show where the warning ` +
            'was created)';
     traceWarningHelperShown = true;

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -81,7 +81,8 @@ function onWarning(warning) {
   }
   if (!trace && !traceWarningHelperShown) {
     const flag = isDeprecation ? '--trace-deprecation' : '--trace-warnings';
-    msg += `\n(Use \`node ${flag} ...\` to show where the warning ` +
+    const argv0 = require('path').basename(process.argv0 || 'node');
+    msg += `\n(Use \`${argv0} ${flag} ...\` to show where the warning ` +
            'was created)';
     traceWarningHelperShown = true;
   }

--- a/test/message/async_error_sync_esm.out
+++ b/test/message/async_error_sync_esm.out
@@ -1,4 +1,5 @@
 (node:*) ExperimentalWarning: The ESM module loader is experimental.
+(Use `node --trace-warnings ...` to show where the warning was created)
 Error: test
     at one (*fixtures*async-error.js:4:9)
     at two (*fixtures*async-error.js:17:9)

--- a/test/message/esm_display_syntax_error.out
+++ b/test/message/esm_display_syntax_error.out
@@ -1,4 +1,5 @@
 (node:*) ExperimentalWarning: The ESM module loader is experimental.
+(Use `node --trace-warnings ...` to show where the warning was created)
 file:///*/test/message/esm_display_syntax_error.mjs:2
 await async () => 0;
 ^^^^^

--- a/test/message/esm_display_syntax_error_import.out
+++ b/test/message/esm_display_syntax_error_import.out
@@ -1,4 +1,5 @@
 (node:*) ExperimentalWarning: The ESM module loader is experimental.
+(Use `node --trace-warnings ...` to show where the warning was created)
 file:///*/test/message/esm_display_syntax_error_import.mjs:5
   notfound
   ^^^^^^^^

--- a/test/message/esm_display_syntax_error_import_module.out
+++ b/test/message/esm_display_syntax_error_import_module.out
@@ -1,4 +1,5 @@
 (node:*) ExperimentalWarning: The ESM module loader is experimental.
+(Use `node --trace-warnings ...` to show where the warning was created)
 file:///*/test/fixtures/es-module-loaders/syntax-error-import.mjs:1
 import { foo, notfound } from './module-named-exports.mjs';
               ^^^^^^^^

--- a/test/message/esm_display_syntax_error_module.out
+++ b/test/message/esm_display_syntax_error_module.out
@@ -1,4 +1,5 @@
 (node:*) ExperimentalWarning: The ESM module loader is experimental.
+(Use `node --trace-warnings ...` to show where the warning was created)
 file:///*/test/fixtures/es-module-loaders/syntax-error.mjs:2
 await async () => 0;
 ^^^^^

--- a/test/message/esm_loader_not_found.out
+++ b/test/message/esm_loader_not_found.out
@@ -1,4 +1,5 @@
 (node:*) ExperimentalWarning: The ESM module loader is experimental.
+(Use `node --trace-warnings ...` to show where the warning was created)
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
 internal/modules/run_main.js:*
     internalBinding('errors').triggerUncaughtException(

--- a/test/message/esm_loader_syntax_error.out
+++ b/test/message/esm_loader_syntax_error.out
@@ -1,4 +1,5 @@
 (node:*) ExperimentalWarning: The ESM module loader is experimental.
+(Use `node --trace-warnings ...` to show where the warning was created)
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
 file://*/test/fixtures/es-module-loaders/syntax-error.mjs:2
 await async () => 0;

--- a/test/message/v8_warning.out
+++ b/test/message/v8_warning.out
@@ -1,1 +1,2 @@
 (node:*) V8: *v8_warning.js:* Invalid asm.js: Invalid return type
+(Use `node --trace-warnings ...` to show where the warning was created)

--- a/test/parallel/test-debugger-pid.js
+++ b/test/parallel/test-debugger-pid.js
@@ -29,9 +29,12 @@ interfacer.on('line', function(line) {
     case 1:
       expected =
         new RegExp(`^\\(node:${pid}\\) \\[DEP0068\\] DeprecationWarning: `);
-      assert.ok(expected.test(line), `expected regexp match for ${line}`);
+      assert.match(line, expected);
       break;
     case 2:
+      assert.match(line, /Use `node --trace-deprecation \.\.\.` to show where /);
+      break;
+    case 3:
       // Doesn't currently work on Windows.
       if (!common.isWindows) {
         expected = "Target process: 655555 doesn't exist.";
@@ -48,6 +51,6 @@ interfacer.on('line', function(line) {
 interfacer.on('exit', function(code, signal) {
   assert.strictEqual(code, 1, `Got unexpected code: ${code}`);
   if (!common.isWindows) {
-    assert.strictEqual(lineCount, 2);
+    assert.strictEqual(lineCount, 3);
   }
 });

--- a/test/parallel/test-env-var-no-warnings.js
+++ b/test/parallel/test-env-var-no-warnings.js
@@ -17,7 +17,7 @@ if (process.argv[2] === 'child') {
       if (env.NODE_NO_WARNINGS === '1')
         assert.strictEqual(stderr, '');
       else
-        assert(/Warning: foo$/.test(stderr.trim()));
+        assert.match(stderr.trim(), /Warning: foo\n/);
     }));
   }
 

--- a/test/pseudo-tty/test-tty-color-support-warning-2.out
+++ b/test/pseudo-tty/test-tty-color-support-warning-2.out
@@ -1,2 +1,3 @@
 
 (node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support-warning.out
+++ b/test/pseudo-tty/test-tty-color-support-warning.out
@@ -1,2 +1,3 @@
 
 (node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support.out
+++ b/test/pseudo-tty/test-tty-color-support.out
@@ -1,1 +1,2 @@
 (node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)


### PR DESCRIPTION
Suggest using `--trace-warnings` or `--trace-deprecation` the first
time a warning is emitted without a stack trace, similar to how
we suggest `--trace-uncaught` when printing uncaught exceptions
without a stack trace.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
