### PR TITLE
lib: fix memory leak, when module require error occurs

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -928,6 +928,13 @@ Module._load = function(request, parent, isMain) {
       delete Module._cache[filename];
       if (parent !== undefined) {
         delete relativeResolveCache[relResolveCacheIdentifier];
+        const children = parent && parent.children;
+        if (ArrayIsArray(children)) {
+          const index = children.indexOf(module);
+          if (index !== -1) {
+            children.splice(index, 1);
+          }
+        }
       }
     } else if (module.exports &&
                ObjectGetPrototypeOf(module.exports) ===

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -302,17 +302,14 @@ assert.throws(
       }
     },
     'fixtures/path.js': {},
-    'fixtures/throws_error.js': {},
     'fixtures/registerExt.test': {},
     'fixtures/registerExt.hello.world': {},
     'fixtures/registerExt2.test': {},
     'fixtures/module-load-order/file1': {},
     'fixtures/module-load-order/file2.js': {},
-    'fixtures/module-load-order/file3.node': {},
     'fixtures/module-load-order/file4.reg': {},
     'fixtures/module-load-order/file5.reg2': {},
     'fixtures/module-load-order/file6/index.js': {},
-    'fixtures/module-load-order/file7/index.node': {},
     'fixtures/module-load-order/file8/index.reg': {},
     'fixtures/module-load-order/file9/index.reg2': {},
     'fixtures/module-require/parent/index.js': {


### PR DESCRIPTION
Delete useless module in parent module: parent.children array when error occuers
so that the memory can be garbage collected.

Fixes: https://github.com/nodejs/node/issues/32836

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)