### PR TITLE
test: only detect uname on supported os

### DIFF
--- a/test/addons/openssl-binding/binding.gyp
+++ b/test/addons/openssl-binding/binding.gyp
@@ -3,15 +3,25 @@
     {
       'target_name': 'binding',
       'includes': ['../common.gypi'],
-      'variables': {
-        # Skip this building on IBM i.
-        'aix_variant_name': '<!(uname -s)',
-      },
       'conditions': [
-        ['node_use_openssl=="true" and '
-         '"<(aix_variant_name)"!="OS400"', {
-          'sources': ['binding.cc'],
-          'include_dirs': ['../../../deps/openssl/openssl/include'],
+        ['node_use_openssl=="true"', {
+          'conditions': [
+            ['OS=="aix"', {
+              'variables': {
+                # Used to differentiate `AIX` and `OS400`(IBM i).
+                'aix_variant_name': '<!(uname -s)',
+              },
+              'conditions': [
+                [ '"<(aix_variant_name)"!="OS400"', { # Not `OS400`(IBM i)
+                  'sources': ['binding.cc'],
+                  'include_dirs': ['../../../deps/openssl/openssl/include'],
+                }],
+              ],
+            }, {
+              'sources': ['binding.cc'],
+              'include_dirs': ['../../../deps/openssl/openssl/include'],
+            }],
+          ],
         }],
         ['OS=="mac"', {
           'xcode_settings': {

--- a/test/addons/zlib-binding/binding.gyp
+++ b/test/addons/zlib-binding/binding.gyp
@@ -2,12 +2,19 @@
   'targets': [
     {
       'target_name': 'binding',
-      'variables': {
-        # Skip this building on IBM i.
-        'aix_variant_name': '<!(uname -s)',
-      },
       'conditions': [
-        [ '"<(aix_variant_name)"!="OS400"', {
+        ['OS=="aix"', {
+          'variables': {
+            # Used to differentiate `AIX` and `OS400`(IBM i).
+            'aix_variant_name': '<!(uname -s)',
+          },
+          'conditions': [
+            [ '"<(aix_variant_name)"!="OS400"', { # Not `OS400`(IBM i)
+              'sources': ['binding.cc'],
+              'include_dirs': ['../../../deps/zlib'],
+            }],
+          ],
+        }, {
           'sources': ['binding.cc'],
           'include_dirs': ['../../../deps/zlib'],
         }],


### PR DESCRIPTION
To skip some tests on IBMi PASE, we use `uname` to detect the true os name, but
on Windows machines there is no `uname` available.

This fix the issue in #31967

Tested on Windows, Mac OS and IBM i PASE. May need AIX test as well.