### PR TITLE
stream: remove unused & undocumented cb

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -1,18 +1,10 @@
 'use strict';
 
-// Undocumented cb() API, needed for core, not for public API.
-// The cb() will be invoked synchronously if _destroy is synchronous.
-// If cb is passed no 'error' event will be emitted.
-function destroy(err, cb) {
+function destroy(err) {
   const r = this._readableState;
   const w = this._writableState;
 
   if ((w && w.destroyed) || (r && r.destroyed)) {
-    if (typeof cb === 'function') {
-      // TODO(ronag): Invoke with `'close'`/`'error'`.
-      cb();
-    }
-
     return this;
   }
 
@@ -50,10 +42,6 @@ function destroy(err, cb) {
     }
     if (r) {
       r.closed = true;
-    }
-
-    if (typeof cb === 'function') {
-      cb(err);
     }
 
     if (err) {


### PR DESCRIPTION
destroy(err, cb) was an undocumented API which
was previously used internally by core modules.
However, this is no longer the case and it should
be possible to safely remove this.

Refs: https://github.com/nodejs/node/pull/32808

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
