### PR TITLE
fs: use finished over destroy w/ cb

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -273,7 +273,7 @@ function closeFsStream(stream, cb, err) {
 }
 
 ReadStream.prototype.close = function(cb) {
-  finished(this, cb);
+  if (typeof cb === 'function') finished(this, cb);
   this.destroy();
 };
 

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -23,7 +23,7 @@ const {
   copyObject,
   getOptions,
 } = require('internal/fs/utils');
-const { Readable, Writable } = require('stream');
+const { Readable, Writable, finished } = require('stream');
 const { toPathIfFileURL } = require('internal/url');
 const kIoDone = Symbol('kIoDone');
 const kIsPerformingIO = Symbol('kIsPerformingIO');
@@ -273,7 +273,8 @@ function closeFsStream(stream, cb, err) {
 }
 
 ReadStream.prototype.close = function(cb) {
-  this.destroy(null, cb);
+  finished(this, cb);
+  this.destroy();
 };
 
 ObjectDefineProperty(ReadStream.prototype, 'pending', {


### PR DESCRIPTION
destroy w/ is undocumented API which also will cause
a race if the stream is already destroying and potentially
invoking the callback too early and without error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
