### PR TITLE
http: doc deprecate abort and improve docs

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2651,8 +2651,8 @@ written twice. This introduces a race condition between threads, and is a
 potential security vulnerability. There is no safe, cross-platform alternative
 API.
 
-<a id="DEPXXX"></a>
-### DEPXXX: Use `request.destroy()` instead of `request.abort()`
+<a id="DEP0XXX"></a>
+### DEP0XXX: Use `request.destroy()` instead of `request.abort()`
 <!-- YAML
 changes:
   - version: REPLACEME

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2652,7 +2652,7 @@ potential security vulnerability. There is no safe, cross-platform alternative
 API.
 
 <a id="DEPXXX"></a>
-### DEPXXX: Use `request.destroy()` in favor of `request.abort()`
+### DEPXXX: Use `request.destroy()` instead of `request.abort()`
 <!-- YAML
 changes:
   - version: REPLACEME
@@ -2662,7 +2662,7 @@ changes:
 
 Type: Documentation-only
 
-Use [`request.destroy()`][] in favor of [`request.abort()`][].
+Use [`request.destroy()`][] instead of [`request.abort()`][].
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2651,7 +2651,6 @@ written twice. This introduces a race condition between threads, and is a
 potential security vulnerability. There is no safe, cross-platform alternative
 API.
 
-
 <a id="DEPXXX"></a>
 ### DEPXXX: Use `request.destroy()` in favor of `request.abort()`
 <!-- YAML

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2651,6 +2651,20 @@ written twice. This introduces a race condition between threads, and is a
 potential security vulnerability. There is no safe, cross-platform alternative
 API.
 
+
+<a id="DEPXXX"></a>
+### DEPXXX: Use `request.destroy()` in favor of `request.abort()`
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32807
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+Use [`request.destroy()`][] in favor of [`request.abort()`][].
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
@@ -2712,8 +2726,10 @@ API.
 [`punycode`]: punycode.html
 [`require.extensions`]: modules.html#modules_require_extensions
 [`require.main`]: modules.html#modules_accessing_the_main_module
+[`request.abort()`]: http.html#http_request_abort
 [`request.socket`]: http.html#http_request_socket
 [`request.connection`]: http.html#http_request_connection
+[`request.destroy()`]: http.html#http_request_destroy_err_callback
 [`response.socket`]: http.html#http_response_socket
 [`response.connection`]: http.html#http_response_connection
 [`response.end()`]: http.html#http_response_end_data_encoding_callback

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2728,7 +2728,7 @@ Use [`request.destroy()`][] in favor of [`request.abort()`][].
 [`request.abort()`]: http.html#http_request_abort
 [`request.socket`]: http.html#http_request_socket
 [`request.connection`]: http.html#http_request_connection
-[`request.destroy()`]: http.html#http_request_destroy_err_callback
+[`request.destroy()`]: http.html#http_request_destroy_error
 [`response.socket`]: http.html#http_response_socket
 [`response.connection`]: http.html#http_response_connection
 [`response.end()`]: http.html#http_response_end_data_encoding_callback

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -626,7 +626,7 @@ is finished.
 
 ### `request.destroy([error])`
 <!-- YAML
-added: 14.0.0
+added: REPLACEME
 -->
 
 * `error` {Error} Optional, an error to emit with `'error'` event.
@@ -638,7 +638,7 @@ in the response to be dropped and the socket to be destroyed.
 
 ##### `request.destroyed`
 <!-- YAML
-added: 14.0.0
+added: REPLACEME
 -->
 
 * {boolean}

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -636,9 +636,9 @@ Destroy the request. Optionally emit an `'error'` event,
 and emit a `'close'` event. Calling this will cause remaining data
 in the response to be dropped and the socket to be destroyed.
 
-See [`writable.destroyed`][] for further details.
+See [`writable.destroy()`][] for further details.
 
-##### `request.destroyed`
+#### `request.destroyed`
 <!-- YAML
 added: REPLACEME
 -->
@@ -646,6 +646,8 @@ added: REPLACEME
 * {boolean}
 
 Is `true` after [`request.destroy()`][] has been called.
+
+See [`writable.destroyed`][] for further details.
 
 ### `request.finished`
 <!-- YAML
@@ -2502,5 +2504,6 @@ not abort the request or do anything besides add a `'timeout'` event.
 [`url.parse()`]: url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
 [`HPE_HEADER_OVERFLOW`]: errors.html#errors_hpe_header_overflow
 [`writable.destroy()`]: stream.html#stream_writable_destroy_error
+[`writable.destroyed`]: stream.html#stream_writable_destroyed
 [`writable.cork()`]: stream.html#stream_writable_cork
 [`writable.uncork()`]: stream.html#stream_writable_uncork

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -636,6 +636,8 @@ Destroy the request. Optionally emit an `'error'` event,
 and emit a `'close'` event. Calling this will cause remaining data
 in the response to be dropped and the socket to be destroyed.
 
+See [`writable.destroyed`][] for further details.
+
 ##### `request.destroyed`
 <!-- YAML
 added: REPLACEME

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -626,7 +626,7 @@ is finished.
 
 ### `request.destroy([error])`
 <!-- YAML
-added: REPLACEME
+added: v0.3.0
 -->
 
 * `error` {Error} Optional, an error to emit with `'error'` event.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2357,7 +2357,6 @@ the following events will be emitted in the following order:
 * `'close'`
 * `'close'` on the `res` object
 
-
 If `req.destroy()` is called before a socket is assigned, the following
 events will be emitted in the following order:
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -624,6 +624,27 @@ If `data` is specified, it is equivalent to calling
 If `callback` is specified, it will be called when the request stream
 is finished.
 
+### `request.destroy([error])`
+<!-- YAML
+added: 14.0.0
+-->
+
+* `error` {Error} Optional, an error to emit with `'error'` event.
+* Returns: {this}
+
+Destroy the request. Optionally emit an `'error'` event,
+and emit a `'close'` event. Calling this will cause remaining data
+in the response to be dropped and the socket to be destroyed.
+
+##### `request.destroyed`
+<!-- YAML
+added: 14.0.0
+-->
+
+* {boolean}
+
+Is `true` after [`request.destroy()`][] has been called.
+
 ### `request.finished`
 <!-- YAML
 added: v0.0.1
@@ -2448,6 +2469,7 @@ not abort the request or do anything besides add a `'timeout'` event.
 [`new URL()`]: url.html#url_constructor_new_url_input_base
 [`removeHeader(name)`]: #http_request_removeheader_name
 [`request.end()`]: #http_request_end_data_encoding_callback
+[`request.destroy()`]: #http_request_destroy_error
 [`request.flushHeaders()`]: #http_request_flushheaders
 [`request.getHeader()`]: #http_request_getheader_name
 [`request.setHeader()`]: #http_request_setheader_name_value
@@ -2477,5 +2499,6 @@ not abort the request or do anything besides add a `'timeout'` event.
 [`socket.unref()`]: net.html#net_socket_unref
 [`url.parse()`]: url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
 [`HPE_HEADER_OVERFLOW`]: errors.html#errors_hpe_header_overflow
+[`writable.destroy()`]: stream.html#stream_writable_destroy_error
 [`writable.cork()`]: stream.html#stream_writable_cork
 [`writable.uncork()`]: stream.html#stream_writable_uncork

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -568,6 +568,7 @@ server.listen(1337, '127.0.0.1', () => {
 ### `request.abort()`
 <!-- YAML
 added: v0.3.8
+deprecated: REPLACEME
 -->
 
 Marks the request as aborting. Calling this will cause remaining data
@@ -2356,8 +2357,44 @@ the following events will be emitted in the following order:
 * `'close'`
 * `'close'` on the `res` object
 
-If `req.abort()` is called before the connection succeeds, the following events
-will be emitted in the following order:
+
+If `req.destroy()` is called before a socket is assigned, the following
+events will be emitted in the following order:
+
+* (`req.destroy()` called here)
+* `'error'` with an error with message `'Error: socket hang up'` and code
+  `'ECONNRESET'`
+* `'close'`
+
+If `req.destroy()` is called before the connection succeeds, the following
+events will be emitted in the following order:
+
+* `'socket'`
+* (`req.destroy()` called here)
+* `'error'` with an error with message `'Error: socket hang up'` and code
+  `'ECONNRESET'`
+* `'close'`
+
+If `req.destroy()` is called after the response is received, the following
+events will be emitted in the following order:
+
+* `'socket'`
+* `'response'`
+  * `'data'` any number of times, on the `res` object
+* (`req.destroy()` called here)
+* `'aborted'` on the `res` object
+* `'close'`
+* `'close'` on the `res` object
+
+If `req.abort()` is called before a socket is assigned, the following
+events will be emitted in the following order:
+
+* (`req.abort()` called here)
+* `'abort'`
+* `'close'`
+
+If `req.abort()` is called before the connection succeeds, the following
+events will be emitted in the following order:
 
 * `'socket'`
 * (`req.abort()` called here)
@@ -2366,8 +2403,8 @@ will be emitted in the following order:
   `'ECONNRESET'`
 * `'close'`
 
-If `req.abort()` is called after the response is received, the following events
-will be emitted in the following order:
+If `req.abort()` is called after the response is received, the following
+events will be emitted in the following order:
 
 * `'socket'`
 * `'response'`


### PR DESCRIPTION
Doc deprecates ClientRequest.abort in favor of
ClientRequest.destroy. Also improves event order
documentation for abort and destroy.

Refs: https://github.com/nodejs/node/issues/32225

Please note that `destroy()` and `abort()` slightly differ in the
case of `... called before a socket is assigned ...`. I'm not sure where we landed in regards to whether or not to address this difference in https://github.com/nodejs/node/issues/32225. This PR is based on the current (master) state of things.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
