### PR TITLE
src: assignment to valid type

### DIFF
--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -185,7 +185,7 @@ void TCPWrap::SetKeepAlive(const FunctionCallbackInfo<Value>& args) {
   Environment* env = wrap->env();
   int enable;
   if (!args[0]->Int32Value(env->context()).To(&enable)) return;
-  unsigned int delay = args[1].As<Uint32>()->Value();
+  unsigned int delay = static_cast<unsigned int>(args[1].As<Uint32>()->Value());
   int err = uv_tcp_keepalive(&wrap->handle_, enable, delay);
   args.GetReturnValue().Set(err);
 }
@@ -278,7 +278,8 @@ void TCPWrap::Listen(const FunctionCallbackInfo<Value>& args) {
 
 void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsUint32());
-  int port = args[2].As<Uint32>()->Value();
+  // explicit cast to fit to libuv's type expectation
+  int port = static_cast<int>(args[2].As<Uint32>()->Value());
   Connect<sockaddr_in>(args,
                        [port](const char* ip_address, sockaddr_in* addr) {
       return uv_ip4_addr(ip_address, port, addr);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
We are doing conversion of arguments to `uint32_t` but the lvalue type
is not consistent with the casting. Also, the lvalue type differs at
different occurrences. Ideally, such changes should be picked up by the linter, can we move forward in this direction 🤔 .

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->