### PR TITLE
test: changed function to arrow function

### DIFF
--- a/test/parallel/test-net-after-close.js
+++ b/test/parallel/test-net-after-close.js
@@ -24,14 +24,14 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const server = net.createServer(common.mustCall(function(s) {
+const server = net.createServer(common.mustCall((s) => {
   console.error('SERVER: got connection');
   s.end();
 }));
 
-server.listen(0, common.mustCall(function() {
-  const c = net.createConnection(this.address().port);
-  c.on('close', common.mustCall(function() {
+server.listen(0, common.mustCall(() => {
+  const c = net.createConnection(server.address().port);
+  c.on('close', common.mustCall(() => {
     console.error('connection closed');
     assert.strictEqual(c._handle, null);
     // Calling functions / accessing properties of a closed socket should not


### PR DESCRIPTION
Convert callback functions that are anonymous
to arrow functions for better readability.
Also adjusted the `this` object in places
where that was required.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
