### PR TITLE
stream: update comment to indicate unused API

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -1,15 +1,13 @@
 'use strict';
 
-// Undocumented cb() API, needed for core, not for public API.
-// The cb() will be invoked synchronously if _destroy is synchronous.
-// If cb is passed no 'error' event will be emitted.
+// Backwards compat. cb() is undocumented and unused in core but
+// unfortunately might be used by modules.
 function destroy(err, cb) {
   const r = this._readableState;
   const w = this._writableState;
 
   if ((w && w.destroyed) || (r && r.destroyed)) {
     if (typeof cb === 'function') {
-      // TODO(ronag): Invoke with `'close'`/`'error'`.
       cb();
     }
 


### PR DESCRIPTION
destroy w/ callback was previously used by node
core. This is no longer the case and the
comments should reflect this to avoid confusion.

We briefly discussed making this API public. I'm still good with that but it would require the `if (destroyed)` branch to use `stream.finished`. Though if and until then this PR updates the comments to reflect the current state of things. The use of `destroy(err, cb)` has been refactored away in recent PRs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
