### PR TITLE
module: empty fallback and null exports as not exported

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1661,13 +1661,15 @@ The resolver can throw the following errors:
 >             loop on any _Package Path Not Exported_ error.
 >    1. Throw a _Package Path Not Exported_ error.
 > 1. Otherwise, if _target_ is an Array, then
->    1. If _target.length is zero, throw an _Invalid Package Target_ error.
+>    1. If _target.length is zero, throw a _Package Path Not Exported_ error.
 >    1. For each item _targetValue_ in _target_, do
 >       1. If _targetValue_ is an Array, continue the loop.
 >       1. Return the result of **PACKAGE_EXPORTS_TARGET_RESOLVE**(_packageURL_,
 >          _targetValue_, _subpath_, _env_), continuing the loop on any
 >          _Package Path Not Exported_ or _Invalid Package Target_ error.
 >    1. Throw the last fallback resolution error.
+> 1. Otherwise, if _target_ is _null_, throw a _Package Path Not Exported_
+>    error.
 > 1. Otherwise throw an _Invalid Package Target_ error.
 
 **ESM_FORMAT**(_url_)

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -552,21 +552,22 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
       , 0, -1), mappingKey);
   } else if (ArrayIsArray(target)) {
     if (target.length === 0)
-      throw new ERR_INVALID_PACKAGE_TARGET(StringPrototypeSlice(baseUrl.pathname
-        , 0, -1), mappingKey, subpath, target);
+      throw new ERR_PACKAGE_PATH_NOT_EXPORTED(
+        StringPrototypeSlice(baseUrl.pathname, 0, -1), mappingKey + subpath);
+    let lastException;
     for (const targetValue of target) {
       try {
         return resolveExportsTarget(baseUrl, targetValue, subpath, mappingKey);
       } catch (e) {
+        lastException = e;
         if (e.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED' &&
             e.code !== 'ERR_INVALID_PACKAGE_TARGET')
           throw e;
       }
     }
     // Throw last fallback error
-    resolveExportsTarget(baseUrl, target[target.length - 1], subpath,
-                         mappingKey);
-    assert(false);
+    assert(lastException !== undefined);
+    throw lastException;
   } else if (typeof target === 'object' && target !== null) {
     const keys = ObjectKeys(target);
     if (keys.some(isArrayIndex)) {
@@ -593,6 +594,9 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
           }
       }
     }
+    throw new ERR_PACKAGE_PATH_NOT_EXPORTED(
+      StringPrototypeSlice(baseUrl.pathname, 0, -1), mappingKey + subpath);
+  } else if (target === null) {
     throw new ERR_PACKAGE_PATH_NOT_EXPORTED(
       StringPrototypeSlice(baseUrl.pathname, 0, -1), mappingKey + subpath);
   }

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -16,7 +16,7 @@ const {
   StringPrototypeStartsWith,
   StringPrototypeSubstr,
 } = primordials;
-
+const assert = require('internal/assert');
 const internalFS = require('internal/fs/utils');
 const { NativeModule } = require('internal/bootstrap/loaders');
 const {
@@ -345,7 +345,7 @@ function resolveExportsTarget(
     return finalizeResolution(resolved, base);
   } else if (ArrayIsArray(target)) {
     if (target.length === 0)
-      throwExportsInvalid(packageSubpath, target, packageJSONUrl, base);
+      throwExportsNotFound(packageSubpath, packageJSONUrl, base);
 
     let lastException;
     for (let i = 0; i < target.length; i++) {
@@ -366,6 +366,7 @@ function resolveExportsTarget(
 
       return finalizeResolution(resolved, base);
     }
+    assert(lastException !== undefined);
     throw lastException;
   } else if (typeof target === 'object' && target !== null) {
     const keys = ObjectGetOwnPropertyNames(target);
@@ -391,6 +392,8 @@ function resolveExportsTarget(
         }
       }
     }
+    throwExportsNotFound(packageSubpath, packageJSONUrl, base);
+  } else if (target === null) {
     throwExportsNotFound(packageSubpath, packageJSONUrl, base);
   }
   throwExportsInvalid(packageSubpath, target, packageJSONUrl, base);

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -64,6 +64,10 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     // Conditional exports with no match are "not exported" errors
     ['pkgexports/invalid1', './invalid1'],
     ['pkgexports/invalid4', './invalid4'],
+    // Null mapping
+    ['pkgexports/null', './null'],
+    // Empty fallback
+    ['pkgexports/nofallback1', './nofallback1'],
   ]);
 
   const invalidExports = new Map([
@@ -74,12 +78,10 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     ['pkgexports/belowdir/pkgexports/asdf.js', './belowdir/'],
     // This target file steps below the package
     ['pkgexports/belowfile', './belowfile'],
-    // Invalid target handling
-    ['pkgexports/null', './null'],
+    // Invalid targets
     ['pkgexports/invalid2', './invalid2'],
     ['pkgexports/invalid3', './invalid3'],
     // Missing / invalid fallbacks
-    ['pkgexports/nofallback1', './nofallback1'],
     ['pkgexports/nofallback2', './nofallback2'],
     // Reaching into nested node_modules
     ['pkgexports/nodemodules', './nodemodules'],

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -66,6 +66,7 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     ['pkgexports/invalid4', './invalid4'],
     // Null mapping
     ['pkgexports/null', './null'],
+    ['pkgexports/null/subpath', './null/subpath'],
     // Empty fallback
     ['pkgexports/nofallback1', './nofallback1'],
   ]);

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -9,6 +9,7 @@
     "./belowfile": "../belowfile",
     "./missingtrailer/": ".",
     "./null": null,
+    "./null/": null,
     "./invalid1": {},
     "./invalid2": 1234,
     "./invalid3": "",


### PR DESCRIPTION
This PR includes two changes to exports edge cases:

1. Empty array mappings (`"./subpath": []`) to throw ERR_PACKAGE_PATH_NOT_EXPORTED.
2. `null` targets (`"./subpath": null`) as also throwing ERR_PACKAGE_PATH_NOT_EXPORTED.

This comes out of the discussion in https://github.com/jkrems/proposal-pkg-exports/issues/46 where the feature is blacklisting subdirectories via eg:

```js
{
  "exports"; {
    "./features/": "./dist/features/",
    "./features/private/": null
  }
}
```

Both of the above cases would then result in conditional object checks falling through (whereas the current ERR_INVALID_PACKAGE_TARGET for both does not).

There is likely still some discussion to be had here:

* Currently empty array mappings are treated as invalid meaning that they always throw as a sort of package author validation step since there's no real reason to use them. Either error can in some way be seen as consistent though - `[[]]` will throw the same error regardless. So it likely is about what is best for usability and what will more likely match import maps.
* `null` in import maps was originally proposed to match the semantics of `[]`, so should likely follow the above.

Questions:

* Do we want to support this use case?
* Does it make sense to support it via `null`?
* If so, should `[]` follow this same error?

I tend to think yes, but let's discuss in the meeting further.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
