### PR TITLE
stream: improve comments regarding end() errors.

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -598,20 +598,16 @@ Writable.prototype.end = function(chunk, encoding, cb) {
   if (typeof cb !== 'function')
     cb = nop;
 
-  // Ignore unnecessary end() calls.
-  // TODO(ronag): Compat. Allow end() after destroy().
+  // This is forgiving in terms of unnecessary calls to end() and can hide
+  // logic errors. However, usually such errors are harmless and causing a
+  // hard error can be disproportionately destructive. It is not always
+  // trivial for the user to determine whether end() needs to be called or not.
   if (!state.errored && !state.ending) {
     endWritable(this, state, cb);
   } else if (state.finished) {
-    const err = new ERR_STREAM_ALREADY_FINISHED('end');
-    process.nextTick(cb, err);
-    // TODO(ronag): Compat. Don't error the stream.
-    // errorOrDestroy(this, err, true);
+    process.nextTick(cb, new ERR_STREAM_ALREADY_FINISHED('end'));
   } else if (state.destroyed) {
-    const err = new ERR_STREAM_DESTROYED('end');
-    process.nextTick(cb, err);
-    // TODO(ronag): Compat. Don't error the stream.
-    // errorOrDestroy(this, err, true);
+    process.nextTick(cb, new ERR_STREAM_DESTROYED('end'));
   } else if (cb !== nop) {
     onFinished(this, state, cb);
   }
@@ -720,6 +716,7 @@ function onCorkedFinish(corkReq, state, err) {
   state.corkedRequestsFree.next = corkReq;
 }
 
+// TODO(ronag): Avoid using events to implement internal logic.
 function onFinished(stream, state, cb) {
   function onerror(err) {
     stream.removeListener('finish', onfinish);


### PR DESCRIPTION
Cleans up comments and TODOs and tries to provide a
more detail description in regards to error behavior
of end().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
