### PR TITLE
doc: improve net docs

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -730,8 +730,7 @@ added: v0.1.90
 * `error` {Object}
 * Returns: {net.Socket}
 
-Ensures that no more I/O activity happens on this socket. It effectively discards
-any buffered data and ends the socket.
+Ensures that no more I/O activity happens on this socket.
 
 See, [`writable.destroy()`][] for further details.
 

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -730,7 +730,8 @@ added: v0.1.90
 * `error` {Object}
 * Returns: {net.Socket}
 
-Ensures that no more I/O activity happens on this socket.
+Ensures that no more I/O activity happens on this socket. This destroys
+the stream but does not explicitly cause a TCP stream reset (RST).
 
 See, [`writable.destroy()`][] for further details.
 

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -733,7 +733,7 @@ added: v0.1.90
 Ensures that no more I/O activity happens on this socket.
 Destroys the stream and closes the connection.
 
-See, [`writable.destroy()`][] for further details.
+See [`writable.destroy()`][] for further details.
 
 ### `socket.destroyed`
 

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -730,8 +730,8 @@ added: v0.1.90
 * `error` {Object}
 * Returns: {net.Socket}
 
-Ensures that no more I/O activity happens on this socket. This destroys
-the stream but does not explicitly cause a TCP stream reset (RST).
+Ensures that no more I/O activity happens on this socket.
+Destroys the stream and closes the connection.
 
 See, [`writable.destroy()`][] for further details.
 

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1261,7 +1261,7 @@ Returns `true` if input is a version 6 IP address, otherwise returns `false`.
 [`socket.connect(path)`]: #net_socket_connect_path_connectlistener
 [`socket.connect(port)`]: #net_socket_connect_port_host_connectlistener
 [`socket.connecting`]: #net_socket_connecting
-[`socket.destroy()`]: #net_socket_destroy_exception
+[`socket.destroy()`]: #net_socket_destroy_error
 [`socket.end()`]: #net_socket_end_data_encoding_callback
 [`socket.pause()`]: #net_socket_pause
 [`socket.resume()`]: #net_socket_resume

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -722,24 +722,25 @@ that the
 [`socket.connect(options[, connectListener])`][`socket.connect(options)`]
 callback is a listener for the `'connect'` event.
 
-### `socket.destroy([exception])`
+### `socket.destroy([error])`
 <!-- YAML
 added: v0.1.90
 -->
 
-* `exception` {Object}
+* `error` {Object}
 * Returns: {net.Socket}
 
-Ensures that no more I/O activity happens on this socket. Only necessary in
-case of errors (parse error or so).
+Ensures that no more I/O activity happens on this socket. Effectivly discards
+any buffered data and ends the socket.
 
-If `exception` is specified, an [`'error'`][] event will be emitted and any
-listeners for that event will receive `exception` as an argument.
+See, [`writable.destroy()`][] for further details.
 
 ### `socket.destroyed`
 
 * {boolean} Indicates if the connection is destroyed or not. Once a
   connection is destroyed no further data can be transferred using it.
+
+See, [`writable.destroyed`][] for further details.
 
 ### `socket.end([data[, encoding]][, callback])`
 <!-- YAML
@@ -754,8 +755,7 @@ added: v0.1.90
 Half-closes the socket. i.e., it sends a FIN packet. It is possible the
 server will still send some data.
 
-If `data` is specified, it is equivalent to calling
-`socket.write(data, encoding)` followed by [`socket.end()`][].
+See, [`writable.end()`][] for further details.
 
 ### `socket.localAddress`
 <!-- YAML
@@ -1268,6 +1268,9 @@ Returns `true` if input is a version 6 IP address, otherwise returns `false`.
 [`socket.setEncoding()`]: #net_socket_setencoding_encoding
 [`socket.setTimeout()`]: #net_socket_settimeout_timeout_callback
 [`socket.setTimeout(timeout)`]: #net_socket_settimeout_timeout_callback
+[`writable.destroyed`]: stream.html#stream_writable_destroyed
+[`writable.destroy()`]: stream.html#stream_writable_destroy_error
+[`writable.end()`]: stream.html#stream_writable_end_chunk_encoding_callback
 [half-closed]: https://tools.ietf.org/html/rfc1122
 [stream_writable_write]: stream.html#stream_writable_write_chunk_encoding_callback
 [unspecified IPv4 address]: https://en.wikipedia.org/wiki/0.0.0.0

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -730,7 +730,7 @@ added: v0.1.90
 * `error` {Object}
 * Returns: {net.Socket}
 
-Ensures that no more I/O activity happens on this socket. Effectivly discards
+Ensures that no more I/O activity happens on this socket. It effectively discards
 any buffered data and ends the socket.
 
 See, [`writable.destroy()`][] for further details.
@@ -740,7 +740,7 @@ See, [`writable.destroy()`][] for further details.
 * {boolean} Indicates if the connection is destroyed or not. Once a
   connection is destroyed no further data can be transferred using it.
 
-See, [`writable.destroyed`][] for further details.
+See [`writable.destroyed`][] for further details.
 
 ### `socket.end([data[, encoding]][, callback])`
 <!-- YAML
@@ -755,7 +755,7 @@ added: v0.1.90
 Half-closes the socket. i.e., it sends a FIN packet. It is possible the
 server will still send some data.
 
-See, [`writable.end()`][] for further details.
+See [`writable.end()`][] for further details.
 
 ### `socket.localAddress`
 <!-- YAML


### PR DESCRIPTION
Clarify destroy behaviour and refer back to streams docs for further and more accurate
description of behavior details.

Refs: https://github.com/nodejs/node/issues/31916

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
