### PR TITLE
n-api: fix win32 main thread detection

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -117,12 +117,14 @@ class ThreadID {
  public:
 #ifdef _WIN32
   typedef DWORD thread_id_t;
-  ThreadID(): _tid(GetCurrentThreadId()) {}
-  inline bool operator==(const ThreadID& other) { return _tid == other._tid; }
+  ThreadID() : _tid(GetCurrentThreadId()) {}
+  inline bool operator==(const ThreadID& other) const {
+    return _tid == other._tid;
+  }
 #else
   typedef uv_thread_t thread_id_t;
-  ThreadID(): _tid(uv_thread_self()) {}
-  inline bool operator==(const ThreadID& other) {
+  ThreadID() : _tid(uv_thread_self()) {}
+  inline bool operator==(const ThreadID& other) const {
     return static_cast<bool>(uv_thread_equal(&_tid, &other._tid));
   }
 #endif  // _WIN32

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -116,9 +116,15 @@ static inline void trigger_fatal_exception(
 class ThreadID {
  public:
 #ifdef _WIN32
+  typedef DWORD thread_id_t;
   ThreadID(): _tid(GetCurrentThreadId()) {}
+  inline bool operator==(const ThreadID& other) { return _tid == other._tid; }
 #else
+  typedef uv_thread_t thread_id_t;
   ThreadID(): _tid(uv_thread_self()) {}
+  inline bool operator==(const ThreadID& other) {
+    return static_cast<bool>(uv_thread_equal(&_tid, &other._tid));
+  }
 #endif  // _WIN32
 
   ThreadID(const ThreadID&) = delete;
@@ -126,20 +132,8 @@ class ThreadID {
   void operator= (const ThreadID&) = delete;
   void operator= (const ThreadID&&) = delete;
 
-#ifdef _WIN32
-  inline bool operator==(const ThreadID& other) { return _tid == other._tid; }
-#else
-  inline bool operator==(const ThreadID& other) {
-    return static_cast<bool>(uv_thread_equal(&_tid, &other._tid));
-  }
-#endif
-
  private:
-#ifdef _WIN32
-  DWORD _tid = 0;
-#else
-  uv_thread_t _tid;
-#endif  // _WIN32
+  thread_id_t _tid;
 };
 
 class ThreadSafeFunction : public node::AsyncResource {


### PR DESCRIPTION
`uv_thread_self()` works on Windows only for threads created using
`uv_thread_start()` because libuv does not use `GetCurrentThreadId()`
for threads that were created otherwise. `uv_thread_equal()` works
correctly.

Thus, on Windows we use `GetCurrentThreadId()` to compare the main
thread with the current thread.

Signed-off-by: @gabrielschulhof

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
