### PR TITLE
build: remove .git folders when testing V8

### DIFF
--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -4,6 +4,7 @@ BUILD_ARCH_TYPE=$1
 V8_BUILD_OPTIONS=$2
 
 cd deps/v8
+find . -type d -name .git | xargs rm -rf
 tools/node/fetch_deps.py .
 
 ARCH="`arch`"


### PR DESCRIPTION
When running `make test-v8` V8's `gclient sync` converts folders
under `deps/v8/third_party` into git repositories. Unfortunately
the files that were checked in under `deps/v8/third_party/zlib`
have been modified from the upstream Chromium repository (some
files have been deleted and there are whitespace differences in
some of the files that were kept) so whenever the Node.js source
tree is hard reset/checked out `gclient sync` notices there are
unstaged changes as the files in the Node.js source tree do not
match those of the upstream Chromium third party zlib commit.

Refs: https://github.com/nodejs/build/issues/2256

cc @nodejs/v8-update @mmarchini 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
