### PR TITLE
tools: decrease timeout in test.py

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -142,7 +142,7 @@ class ProgressIndicator(object):
       # Wait for the remaining threads
       for thread in threads:
         # Use a timeout so that signals (ctrl-c) will be processed.
-        thread.join(timeout=10000000)
+        thread.join(timeout=1000000)
     except (KeyboardInterrupt, SystemExit):
       self.shutdown_event.set()
     except Exception:


### PR DESCRIPTION
This fixes the following crash on Windows for me. I don't know
why this I only started to see this now, but anyway, the new timeout
value is still longer than a week and a half.

    File "tools/test.py", line 1725, in <module>
        sys.exit(Main())
    File "tools/test.py", line 1701, in Main
        if RunTestCases(cases_to_run, options.progress, options.j, options.flaky_tests):
    File "tools/test.py", line 923, in RunTestCases
        return progress.Run(tasks)
    File "tools/test.py", line 145, in Run
        thread.join(timeout=10000000)
    File "C:\Users\anna\AppData\Local\Programs\Python\Python38-32\lib\threading.py", line 1015, in join
        self._wait_for_tstate_lock(timeout=max(timeout, 0))
    File "C:\Users\anna\AppData\Local\Programs\Python\Python38-32\lib\threading.py", line 1027, in _wait_for_tstate_lock
        elif lock.acquire(block, timeout):
    OverflowError: timeout value is too large

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
