### PR TITLE
streams: add null check in Readable.from

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1698,7 +1698,8 @@ added:
 -->
 
 * `iterable` {Iterable} Object implementing the `Symbol.asyncIterator` or
-  `Symbol.iterator` iterable protocol.
+  `Symbol.iterator` iterable protocol. Emits an 'error' event if a null
+   value is passed.
 * `options` {Object} Options provided to `new stream.Readable([options])`.
   By default, `Readable.from()` will set `options.objectMode` to `true`, unless
   this is explicitly opted out by setting `options.objectMode` to `false`.

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -7,7 +7,8 @@ const {
 const { Buffer } = require('buffer');
 
 const {
-  ERR_INVALID_ARG_TYPE
+  ERR_INVALID_ARG_TYPE,
+  ERR_STREAM_NULL_VALUES
 } = require('internal/errors').codes;
 
 function from(Readable, iterable, opts) {
@@ -73,15 +74,20 @@ function from(Readable, iterable, opts) {
       needToClose = false;
       const { value, done } = await iterator.next();
       needToClose = !done;
-      const resolved = await value;
       if (done) {
         readable.push(null);
       } else if (readable.destroyed) {
         await close();
-      } else if (readable.push(resolved)) {
-        next();
       } else {
-        reading = false;
+        const res = await value;
+        if (res === null) {
+          reading = false;
+          throw new ERR_STREAM_NULL_VALUES();
+        } else if (readable.push(res)) {
+          next();
+        } else {
+          reading = false;
+        }
       }
     } catch (err) {
       readable.destroy(err);

--- a/test/parallel/test-readable-from-iterator-closing.js
+++ b/test/parallel/test-readable-from-iterator-closing.js
@@ -168,18 +168,17 @@ async function closeAfterNullYielded() {
   const finallyMustCall = mustCall();
   const dataMustCall = mustCall(3);
 
-  function* infiniteGenerate() {
+  function* generate() {
     try {
       yield 'a';
       yield 'a';
       yield 'a';
-      while (true) yield null;
     } finally {
       finallyMustCall();
     }
   }
 
-  const stream = Readable.from(infiniteGenerate());
+  const stream = Readable.from(generate());
 
   stream.on('data', (chunk) => {
     dataMustCall();

--- a/test/parallel/test-stream-readable-next-no-null.js
+++ b/test/parallel/test-stream-readable-next-no-null.js
@@ -1,0 +1,19 @@
+'use strict';
+const { mustNotCall, expectsError } = require('../common');
+const { Readable } = require('stream');
+
+async function* generate() {
+  yield null;
+}
+
+const stream = Readable.from(generate());
+
+stream.on('error', expectsError({
+  code: 'ERR_STREAM_NULL_VALUES',
+  name: 'TypeError',
+  message: 'May not write null values to stream'
+}));
+
+stream.on('data', mustNotCall((chunk) => {}));
+
+stream.on('end', mustNotCall());


### PR DESCRIPTION
Throws `ERR_STREAM_NULL_VALUES` error if a null value is passed to
`Readable.from`. Also added docs for the same.

Fixes: https://github.com/nodejs/node/issues/32845

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests added
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
