### PR TITLE
module: development and production exports conditions

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -358,6 +358,9 @@ Node.js supports the following conditions:
 * `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
    module file. _This condition should always come after `"import"` or
    `"require"`._
+* `"production"` - matched if `process.env.NODE_ENV` is set to `production`.
+* `"development"` - matched if `process.env.NODE_ENV` is not set to `production`
+   so that `"production"` and `"development"` are fully mutually exclusive.
 * `"default"` - the generic fallback that will always match. Can be a CommonJS
    or ES module file. _This condition should always come last._
 
@@ -1472,7 +1475,9 @@ In the following algorithms, all subroutine errors are propagated as errors
 of these top-level routines unless stated otherwise.
 
 _defaultEnv_ is the conditional environment name priority array,
-`["node", "import"]`.
+`["node", "import", "development"]`. If `process.env.NODE_ENV` is set to
+`production` then the `"production"` condition is used in place of
+`"development"`.
 
 The resolver can throw the following errors:
 * _Invalid Module Specifier_: Module specifier is an invalid URL, package name

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -386,6 +386,10 @@ Conditional exports can also be extended to exports subpaths, for example:
   "exports": {
     ".": "./main.js",
     "./feature": {
+      "production": {
+        "browser": "./feature-browser-production.js",
+        "default": "./feature-production.js"
+      },
       "browser": "./feature-browser.js",
       "default": "./feature.js"
     }
@@ -394,8 +398,9 @@ Conditional exports can also be extended to exports subpaths, for example:
 ```
 
 Defines a package where `require('pkg/feature')` and `import 'pkg/feature'`
-could provide different implementations between the browser and Node.js,
-given third-party tool support for a `"browser"` condition.
+could provide different implementations between the browser and Node.js
+given third-party tool support for a `"browser"` condition, while also
+supporting production and development variants.
 
 #### Nested conditions
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -524,6 +524,8 @@ function isArrayIndex(p) {
   return n >= 0 && n < (2 ** 32) - 1;
 }
 
+const devCondition =
+    process.env.NODE_ENV === 'production' ? 'production' : 'development';
 function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
   if (typeof target === 'string') {
     let resolvedTarget, resolvedTargetPath;
@@ -575,6 +577,14 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
     }
     for (const p of keys) {
       switch (p) {
+        case devCondition:
+          try {
+            return resolveExportsTarget(baseUrl, target[p], subpath,
+                                        mappingKey);
+          } catch (e) {
+            if (e.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw e;
+          }
+          break;
         case 'node':
         case 'require':
           try {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -46,7 +46,11 @@ const {
   ERR_UNSUPPORTED_ESM_URL_SCHEME,
 } = require('internal/errors').codes;
 
-const DEFAULT_CONDITIONS = ObjectFreeze(['node', 'import']);
+const DEFAULT_CONDITIONS = ObjectFreeze([
+  'node',
+  'import',
+  process.env.NODE_ENV === 'production' ? 'production' : 'development'
+]);
 const DEFAULT_CONDITIONS_SET = new SafeSet(DEFAULT_CONDITIONS);
 
 function getConditionsSet(conditions) {

--- a/test/es-module/test-esm-exports-dev-production.mjs
+++ b/test/es-module/test-esm-exports-dev-production.mjs
@@ -1,0 +1,27 @@
+// Flags: --experimental-wasm-modules
+import '../common/index.mjs';
+import { path } from '../common/fixtures.mjs';
+import { strictEqual } from 'assert';
+import { spawnSync } from 'child_process';
+
+{
+  const output = spawnSync(process.execPath, [path('/pkgexports-dev.mjs')], {
+    env: Object.assign({}, process.env, {
+      NODE_ENV: 'production'
+    })
+  });
+  strictEqual(output.stdout.toString().trim(), 'production');
+}
+
+{
+  const output = spawnSync(process.execPath, [path('/pkgexports-dev.mjs')], {
+  });
+  strictEqual(output.stdout.toString().trim(), 'development');
+}
+
+{
+  const output = spawnSync(process.execPath, [path('/pkgexports-dev.mjs')], {
+    NODE_ENV: 'any'
+  });
+  strictEqual(output.stdout.toString().trim(), 'development');
+}

--- a/test/fixtures/es-module-loaders/loader-with-custom-condition.mjs
+++ b/test/fixtures/es-module-loaders/loader-with-custom-condition.mjs
@@ -1,8 +1,11 @@
 import {ok, deepStrictEqual} from 'assert';
 
+const env =
+    process.env.NODE_ENV === 'production' ? 'production' : 'development';
+
 export async function resolve(specifier, context, defaultResolve) {
   ok(Array.isArray(context.conditions), 'loader receives conditions array');
-  deepStrictEqual([...context.conditions].sort(), ['import', 'node']);
+  deepStrictEqual([...context.conditions].sort(), [env, 'import', 'node']);
   return defaultResolve(specifier, {
     ...context,
     conditions: ['custom-condition', ...context.conditions],

--- a/test/fixtures/node_modules/pkgexports-dev/dev.js
+++ b/test/fixtures/node_modules/pkgexports-dev/dev.js
@@ -1,0 +1,1 @@
+module.exports = 'development';

--- a/test/fixtures/node_modules/pkgexports-dev/dev.mjs
+++ b/test/fixtures/node_modules/pkgexports-dev/dev.mjs
@@ -1,0 +1,1 @@
+export default 'development';

--- a/test/fixtures/node_modules/pkgexports-dev/package.json
+++ b/test/fixtures/node_modules/pkgexports-dev/package.json
@@ -1,0 +1,12 @@
+{
+  "exports": {
+    "development": {
+      "require": "./dev.js",
+      "import": "./dev.mjs"
+    },
+    "production": {
+      "require": "./prod.js",
+      "import": "./prod.mjs"
+    }
+  }
+}

--- a/test/fixtures/node_modules/pkgexports-dev/prod.js
+++ b/test/fixtures/node_modules/pkgexports-dev/prod.js
@@ -1,0 +1,1 @@
+module.exports = 'production';

--- a/test/fixtures/node_modules/pkgexports-dev/prod.mjs
+++ b/test/fixtures/node_modules/pkgexports-dev/prod.mjs
@@ -1,0 +1,1 @@
+export default 'production';

--- a/test/fixtures/pkgexports-dev.mjs
+++ b/test/fixtures/pkgexports-dev.mjs
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+import { strictEqual } from 'assert';
+
+const require = createRequire(fileURLToPath(import.meta.url));
+
+const production = process.env.NODE_ENV === 'production';
+const expectValue = production ? 'production' : 'development';
+
+strictEqual(require('pkgexports-dev'), expectValue);
+
+(async () => {
+  const { default: value } = await import('pkgexports-dev');
+  strictEqual(value, expectValue);
+
+  console.log(expectValue);
+})();


### PR DESCRIPTION
This supports two new conditions in conditional exports - `"development"` and `"production"`. By default the `"development"` condition is always matched unless `process.env.NODE_ENV` is set to `"production"` in which case the `"production"` condition is matched.

By making this implementation simply a specification of what the standard in the ecosystem already is, the hope is that this will provide a simple to adopt incremental approach to the problem of production and development condition branching.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
