### PR TITLE
src: deprecate embedder APIs with replacements

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -227,15 +227,14 @@ NODE_EXTERN int Start(int argc, char* argv[]);
 // in the loop and / or actively executing JavaScript code).
 NODE_EXTERN int Stop(Environment* env);
 
-// TODO(addaleax): Officially deprecate this and replace it with something
-// better suited for a public embedder API.
 // It is recommended to use InitializeNodeWithArgs() instead as an embedder.
 // Init() calls InitializeNodeWithArgs() and exits the process with the exit
 // code returned from it.
-NODE_EXTERN void Init(int* argc,
-                      const char** argv,
-                      int* exec_argc,
-                      const char*** exec_argv);
+NODE_DEPRECATED("Use InitializeNodeWithArgs() instead",
+    NODE_EXTERN void Init(int* argc,
+                          const char** argv,
+                          int* exec_argc,
+                          const char*** exec_argv));
 // Set up per-process state needed to run Node.js. This will consume arguments
 // from argv, fill exec_argv, and possibly add errors resulting from parsing
 // the arguments to `errors`. The return value is a suggested exit code for the
@@ -428,12 +427,13 @@ struct InspectorParentHandle {
 // Returns nullptr when the Environment cannot be created e.g. there are
 // pending JavaScript exceptions.
 // It is recommended to use the second variant taking a flags argument.
-NODE_EXTERN Environment* CreateEnvironment(IsolateData* isolate_data,
-                                           v8::Local<v8::Context> context,
-                                           int argc,
-                                           const char* const* argv,
-                                           int exec_argc,
-                                           const char* const* exec_argv);
+NODE_DEPRECATED("Use overload taking a flags argument",
+    NODE_EXTERN Environment* CreateEnvironment(IsolateData* isolate_data,
+                                               v8::Local<v8::Context> context,
+                                               int argc,
+                                               const char* const* argv,
+                                               int exec_argc,
+                                               const char* const* exec_argv));
 NODE_EXTERN Environment* CreateEnvironment(
     IsolateData* isolate_data,
     v8::Local<v8::Context> context,
@@ -463,8 +463,8 @@ struct StartExecutionCallbackInfo {
 using StartExecutionCallback =
     std::function<v8::MaybeLocal<v8::Value>(const StartExecutionCallbackInfo&)>;
 
-// TODO(addaleax): Deprecate this in favour of the MaybeLocal<> overload.
-NODE_EXTERN void LoadEnvironment(Environment* env);
+NODE_DEPRECATED("Use variants returning MaybeLocal<> instead",
+    NODE_EXTERN void LoadEnvironment(Environment* env));
 // The `InspectorParentHandle` arguments here are ignored and not used.
 // For passing `InspectorParentHandle`, use `CreateEnvironment()`.
 NODE_EXTERN v8::MaybeLocal<v8::Value> LoadEnvironment(
@@ -495,18 +495,18 @@ NODE_EXTERN Environment* GetCurrentEnvironment(v8::Local<v8::Context> context);
 // This returns the MultiIsolatePlatform used in the main thread of Node.js.
 // If NODE_USE_V8_PLATFORM has not been defined when Node.js was built,
 // it returns nullptr.
-// TODO(addaleax): Deprecate in favour of GetMultiIsolatePlatform().
-NODE_EXTERN MultiIsolatePlatform* GetMainThreadMultiIsolatePlatform();
+NODE_DEPRECATED("Use GetMultiIsolatePlatform(env) instead",
+    NODE_EXTERN MultiIsolatePlatform* GetMainThreadMultiIsolatePlatform());
 // This returns the MultiIsolatePlatform used for an Environment or IsolateData
 // instance, if one exists.
 NODE_EXTERN MultiIsolatePlatform* GetMultiIsolatePlatform(Environment* env);
 NODE_EXTERN MultiIsolatePlatform* GetMultiIsolatePlatform(IsolateData* env);
 
 // Legacy variants of MultiIsolatePlatform::Create().
-// TODO(addaleax): Deprecate in favour of the v8::TracingController variant.
-NODE_EXTERN MultiIsolatePlatform* CreatePlatform(
-    int thread_pool_size,
-    node::tracing::TracingController* tracing_controller);
+NODE_DEPRECATED("Use variant taking a v8::TracingController* pointer instead",
+    NODE_EXTERN MultiIsolatePlatform* CreatePlatform(
+        int thread_pool_size,
+        node::tracing::TracingController* tracing_controller));
 NODE_EXTERN MultiIsolatePlatform* CreatePlatform(
     int thread_pool_size,
     v8::TracingController* tracing_controller);


### PR DESCRIPTION
Implement a number of TODO comments aiming at the eventual removal of
some embedder APIs that now have replacements available.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
