### PR TITLE
lib: remove unnecessary id comparison

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -394,8 +394,7 @@ function compareTimersLists(a, b) {
   if (expiryDiff === 0) {
     if (a.id < b.id)
       return -1;
-    if (a.id > b.id)
-      return 1;
+    return 1;
   }
   return expiryDiff;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

If we look at the generation of the list item that is inserted into the
priority queue, we can observe that we are doing `++id` before inserting
or updating the value in the list, and `id` is a global object. Thus it is
safe to say that no two element id can be equal. Also in the walk, we are
iterating from root to leaf nodes, so always comparing two different
elements.

Benchmark results

```
 timers/immediate.js type='breadth' n=5000000                                 4.09 %       ±7.09% ±9.44% ±12.30%
 timers/immediate.js type='breadth1' n=5000000                                0.42 %       ±3.96% ±5.29%  ±6.90%
 timers/immediate.js type='breadth4' n=5000000                               -1.32 %       ±2.57% ±3.42%  ±4.45%
 timers/immediate.js type='clear' n=5000000                           **     -4.10 %       ±2.54% ±3.40%  ±4.46%
 timers/immediate.js type='depth' n=5000000                                   0.23 %       ±1.59% ±2.12%  ±2.76%
 timers/immediate.js type='depth1' n=5000000                                 -0.72 %       ±1.62% ±2.15%  ±2.80%
 timers/set-immediate-breadth-args.js n=5000000                              -2.87 %       ±6.23% ±8.29% ±10.79%
 timers/set-immediate-breadth.js n=10000000                                   2.16 %       ±5.94% ±7.91% ±10.29%
 timers/set-immediate-depth-args.js n=5000000                                 0.66 %       ±2.48% ±3.32%  ±4.37%
 timers/timers-breadth-args.js n=1000000                                      1.64 %       ±3.89% ±5.18%  ±6.74%
 timers/timers-breadth.js n=5000000                                          -2.47 %       ±6.48% ±8.63% ±11.23%
 timers/timers-cancel-pooled.js n=5000000                                    -0.30 %       ±3.37% ±4.48%  ±5.83%
 timers/timers-cancel-unpooled.js direction='end' n=1000000                   2.31 %       ±4.31% ±5.74%  ±7.46%
 timers/timers-cancel-unpooled.js direction='start' n=1000000                -0.29 %       ±3.16% ±4.21%  ±5.49%
 timers/timers-depth.js n=1000                                               -0.33 %       ±1.61% ±2.14%  ±2.78%
 timers/timers-insert-pooled.js n=5000000                                     3.67 %       ±4.11% ±5.47%  ±7.13%
 timers/timers-insert-unpooled.js direction='end' n=1000000          ***      5.87 %       ±1.09% ±1.46%  ±1.91%
 timers/timers-insert-unpooled.js direction='start' n=1000000                -0.69 %       ±1.42% ±1.90%  ±2.48%
 timers/timers-timeout-nexttick.js n=50000                                    2.17 %       ±4.95% ±6.58%  ±8.56%
 timers/timers-timeout-nexttick.js n=5000000                                  0.10 %       ±5.32% ±7.08%  ±9.21%
 timers/timers-timeout-pooled.js n=10000000                                   3.32 %       ±4.41% ±5.88%  ±7.68%
 timers/timers-timeout-unpooled.js n=1000000                                  1.19 %       ±2.77% ±3.69%  ±4.82%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case there are 22 comparisons, you can thus
expect the following amount of false-positive results:
  1.10 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.22 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->